### PR TITLE
feat(davinci): refuse corpus sweeps over contaminated fixtures

### DIFF
--- a/davinci-road/plan/corpus-baseline-notes.md
+++ b/davinci-road/plan/corpus-baseline-notes.md
@@ -12,9 +12,22 @@
 
 ```sh
 cargo build --release -p vize
-node tools/davinci/corpus-baseline.mjs            # rewrite the committed baseline
-node tools/davinci/corpus-diff.mjs                # gate a fresh run against it
+node tools/davinci/corpus-baseline.mjs --clean-fixtures   # rewrite the committed baseline
+node tools/davinci/corpus-diff.mjs --clean-fixtures       # gate a fresh run against it
 ```
+
+**Both tools refuse to sweep contaminated fixtures.** A run only produces
+comparable hashes when it starts from the pinned tree, so each tool
+pre-flights it: every fixture submodule must sit at its recorded sha, and no
+`node_modules` may be materialized inside a checkout. A sweep leaves ~142 of
+them behind (see Re-record 2 below), so the next run without
+`--clean-fixtures` stops immediately with the offending paths instead of
+spending minutes producing hashes nobody can trust. `--clean-fixtures`
+removes them first; `--allow-dirty-fixtures` sweeps anyway and is only for
+deliberate experiments, since its hashes are not comparable to the committed
+baseline. Drifted submodules are never auto-repaired — the tool prints the
+`git submodule update` line and stops, because silently re-hydrating a
+fixture would change what the corpus measures.
 
 Both tools spawn `tools/fixtures/tool-matrix-report.mjs` across all shards
 (4 parallel shard processes by default; the harness is serial inside a

--- a/tools/davinci/corpus-baseline.mjs
+++ b/tools/davinci/corpus-baseline.mjs
@@ -40,10 +40,19 @@ import {
   runMatrix,
   scratchRoot,
 } from "./lib/corpus-baseline-run.mjs";
+import { assertFixturesPristine, cleanFixtures } from "./lib/corpus-fixture-hygiene.mjs";
 import { repoRoot } from "./lib/paths.mjs";
 
 function parseArgs(argv) {
-  const args = { shards: 4, vizeBin: null, out: null, timeoutMs: null, keepRaw: false };
+  const args = {
+    shards: 4,
+    vizeBin: null,
+    out: null,
+    timeoutMs: null,
+    keepRaw: false,
+    cleanFixtures: false,
+    allowDirtyFixtures: false,
+  };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     const value = () => {
@@ -55,9 +64,11 @@ function parseArgs(argv) {
     else if (arg === "--out") args.out = value();
     else if (arg === "--timeout-ms") args.timeoutMs = positiveInteger(value(), arg);
     else if (arg === "--keep-raw") args.keepRaw = true;
+    else if (arg === "--clean-fixtures") args.cleanFixtures = true;
+    else if (arg === "--allow-dirty-fixtures") args.allowDirtyFixtures = true;
     else if (arg === "--help" || arg === "-h") {
       process.stdout.write(
-        "usage: node tools/davinci/corpus-baseline.mjs [--shards n] [--vize-bin path] [--out path] [--timeout-ms n] [--keep-raw]\n",
+        "usage: node tools/davinci/corpus-baseline.mjs [--shards n] [--vize-bin path] [--out path] [--timeout-ms n] [--keep-raw] [--clean-fixtures] [--allow-dirty-fixtures]\n",
       );
       process.exit(0);
     } else throw new Error(`unknown argument: ${arg}`);
@@ -80,6 +91,17 @@ async function main() {
   const outPath = args.out == null ? BASELINE_PATH : path.resolve(args.out);
   const scratchDir = scratchRoot(`baseline-${process.pid}`);
   const log = (line) => process.stdout.write(`${line}\n`);
+
+  if (args.cleanFixtures) {
+    const removed = cleanFixtures();
+    log(`corpus-baseline: cleaned ${removed} materialized node_modules from the fixtures`);
+  }
+  assertFixturesPristine(
+    (lines) => {
+      throw new Error(lines.join("\n"));
+    },
+    { allowMaterialized: args.allowDirtyFixtures },
+  );
 
   log(
     `corpus-baseline: ${manifest.projects.length} projects x ${SURFACES.length} surfaces, ${args.shards} parallel shards`,

--- a/tools/davinci/corpus-diff.mjs
+++ b/tools/davinci/corpus-diff.mjs
@@ -53,6 +53,7 @@ import {
   runMatrix,
   scratchRoot,
 } from "./lib/corpus-baseline-run.mjs";
+import { assertFixturesPristine, cleanFixtures } from "./lib/corpus-fixture-hygiene.mjs";
 import { repoRoot } from "./lib/paths.mjs";
 
 function parseArgs(argv) {
@@ -64,6 +65,8 @@ function parseArgs(argv) {
     timeoutMs: null,
     keepRaw: false,
     surfaces: [],
+    cleanFixtures: false,
+    allowDirtyFixtures: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -77,6 +80,8 @@ function parseArgs(argv) {
     else if (arg === "--write-fresh") args.writeFresh = value();
     else if (arg === "--timeout-ms") args.timeoutMs = positiveInteger(value(), arg);
     else if (arg === "--keep-raw") args.keepRaw = true;
+    else if (arg === "--clean-fixtures") args.cleanFixtures = true;
+    else if (arg === "--allow-dirty-fixtures") args.allowDirtyFixtures = true;
     else if (arg === "--surface") {
       args.surfaces.push(
         ...value()
@@ -86,7 +91,7 @@ function parseArgs(argv) {
       );
     } else if (arg === "--help" || arg === "-h") {
       process.stdout.write(
-        "usage: node tools/davinci/corpus-diff.mjs [--surface s[,s]] [--shards n] [--vize-bin path] [--baseline path] [--write-fresh path] [--timeout-ms n] [--keep-raw]\n",
+        "usage: node tools/davinci/corpus-diff.mjs [--surface s[,s]] [--shards n] [--vize-bin path] [--baseline path] [--write-fresh path] [--timeout-ms n] [--keep-raw] [--clean-fixtures] [--allow-dirty-fixtures]\n",
       );
       process.exit(0);
     } else throw new Error(`unknown argument: ${arg}`);
@@ -109,6 +114,12 @@ async function main() {
   const baselinePath = args.baseline == null ? BASELINE_PATH : path.resolve(args.baseline);
   const baselineLabel = path.relative(repoRoot, baselinePath);
   const log = (line) => process.stdout.write(`${line}\n`);
+
+  if (args.cleanFixtures) {
+    const removed = cleanFixtures();
+    log(`corpus-diff: cleaned ${removed} materialized node_modules from the fixtures`);
+  }
+  assertFixturesPristine(fail, { allowMaterialized: args.allowDirtyFixtures });
 
   if (!existsSync(baselinePath)) {
     fail([

--- a/tools/davinci/lib/corpus-fixture-hygiene.mjs
+++ b/tools/davinci/lib/corpus-fixture-hygiene.mjs
@@ -87,7 +87,7 @@ export function materializedNodeModules(maxDepth = 3) {
     }
   };
   walk(root, 0);
-  return found.sort();
+  return found.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 }
 
 /** Deletes every path `materializedNodeModules` reports. Returns the count. */

--- a/tools/davinci/lib/corpus-fixture-hygiene.mjs
+++ b/tools/davinci/lib/corpus-fixture-hygiene.mjs
@@ -1,0 +1,145 @@
+// Fixture hygiene for the davinci corpus sweeps (TS-11).
+//
+// A corpus run only produces comparable hashes when it starts from the
+// fixtures the manifest pins: every submodule at its recorded sha, and no
+// stray build state inside the checkouts. Two things break that in practice:
+//
+//   - `vize check` materializes tsgo project state, including a `node_modules`
+//     directory, *inside* the checked project. One sweep leaves ~142 fixture
+//     projects dirty, and the next sweep then measures a different tree than
+//     the baseline did (davinci-road/plan/corpus-baseline-notes.md,
+//     "Re-record 2" — that inheritance produced drift on two surfaces and cost
+//     a full investigation before it was understood).
+//   - a partially-hydrated or drifted submodule silently narrows the corpus,
+//     which the scope proof catches only when a project disappears entirely.
+//
+// The failure mode both share is silence: the sweep completes, prints hashes,
+// and nothing says the inputs were not the pinned ones. This module makes the
+// inputs an explicit precondition instead.
+//
+// Node builtins only; output is deterministic (sorted paths, no timestamps).
+
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./paths.mjs";
+
+export const FIXTURE_ROOT = path.join("tests", "_fixtures", "_git");
+
+/** Submodule states `git submodule status` marks as not-at-the-recorded-sha. */
+const DIRTY_PREFIXES = new Map([
+  ["-", "not initialized"],
+  ["+", "checked out at a different sha"],
+  ["U", "has merge conflicts"],
+]);
+
+function git(args) {
+  const result = spawnSync("git", args, { cwd: repoRoot, encoding: "utf8" });
+  if (result.error != null) throw result.error;
+  return result;
+}
+
+/**
+ * Submodules under the fixture root that are not at their recorded sha.
+ * Returns `[{ path, reason }]`, sorted by path.
+ */
+export function driftedSubmodules() {
+  const result = git(["submodule", "status", "--", FIXTURE_ROOT]);
+  if (result.status !== 0) return [];
+  const drifted = [];
+  for (const line of result.stdout.split("\n")) {
+    if (line === "") continue;
+    const reason = DIRTY_PREFIXES.get(line[0]);
+    if (reason == null) continue;
+    // ` <sha> <path> (<describe>)` — the path is the second field.
+    const fields = line.slice(1).trim().split(/\s+/);
+    if (fields.length < 2) continue;
+    drifted.push({ path: fields[1], reason });
+  }
+  return drifted.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}
+
+/**
+ * `node_modules` directories materialized inside fixture checkouts, sorted.
+ * Only the shallow levels a tool run can create are scanned, so a legitimately
+ * committed deep `node_modules` fixture stays out of the result.
+ */
+export function materializedNodeModules(maxDepth = 3) {
+  const root = path.join(repoRoot, FIXTURE_ROOT);
+  const found = [];
+  const walk = (dir, depth) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.name === "node_modules") {
+        found.push(path.relative(repoRoot, full));
+        continue; // never descend into one
+      }
+      if (entry.name === ".git" || depth >= maxDepth) continue;
+      walk(full, depth + 1);
+    }
+  };
+  walk(root, 0);
+  return found.sort();
+}
+
+/** Deletes every path `materializedNodeModules` reports. Returns the count. */
+export function cleanFixtures() {
+  const targets = materializedNodeModules();
+  for (const relative of targets) {
+    fs.rmSync(path.join(repoRoot, relative), { recursive: true, force: true });
+  }
+  return targets.length;
+}
+
+const CLEAN_HINT =
+  "clean them with `--clean-fixtures`, or by hand:\n" +
+  `  find ${FIXTURE_ROOT} -type d -name node_modules -prune -exec rm -rf {} +`;
+
+const HYDRATE_HINT = `  git submodule update --init --checkout --force -- ${FIXTURE_ROOT}`;
+
+/**
+ * Fails loudly when the fixtures are not the pinned ones.
+ *
+ * `fail` is the caller's reporter and takes the message as an array of lines,
+ * matching both corpus tools. A contaminated tree stops the run *before* it
+ * spends minutes producing hashes nobody can trust.
+ */
+export function assertFixturesPristine(fail, { allowMaterialized = false } = {}) {
+  const drifted = driftedSubmodules();
+  const materialized = allowMaterialized ? [] : materializedNodeModules();
+  if (drifted.length === 0 && materialized.length === 0) return;
+
+  const lines = ["corpus fixtures are not at their pinned state:"];
+  if (drifted.length > 0) {
+    lines.push(`  ${drifted.length} submodule(s) drifted from the recorded sha:`);
+    for (const { path: submodule, reason } of drifted.slice(0, 5)) {
+      lines.push(`    ${submodule} — ${reason}`);
+    }
+    if (drifted.length > 5) lines.push(`    … and ${drifted.length - 5} more`);
+    lines.push("  hydrate them with:");
+    lines.push(HYDRATE_HINT);
+  }
+  if (materialized.length > 0) {
+    lines.push(
+      `  ${materialized.length} materialized node_modules directory(ies) left by a previous run:`,
+    );
+    for (const relative of materialized.slice(0, 5)) lines.push(`    ${relative}`);
+    if (materialized.length > 5) lines.push(`    … and ${materialized.length - 5} more`);
+    lines.push(`  ${CLEAN_HINT}`);
+  }
+  lines.push(
+    "  a sweep over contaminated fixtures measures a different tree than the",
+    "  baseline did — see davinci-road/plan/corpus-baseline-notes.md, Re-record 2",
+    "  (pass --allow-dirty-fixtures to sweep anyway; the hashes are then not",
+    "  comparable to the committed baseline)",
+  );
+  fail(lines.flatMap((line) => line.split("\n")));
+}


### PR DESCRIPTION
## The silence this closes

A corpus sweep only produces comparable hashes when it starts from the tree the manifest pins — but nothing checked that, and the failure mode is silence: the sweep completes, prints hashes, and never says the inputs were not the pinned ones.

Two things break it in practice. `vize check` materializes tsgo project state, including a `node_modules` directory, **inside** each checked project, so one sweep leaves ~142 fixture projects dirty and the next sweep measures a different tree than the baseline did. That exact inheritance produced drift on two surfaces during phase 1 and cost a full investigation before it was understood (`corpus-baseline-notes.md`, "Re-record 2"). The other is a partially-hydrated or drifted submodule, which silently narrows the corpus — the scope proof only catches it when a project disappears entirely.

## What changes

`tools/davinci/{corpus-baseline,corpus-diff}.mjs` both pre-flight the fixtures before spending a minute of work:

- every fixture submodule must sit at its recorded sha (`-`/`+`/`U` states are reported with the reason), and
- no `node_modules` may be materialized inside a checkout.

A contaminated tree **stops the run immediately**, listing the offending paths and the exact command that fixes them.

- `--clean-fixtures` removes the materialized directories first, then proceeds.
- `--allow-dirty-fixtures` sweeps anyway — for deliberate experiments — and the message says plainly that those hashes are not comparable to the committed baseline.
- **Drifted submodules are never auto-repaired.** Silently re-hydrating a fixture would change what the corpus measures, so the tool prints the `git submodule update` line and stops. Cleaning stray build output is safe; changing which revision is measured is not.

The scan is depth-limited to the levels a tool run can create, so a legitimately committed deep `node_modules` fixture stays out of the result, and it never descends into one it finds.

## Verified against the real thing

This session's own tree was contaminated, which made for an honest test:

- guard refused, naming **151** materialized directories (first 5 listed, remainder counted);
- `--clean-fixtures` removed all 151 and the sweep proceeded — `find … -name node_modules` afterwards returns 0;
- a clean tree passes untouched.

Also: `vp fmt --check` clean, `vp check` 0 errors, all three files under the 350-line budget (145 / 242 / 146), and `node --test tests/tooling/source-file-lengths.test.ts` **7/7** — run locally against the pinned toolchain from `.moonbit-version`, which #4428 made possible.

## Note for anyone who hit "moon is broken locally"

It is not the machine. `.github/actions/setup-moonbit/install-moonbit.mjs` reads `.moonbit-version` and installs that exact compiler; run it with `RUNNER_TEMP`/`GITHUB_PATH`/`GITHUB_ENV` pointed at a scratch directory and the MoonBit-backed checks — including the 350-line budget that has bitten several davinci PRs — run locally:

```sh
cd tools/moon && moon run -q --target native cmd/source_file_lengths -- --check --max-lines 350 --limit 5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4511"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789825047&installation_model_id=422833&pr_number=4511&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4511&signature=b41327fe902fa0da82bfc70fe0ae9fbdb8c9ee6be4176600e088a2be4c94bb67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->