### PR TITLE
fix(maestro): prefer authored component hovers

### DIFF
--- a/crates/vize_maestro/src/ide/hover/corsa.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa.rs
@@ -133,6 +133,24 @@ impl HoverService {
         }
 
         if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset)
+            && let Some(mut hover) = Self::hover_component_tag(ctx)
+        {
+            if hover.range.is_none() {
+                hover.range = authored_hover_token_range(ctx);
+            }
+            return Some(hover);
+        }
+
+        if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset)
+            && let Some(mut hover) = super::component_prop::hover_attribute(ctx)
+        {
+            if hover.range.is_none() {
+                hover.range = authored_hover_token_range(ctx);
+            }
+            return Some(hover);
+        }
+
+        if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset)
             && let Some(hover) =
                 Self::hover_html_attribute_with_corsa(ctx, corsa_bridge.as_ref()).await
         {

--- a/tests/tooling/lsp-hover-type-backed.test.ts
+++ b/tests/tooling/lsp-hover-type-backed.test.ts
@@ -16,15 +16,31 @@ import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
 
 const source = `<script setup lang="ts">
 import { computed, ref } from 'vue'
+import Child from './Child.vue'
 
 const count = ref(1)
 const doubled = computed(() => count.value * 2)
 const label: string = 'hello'
+function save(value: string) {
+  return value
+}
 </script>
 
 <template>
   <button :title="label">{{ count }} {{ doubled }}</button>
+  <Child :label="label" @save="save">
+    <template #default="{ value }">{{ value }}</template>
+  </Child>
 </template>
+`;
+
+const childSource = `<script setup lang="ts">
+defineProps<{ label: string }>()
+defineEmits<{ save: [value: string] }>()
+defineSlots<{ default(props: { value: string }): unknown }>()
+</script>
+
+<template><slot :value="label" /></template>
 `;
 
 test("hover and definition answer authored template anchors with backend type text", async (t) => {
@@ -68,6 +84,9 @@ test("hover and definition answer authored template anchors with backend type te
       }),
     );
 
+    const childPath = path.join(workspaceDir, "src/Child.vue");
+    const childUri = pathToFileURL(childPath).href;
+    fs.writeFileSync(childPath, childSource, "utf8");
     const filePath = path.join(workspaceDir, "src/App.vue");
     const uri = pathToFileURL(filePath).href;
     fs.writeFileSync(filePath, source, "utf8");
@@ -122,6 +141,20 @@ test("hover and definition answer authored template anchors with backend type te
     assert.doesNotMatch(templateCountHoverText, /Ref</);
     assertNoHeuristic(templateCountHoverText);
     await assertDefinition(session, uri, countUsage.start, countDeclaration, "template count");
+
+    const childTag = rangeFor("Child", source.indexOf("<Child"));
+    const childTagHover = await hoverAt(session, uri, childTag.start);
+    assert.deepEqual(
+      childTagHover?.range,
+      childTag,
+      "component tag hover must select the authored tag token",
+    );
+    const childTagText = hoverToText(childTagHover);
+    assert.match(childTagText, /Component usage/);
+    assert.match(childTagText, /:label="label"/);
+    assert.match(childTagText, /@save="save"/);
+    assert.match(childTagText, /#default/);
+    await assertDefinitionUri(session, uri, childTag.start, childUri, "Child component tag");
   } finally {
     if (initialized) {
       await session.shutdown();
@@ -175,6 +208,28 @@ async function assertDefinition(
       uri,
     },
     `${label} definition must jump to the authored script declaration`,
+  );
+}
+
+async function assertDefinitionUri(
+  session: LspSession,
+  uri: string,
+  position: Position,
+  expectedUri: string,
+  label: string,
+): Promise<void> {
+  const response = await session.request(
+    "textDocument/definition",
+    {
+      textDocument: { uri },
+      position,
+    },
+    120_000,
+  );
+  assert.equal(
+    firstLocation(response as Parameters<typeof firstLocation>[0]).uri,
+    expectedUri,
+    `${label} definition must jump to the authored Vue component file`,
   );
 }
 


### PR DESCRIPTION
## Summary
- prefer authored Vue component hover handling before Corsa HTML fallbacks
- pin component tag hover range, usage summary, and authored definition navigation in the type-backed LSP fixture

## Verification
- cargo build -p vize
- VIZE_LSP_BIN=$PWD/target/debug/vize CORSA_BIN=/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.bin/tsgo VIZE_TEST_REQUIRE_TSGO=1 node --test tests/tooling/lsp-hover-type-backed.test.ts
- cargo test -p vize_maestro hover_with_corsa --features native -- --nocapture
- ./node_modules/.bin/vp check crates/vize_maestro/src/ide/hover/corsa.rs tests/tooling/lsp-hover-type-backed.test.ts
- MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts
- cargo fmt --check --package vize_maestro

Refs #4592
Refs #4585

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790024729&installation_model_id=422833&pr_number=4602&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4602&signature=6afc898e91e788e692f7915aca93e55300f04c35017f9a142d81bb2176a9a47f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->