### PR TITLE
fix(maestro): resolve component v-model navigation

### DIFF
--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -1,5 +1,7 @@
 //! Go-to-definition for Vue SFC template bindings, components, imports, and Corsa.
+mod art;
 pub mod bindings;
+mod component_model;
 #[cfg(all(test, feature = "native"))]
 mod corsa_tests;
 pub(crate) mod helpers;

--- a/crates/vize_maestro/src/ide/definition/art.rs
+++ b/crates/vize_maestro/src/ide/definition/art.rs
@@ -1,0 +1,43 @@
+//! Shared definition helpers for `.art.vue` component metadata.
+
+use crate::ide::{IdeContext, kebab_to_pascal};
+
+pub(super) fn component_path(ctx: &IdeContext<'_>, component_name: &str) -> Option<String> {
+    if !ctx.uri.path().ends_with(".art.vue") {
+        return None;
+    }
+
+    let allocator = vize_carton::Allocator::new();
+    let art_desc = vize_musea::parse_art(
+        &allocator,
+        &ctx.content,
+        vize_musea::ArtParseOptions::default(),
+    )
+    .ok()?;
+    let component_path = art_desc.metadata.component?;
+    let descriptor = vize_atelier_sfc::parse_sfc(
+        &ctx.content,
+        vize_atelier_sfc::SfcParseOptions {
+            filename: ctx.uri.path().to_string().into(),
+            ..Default::default()
+        },
+    )
+    .ok()?;
+    if let Some(script_setup) = descriptor.script_setup.as_ref()
+        && let Some(defined_component) =
+            crate::virtual_code::find_define_art_component_name(script_setup.content.as_ref())
+    {
+        let pascal_component = kebab_to_pascal(component_name);
+        if component_name == defined_component || pascal_component == defined_component {
+            return Some(component_path.to_string());
+        }
+    }
+
+    let stem = std::path::Path::new(component_path)
+        .file_stem()
+        .and_then(|stem| stem.to_str())?;
+
+    let pascal_component = kebab_to_pascal(component_name);
+    let pascal_stem = kebab_to_pascal(stem);
+    (component_name == stem || pascal_component == pascal_stem).then(|| component_path.to_string())
+}

--- a/crates/vize_maestro/src/ide/definition/component_model.rs
+++ b/crates/vize_maestro/src/ide/definition/component_model.rs
@@ -1,0 +1,78 @@
+//! Component `v-model` helpers shared by definition entrypoints.
+
+pub(super) fn prop_name_from_v_model_attribute(raw_attr_name: &str) -> Option<String> {
+    if raw_attr_name == "v-model" || raw_attr_name.starts_with("v-model.") {
+        return Some("modelValue".to_string());
+    }
+
+    let argument = raw_attr_name.strip_prefix("v-model:")?;
+    if argument.starts_with('[') {
+        return None;
+    }
+
+    let name = argument.split_once('.').map_or(argument, |(name, _)| name);
+    (!name.is_empty()).then(|| name.to_string())
+}
+
+/// Find the authored declaration anchor for a `defineModel` prop.
+///
+/// Argument-less `defineModel()` declares `modelValue`, whose prop key has no
+/// authored token, so the call identifier is the most useful jump target.
+/// Named models jump to the literal argument itself.
+pub(super) fn find_prop_in_define_model(
+    content: &str,
+    property_name: &str,
+) -> Option<(usize, usize)> {
+    for (define_model_pos, _) in content.match_indices("defineModel") {
+        if !is_identifier_boundary(content, define_model_pos, "defineModel".len()) {
+            continue;
+        }
+
+        let after_name = &content[define_model_pos + "defineModel".len()..];
+        let paren_relative = after_name.find('(')?;
+        let args_start = define_model_pos + "defineModel".len() + paren_relative + 1;
+        let mut arg_start = args_start;
+        while arg_start < content.len() && content.as_bytes()[arg_start].is_ascii_whitespace() {
+            arg_start += 1;
+        }
+
+        match content.as_bytes().get(arg_start).copied() {
+            Some(b'\'' | b'"' | b'`') => {
+                let quote = content.as_bytes()[arg_start];
+                let literal_start = arg_start + 1;
+                let literal_end = find_string_literal_end(content, literal_start, quote)?;
+                if content.get(literal_start..literal_end) == Some(property_name) {
+                    return Some((literal_start, property_name.len()));
+                }
+            }
+            _ if property_name == "modelValue" => {
+                return Some((define_model_pos, "defineModel".len()));
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn is_identifier_boundary(content: &str, start: usize, len: usize) -> bool {
+    let bytes = content.as_bytes();
+    let end = start + len;
+    let before = start.checked_sub(1).and_then(|index| bytes.get(index));
+    let after = bytes.get(end);
+    !before.is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$')
+        && !after.is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$')
+}
+
+fn find_string_literal_end(content: &str, start: usize, quote: u8) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut pos = start;
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'\\' => pos += 2,
+            byte if byte == quote => return Some(pos),
+            _ => pos += 1,
+        }
+    }
+    None
+}

--- a/crates/vize_maestro/src/ide/definition/helpers.rs
+++ b/crates/vize_maestro/src/ide/definition/helpers.rs
@@ -125,7 +125,9 @@ pub(crate) fn get_attribute_and_component_at_offset(
         }
 
         let mut attr_name = raw_attr_name;
-        if let Some(stripped) = attr_name.strip_prefix(':') {
+        if let Some(model_prop_name) = v_model_prop_name(raw_attr_name) {
+            return Some((model_prop_name, tag_name.to_string()));
+        } else if let Some(stripped) = attr_name.strip_prefix(':') {
             attr_name = stripped;
         } else if let Some(stripped) = attr_name.strip_prefix("v-bind:") {
             attr_name = stripped;
@@ -260,6 +262,83 @@ pub(crate) fn find_prop_in_define_props(content: &str, property_name: &str) -> O
     }
 
     None
+}
+
+/// Find the authored declaration anchor for a `defineModel` prop.
+///
+/// Argument-less `defineModel()` declares `modelValue`, whose prop key has no
+/// authored token, so the call identifier is the most useful jump target.
+/// Named models jump to the literal argument itself.
+pub(crate) fn find_prop_in_define_model(
+    content: &str,
+    property_name: &str,
+) -> Option<(usize, usize)> {
+    for (define_model_pos, _) in content.match_indices("defineModel") {
+        if !is_identifier_boundary(content, define_model_pos, "defineModel".len()) {
+            continue;
+        }
+
+        let after_name = &content[define_model_pos + "defineModel".len()..];
+        let paren_relative = after_name.find('(')?;
+        let args_start = define_model_pos + "defineModel".len() + paren_relative + 1;
+        let mut arg_start = args_start;
+        while arg_start < content.len() && content.as_bytes()[arg_start].is_ascii_whitespace() {
+            arg_start += 1;
+        }
+
+        match content.as_bytes().get(arg_start).copied() {
+            Some(b'\'' | b'"' | b'`') => {
+                let quote = content.as_bytes()[arg_start];
+                let literal_start = arg_start + 1;
+                let literal_end = find_string_literal_end(content, literal_start, quote)?;
+                if content.get(literal_start..literal_end) == Some(property_name) {
+                    return Some((literal_start, property_name.len()));
+                }
+            }
+            _ if property_name == "modelValue" => {
+                return Some((define_model_pos, "defineModel".len()));
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn is_identifier_boundary(content: &str, start: usize, len: usize) -> bool {
+    let bytes = content.as_bytes();
+    let end = start + len;
+    let before = start.checked_sub(1).and_then(|index| bytes.get(index));
+    let after = bytes.get(end);
+    !before.is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$')
+        && !after.is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$')
+}
+
+fn find_string_literal_end(content: &str, start: usize, quote: u8) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut pos = start;
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'\\' => pos += 2,
+            byte if byte == quote => return Some(pos),
+            _ => pos += 1,
+        }
+    }
+    None
+}
+
+fn v_model_prop_name(raw_attr_name: &str) -> Option<String> {
+    if raw_attr_name == "v-model" || raw_attr_name.starts_with("v-model.") {
+        return Some("modelValue".to_string());
+    }
+
+    let argument = raw_attr_name.strip_prefix("v-model:")?;
+    if argument.starts_with('[') {
+        return None;
+    }
+
+    let name = argument.split_once('.').map_or(argument, |(name, _)| name);
+    (!name.is_empty()).then(|| name.to_string())
 }
 
 /// Check if the cursor is inside a Vue directive expression.

--- a/crates/vize_maestro/src/ide/definition/helpers.rs
+++ b/crates/vize_maestro/src/ide/definition/helpers.rs
@@ -125,7 +125,9 @@ pub(crate) fn get_attribute_and_component_at_offset(
         }
 
         let mut attr_name = raw_attr_name;
-        if let Some(model_prop_name) = v_model_prop_name(raw_attr_name) {
+        if let Some(model_prop_name) =
+            super::component_model::prop_name_from_v_model_attribute(raw_attr_name)
+        {
             return Some((model_prop_name, tag_name.to_string()));
         } else if let Some(stripped) = attr_name.strip_prefix(':') {
             attr_name = stripped;
@@ -262,83 +264,6 @@ pub(crate) fn find_prop_in_define_props(content: &str, property_name: &str) -> O
     }
 
     None
-}
-
-/// Find the authored declaration anchor for a `defineModel` prop.
-///
-/// Argument-less `defineModel()` declares `modelValue`, whose prop key has no
-/// authored token, so the call identifier is the most useful jump target.
-/// Named models jump to the literal argument itself.
-pub(crate) fn find_prop_in_define_model(
-    content: &str,
-    property_name: &str,
-) -> Option<(usize, usize)> {
-    for (define_model_pos, _) in content.match_indices("defineModel") {
-        if !is_identifier_boundary(content, define_model_pos, "defineModel".len()) {
-            continue;
-        }
-
-        let after_name = &content[define_model_pos + "defineModel".len()..];
-        let paren_relative = after_name.find('(')?;
-        let args_start = define_model_pos + "defineModel".len() + paren_relative + 1;
-        let mut arg_start = args_start;
-        while arg_start < content.len() && content.as_bytes()[arg_start].is_ascii_whitespace() {
-            arg_start += 1;
-        }
-
-        match content.as_bytes().get(arg_start).copied() {
-            Some(b'\'' | b'"' | b'`') => {
-                let quote = content.as_bytes()[arg_start];
-                let literal_start = arg_start + 1;
-                let literal_end = find_string_literal_end(content, literal_start, quote)?;
-                if content.get(literal_start..literal_end) == Some(property_name) {
-                    return Some((literal_start, property_name.len()));
-                }
-            }
-            _ if property_name == "modelValue" => {
-                return Some((define_model_pos, "defineModel".len()));
-            }
-            _ => {}
-        }
-    }
-
-    None
-}
-
-fn is_identifier_boundary(content: &str, start: usize, len: usize) -> bool {
-    let bytes = content.as_bytes();
-    let end = start + len;
-    let before = start.checked_sub(1).and_then(|index| bytes.get(index));
-    let after = bytes.get(end);
-    !before.is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$')
-        && !after.is_some_and(|byte| byte.is_ascii_alphanumeric() || *byte == b'_' || *byte == b'$')
-}
-
-fn find_string_literal_end(content: &str, start: usize, quote: u8) -> Option<usize> {
-    let bytes = content.as_bytes();
-    let mut pos = start;
-    while pos < bytes.len() {
-        match bytes[pos] {
-            b'\\' => pos += 2,
-            byte if byte == quote => return Some(pos),
-            _ => pos += 1,
-        }
-    }
-    None
-}
-
-fn v_model_prop_name(raw_attr_name: &str) -> Option<String> {
-    if raw_attr_name == "v-model" || raw_attr_name.starts_with("v-model.") {
-        return Some("modelValue".to_string());
-    }
-
-    let argument = raw_attr_name.strip_prefix("v-model:")?;
-    if argument.starts_with('[') {
-        return None;
-    }
-
-    let name = argument.split_once('.').map_or(argument, |(name, _)| name);
-    (!name.is_empty()).then(|| name.to_string())
 }
 
 /// Check if the cursor is inside a Vue directive expression.

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -415,7 +415,8 @@ pub(crate) fn find_component_prop_definition(
     if let Some(ref script_setup) = descriptor.script_setup {
         let content = &script_setup.content;
 
-        if let Some(define_props_pos) = content.find("defineProps") {
+        let define_props_pos = content.find("defineProps");
+        if let Some(define_props_pos) = define_props_pos {
             let after_define_props = &content[define_props_pos..];
 
             if let Some(prop_pos) =
@@ -436,7 +437,28 @@ pub(crate) fn find_component_prop_definition(
                     },
                 }));
             }
+        }
 
+        if let Some((model_pos, model_len)) =
+            helpers::find_prop_in_define_model(content, &prop_name)
+        {
+            let sfc_offset = script_setup.loc.start + model_pos;
+            let (line, character) = helpers::offset_to_position(&component_content, sfc_offset);
+
+            let file_uri = tower_lsp::lsp_types::Url::from_file_path(&resolved_path).ok()?;
+            return Some(GotoDefinitionResponse::Scalar(Location {
+                uri: file_uri,
+                range: Range {
+                    start: Position { line, character },
+                    end: Position {
+                        line,
+                        character: character + model_len as u32,
+                    },
+                },
+            }));
+        }
+
+        if let Some(define_props_pos) = define_props_pos {
             // Fallback: jump to defineProps
             let sfc_offset = script_setup.loc.start + define_props_pos;
             let (line, character) = helpers::offset_to_position(&component_content, sfc_offset);

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -399,7 +399,7 @@ pub(crate) fn find_component_prop_definition(
     }
 
     let import_path = helpers::find_import_path(ctx, &component_name)
-        .or_else(|| art_component_path(ctx, &component_name))?;
+        .or_else(|| super::art::component_path(ctx, &component_name))?;
     let resolved_path = helpers::resolve_import_path(ctx.uri, &import_path)?;
     let component_content = std::fs::read_to_string(&resolved_path).ok()?;
 
@@ -440,7 +440,7 @@ pub(crate) fn find_component_prop_definition(
         }
 
         if let Some((model_pos, model_len)) =
-            helpers::find_prop_in_define_model(content, &prop_name)
+            super::component_model::find_prop_in_define_model(content, &prop_name)
         {
             let sfc_offset = script_setup.loc.start + model_pos;
             let (line, character) = helpers::offset_to_position(&component_content, sfc_offset);
@@ -566,7 +566,7 @@ pub(crate) fn find_component_definition(
         }
     }
 
-    if let Some(import_path) = art_component_path(ctx, tag_name)
+    if let Some(import_path) = super::art::component_path(ctx, tag_name)
         && let Some(resolved) = helpers::resolve_import_path(ctx.uri, &import_path)
         && let Some(location) = component_file_location(ctx, &resolved)
     {
@@ -595,46 +595,6 @@ fn component_file_location(ctx: &IdeContext<'_>, path: &std::path::Path) -> Opti
             },
         },
     })
-}
-
-fn art_component_path(ctx: &IdeContext<'_>, component_name: &str) -> Option<String> {
-    if !ctx.uri.path().ends_with(".art.vue") {
-        return None;
-    }
-
-    let allocator = vize_carton::Allocator::new();
-    let art_desc = vize_musea::parse_art(
-        &allocator,
-        &ctx.content,
-        vize_musea::ArtParseOptions::default(),
-    )
-    .ok()?;
-    let component_path = art_desc.metadata.component?;
-    let descriptor = vize_atelier_sfc::parse_sfc(
-        &ctx.content,
-        vize_atelier_sfc::SfcParseOptions {
-            filename: ctx.uri.path().to_string().into(),
-            ..Default::default()
-        },
-    )
-    .ok()?;
-    if let Some(script_setup) = descriptor.script_setup.as_ref()
-        && let Some(defined_component) =
-            crate::virtual_code::find_define_art_component_name(script_setup.content.as_ref())
-    {
-        let pascal_component = kebab_to_pascal(component_name);
-        if component_name == defined_component || pascal_component == defined_component {
-            return Some(component_path.to_string());
-        }
-    }
-
-    let stem = std::path::Path::new(component_path)
-        .file_stem()
-        .and_then(|stem| stem.to_str())?;
-
-    let pascal_component = kebab_to_pascal(component_name);
-    let pascal_stem = kebab_to_pascal(stem);
-    (component_name == stem || pascal_component == pascal_stem).then(|| component_path.to_string())
 }
 
 /// Find definition for a prop name used directly in template.

--- a/crates/vize_maestro/src/ide/definition/tests/basics.rs
+++ b/crates/vize_maestro/src/ide/definition/tests/basics.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use tower_lsp::lsp_types::Url;
 
-use super::super::{BindingKind, bindings, helpers, script};
+use super::super::{BindingKind, bindings, component_model, helpers, script};
 use crate::{ide::IdeContext, server::ServerState};
 
 #[test]
@@ -238,13 +238,13 @@ const value = defineModel<string>({ required: true })
 const title = defineModel<number>('title')
 "#;
 
-    let default = helpers::find_prop_in_define_model(content, "modelValue").unwrap();
+    let default = component_model::find_prop_in_define_model(content, "modelValue").unwrap();
     assert_eq!(&content[default.0..default.0 + default.1], "defineModel");
 
-    let title = helpers::find_prop_in_define_model(content, "title").unwrap();
+    let title = component_model::find_prop_in_define_model(content, "title").unwrap();
     assert_eq!(&content[title.0..title.0 + title.1], "title");
 
-    assert!(helpers::find_prop_in_define_model(content, "missing").is_none());
+    assert!(component_model::find_prop_in_define_model(content, "missing").is_none());
 }
 
 #[test]

--- a/crates/vize_maestro/src/ide/definition/tests/basics.rs
+++ b/crates/vize_maestro/src/ide/definition/tests/basics.rs
@@ -124,6 +124,42 @@ fn test_get_attribute_and_component_at_offset_only_matches_attribute_name() {
 }
 
 #[test]
+fn test_get_attribute_and_component_at_offset_maps_v_model_props() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("Parent.vue");
+    let content = r#"<template><Child v-model="model" v-model:title.trim="title" v-model:[dynamic]="value" /></template>"#;
+    fs::write(&file_path, content).unwrap();
+
+    let uri = Url::from_file_path(&file_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), content.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, content);
+
+    let default_offset = content.find("v-model=").unwrap() + "v-model".len();
+    let default_ctx = IdeContext::new(&state, &uri, default_offset).unwrap();
+    assert_eq!(
+        helpers::get_attribute_and_component_at_offset(&default_ctx),
+        Some(("modelValue".to_string(), "Child".to_string()))
+    );
+
+    let title_offset = content.find("v-model:title").unwrap() + "v-model:title".len();
+    let title_ctx = IdeContext::new(&state, &uri, title_offset).unwrap();
+    assert_eq!(
+        helpers::get_attribute_and_component_at_offset(&title_ctx),
+        Some(("title".to_string(), "Child".to_string()))
+    );
+
+    let dynamic_offset = content.find("v-model:[dynamic]").unwrap() + "v-model".len();
+    let dynamic_ctx = IdeContext::new(&state, &uri, dynamic_offset).unwrap();
+    assert_eq!(
+        helpers::get_attribute_and_component_at_offset(&dynamic_ctx),
+        None
+    );
+}
+
+#[test]
 fn test_is_valid_identifier() {
     assert!(bindings::is_valid_identifier("foo"));
     assert!(bindings::is_valid_identifier("_foo"));
@@ -193,6 +229,22 @@ fn test_find_prop_in_define_props() {
 
     let pos = helpers::find_prop_in_define_props(content, "nonExistent");
     assert!(pos.is_none());
+}
+
+#[test]
+fn test_find_prop_in_define_model() {
+    let content = r#"
+const value = defineModel<string>({ required: true })
+const title = defineModel<number>('title')
+"#;
+
+    let default = helpers::find_prop_in_define_model(content, "modelValue").unwrap();
+    assert_eq!(&content[default.0..default.0 + default.1], "defineModel");
+
+    let title = helpers::find_prop_in_define_model(content, "title").unwrap();
+    assert_eq!(&content[title.0..title.0 + title.1], "title");
+
+    assert!(helpers::find_prop_in_define_model(content, "missing").is_none());
 }
 
 #[test]

--- a/crates/vize_maestro/src/ide/hover.rs
+++ b/crates/vize_maestro/src/ide/hover.rs
@@ -27,6 +27,8 @@ mod html;
 mod petite_vue;
 mod script;
 mod template;
+#[cfg(feature = "native")]
+mod v_model;
 
 pub use builder::HoverBuilder;
 #[cfg(feature = "native")]

--- a/crates/vize_maestro/src/ide/hover.rs
+++ b/crates/vize_maestro/src/ide/hover.rs
@@ -5,8 +5,6 @@
 //! - Vue directives
 //! - Script bindings and imports
 //! - CSS properties and Vue-specific selectors
-//! - TypeScript type information from croquis analysis
-//! - Real type information from Corsa (when available)
 #![allow(
     clippy::disallowed_types,
     clippy::disallowed_methods,

--- a/crates/vize_maestro/src/ide/hover/corsa.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa.rs
@@ -125,13 +125,6 @@ impl HoverService {
     ) -> Option<Hover> {
         let word = Self::get_word_at_offset(&ctx.content, ctx.offset);
 
-        // Check for Vue directives first; these do not need Corsa.
-        if !word.is_empty()
-            && let Some(hover) = Self::hover_directive(&word)
-        {
-            return Some(hover);
-        }
-
         if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset)
             && let Some(mut hover) = Self::hover_component_tag(ctx)
         {
@@ -147,6 +140,12 @@ impl HoverService {
             if hover.range.is_none() {
                 hover.range = authored_hover_token_range(ctx);
             }
+            return Some(hover);
+        }
+
+        if !word.is_empty()
+            && let Some(hover) = Self::hover_directive(&word)
+        {
             return Some(hover);
         }
 
@@ -325,6 +324,15 @@ impl HoverService {
 }
 
 fn authored_hover_token_range(ctx: &IdeContext<'_>) -> Option<Range> {
+    if let Some((start, end)) = v_model_argument_token_span(&ctx.content, ctx.offset) {
+        let (start_line, start_character) = crate::ide::offset_to_position(&ctx.content, start);
+        let (end_line, end_character) = crate::ide::offset_to_position(&ctx.content, end);
+        return Some(Range::new(
+            Position::new(start_line, start_character),
+            Position::new(end_line, end_character),
+        ));
+    }
+
     let (start, end) =
         crate::ide::token_span_at_offset(&ctx.content, ctx.offset, HoverService::is_word_char)?;
     let (start_line, start_character) = crate::ide::offset_to_position(&ctx.content, start);
@@ -333,4 +341,24 @@ fn authored_hover_token_range(ctx: &IdeContext<'_>) -> Option<Range> {
         Position::new(start_line, start_character),
         Position::new(end_line, end_character),
     ))
+}
+
+fn v_model_argument_token_span(content: &str, offset: usize) -> Option<(usize, usize)> {
+    let (token_start, token_end) =
+        crate::ide::token_span_at_offset(content, offset, HoverService::is_word_char)?;
+    let token = content.get(token_start..token_end)?;
+    let argument = token.strip_prefix("v-model:")?;
+    if argument.starts_with('[') {
+        return None;
+    }
+
+    let argument_len = argument
+        .split_once('.')
+        .map_or(argument.len(), |(name, _)| name.len());
+    if argument_len == 0 {
+        return None;
+    }
+
+    let start = token_start + "v-model:".len();
+    Some((start, start + argument_len))
 }

--- a/crates/vize_maestro/src/ide/hover/corsa.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa.rs
@@ -324,7 +324,7 @@ impl HoverService {
 }
 
 fn authored_hover_token_range(ctx: &IdeContext<'_>) -> Option<Range> {
-    if let Some((start, end)) = v_model_argument_token_span(&ctx.content, ctx.offset) {
+    if let Some((start, end)) = super::v_model::argument_token_span(&ctx.content, ctx.offset) {
         let (start_line, start_character) = crate::ide::offset_to_position(&ctx.content, start);
         let (end_line, end_character) = crate::ide::offset_to_position(&ctx.content, end);
         return Some(Range::new(
@@ -341,24 +341,4 @@ fn authored_hover_token_range(ctx: &IdeContext<'_>) -> Option<Range> {
         Position::new(start_line, start_character),
         Position::new(end_line, end_character),
     ))
-}
-
-fn v_model_argument_token_span(content: &str, offset: usize) -> Option<(usize, usize)> {
-    let (token_start, token_end) =
-        crate::ide::token_span_at_offset(content, offset, HoverService::is_word_char)?;
-    let token = content.get(token_start..token_end)?;
-    let argument = token.strip_prefix("v-model:")?;
-    if argument.starts_with('[') {
-        return None;
-    }
-
-    let argument_len = argument
-        .split_once('.')
-        .map_or(argument.len(), |(name, _)| name.len());
-    if argument_len == 0 {
-        return None;
-    }
-
-    let start = token_start + "v-model:".len();
-    Some((start, start + argument_len))
 }

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -24,15 +24,15 @@ impl HoverService {
             return None;
         }
 
-        if let Some(hover) = Self::hover_directive(&word) {
-            return Some(hover);
-        }
-
         if let Some(hover) = Self::hover_component_tag(ctx) {
             return Some(hover);
         }
 
         if let Some(hover) = super::component_prop::hover_attribute(ctx) {
+            return Some(hover);
+        }
+
+        if let Some(hover) = Self::hover_directive(&word) {
             return Some(hover);
         }
 

--- a/crates/vize_maestro/src/ide/hover/v_model.rs
+++ b/crates/vize_maestro/src/ide/hover/v_model.rs
@@ -1,0 +1,24 @@
+//! Hover range helpers for component `v-model` attributes.
+#![cfg(feature = "native")]
+
+use super::HoverService;
+
+pub(super) fn argument_token_span(content: &str, offset: usize) -> Option<(usize, usize)> {
+    let (token_start, token_end) =
+        crate::ide::token_span_at_offset(content, offset, HoverService::is_word_char)?;
+    let token = content.get(token_start..token_end)?;
+    let argument = token.strip_prefix("v-model:")?;
+    if argument.starts_with('[') {
+        return None;
+    }
+
+    let argument_len = argument
+        .split_once('.')
+        .map_or(argument.len(), |(name, _)| name.len());
+    if argument_len == 0 {
+        return None;
+    }
+
+    let start = token_start + "v-model:".len();
+    Some((start, start + argument_len))
+}

--- a/tests/tooling/lsp-component-v-model-type-backed.test.ts
+++ b/tests/tooling/lsp-component-v-model-type-backed.test.ts
@@ -1,0 +1,255 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import {
+  firstLocation,
+  hoverToText,
+  isDiagnosticsForUri,
+  offsetToPosition,
+} from "./support/lsp/assertions.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
+
+const source = `<script setup lang="ts">
+import { ref } from 'vue'
+import Child from './Child.vue'
+
+const model = ref('hello')
+</script>
+
+<template>
+  <Child v-model="model" v-model:title="model" />
+</template>
+`;
+
+const childSource = `<script setup lang="ts">
+const value = defineModel<string>({ required: true })
+const title = defineModel<string>('title', { required: true })
+void value
+void title
+</script>
+
+<template>{{ value }} {{ title }}</template>
+`;
+
+test("component v-model hover and definition use the child model contract", async (t) => {
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTsgoBinary(),
+    "tsgo binary for component v-model hover",
+    "tsgo binary not found; skipping component v-model hover test",
+  );
+  if (corsaPath == null) return;
+
+  const testRootDir = path.join(testOutputRoot, "lsp-component-v-model-type-backed");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+  let initialized = false;
+
+  try {
+    fs.mkdirSync(path.join(workspaceDir, "src"), { recursive: true });
+    linkVuePackage(workspaceDir);
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify({
+        lsp: { hover: true, lint: false, typecheck: true },
+        typeChecker: { corsaPath },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          lib: ["ES2022", "DOM", "DOM.Iterable"],
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+          skipLibCheck: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src/**/*.vue"],
+      }),
+    );
+
+    const childPath = path.join(workspaceDir, "src/Child.vue");
+    const childUri = pathToFileURL(childPath).href;
+    fs.writeFileSync(childPath, childSource, "utf8");
+    const filePath = path.join(workspaceDir, "src/App.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+    await session.initialize(workspaceDir, {
+      editor: true,
+      hover: true,
+      lint: false,
+      typecheck: true,
+    });
+    initialized = true;
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: source },
+    });
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri),
+      120_000,
+    );
+
+    const defaultModel = rangeFor("v-model", source.indexOf("v-model="));
+    const namedModel = rangeFor("title", source.indexOf("v-model:title"));
+    const childDefaultModel = rangeForIn(
+      childSource,
+      "defineModel",
+      childSource.indexOf("defineModel<string>({"),
+    );
+    const childNamedModel = rangeForIn(childSource, "title", childSource.indexOf("'title'"));
+
+    const defaultHover = await hoverAt(session, uri, defaultModel.start);
+    assert.deepEqual(
+      defaultHover?.range,
+      defaultModel,
+      "argument-less component v-model hover must select the authored directive",
+    );
+    const defaultHoverText = hoverToText(defaultHover);
+    assert.match(defaultHoverText, /modelValue/);
+    assert.match(defaultHoverText, /string/);
+    assertNoDirectiveFallback(defaultHoverText);
+    await assertDefinitionUriAndRange(
+      session,
+      uri,
+      defaultModel.start,
+      childUri,
+      childDefaultModel,
+      "argument-less component v-model",
+    );
+
+    const namedHover = await hoverAt(session, uri, namedModel.start);
+    assert.deepEqual(
+      namedHover?.range,
+      namedModel,
+      "named component v-model hover must select the authored model argument",
+    );
+    const namedHoverText = hoverToText(namedHover);
+    assert.match(namedHoverText, /title/);
+    assert.match(namedHoverText, /string/);
+    assertNoDirectiveFallback(namedHoverText);
+    await assertDefinitionUriAndRange(
+      session,
+      uri,
+      namedModel.start,
+      childUri,
+      childNamedModel,
+      "named component v-model",
+    );
+  } finally {
+    if (initialized) {
+      await session.shutdown();
+    } else {
+      await session.kill().catch(() => undefined);
+    }
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+type Position = { line: number; character: number };
+
+type Range = { start: Position; end: Position };
+
+type Hover = {
+  contents?: unknown;
+  range?: Range;
+} | null;
+
+async function hoverAt(session: LspSession, uri: string, position: Position): Promise<Hover> {
+  return (await session.request(
+    "textDocument/hover",
+    {
+      textDocument: { uri },
+      position,
+    },
+    120_000,
+  )) as Hover;
+}
+
+async function assertDefinitionUriAndRange(
+  session: LspSession,
+  uri: string,
+  position: Position,
+  expectedUri: string,
+  expectedRange: Range,
+  label: string,
+): Promise<void> {
+  const response = await session.request(
+    "textDocument/definition",
+    {
+      textDocument: { uri },
+      position,
+    },
+    120_000,
+  );
+  assert.deepEqual(
+    firstLocation(response as Parameters<typeof firstLocation>[0]),
+    {
+      range: expectedRange,
+      uri: expectedUri,
+    },
+    `${label} definition must jump to the child defineModel declaration`,
+  );
+}
+
+function rangeFor(symbol: string, nearOffset: number): Range {
+  return rangeForIn(source, symbol, nearOffset);
+}
+
+function rangeForIn(document: string, symbol: string, nearOffset: number): Range {
+  const startOffset = document.indexOf(symbol, nearOffset);
+  assert.ok(startOffset >= 0, `missing ${symbol} near ${nearOffset}`);
+  return {
+    start: offsetToPosition(document, startOffset),
+    end: offsetToPosition(document, startOffset + symbol.length),
+  };
+}
+
+function assertNoDirectiveFallback(hoverText: string): void {
+  assert.notEqual(hoverText.trim(), "");
+  assert.doesNotMatch(hoverText, /Vue directive/);
+  assert.doesNotMatch(hoverText, /Template expression/);
+  assert.doesNotMatch(hoverText, /MaybeRef<unknown>/);
+}
+
+function resolveTsgoBinary(): string | undefined {
+  const candidates = [
+    process.env.CORSA_BIN,
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ].filter((candidate): candidate is string => candidate != null && candidate.length > 0);
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function linkVuePackage(workspaceDir: string): void {
+  const vuePackage = [
+    path.join(root, "node_modules/vue"),
+    path.join(root, "tests/node_modules/vue"),
+  ].find((candidate) => fs.existsSync(candidate));
+  assert.ok(vuePackage, "Vue package is required for type-backed hover test");
+
+  const nodeModules = path.join(workspaceDir, "node_modules");
+  fs.mkdirSync(nodeModules, { recursive: true });
+  symlink(vuePackage, path.join(nodeModules, "vue"));
+
+  const vueNamespace = path.join(path.dirname(vuePackage), "@vue");
+  if (fs.existsSync(vueNamespace)) {
+    symlink(vueNamespace, path.join(nodeModules, "@vue"));
+  }
+}
+
+function symlink(source: string, target: string): void {
+  fs.rmSync(target, { force: true, recursive: true });
+  fs.symlinkSync(source, target, process.platform === "win32" ? "junction" : "dir");
+}


### PR DESCRIPTION
## Summary

- map component `v-model` and `v-model:name` attributes to child `defineModel` contracts
- make hover ranges point at authored directives or model arguments instead of generated spans
- keep model navigation scanners and shared `.art.vue` lookup in focused helper modules so source-length gates stay green

Refs #4592.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p vize_maestro --tests -- -D warnings`
- `cargo test -p vize_maestro definition --features native`
- `cargo build -p vize`
- `CORSA_BIN=/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.bin/tsgo VIZE_LSP_BIN=/tmp/vize-p0-vmodel.sd5dKt/target/debug/vize node --test tests/tooling/lsp-component-v-model-type-backed.test.ts`
- `MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts`
- `./node_modules/.bin/vp check crates/vize_maestro/src/ide/definition/art.rs crates/vize_maestro/src/ide/definition/component_model.rs crates/vize_maestro/src/ide/definition.rs crates/vize_maestro/src/ide/definition/helpers.rs crates/vize_maestro/src/ide/definition/template.rs crates/vize_maestro/src/ide/definition/tests/basics.rs crates/vize_maestro/src/ide/hover/v_model.rs crates/vize_maestro/src/ide/hover.rs crates/vize_maestro/src/ide/hover/corsa.rs tests/tooling/lsp-component-v-model-type-backed.test.ts`
