### PR TITLE
fix(croquis): ignore numeric literal tails

### DIFF
--- a/crates/vize_croquis/src/drawer/helpers/identifiers/fast.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/fast.rs
@@ -122,6 +122,16 @@ fn extract_identifier_refs_fast_with_base(expr: &str, base_offset: u32) -> Vec<I
             }
         }
 
+        // Numeric literals may contain ASCII identifier characters in exponents,
+        // radices, separators, and BigInt suffixes (`1e22`, `0xFF`, `123n`).
+        // Treating the alphabetic tail as a standalone identifier produces
+        // undefined-reference false positives, so consume the whole literal
+        // before looking for identifiers.
+        if c.is_ascii_digit() || (c == b'.' && i + 1 < len && bytes[i + 1].is_ascii_digit()) {
+            i = consume_number_like(bytes, i);
+            continue;
+        }
+
         // Start of identifier
         if c.is_ascii_alphabetic() || c == b'_' || c == b'$' {
             let start = i;
@@ -166,6 +176,19 @@ fn extract_identifier_refs_fast_with_base(expr: &str, base_offset: u32) -> Vec<I
     }
 
     identifiers
+}
+
+fn consume_number_like(bytes: &[u8], start: usize) -> usize {
+    let mut i = start + 1;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c.is_ascii_alphanumeric() || c == b'_' || c == b'.' {
+            i += 1;
+        } else {
+            break;
+        }
+    }
+    i
 }
 
 fn is_spread_before_identifier(bytes: &[u8], dot_index: usize) -> bool {

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
@@ -135,6 +135,22 @@ fn test_extract_identifiers_ignores_regex_literals() {
 }
 
 #[test]
+fn test_extract_identifiers_ignores_numeric_literal_tails() {
+    fn to_pairs(ids: Vec<IdentifierRef>) -> Vec<(CompactString, u32)> {
+        ids.into_iter()
+            .map(|identifier| (identifier.name, identifier.offset))
+            .collect()
+    }
+
+    let expr = "1e22 + 0xFF + 0b1010 + 123n + .5e-2 + count";
+    assert_eq!(extract_identifiers_oxc(expr), vec!["count"]);
+    assert_eq!(
+        to_pairs(extract_identifier_refs_oxc(expr)),
+        vec![("count".into(), expr.find("count").unwrap() as u32)]
+    );
+}
+
+#[test]
 fn test_extract_identifier_refs_preserve_root_offsets() {
     fn to_pairs(ids: Vec<IdentifierRef>) -> Vec<(CompactString, u32)> {
         ids.into_iter()


### PR DESCRIPTION
## Summary
- consume numeric-literal tails in the Croquis fast identifier scanner
- prevent exponent, radix, and BigInt suffix text from becoming undefined-reference identifiers
- add offset-preserving coverage for the fast identifier path

## Verification
- cargo test -p vize_croquis drawer::helpers::identifiers::tests::test_extract_identifiers_ignores_numeric_literal_tails
- cargo test -p vize_croquis drawer::helpers::identifiers::tests
- cargo fmt --check --package vize_croquis
- MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts

Refs #4365

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790025107&installation_model_id=422833&pr_number=4604&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4604&signature=b62f69446f486dddda6a7f9915119ed0eac9ee32a7568d3d221534cd4cabbf17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->