### PR TITLE
fix(disegno): encode unsafe folio modifiers

### DIFF
--- a/crates/vize_disegno/src/folio/parse/binding_line.rs
+++ b/crates/vize_disegno/src/folio/parse/binding_line.rs
@@ -15,8 +15,25 @@ use super::super::owned::{
 use super::expr_token::take_expr;
 use super::line::{Item, err, final_span, name_value, tail_span, take_quoted};
 
-/// Parse a `"a,b"` modifier payload into owned names.
+/// Parse a legacy `"a,b"` or canonical `["a","b"]` modifier payload into owned names.
 fn take_mods(rest: &str, line_no: usize) -> Result<(Vec<String>, &str), FolioError> {
+    if let Some(mut tail) = rest.strip_prefix('[') {
+        let mut modifiers = Vec::new();
+        loop {
+            let (modifier, after) = take_quoted(tail, line_no)?;
+            if modifier.is_empty() {
+                return Err(err(line_no, cstr!("invalid modifier list")));
+            }
+            modifiers.push(modifier);
+            if let Some(after) = after.strip_prefix(']') {
+                return Ok((modifiers, after));
+            }
+            let Some(after) = after.strip_prefix(',') else {
+                return Err(err(line_no, cstr!("invalid modifier list")));
+            };
+            tail = after;
+        }
+    }
     let (joined, tail) = take_quoted(rest, line_no)?;
     let mut modifiers = Vec::new();
     for part in joined.as_str().split(',') {

--- a/crates/vize_disegno/src/folio/parse/line.rs
+++ b/crates/vize_disegno/src/folio/parse/line.rs
@@ -5,8 +5,8 @@
 //! [`expr_token`](super::expr_token) - `js(...)`, `opaque(...)`,
 //! `foreign(...)`. Quoted strings escape `\\`, `\"`, `\n`, `\r`,
 //! `\t`; values embedding other control characters, attribute names
-//! containing `=`, ` ` or `"`, and modifier names containing `,` or `"`
-//! are outside the contract (the derived-page "documented edges" rule).
+//! containing `=`, ` ` or `"` are outside the contract (the
+//! derived-page "documented edges" rule).
 
 use vize_carton::{Span, String, cstr};
 use vize_davinci::folio::FolioError;

--- a/crates/vize_disegno/src/folio/print/binding.rs
+++ b/crates/vize_disegno/src/folio/print/binding.rs
@@ -58,14 +58,27 @@ fn print_mods<W: Write>(w: &mut W, modifiers: &[String]) -> Result {
     if modifiers.is_empty() {
         return Ok(());
     }
-    w.write_str(" mods=\"")?;
+    if modifiers
+        .iter()
+        .all(|modifier| !modifier.as_str().contains([',', '"', '\\', '\n', '\r']))
+    {
+        w.write_str(" mods=\"")?;
+        for (i, modifier) in modifiers.iter().enumerate() {
+            if i > 0 {
+                w.write_char(',')?;
+            }
+            w.write_str(modifier.as_str())?;
+        }
+        return w.write_char('"');
+    }
+    w.write_str(" mods=[")?;
     for (i, modifier) in modifiers.iter().enumerate() {
         if i > 0 {
             w.write_char(',')?;
         }
-        w.write_str(modifier.as_str())?;
+        quoted(w, modifier.as_str())?;
     }
-    w.write_char('"')
+    w.write_char(']')
 }
 
 fn print_bind<W: Write>(w: &mut W, bind: &FolioBind, depth: usize, mode: FolioMode) -> Result {

--- a/crates/vize_disegno/tests/folio_laws.rs
+++ b/crates/vize_disegno/tests/folio_laws.rs
@@ -198,6 +198,44 @@ fn parse_print_is_structural_identity() {
 }
 
 #[test]
+fn unsafe_modifier_names_round_trip_through_canonical_brackets() {
+    let value = DisegnoFolio {
+        ops: vec![FolioOp::Element(FolioElement {
+            tag: String::from("div"),
+            namespace: Namespace::Html,
+            attributes: vec![],
+            bindings: vec![FolioBinding::VueDirective(FolioVueDirective {
+                name: String::from("if*\"props"),
+                argument: None,
+                modifiers: vec![
+                    String::from("showLineNumbers\""),
+                    String::from("with,comma"),
+                ],
+                value: None,
+                span: Span::new(97, 125),
+            })],
+            children: vec![],
+            span: Span::new(92, 290),
+        })],
+    };
+    let canonical = "\
+[disegno]
+ops=2
+
+[disegno.ops]
+ui.element div @92:290
+  vue.directive \"if*\\\"props\" mods=[\"showLineNumbers\\\"\",\"with,comma\"] @97:125
+
+";
+    let printed = value.print_to_string(FolioMode::Full);
+    assert_eq!(printed.as_str(), canonical);
+    assert_eq!(
+        DisegnoFolio::parse(printed.as_str()).expect("printed text parses"),
+        value
+    );
+}
+
+#[test]
 fn a_hand_built_value_prints_the_canonical_text() {
     assert_eq!(
         hand_built().print_to_string(FolioMode::Full).as_str(),


### PR DESCRIPTION
## Summary
- add a canonical bracket-list spelling for modifier names that cannot be represented by the legacy comma-joined folio format
- preserve the existing legacy `mods="a,b"` spelling for ordinary modifier names
- cover the s1_lowering reproducer shape where a malformed Vue modifier contains a quote

Closes #4568.

## Verification
- `cargo test -p vize_disegno`
- `cargo +nightly fuzz run --fuzz-dir tests/fuzz s1_lowering /private/tmp/vize-fuzz-32552864773.2Rwhbn/s1_lowering/crash-081548138a3824ecb1dc219da5ec0bb7cf8275aa -- -runs=1`
- `cargo +nightly fuzz run --fuzz-dir tests/fuzz s1_lowering -- -runs=10000`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789970898&installation_model_id=422833&pr_number=4570&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4570&signature=0f007b199ba7269079da06c0dc68efd85cce61ad2797c9259571daf81e1e55af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for modifiers containing commas, quotes, backslashes, or line breaks.
  - Added canonical bracketed formatting for complex modifier lists while retaining compact output for simple values.
  - Malformed modifier lists now return a clear validation error.

- **Bug Fixes**
  - Complex Vue directive names and modifiers now round-trip reliably without losing or altering content.

- **Tests**
  - Added coverage for parsing and formatting unsafe modifier values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #4569.