### PR TITLE
chore(release): track patina crate publishing

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -77,7 +77,6 @@ jobs:
     timeout-minutes: 25
     permissions:
       contents: read
-      # Squash pushes carry no pull-request metadata; the associated-pulls API recovers the merged marker.
       pull-requests: read
     # Matrix legs run in parallel and keep breaking changes attributed per crate.
     # PRs compare against base; pushes compare against previous main. Schedules lack an exact base.
@@ -98,11 +97,11 @@ jobs:
           - vize_croquis
           - vize_fresco
           - vize_musea
+          - vize_patina
           - vize_relief
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          # cargo-semver-checks materializes the baseline rev from git history.
           fetch-depth: 0
       - name: Resolve SemVer change marker
         env:

--- a/crates/vize_atelier_jsx/Cargo.toml
+++ b/crates/vize_atelier_jsx/Cargo.toml
@@ -42,9 +42,8 @@ serde_json = { workspace = true }
 
 [features]
 default = []
-# Mirror the relief legacy surface so the `InterpolationNode::raw` field stays
-# in sync under workspace feature unification (see vize_armature's `legacy`).
-legacy = ["vize_relief/_legacy"]
+# Mirror the legacy parser/AST surface across the SFC and SSR dependencies.
+legacy = ["vize_atelier_sfc/legacy", "vize_atelier_ssr/legacy"]
 
 [[bench]]
 name = "jsx_compile"

--- a/crates/vize_atelier_sfc/Cargo.toml
+++ b/crates/vize_atelier_sfc/Cargo.toml
@@ -11,6 +11,7 @@ metadata.vize.stability = "alpha-supported"
 [features]
 default = ["native"]
 native = ["dep:lightningcss", "lightningcss/serde", "dep:parcel_selectors"]
+legacy = ["vize_atelier_core/legacy", "vize_atelier_ssr/legacy"]
 # Arms the Davinci P1-7 differential lane across the atelier crates: every
 # retained-AST consumption dual-runs the legacy re-parse and panics on
 # divergence. Off in production builds; the corpus-runnable entry below

--- a/crates/vize_atelier_ssr/Cargo.toml
+++ b/crates/vize_atelier_ssr/Cargo.toml
@@ -8,6 +8,10 @@ repository.workspace = true
 description = "Vue SSR compiler for Vize"
 metadata.vize.stability = "compatibility-preview"
 
+[features]
+default = []
+legacy = ["vize_armature/legacy", "vize_atelier_core/legacy"]
+
 [dependencies]
 vize_carton = { workspace = true }
 vize_relief = { workspace = true }

--- a/tests/tooling/moonbit-publish-crates.test.ts
+++ b/tests/tooling/moonbit-publish-crates.test.ts
@@ -97,14 +97,13 @@ test("publish_crates exactly partitions every publishable workspace crate", () =
 test("publish_crates only defers crates that have not been created on crates.io", () => {
   assert.deepEqual(getPendingFirstPublishCrates(), [
     "vize_croquis_cf",
-    "vize_atelier_jsx",
     "vize_marquette",
     "vize_doctor",
   ]);
 });
 
 test("publish_crates only blocks crates that depend on first-publish exclusions", () => {
-  assert.deepEqual(getBlockedByPendingFirstPublishCrates(), ["vize_canon", "vize_patina"]);
+  assert.deepEqual(getBlockedByPendingFirstPublishCrates(), ["vize_canon"]);
 });
 
 test("publish_crates native script covers publish and idempotent dry-run modes", () => {

--- a/tools/moon/cmd/publish_crates/main.mbt
+++ b/tools/moon/cmd/publish_crates/main.mbt
@@ -22,6 +22,8 @@ let published_crates : Array[String] = [
   "vize_atelier_vapor",
   "vize_atelier_ssr",
   "vize_atelier_sfc",
+  "vize_atelier_jsx",
+  "vize_patina",
   "vize_musea",
   "vize_fresco",
 ]
@@ -30,7 +32,6 @@ let published_crates : Array[String] = [
 /// Trusted Publishing can take over subsequent versions.
 let pending_first_publish_crates : Array[String] = [
   "vize_croquis_cf",
-  "vize_atelier_jsx",
   "vize_marquette",
   "vize_doctor",
 ]
@@ -39,7 +40,6 @@ let pending_first_publish_crates : Array[String] = [
 /// its manual first publish.
 let blocked_by_pending_first_publish_crates : Array[String] = [
   "vize_canon",
-  "vize_patina",
 ]
 
 /// Parses a positive integer from a string and falls back on invalid input.


### PR DESCRIPTION
## Summary
- add `vize_atelier_jsx` and `vize_patina` back to the crates.io publish plan now that both crates have been created
- include `vize_patina` in the cargo-semver-checks matrix
- fix the `vize_atelier_jsx/legacy` feature propagation so rustdoc can build the legacy surface before adding the JSX crate to the semver matrix in a follow-up PR
- update publish-plan tests for the remaining first-publish blockers

Fixes #4527.

## Verification
- `cargo +1.98.0 check -p vize_atelier_jsx --features legacy`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo semver-checks check-release --package vize_patina --baseline-rev origin/main`
- `MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/moonbit-publish-crates.test.ts tests/tooling/github-workflows-semver.test.ts tests/tooling/source-file-lengths.test.ts`

## Follow-up
- Add `vize_atelier_jsx` to the cargo-semver-checks matrix after this baseline legacy-feature fix lands.
