### PR TITLE
test(maestro): require type backed hovers

### DIFF
--- a/tests/tooling/lsp-hover-type-backed.test.ts
+++ b/tests/tooling/lsp-hover-type-backed.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { hoverToText, isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
+
+const source = `<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+const count = ref(1)
+const doubled = computed(() => count.value * 2)
+const label: string = 'hello'
+</script>
+
+<template>
+  <button :title="label">{{ count }} {{ doubled }}</button>
+</template>
+`;
+
+test("hover answers authored script and template anchors with backend type text", async (t) => {
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTsgoBinary(),
+    "tsgo binary for type-backed hover",
+    "tsgo binary not found; skipping type-backed hover test",
+  );
+  if (corsaPath == null) return;
+
+  const testRootDir = path.join(testOutputRoot, "lsp-hover-type-backed");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+  let initialized = false;
+
+  try {
+    fs.mkdirSync(path.join(workspaceDir, "src"), { recursive: true });
+    linkVuePackage(workspaceDir);
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify({ lsp: { hover: true, lint: false, typecheck: true }, typeChecker: { corsaPath } }),
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          lib: ["ES2022", "DOM", "DOM.Iterable"],
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+          skipLibCheck: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src/**/*.vue"],
+      }),
+    );
+
+    const filePath = path.join(workspaceDir, "src/App.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+    await session.initialize(workspaceDir, {
+      editor: true,
+      hover: true,
+      lint: false,
+      typecheck: true,
+    });
+    initialized = true;
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: source },
+    });
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri),
+      120_000,
+    );
+
+    const scriptHover = await hoverText(session, uri, source.indexOf("label: string") + 2);
+    assert.match(scriptHover, /^```typescript\n/);
+    assert.match(scriptHover, /const label: string/);
+    assertNoHeuristic(scriptHover);
+
+    const templateLabelHover = await hoverText(session, uri, source.indexOf(':title="label"') + 9);
+    assert.match(templateLabelHover, /^```typescript\n/);
+    assert.match(templateLabelHover, /const label: string/);
+    assertNoHeuristic(templateLabelHover);
+
+    const templateCountHover = await hoverText(session, uri, source.indexOf("{{ count") + 4);
+    assert.match(templateCountHover, /^```typescript\n/);
+    assert.match(templateCountHover, /const count: number/);
+    assert.doesNotMatch(templateCountHover, /Ref</);
+    assertNoHeuristic(templateCountHover);
+  } finally {
+    if (initialized) {
+      await session.shutdown();
+    } else {
+      await session.kill().catch(() => undefined);
+    }
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+async function hoverText(session: LspSession, uri: string, offset: number): Promise<string> {
+  return hoverToText(
+    await session.request("textDocument/hover", {
+      textDocument: { uri },
+      position: offsetToPosition(source, offset),
+    }),
+  );
+}
+
+function assertNoHeuristic(hoverText: string): void {
+  assert.notEqual(hoverText.trim(), "");
+  assert.doesNotMatch(hoverText, /_Script binding_|_Template binding/);
+  assert.doesNotMatch(hoverText, /MaybeRef<unknown>/);
+}
+
+function resolveTsgoBinary(): string | undefined {
+  const candidates = [
+    process.env.CORSA_BIN,
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ].filter((candidate): candidate is string => candidate != null && candidate.length > 0);
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function linkVuePackage(workspaceDir: string): void {
+  const vuePackage = [
+    path.join(root, "node_modules/vue"),
+    path.join(root, "tests/node_modules/vue"),
+  ].find((candidate) => fs.existsSync(candidate));
+  assert.ok(vuePackage, "Vue package is required for type-backed hover test");
+
+  const nodeModules = path.join(workspaceDir, "node_modules");
+  fs.mkdirSync(nodeModules, { recursive: true });
+  symlink(vuePackage, path.join(nodeModules, "vue"));
+
+  const vueNamespace = path.join(path.dirname(vuePackage), "@vue");
+  if (fs.existsSync(vueNamespace)) {
+    symlink(vueNamespace, path.join(nodeModules, "@vue"));
+  }
+}
+
+function symlink(source: string, target: string): void {
+  fs.rmSync(target, { force: true, recursive: true });
+  fs.symlinkSync(source, target, process.platform === "win32" ? "junction" : "dir");
+}

--- a/tests/tooling/lsp-hover-type-backed.test.ts
+++ b/tests/tooling/lsp-hover-type-backed.test.ts
@@ -42,7 +42,10 @@ test("hover answers authored script and template anchors with backend type text"
     linkVuePackage(workspaceDir);
     fs.writeFileSync(
       path.join(workspaceDir, "vize.config.json"),
-      JSON.stringify({ lsp: { hover: true, lint: false, typecheck: true }, typeChecker: { corsaPath } }),
+      JSON.stringify({
+        lsp: { hover: true, lint: false, typecheck: true },
+        typeChecker: { corsaPath },
+      }),
     );
     fs.writeFileSync(
       path.join(workspaceDir, "tsconfig.json"),


### PR DESCRIPTION
## Summary
- add a typecheck-enabled LSP hover oracle for authored script and template anchors
- require backend TypeScript markdown for script const, template const, and unwrapped ref hovers
- reject heuristic hover markers, empty hover text, MaybeRef<unknown>, and template-side Ref leakage

Closes #4588.

## Verification
- VIZE_LSP_BIN=/var/folders/8k/gm2q62k57yb9h1kmw2kf2tzm0000gn/T/vize-4588-hover.XXXXXX.aD9gjCTb2r/target/ci/vize CORSA_BIN=/var/folders/8k/gm2q62k57yb9h1kmw2kf2tzm0000gn/T/vize-4588-hover.XXXXXX.aD9gjCTb2r/node_modules/.bin/tsgo VIZE_TEST_REQUIRE_TSGO=1 node --test tests/tooling/lsp-hover-type-backed.test.ts
- MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for type-aware hover information in Vue script and template code.
  * Verifies hover results display resolved types and rejects incomplete or heuristic type information.
  * Automatically skips when the required type-checking tool is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->