### PR TITLE
chore: bump dashmap so Cargo consumers can take oxc_resolver 11.22+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -3716,7 +3716,7 @@ dependencies = [
  "corsa",
  "corsa_lsp",
  "criterion",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "dirs",
  "glob",
  "insta",
@@ -3776,7 +3776,7 @@ name = "vize_croquis"
 version = "0.356.0"
 dependencies = [
  "criterion",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "davinci_harness",
  "insta",
  "once_cell",
@@ -3937,7 +3937,7 @@ name = "vize_maestro"
 version = "0.356.0"
 dependencies = [
  "async-trait",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "futures",
  "ignore",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -143,7 +143,7 @@ memoffset = "=0.9.1"
 memchr = "=2.8.3"
 regex = "=1.13.1"
 smallvec = { version = "=1.15.2", features = ["union"] }
-dashmap = "=6.1.0"
+dashmap = "=6.2.1"
 xxhash-rust = { version = "=0.8.18", features = ["xxh3"] }
 sha2 = "=0.11.0"
 htmlize = { version = "=1.1.0", features = ["unescape"] }


### PR DESCRIPTION
## Summary

Bump the workspace `dashmap` exact pin from `=6.1.0` to `=6.2.1` so Cargo consumers that also depend on `oxc_resolver` can take resolver 11.22+ without a `[patch]`.

Exact-pin policy is unchanged. `serde` / `serde_json` / `compact_str` pins are not part of this PR.

Closes #4564

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [x] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

- #4564
- Consumer currently stuck on `oxc_resolver 11.21.0`:
  https://github.com/alexzhang1030/vue-vet/pull/182

## Verification Evidence

- [x] `cargo update -p dashmap@6.1.0 --precise 6.2.1`
- [x] `cargo check -p vize_croquis -p vize_maestro -p vize_canon -p vize_atelier_sfc`
- [x] `Cargo.lock` now records `dashmap 6.2.1`; `dashmap 5.5.3` (LightningCSS) is unchanged

- [ ] Minimal fixture or focused regression test added or updated (N/A: pin bump)
- [x] Snapshot/baseline changes reviewed and explained (none)
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered (patch bump of a concurrent map crate)
- [x] Performance status or PR benchmark impact considered (no compiler/codegen change)
- [ ] Fuzzing target or crash-reproducer coverage considered (N/A)
- [ ] Editor/LSP scenario coverage considered (N/A)
- [x] Ecosystem or broad app compatibility impact considered (unblocks `oxc_resolver 11.22+`; callers that also exact-pin `dashmap =6.1.0` need to move with this)
- [ ] Docs, release, or stability notes updated when public behavior changed (N/A: no public API)

## Risk

- Lockfile change for Vize itself.
- Callers that exact-pin `dashmap =6.1.0` must bump in lockstep.
- No public API change.
- Not bundled with the `compile` feature PR (#4566 / #4565).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4567"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789920660&installation_model_id=422833&pr_number=4567&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4567&signature=87c459d55a9f2def83ff6d09609ea87e672048f201d8ee1c7619b86de512e48c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the DashMap dependency to version 6.2.1.
  * No other workspace configuration or dependency settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->