### PR TITLE
test(canon): expose compiler options in json evidence

### DIFF
--- a/crates/vize/src/commands/check/reporting.rs
+++ b/crates/vize/src/commands/check/reporting.rs
@@ -1,6 +1,7 @@
 //! Reporting data structures for `vize check`.
 
 use serde::Serialize;
+use serde_json::{Map, Value};
 
 /// JSON output structure for `--format json`.
 #[derive(Serialize)]
@@ -25,6 +26,8 @@ pub(crate) struct JsonProgramResult {
     pub root: std::string::String,
     #[serde(rename = "tsconfig", skip_serializing_if = "Option::is_none")]
     pub tsconfig: Option<std::string::String>,
+    #[serde(rename = "compilerOptions", skip_serializing_if = "Option::is_none")]
+    pub compiler_options: Option<Map<std::string::String, Value>>,
     pub files: Vec<std::string::String>,
 }
 

--- a/crates/vize/src/commands/check/runner/output_json.rs
+++ b/crates/vize/src/commands/check/runner/output_json.rs
@@ -73,16 +73,27 @@ pub(super) fn emit_json(
             if root.is_empty() {
                 root = ".".into();
             }
-            JsonProgramResult {
+            Ok(JsonProgramResult {
                 root: root.into(),
                 tsconfig: execution
                     .tsconfig_path
                     .as_ref()
                     .map(|path| display_path(cwd, path).into()),
+                compiler_options: execution
+                    .tsconfig_path
+                    .as_ref()
+                    .map(|path| vize_canon::snapshot_tsconfig_compiler_options(cwd, path))
+                    .transpose()
+                    .map_err(|error| {
+                        vize_carton::cstr!(
+                            "Failed to snapshot compiler options for JSON output: {}",
+                            error
+                        )
+                    })?,
                 files,
-            }
+            })
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, vize_carton::String>>()?;
 
     let reported_keys = executions
         .iter()

--- a/crates/vize/tests/check_default_run_project_root_cli.rs
+++ b/crates/vize/tests/check_default_run_project_root_cli.rs
@@ -231,6 +231,14 @@ fn default_run_inside_an_owning_ancestor_program_checks_the_app_and_notes_the_sc
                 {
                     "root": case.workspace,
                     "tsconfig": case.workspace.join("tsconfig.json"),
+                    "compilerOptions": {
+                        "module": "ESNext",
+                        "moduleResolution": "bundler",
+                        "noEmit": true,
+                        "skipLibCheck": true,
+                        "strict": true,
+                        "target": "ES2022",
+                    },
                     "files": [
                         case.workspace.join("helpers/h1.ts"),
                         case.workspace.join("helpers/h2.ts"),
@@ -298,6 +306,14 @@ fn default_run_with_a_local_tsconfig_stays_in_the_app() {
                 {
                     "root": ".",
                     "tsconfig": "tsconfig.json",
+                    "compilerOptions": {
+                        "module": "ESNext",
+                        "moduleResolution": "bundler",
+                        "noEmit": true,
+                        "skipLibCheck": true,
+                        "strict": true,
+                        "target": "ES2022",
+                    },
                     "files": ["src/Broken.vue"]
                 }
             ],

--- a/tests/tooling/cli-check-json-shape.test.ts
+++ b/tests/tooling/cli-check-json-shape.test.ts
@@ -10,16 +10,11 @@ import { typecheckDependencySkip } from "./support/typecheck-dependency.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
-/**
- * Resolves how to launch the `vize` CLI, mirroring the check-contract launcher:
- * a prebuilt binary wins, otherwise fall back to cargo so fresh checkouts work.
- */
 function resolveVizeCommand(): { command: string; prefix: string[] } {
   const candidates = [
     path.join(root, "target/ci/vize"),
     path.join(root, "target/release/vize"),
     path.join(root, "target/debug/vize"),
-    "vize",
   ];
   for (const candidate of candidates) {
     const probe = spawnSync(candidate, ["--version"], { cwd: root, encoding: "utf8" });
@@ -32,11 +27,6 @@ function resolveVizeCommand(): { command: string; prefix: string[] } {
 
 const VIZE = resolveVizeCommand();
 
-/**
- * `--format json` runs the inputs through the Corsa/tsgo type-checker, so these
- * cases require a discoverable checker. Returns null when neither is installed
- * so the suite skips gracefully instead of failing (mirrors production-readiness).
- */
 function resolveCheckerPath(): string | null {
   const candidates = [
     path.join(root, "node_modules/.bin/corsa"),
@@ -87,7 +77,12 @@ function withWorkspace<T>(run: (dir: string) => T): T {
 
 type CheckJson = {
   files: Array<{ file: string; virtualTs?: string; diagnostics: string[] }>;
-  programs: Array<{ root: string; tsconfig?: string; files: string[] }>;
+  programs: Array<{
+    root: string;
+    tsconfig?: string;
+    compilerOptions?: Record<string, unknown>;
+    files: string[];
+  }>;
   errorCount: number;
   warningCount: number;
   fileCount: number;
@@ -103,6 +98,14 @@ function parseJson(result: CheckResult): CheckJson {
 // never assert the checker's message text, only the stable JSON shape.
 const BAD_TS = "export const x: string = 123;";
 const GOOD_TS = "export const answer = 42 as const;\n";
+const PROJECT_REF_COMPILER_OPTIONS = {
+  composite: true,
+  module: "ESNext",
+  moduleResolution: "Bundler",
+  noEmit: true,
+  strict: true,
+  target: "ES2022",
+};
 
 test("vize check --format json has a stable top-level shape and key names", checkerOptions, () => {
   withWorkspace((dir) => {
@@ -323,11 +326,13 @@ test("vize check --format json exposes project-reference program inputs", checke
         {
           root: "packages/alpha",
           tsconfig: "packages/alpha/tsconfig.json",
+          compilerOptions: PROJECT_REF_COMPILER_OPTIONS,
           files: ["packages/alpha/src/index.ts"],
         },
         {
           root: "packages/bravo",
           tsconfig: "packages/bravo/tsconfig.json",
+          compilerOptions: PROJECT_REF_COMPILER_OPTIONS,
           files: ["packages/bravo/src/index.ts"],
         },
       ],


### PR DESCRIPTION
## Summary
- add `programs[].compilerOptions` to `vize check --format json` for tsconfig-backed programs
- assert project-reference JSON evidence includes effective compiler options as well as input files
- keep the JSON shape test pinned to repo-built binaries/cargo fallback instead of a globally installed `vize`

## Validation
- `cargo check -p vize --locked`
- `cargo build -p vize`
- `node --test tests/tooling/cli-check-json-shape.test.ts`
- `rustfmt crates/vize/src/commands/check/reporting.rs crates/vize/src/commands/check/runner/output_json.rs`
- `node_modules/.bin/oxfmt --check tests/tooling/cli-check-json-shape.test.ts`
- `git diff --check`

Refs #3984

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789995582&installation_model_id=422833&pr_number=4576&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4576&signature=c128f865982b0ba9c1ea9a2b47c304b34dba139963f9b1b548abae3eb443b40d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON check results now include effective TypeScript compiler options when a `tsconfig` is available.
  * Compiler options are reported for each program, including referenced projects, making configuration easier to inspect.

* **Bug Fixes**
  * Configuration snapshot errors are now surfaced instead of producing incomplete JSON results.
  * Improved CLI validation provides more consistent JSON output and program configuration reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->