### PR TITLE
fix(vite-plugin): resolve indexed access prop types

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -6,6 +6,7 @@
 mod ast_resolve;
 mod defaults;
 mod emits;
+mod indexed_access;
 mod runtime_type;
 mod text_resolve;
 mod types;

--- a/crates/vize_atelier_sfc/src/compile_script/props/ast_resolve.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props/ast_resolve.rs
@@ -4,6 +4,9 @@
 //! prop types, resolving interface/type-alias references, mapped types, and
 //! literal unions into runtime constructors.
 
+use super::indexed_access::resolve_indexed_access_js_type;
+use super::runtime_type::ts_type_to_js_type;
+use super::types::PropTypeInfo;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     Expression, PropertyKey, Statement, TSLiteral, TSMappedTypeModifierOperator, TSSignature,
@@ -13,10 +16,6 @@ use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
 use vize_carton::FxHashMap;
 use vize_carton::{String, ToCompactString};
-
-use super::runtime_type::ts_type_to_js_type;
-use super::types::PropTypeInfo;
-
 pub(super) const TYPE_ALIAS_PREFIX: &str = "type __VizeProps = ";
 
 pub(super) fn extract_prop_types_from_ast(
@@ -59,8 +58,7 @@ pub(super) fn wrap_type_alias_source(type_args: &str) -> String {
     source.push(';');
     source
 }
-
-fn collect_props_from_ts_type(
+pub(super) fn collect_props_from_ts_type(
     ts_type: &TSType<'_>,
     source: &str,
     interfaces: Option<&FxHashMap<String, String>>,
@@ -153,7 +151,6 @@ fn collect_props_from_ts_type(
         _ => false,
     }
 }
-
 fn collect_props_from_ts_type_literal(
     type_lit: &TSTypeLiteral<'_>,
     source: &str,
@@ -444,7 +441,10 @@ fn ts_type_to_js_type_from_ast_inner(
             }
             "null".to_compact_string()
         }
-        TSType::TSIndexedAccessType(_) => "null".to_compact_string(),
+        TSType::TSIndexedAccessType(indexed) => {
+            resolve_indexed_access_js_type(indexed, source, interfaces, type_aliases, seen)
+                .unwrap_or_else(|| "null".to_compact_string())
+        }
         _ => "null".to_compact_string(),
     }
 }
@@ -465,7 +465,7 @@ fn js_type_for_ts_literal(literal: &TSLiteral<'_>) -> String {
     }
 }
 
-fn combine_runtime_js_types(types: impl IntoIterator<Item = String>) -> String {
+pub(super) fn combine_runtime_js_types(types: impl IntoIterator<Item = String>) -> String {
     let mut js_types: Vec<String> = Vec::new();
     for js_type in types {
         if js_type == "null" {
@@ -504,7 +504,7 @@ fn type_includes_top_level_null_from_ast(ts_type: &TSType<'_>) -> bool {
     }
 }
 
-fn literal_values_from_ts_type(
+pub(super) fn literal_values_from_ts_type(
     ts_type: &TSType<'_>,
     source: &str,
     interfaces: Option<&FxHashMap<String, String>>,

--- a/crates/vize_atelier_sfc/src/compile_script/props/indexed_access.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props/indexed_access.rs
@@ -1,0 +1,54 @@
+//! Indexed access prop runtime-type resolution.
+
+use oxc_ast::ast::TSIndexedAccessType;
+use vize_carton::FxHashMap;
+use vize_carton::String;
+
+use super::ast_resolve::{
+    collect_props_from_ts_type, combine_runtime_js_types, literal_values_from_ts_type,
+};
+
+pub(super) fn is_utility_object_type(type_name: &str) -> bool {
+    matches!(
+        type_name,
+        "Partial" | "Required" | "Pick" | "Omit" | "Record"
+    )
+}
+
+pub(super) fn resolve_indexed_access_js_type(
+    indexed: &TSIndexedAccessType<'_>,
+    source: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+    seen: &mut Vec<String>,
+) -> Option<String> {
+    let keys = literal_values_from_ts_type(
+        &indexed.index_type,
+        source,
+        interfaces,
+        type_aliases,
+        None,
+        seen,
+    )?;
+    let mut props = Vec::new();
+    if !collect_props_from_ts_type(
+        &indexed.object_type,
+        source,
+        interfaces,
+        type_aliases,
+        seen,
+        &mut props,
+    ) {
+        return None;
+    }
+
+    let mut js_types = Vec::new();
+    for key in keys {
+        js_types.extend(
+            props
+                .iter()
+                .filter_map(|(name, info)| (name == key).then_some(info.js_type.clone())),
+        );
+    }
+    (!js_types.is_empty()).then(|| combine_runtime_js_types(js_types))
+}

--- a/crates/vize_atelier_sfc/src/compile_script/props/runtime_type.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props/runtime_type.rs
@@ -1,9 +1,9 @@
 //! Runtime prop-type mapping: converting TypeScript type text into JavaScript
 //! runtime constructors and related string-level helpers.
 
+use super::indexed_access::is_utility_object_type;
 use vize_carton::FxHashMap;
 use vize_carton::{String, ToCompactString};
-
 pub(crate) fn runtime_prop_key(name: &str) -> String {
     if is_valid_identifier(name) {
         return name.to_compact_string();
@@ -26,7 +26,6 @@ pub(super) fn type_includes_top_level_undefined(ts_type: &str) -> bool {
         .into_iter()
         .any(|part| part.trim() == "undefined")
 }
-
 pub(super) fn type_includes_top_level_null(ts_type: &str) -> bool {
     split_type_at_top_level(ts_type.trim(), '|')
         .into_iter()
@@ -258,6 +257,7 @@ pub(crate) fn ts_type_to_js_type(ts_type: &str) -> String {
                         type_name.to_compact_string()
                     }
                     // Vue reactive types that are objects at runtime
+                    _ if is_utility_object_type(type_name) => "Object".to_compact_string(),
                     "Ref"
                     | "ShallowRef"
                     | "ComputedRef"

--- a/crates/vize_atelier_sfc/src/compile_script/props/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props/tests.rs
@@ -144,3 +144,72 @@ fn extract_props_keeps_runtime_union_after_omit_intersection() {
         .expect("onClick prop should be extracted");
     assert_eq!(on_click.1.js_type.as_str(), "[Function, Array]");
 }
+
+#[test]
+fn indexed_access_to_known_object_member_keeps_runtime_type() {
+    let mut interfaces: FxHashMap<vize_carton::String, vize_carton::String> = FxHashMap::default();
+    interfaces.insert(
+        "TableColumnCtx".to_compact_string(),
+        "{ showOverflowTooltip?: boolean | TableOverflowTooltipOptions; tooltipFormatter?: TableOverflowTooltipFormatter<T> }".to_compact_string(),
+    );
+    interfaces.insert(
+        "TableColumnProps".to_compact_string(),
+        "{ showOverflowTooltip?: TableColumnCtx<T>['showOverflowTooltip']; tooltipFormatter?: TableColumnCtx<T>['tooltipFormatter'] }".to_compact_string(),
+    );
+    let mut type_aliases: FxHashMap<vize_carton::String, vize_carton::String> =
+        FxHashMap::default();
+    type_aliases.insert(
+        "TableOverflowTooltipOptions".to_compact_string(),
+        "Partial<Omit<UseTooltipProps, 'content'>>".to_compact_string(),
+    );
+    type_aliases.insert(
+        "TableOverflowTooltipFormatter".to_compact_string(),
+        "(data: { row: T }) => string".to_compact_string(),
+    );
+
+    let props = extract_prop_types_from_type_with_context(
+        "TableColumnProps<T>",
+        Some(&interfaces),
+        Some(&type_aliases),
+    );
+
+    let show_overflow = props
+        .iter()
+        .find(|(name, _)| name == "showOverflowTooltip")
+        .expect("showOverflowTooltip prop should be extracted");
+    assert_eq!(show_overflow.1.js_type.as_str(), "[Boolean, Object]");
+
+    let formatter = props
+        .iter()
+        .find(|(name, _)| name == "tooltipFormatter")
+        .expect("tooltipFormatter prop should be extracted");
+    assert_eq!(formatter.1.js_type.as_str(), "Function");
+}
+
+#[test]
+fn indexed_access_to_union_and_keyof_keys_keeps_runtime_union() {
+    let mut interfaces: FxHashMap<vize_carton::String, vize_carton::String> = FxHashMap::default();
+    interfaces.insert(
+        "ValueCtx".to_compact_string(),
+        "{ enabled?: boolean; label?: string; count?: number }".to_compact_string(),
+    );
+    interfaces.insert(
+        "ValueProps".to_compact_string(),
+        "{ explicit?: ValueCtx['enabled' | 'label']; every?: ValueCtx[keyof ValueCtx] }"
+            .to_compact_string(),
+    );
+
+    let props = extract_prop_types_from_type_with_context("ValueProps", Some(&interfaces), None);
+
+    let explicit = props
+        .iter()
+        .find(|(name, _)| name == "explicit")
+        .expect("explicit prop should be extracted");
+    assert_eq!(explicit.1.js_type.as_str(), "[Boolean, String]");
+
+    let every = props
+        .iter()
+        .find(|(name, _)| name == "every")
+        .expect("every prop should be extracted");
+    assert_eq!(every.1.js_type.as_str(), "[Boolean, String, Number]");
+}

--- a/crates/vize_atelier_sfc/tests/indexed_access_props.rs
+++ b/crates/vize_atelier_sfc/tests/indexed_access_props.rs
@@ -1,0 +1,72 @@
+use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
+use vize_carton::String;
+
+#[test]
+fn module_mode_keeps_runtime_types_for_indexed_access_props() {
+    let source = r#"
+<script setup lang="ts">
+interface TableColumnCtx<T> {
+  showOverflowTooltip?: boolean | TableOverflowTooltipOptions
+  tooltipFormatter?: TableOverflowTooltipFormatter<T>
+}
+interface TableColumnProps<T> {
+  showOverflowTooltip?: TableColumnCtx<T>['showOverflowTooltip']
+  tooltipFormatter?: TableColumnCtx<T>['tooltipFormatter']
+}
+type TableOverflowTooltipOptions = Partial<Omit<UseTooltipProps, 'content'>>
+type TableOverflowTooltipFormatter<T> = (data: { row: T }) => string
+
+withDefaults(defineProps<TableColumnProps<Row>>(), {
+  showOverflowTooltip: undefined,
+})
+</script>
+<template><div /></template>
+"#;
+    let descriptor = parse_sfc(
+        source,
+        SfcParseOptions {
+            filename: "IndexedAccessProps.vue".into(),
+            ..SfcParseOptions::default()
+        },
+    )
+    .expect("parse SFC");
+    let result = compile_sfc(&descriptor, SfcCompileOptions::default()).expect("compile SFC");
+    let code = result.code;
+    let normalized = code.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    assert_eq!(
+        prop_entry(&normalized, "showOverflowTooltip"),
+        "showOverflowTooltip: { type: [Boolean, Object], required: false, default: undefined }",
+        "expected indexed access to preserve Boolean/Object runtime type, got:\n{code}",
+    );
+    assert_eq!(
+        prop_entry(&normalized, "tooltipFormatter"),
+        "tooltipFormatter: { type: Function, required: false }",
+        "expected indexed access to preserve Function runtime type, got:\n{code}",
+    );
+}
+
+fn prop_entry(code: &str, name: &str) -> String {
+    let mut prefix = String::from(name);
+    prefix.push_str(": ");
+    let start = code.find(prefix.as_str()).expect("prop entry should exist");
+    let entry = &code[start..];
+    let mut depth = 0i32;
+    let mut saw_value = false;
+    for (idx, ch) in entry[prefix.len()..].char_indices() {
+        match ch {
+            '{' | '[' | '(' => {
+                saw_value = true;
+                depth += 1;
+            }
+            '}' | ']' | ')' => {
+                depth -= 1;
+                if saw_value && depth == 0 {
+                    return String::from(&entry[..prefix.len() + idx + ch.len_utf8()]);
+                }
+            }
+            _ => {}
+        }
+    }
+    panic!("prop entry should have a complete value: {name}");
+}


### PR DESCRIPTION
## Summary
- resolve runtime prop constructors through known indexed access types
- treat TypeScript utility object aliases like Partial/Omit/Pick as Object at runtime
- add resolver and SFC regressions for Element Plus table tooltip props

## Tests
- cargo test -p vize_atelier_sfc --test indexed_access_props -- --quiet
- cargo test -p vize_atelier_sfc compile_script::props::tests --lib -- --quiet
- cargo test -p vize_atelier_sfc compile_script::inline::tests::tests::test_define_props_type_only_conditional_indexed_and_template_key_types --lib -- --quiet
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/davinci-assertion-lint.test.ts
- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p vize_atelier_sfc --lib --test indexed_access_props -- -D warnings -D clippy::wildcard_imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4539"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789884881&installation_model_id=422833&pr_number=4539&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4539&signature=b93ded78f83a817042c3bebed7dfc6a80bd7e3df73b429cfd74d4f9509e47812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved runtime prop type detection for indexed-access TypeScript types.
  * Preserved Boolean, Object, Function, String, and Number prop types through interfaces and type aliases.
  * Recognized utility object types as runtime `Object` props.

* **Bug Fixes**
  * Resolved incorrect or missing runtime types for indexed-access props, including optional props and defaults.

* **Tests**
  * Added coverage for interface members, union-key access, `keyof` access, and module-based component compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->