### PR TITLE
fix(content-mapper): support TypeScript round 2 protocol

### DIFF
--- a/crates/vize/src/commands/content_mapper.rs
+++ b/crates/vize/src/commands/content_mapper.rs
@@ -1,6 +1,6 @@
 //! TypeScript content-mapper protocol server.
 //!
-//! Speaks protocol v1 as merged upstream in microsoft/typescript-go#4712:
+//! Speaks the TypeScript content-mapper protocol:
 //! `initialize` negotiates the position encoding, `openProject` and
 //! `closeProject` bracket each TypeScript project's mapper options and
 //! compiler options, and `transform` projects one Vue SFC into virtual
@@ -51,7 +51,7 @@ struct Request {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct InitializeParams {
-    protocol_version: u8,
+    protocol_version: Option<u8>,
     #[allow(dead_code)]
     locale: Option<CompactString>,
     position_encodings: Vec<CompactString>,
@@ -89,10 +89,13 @@ fn serve<R: BufRead, W: Write>(reader: &mut R, writer: &mut W) -> io::Result<()>
                         continue;
                     }
                 };
-                if params.protocol_version != PROTOCOL_VERSION {
+                if params
+                    .protocol_version
+                    .is_some_and(|version| version != PROTOCOL_VERSION)
+                {
                     let message = cstr!(
                         "Unsupported protocol version {} (expected {PROTOCOL_VERSION})",
-                        params.protocol_version
+                        params.protocol_version.unwrap_or_default()
                     );
                     write_error(writer, id, -32602, &message)?;
                     continue;
@@ -112,15 +115,14 @@ fn serve<R: BufRead, W: Write>(reader: &mut R, writer: &mut W) -> io::Result<()>
                 }
 
                 initialized = true;
-                write_result(
-                    writer,
-                    id,
-                    json!({
-                        "protocolVersion": PROTOCOL_VERSION,
-                        "positionEncoding": "utf-8",
-                        "diagnosticSource": "vize",
-                    }),
-                )?;
+                let mut result = json!({
+                    "positionEncoding": "utf-8",
+                    "diagnosticSource": "vize",
+                });
+                if params.protocol_version.is_some() {
+                    result["protocolVersion"] = json!(PROTOCOL_VERSION);
+                }
+                write_result(writer, id, result)?;
             }
             "openProject" | "closeProject" | "transform" if !initialized => {
                 write_error(writer, id, -32002, "Content mapper is not initialized")?;

--- a/crates/vize/src/commands/content_mapper/tests.rs
+++ b/crates/vize/src/commands/content_mapper/tests.rs
@@ -45,6 +45,24 @@ fn negotiates_utf8_and_transforms_vue_sfc() {
 }
 
 #[test]
+fn negotiates_utf8_without_legacy_protocol_version() {
+    let input = frames(&[json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "positionEncodings": ["utf-16", "utf-8"],
+            "locale": "en-US"
+        }
+    })]);
+    let responses = exchange(&input);
+
+    assert_eq!(responses[0]["result"]["protocolVersion"], Value::Null);
+    assert_eq!(responses[0]["result"]["positionEncoding"], "utf-8");
+    assert_eq!(responses[0]["result"]["diagnosticSource"], "vize");
+}
+
+#[test]
 fn parse_errors_are_successful_transform_results() {
     let input = frames(&[
         initialize_request(),
@@ -60,6 +78,7 @@ fn parse_errors_are_successful_transform_results() {
             .unwrap()
             .is_empty()
     );
+    assert_eq!(responses[2]["result"]["diagnostics"][0]["code"], 100_002);
 }
 
 #[test]

--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -9,6 +9,7 @@ use vize_carton::String as CompactString;
 mod leak_assertions;
 #[allow(dead_code)]
 mod navigation;
+pub mod raw_requests;
 mod responder;
 pub use leak_assertions::{assert_no_generated_uri, assert_no_generated_uri_or_zero_range};
 #[allow(unused_imports)]

--- a/crates/vize/tests/content_mapper_lsp_support/raw_requests.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/raw_requests.rs
@@ -1,0 +1,29 @@
+use serde_json::Value;
+
+pub struct RawInitialize;
+pub struct RawSetContentMapperContributions;
+pub struct RawSignatureHelp;
+
+macro_rules! raw_request {
+    ($request:ty, $method:literal) => {
+        impl lsp_types::request::Request for $request {
+            type Params = Value;
+            type Result = Value;
+            const METHOD: &'static str = $method;
+        }
+    };
+}
+
+raw_request!(RawInitialize, "initialize");
+raw_request!(
+    RawSetContentMapperContributions,
+    "custom/setContentMapperContributions"
+);
+raw_request!(RawSignatureHelp, "textDocument/signatureHelp");
+
+pub struct RawInitialized;
+
+impl lsp_types::notification::Notification for RawInitialized {
+    type Params = Value;
+    const METHOD: &'static str = "initialized";
+}

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -5,9 +5,12 @@ use std::time::Duration;
 
 use corsa_lsp::{LspClient, LspSpawnConfig, VirtualDocument, jsonrpc::InboundEvent};
 use lsp_types::{FileChangeType, Uri};
-use serde_json::{Value, json};
+use serde_json::json;
 
 mod content_mapper_lsp_support;
+use content_mapper_lsp_support::raw_requests::{
+    RawInitialize, RawInitialized, RawSetContentMapperContributions, RawSignatureHelp,
+};
 use content_mapper_lsp_support::{
     EditorResponder, assert_component_completions, assert_component_members,
     assert_component_navigation, assert_no_generated_uri_or_zero_range, completion,
@@ -24,34 +27,6 @@ impl Drop for StopOnDrop<'_> {
     fn drop(&mut self) {
         self.0.store(true, Ordering::Relaxed);
     }
-}
-
-struct RawInitialize;
-struct RawSetContentMapperContributions;
-struct RawSignatureHelp;
-
-macro_rules! raw_request {
-    ($request:ty, $method:literal) => {
-        impl lsp_types::request::Request for $request {
-            type Params = Value;
-            type Result = Value;
-            const METHOD: &'static str = $method;
-        }
-    };
-}
-
-raw_request!(RawInitialize, "initialize");
-raw_request!(
-    RawSetContentMapperContributions,
-    "custom/setContentMapperContributions"
-);
-raw_request!(RawSignatureHelp, "textDocument/signatureHelp");
-
-struct RawInitialized;
-
-impl lsp_types::notification::Notification for RawInitialized {
-    type Params = Value;
-    const METHOD: &'static str = "initialized";
 }
 
 #[test]
@@ -127,7 +102,18 @@ fn standard_tsgo_lsp_maps_core_symbol_features_to_authored_vue() {
 
             let contributed = client
                 .request::<RawSetContentMapperContributions>(json!({
-                    "contributions": [{ "contributorId": "vize", "extensions": [".vue"] }],
+                    "contributions": [{
+                        "contributorId": "vize",
+                        "extensions": [".vue"],
+                        "inferredProjectContribution": {
+                            "options": {},
+                            "manifest": {
+                                "name": "vize",
+                                "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
+                                "compilerOptions": ["noUnusedLocals"]
+                            }
+                        }
+                    }],
                     "openDocuments": [{ "uri": child_uri }, { "uri": app_uri }]
                 }))
                 .await

--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -151,7 +151,18 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
 
             let contributed = client
                 .request::<RawSetContentMapperContributions>(json!({
-                    "contributions": [{ "contributorId": "vize", "extensions": [".vue"] }],
+                    "contributions": [{
+                        "contributorId": "vize",
+                        "extensions": [".vue"],
+                        "inferredProjectContribution": {
+                            "options": {},
+                            "manifest": {
+                                "name": "vize",
+                                "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
+                                "compilerOptions": ["noUnusedLocals"]
+                            }
+                        }
+                    }],
                     "openDocuments": cases.iter().map(|case| json!({ "uri": case.0 })).collect::<Vec<_>>()
                 }))
                 .await

--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -42,7 +42,8 @@ pub use type_checker::{
     DeclarationOutput, IncrementalCheckMetrics, TypeCheckResult, TypeChecker,
 };
 pub use virtual_project::{
-    BatchTopologyMetrics, CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperDiagnostic,
+    BatchTopologyMetrics, CONTENT_MAPPER_GENERATED_DIAGNOSTIC_CODE,
+    CONTENT_MAPPER_SFC_PARSE_ERROR_CODE, CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperDiagnostic,
     ContentMapperDiagnosticDirective, ContentMapperDiagnosticDirectives, ContentMapperSemanticLink,
     ContentMapperSpan, ContentMapperTransform, ContentMapperTransformOptions,
     ContentMapperUnusedExpectDiagnostic, OriginalPosition, PACKAGE_REACHABILITY_BUDGET_REVISION,

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -30,6 +30,7 @@ mod art_usage;
 mod build;
 mod content_mapper;
 pub use content_mapper::{
+    CONTENT_MAPPER_GENERATED_DIAGNOSTIC_CODE, CONTENT_MAPPER_SFC_PARSE_ERROR_CODE,
     CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperDiagnostic, ContentMapperDiagnosticDirective,
     ContentMapperDiagnosticDirectives, ContentMapperSemanticLink, ContentMapperSpan,
     ContentMapperTransform, ContentMapperTransformOptions, ContentMapperUnusedExpectDiagnostic,

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -19,6 +19,7 @@ use alias::{is_alias_projection, is_synthetic_content_mapper_identifier};
 mod protocol;
 use protocol::protocol_semantic_links;
 pub use protocol::{
+    CONTENT_MAPPER_GENERATED_DIAGNOSTIC_CODE, CONTENT_MAPPER_SFC_PARSE_ERROR_CODE,
     CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperDiagnostic, ContentMapperDiagnosticDirective,
     ContentMapperDiagnosticDirectives, ContentMapperSemanticLink, ContentMapperSpan,
     ContentMapperTransform, ContentMapperUnusedExpectDiagnostic,
@@ -49,14 +50,10 @@ enum ContentMapperSpanKind {
     Alias = 2,
 }
 
-/// Settings resolved from a TypeScript content-mapper entry and its declared
-/// compiler-option dependencies.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ContentMapperTransformOptions {
-    /// Resolve Vue Options API instance bindings in templates.
     options_api: bool,
-    /// Preserve diagnostics for user-authored unused locals.
     preserve_unused_diagnostics: bool,
 }
 
@@ -208,6 +205,7 @@ fn sfc_parse_diagnostic(source: &str, error: &SfcError) -> ContentMapperDiagnost
         message_text: error.message.clone(),
         start,
         length,
+        code: CONTENT_MAPPER_SFC_PARSE_ERROR_CODE,
     }
 }
 
@@ -221,6 +219,7 @@ fn generated_diagnostic(source: &str, diagnostic: &Diagnostic) -> ContentMapperD
         message_text: diagnostic.message.clone(),
         start,
         length,
+        code: CONTENT_MAPPER_GENERATED_DIAGNOSTIC_CODE,
     }
 }
 

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs
@@ -10,6 +10,8 @@ use vize_carton::String as CompactString;
 /// `.tsx` because the generated module can contain a JSX render expression even
 /// when the authored `<script>` block has no JSX of its own.
 pub const CONTENT_MAPPER_VIRTUAL_EXTENSION: &str = ".tsx";
+pub const CONTENT_MAPPER_SFC_PARSE_ERROR_CODE: i32 = 100_001;
+pub const CONTENT_MAPPER_GENERATED_DIAGNOSTIC_CODE: i32 = 100_002;
 
 /// A TypeScript content-mapper transform result.
 #[derive(Debug, Serialize)]
@@ -49,6 +51,7 @@ pub struct ContentMapperDiagnostic {
     pub message_text: CompactString,
     pub start: usize,
     pub length: usize,
+    pub code: i32,
 }
 
 /// Framework directives that suppress TypeScript diagnostics in virtual

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_tests.rs
@@ -8,8 +8,9 @@ use super::span_features::{
     content_mapper_span_features,
 };
 use crate::batch::{
-    CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperTransformOptions,
-    generate_vue_content_mapper_transform, generate_vue_content_mapper_transform_with_options,
+    CONTENT_MAPPER_GENERATED_DIAGNOSTIC_CODE, CONTENT_MAPPER_VIRTUAL_EXTENSION,
+    ContentMapperTransformOptions, generate_vue_content_mapper_transform,
+    generate_vue_content_mapper_transform_with_options,
 };
 
 #[path = "content_mapper_component_export_tests.rs"]
@@ -189,6 +190,10 @@ fn authored_parse_errors_are_mapper_diagnostics() {
     assert!(result.mappings.is_empty());
     assert!(result.text.contains("__vize_component"));
     assert!(result.diagnostics[0].start <= source.len());
+    assert_eq!(
+        result.diagnostics[0].code,
+        CONTENT_MAPPER_GENERATED_DIAGNOSTIC_CODE
+    );
 }
 
 /// Opening line of the generated template scope.

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -133,6 +133,7 @@ pub use corsa_bridge::{
 #[cfg(feature = "native")]
 pub use batch::{
     BatchTopologyMetrics, BatchTypeChecker, BatchTypeCheckerOptions,
+    CONTENT_MAPPER_GENERATED_DIAGNOSTIC_CODE, CONTENT_MAPPER_SFC_PARSE_ERROR_CODE,
     CONTENT_MAPPER_VIRTUAL_EXTENSION, ContentMapperDiagnostic, ContentMapperDiagnosticDirective,
     ContentMapperDiagnosticDirectives, ContentMapperSemanticLink, ContentMapperSpan,
     ContentMapperTransform, ContentMapperTransformOptions, ContentMapperUnusedExpectDiagnostic,


### PR DESCRIPTION
## Summary
- accept the post-microsoft/TypeScript#63936 initialize shape without protocolVersion while keeping compatibility with older native-preview builds
- emit required mapper diagnostic codes for parse and generated diagnostics
- update direct tsgo LSP contribution fixtures to inferredProjectContribution
- keep original-span splitting for the currently pinned typescript-go conformance SHA, which still rejects partial overlapping original spans with TS100038

## Verification
- cargo fmt
- cargo test -p vize_canon content_mapper -- --test-threads=1
- cargo test -p vize content_mapper -- --test-threads=1
- node --test tests/tooling/source-file-lengths.test.ts (blocked locally by MoonBit lexscan toolchain mismatch before source-length assertions; exact line counts are now below the 350-line gate)

Note: @typescript/native-preview latest on npm has not yet published microsoft/TypeScript#63936, so this PR avoids a package bump and lets Actions run the exact conformance lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content-mapper initialization now supports requests that omit the protocol version.
  * Protocol versions are validated and returned only when explicitly provided.
  * Diagnostics now include standardized codes for generated diagnostics and single-file component parse errors.
  * LSP content-mapper contributions support inferred project settings, executable configuration, and compiler options.

* **Bug Fixes**
  * Improved compatibility with clients using the updated content-mapper initialization protocol.

* **Tests**
  * Expanded coverage for initialization, diagnostics, and LSP contribution configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->