### PR TITLE
test(editor): pin typed ref hover surfaces

### DIFF
--- a/editors/vscode/test/suite/real-scenario-expected.cjs
+++ b/editors/vscode/test/suite/real-scenario-expected.cjs
@@ -28,6 +28,47 @@ const renamedSource = formattedSource
   .replace("const total =", "const quantity =")
   .replace(':count="total"', ':count="quantity"');
 
+const refSurfaceSource = [
+  '<script setup lang="ts">',
+  'import { computed, ref } from "vue";',
+  "",
+  "const count = ref(1);",
+  "const doubled = computed(() => count.value * 2);",
+  "</script>",
+  "",
+  "<template>",
+  "  <p>{{ count }} {{ doubled }}</p>",
+  "</template>",
+  "",
+].join("\n");
+
+const refSurfaceHovers = {
+  scriptCount: [
+    {
+      contents: ["```typescript\nconst count: Ref<number, number>\n```"],
+      range: [3, 6, 3, 11],
+    },
+  ],
+  scriptDoubled: [
+    {
+      contents: ["```typescript\nconst doubled: ComputedRef<number>\n```"],
+      range: [4, 6, 4, 13],
+    },
+  ],
+  templateCount: [
+    {
+      contents: ["```typescript\nconst count: number\n```"],
+      range: [8, 8, 8, 13],
+    },
+  ],
+  templateDoubled: [
+    {
+      contents: ["```typescript\nconst doubled: number\n```"],
+      range: [8, 20, 8, 27],
+    },
+  ],
+};
+
 // The authored `<Child  :count="total" />` carries two independent authored
 // bugs on one line: two spaces after the tag name (a fixable lint warning) and
 // a string bound to a `number` prop (the type bug the scorecard asks for).
@@ -135,6 +176,8 @@ module.exports = {
   formattingEdits,
   quickFixRange,
   quickFixedSource,
+  refSurfaceHovers,
+  refSurfaceSource,
   renameEdit,
   renameNewName,
   renamePosition,

--- a/editors/vscode/test/suite/real-scenario.cjs
+++ b/editors/vscode/test/suite/real-scenario.cjs
@@ -41,6 +41,7 @@ exports.runRealServerScenario = async function runRealServerScenario() {
   // last step logged here is the only evidence of where a stall happened.
   const steps = [
     { label: "diagnostic at authored span", run: () => stepDiagnosticAtAuthoredSpan(document) },
+    { label: "typed ref hover surfaces", run: () => stepTypedRefHoverSurfaces() },
     { label: "quick fix", run: () => stepQuickFix(document, editor) },
     { label: "format on save", run: () => stepFormatOnSave(document) },
     { label: "semantic tokens", run: () => stepSemanticTokens(document) },
@@ -83,6 +84,55 @@ async function stepDiagnosticAtAuthoredSpan(document) {
   );
 
   assert.deepEqual(sortDiagnostics(diagnostics).map(describeDiagnostic), expected.diagnostics);
+}
+
+/** Step 1b: ref/computed hover text remains backend-typed in the packaged host. */
+async function stepTypedRefHoverSurfaces() {
+  const diskPath = path.join(getWorkspaceFolderPath(), "src", "RefSurface.vue");
+  const brokenSource = expected.refSurfaceSource.replace(
+    "</script>",
+    "const broken: string = 1;\n</script>",
+  );
+  fs.writeFileSync(diskPath, brokenSource, "utf8");
+  const uri = vscode.Uri.file(diskPath);
+  const document = await vscode.workspace.openTextDocument(uri);
+  await vscode.window.showTextDocument(document);
+
+  await waitForDiagnostics(
+    uri,
+    (next) => next.some((diagnostic) => diagnostic.source === "vize/types"),
+    "ref surface initial type diagnostic",
+    180_000,
+  );
+  const edit = new vscode.WorkspaceEdit();
+  edit.replace(
+    uri,
+    new vscode.Range(document.positionAt(0), document.positionAt(document.getText().length)),
+    expected.refSurfaceSource,
+  );
+  const applied = await vscode.workspace.applyEdit(edit);
+  assert.equal(applied, true, "expected ref surface repair edit to apply");
+
+  const diagnostics = await waitForDiagnostics(
+    uri,
+    (next) => next.length === 0,
+    "ref surface diagnostics",
+    180_000,
+  );
+  assert.deepEqual(diagnostics, []);
+
+  const hovers = {
+    scriptCount: await hoverAt(uri, 3, 8),
+    scriptDoubled: await hoverAt(uri, 4, 8),
+    templateCount: await hoverAt(uri, 8, 10),
+    templateDoubled: await hoverAt(uri, 8, 22),
+  };
+  assert.deepEqual(hovers, expected.refSurfaceHovers);
+  for (const value of Object.values(hovers).flatMap((hover) =>
+    hover.flatMap((item) => item.contents),
+  )) {
+    assert.doesNotMatch(value, /Ref<unknown>|ComputedRef<unknown>|MaybeRef<unknown>/);
+  }
 }
 
 /** Step 2: the quick fix the server offers on the lint warning's own span. */
@@ -159,4 +209,28 @@ function sortDiagnostics(diagnostics) {
     }
     return left.range.start.character - right.range.start.character;
   });
+}
+
+async function hoverAt(uri, line, character) {
+  const hovers = await vscode.commands.executeCommand(
+    "vscode.executeHoverProvider",
+    uri,
+    new vscode.Position(line, character),
+  );
+  return hovers.map(describeHover);
+}
+
+function describeHover(hover) {
+  return {
+    contents: hover.contents.map((content) => {
+      if (typeof content === "string") return content;
+      if (typeof content?.value === "string") return content.value;
+      return String(content);
+    }),
+    range: hover.range === undefined ? undefined : describeRange(hover.range),
+  };
+}
+
+function describeRange(range) {
+  return [range.start.line, range.start.character, range.end.line, range.end.character];
 }

--- a/tools/zed-vize/real-server-ref-surface.mjs
+++ b/tools/zed-vize/real-server-ref-surface.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const refSurfaceSource = `<script setup lang="ts">
+import { computed, ref } from "vue";
+
+const count = ref(1);
+const doubled = computed(() => count.value * 2);
+</script>
+
+<template>
+  <p>{{ count }} {{ doubled }}</p>
+</template>
+`;
+
+const expectedRefSurfaceHovers = {
+  scriptCount: {
+    contents: {
+      kind: "markdown",
+      value: "```typescript\nconst count: Ref<number, number>\n```",
+    },
+    range: {
+      end: { character: 11, line: 3 },
+      start: { character: 6, line: 3 },
+    },
+  },
+  scriptDoubled: {
+    contents: {
+      kind: "markdown",
+      value: "```typescript\nconst doubled: ComputedRef<number>\n```",
+    },
+    range: {
+      end: { character: 13, line: 4 },
+      start: { character: 6, line: 4 },
+    },
+  },
+  templateCount: {
+    contents: {
+      kind: "markdown",
+      value: "```typescript\nconst count: number\n```",
+    },
+    range: {
+      end: { character: 13, line: 8 },
+      start: { character: 8, line: 8 },
+    },
+  },
+  templateDoubled: {
+    contents: {
+      kind: "markdown",
+      value: "```typescript\nconst doubled: number\n```",
+    },
+    range: {
+      end: { character: 27, line: 8 },
+      start: { character: 20, line: 8 },
+    },
+  },
+};
+
+export async function assertRefSurfaceHovers({ isDiagnosticsForUri, session, workspacePath }) {
+  const documentPath = path.join(workspacePath, "src", "RefSurface.vue");
+  fs.writeFileSync(documentPath, refSurfaceSource, "utf8");
+  const uri = pathToFileURL(documentPath).href;
+  session.notify("textDocument/didOpen", {
+    textDocument: {
+      uri,
+      languageId: "vue",
+      version: 1,
+      text: refSurfaceSource,
+    },
+  });
+  const diagnostics = await session.waitForNotification(
+    "textDocument/publishDiagnostics",
+    (params) => isDiagnosticsForUri(params, uri),
+    120_000,
+  );
+  assert.deepEqual(diagnostics.diagnostics, []);
+
+  const hovers = {
+    scriptCount: await hoverAt(session, uri, 3, 8),
+    scriptDoubled: await hoverAt(session, uri, 4, 8),
+    templateCount: await hoverAt(session, uri, 8, 10),
+    templateDoubled: await hoverAt(session, uri, 8, 22),
+  };
+  assert.deepEqual(hovers, expectedRefSurfaceHovers);
+  for (const value of Object.values(hovers).map((hover) => hover.contents.value)) {
+    assert.doesNotMatch(value, /Ref<unknown>|ComputedRef<unknown>|MaybeRef<unknown>/);
+  }
+}
+
+function hoverAt(session, uri, line, character) {
+  return session.request(
+    "textDocument/hover",
+    { textDocument: { uri }, position: { character, line } },
+    120_000,
+  );
+}

--- a/tools/zed-vize/run-real-server.mjs
+++ b/tools/zed-vize/run-real-server.mjs
@@ -13,6 +13,7 @@ import {
   prepareRealVueWorkspace,
   resolveRealServerPath,
 } from "../editor-e2e/real-vue-workspace.mjs";
+import { assertRefSurfaceHovers } from "./real-server-ref-surface.mjs";
 import { isDiagnosticsForUri } from "../../tests/tooling/support/lsp/assertions.ts";
 import { LspSession } from "../../tests/tooling/support/lsp/session.ts";
 
@@ -232,6 +233,8 @@ try {
     120_000,
   );
   assert.deepEqual(hover, expectedHover);
+
+  await assertRefSurfaceHovers({ isDiagnosticsForUri, session, workspacePath });
 
   const codeActions = await session.request(
     "textDocument/codeAction",


### PR DESCRIPTION
## Summary
- add typed ref/computed hover probes to the packaged VS Code real-server scenario
- add the same complete-response hover probes to the Zed real-server scenario as the non-VSCode host gate
- assert script hovers stay precise and template hovers stay unwrapped instead of degrading to Ref<unknown>, ComputedRef<unknown>, or MaybeRef<unknown>

Refs #4589.

## Verification
- node --test tests/tooling/editor-real-server-e2e.test.ts tests/tooling/editor-real-server-zed-e2e.test.ts
- VIZE_SERVER_PATH=/var/folders/8k/gm2q62k57yb9h1kmw2kf2tzm0000gn/T/vize-4590-jsx.XXXXXX.htA12mvzjw/target/ci/vize node tools/zed-vize/run-real-server.mjs
- ./node_modules/.bin/vp check
- MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790023037&installation_model_id=422833&pr_number=4598&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4598&signature=08e09211aef928d614eb24780bedf6384cc249de26c9f7f589125990787eb597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for Vue `ref` and `computed` type information in script and template contexts.
  - Added hover validation to ensure accurate inferred types and reject unresolved generic types.
  - Added diagnostics checks confirming the new scenarios compile without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->