### PR TITLE
fix(editor): resolve package SFC hovers

### DIFF
--- a/editors/vscode/typescript-vue-plugin/import-resolution.cjs
+++ b/editors/vscode/typescript-vue-plugin/import-resolution.cjs
@@ -1,6 +1,7 @@
 "use strict";
 
 const path = require("node:path");
+const { isRelativeSpecifier, resolveExistingModuleSpecifier } = require("./module-resolution.cjs");
 
 const vueExtension = ".vue";
 
@@ -20,7 +21,7 @@ function resolveVueImportDefinition(ts, support, fileName, position) {
     : undefined;
   const vueImport = directVuePath
     ? { ...directImport, vuePath: directVuePath }
-    : findVueBarrelImportAtPosition(ts, support, fileName, sourceText, position);
+    : findVueReExportImportAtPosition(ts, support, fileName, sourceText, position);
   if (!vueImport?.vuePath) {
     return undefined;
   }
@@ -112,8 +113,13 @@ function findVueImportAtPosition(ts, sourceText, position) {
   };
 }
 
-function findVueBarrelImportAtPosition(ts, support, fileName, sourceText, position) {
-  const importBinding = findRelativeImportBindingAtPosition(ts, sourceText, position);
+function findVueReExportImportAtPosition(ts, support, fileName, sourceText, position) {
+  const importBinding = findNamedImportBindingAtPosition(
+    ts,
+    sourceText,
+    position,
+    (specifier) => !isRelativeVueSpecifier(specifier),
+  );
   if (!importBinding) {
     return undefined;
   }
@@ -127,7 +133,7 @@ function findVueBarrelImportAtPosition(ts, support, fileName, sourceText, positi
   return vuePath ? { ...importBinding, vuePath } : undefined;
 }
 
-function findRelativeImportBindingAtPosition(ts, sourceText, position) {
+function findNamedImportBindingAtPosition(ts, sourceText, position, acceptsSpecifier) {
   const sourceFile = ts.createSourceFile(
     "vize-vue-import.ts",
     sourceText,
@@ -142,7 +148,7 @@ function findRelativeImportBindingAtPosition(ts, sourceText, position) {
       return;
     }
     const specifier = node.moduleSpecifier.text;
-    if (!isRelativeSpecifier(specifier) || isRelativeVueSpecifier(specifier)) {
+    if (!acceptsSpecifier(specifier)) {
       return;
     }
     const importClause = node.importClause;
@@ -179,7 +185,12 @@ function resolveVueReExport(
   exportedName,
   seen = new Set(),
 ) {
-  const barrelPath = resolveExistingModuleSpecifier(containingFile, specifier, support.fileExists);
+  const barrelPath = resolveExistingModuleSpecifier(
+    containingFile,
+    specifier,
+    support.fileExists,
+    support.readFile,
+  );
   if (!barrelPath || seen.has(barrelPath)) {
     return undefined;
   }
@@ -255,32 +266,6 @@ function resolveExistingVueSpecifier(containingFile, specifier, fileExists) {
 
   const vuePath = path.resolve(path.dirname(containingFile), specifier);
   return fileExists(vuePath) ? vuePath : undefined;
-}
-
-function resolveExistingModuleSpecifier(containingFile, specifier, fileExists) {
-  if (!isRelativeSpecifier(specifier) || typeof containingFile !== "string") {
-    return undefined;
-  }
-
-  const basePath = path.resolve(path.dirname(containingFile), specifier);
-  const candidates = [
-    basePath,
-    `${basePath}.ts`,
-    `${basePath}.tsx`,
-    `${basePath}.js`,
-    `${basePath}.jsx`,
-    path.join(basePath, "index.ts"),
-    path.join(basePath, "index.tsx"),
-    path.join(basePath, "index.js"),
-    path.join(basePath, "index.jsx"),
-  ];
-  return candidates.find((candidate) => fileExists(candidate));
-}
-
-function isRelativeSpecifier(specifier) {
-  return (
-    typeof specifier === "string" && (specifier.startsWith("./") || specifier.startsWith("../"))
-  );
 }
 
 function isRelativeVueSpecifier(specifier) {

--- a/editors/vscode/typescript-vue-plugin/module-resolution.cjs
+++ b/editors/vscode/typescript-vue-plugin/module-resolution.cjs
@@ -1,0 +1,121 @@
+"use strict";
+
+const path = require("node:path");
+
+function resolveExistingModuleSpecifier(containingFile, specifier, fileExists, readFile) {
+  if (typeof containingFile !== "string" || typeof specifier !== "string") {
+    return undefined;
+  }
+  if (isRelativeSpecifier(specifier)) {
+    return resolveSourceCandidate(
+      path.resolve(path.dirname(containingFile), specifier),
+      fileExists,
+    );
+  }
+  if (path.isAbsolute(specifier)) {
+    return undefined;
+  }
+  return resolvePackageSpecifier(containingFile, specifier, fileExists, readFile);
+}
+
+function resolvePackageSpecifier(containingFile, specifier, fileExists, readFile) {
+  const parsed = parsePackageSpecifier(specifier);
+  if (!parsed) {
+    return undefined;
+  }
+  for (const modulesDir of nodeModulesAncestors(path.dirname(containingFile))) {
+    const packageRoot = path.join(modulesDir, parsed.packageName);
+    const packageJson = path.join(packageRoot, "package.json");
+    if (!fileExists(packageJson)) {
+      continue;
+    }
+    if (parsed.subpath) {
+      return resolveSourceCandidate(path.join(packageRoot, parsed.subpath), fileExists);
+    }
+    const manifest = readPackageManifest(packageJson, readFile);
+    for (const field of ["types", "typings", "module", "main"]) {
+      const target = typeof manifest?.[field] === "string" ? manifest[field] : undefined;
+      const resolved = target
+        ? resolveSourceCandidate(path.join(packageRoot, target), fileExists)
+        : undefined;
+      if (resolved) {
+        return resolved;
+      }
+    }
+    const resolved = resolveSourceCandidate(path.join(packageRoot, "index"), fileExists);
+    if (resolved) {
+      return resolved;
+    }
+  }
+  return undefined;
+}
+
+function parsePackageSpecifier(specifier) {
+  const parts = specifier.split("/");
+  if (parts.length === 0 || parts[0] === "") {
+    return undefined;
+  }
+  if (parts[0].startsWith("@")) {
+    if (parts.length < 2 || parts[1] === "") {
+      return undefined;
+    }
+    return {
+      packageName: `${parts[0]}/${parts[1]}`,
+      subpath: parts.slice(2).join("/"),
+    };
+  }
+  return {
+    packageName: parts[0],
+    subpath: parts.slice(1).join("/"),
+  };
+}
+
+function* nodeModulesAncestors(startDirectory) {
+  let current = path.resolve(startDirectory);
+  while (true) {
+    yield path.join(current, "node_modules");
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+}
+
+function readPackageManifest(packageJson, readFile) {
+  const source = typeof readFile === "function" ? readFile(packageJson) : undefined;
+  if (typeof source !== "string") {
+    return undefined;
+  }
+  try {
+    return JSON.parse(source);
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveSourceCandidate(basePath, fileExists) {
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    `${basePath}.js`,
+    `${basePath}.jsx`,
+    path.join(basePath, "index.ts"),
+    path.join(basePath, "index.tsx"),
+    path.join(basePath, "index.js"),
+    path.join(basePath, "index.jsx"),
+  ];
+  return candidates.find((candidate) => fileExists(candidate));
+}
+
+function isRelativeSpecifier(specifier) {
+  return (
+    typeof specifier === "string" && (specifier.startsWith("./") || specifier.startsWith("../"))
+  );
+}
+
+module.exports = {
+  isRelativeSpecifier,
+  resolveExistingModuleSpecifier,
+};

--- a/tests/tooling/vscode-typescript-vue-plugin-types.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin-types.test.ts
@@ -79,6 +79,27 @@ test("TypeScript Vue plugin exposes generated SFC component types", () => {
         ?.fileName,
       project.appVue,
     );
+    const packageInfo = service.getQuickInfoAtPosition(
+      project.mainTs,
+      source.indexOf("PackageApp }") + 1,
+    );
+    const packageDisplay = displayPartsText(packageInfo?.displayParts);
+    assert.match(packageDisplay, /^const PackageApp: VueComponent/);
+    assert.match(packageDisplay, /props: \{ packageTitle: string \}/);
+    assert.doesNotMatch(
+      packageDisplay,
+      /__vizeComponentMarker|__vizeRawProps|__VizeComponentConstructor/,
+    );
+    assert.equal(
+      service.getDefinitionAtPosition(project.mainTs, source.indexOf("PackageApp;") + 1)?.[0]
+        ?.fileName,
+      project.packageVue,
+    );
+    assert.equal(
+      service.getTypeDefinitionAtPosition(project.mainTs, source.indexOf("PackageApp;") + 1)?.[0]
+        ?.fileName,
+      project.packageVue,
+    );
     assert.match(
       formatDiagnostics(service.getSemanticDiagnostics(project.mainTs)),
       /Property 'title' is missing/,
@@ -127,9 +148,11 @@ function createProject() {
     [
       'import App from "./App.vue";',
       'import { BarrelApp } from "./components";',
+      'import { PackageApp } from "@acme/ui";',
       'import "./SideEffect.vue";',
       'const props: InstanceType<typeof App>["$props"] = {};',
       "BarrelApp;",
+      "PackageApp;",
       "props;",
       "",
     ].join("\n"),
@@ -155,6 +178,21 @@ function createProject() {
   fs.writeFileSync(
     path.join(componentsDir, "index.ts"),
     'export { default as BarrelApp } from "../App.vue";\n',
+  );
+  const packageDir = path.join(rootDir, "node_modules/@acme/ui");
+  fs.mkdirSync(packageDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({ name: "@acme/ui", types: "index.ts", version: "1.0.0" }),
+  );
+  fs.writeFileSync(
+    path.join(packageDir, "index.ts"),
+    'export { default as PackageApp } from "./PackageApp.vue";\n',
+  );
+  const packageVue = path.join(packageDir, "PackageApp.vue");
+  fs.writeFileSync(
+    packageVue,
+    '<script setup lang="ts">\ndefineProps<{ packageTitle: string }>();\n</script>\n',
   );
 
   const ambientDts = path.join(srcDir, "vite-client.d.ts");
@@ -196,7 +234,7 @@ function createProject() {
     ].join("\n"),
   );
 
-  return { ambientDts, appVue, mainTs, nativeCalls, root: rootDir };
+  return { ambientDts, appVue, mainTs, nativeCalls, packageVue, root: rootDir };
 }
 
 function createHost(rootDir: string, rootFiles: string[]) {


### PR DESCRIPTION
## Summary
- resolve Vue SFC component contracts through package entry barrels in the VS Code TypeScript plugin
- follow package.json types/typings/module/main and index source entries before chasing named re-exports to .vue files
- assert package-boundary hover, definition, and type-definition stay on the authored Vue component without internal carrier types

## Verification
- node --test tests/tooling/vscode-typescript-vue-plugin-types.test.ts
- ./node_modules/.bin/vp check --fix editors/vscode/typescript-vue-plugin/import-resolution.cjs editors/vscode/typescript-vue-plugin/module-resolution.cjs tests/tooling/vscode-typescript-vue-plugin-types.test.ts
- ./node_modules/.bin/vp check editors/vscode/typescript-vue-plugin/import-resolution.cjs editors/vscode/typescript-vue-plugin/module-resolution.cjs tests/tooling/vscode-typescript-vue-plugin-types.test.ts
- MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts

Refs #4591
Refs #4585

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790042665&installation_model_id=422833&pr_number=4605&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4605&signature=952c899295ea991db218d97ac6f8abc6b2e7adaef9f10acf1a63f39ac128eab6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import resolution for Vue components referenced through package entry points.
  * Added support for resolving modules across ancestor dependency folders, package manifests, index files, and common TypeScript/JavaScript extensions.
  * Improved component definition, type definition, quick info, and generated props support for package-based imports.

* **Tests**
  * Added coverage for Vue components imported from a package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->