### PR TITLE
chore(rust): update toolchain to 1.98.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -79,11 +79,8 @@ jobs:
       contents: read
       # Squash pushes carry no pull-request metadata; the associated-pulls API recovers the merged marker.
       pull-requests: read
-    # Matrix legs run in parallel and keep breaking changes attributed per crate.
-    # PRs compare against base; pushes compare against previous main. Schedules lack an exact base.
     # Conventional breaking markers (`type(scope)!:` / `BREAKING CHANGE:`) are major.
     # Keep this list in sync with crates published by tools/moon/cmd/publish_crates.
-    # Omit unpublished crates and their dependents so registry fallback cannot hit "not found".
     strategy:
       fail-fast: false
       matrix:
@@ -109,6 +106,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.event_name == 'push' && github.token || '' }}
         run: node tools/github/semver-change-marker.mjs "$RUNNER_TEMP/semver-change-marker.txt"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: 1.95.0
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
           wild-version: "0.9.0"
@@ -123,6 +122,7 @@ jobs:
       - name: Check public API SemVer compatibility
         env:
           BASELINE_REV: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before || '') }}
+          RUSTUP_TOOLCHAIN: 1.95.0
         run: |
           case "$BASELINE_REV" in 0000000000000000000000000000000000000000) BASELINE_REV="";; esac
           SEMVER_CHANGE_MARKER="$(cat "$RUNNER_TEMP/semver-change-marker.txt")"

--- a/crates/vize/src/commands/check/imports_resolution.rs
+++ b/crates/vize/src/commands/check/imports_resolution.rs
@@ -105,7 +105,8 @@ fn rewrite_js_to_ts(
         (stem, &[".cts", ".d.cts"])
     } else if let Some(stem) = name.strip_suffix(".jsx") {
         (stem, &[".tsx"])
-    } else if let Some(stem) = name.strip_suffix(".js") {
+    } else {
+        let stem = name.strip_suffix(".js")?;
         (
             stem,
             if include_jsx {
@@ -114,8 +115,6 @@ fn rewrite_js_to_ts(
                 &[".ts", ".d.ts"]
             },
         )
-    } else {
-        return None;
     };
     for ext in extensions {
         let candidate = base.with_file_name(cstr!("{stem}{ext}"));

--- a/crates/vize_atelier_sfc/src/compile/template_only.rs
+++ b/crates/vize_atelier_sfc/src/compile/template_only.rs
@@ -94,42 +94,40 @@ pub(super) fn compile_template_only(
         )
     };
 
-    let mut code = match template_result {
-        Ok(template_output) => {
-            warnings.extend(template_output.warnings);
-            let mut code = template_output.code;
-            if input.is_vapor {
-                code.push_str("const _sfc_main = { __vapor: true }\n");
-                append_component_render_export(
-                    &mut code,
-                    "_sfc_main",
-                    RenderFunctionName::Render,
-                    &input.compiled_styles.css_modules,
-                );
-            } else if input.options.template.ssr {
-                code.push_str("const _sfc_main = {}\n");
-                append_component_render_export(
-                    &mut code,
-                    "_sfc_main",
-                    RenderFunctionName::SsrRender,
-                    &input.compiled_styles.css_modules,
-                );
-            } else if !input.compiled_styles.css_modules.is_empty() {
-                code.push_str("const _sfc_main = {}\n");
-                append_component_render_export(
-                    &mut code,
-                    "_sfc_main",
-                    RenderFunctionName::Render,
-                    &input.compiled_styles.css_modules,
-                );
-            }
-            code
+    // Previously this just collected the error into a local vec
+    // and continued, returning Ok with empty code — so callers
+    // wrote a 0-byte module and exited 0 (#958). Propagate the
+    // template error up so the build/CLI surfaces it.
+    let template_output = template_result?;
+    warnings.extend(template_output.warnings);
+    let mut code = {
+        let mut code = template_output.code;
+        if input.is_vapor {
+            code.push_str("const _sfc_main = { __vapor: true }\n");
+            append_component_render_export(
+                &mut code,
+                "_sfc_main",
+                RenderFunctionName::Render,
+                &input.compiled_styles.css_modules,
+            );
+        } else if input.options.template.ssr {
+            code.push_str("const _sfc_main = {}\n");
+            append_component_render_export(
+                &mut code,
+                "_sfc_main",
+                RenderFunctionName::SsrRender,
+                &input.compiled_styles.css_modules,
+            );
+        } else if !input.compiled_styles.css_modules.is_empty() {
+            code.push_str("const _sfc_main = {}\n");
+            append_component_render_export(
+                &mut code,
+                "_sfc_main",
+                RenderFunctionName::Render,
+                &input.compiled_styles.css_modules,
+            );
         }
-        // Previously this just collected the error into a local vec
-        // and continued, returning Ok with empty code — so callers
-        // wrote a 0-byte module and exited 0 (#958). Propagate the
-        // template error up so the build/CLI surfaces it.
-        Err(e) => return Err(e),
+        code
     };
 
     finalize_output_mode(

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs
@@ -72,11 +72,8 @@ pub(super) fn build_user_props_decl(
             Some(&ctx.type_aliases),
         );
         if prop_types.is_empty() {
-            if let Some(ref destructure) = ctx.macros.props_destructure {
-                build_unknown_type_destructured_props_decl(&mut decl, destructure);
-            } else {
-                return None;
-            }
+            let destructure = ctx.macros.props_destructure.as_ref()?;
+            build_unknown_type_destructured_props_decl(&mut decl, destructure);
         } else {
             decl.extend_from_slice(b"{\n");
             let total_items = prop_types.len();

--- a/crates/vize_canon/src/virtual_ts/expressions/vif_chain.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions/vif_chain.rs
@@ -146,14 +146,13 @@ fn parse_guard_terms(guard: &str) -> Option<Vec<GuardTerm<'_>>> {
                 condition,
                 raw,
             });
-        } else if let Some(condition) = strip_wrapped_condition(raw) {
+        } else {
+            let condition = strip_wrapped_condition(raw)?;
             terms.push(GuardTerm {
                 negated: false,
                 condition,
                 raw,
             });
-        } else {
-            return None;
         }
     }
     (!terms.is_empty()).then_some(terms)

--- a/crates/vize_croquis/src/script_parser/extract/plain_values/sources.rs
+++ b/crates/vize_croquis/src/script_parser/extract/plain_values/sources.rs
@@ -529,14 +529,13 @@ fn getter_call_plain_value(
     source: &str,
 ) -> Option<ReactivePlainValue> {
     let (context_name, getter_name, source_name, _) = getter_call_source(result, expr)?;
-    Some(ReactivePlainValue {
+    (!context_name.is_empty()).then(|| ReactivePlainValue {
         source_name,
         argument_name: super::super::common::expression_label(source, expr.span()),
         getter_name,
         start: expr.span().start,
         end: expr.span().end,
     })
-    .filter(|_| !context_name.is_empty())
 }
 
 pub(super) fn getter_call_source(

--- a/crates/vize_croquis_cf/src/rules/reactivity/component.rs
+++ b/crates/vize_croquis_cf/src/rules/reactivity/component.rs
@@ -89,7 +89,7 @@ pub(super) fn analyze_component_reactivity(analysis: &vize_croquis::Croquis) -> 
 
     // Check if props are properly wrapped with toRef/toRefs when destructured
     if let Some(props_destructure) = analysis.macros.props_destructure() {
-        for (key, _binding) in props_destructure.bindings.iter() {
+        for key in props_destructure.bindings.keys() {
             // Check if this destructured prop has a corresponding toRef
             if !torefs_sources.contains(key.as_str()) {
                 // This prop is destructured without toRefs - Vue handles this with

--- a/crates/vize_doctor/src/fingerprint.rs
+++ b/crates/vize_doctor/src/fingerprint.rs
@@ -76,7 +76,7 @@ impl FromStr for ContentFingerprint {
 
         let hex = &value.as_bytes()[CONTENT_FINGERPRINT_PREFIX.len()..];
         let mut digest = [0; DIGEST_BYTES];
-        for (index, pair) in hex.chunks_exact(2).enumerate() {
+        for (index, pair) in hex.as_chunks::<2>().0.iter().enumerate() {
             let high =
                 decode_lower_hex(pair[0]).ok_or(ContentFingerprintParseError::InvalidHex {
                     index: CONTENT_FINGERPRINT_PREFIX.len() + index * 2,

--- a/crates/vize_maestro/src/ide/corsa_support/virtual_document.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/virtual_document.rs
@@ -120,10 +120,9 @@ fn virtual_document_target(uri: &str) -> Option<(Url, VirtualDocumentKind)> {
         }
     } else if let Some(authored) = path.strip_suffix(".script.ts") {
         (authored, VirtualDocumentKind::Script)
-    } else if let Some(authored) = path.strip_suffix(".setup.ts") {
-        (authored, VirtualDocumentKind::ScriptSetup)
     } else {
-        return None;
+        let authored = path.strip_suffix(".setup.ts")?;
+        (authored, VirtualDocumentKind::ScriptSetup)
     };
     if !authored_path.ends_with(".vue") {
         return None;

--- a/crates/vize_patina/src/linter/engine/tag_scan.rs
+++ b/crates/vize_patina/src/linter/engine/tag_scan.rs
@@ -22,10 +22,8 @@ pub(super) fn find_start_tag_end(bytes: &[u8], lt_idx: usize) -> Option<usize> {
             b'>' => return Some(idx),
             quote => {
                 // Skip the quoted attribute value, including any `>`/`<` inside.
-                match memchr::memchr(quote, &bytes[idx + 1..]) {
-                    Some(end) => pos = idx + 1 + end + 1,
-                    None => return None,
-                }
+                let end = memchr::memchr(quote, &bytes[idx + 1..])?;
+                pos = idx + 1 + end + 1;
             }
         }
     }
@@ -37,10 +35,7 @@ pub(super) fn find_closing_tag(bytes: &[u8], tag_name: &[u8], from: usize) -> Op
     let mut pos = from;
 
     while pos < bytes.len() {
-        let next_lt = match memchr::memmem::find(&bytes[pos..], b"</") {
-            Some(offset) => pos + offset,
-            None => return None,
-        };
+        let next_lt = pos + memchr::memmem::find(&bytes[pos..], b"</")?;
 
         if closing_tag_name_at(bytes, next_lt)
             .is_some_and(|(name, _)| name.eq_ignore_ascii_case(tag_name))

--- a/crates/vize_patina/src/linter/engine/template_extract.rs
+++ b/crates/vize_patina/src/linter/engine/template_extract.rs
@@ -75,10 +75,7 @@ fn find_template_block_start(bytes: &[u8]) -> Option<(usize, usize)> {
     let mut pos = 0;
 
     while pos < bytes.len() {
-        let next_lt = match memchr::memchr(b'<', &bytes[pos..]) {
-            Some(offset) => pos + offset,
-            None => return None,
-        };
+        let next_lt = pos + memchr::memchr(b'<', &bytes[pos..])?;
 
         if bytes[next_lt..].starts_with(b"<!--") {
             pos = memchr::memmem::find(&bytes[next_lt + 4..], b"-->")

--- a/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/declared.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/declared.rs
@@ -161,12 +161,8 @@ fn collect_object_emits(object: &ObjectExpression<'_>) -> Option<FxHashSet<Compa
                 if property.computed {
                     return None;
                 }
-                match property_key_name(&property.key) {
-                    Some(name) => {
-                        names.insert(CompactString::new(name));
-                    }
-                    None => return None,
-                }
+                let name = property_key_name(&property.key)?;
+                names.insert(CompactString::new(name));
             }
             // `{ ...others }`: the set is no longer fully known.
             ObjectPropertyKind::SpreadProperty(_) => return None,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.98.0"
 components = ["clippy", "rust-src", "rustfmt"]
 targets = ["wasm32-unknown-unknown", "wasm32-wasip2"]


### PR DESCRIPTION
## Summary
- update the pinned Rust toolchain to 1.98.0
- catch up Rust 1.98 clippy diagnostics across the workspace
- keep cargo-semver-checks on Rust 1.95.0 while cargo-semver-checks 0.47.0 cannot read Rust 1.98 rustdoc JSON v60

## Verification
- `cargo +1.98.0 fmt --check`
- `cargo +1.98.0 clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo semver-checks check-release --package vize_armature --baseline-rev origin/main`
- `cargo +1.98.0 check -p vize_canon`
- `MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts`
