### PR TITLE
chore(ci): include jsx in semver checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -78,7 +78,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    # Conventional breaking markers (`type(scope)!:` / `BREAKING CHANGE:`) are major.
     # Keep this list in sync with crates published by tools/moon/cmd/publish_crates.
     strategy:
       fail-fast: false
@@ -87,6 +86,7 @@ jobs:
           - vize_armature
           - vize_atelier_core
           - vize_atelier_dom
+          - vize_atelier_jsx
           - vize_atelier_sfc
           - vize_atelier_ssr
           - vize_atelier_vapor


### PR DESCRIPTION
## Summary
- include `vize_atelier_jsx` in the cargo-semver-checks matrix now that its baseline `legacy` feature graph builds

## Verification
- `MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts tests/tooling/github-workflows-semver.test.ts`
- `RUSTUP_TOOLCHAIN=1.95.0 cargo semver-checks check-release --package vize_atelier_jsx --baseline-rev origin/main`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790012485&installation_model_id=422833&pr_number=4581&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4581&signature=14829a0a58615fd3eea9c494c695a0cf140906910556d101aacc49fbbb51ef02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->