### PR TITLE
test(editor): track typed editor P0 roadmap

### DIFF
--- a/docs/release/typed-dx-roadmap.md
+++ b/docs/release/typed-dx-roadmap.md
@@ -1,0 +1,39 @@
+# Typed DX production roadmap
+
+This is the P0 execution lane for #3957 and #4585. Typed authoring is not
+production-ready until every row below has an external behavior oracle and the
+implementation passes that oracle in CLI, LSP, and packaged editor contexts
+where applicable.
+
+Internal virtual-code snapshots are useful debugging evidence, but they do not
+complete a row. Every row must prove the authored user-facing behavior.
+
+## P0 matrix
+
+| issue | invariant                                                                                           | required oracle                                                                                                                                              | first fix target                     |
+| ----- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------ |
+| #4586 | Multi-root fallthrough diagnostics point at authored template ranges, never the first script token. | CLI `vize check` and LSP `publishDiagnostics` assert the same authored template range, with a single-root control.                                           | Diagnostic source mapping            |
+| #4587 | Authored script TypeScript diagnostics are never swallowed.                                         | `const a: string = 1` reports in CLI and LSP, then clears on repair with monotonic versions.                                                                 | Checker diagnostic ownership         |
+| #4588 | Hover is non-empty and checker-backed on known typed anchors.                                       | Script binding, template binding, prop, emit, slot, ref, and component import hover all return useful typed content.                                         | Hover provenance and request routing |
+| #4589 | Editor integrations do not degrade common typed values to `Ref<unknown>`.                           | Packaged editor-host smoke proves precise `ref`, computed, template-ref, props, emits, slots, and component value types.                                     | Packaged editor type surface         |
+| #4590 | Supported Vue JSX/TSX entrypoints have JSX intrinsic globals and component typing.                  | CLI and LSP JSX/TSX diagnostics reject invalid props but never emit TS7026 for supported Vue JSX.                                                            | JSX global and component type setup  |
+| #4591 | Imported SFCs show useful component contracts instead of internal marker carriers.                  | Hover/display includes props, emits, slots, model, and declaration anchors without dominant `__vizeComponentMarker` leakage.                                 | Component contract display           |
+| #4592 | Template hover and navigation are reliable across typed component surfaces.                         | Template identifiers, component tags, props, emits, slots, `v-model`, refs, `v-for`/`v-if`, aliases, barrels, and packages have authored hover/jump targets. | Template semantic links              |
+
+## Delivery order
+
+1. Add or extend the external behavior oracle for one row.
+2. Make the oracle fail for the current behavior or document the current failure
+   in a reviewed expected-failure ledger that names the P0 issue.
+3. Fix exactly that invariant.
+4. Promote the oracle into the relevant CI gate.
+5. Update this roadmap only with machine evidence.
+
+## PR policy
+
+- One P0 invariant per PR.
+- No umbrella implementation PRs.
+- Conventional titles.
+- PR descriptions must be created from body files and raw-checked for literal
+  newline escape corruption.
+- Auto-merge only after required checks and review are green.

--- a/tests/tooling/typed-dx-roadmap.test.ts
+++ b/tests/tooling/typed-dx-roadmap.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const roadmapPath = path.join(repoRoot, "docs/release/typed-dx-roadmap.md");
+
+const requiredIssues = [4586, 4587, 4588, 4589, 4590, 4591, 4592] as const;
+
+test("typed DX roadmap keeps every P0 child issue in the execution matrix", () => {
+  const roadmap = fs.readFileSync(roadmapPath, "utf8");
+
+  assert.match(roadmap, /^# Typed DX production roadmap$/m);
+  assert.match(roadmap, /This is the P0 execution lane for #3957 and #4585\./);
+
+  for (const issue of requiredIssues) {
+    assert.match(roadmap, new RegExp(`\\\\| #${issue} \\\\|`), `missing #${issue}`);
+  }
+
+  for (const phrase of [
+    "authored template ranges",
+    "Authored script TypeScript diagnostics",
+    "Hover is non-empty and checker-backed",
+    "Ref<unknown>",
+    "TS7026",
+    "__vizeComponentMarker",
+    "Template hover and navigation",
+  ]) {
+    assert.match(roadmap, new RegExp(escapeRegExp(phrase)), `missing phrase: ${phrase}`);
+  }
+});
+
+test("typed DX roadmap forbids umbrella implementation delivery", () => {
+  const roadmap = fs.readFileSync(roadmapPath, "utf8");
+
+  assert.match(roadmap, /One P0 invariant per PR\./);
+  assert.match(roadmap, /No umbrella implementation PRs\./);
+  assert.match(roadmap, /external behavior oracle/);
+  assert.match(roadmap, /body files and raw-checked/);
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
Refs #4585
Refs #3957
Refs #4586
Refs #4587
Refs #4588
Refs #4589
Refs #4590
Refs #4591
Refs #4592

## Summary
- add a typed DX P0 execution roadmap for diagnostics, hover, navigation, JSX, component contract display, and packaged editor type surfaces
- pin every typed DX child issue in a CI-checked matrix so the lane cannot drift back into umbrella work
- document the one-invariant-per-PR policy and PR-body raw-check requirement for this lane

## Verification
- node --test tests/tooling/typed-dx-roadmap.test.ts
- MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790016127&installation_model_id=422833&pr_number=4593&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4593&signature=ee733c3674104231cc4af56c77a5dc962b1807a8cda851f260baf8d7999acb59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->