### PR TITLE
fix(lsp): keep references after empty canonical hits

### DIFF
--- a/crates/vize_maestro/src/ide/corsa_support/location_merge.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/location_merge.rs
@@ -154,4 +154,20 @@ mod tests {
         );
         assert_eq!(merge_canonical_locations(None, None, None), None);
     }
+
+    #[test]
+    fn an_empty_canonical_answer_still_keeps_authored_hits() {
+        let sfc = "file:///app/App.vue";
+        let merged = merge_canonical_locations(
+            Some(vec![]),
+            None,
+            Some(vec![location(sfc, 3, 6, 16), location(sfc, 9, 18, 28)]),
+        )
+        .unwrap();
+
+        assert_eq!(
+            merged,
+            vec![location(sfc, 3, 6, 16), location(sfc, 9, 18, 28)]
+        );
+    }
 }

--- a/crates/vize_maestro/src/ide/references.rs
+++ b/crates/vize_maestro/src/ide/references.rs
@@ -87,7 +87,10 @@ impl ReferencesService {
     ) -> Option<Vec<Location>> {
         let canonical_locations =
             canonical::references(ctx, include_declaration, corsa_bridge.as_deref()).await;
-        if canonical_locations.is_some() {
+        if canonical_locations
+            .as_ref()
+            .is_some_and(|locations| !locations.is_empty())
+        {
             return canonical_locations;
         }
         let Some(block_type) = ctx.block_type else {


### PR DESCRIPTION
## Summary
- keep same-SFC authored references when canonical Corsa references answers with an empty set
- preserve the existing fast path for non-empty canonical answers so template shadowing remains authoritative
- cover the empty-canonical/authored-hit merge contract

## Validation
- cargo check -p vize --locked
- cargo test -p vize_maestro ide::corsa_support::location_merge::tests -- --nocapture
- CORSA_PATH="$PWD/node_modules/.bin/tsgo" cargo test -p vize_maestro ide::references::corsa_tests::canonical_references_cross_vue_files_and_honor_include_declaration -- --nocapture
- FIXTURE_SHARD_INDEX=9 FIXTURE_SHARD_COUNT=134 CORSA_PATH="$PWD/node_modules/.bin/tsgo" REAL_PROJECT_LSP_TIMEOUT_MS=120000 VIZE_LSP_BIN="$PWD/target/debug/vize" node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts
  - progresses past the Elk authored describedBy references assertion
  - next remaining #3975 blocker is diagnostics publication/repair timeout

Fixes one #3975 LSP authored-reference blocker; #3975 remains open for the diagnostics lifecycle blocker.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789984563&installation_model_id=422833&pr_number=4574&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4574&signature=7f08c6cc02af72ca56baf2881aa13a6f2a09a3146d8f5f246ce83727ff09df4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reference results when canonical lookup returns no locations by using available block-specific results.
  * Preserved authored locations in cases where canonical results are empty.
* **Tests**
  * Added regression coverage for reference location preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->