### PR TITLE
test(maestro): gate reactive editor hover contracts

### DIFF
--- a/editors/nvim/test/ref_surface_hover.lua
+++ b/editors/nvim/test/ref_surface_hover.lua
@@ -1,0 +1,94 @@
+local M = {}
+
+local function write_file(path, contents)
+  local handle = assert(io.open(path, "w"))
+  handle:write(contents)
+  handle:close()
+end
+
+local function assert_ref_surface_hover(ctx, bufnr, uri, position, expected_hover, label)
+  local result = ctx.request(ctx.client, bufnr, "textDocument/hover", {
+    position = position,
+    textDocument = { uri = uri },
+  })
+  ctx.assert_eq(result, expected_hover, label)
+  assert(
+    not result.contents.value:match("Ref<unknown>")
+      and not result.contents.value:match("ComputedRef<unknown>")
+      and not result.contents.value:match("MaybeRef<unknown>"),
+    label .. " degraded to an unknown reactive type: " .. result.contents.value
+  )
+end
+
+function M.run(ctx)
+  local ref_path = ctx.workspace_path .. "/src/RefSurface.vue"
+  write_file(ref_path, ctx.expected.ref_surface_source)
+  vim.cmd("edit " .. vim.fn.fnameescape(ref_path))
+
+  local ref_bufnr = vim.api.nvim_get_current_buf()
+  ctx.assert_eq(vim.bo[ref_bufnr].filetype, "vue", "RefSurface fixture filetype")
+  assert(vim.lsp.buf_attach_client(ref_bufnr, ctx.client.id), "RefSurface buffer did not attach")
+
+  local ref_uri = vim.uri_from_bufnr(ref_bufnr)
+  local settled = vim.wait(180000, function()
+    return ctx.published[ref_uri] ~= nil
+  end, 100)
+  if not settled then
+    ctx.fail("real server did not publish RefSurface diagnostics", ctx.published)
+  end
+  ctx.assert_eq(ctx.published[ref_uri], {}, "RefSurface diagnostics")
+
+  local hovers = ctx.expected.ref_surface_hovers
+  assert_ref_surface_hover(
+    ctx,
+    ref_bufnr,
+    ref_uri,
+    { character = 8, line = 3 },
+    hovers.script_count,
+    "script ref hover"
+  )
+  assert_ref_surface_hover(
+    ctx,
+    ref_bufnr,
+    ref_uri,
+    { character = 8, line = 4 },
+    hovers.script_doubled,
+    "script computed hover"
+  )
+  assert_ref_surface_hover(
+    ctx,
+    ref_bufnr,
+    ref_uri,
+    { character = 8, line = 5 },
+    hovers.script_button,
+    "script template-ref hover"
+  )
+  assert_ref_surface_hover(
+    ctx,
+    ref_bufnr,
+    ref_uri,
+    { character = 28, line = 9 },
+    hovers.template_count,
+    "template ref hover"
+  )
+  assert_ref_surface_hover(
+    ctx,
+    ref_bufnr,
+    ref_uri,
+    { character = 40, line = 9 },
+    hovers.template_doubled,
+    "template computed hover"
+  )
+  assert_ref_surface_hover(
+    ctx,
+    ref_bufnr,
+    ref_uri,
+    { character = 54, line = 9 },
+    hovers.template_button,
+    "template template-ref hover"
+  )
+
+  vim.api.nvim_set_current_buf(ctx.scenario_bufnr)
+end
+
+return M

--- a/editors/nvim/test/vize_e2e_expected.lua
+++ b/editors/nvim/test/vize_e2e_expected.lua
@@ -35,11 +35,27 @@ local formatted_source =
 local renamed_source = replace_once(formatted_source, "const total =", "const quantity =")
 renamed_source = replace_once(renamed_source, ':count="total"', ':count="quantity"')
 
+local ref_surface_source = table.concat({
+  '<script setup lang="ts">',
+  'import { computed, ref, useTemplateRef } from "vue";',
+  "",
+  "const count = ref(1);",
+  "const doubled = computed(() => count.value * 2);",
+  'const button = useTemplateRef<HTMLButtonElement>("button");',
+  "</script>",
+  "",
+  "<template>",
+  '  <button ref="button">{{ count }} {{ doubled }} {{ button }}</button>',
+  "</template>",
+  "",
+}, "\n")
+
 return {
   authored_source = authored_source,
   quick_fixed_source = quick_fixed_source,
   formatted_source = formatted_source,
   renamed_source = renamed_source,
+  ref_surface_source = ref_surface_source,
 
   -- The authored `<Child  :count="total" />` carries two independent authored
   -- bugs on one line: two spaces after the tag name (a fixable lint warning)
@@ -82,6 +98,69 @@ return {
     range = {
       ["end"] = { character = 11, line = 3 },
       start = { character = 6, line = 3 },
+    },
+  },
+
+  ref_surface_hovers = {
+    script_count = {
+      contents = {
+        kind = "markdown",
+        value = "```typescript\nconst count: Ref<number, number>\n```",
+      },
+      range = {
+        ["end"] = { character = 11, line = 3 },
+        start = { character = 6, line = 3 },
+      },
+    },
+    script_doubled = {
+      contents = {
+        kind = "markdown",
+        value = "```typescript\nconst doubled: ComputedRef<number>\n```",
+      },
+      range = {
+        ["end"] = { character = 13, line = 4 },
+        start = { character = 6, line = 4 },
+      },
+    },
+    script_button = {
+      contents = {
+        kind = "markdown",
+        value = "```typescript\nconst button: Readonly<ShallowRef<HTMLButtonElement | null, HTMLButtonElement | null>>\n```",
+      },
+      range = {
+        ["end"] = { character = 12, line = 5 },
+        start = { character = 6, line = 5 },
+      },
+    },
+    template_count = {
+      contents = {
+        kind = "markdown",
+        value = "```typescript\nconst count: number\n```",
+      },
+      range = {
+        ["end"] = { character = 31, line = 9 },
+        start = { character = 26, line = 9 },
+      },
+    },
+    template_doubled = {
+      contents = {
+        kind = "markdown",
+        value = "```typescript\nconst doubled: number\n```",
+      },
+      range = {
+        ["end"] = { character = 45, line = 9 },
+        start = { character = 38, line = 9 },
+      },
+    },
+    template_button = {
+      contents = {
+        kind = "markdown",
+        value = "```typescript\nconst button: HTMLButtonElement | null\n```",
+      },
+      range = {
+        ["end"] = { character = 58, line = 9 },
+        start = { character = 52, line = 9 },
+      },
     },
   },
 

--- a/editors/nvim/test/vize_e2e_spec.lua
+++ b/editors/nvim/test/vize_e2e_spec.lua
@@ -19,6 +19,7 @@ local plugin_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:
 vim.opt.runtimepath:prepend(plugin_root)
 
 local expected = dofile(plugin_root .. "/test/vize_e2e_expected.lua")
+local ref_surface_hover = dofile(plugin_root .. "/test/ref_surface_hover.lua")
 local config = require("vize.config")
 
 local server_path = os.getenv("VIZE_E2E_SERVER")
@@ -51,12 +52,6 @@ local function read_file(path)
   local contents = handle:read("*a")
   handle:close()
   return contents
-end
-
-local function write_file(path, contents)
-  local handle = assert(io.open(path, "w"))
-  handle:write(contents)
-  handle:close()
 end
 
 local function sorted_by_start(diagnostics)
@@ -136,91 +131,6 @@ local function step_hover(client, bufnr, uri)
     textDocument = { uri = uri },
   })
   assert_eq(result, expected.hover, "script binding hover")
-end
-
-local function assert_ref_surface_hover(client, bufnr, uri, position, expected_hover, label)
-  local result = request(client, bufnr, "textDocument/hover", {
-    position = position,
-    textDocument = { uri = uri },
-  })
-  assert_eq(result, expected_hover, label)
-  assert(
-    not result.contents.value:match("Ref<unknown>")
-      and not result.contents.value:match("ComputedRef<unknown>")
-      and not result.contents.value:match("MaybeRef<unknown>"),
-    label .. " degraded to an unknown reactive type: " .. result.contents.value
-  )
-end
-
---- Step 3b: ref/computed/template-ref hover text stays precise outside VS Code.
-local function step_typed_ref_hover_surfaces(client, scenario_bufnr, published)
-  local ref_path = workspace_path .. "/src/RefSurface.vue"
-  write_file(ref_path, expected.ref_surface_source)
-  vim.cmd("edit " .. vim.fn.fnameescape(ref_path))
-
-  local ref_bufnr = vim.api.nvim_get_current_buf()
-  assert_eq(vim.bo[ref_bufnr].filetype, "vue", "RefSurface fixture filetype")
-  assert(vim.lsp.buf_attach_client(ref_bufnr, client.id), "RefSurface buffer did not attach")
-
-  local ref_uri = vim.uri_from_bufnr(ref_bufnr)
-  local settled = vim.wait(180000, function()
-    return published[ref_uri] ~= nil
-  end, 100)
-  if not settled then
-    fail("real server did not publish RefSurface diagnostics", published)
-  end
-  assert_eq(published[ref_uri], {}, "RefSurface diagnostics")
-
-  assert_ref_surface_hover(
-    client,
-    ref_bufnr,
-    ref_uri,
-    { character = 8, line = 3 },
-    expected.ref_surface_hovers.script_count,
-    "script ref hover"
-  )
-  assert_ref_surface_hover(
-    client,
-    ref_bufnr,
-    ref_uri,
-    { character = 8, line = 4 },
-    expected.ref_surface_hovers.script_doubled,
-    "script computed hover"
-  )
-  assert_ref_surface_hover(
-    client,
-    ref_bufnr,
-    ref_uri,
-    { character = 8, line = 5 },
-    expected.ref_surface_hovers.script_button,
-    "script template-ref hover"
-  )
-  assert_ref_surface_hover(
-    client,
-    ref_bufnr,
-    ref_uri,
-    { character = 28, line = 9 },
-    expected.ref_surface_hovers.template_count,
-    "template ref hover"
-  )
-  assert_ref_surface_hover(
-    client,
-    ref_bufnr,
-    ref_uri,
-    { character = 40, line = 9 },
-    expected.ref_surface_hovers.template_doubled,
-    "template computed hover"
-  )
-  assert_ref_surface_hover(
-    client,
-    ref_bufnr,
-    ref_uri,
-    { character = 54, line = 9 },
-    expected.ref_surface_hovers.template_button,
-    "template template-ref hover"
-  )
-
-  vim.api.nvim_set_current_buf(scenario_bufnr)
 end
 
 --- Step 4: the quick fix the server offers on the lint warning's own span.
@@ -375,7 +285,16 @@ local function main()
   step_diagnostics(uri, published)
   step_completion(client, bufnr, uri)
   step_hover(client, bufnr, uri)
-  step_typed_ref_hover_surfaces(client, bufnr, published)
+  ref_surface_hover.run({
+    assert_eq = assert_eq,
+    client = client,
+    expected = expected,
+    fail = fail,
+    published = published,
+    request = request,
+    scenario_bufnr = bufnr,
+    workspace_path = workspace_path,
+  })
   step_quick_fix(client, bufnr, uri, offset_encoding)
   step_format_on_save(client, bufnr, uri, scenario_path, published_version_counts)
   step_semantic_tokens(client, bufnr, uri)

--- a/editors/nvim/test/vize_e2e_spec.lua
+++ b/editors/nvim/test/vize_e2e_spec.lua
@@ -53,6 +53,12 @@ local function read_file(path)
   return contents
 end
 
+local function write_file(path, contents)
+  local handle = assert(io.open(path, "w"))
+  handle:write(contents)
+  handle:close()
+end
+
 local function sorted_by_start(diagnostics)
   local sorted = vim.deepcopy(diagnostics)
   table.sort(sorted, function(left, right)
@@ -130,6 +136,91 @@ local function step_hover(client, bufnr, uri)
     textDocument = { uri = uri },
   })
   assert_eq(result, expected.hover, "script binding hover")
+end
+
+local function assert_ref_surface_hover(client, bufnr, uri, position, expected_hover, label)
+  local result = request(client, bufnr, "textDocument/hover", {
+    position = position,
+    textDocument = { uri = uri },
+  })
+  assert_eq(result, expected_hover, label)
+  assert(
+    not result.contents.value:match("Ref<unknown>")
+      and not result.contents.value:match("ComputedRef<unknown>")
+      and not result.contents.value:match("MaybeRef<unknown>"),
+    label .. " degraded to an unknown reactive type: " .. result.contents.value
+  )
+end
+
+--- Step 3b: ref/computed/template-ref hover text stays precise outside VS Code.
+local function step_typed_ref_hover_surfaces(client, scenario_bufnr, published)
+  local ref_path = workspace_path .. "/src/RefSurface.vue"
+  write_file(ref_path, expected.ref_surface_source)
+  vim.cmd("edit " .. vim.fn.fnameescape(ref_path))
+
+  local ref_bufnr = vim.api.nvim_get_current_buf()
+  assert_eq(vim.bo[ref_bufnr].filetype, "vue", "RefSurface fixture filetype")
+  assert(vim.lsp.buf_attach_client(ref_bufnr, client.id), "RefSurface buffer did not attach")
+
+  local ref_uri = vim.uri_from_bufnr(ref_bufnr)
+  local settled = vim.wait(180000, function()
+    return published[ref_uri] ~= nil
+  end, 100)
+  if not settled then
+    fail("real server did not publish RefSurface diagnostics", published)
+  end
+  assert_eq(published[ref_uri], {}, "RefSurface diagnostics")
+
+  assert_ref_surface_hover(
+    client,
+    ref_bufnr,
+    ref_uri,
+    { character = 8, line = 3 },
+    expected.ref_surface_hovers.script_count,
+    "script ref hover"
+  )
+  assert_ref_surface_hover(
+    client,
+    ref_bufnr,
+    ref_uri,
+    { character = 8, line = 4 },
+    expected.ref_surface_hovers.script_doubled,
+    "script computed hover"
+  )
+  assert_ref_surface_hover(
+    client,
+    ref_bufnr,
+    ref_uri,
+    { character = 8, line = 5 },
+    expected.ref_surface_hovers.script_button,
+    "script template-ref hover"
+  )
+  assert_ref_surface_hover(
+    client,
+    ref_bufnr,
+    ref_uri,
+    { character = 28, line = 9 },
+    expected.ref_surface_hovers.template_count,
+    "template ref hover"
+  )
+  assert_ref_surface_hover(
+    client,
+    ref_bufnr,
+    ref_uri,
+    { character = 40, line = 9 },
+    expected.ref_surface_hovers.template_doubled,
+    "template computed hover"
+  )
+  assert_ref_surface_hover(
+    client,
+    ref_bufnr,
+    ref_uri,
+    { character = 54, line = 9 },
+    expected.ref_surface_hovers.template_button,
+    "template template-ref hover"
+  )
+
+  vim.api.nvim_set_current_buf(scenario_bufnr)
 end
 
 --- Step 4: the quick fix the server offers on the lint warning's own span.
@@ -284,6 +375,7 @@ local function main()
   step_diagnostics(uri, published)
   step_completion(client, bufnr, uri)
   step_hover(client, bufnr, uri)
+  step_typed_ref_hover_surfaces(client, bufnr, published)
   step_quick_fix(client, bufnr, uri, offset_encoding)
   step_format_on_save(client, bufnr, uri, scenario_path, published_version_counts)
   step_semantic_tokens(client, bufnr, uri)

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -208,6 +208,8 @@ test("the packaged Neovim archive ships the real-server scenario", () => {
 
   assert.match(assertion, /"nvim\/test\/vize_e2e_expected\.lua"/);
   assert.match(assertion, /"nvim\/test\/vize_e2e_spec\.lua"/);
+  assert.match(assertion, /"nvim\/test\/ref_surface_hover\.lua"/);
+  assert.match(assertion, /\^nvim\\\/test\\\/ref_surface_hover\\\.lua\$/);
   assert.match(assertion, /\^nvim\\\/test\\\/vize_e2e_\(\?:expected\|spec\)\\\.lua\$/);
 });
 
@@ -258,11 +260,13 @@ test("the Neovim real-server scenario pins completion and hover responses", () =
   assert.match(scenario, /sorted_matching_labels\(items, expected\.completion_include\)/);
   assert.match(scenario, /sorted_matching_labels\(items, expected\.completion_exclude\)/);
   assert.match(scenario, /assert_eq\(result, expected\.hover, "script binding hover"\)/);
+  assert.match(scenario, /ref_surface_hover\.run/);
   assert.doesNotMatch(scenario, /\.includes\(|\.contains\(/);
 
   assert.match(expected, /completion_include = \{ "Child", "total" \}/);
   assert.match(expected, /completion_exclude = \{ "count", "v-if" \}/);
   assert.match(expected, /const total: "3"/);
+  assert.match(expected, /ref_surface_hovers = \{/);
   assert.match(expected, /character = 11, line = 3/);
 });
 

--- a/tests/tooling/lsp-reactive-hover-type-backed.test.ts
+++ b/tests/tooling/lsp-reactive-hover-type-backed.test.ts
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { hoverToText, isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
+
+const source = `<script setup lang="ts">
+import { computed, ref, useTemplateRef } from 'vue'
+
+const count = ref(1)
+const doubled = computed(() => count.value * 2)
+const button = useTemplateRef<HTMLButtonElement>('button')
+</script>
+
+<template>
+  <button ref="button">{{ count }} {{ doubled }} {{ button }}</button>
+</template>
+`;
+
+test("type-backed hover keeps reactive script and template surfaces precise", async (t) => {
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTsgoBinary(),
+    "tsgo binary for type-backed reactive hover",
+    "tsgo binary not found; skipping type-backed reactive hover test",
+  );
+  if (corsaPath == null) return;
+
+  const testRootDir = path.join(testOutputRoot, "lsp-reactive-hover-type-backed");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+  let initialized = false;
+
+  try {
+    fs.mkdirSync(path.join(workspaceDir, "src"), { recursive: true });
+    linkVuePackage(workspaceDir);
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify({
+        lsp: { hover: true, lint: false, typecheck: true },
+        typeChecker: { corsaPath },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          lib: ["ES2022", "DOM", "DOM.Iterable"],
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+          skipLibCheck: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src/**/*.vue"],
+      }),
+    );
+
+    const filePath = path.join(workspaceDir, "src/App.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+    await session.initialize(workspaceDir, {
+      editor: true,
+      hover: true,
+      lint: false,
+      typecheck: true,
+    });
+    initialized = true;
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: source },
+    });
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri),
+      120_000,
+    );
+
+    await assertHover(
+      session,
+      uri,
+      rangeFor("count", source.indexOf("count = ref")),
+      /const count: Ref<number(?:, number)?>/,
+    );
+    await assertHover(
+      session,
+      uri,
+      rangeFor("doubled", source.indexOf("doubled = computed")),
+      /const doubled: ComputedRef<number>/,
+    );
+    await assertHover(
+      session,
+      uri,
+      rangeFor("button", source.indexOf("button = useTemplateRef")),
+      /const button: .*HTMLButtonElement.*null/,
+    );
+    await assertHover(
+      session,
+      uri,
+      rangeFor("count", source.indexOf("{{ count")),
+      /const count: number/,
+    );
+    await assertHover(
+      session,
+      uri,
+      rangeFor("doubled", source.indexOf("{{ doubled")),
+      /const doubled: number/,
+    );
+  } finally {
+    if (initialized) {
+      await session.shutdown();
+    } else {
+      await session.kill().catch(() => undefined);
+    }
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+type Position = { line: number; character: number };
+
+type Range = { start: Position; end: Position };
+
+async function assertHover(
+  session: LspSession,
+  uri: string,
+  expectedRange: Range,
+  expectedText: RegExp,
+): Promise<void> {
+  const hover = await session.request(
+    "textDocument/hover",
+    {
+      position: expectedRange.start,
+      textDocument: { uri },
+    },
+    120_000,
+  );
+  assert.deepEqual(
+    (hover as { range?: Range } | null)?.range,
+    expectedRange,
+    "hover must select the authored token, not generated TypeScript",
+  );
+  const hoverText = hoverToText(hover as Parameters<typeof hoverToText>[0]);
+  assert.match(hoverText, /^```typescript\n/);
+  assert.match(hoverText, expectedText);
+  assert.doesNotMatch(hoverText, /Ref<unknown>|ComputedRef<unknown>|MaybeRef<unknown>/);
+}
+
+function rangeFor(symbol: string, nearOffset: number): Range {
+  const startOffset = source.indexOf(symbol, nearOffset);
+  assert.ok(startOffset >= 0, `missing ${symbol} near ${nearOffset}`);
+  return {
+    end: offsetToPosition(source, startOffset + symbol.length),
+    start: offsetToPosition(source, startOffset),
+  };
+}
+
+function resolveTsgoBinary(): string | undefined {
+  const candidates = [
+    process.env.CORSA_BIN,
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ].filter((candidate): candidate is string => candidate != null && candidate.length > 0);
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function linkVuePackage(workspaceDir: string): void {
+  const vuePackage = [
+    path.join(root, "node_modules/vue"),
+    path.join(root, "tests/node_modules/vue"),
+  ].find((candidate) => fs.existsSync(candidate));
+  assert.ok(vuePackage, "Vue package is required for type-backed reactive hover test");
+
+  const nodeModules = path.join(workspaceDir, "node_modules");
+  fs.mkdirSync(nodeModules, { recursive: true });
+  symlink(vuePackage, path.join(nodeModules, "vue"));
+
+  const vueNamespace = path.join(path.dirname(vuePackage), "@vue");
+  if (fs.existsSync(vueNamespace)) {
+    symlink(vueNamespace, path.join(nodeModules, "@vue"));
+  }
+}
+
+function symlink(sourcePath: string, targetPath: string): void {
+  fs.rmSync(targetPath, { force: true, recursive: true });
+  fs.symlinkSync(sourcePath, targetPath, process.platform === "win32" ? "junction" : "dir");
+}

--- a/tools/nvim-vize/assert-nvim-package.mjs
+++ b/tools/nvim-vize/assert-nvim-package.mjs
@@ -38,6 +38,7 @@ const requiredFiles = [
   "nvim/lua/vize/config.lua",
   "nvim/lua/vize/init.lua",
   "nvim/plugin/vize.lua",
+  "nvim/test/ref_surface_hover.lua",
   "nvim/test/vize_e2e_expected.lua",
   "nvim/test/vize_e2e_spec.lua",
   "nvim/test/vize_spec.lua",
@@ -60,6 +61,7 @@ const allowedEntries = [
   /^nvim\/plugin\/$/,
   /^nvim\/plugin\/vize\.lua$/,
   /^nvim\/test\/$/,
+  /^nvim\/test\/ref_surface_hover\.lua$/,
   /^nvim\/test\/vize_e2e_(?:expected|spec)\.lua$/,
   /^nvim\/test\/vize_spec\.lua$/,
 ];


### PR DESCRIPTION
Refs #4589

## Summary

- add a type-backed LSP oracle for script `ref`, `computed`, and `useTemplateRef` hovers
- extend the Neovim real-server scenario so the non-VSCode editor gate catches reactive hover degradation
- assert that script and template hovers do not fall back to `Ref<unknown>`, `ComputedRef<unknown>`, or `MaybeRef<unknown>`

## Validation

- `cargo build -p vize`
- `CORSA_BIN=/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.bin/tsgo VIZE_LSP_BIN=/tmp/vize-p0-ref-hover.31P0Ec/target/debug/vize node --test tests/tooling/lsp-reactive-hover-type-backed.test.ts`
- `VIZE_E2E_SERVER=/tmp/vize-p0-ref-hover.31P0Ec/target/debug/vize VIZE_TEST_SERVER=/tmp/vize-p0-ref-hover.31P0Ec/target/debug/vize ./node_modules/.bin/vp run --workspace-root test:nvim-extension:real-server`
- `node --test tests/tooling/vscode-typescript-vue-plugin-types.test.ts tests/tooling/vscode-typescript-vue-plugin.test.ts`
- `node --test tests/tooling/editor-real-server-e2e.test.ts`
- `./node_modules/.bin/vp run --workspace-root test:nvim-extension:package`
- `MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts`
- `./node_modules/.bin/vp check tests/tooling/lsp-reactive-hover-type-backed.test.ts tests/tooling/editor-real-server-e2e.test.ts tools/nvim-vize/assert-nvim-package.mjs`
