### PR TITLE
test(canon): expose project graph evidence in json

### DIFF
--- a/crates/vize/src/commands/check/reporting.rs
+++ b/crates/vize/src/commands/check/reporting.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 #[allow(clippy::disallowed_types)]
 pub(crate) struct JsonOutput {
     pub files: Vec<JsonFileResult>,
+    pub programs: Vec<JsonProgramResult>,
     #[serde(rename = "errorCount")]
     pub error_count: usize,
     #[serde(rename = "warningCount")]
@@ -15,6 +16,16 @@ pub(crate) struct JsonOutput {
     pub file_count: usize,
     #[serde(rename = "declarations", skip_serializing_if = "Option::is_none")]
     pub declarations: Option<Vec<std::string::String>>,
+}
+
+/// Effective TypeScript program evidence in JSON output.
+#[derive(Serialize)]
+#[allow(clippy::disallowed_types)]
+pub(crate) struct JsonProgramResult {
+    pub root: std::string::String,
+    #[serde(rename = "tsconfig", skip_serializing_if = "Option::is_none")]
+    pub tsconfig: Option<std::string::String>,
+    pub files: Vec<std::string::String>,
 }
 
 /// Per-file result in JSON output.

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -11,7 +11,7 @@ use super::{
     imports::ImportFileOptions,
     path_cache::CanonicalPathCache,
     patterns::CheckFileOptions,
-    reporting::{JsonFileResult, JsonOutput},
+    reporting::{JsonFileResult, JsonOutput, JsonProgramResult},
     tsconfig_inputs::{TsconfigInputCache, tsconfig_allows_js},
 };
 

--- a/crates/vize/src/commands/check/runner/execution.rs
+++ b/crates/vize/src/commands/check/runner/execution.rs
@@ -35,6 +35,7 @@ pub(super) struct CheckerSettings {
 pub(super) struct ProgramExecution {
     pub(super) checker: BatchTypeChecker,
     pub(super) result: BatchTypeCheckResult,
+    pub(super) input_files: Vec<PathBuf>,
     pub(super) reported_files: FxHashSet<PathBuf>,
     pub(super) tsconfig_path: Option<PathBuf>,
     pub(super) program_root: PathBuf,
@@ -164,6 +165,7 @@ pub(super) fn execute_program(
     Ok(ProgramExecution {
         checker,
         result,
+        input_files: input.files.to_vec(),
         reported_files: input.reported_files,
         tsconfig_path: input.tsconfig_path,
         program_root: input.program_root,

--- a/crates/vize/src/commands/check/runner/input_scope.rs
+++ b/crates/vize/src/commands/check/runner/input_scope.rs
@@ -162,6 +162,7 @@ pub(super) fn report_no_inputs(args: &CheckArgs) {
     if args.format == "json" {
         emit_json_output(JsonOutput {
             files: Vec::new(),
+            programs: Vec::new(),
             error_count: 0,
             warning_count: 0,
             file_count: 0,

--- a/crates/vize/src/commands/check/runner/output.rs
+++ b/crates/vize/src/commands/check/runner/output.rs
@@ -100,6 +100,7 @@ fn report_executions(
         if args.format == "json" {
             emit_json_output(JsonOutput {
                 files: Vec::new(),
+                programs: Vec::new(),
                 error_count: 0,
                 warning_count: 0,
                 file_count: 0,

--- a/crates/vize/src/commands/check/runner/output_json.rs
+++ b/crates/vize/src/commands/check/runner/output_json.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use vize_carton::{FxHashSet, String};
 
 use super::super::{
-    CheckArgs, JsonFileResult, JsonOutput, ProgramExecution,
+    CheckArgs, JsonFileResult, JsonOutput, JsonProgramResult, ProgramExecution,
     diagnostics::{emit_json_output, is_reported},
     display_path,
 };
@@ -59,6 +59,30 @@ pub(super) fn emit_json(
     files_json.sort_by(|left, right| left.file.cmp(&right.file));
     files_json.dedup_by(|left, right| left.file == right.file);
     let reported_file_count = files_json.len();
+    let programs_json = executions
+        .iter()
+        .map(|execution| {
+            let mut files = execution
+                .input_files
+                .iter()
+                .map(|path| display_path(cwd, path).into())
+                .collect::<Vec<_>>();
+            files.sort();
+            files.dedup();
+            let mut root = display_path(cwd, &execution.program_root);
+            if root.is_empty() {
+                root = ".".into();
+            }
+            JsonProgramResult {
+                root: root.into(),
+                tsconfig: execution
+                    .tsconfig_path
+                    .as_ref()
+                    .map(|path| display_path(cwd, path).into()),
+                files,
+            }
+        })
+        .collect::<Vec<_>>();
 
     let reported_keys = executions
         .iter()
@@ -78,6 +102,7 @@ pub(super) fn emit_json(
 
     emit_json_output(JsonOutput {
         files: files_json,
+        programs: programs_json,
         error_count: total_errors,
         warning_count: total_warnings,
         file_count: reported_file_count,

--- a/crates/vize/src/commands/check/runner/socket.rs
+++ b/crates/vize/src/commands/check/runner/socket.rs
@@ -16,7 +16,6 @@ use crate::{
     },
     profile_support,
 };
-
 use super::{
     collect::collect_vue_files, display_path, output::save_virtual_ts_targets_or_exit,
     text_style::TextStyle,
@@ -188,7 +187,6 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
             args.quiet,
         );
     }
-
     let render_start = Instant::now();
     if args.format == "json" {
         let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));

--- a/crates/vize/src/commands/check/runner/socket.rs
+++ b/crates/vize/src/commands/check/runner/socket.rs
@@ -207,6 +207,7 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
 
         let json_output = JsonOutput {
             files: files_json,
+            programs: Vec::new(),
             error_count: total_errors,
             warning_count: total_warnings,
             file_count: results.len(),

--- a/crates/vize/src/commands/check/runner/socket.rs
+++ b/crates/vize/src/commands/check/runner/socket.rs
@@ -9,16 +9,16 @@ use std::{
 
 use vize_carton::{String, cstr, profile, profiler::global_profiler};
 
+use super::{
+    collect::collect_vue_files, display_path, output::save_virtual_ts_targets_or_exit,
+    text_style::TextStyle,
+};
 use crate::{
     commands::check::{
         CheckArgs, JsonRpcResponse, ServerCheckResult,
         reporting::{JsonFileResult, JsonOutput},
     },
     profile_support,
-};
-use super::{
-    collect::collect_vue_files, display_path, output::save_virtual_ts_targets_or_exit,
-    text_style::TextStyle,
 };
 use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report};
 

--- a/crates/vize/tests/check_default_run_project_root_cli.rs
+++ b/crates/vize/tests/check_default_run_project_root_cli.rs
@@ -227,6 +227,18 @@ fn default_run_inside_an_owning_ancestor_program_checks_the_app_and_notes_the_sc
                     ]
                 },
             ],
+            "programs": [
+                {
+                    "root": case.workspace,
+                    "tsconfig": case.workspace.join("tsconfig.json"),
+                    "files": [
+                        case.workspace.join("helpers/h1.ts"),
+                        case.workspace.join("helpers/h2.ts"),
+                        case.workspace.join("helpers/h3.ts"),
+                        "src/Broken.vue",
+                    ]
+                }
+            ],
             "errorCount": 1,
             "warningCount": 0,
             "fileCount": 4
@@ -281,6 +293,13 @@ fn default_run_with_a_local_tsconfig_stays_in_the_app() {
                         "error:2:7 [TS2322] Type 'string' is not assignable to type 'number'."
                     ]
                 },
+            ],
+            "programs": [
+                {
+                    "root": ".",
+                    "tsconfig": "tsconfig.json",
+                    "files": ["src/Broken.vue"]
+                }
             ],
             "errorCount": 1,
             "warningCount": 0,

--- a/tests/_helpers/realworld-typecheck.ts
+++ b/tests/_helpers/realworld-typecheck.ts
@@ -9,6 +9,7 @@ export type CheckReport = {
   errorCount: number;
   fileCount: number;
   files: Array<{ diagnostics: string[]; file: string }>;
+  programs: Array<{ files: string[]; root: string; tsconfig?: string }>;
   warningCount: number;
 };
 
@@ -19,6 +20,11 @@ export type CommandResult = {
 };
 
 export type VizeCheckResult = CommandResult & { report: CheckReport };
+
+export function omitProgramEvidence(report: CheckReport): Omit<CheckReport, "programs"> {
+  const { programs: _programs, ...diagnosticReport } = report;
+  return diagnosticReport;
+}
 
 export function runVizeCheck(
   workspaceDir: string,

--- a/tests/_helpers/vize-check.ts
+++ b/tests/_helpers/vize-check.ts
@@ -21,6 +21,11 @@ export type VizeCheckJson = {
   warningCount: number;
 };
 
+export function stringifyDiagnosticSnapshot(parsed: VizeCheckJson, cwd: string): string {
+  const { programs: _programs, ...diagnosticReport } = parsed;
+  return JSON.stringify(diagnosticReport, null, 2).replaceAll(cwd, "<cwd>") + "\n";
+}
+
 type RunVizeCheckJsonOptions = {
   allowExitCodes?: readonly number[];
   corsaPath?: string;

--- a/tests/_helpers/vize-check.ts
+++ b/tests/_helpers/vize-check.ts
@@ -17,6 +17,7 @@ export type VizeCheckJson = {
   errorCount: number;
   fileCount: number;
   files: VizeCheckFileJson[];
+  programs: Array<{ files: string[]; root: string; tsconfig?: string }>;
   warningCount: number;
 };
 

--- a/tests/snapshots/check/ant-design-vue.ts
+++ b/tests/snapshots/check/ant-design-vue.ts
@@ -10,6 +10,7 @@ import {
   requireVizeAndCorsaBins,
 } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
+import { stringifyDiagnosticSnapshot } from "../../_helpers/vize-check.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
@@ -50,8 +51,7 @@ describe(`${app.name} check (type checker)`, () => {
     // assertion above is the meaningful gate until the determinism work
     // lands. Re-enable assertSnapshot once #510 is resolved.
     if (process.env.VIZE_CHECK_ASSERT_SNAPSHOT === "1") {
-      const prettyOutput =
-        JSON.stringify(parsed, null, 2).replaceAll(checkConfig.cwd, "<cwd>") + "\n";
+      const prettyOutput = stringifyDiagnosticSnapshot(parsed, checkConfig.cwd);
       assertSnapshot(SNAPSHOT_DIR, `${app.name}-check`, prettyOutput);
     }
   });

--- a/tests/snapshots/check/compiler-macros.ts
+++ b/tests/snapshots/check/compiler-macros.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { compilerMacrosApp, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
-import { runVizeCheckJson } from "../../_helpers/vize-check.ts";
+import { runVizeCheckJson, stringifyDiagnosticSnapshot } from "../../_helpers/vize-check.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
@@ -21,8 +21,7 @@ describe(`${app.name} check (type checker)`, () => {
     console.log(`fileCount=${parsed.fileCount}, errorCount=${parsed.errorCount}`);
     assert.ok(parsed.fileCount > 0, "fileCount should be > 0");
 
-    const prettyOutput =
-      JSON.stringify(parsed, null, 2).replaceAll(checkConfig.cwd, "<cwd>") + "\n";
+    const prettyOutput = stringifyDiagnosticSnapshot(parsed, checkConfig.cwd);
     assertSnapshot(SNAPSHOT_DIR, `${app.name}-check`, prettyOutput);
   });
 });

--- a/tests/snapshots/check/create-vue-generated-template-oracle.ts
+++ b/tests/snapshots/check/create-vue-generated-template-oracle.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import { withPinnedFixtureWorkspace } from "../../_helpers/realworld-patch.ts";
 import {
   type CommandResult,
+  omitProgramEvidence,
   resolveTsgoBinary,
   resolveVueTscBinary,
   runVizeCheck,
@@ -107,7 +108,11 @@ function expectedReport(diagnosticsByFile: Record<string, string[]>): unknown {
 
 function assertCleanParity(vize: VizeCheckResult, vueTsc: CommandResult): void {
   assert.equal(vize.status, 0, vize.stderr || vize.stdout);
-  assert.deepEqual(vize.report, expectedReport({}), JSON.stringify(vize.report));
+  assert.deepEqual(
+    omitProgramEvidence(vize.report),
+    expectedReport({}),
+    JSON.stringify(vize.report),
+  );
   assert.equal(vueTsc.status, 0, vueTsc.stderr || vueTsc.stdout);
   assert.equal(vueTsc.stdout, "", vueTsc.stdout);
 }
@@ -115,7 +120,7 @@ function assertCleanParity(vize: VizeCheckResult, vueTsc: CommandResult): void {
 function assertBrokenParity(vize: VizeCheckResult, vueTsc: CommandResult): void {
   assert.equal(vize.status, 1, vize.stderr || vize.stdout);
   assert.deepEqual(
-    vize.report,
+    omitProgramEvidence(vize.report),
     expectedReport({ [helloWorldPath]: [brokenDiagnostic] }),
     JSON.stringify(vize.report),
   );

--- a/tests/snapshots/check/ecosystem-products.ts
+++ b/tests/snapshots/check/ecosystem-products.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { ecosystemProductsApp, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
-import { runVizeCheckJson } from "../../_helpers/vize-check.ts";
+import { runVizeCheckJson, stringifyDiagnosticSnapshot } from "../../_helpers/vize-check.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
@@ -55,8 +55,7 @@ describe(`${app.name} check (type checker)`, () => {
     console.log(`fileCount=${parsed.fileCount}, errorCount=${parsed.errorCount}`);
     assert.ok(parsed.fileCount > 0, "fileCount should be > 0");
 
-    const prettyOutput =
-      JSON.stringify(parsed, null, 2).replaceAll(checkConfig.cwd, "<cwd>") + "\n";
+    const prettyOutput = stringifyDiagnosticSnapshot(parsed, checkConfig.cwd);
     assertSnapshot(SNAPSHOT_DIR, `${app.name}-check`, prettyOutput);
   });
 });

--- a/tests/snapshots/check/elk.ts
+++ b/tests/snapshots/check/elk.ts
@@ -6,6 +6,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { elkApp, CORSA_BIN, VIZE_BIN, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
+import { stringifyDiagnosticSnapshot } from "../../_helpers/vize-check.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
@@ -77,7 +78,7 @@ describe(`${app.name} check (type checker)`, () => {
     console.log(`fileCount=${parsed.fileCount}, errorCount=${parsed.errorCount}`);
     assert.ok(parsed.fileCount > 0, "fileCount should be > 0");
 
-    const prettyOutput = JSON.stringify(parsed, null, 2).replaceAll(checkCwd, "<cwd>") + "\n";
+    const prettyOutput = stringifyDiagnosticSnapshot(parsed, checkCwd);
     assertSnapshot(SNAPSHOT_DIR, `${app.name}-check`, prettyOutput);
   });
 });

--- a/tests/snapshots/check/javascript-sfc-checkjs-oracle.ts
+++ b/tests/snapshots/check/javascript-sfc-checkjs-oracle.ts
@@ -5,6 +5,7 @@ import { test } from "node:test";
 
 import { repoRoot } from "../../_helpers/realworld-patch.ts";
 import {
+  omitProgramEvidence,
   resolveTsgoBinary,
   resolveVueTscBinary,
   runVizeCheck,
@@ -173,7 +174,7 @@ test("vize check matches vue-tsc on JavaScript SFCs under checkJs", async (t) =>
 
         const first = runVizeCheck(workspaceDir, corsaPath, []);
         assert.deepEqual(
-          first.report,
+          omitProgramEvidence(first.report),
           expectedReport(testCase.diagnostics),
           JSON.stringify(first.report),
         );

--- a/tests/snapshots/check/misskey.ts
+++ b/tests/snapshots/check/misskey.ts
@@ -3,6 +3,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { misskeyApp, MISSKEY_WORK_DIR, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
+import { stringifyDiagnosticSnapshot } from "../../_helpers/vize-check.ts";
 import { runBudgetedBatchVizeCheck } from "../_helpers/batch-check-performance.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -23,10 +24,10 @@ describe(`${app.name} check (type checker)`, () => {
         `coldMs=${cold.durationMs.toFixed(0)}, warmMs=${warm.durationMs.toFixed(0)}`,
     );
 
-    const prettyOutput =
-      JSON.stringify(cold.result, null, 2)
-        .replaceAll(checkConfig.cwd, "<cwd>")
-        .replaceAll(MISSKEY_WORK_DIR, "<project>") + "\n";
+    const prettyOutput = stringifyDiagnosticSnapshot(cold.result, checkConfig.cwd).replaceAll(
+      MISSKEY_WORK_DIR,
+      "<project>",
+    );
     assertSnapshot(SNAPSHOT_DIR, `${app.name}-check`, prettyOutput);
   });
 });

--- a/tests/snapshots/check/npmx.ts
+++ b/tests/snapshots/check/npmx.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { npmxApp, CORSA_BIN, VIZE_BIN, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
+import { stringifyDiagnosticSnapshot } from "../../_helpers/vize-check.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
@@ -38,8 +39,7 @@ describe(`${app.name} check (type checker)`, () => {
     console.log(`fileCount=${parsed.fileCount}, errorCount=${parsed.errorCount}`);
     assert.ok(parsed.fileCount > 0, "fileCount should be > 0");
 
-    const prettyOutput =
-      JSON.stringify(parsed, null, 2).replaceAll(checkConfig.cwd, "<cwd>") + "\n";
+    const prettyOutput = stringifyDiagnosticSnapshot(parsed, checkConfig.cwd);
     assertSnapshot(SNAPSHOT_DIR, `${app.name}-check`, prettyOutput);
   });
 });

--- a/tests/snapshots/check/nuxt-no-tsconfig-oracle.ts
+++ b/tests/snapshots/check/nuxt-no-tsconfig-oracle.ts
@@ -5,6 +5,7 @@ import { test } from "node:test";
 
 import { withPinnedFixtureWorkspace } from "../../_helpers/realworld-patch.ts";
 import {
+  omitProgramEvidence,
   resolveTsgoBinary,
   runVizeCheck,
   symlinkVueTypes,
@@ -50,7 +51,7 @@ function runWithoutTsconfig(workspaceDir: string, corsaPath: string): VizeCheckR
 
 function assertClean(result: VizeCheckResult): void {
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.deepEqual(result.report, {
+  assert.deepEqual(omitProgramEvidence(result.report), {
     errorCount: 0,
     fileCount: 1,
     files: [{ diagnostics: [], file: appPath }],

--- a/tests/snapshots/check/nuxt-ui.ts
+++ b/tests/snapshots/check/nuxt-ui.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { nuxtUiApp, CORSA_BIN, VIZE_BIN, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
+import { stringifyDiagnosticSnapshot } from "../../_helpers/vize-check.ts";
 import { normalizeTargetParameterLabels } from "../_helpers/diagnostics.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -39,8 +40,7 @@ describe(`${app.name} check (type checker)`, () => {
     console.log(`fileCount=${parsed.fileCount}, errorCount=${parsed.errorCount}`);
     assert.ok(parsed.fileCount > 0, "fileCount should be > 0");
 
-    const prettyOutput =
-      JSON.stringify(parsed, null, 2).replaceAll(checkConfig.cwd, "<cwd>") + "\n";
+    const prettyOutput = stringifyDiagnosticSnapshot(parsed, checkConfig.cwd);
     assertSnapshot(SNAPSHOT_DIR, `${app.name}-check`, prettyOutput);
   });
 });

--- a/tests/snapshots/check/options-api-inherited-members.ts
+++ b/tests/snapshots/check/options-api-inherited-members.ts
@@ -5,6 +5,7 @@ import { test } from "node:test";
 
 import { repoRoot } from "../../_helpers/realworld-patch.ts";
 import {
+  omitProgramEvidence,
   resolveTsgoBinary,
   resolveVueTscBinary,
   runVizeCheck,
@@ -101,7 +102,7 @@ test("legacy inherited members match the complete vue-tsc oracle", async (t) => 
         const first = runVizeCheck(workspaceDir, corsaPath, ["**/*.vue"]);
         assert.equal(first.status, 0, first.stderr || first.stdout);
         assert.equal(first.stderr, "");
-        assert.deepEqual(first.report, {
+        assert.deepEqual(omitProgramEvidence(first.report), {
           files: [{ file: "Uses.vue", diagnostics: [] }],
           errorCount: 0,
           warningCount: 0,

--- a/tests/snapshots/check/reka-ui.ts
+++ b/tests/snapshots/check/reka-ui.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { rekaUiApp, CORSA_BIN, VIZE_BIN, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
+import { stringifyDiagnosticSnapshot } from "../../_helpers/vize-check.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
@@ -38,8 +39,7 @@ describe(`${app.name} check (type checker)`, () => {
     console.log(`fileCount=${parsed.fileCount}, errorCount=${parsed.errorCount}`);
     assert.ok(parsed.fileCount > 0, "fileCount should be > 0");
 
-    const prettyOutput =
-      JSON.stringify(parsed, null, 2).replaceAll(checkConfig.cwd, "<cwd>") + "\n";
+    const prettyOutput = stringifyDiagnosticSnapshot(parsed, checkConfig.cwd);
     assertSnapshot(SNAPSHOT_DIR, `${app.name}-check`, prettyOutput);
   });
 });

--- a/tests/snapshots/check/style-preprocessors.ts
+++ b/tests/snapshots/check/style-preprocessors.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { stylePreprocessorsApp, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
-import { runVizeCheckJson } from "../../_helpers/vize-check.ts";
+import { runVizeCheckJson, stringifyDiagnosticSnapshot } from "../../_helpers/vize-check.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
@@ -22,8 +22,7 @@ describe(`${app.name} check (type checker)`, () => {
     assert.ok(parsed.fileCount > 0, "fileCount should be > 0");
     assert.equal(parsed.errorCount, 0, "errorCount should be 0 (style lang does not affect TS)");
 
-    const prettyOutput =
-      JSON.stringify(parsed, null, 2).replaceAll(checkConfig.cwd, "<cwd>") + "\n";
+    const prettyOutput = stringifyDiagnosticSnapshot(parsed, checkConfig.cwd);
     assertSnapshot(SNAPSHOT_DIR, `${app.name}-check`, prettyOutput);
   });
 });

--- a/tests/snapshots/check/typecheck-errors.ts
+++ b/tests/snapshots/check/typecheck-errors.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { typecheckErrorsApp, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
-import { runVizeCheckJson } from "../../_helpers/vize-check.ts";
+import { runVizeCheckJson, stringifyDiagnosticSnapshot } from "../../_helpers/vize-check.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
@@ -22,8 +22,7 @@ describe(`${app.name} check (type checker)`, () => {
     assert.ok(parsed.fileCount > 0, "fileCount should be > 0");
     assert.ok(parsed.errorCount > 0, "errorCount should be > 0 (intentional type errors)");
 
-    const prettyOutput =
-      JSON.stringify(parsed, null, 2).replaceAll(checkConfig.cwd, "<cwd>") + "\n";
+    const prettyOutput = stringifyDiagnosticSnapshot(parsed, checkConfig.cwd);
     assertSnapshot(SNAPSHOT_DIR, `${app.name}-check`, prettyOutput);
   });
 });

--- a/tests/snapshots/check/vue-benchmarks-correctness-plants.ts
+++ b/tests/snapshots/check/vue-benchmarks-correctness-plants.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import { repoRoot } from "../../_helpers/realworld-patch.ts";
 import {
   type CommandResult,
+  omitProgramEvidence,
   resolveTsgoBinary,
   resolveVueTscBinary,
   runVizeCheck,
@@ -260,7 +261,11 @@ function assertClean(
   files: Record<string, string>,
 ): void {
   assert.equal(vize.status, 0, vize.stderr || vize.stdout);
-  assert.deepEqual(vize.report, expectedReport(files, {}), JSON.stringify(vize.report));
+  assert.deepEqual(
+    omitProgramEvidence(vize.report),
+    expectedReport(files, {}),
+    JSON.stringify(vize.report),
+  );
   assert.equal(vueTsc.status, 0, vueTsc.stderr || vueTsc.stdout);
   assert.equal(vueTsc.stdout, "");
 }

--- a/tests/snapshots/check/vue-benchmarks-correctness-plants.ts
+++ b/tests/snapshots/check/vue-benchmarks-correctness-plants.ts
@@ -189,7 +189,7 @@ test("vue-benchmarks correctness plants fail closed on current main", async (t) 
         const vueTsc = runVueTsc(workspaceDir, vueTscPath);
         assert.equal(brokenFirst.status, 1, brokenFirst.stderr || brokenFirst.stdout);
         assert.deepEqual(
-          brokenFirst.report,
+          omitProgramEvidence(brokenFirst.report),
           expectedReport(plant.files, plant.diagnostics),
           JSON.stringify(brokenFirst.report),
         );

--- a/tests/snapshots/check/vue-benchmarks-scaled-corpus-plants.ts
+++ b/tests/snapshots/check/vue-benchmarks-scaled-corpus-plants.ts
@@ -225,7 +225,7 @@ test("vue-benchmarks plants stay caught across the scaled unique corpus", async 
 
       assert.equal(brokenFirst.status, 1, brokenFirst.stderr || brokenFirst.stdout);
       assert.deepEqual(
-        brokenFirst.report,
+        omitProgramEvidence(brokenFirst.report),
         expectedReport(corpusFiles, plants),
         JSON.stringify(brokenFirst.report),
       );

--- a/tests/snapshots/check/vue-benchmarks-scaled-corpus-plants.ts
+++ b/tests/snapshots/check/vue-benchmarks-scaled-corpus-plants.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import { repoRoot } from "../../_helpers/realworld-patch.ts";
 import {
   type CommandResult,
+  omitProgramEvidence,
   resolveTsgoBinary,
   resolveVueTscBinary,
   runVizeCheck,
@@ -302,7 +303,11 @@ function expectedReport(corpusFiles: string[], activePlants: ScaledPlant[]): unk
 
 function assertClean(vize: VizeCheckResult, vueTsc: CommandResult, corpusFiles: string[]): void {
   assert.equal(vize.status, 0, vize.stderr || vize.stdout);
-  assert.deepEqual(vize.report, expectedReport(corpusFiles, []), JSON.stringify(vize.report));
+  assert.deepEqual(
+    omitProgramEvidence(vize.report),
+    expectedReport(corpusFiles, []),
+    JSON.stringify(vize.report),
+  );
   assert.equal(vueTsc.status, 0, vueTsc.stderr || vueTsc.stdout);
   assert.equal(vueTsc.stdout, "");
 }

--- a/tests/snapshots/check/vue-element-admin-legacy-lsp-oracle.ts
+++ b/tests/snapshots/check/vue-element-admin-legacy-lsp-oracle.ts
@@ -7,6 +7,7 @@ import {
   type PinnedFixtureWorkspace,
 } from "../../_helpers/realworld-patch.ts";
 import {
+  omitProgramEvidence,
   resolveTsgoBinary,
   runVizeCheck,
   symlinkVueTypes,
@@ -176,7 +177,7 @@ function repairDataKeyRename(fixture: PinnedFixtureWorkspace): string {
 
 function assertCleanCheck(result: VizeCheckResult): void {
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.deepEqual(result.report, {
+  assert.deepEqual(omitProgramEvidence(result.report), {
     files: [{ file: sourcePath, diagnostics: [] }],
     errorCount: 0,
     warningCount: 0,
@@ -186,7 +187,7 @@ function assertCleanCheck(result: VizeCheckResult): void {
 
 function assertBrokenCheck(result: VizeCheckResult): void {
   assert.equal(result.status, 1, result.stderr || result.stdout);
-  assert.deepEqual(result.report, {
+  assert.deepEqual(omitProgramEvidence(result.report), {
     files: [
       {
         file: sourcePath,

--- a/tests/snapshots/check/vue-element-admin-legacy-oracle.ts
+++ b/tests/snapshots/check/vue-element-admin-legacy-oracle.ts
@@ -9,6 +9,7 @@ import { pathToFileURL } from "node:url";
 import { assertParsesAsModule } from "../../_helpers/assertions.ts";
 import { withPinnedFixtureWorkspace } from "../../_helpers/realworld-patch.ts";
 import {
+  omitProgramEvidence,
   resolveVizeCommand,
   resolveTsgoBinary,
   runVizeCheck,
@@ -365,7 +366,7 @@ function isMissingListDiagnostic(diagnostic: PublishDiagnosticsParams["diagnosti
 
 function assertCleanCheck(result: VizeCheckResult): void {
   assert.equal(result.status, 0, result.stderr || result.stdout);
-  assert.deepEqual(result.report, {
+  assert.deepEqual(omitProgramEvidence(result.report), {
     files: [{ file: sourcePath, diagnostics: [] }],
     errorCount: 0,
     warningCount: 0,
@@ -375,7 +376,7 @@ function assertCleanCheck(result: VizeCheckResult): void {
 
 function assertBrokenCheck(result: VizeCheckResult): void {
   assert.equal(result.status, 1, result.stderr || result.stdout);
-  assert.deepEqual(result.report, {
+  assert.deepEqual(omitProgramEvidence(result.report), {
     files: [
       {
         file: sourcePath,

--- a/tests/snapshots/check/vue-element-admin-unmapped-diagnostic-oracle.ts
+++ b/tests/snapshots/check/vue-element-admin-unmapped-diagnostic-oracle.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 import { withPinnedFixtureWorkspace } from "../../_helpers/realworld-patch.ts";
 import {
   type CheckReport,
+  omitProgramEvidence,
   resolveTsgoBinary,
   runVizeCheck,
   symlinkVueTypes,
@@ -146,10 +147,14 @@ function byPosition(
   );
 }
 
-function sortedReport(report: CheckReport): CheckReport {
+function sortedReport(report: CheckReport): Omit<CheckReport, "programs"> {
+  const diagnosticReport = omitProgramEvidence(report);
   return {
-    ...report,
-    files: report.files.map((file) => ({ ...file, diagnostics: [...file.diagnostics].sort() })),
+    ...diagnosticReport,
+    files: diagnosticReport.files.map((file) => ({
+      ...file,
+      diagnostics: [...file.diagnostics].sort(),
+    })),
   };
 }
 

--- a/tests/snapshots/check/vue2-class-component-oracle.ts
+++ b/tests/snapshots/check/vue2-class-component-oracle.ts
@@ -5,7 +5,11 @@ import {
   type PinnedFixtureWorkspace,
   withPinnedFixtureWorkspace,
 } from "../../_helpers/realworld-patch.ts";
-import { resolveTsgoBinary, runVizeCheck } from "../../_helpers/realworld-typecheck.ts";
+import {
+  omitProgramEvidence,
+  resolveTsgoBinary,
+  runVizeCheck,
+} from "../../_helpers/realworld-typecheck.ts";
 
 const FIXTURE_ID = "mobile-web-best-practice";
 const CARD_PATH = "src/views/home/widgets/card.vue";
@@ -43,7 +47,7 @@ test("pinned Vue 2 class-component app detects and repairs an exact authored err
       assert.equal(repairedSource, pinnedSource, "repair must restore the exact pinned source");
       const repaired = runVizeCheck(fixture.workspaceDir, corsaPath, [CARD_PATH]);
       assert.equal(repaired.status, 0, repaired.stderr || repaired.stdout);
-      assert.deepEqual(repaired.report, clean.report);
+      assert.deepEqual(omitProgramEvidence(repaired.report), omitProgramEvidence(clean.report));
       assert.equal(repaired.stdout, clean.stdout, "repair must restore byte-stable JSON");
     },
   );

--- a/tests/snapshots/check/vue2-elm.ts
+++ b/tests/snapshots/check/vue2-elm.ts
@@ -9,6 +9,7 @@ import {
   withPinnedFixtureWorkspace,
 } from "../../_helpers/realworld-patch.ts";
 import {
+  omitProgramEvidence,
   resolveTsgoBinary,
   runVizeCheck,
   symlinkVueTypes,
@@ -61,7 +62,11 @@ async function verifyVue2ElmSnapshot(): Promise<void> {
       assert.ok(first.report.errorCount > 0, "the legacy surface is intentionally not clean");
       assertDiagnosticsStayInAuthoredBlocks(fixture.workspaceDir, first.report.files);
 
-      assertSnapshot(SNAPSHOT_DIR, "vue2-elm-check", `${JSON.stringify(first.report, null, 2)}\n`);
+      assertSnapshot(
+        SNAPSHOT_DIR,
+        "vue2-elm-check",
+        `${JSON.stringify(omitProgramEvidence(first.report), null, 2)}\n`,
+      );
     },
   );
 }

--- a/tests/snapshots/check/vuefes.ts
+++ b/tests/snapshots/check/vuefes.ts
@@ -103,8 +103,9 @@ describe(`${app.name} check (type checker)`, () => {
       "unmapped diagnostics found",
     );
 
+    const { programs: _programs, ...snapshotOutput } = parsed;
     const prettyOutput =
-      JSON.stringify(parsed, null, 2).replaceAll(checkConfig.cwd, "<cwd>") + "\n";
+      JSON.stringify(snapshotOutput, null, 2).replaceAll(checkConfig.cwd, "<cwd>") + "\n";
     assertSnapshot(SNAPSHOT_DIR, `${app.name}-check`, prettyOutput);
   });
 });

--- a/tests/tooling/cli-check-collection.test.ts
+++ b/tests/tooling/cli-check-collection.test.ts
@@ -90,6 +90,7 @@ test("empty collection emits clean JSON and exits 0 without invoking corsa", () 
     const noInputsParsed = JSON.parse(noInputs.stdout);
     assert.deepEqual(noInputsParsed, {
       files: [],
+      programs: [],
       errorCount: 0,
       warningCount: 0,
       fileCount: 0,
@@ -105,6 +106,7 @@ test("empty collection emits clean JSON and exits 0 without invoking corsa", () 
     const noMatchParsed = JSON.parse(noMatch.stdout);
     assert.deepEqual(noMatchParsed, {
       files: [],
+      programs: [],
       errorCount: 0,
       warningCount: 0,
       fileCount: 0,
@@ -138,6 +140,7 @@ test("unsupported file extensions (.js) collect nothing", () => {
     const parsed = JSON.parse(result.stdout);
     assert.deepEqual(parsed, {
       files: [],
+      programs: [],
       errorCount: 0,
       warningCount: 0,
       fileCount: 0,

--- a/tests/tooling/cli-check-json-shape.test.ts
+++ b/tests/tooling/cli-check-json-shape.test.ts
@@ -87,6 +87,7 @@ function withWorkspace<T>(run: (dir: string) => T): T {
 
 type CheckJson = {
   files: Array<{ file: string; virtualTs?: string; diagnostics: string[] }>;
+  programs: Array<{ root: string; tsconfig?: string; files: string[] }>;
   errorCount: number;
   warningCount: number;
   fileCount: number;
@@ -112,7 +113,7 @@ test("vize check --format json has a stable top-level shape and key names", chec
     const parsed = parseJson(result);
     assert.deepEqual(
       Object.keys(parsed).sort(),
-      ["errorCount", "fileCount", "files", "warningCount"],
+      ["errorCount", "fileCount", "files", "programs", "warningCount"],
       "top-level keys should be exactly the documented camelCase envelope",
     );
     // `--declaration` is absent, so the emitter must not surface a declarations key.
@@ -133,6 +134,12 @@ test("vize check --format json has a stable top-level shape and key names", chec
     assert.equal(typeof parsed.errorCount, "number");
     assert.equal(typeof parsed.warningCount, "number");
     assert.equal(typeof parsed.fileCount, "number");
+    assert.deepEqual(parsed.programs, [
+      {
+        root: ".",
+        files: ["bad.ts"],
+      },
+    ]);
   });
 });
 
@@ -268,5 +275,68 @@ test("vize check --format json reports only the requested subset of files", chec
       parsed.files.every((f) => f.file !== "src/Bad.vue"),
       "the unrequested sibling must not appear in the report",
     );
+  });
+});
+
+test("vize check --format json exposes project-reference program inputs", checkerOptions, () => {
+  withWorkspace((dir) => {
+    fs.mkdirSync(path.join(dir, "packages/alpha/src"), { recursive: true });
+    fs.mkdirSync(path.join(dir, "packages/bravo/src"), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, "tsconfig.json"),
+      JSON.stringify({
+        files: [],
+        references: [{ path: "./packages/alpha" }, { path: "./packages/bravo" }],
+      }),
+      "utf8",
+    );
+    for (const name of ["alpha", "bravo"]) {
+      fs.writeFileSync(
+        path.join(dir, `packages/${name}/tsconfig.json`),
+        JSON.stringify({
+          compilerOptions: {
+            composite: true,
+            strict: true,
+            target: "ES2022",
+            module: "ESNext",
+            moduleResolution: "Bundler",
+            noEmit: true,
+          },
+          include: ["src/**/*.ts"],
+        }),
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(dir, `packages/${name}/src/index.ts`),
+        `export const ${name} = 1;\n`,
+        "utf8",
+      );
+    }
+
+    const result = runCheck(["--format", "json", "--corsa-path", CHECKER as string], dir);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+    const parsed = parseJson(result);
+    assert.deepEqual(
+      parsed.programs,
+      [
+        {
+          root: "packages/alpha",
+          tsconfig: "packages/alpha/tsconfig.json",
+          files: ["packages/alpha/src/index.ts"],
+        },
+        {
+          root: "packages/bravo",
+          tsconfig: "packages/bravo/tsconfig.json",
+          files: ["packages/bravo/src/index.ts"],
+        },
+      ],
+      "project-reference runs should expose each effective program and its registered input set",
+    );
+    assert.deepEqual(
+      parsed.files.map((file) => file.file),
+      ["packages/alpha/src/index.ts", "packages/bravo/src/index.ts"],
+    );
+    assert.equal(parsed.fileCount, 2);
   });
 });

--- a/tests/tooling/fixture-tool-matrix-typechecker.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typechecker.test.ts
@@ -18,6 +18,12 @@ function validOutput() {
         diagnostics: ["error:1:1 [TS1] synthetic error"],
       },
     ],
+    programs: [
+      {
+        root: ".",
+        files: ["src/App.vue"],
+      },
+    ],
     errorCount: 1,
     warningCount: 0,
     fileCount: 1,
@@ -55,7 +61,7 @@ test("typechecker oracle accepts exact error, warning, project, and zero-file re
 
   validateTypecheckerOutput(
     { id: "no-sfc", expectedVueFileCount: 0 },
-    { files: [], errorCount: 0, warningCount: 0, fileCount: 0 },
+    { files: [], programs: [], errorCount: 0, warningCount: 0, fileCount: 0 },
     0,
     [],
   );
@@ -118,7 +124,7 @@ test("typechecker oracle rejects malformed or internally inconsistent reports", 
     },
     {
       name: "non-empty fixture with no checked files",
-      output: { files: [], errorCount: 0, warningCount: 0, fileCount: 0 },
+      output: { files: [], programs: [], errorCount: 0, warningCount: 0, fileCount: 0 },
       exitCode: 0,
       message: /non-empty fixture checked zero Vue files/,
     },
@@ -241,7 +247,7 @@ test("fixture tool matrix records typechecker schema failures", () => {
   fs.writeFileSync(
     executable,
     `#!/usr/bin/env node
-process.stdout.write(JSON.stringify({ files: [], errorCount: 0, warningCount: 0, fileCount: 0 }));\n`,
+process.stdout.write(JSON.stringify({ files: [], programs: [], errorCount: 0, warningCount: 0, fileCount: 0 }));\n`,
   );
   fs.chmodSync(executable, 0o755);
 
@@ -281,7 +287,7 @@ test("fixture tool matrix rejects partial typechecker coverage", () => {
   fs.writeFileSync(
     executable,
     `#!/usr/bin/env node
-process.stdout.write(JSON.stringify({ files: [{ file: "src/App.vue", diagnostics: [] }], errorCount: 0, warningCount: 0, fileCount: 1 }));\n`,
+process.stdout.write(JSON.stringify({ files: [{ file: "src/App.vue", diagnostics: [] }], programs: [{ root: ".", files: ["src/App.vue"] }], errorCount: 0, warningCount: 0, fileCount: 1 }));\n`,
   );
   fs.chmodSync(executable, 0o755);
 

--- a/tools/fixtures/tool-matrix-typechecker.mjs
+++ b/tools/fixtures/tool-matrix-typechecker.mjs
@@ -2,8 +2,9 @@ import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { isAbsolute } from "node:path";
 
-const outputKeys = ["errorCount", "fileCount", "files", "warningCount"];
+const outputKeys = ["errorCount", "fileCount", "files", "programs", "warningCount"];
 const fileKeys = ["diagnostics", "file"];
+const programKeys = ["files", "root", "tsconfig"];
 const typecheckSourcePattern = /\.(?:vue|ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
 
 export function validateTypecheckerOutput(
@@ -21,6 +22,7 @@ export function validateTypecheckerOutput(
     }
   }
   if (!Array.isArray(output.files)) invalid("files must be an array");
+  if (!Array.isArray(output.programs)) invalid("programs must be an array");
   if (output.fileCount > output.files.length) {
     invalid(`fileCount ${output.fileCount} exceeds ${output.files.length} file entries`);
   }
@@ -59,6 +61,24 @@ export function validateTypecheckerOutput(
       if (diagnostic.startsWith("error:")) errorCount += 1;
       else if (diagnostic.startsWith("warning:")) warningCount += 1;
       else invalid(`diagnostic has no error or warning prefix: ${file.file}`);
+    }
+  }
+  for (const [index, program] of output.programs.entries()) {
+    requireRecord(program, `programs[${index}]`);
+    const expectedKeys =
+      typeof program.tsconfig === "string"
+        ? programKeys
+        : programKeys.filter((key) => key !== "tsconfig");
+    requireExactKeys(program, expectedKeys, `programs[${index}]`);
+    if (typeof program.root !== "string" || program.root.length === 0) {
+      invalid(`programs[${index}].root must be a non-empty string`);
+    }
+    if ("tsconfig" in program && program.tsconfig.length === 0) {
+      invalid(`programs[${index}].tsconfig must be a non-empty string`);
+    }
+    if (!Array.isArray(program.files)) invalid(`programs[${index}].files must be an array`);
+    for (const [fileIndex, file] of program.files.entries()) {
+      requireRelativePath(file, `programs[${index}].files[${fileIndex}]`);
     }
   }
 

--- a/tools/fixtures/tool-matrix-typechecker.mjs
+++ b/tools/fixtures/tool-matrix-typechecker.mjs
@@ -15,14 +15,16 @@ export function validateTypecheckerOutput(
   authoredFiles = expectedFiles,
 ) {
   requireRecord(output, "envelope");
-  requireExactKeys(output, outputKeys, "envelope");
+  const expectedOutputKeys = Array.isArray(output.programs)
+    ? outputKeys
+    : outputKeys.filter((key) => key !== "programs");
+  requireExactKeys(output, expectedOutputKeys, "envelope");
   for (const field of ["errorCount", "warningCount", "fileCount"]) {
     if (!Number.isSafeInteger(output[field]) || output[field] < 0) {
       invalid(`${field} must be a non-negative safe integer`);
     }
   }
   if (!Array.isArray(output.files)) invalid("files must be an array");
-  if (!Array.isArray(output.programs)) invalid("programs must be an array");
   if (output.fileCount > output.files.length) {
     invalid(`fileCount ${output.fileCount} exceeds ${output.files.length} file entries`);
   }
@@ -63,7 +65,7 @@ export function validateTypecheckerOutput(
       else invalid(`diagnostic has no error or warning prefix: ${file.file}`);
     }
   }
-  for (const [index, program] of output.programs.entries()) {
+  for (const [index, program] of (output.programs ?? []).entries()) {
     requireRecord(program, `programs[${index}]`);
     const expectedKeys =
       typeof program.tsconfig === "string"


### PR DESCRIPTION
## Summary
- add a programs array to vize check --format json so project graph evidence includes effective roots, tsconfig paths, and registered input files
- preserve empty/socket JSON contracts with programs: []
- cover project-reference program input evidence in the CLI JSON shape tests

Refs #3984.

## Validation
- cargo check -p vize --locked
- CORSA_PATH="$PWD/node_modules/.bin/tsgo" node --test tests/tooling/cli-check-json-shape.test.ts
- CORSA_PATH="$PWD/node_modules/.bin/tsgo" cargo test -p vize --test check_cli -- --nocapture
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789988698&installation_model_id=422833&pr_number=4575&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4575&signature=cd80173d90e9091f521a011b3cf9c127c0b26485af7562e8dc97f71beefed5c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON check results now include program metadata, including program roots, input files, reported files, and applicable TypeScript configuration paths.
  * Single-file and project-reference checks expose the effective programs used during analysis.
  * Checks with no inputs or virtual files consistently return an empty `programs` array.
  * File paths in program metadata are normalized for consistent reporting.

* **Tests**
  * Added coverage validating program metadata in standard and project-reference JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->