### PR TITLE
fix(relief): render real error positions

### DIFF
--- a/crates/vize_relief/src/errors/render.rs
+++ b/crates/vize_relief/src/errors/render.rs
@@ -8,19 +8,15 @@
 //! the derive printed when locations still stored their covered text inline —
 //! `source` included, sliced from the file's source text.
 //!
-//! The `line`/`column` fields printed here reproduce the retired parser
-//! tracking byte-for-byte (Davinci P1-4): the parser never populated its
-//! newline table, so every stored `Position` was `line: 1, column:
-//! offset + 1` regardless of the real line. Corpus oracles pin diagnostic
-//! messages containing that frozen shape, so this renderer reconstructs it
-//! from the offset instead of deriving the real line/column. Switching this
-//! output to true `vize_carton::line_index` derivation is a recorded,
-//! corpus-visible behavior change for the plan to schedule — not a byte-safe
-//! cleanup.
+//! The `line`/`column` fields printed here are derived from the source text at
+//! render time. `SourceLocation` itself intentionally keeps only byte spans;
+//! consumers that need display coordinates should derive them at the edge from
+//! the exact source text being rendered.
 
 use core::fmt;
 
 use crate::relief::SourceLocation;
+use vize_carton::line_index::LineIndex;
 
 use super::CompilerError;
 
@@ -73,26 +69,42 @@ struct LocationWithSource<'a> {
 impl fmt::Debug for LocationWithSource<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SourceLocation")
-            .field("start", &FrozenPosition(self.loc.span.start))
-            .field("end", &FrozenPosition(self.loc.span.end))
+            .field(
+                "start",
+                &RenderedPosition::new(self.loc.span.start, self.source),
+            )
+            .field(
+                "end",
+                &RenderedPosition::new(self.loc.span.end, self.source),
+            )
             .field("source", &self.loc.span.slice(self.source))
             .finish()
     }
 }
 
-/// Renders a byte offset in the retired `Position` debug shape.
-///
-/// `line: 1, column: offset + 1` is not a placeholder: it is exactly what the
-/// retired parser tracking stored for every node (see the module docs), and
-/// the pinned diagnostic bytes depend on it.
-struct FrozenPosition(u32);
+struct RenderedPosition {
+    offset: u32,
+    line: u32,
+    column: u32,
+}
 
-impl fmt::Debug for FrozenPosition {
+impl RenderedPosition {
+    fn new(offset: u32, source: &str) -> Self {
+        let (line, column) = LineIndex::new(source).line_col(offset as usize);
+        Self {
+            offset,
+            line: line + 1,
+            column: column + 1,
+        }
+    }
+}
+
+impl fmt::Debug for RenderedPosition {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Position")
-            .field("offset", &self.0)
-            .field("line", &1u32)
-            .field("column", &(self.0 + 1))
+            .field("offset", &self.offset)
+            .field("line", &self.line)
+            .field("column", &self.column)
             .finish()
     }
 }
@@ -105,7 +117,7 @@ mod tests {
     use super::CompilerErrorWithSource;
 
     #[test]
-    fn debug_prints_the_pre_span_derive_shape() {
+    fn debug_prints_single_line_positions() {
         let loc = SourceLocation::new(5, 9);
         let error = CompilerError::with_message(
             ErrorCode::MissingEndTag,
@@ -124,6 +136,26 @@ mod tests {
              start: Position { offset: 5, line: 1, column: 6 }, \
              end: Position { offset: 9, line: 1, column: 10 }, \
              source: \"text\" }) }"
+        );
+    }
+
+    #[test]
+    fn debug_prints_real_multiline_positions() {
+        let loc = SourceLocation::new(10, 14);
+        let error =
+            CompilerError::with_message(ErrorCode::InvalidExpression, "bad expression", Some(loc));
+        let rendered = format!(
+            "{:?}",
+            CompilerErrorWithSource::new(&error, "<div>\n  {{ bad }}\n</div>")
+        );
+        assert_eq!(
+            rendered,
+            "CompilerError { code: InvalidExpression, \
+             message: \"bad expression\", \
+             loc: Some(SourceLocation { \
+             start: Position { offset: 10, line: 2, column: 5 }, \
+             end: Position { offset: 14, line: 2, column: 9 }, \
+             source: \" bad\" }) }"
         );
     }
 

--- a/crates/vize_relief/src/errors/render.rs
+++ b/crates/vize_relief/src/errors/render.rs
@@ -68,14 +68,15 @@ struct LocationWithSource<'a> {
 
 impl fmt::Debug for LocationWithSource<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let line_index = LineIndex::new(self.source);
         f.debug_struct("SourceLocation")
             .field(
                 "start",
-                &RenderedPosition::new(self.loc.span.start, self.source),
+                &RenderedPosition::new(self.loc.span.start, &line_index),
             )
             .field(
                 "end",
-                &RenderedPosition::new(self.loc.span.end, self.source),
+                &RenderedPosition::new(self.loc.span.end, &line_index),
             )
             .field("source", &self.loc.span.slice(self.source))
             .finish()
@@ -89,8 +90,8 @@ struct RenderedPosition {
 }
 
 impl RenderedPosition {
-    fn new(offset: u32, source: &str) -> Self {
-        let (line, column) = LineIndex::new(source).line_col(offset as usize);
+    fn new(offset: u32, line_index: &LineIndex<'_>) -> Self {
+        let (line, column) = line_index.line_col(offset as usize);
         Self {
             offset,
             line: line + 1,
@@ -141,21 +142,21 @@ mod tests {
 
     #[test]
     fn debug_prints_real_multiline_positions() {
-        let loc = SourceLocation::new(10, 14);
+        let loc = SourceLocation::new(14, 18);
         let error =
             CompilerError::with_message(ErrorCode::InvalidExpression, "bad expression", Some(loc));
         let rendered = format!(
             "{:?}",
-            CompilerErrorWithSource::new(&error, "<div>\n  {{ bad }}\n</div>")
+            CompilerErrorWithSource::new(&error, "root\n  😀{{ éx }}\n</div>")
         );
         assert_eq!(
             rendered,
             "CompilerError { code: InvalidExpression, \
              message: \"bad expression\", \
              loc: Some(SourceLocation { \
-             start: Position { offset: 10, line: 2, column: 5 }, \
-             end: Position { offset: 14, line: 2, column: 9 }, \
-             source: \" bad\" }) }"
+             start: Position { offset: 14, line: 2, column: 8 }, \
+             end: Position { offset: 18, line: 2, column: 11 }, \
+             source: \"éx \" }) }"
         );
     }
 

--- a/davinci-road/plan/sourcelocation-inventory.md
+++ b/davinci-road/plan/sourcelocation-inventory.md
@@ -84,12 +84,12 @@ Where each read went:
   `parse_vize_directive` with the comment's start line, which that caller
   discards (only the directive kind survives); it now passes the constant
   line the retired tracking always reported
-- `crates/vize_relief/src/errors/render.rs:88` — the one output path that printed stored
-  line/column (the SFC gate / binding-boundary debug rendering) reproduces
-  the retired tracking's frozen `line: 1, column: offset + 1` shape from
-  the span offset, byte-for-byte, because corpus oracles pin those
-  diagnostic bytes; switching it to true `LineIndex` derivation is a
-  recorded corpus-visible behavior change for the plan to schedule
+- `crates/vize_relief/src/errors/render.rs:85` — the one output path that printed stored
+  line/column (the SFC gate / binding-boundary debug rendering) now derives
+  display coordinates from the rendered source text via `LineIndex`. This
+  keeps `SourceLocation` span-only while making multiline diagnostics point
+  at the actual line and column instead of the retired frozen
+  `line: 1, column: offset + 1` approximation
 - `crates/vize_maestro/src/utils/position.rs` — `source_location_to_range`
   / `internal_to_lsp_position` converted stored `Position`s to LSP
   positions; they had no callers and are deleted (regeneration asserts they

--- a/davinci-road/plan/sourcelocation-inventory.md
+++ b/davinci-road/plan/sourcelocation-inventory.md
@@ -84,7 +84,7 @@ Where each read went:
   `parse_vize_directive` with the comment's start line, which that caller
   discards (only the directive kind survives); it now passes the constant
   line the retired tracking always reported
-- `crates/vize_relief/src/errors/render.rs:85` — the one output path that printed stored
+- `crates/vize_relief/src/errors/render.rs:86` — the one output path that printed stored
   line/column (the SFC gate / binding-boundary debug rendering) now derives
   display coordinates from the rendered source text via `LineIndex`. This
   keeps `SourceLocation` span-only while making multiline diagnostics point

--- a/tests/snapshots/check/create-vue-patch-oracle.ts
+++ b/tests/snapshots/check/create-vue-patch-oracle.ts
@@ -597,7 +597,7 @@ function assertBrokenBuild(result: BuildResult): void {
     code: 'export default {\n  __name: "App",\n  setup(__props) {}\n};',
     css: null,
     errors: [
-      'Template compilation errors: [CompilerError { code: InvalidEndTag, message: "Invalid end tag.", loc: Some(SourceLocation { start: Position { offset: 18, line: 1, column: 19 }, end: Position { offset: 23, line: 1, column: 24 }, source: "</h2>" }) }, CompilerError { code: MissingEndTag, message: "Element is missing end tag.", loc: Some(SourceLocation { start: Position { offset: 3, line: 1, column: 4 }, end: Position { offset: 7, line: 1, column: 8 }, source: "<h1>" }) }]',
+      'Template compilation errors: [CompilerError { code: InvalidEndTag, message: "Invalid end tag.", loc: Some(SourceLocation { start: Position { offset: 18, line: 2, column: 18 }, end: Position { offset: 23, line: 2, column: 23 }, source: "</h2>" }) }, CompilerError { code: MissingEndTag, message: "Element is missing end tag.", loc: Some(SourceLocation { start: Position { offset: 3, line: 2, column: 3 }, end: Position { offset: 7, line: 2, column: 7 }, source: "<h1>" }) }]',
     ],
     warnings: [],
     script_lang: "ts",

--- a/tests/snapshots/check/vue-router-patch-oracle.ts
+++ b/tests/snapshots/check/vue-router-patch-oracle.ts
@@ -36,7 +36,7 @@ const symbol = "packageBoundary";
 const sourceSha256 = "f5c888da7bae9c61151c7fbfde578ccdb768e75fbe2e69637d8298ca4f702c96";
 const cleanOutputSha256 = "84e9feaa14017c1c0e27a6b8955bd4a591b3b61e8708f3ead335aaa0c7c96013";
 const cleanCodeSha256 = "2e99ba339b7fb47f5788a990245b0292ede267d6bdfcb6c80cbe4c76da9cdebc";
-const brokenOutputSha256 = "f71d3b39b2481594dc6ee9bf43911aaeca29194f95dd45e5f8c999d960ab04c1";
+const brokenOutputSha256 = "0914134eb2d13c322402dcf94b608ac904f9ff2ed021c69cd414d5eed84f5654";
 const brokenCodeSha256 = "eed24c03d97029fca5d3d13f81ac416099d3876e7f36572d113acc0768872679";
 const cleanHref = ':href="String(to)"';
 const brokenHref = ':href="String(to"';
@@ -451,7 +451,7 @@ function assertBrokenBuild(result: BuildResult): void {
     {
       css: null,
       errors: [
-        'Template compilation errors: [CompilerError { code: InvalidExpression, message: "Error parsing JavaScript expression: mismatched expression delimiters", loc: Some(SourceLocation { start: Position { offset: 157, line: 1, column: 158 }, end: Position { offset: 166, line: 1, column: 167 }, source: "String(to" }) }]',
+        'Template compilation errors: [CompilerError { code: InvalidExpression, message: "Error parsing JavaScript expression: mismatched expression delimiters", loc: Some(SourceLocation { start: Position { offset: 157, line: 9, column: 12 }, end: Position { offset: 166, line: 9, column: 21 }, source: "String(to" }) }]',
       ],
       filename: "AppLink.vue",
       macro_artifacts: [],

--- a/tools/davinci/sourcelocation-inventory.mjs
+++ b/tools/davinci/sourcelocation-inventory.mjs
@@ -110,9 +110,9 @@ function generate() {
     "crates/vize_armature/src/parser/element/comment.rs",
     /parse_vize_directive\(content, 1, loc\.span\.start\)/,
   );
-  const g2FrozenRender = citeAnchor(
+  const g2RenderedPosition = citeAnchor(
     "crates/vize_relief/src/errors/render.rs",
-    /struct FrozenPosition/,
+    /struct RenderedPosition/,
   );
   const g2LineIndex = citeAnchor("crates/vize_carton/src/line_index.rs", /pub struct LineIndex/);
   const g2ReliefTest = citeAnchor(
@@ -214,12 +214,12 @@ Where each read went:
   \`parse_vize_directive\` with the comment's start line, which that caller
   discards (only the directive kind survives); it now passes the constant
   line the retired tracking always reported
-- \`${g2FrozenRender}\` — the one output path that printed stored
-  line/column (the SFC gate / binding-boundary debug rendering) reproduces
-  the retired tracking's frozen \`line: 1, column: offset + 1\` shape from
-  the span offset, byte-for-byte, because corpus oracles pin those
-  diagnostic bytes; switching it to true \`LineIndex\` derivation is a
-  recorded corpus-visible behavior change for the plan to schedule
+- \`${g2RenderedPosition}\` — the one output path that printed stored
+  line/column (the SFC gate / binding-boundary debug rendering) now derives
+  display coordinates from the rendered source text via \`LineIndex\`. This
+  keeps \`SourceLocation\` span-only while making multiline diagnostics point
+  at the actual line and column instead of the retired frozen
+  \`line: 1, column: offset + 1\` approximation
 - \`crates/vize_maestro/src/utils/position.rs\` — \`source_location_to_range\`
   / \`internal_to_lsp_position\` converted stored \`Position\`s to LSP
   positions; they had no callers and are deleted (regeneration asserts they


### PR DESCRIPTION
## Summary
- derive compiler error debug positions from the rendered source text instead of frozen offset columns
- cover multiline error locations in vize_relief
- update the Vue Router patch oracle for the corrected line/column output

Fixes #4350

## Verification
- cargo +1.98.0 fmt --check
- cargo +1.98.0 test -p vize_relief errors::render
- cargo +1.98.0 build -p vize
- cd tests && VIZE_TEST_BIN=../target/debug/vize node --test --test-concurrency=1 snapshots/check/vue-router-patch-oracle.ts
- MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts