### PR TITLE
fix(lsp): resolve Nuxt aliases before generated config

### DIFF
--- a/crates/vize_maestro/src/ide/definition/import_resolver.rs
+++ b/crates/vize_maestro/src/ide/definition/import_resolver.rs
@@ -50,7 +50,40 @@ pub(crate) fn resolve_import_specifier(uri: &Url, specifier: &str) -> Option<Pat
             return Some(path);
         }
     }
+    if let Some(path) = resolve_nuxt_source_alias(&file, specifier) {
+        return Some(path);
+    }
     module_specifier::resolve_specifier(uri, specifier)
+}
+
+fn resolve_nuxt_source_alias(file: &Path, specifier: &str) -> Option<PathBuf> {
+    let rest = specifier
+        .strip_prefix("~/")
+        .or_else(|| specifier.strip_prefix("@/"))?;
+    let root = nearest_nuxt_root(file)?;
+    [
+        root.join("app").join(rest),
+        root.join(rest),
+        root.join("src").join(rest),
+    ]
+    .into_iter()
+    .find_map(|base| probe(&base))
+}
+
+fn nearest_nuxt_root(file: &Path) -> Option<PathBuf> {
+    file.ancestors()
+        .skip(1)
+        .find(|dir| {
+            [
+                "nuxt.config.ts",
+                "nuxt.config.mts",
+                "nuxt.config.js",
+                "nuxt.config.mjs",
+            ]
+            .iter()
+            .any(|config| dir.join(config).is_file())
+        })
+        .map(Path::to_path_buf)
 }
 
 fn probe(base: &Path) -> Option<PathBuf> {

--- a/crates/vize_maestro/src/ide/definition/import_resolver_tests.rs
+++ b/crates/vize_maestro/src/ide/definition/import_resolver_tests.rs
@@ -66,6 +66,41 @@ import Widget from '@scope/ui'
     );
 }
 
+#[test]
+fn nuxt_source_aliases_work_before_generated_tsconfig_exists() {
+    let workspace = tempdir().unwrap();
+    let source = workspace.path().join("app/pages/accounts.vue");
+    let component = workspace
+        .path()
+        .join("app/components/AccountSearchResult.vue");
+    write(
+        &workspace.path().join("tsconfig.json"),
+        r#"{"references":[{"path":"./.nuxt/tsconfig.app.json"}],"files":[]}"#,
+    );
+    write(
+        &workspace.path().join("nuxt.config.ts"),
+        "export default defineNuxtConfig({})\n",
+    );
+    write(
+        &source,
+        r#"<script setup lang="ts">
+import AccountSearchResult from '~/components/AccountSearchResult.vue'
+</script>
+<template><AccountSearchResult /></template>
+"#,
+    );
+    write(&component, "<template />\n");
+
+    let uri = Url::from_file_path(&source).unwrap();
+    assert_eq!(
+        resolve_import_specifier(&uri, "~/components/AccountSearchResult.vue")
+            .unwrap()
+            .canonicalize()
+            .unwrap(),
+        component.canonicalize().unwrap()
+    );
+}
+
 fn write(path: &Path, content: &str) {
     std::fs::create_dir_all(path.parent().unwrap()).unwrap();
     std::fs::write(path, content).unwrap();

--- a/crates/vize_maestro/src/ide/file_rename/alias.rs
+++ b/crates/vize_maestro/src/ide/file_rename/alias.rs
@@ -149,19 +149,46 @@ fn probe_alias_target(
 /// The `paths` aliases governing `source_path`, resolved by the shared
 /// reader (nearest tsconfig, references-follow, string-aware jsonc).
 fn project_aliases(source_path: &Path) -> Option<Vec<AliasEntry>> {
-    let paths = crate::ide::tsconfig_paths::project_paths(source_path)?;
     let mut aliases = Vec::new();
-    for (pattern, target) in &paths.entries {
-        // Exact-match aliases name one module; a rename cannot re-spell them.
-        let (Some(pattern_prefix), Some(target)) =
-            (pattern.strip_suffix('*'), target.strip_suffix('*'))
-        else {
-            continue;
-        };
-        aliases.push(AliasEntry {
-            pattern_prefix: pattern_prefix.to_string(),
-            target_base: normalize_path_buf(&paths.anchor.join(target)),
-        });
+    if let Some(paths) = crate::ide::tsconfig_paths::project_paths(source_path) {
+        for (pattern, target) in &paths.entries {
+            // Exact-match aliases name one module; a rename cannot re-spell them.
+            let (Some(pattern_prefix), Some(target)) =
+                (pattern.strip_suffix('*'), target.strip_suffix('*'))
+            else {
+                continue;
+            };
+            aliases.push(AliasEntry {
+                pattern_prefix: pattern_prefix.to_string(),
+                target_base: normalize_path_buf(&paths.anchor.join(target)),
+            });
+        }
+    }
+    if let Some(root) = nearest_nuxt_root(source_path) {
+        for pattern_prefix in ["~/", "@/"] {
+            for target_base in [root.join("app"), root.clone(), root.join("src")] {
+                aliases.push(AliasEntry {
+                    pattern_prefix: pattern_prefix.to_string(),
+                    target_base: normalize_path_buf(&target_base),
+                });
+            }
+        }
     }
     (!aliases.is_empty()).then_some(aliases)
+}
+
+fn nearest_nuxt_root(file: &Path) -> Option<PathBuf> {
+    file.ancestors()
+        .skip(1)
+        .find(|dir| {
+            [
+                "nuxt.config.ts",
+                "nuxt.config.mts",
+                "nuxt.config.js",
+                "nuxt.config.mjs",
+            ]
+            .iter()
+            .any(|config| dir.join(config).is_file())
+        })
+        .map(Path::to_path_buf)
 }

--- a/crates/vize_maestro/src/ide/file_rename/alias_tests.rs
+++ b/crates/vize_maestro/src/ide/file_rename/alias_tests.rs
@@ -199,6 +199,69 @@ fn nuxt_alias_rename_edits_use_the_open_importer_buffer() {
 }
 
 #[test]
+fn nuxt_alias_rename_edits_work_before_generated_tsconfig_exists() {
+    let dir = test_dir();
+    let root = dir.path();
+    let pages = root.join("app/pages/[[server]]/list/[list]/index");
+    let components = root.join("app/components/list");
+    fs::create_dir_all(&pages).unwrap();
+    fs::create_dir_all(&components).unwrap();
+    fs::write(
+        root.join("tsconfig.json"),
+        r#"{"references":[{"path":"./.nuxt/tsconfig.app.json"}],"files":[]}"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("nuxt.config.ts"),
+        "export default defineNuxtConfig({})\n",
+    )
+    .unwrap();
+
+    let importer = pages.join("accounts.vue");
+    fs::write(
+        &importer,
+        "<script setup lang=\"ts\">\nimport Result from '~/components/list/__VizeOracleResult.vue'\n</script>\n",
+    )
+    .unwrap();
+    let copied = components.join("__VizeOracleResult.vue");
+    let renamed = components.join("__VizeOracleRenamedResult.vue");
+    fs::write(&copied, "<template />\n").unwrap();
+
+    let state = ServerState::new();
+    state.set_workspace_root(root.to_path_buf());
+
+    let edit = collect_import_rename_edits(
+        &state,
+        &[FileRename {
+            old_uri: file_uri(&copied),
+            new_uri: file_uri(&renamed),
+        }],
+        true,
+    )
+    .expect("rename edit for Nuxt alias without generated tsconfig");
+
+    assert_snapshot!(serde_json::to_string_pretty(&normalize_edit(root, &edit)).unwrap(), @r###"
+    {
+      "app/pages/[[server]]/list/[list]/index/accounts.vue": [
+        {
+          "newText": "~/components/list/__VizeOracleRenamedResult.vue",
+          "range": {
+            "end": {
+              "character": 60,
+              "line": 1
+            },
+            "start": {
+              "character": 20,
+              "line": 1
+            }
+          }
+        }
+      ]
+    }
+    "###);
+}
+
+#[test]
 fn aliased_directory_index_specifiers_keep_the_barrel_spelling() {
     let dir = test_dir();
     let root = dir.path();


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789979908&installation_model_id=422833&pr_number=4573&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4573&signature=f8665dd3145d1c7b459f70b85fdc60c69ecd1f7f3ef6ae69ee19dc67fc849cb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving Nuxt `~/` and `@/` import aliases across app, project-root, and source directories.
  * Added Nuxt alias support for updating imports when files are renamed, even before generated configuration files exist.

* **Bug Fixes**
  * Improved import resolution and rename handling for Nuxt projects without generated `.nuxt` configuration files.

* **Tests**
  * Added regression coverage for Nuxt alias resolution and rename updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->