### PR TITLE
test(canon): cover Vue JSX intrinsic globals

### DIFF
--- a/tests/snapshots/check/jsx-intrinsic-globals-oracle.ts
+++ b/tests/snapshots/check/jsx-intrinsic-globals-oracle.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  resolveTsgoBinary,
+  runVizeCheck,
+  symlinkVueTypes,
+  type VizeCheckResult,
+} from "../../_helpers/realworld-typecheck.ts";
+import { testOutputRoot } from "../../tooling/support/lsp/paths.ts";
+
+test("Vue JSX intrinsic globals stay present while component props remain strict", () => {
+  const corsaPath = resolveTsgoBinary();
+  const testRootDir = path.join(testOutputRoot, "jsx-intrinsic-globals-oracle");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+
+  try {
+    const srcDir = path.join(workspaceDir, "src");
+    fs.mkdirSync(srcDir, { recursive: true });
+    symlinkVueTypes(workspaceDir);
+    writeJson(path.join(workspaceDir, "vize.config.json"), {
+      typeChecker: { corsaPath, jsxTypecheck: true },
+    });
+    writeJson(path.join(workspaceDir, "tsconfig.json"), {
+      compilerOptions: {
+        allowJs: true,
+        checkJs: true,
+        jsx: "preserve",
+        jsxImportSource: "vue",
+        module: "ESNext",
+        moduleResolution: "bundler",
+        noEmit: true,
+        strict: true,
+        target: "ES2022",
+      },
+      include: ["src/**/*"],
+    });
+    fs.writeFileSync(
+      path.join(srcDir, "Counter.vue"),
+      `<script setup lang="ts">
+defineProps<{ count: number }>();
+</script>
+
+<template>
+  <button>{{ count }}</button>
+</template>
+`,
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(srcDir, "Intrinsic.tsx"),
+      `export const view = <main><h1>Dashboard</h1><button disabled>Save</button></main>;
+`,
+      "utf8",
+    );
+    const consumerPath = path.join(srcDir, "Consumer.tsx");
+    const brokenConsumer = `import Counter from "./Counter.vue";
+
+export const view = <section><Counter count="wrong" /></section>;
+`;
+    fs.writeFileSync(consumerPath, brokenConsumer, "utf8");
+
+    const broken = runVizeCheck(workspaceDir, corsaPath, []);
+    assertNoIntrinsicElementDiagnostic(broken);
+    assert.deepEqual(diagnosticsFor(broken, "src/Intrinsic.tsx"), []);
+    assert.deepEqual(diagnosticsFor(broken, "src/Consumer.tsx"), [
+      "error:3:39 [TS2322] Type 'string' is not assignable to type 'number'.",
+    ]);
+
+    fs.writeFileSync(consumerPath, brokenConsumer.replace('"wrong"', "{1}"), "utf8");
+    const repaired = runVizeCheck(workspaceDir, corsaPath, []);
+    assertNoIntrinsicElementDiagnostic(repaired);
+    assert.equal(repaired.report.errorCount, 0, JSON.stringify(repaired.report, null, 2));
+  } finally {
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function diagnosticsFor(result: VizeCheckResult, file: string): string[] {
+  return result.report.files.find((entry) => entry.file === file)?.diagnostics ?? [];
+}
+
+function assertNoIntrinsicElementDiagnostic(result: VizeCheckResult): void {
+  const diagnostics = result.report.files.flatMap((entry) => entry.diagnostics);
+  assert.ok(
+    diagnostics.every((diagnostic) => !diagnostic.includes("JSX.IntrinsicElements")),
+    diagnostics.join("\n"),
+  );
+  assert.ok(
+    diagnostics.every((diagnostic) => !diagnostic.includes("[TS7026]")),
+    diagnostics.join("\n"),
+  );
+}

--- a/tests/tooling/snapshot-baselines.test.ts
+++ b/tests/tooling/snapshot-baselines.test.ts
@@ -35,6 +35,8 @@ const assertionOnlyCheckTests = {
     "UI library patch oracle asserts global component slot types across editor revisions",
   "javascript-sfc-checkjs-oracle":
     "checkJs oracle asserts exact per-case diagnostics and vue-tsc agreement on JavaScript SFCs",
+  "jsx-intrinsic-globals-oracle":
+    "JSX oracle builds a throwaway workspace and asserts exact intrinsic-global cleanliness plus strict component prop diagnostics",
   "nuxt-ui-ambient-oracle":
     "framework patch oracle asserts generated Nuxt ambient and #imports virtual-module types across editor revisions",
   "nuxt-no-tsconfig-oracle":


### PR DESCRIPTION
## Summary
- add a CLI/check oracle for Vue JSX intrinsic globals across TSX files
- assert TS7026 / missing JSX.IntrinsicElements never appears while intrinsic tags remain clean
- assert imported SFC component props still fail on invalid values and repair back to zero diagnostics

Closes #4590.

## Verification
- VIZE_BIN=$PWD/target/ci/vize CORSA_BIN=$PWD/node_modules/.bin/tsgo VIZE_TEST_REQUIRE_TSGO=1 node --test tests/snapshots/check/jsx-intrinsic-globals-oracle.ts
- VIZE_LSP_BIN=$PWD/target/ci/vize CORSA_BIN=$PWD/node_modules/.bin/tsgo VIZE_TEST_REQUIRE_TSGO=1 node --test tests/tooling/lsp-typecheck-jsx-component.test.ts
- ./node_modules/.bin/vp check
- MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790022770&installation_model_id=422833&pr_number=4597&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4597&signature=082e5ec5ae2046027eafba5583f5ba878f88cb5c69277e3c5fd76da315b17de3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added JSX intrinsic globals oracle coverage to the snapshot test registry.
  * Documented the coverage provided by this test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->