### PR TITLE
fix(editor): resolve SFC barrel hovers

### DIFF
--- a/editors/vscode/typescript-vue-plugin/import-resolution.cjs
+++ b/editors/vscode/typescript-vue-plugin/import-resolution.cjs
@@ -1,0 +1,297 @@
+"use strict";
+
+const path = require("node:path");
+
+const vueExtension = ".vue";
+
+function resolveVueImportDefinition(ts, support, fileName, position) {
+  if (typeof fileName !== "string") {
+    return undefined;
+  }
+
+  const sourceText = support.readFile(fileName);
+  if (typeof sourceText !== "string") {
+    return undefined;
+  }
+
+  const directImport = findVueImportAtPosition(ts, sourceText, position);
+  const directVuePath = directImport
+    ? resolveExistingVueSpecifier(fileName, directImport.specifier, support.fileExists)
+    : undefined;
+  const vueImport = directVuePath
+    ? { ...directImport, vuePath: directVuePath }
+    : findVueBarrelImportAtPosition(ts, support, fileName, sourceText, position);
+  if (!vueImport?.vuePath) {
+    return undefined;
+  }
+
+  return {
+    definition: {
+      fileName: vueImport.vuePath,
+      kind: ts.ScriptElementKind.scriptElement,
+      name: path.basename(vueImport.vuePath),
+      textSpan: { start: 0, length: 0 },
+    },
+    localName: vueImport.localName,
+    textSpan: vueImport.textSpan,
+  };
+}
+
+function findVueImportAtPosition(ts, sourceText, position) {
+  const sourceFile = ts.createSourceFile(
+    "vize-vue-import.ts",
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const imports = [];
+
+  visit(sourceFile, (node) => {
+    if (!ts.isImportDeclaration(node) || !isStringLiteralLike(ts, node.moduleSpecifier)) {
+      return;
+    }
+
+    const specifier = node.moduleSpecifier.text;
+    if (!isRelativeVueSpecifier(specifier)) {
+      return;
+    }
+
+    const localNames = new Set();
+    const importClause = node.importClause;
+    if (importClause?.name) {
+      localNames.add(importClause.name.text);
+    }
+    const namedBindings = importClause?.namedBindings;
+    if (namedBindings && ts.isNamespaceImport(namedBindings)) {
+      localNames.add(namedBindings.name.text);
+    } else if (namedBindings && ts.isNamedImports(namedBindings)) {
+      for (const element of namedBindings.elements) {
+        localNames.add(element.name.text);
+      }
+    }
+
+    imports.push({
+      localNames,
+      specifier,
+      specifierSpan: {
+        length: specifier.length,
+        start: node.moduleSpecifier.getStart(sourceFile) + 1,
+      },
+    });
+  });
+
+  for (const vueImport of imports) {
+    if (containsPosition(vueImport.specifierSpan, position)) {
+      return {
+        localName: [...vueImport.localNames][0],
+        specifier: vueImport.specifier,
+        textSpan: vueImport.specifierSpan,
+      };
+    }
+  }
+
+  const identifier = identifierAtPosition(ts, sourceFile, position);
+  if (!identifier) {
+    return undefined;
+  }
+
+  const identifierText = identifier.text;
+  const vueImport = imports.find((entry) => entry.localNames.has(identifierText));
+  if (!vueImport) {
+    return undefined;
+  }
+
+  return {
+    localName: identifierText,
+    specifier: vueImport.specifier,
+    textSpan: {
+      length: identifier.getEnd() - identifier.getStart(sourceFile),
+      start: identifier.getStart(sourceFile),
+    },
+  };
+}
+
+function findVueBarrelImportAtPosition(ts, support, fileName, sourceText, position) {
+  const importBinding = findRelativeImportBindingAtPosition(ts, sourceText, position);
+  if (!importBinding) {
+    return undefined;
+  }
+  const vuePath = resolveVueReExport(
+    ts,
+    support,
+    fileName,
+    importBinding.specifier,
+    importBinding.importedName,
+  );
+  return vuePath ? { ...importBinding, vuePath } : undefined;
+}
+
+function findRelativeImportBindingAtPosition(ts, sourceText, position) {
+  const sourceFile = ts.createSourceFile(
+    "vize-vue-import.ts",
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const imports = [];
+
+  visit(sourceFile, (node) => {
+    if (!ts.isImportDeclaration(node) || !isStringLiteralLike(ts, node.moduleSpecifier)) {
+      return;
+    }
+    const specifier = node.moduleSpecifier.text;
+    if (!isRelativeSpecifier(specifier) || isRelativeVueSpecifier(specifier)) {
+      return;
+    }
+    const importClause = node.importClause;
+    const namedBindings = importClause?.namedBindings;
+    if (namedBindings && ts.isNamedImports(namedBindings)) {
+      for (const element of namedBindings.elements) {
+        const localName = element.name.text;
+        imports.push({
+          importedName: element.propertyName?.text || localName,
+          localName,
+          specifier,
+          textSpan: {
+            length: element.name.getEnd() - element.name.getStart(sourceFile),
+            start: element.name.getStart(sourceFile),
+          },
+        });
+      }
+    }
+  });
+
+  const direct = imports.find((entry) => containsPosition(entry.textSpan, position));
+  if (direct) {
+    return direct;
+  }
+  const identifier = identifierAtPosition(ts, sourceFile, position);
+  return identifier ? imports.find((entry) => entry.localName === identifier.text) : undefined;
+}
+
+function resolveVueReExport(
+  ts,
+  support,
+  containingFile,
+  specifier,
+  exportedName,
+  seen = new Set(),
+) {
+  const barrelPath = resolveExistingModuleSpecifier(containingFile, specifier, support.fileExists);
+  if (!barrelPath || seen.has(barrelPath)) {
+    return undefined;
+  }
+  seen.add(barrelPath);
+  const sourceText = support.readFile(barrelPath);
+  if (typeof sourceText !== "string") {
+    return undefined;
+  }
+  const sourceFile = ts.createSourceFile(
+    barrelPath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  let result;
+  visit(sourceFile, (node) => {
+    if (result || !ts.isExportDeclaration(node) || !isStringLiteralLike(ts, node.moduleSpecifier)) {
+      return;
+    }
+    const exportClause = node.exportClause;
+    if (!exportClause || !ts.isNamedExports(exportClause)) {
+      return;
+    }
+    for (const element of exportClause.elements) {
+      if (element.name.text !== exportedName) {
+        continue;
+      }
+      const targetName = element.propertyName?.text || element.name.text;
+      const targetSpecifier = node.moduleSpecifier.text;
+      result = isRelativeVueSpecifier(targetSpecifier)
+        ? resolveExistingVueSpecifier(barrelPath, targetSpecifier, support.fileExists)
+        : resolveVueReExport(ts, support, barrelPath, targetSpecifier, targetName, seen);
+      return;
+    }
+  });
+  return result;
+}
+
+function identifierAtPosition(ts, sourceFile, position) {
+  let result;
+  visit(sourceFile, (node) => {
+    if (
+      result ||
+      !ts.isIdentifier(node) ||
+      position < node.getStart(sourceFile) ||
+      position > node.getEnd()
+    ) {
+      return;
+    }
+    result = node;
+  });
+  return result;
+}
+
+function visit(node, callback) {
+  callback(node);
+  node.forEachChild((child) => visit(child, callback));
+}
+
+function isStringLiteralLike(ts, node) {
+  return ts.isStringLiteral(node) || node.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral;
+}
+
+function containsPosition(span, position) {
+  return position >= span.start && position <= span.start + span.length;
+}
+
+function resolveExistingVueSpecifier(containingFile, specifier, fileExists) {
+  if (!isRelativeVueSpecifier(specifier) || typeof containingFile !== "string") {
+    return undefined;
+  }
+
+  const vuePath = path.resolve(path.dirname(containingFile), specifier);
+  return fileExists(vuePath) ? vuePath : undefined;
+}
+
+function resolveExistingModuleSpecifier(containingFile, specifier, fileExists) {
+  if (!isRelativeSpecifier(specifier) || typeof containingFile !== "string") {
+    return undefined;
+  }
+
+  const basePath = path.resolve(path.dirname(containingFile), specifier);
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    `${basePath}.js`,
+    `${basePath}.jsx`,
+    path.join(basePath, "index.ts"),
+    path.join(basePath, "index.tsx"),
+    path.join(basePath, "index.js"),
+    path.join(basePath, "index.jsx"),
+  ];
+  return candidates.find((candidate) => fileExists(candidate));
+}
+
+function isRelativeSpecifier(specifier) {
+  return (
+    typeof specifier === "string" && (specifier.startsWith("./") || specifier.startsWith("../"))
+  );
+}
+
+function isRelativeVueSpecifier(specifier) {
+  return (
+    typeof specifier === "string" &&
+    specifier.endsWith(vueExtension) &&
+    (specifier.startsWith("./") || specifier.startsWith("../"))
+  );
+}
+
+module.exports = {
+  resolveExistingVueSpecifier,
+  resolveVueImportDefinition,
+};

--- a/editors/vscode/typescript-vue-plugin/index.cjs
+++ b/editors/vscode/typescript-vue-plugin/index.cjs
@@ -2,9 +2,11 @@
 
 const path = require("node:path");
 const { vueComponentDisplayParts } = require("./component-contracts.cjs");
+const {
+  resolveExistingVueSpecifier,
+  resolveVueImportDefinition,
+} = require("./import-resolution.cjs");
 const { installVueVirtualModules } = require("./virtual-modules.cjs");
-
-const vueExtension = ".vue";
 
 function init({ typescript: ts }) {
   return {
@@ -141,155 +143,6 @@ function filterVueImportDiagnostics(ts, diagnostics, { fileExists, fileName }) {
 function diagnosticVueSpecifier(ts, diagnostic) {
   const message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
   return message.match(/Cannot find module ['"]([^'"]+\.vue)['"]/)?.[1];
-}
-
-function resolveVueImportDefinition(ts, support, fileName, position) {
-  if (typeof fileName !== "string") {
-    return undefined;
-  }
-
-  const sourceText = support.readFile(fileName);
-  if (typeof sourceText !== "string") {
-    return undefined;
-  }
-
-  const vueImport = findVueImportAtPosition(ts, sourceText, position);
-  const vuePath = resolveExistingVueSpecifier(fileName, vueImport?.specifier, support.fileExists);
-  if (!vueImport || !vuePath) {
-    return undefined;
-  }
-
-  return {
-    definition: {
-      fileName: vuePath,
-      kind: ts.ScriptElementKind.scriptElement,
-      name: path.basename(vuePath),
-      textSpan: { start: 0, length: 0 },
-    },
-    localName: vueImport.localName,
-    textSpan: vueImport.textSpan,
-  };
-}
-
-function findVueImportAtPosition(ts, sourceText, position) {
-  const sourceFile = ts.createSourceFile(
-    "vize-vue-import.ts",
-    sourceText,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
-  const imports = [];
-
-  visit(sourceFile, (node) => {
-    if (!ts.isImportDeclaration(node) || !isStringLiteralLike(ts, node.moduleSpecifier)) {
-      return;
-    }
-
-    const specifier = node.moduleSpecifier.text;
-    if (!isRelativeVueSpecifier(specifier)) {
-      return;
-    }
-
-    const localNames = new Set();
-    const importClause = node.importClause;
-    if (importClause?.name) {
-      localNames.add(importClause.name.text);
-    }
-    const namedBindings = importClause?.namedBindings;
-    if (namedBindings && ts.isNamespaceImport(namedBindings)) {
-      localNames.add(namedBindings.name.text);
-    } else if (namedBindings && ts.isNamedImports(namedBindings)) {
-      for (const element of namedBindings.elements) {
-        localNames.add(element.name.text);
-      }
-    }
-
-    imports.push({
-      localNames,
-      specifier,
-      specifierSpan: {
-        length: specifier.length,
-        start: node.moduleSpecifier.getStart(sourceFile) + 1,
-      },
-    });
-  });
-
-  for (const vueImport of imports) {
-    if (containsPosition(vueImport.specifierSpan, position)) {
-      return {
-        localName: [...vueImport.localNames][0],
-        specifier: vueImport.specifier,
-        textSpan: vueImport.specifierSpan,
-      };
-    }
-  }
-
-  const identifier = identifierAtPosition(ts, sourceFile, position);
-  if (!identifier) {
-    return undefined;
-  }
-
-  const identifierText = identifier.text;
-  const vueImport = imports.find((entry) => entry.localNames.has(identifierText));
-  if (!vueImport) {
-    return undefined;
-  }
-
-  return {
-    localName: identifierText,
-    specifier: vueImport.specifier,
-    textSpan: {
-      length: identifier.getEnd() - identifier.getStart(sourceFile),
-      start: identifier.getStart(sourceFile),
-    },
-  };
-}
-
-function identifierAtPosition(ts, sourceFile, position) {
-  let result;
-  visit(sourceFile, (node) => {
-    if (
-      result ||
-      !ts.isIdentifier(node) ||
-      position < node.getStart(sourceFile) ||
-      position > node.getEnd()
-    ) {
-      return;
-    }
-    result = node;
-  });
-  return result;
-}
-
-function visit(node, callback) {
-  callback(node);
-  node.forEachChild((child) => visit(child, callback));
-}
-
-function isStringLiteralLike(ts, node) {
-  return ts.isStringLiteral(node) || node.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral;
-}
-
-function containsPosition(span, position) {
-  return position >= span.start && position <= span.start + span.length;
-}
-
-function resolveExistingVueSpecifier(containingFile, specifier, fileExists) {
-  if (!isRelativeVueSpecifier(specifier) || typeof containingFile !== "string") {
-    return undefined;
-  }
-
-  const vuePath = path.resolve(path.dirname(containingFile), specifier);
-  return fileExists(vuePath) ? vuePath : undefined;
-}
-
-function isRelativeVueSpecifier(specifier) {
-  return (
-    typeof specifier === "string" &&
-    specifier.endsWith(vueExtension) &&
-    (specifier.startsWith("./") || specifier.startsWith("../"))
-  );
 }
 
 function bind(fn, thisArg) {

--- a/tests/tooling/vscode-typescript-vue-plugin-types.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin-types.test.ts
@@ -58,6 +58,27 @@ test("TypeScript Vue plugin exposes generated SFC component types", () => {
       source.indexOf("SideEffect.vue") + 1,
     );
     assert.match(displayPartsText(sideEffectInfo?.displayParts), /^const component: VueComponent/);
+    const barrelInfo = service.getQuickInfoAtPosition(
+      project.mainTs,
+      source.indexOf("BarrelApp }") + 1,
+    );
+    const barrelDisplay = displayPartsText(barrelInfo?.displayParts);
+    assert.match(barrelDisplay, /^const BarrelApp: VueComponent/);
+    assert.match(barrelDisplay, /props: \{ title: "hello   world"/);
+    assert.doesNotMatch(
+      barrelDisplay,
+      /__vizeComponentMarker|__vizeRawProps|__VizeComponentConstructor/,
+    );
+    assert.equal(
+      service.getDefinitionAtPosition(project.mainTs, source.indexOf("BarrelApp;") + 1)?.[0]
+        ?.fileName,
+      project.appVue,
+    );
+    assert.equal(
+      service.getTypeDefinitionAtPosition(project.mainTs, source.indexOf("BarrelApp;") + 1)?.[0]
+        ?.fileName,
+      project.appVue,
+    );
     assert.match(
       formatDiagnostics(service.getSemanticDiagnostics(project.mainTs)),
       /Property 'title' is missing/,
@@ -105,8 +126,10 @@ function createProject() {
     mainTs,
     [
       'import App from "./App.vue";',
+      'import { BarrelApp } from "./components";',
       'import "./SideEffect.vue";',
       'const props: InstanceType<typeof App>["$props"] = {};',
+      "BarrelApp;",
       "props;",
       "",
     ].join("\n"),
@@ -127,6 +150,12 @@ function createProject() {
     ].join("\n"),
   );
   fs.writeFileSync(path.join(srcDir, "SideEffect.vue"), "<template />\n");
+  const componentsDir = path.join(srcDir, "components");
+  fs.mkdirSync(componentsDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(componentsDir, "index.ts"),
+    'export { default as BarrelApp } from "../App.vue";\n',
+  );
 
   const ambientDts = path.join(srcDir, "vite-client.d.ts");
   fs.writeFileSync(


### PR DESCRIPTION
## Summary
- resolve Vue SFC component contracts through relative TypeScript barrel re-exports in the VS Code TypeScript plugin
- keep quick info free of internal carrier types for barrel-imported components
- assert definition and type-definition jump back to the authored Vue SFC

## Verification
- node --test tests/tooling/vscode-typescript-vue-plugin-types.test.ts
- ./node_modules/.bin/vp check --fix editors/vscode/typescript-vue-plugin/index.cjs tests/tooling/vscode-typescript-vue-plugin-types.test.ts
- ./node_modules/.bin/vp check tests/tooling/vscode-typescript-vue-plugin-types.test.ts editors/vscode/typescript-vue-plugin/index.cjs
- MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts

Refs #4591
Refs #4585

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790024932&installation_model_id=422833&pr_number=4603&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4603&signature=9f91f3ad27d7a36492f39f1b607e3d15961be0843cd29c4ad11f79b80a1c84ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->