### PR TITLE
fix(editor): summarize Vue SFC import hovers

### DIFF
--- a/editors/vscode/typescript-vue-plugin/component-contracts.cjs
+++ b/editors/vscode/typescript-vue-plugin/component-contracts.cjs
@@ -1,0 +1,154 @@
+"use strict";
+
+function vueComponentDisplayParts(ts, sourceText, localName) {
+  if (typeof sourceText !== "string") {
+    return undefined;
+  }
+
+  const script = extractScript(sourceText);
+  const lines = [`const ${localName || "component"}: VueComponent`];
+  const props = extractMacroType(ts, script, "defineProps");
+  const emits = extractMacroType(ts, script, "defineEmits");
+  const slots = extractMacroType(ts, script, "defineSlots");
+  const model = extractModelContract(ts, script);
+  if (props || emits || slots || model) {
+    lines.push("{");
+    if (props) lines.push(`  props: ${compactType(props)};`);
+    if (emits) lines.push(`  emits: ${compactType(emits)};`);
+    if (slots) lines.push(`  slots: ${compactType(slots)};`);
+    if (model) lines.push(`  model: ${model};`);
+    lines.push("}");
+  }
+
+  return [{ kind: ts.SymbolDisplayPartKind.text, text: lines.join("\n") }];
+}
+
+function extractScript(sourceText) {
+  const blocks = [];
+  const scriptRe = /<script\b[^>]*>([\s\S]*?)<\/script>/gi;
+  for (let match; (match = scriptRe.exec(sourceText));) {
+    blocks.push(match[1]);
+  }
+  return blocks.length > 0 ? blocks.join("\n") : sourceText;
+}
+
+function extractMacroType(ts, scriptText, macroName) {
+  const call = findMacroCall(ts, scriptText, macroName);
+  const typeArgument = call?.typeArguments?.[0];
+  return typeArgument ? typeArgument.getText(call.getSourceFile()) : undefined;
+}
+
+function extractModelContract(ts, scriptText) {
+  const call = findMacroCall(ts, scriptText, "defineModel");
+  const typeArgument = call?.typeArguments?.[0];
+  if (!typeArgument) return undefined;
+  const firstArg = call.arguments?.[0];
+  const name = firstArg && isStringLiteralLike(ts, firstArg) ? firstArg.text : "modelValue";
+  return `${JSON.stringify(name)}: ${compactType(typeArgument.getText(call.getSourceFile()))}`;
+}
+
+function findMacroCall(ts, scriptText, macroName) {
+  const sourceFile = ts.createSourceFile(
+    "vize-component-contract.ts",
+    scriptText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  let result;
+  visit(sourceFile, (node) => {
+    if (
+      !result &&
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === macroName
+    ) {
+      result = node;
+    }
+  });
+  return result;
+}
+
+function visit(node, callback) {
+  callback(node);
+  node.forEachChild((child) => visit(child, callback));
+}
+
+function isStringLiteralLike(ts, node) {
+  return ts.isStringLiteral(node) || node.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral;
+}
+
+function compactType(sourceText) {
+  let output = "";
+  let pendingSpace = false;
+  for (const token of lexicalTokens(sourceText)) {
+    if (token.kind === "space") {
+      pendingSpace = output.length > 0;
+      continue;
+    }
+    if (pendingSpace) {
+      output += " ";
+    }
+    output += token.text;
+    pendingSpace = false;
+  }
+  return output.trim();
+}
+
+function lexicalTokens(sourceText) {
+  const tokens = [];
+  for (let index = 0; index < sourceText.length;) {
+    const char = sourceText[index];
+    if (/\s/.test(char)) {
+      const end = consumeWhile(sourceText, index, (value) => /\s/.test(value));
+      tokens.push({ kind: "space", text: sourceText.slice(index, end) });
+      index = end;
+      continue;
+    }
+    if ((char === "/" && sourceText[index + 1] === "/") || sourceText.startsWith("/*", index)) {
+      index = consumeComment(sourceText, index);
+      continue;
+    }
+    if (char === "'" || char === '"' || char === "`") {
+      const end = consumeQuoted(sourceText, index, char);
+      tokens.push({ kind: "text", text: sourceText.slice(index, end) });
+      index = end;
+      continue;
+    }
+    tokens.push({ kind: "text", text: char });
+    index += 1;
+  }
+  return tokens;
+}
+
+function consumeWhile(sourceText, start, predicate) {
+  let index = start;
+  while (index < sourceText.length && predicate(sourceText[index])) index += 1;
+  return index;
+}
+
+function consumeComment(sourceText, start) {
+  if (sourceText[start + 1] === "/") {
+    const end = sourceText.indexOf("\n", start + 2);
+    return end < 0 ? sourceText.length : end;
+  }
+  const end = sourceText.indexOf("*/", start + 2);
+  return end < 0 ? sourceText.length : end + 2;
+}
+
+function consumeQuoted(sourceText, start, quote) {
+  let escaped = false;
+  for (let index = start + 1; index < sourceText.length; index += 1) {
+    const char = sourceText[index];
+    if (escaped) {
+      escaped = false;
+    } else if (char === "\\") {
+      escaped = true;
+    } else if (char === quote) {
+      return index + 1;
+    }
+  }
+  return sourceText.length;
+}
+
+module.exports = { vueComponentDisplayParts };

--- a/editors/vscode/typescript-vue-plugin/index.cjs
+++ b/editors/vscode/typescript-vue-plugin/index.cjs
@@ -1,6 +1,7 @@
 "use strict";
 
 const path = require("node:path");
+const { vueComponentDisplayParts } = require("./component-contracts.cjs");
 const { installVueVirtualModules } = require("./virtual-modules.cjs");
 
 const vueExtension = ".vue";
@@ -92,12 +93,15 @@ function createLanguageServiceProxy(ts, languageService, support) {
     if (!vueDefinition) {
       return quickInfo;
     }
+    const sourceText = support.readFile(vueDefinition.definition.fileName);
+    const displayParts = vueComponentDisplayParts(ts, sourceText, vueDefinition.localName);
 
     return {
       kind: ts.ScriptElementKind.alias,
       kindModifiers: "",
       textSpan: vueDefinition.textSpan,
       ...(quickInfo || {}),
+      ...(displayParts ? { displayParts } : {}),
       documentation: [
         ...(quickInfo?.documentation || []),
         {
@@ -162,6 +166,7 @@ function resolveVueImportDefinition(ts, support, fileName, position) {
       name: path.basename(vuePath),
       textSpan: { start: 0, length: 0 },
     },
+    localName: vueImport.localName,
     textSpan: vueImport.textSpan,
   };
 }
@@ -213,6 +218,7 @@ function findVueImportAtPosition(ts, sourceText, position) {
   for (const vueImport of imports) {
     if (containsPosition(vueImport.specifierSpan, position)) {
       return {
+        localName: [...vueImport.localNames][0],
         specifier: vueImport.specifier,
         textSpan: vueImport.specifierSpan,
       };
@@ -231,6 +237,7 @@ function findVueImportAtPosition(ts, sourceText, position) {
   }
 
   return {
+    localName: identifierText,
     specifier: vueImport.specifier,
     textSpan: {
       length: identifier.getEnd() - identifier.getStart(sourceFile),

--- a/tests/tooling/vscode-typescript-vue-plugin-types.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin-types.test.ts
@@ -43,15 +43,29 @@ test("TypeScript Vue plugin exposes generated SFC component types", () => {
       source.indexOf("App from") + 1,
     );
 
-    assert.match(displayPartsText(quickInfo?.displayParts), /title: string/);
+    const display = displayPartsText(quickInfo?.displayParts);
+    assert.match(
+      display,
+      /props: \{ title: "hello   world"; count\?: number; format\?: \(value: \{ nested: string \}\) => string \}/,
+    );
+    assert.match(display, /emits: \{ save: \[id: string\] \}/);
+    assert.match(display, /slots: \{ default\(props: \{ title: string \}\): unknown \}/);
+    assert.match(display, /model: "modelValue": boolean/);
+    assert.doesNotMatch(display, /ignored|notAnEmit/);
+    assert.doesNotMatch(display, /__vizeComponentMarker|__vizeRawProps|__VizeComponentConstructor/);
+    const sideEffectInfo = service.getQuickInfoAtPosition(
+      project.mainTs,
+      source.indexOf("SideEffect.vue") + 1,
+    );
+    assert.match(displayPartsText(sideEffectInfo?.displayParts), /^const component: VueComponent/);
     assert.match(
       formatDiagnostics(service.getSemanticDiagnostics(project.mainTs)),
       /Property 'title' is missing/,
     );
     assert.equal(
       nativeGenerationCount(project.nativeCalls),
-      1,
-      "expected one native generation across the initial queries",
+      2,
+      "expected native generation for the imported component and side-effect specifier",
     );
 
     fs.writeFileSync(
@@ -64,11 +78,16 @@ test("TypeScript Vue plugin exposes generated SFC component types", () => {
       project.mainTs,
       source.indexOf("App from") + 1,
     );
-    assert.match(displayPartsText(refreshedInfo?.displayParts), /count: number/);
-    assert.doesNotMatch(displayPartsText(refreshedInfo?.displayParts), /title: string/);
+    const refreshedDisplay = displayPartsText(refreshedInfo?.displayParts);
+    assert.match(refreshedDisplay, /props: \{ count: number \}/);
+    assert.doesNotMatch(refreshedDisplay, /title: string/);
+    assert.doesNotMatch(
+      refreshedDisplay,
+      /__vizeComponentMarker|__vizeRawProps|__VizeComponentConstructor/,
+    );
     assert.equal(
       nativeGenerationCount(project.nativeCalls),
-      2,
+      3,
       "expected one additional native generation after the SFC edit",
     );
   } finally {
@@ -86,6 +105,7 @@ function createProject() {
     mainTs,
     [
       'import App from "./App.vue";',
+      'import "./SideEffect.vue";',
       'const props: InstanceType<typeof App>["$props"] = {};',
       "props;",
       "",
@@ -94,8 +114,19 @@ function createProject() {
   const appVue = path.join(srcDir, "App.vue");
   fs.writeFileSync(
     appVue,
-    '<script setup lang="ts">\ndefineProps<{ title: string; count?: number }>();\n</script>\n',
+    [
+      '<script setup lang="ts">',
+      "// defineProps<{ ignored: string }>",
+      'const stringLiteral = "defineEmits<{ notAnEmit: [] }>();";',
+      'defineProps<{ title: "hello   world"; count?: number; format?: (value: { nested: string }) => string }>();',
+      "defineEmits<{ save: [id: string] }>();",
+      "defineSlots<{ default(props: { title: string }): unknown }>();",
+      "defineModel<boolean>();",
+      "</script>",
+      "",
+    ].join("\n"),
   );
+  fs.writeFileSync(path.join(srcDir, "SideEffect.vue"), "<template />\n");
 
   const ambientDts = path.join(srcDir, "vite-client.d.ts");
   fs.writeFileSync(
@@ -129,8 +160,8 @@ function createProject() {
       '  const callsFile = path.join(__dirname, "calls.txt");',
       '  const calls = Number(fs.readFileSync(callsFile, "utf8")) + 1;',
       "  fs.writeFileSync(callsFile, String(calls));",
-      "  const props = source.match(/defineProps<([\\s\\S]*?)>\\s*\\(\\s*\\)/)?.[1] || '{}';",
-      "  return { virtualTs: `declare const component: new () => { $props: ${props} };\\nexport default component;\\n` };",
+      "  const props = source.match(/^\\s*defineProps<([\\s\\S]*?)>\\s*\\(\\s*\\)/m)?.[1] || '{}';",
+      "  return { virtualTs: `declare const component: { readonly __vizeComponentMarker: true; readonly __vizeRawProps?: ${props} } & (new () => { $props: ${props} });\\nexport default component;\\n` };",
       "};",
       "",
     ].join("\n"),


### PR DESCRIPTION
## Summary
- replace raw generated Vue import quickInfo display with a user-facing SFC component summary in the TypeScript Vue plugin
- include props, emits, slots, and model contracts when they are authored in the SFC
- keep internal carrier names like __vizeComponentMarker, __vizeRawProps, and __VizeComponentConstructor out of the primary hover display

Refs #4591.

## Verification
- node --test tests/tooling/vscode-typescript-vue-plugin-types.test.ts tests/tooling/vscode-typescript-vue-plugin.test.ts tests/tooling/vscode-typescript-vue-plugin-module-resolution.test.ts
- ./node_modules/.bin/vp check editors/vscode/typescript-vue-plugin/index.cjs tests/tooling/vscode-typescript-vue-plugin-types.test.ts tests/tooling/vscode-typescript-vue-plugin.test.ts tests/tooling/vscode-typescript-vue-plugin-module-resolution.test.ts
- MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4599"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790023292&installation_model_id=422833&pr_number=4599&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4599&signature=597574ccee560c1028e68d7cdb33041e0c85b3bc637ccf04a4cba733e2880b5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Vue import quick info with generated component signatures.
  * Displays inferred contracts for props, emits, slots, and models.
  * Improves definition results for imported Vue components.

* **Bug Fixes**
  * Hides internal tooling markers from displayed type information.
  * Provides more accurate component type details in Vue single-file components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->