### PR TITLE
test(editor): add typed oracle matrix

### DIFF
--- a/docs/release/typed-editor-oracle-matrix.md
+++ b/docs/release/typed-editor-oracle-matrix.md
@@ -1,0 +1,17 @@
+# Typed editor oracle matrix
+
+This matrix is the external-behavior ledger for #4585. It keeps the typed editor
+surface honest without turning #4585 into an umbrella implementation PR.
+
+| Slice                                                                                                                              | Status    | Evidence                                                          | Follow-up    |
+| ---------------------------------------------------------------------------------------------------------------------------------- | --------- | ----------------------------------------------------------------- | ------------ |
+| CLI authored script diagnostics report `const count: string = 0` at the authored script span.                                      | Covered   | `crates/vize/tests/check_text_diagnostics_cli.rs`                 | #4587        |
+| LSP authored script diagnostics report and clear `const a: string = 1`.                                                            | Covered   | `tests/tooling/lsp-authored-script-diagnostics.test.ts`           | #4587        |
+| CLI fallthrough diagnostics use authored template ranges, not the leading script token.                                            | Covered   | `crates/vize_canon/src/sfc_typecheck/tests/fallthrough_ranges.rs` | #4586        |
+| LSP fallthrough diagnostics publish and clear on authored template usage.                                                          | Covered   | `tests/tooling/lsp-fallthrough-attrs.test.ts`                     | #4586        |
+| LSP hover and definition cover script bindings, template identifiers, component tags, and slot names.                              | Covered   | `tests/tooling/lsp-hover-type-backed.test.ts`                     | #4588, #4592 |
+| Vue JSX intrinsic globals suppress TS7026 while component props stay strict.                                                       | Covered   | `tests/snapshots/check/jsx-intrinsic-globals-oracle.ts`           | #4590        |
+| Packaged VS Code host smoke rejects empty hover and `Ref<unknown>`/`ComputedRef<unknown>`/`MaybeRef<unknown>` for reactive values. | Covered   | `editors/vscode/test/suite/real-scenario.cjs`                     | #4589        |
+| Imported SFC hovers show props, emits, slots, model, and marker-free component contracts in LSP script surfaces.                   | Known gap | pending PR #4608                                                  | #4591        |
+| Component `v-model` template navigation resolves to child `defineModel` declarations.                                              | Known gap | pending PR #4607                                                  | #4592        |
+| Non-VSCode editor-host smoke rejects reactive hover degradation.                                                                   | Known gap | pending PR #4609                                                  | #4589        |

--- a/tests/tooling/typed-editor-oracle-matrix.test.ts
+++ b/tests/tooling/typed-editor-oracle-matrix.test.ts
@@ -1,0 +1,223 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import { root } from "./support/lsp/paths.ts";
+
+type MatrixRow = {
+  evidence: Evidence[];
+  followUp: string;
+  id: string;
+  status: "covered" | "known-gap";
+};
+
+type Evidence =
+  | { kind: "file"; path: string; requiredText: string[] }
+  | { kind: "pending-pr"; pr: number; reason: string };
+
+const matrix: MatrixRow[] = [
+  {
+    evidence: [
+      {
+        kind: "file",
+        path: "crates/vize/tests/check_text_diagnostics_cli.rs",
+        requiredText: [
+          "const count: string = 0;",
+          "Type 'number' is not assignable to type 'string'.",
+        ],
+      },
+    ],
+    followUp: "#4587",
+    id: "cli-authored-script-diagnostics",
+    status: "covered",
+  },
+  {
+    evidence: [
+      {
+        kind: "file",
+        path: "tests/tooling/lsp-authored-script-diagnostics.test.ts",
+        requiredText: ["const a: string = 1", "params.version === 2"],
+      },
+    ],
+    followUp: "#4587",
+    id: "lsp-authored-script-diagnostics",
+    status: "covered",
+  },
+  {
+    evidence: [
+      {
+        kind: "file",
+        path: "crates/vize_canon/src/sfc_typecheck/tests/fallthrough_ranges.rs",
+        requiredText: [
+          "fallthrough_diagnostic_range_uses_authored_template_offsets",
+          "diagnostic.start > script_start",
+        ],
+      },
+    ],
+    followUp: "#4586",
+    id: "cli-fallthrough-template-range",
+    status: "covered",
+  },
+  {
+    evidence: [
+      {
+        kind: "file",
+        path: "tests/tooling/lsp-fallthrough-attrs.test.ts",
+        requiredText: ["publishes and clears fallthrough attribute diagnostics", 'id="outer"'],
+      },
+    ],
+    followUp: "#4586",
+    id: "lsp-fallthrough-template-range",
+    status: "covered",
+  },
+  {
+    evidence: [
+      {
+        kind: "file",
+        path: "tests/tooling/lsp-hover-type-backed.test.ts",
+        requiredText: [
+          "hover and definition answer authored template anchors with backend type text",
+          "component slot hover must select the authored slot name",
+        ],
+      },
+    ],
+    followUp: "#4588 #4592",
+    id: "lsp-hover-definition-template-anchors",
+    status: "covered",
+  },
+  {
+    evidence: [
+      {
+        kind: "file",
+        path: "tests/snapshots/check/jsx-intrinsic-globals-oracle.ts",
+        requiredText: ["JSX.IntrinsicElements", "[TS7026]"],
+      },
+    ],
+    followUp: "#4590",
+    id: "cli-jsx-intrinsic-globals",
+    status: "covered",
+  },
+  {
+    evidence: [
+      {
+        kind: "file",
+        path: "editors/vscode/test/suite/real-scenario.cjs",
+        requiredText: ["refSurfaceHovers", "Ref<unknown>|ComputedRef<unknown>|MaybeRef<unknown>"],
+      },
+    ],
+    followUp: "#4589",
+    id: "vscode-host-reactive-hover-surface",
+    status: "covered",
+  },
+  {
+    evidence: [
+      {
+        kind: "pending-pr",
+        pr: 4608,
+        reason: "LSP imported component hovers need marker-free component contracts.",
+      },
+    ],
+    followUp: "#4591",
+    id: "lsp-imported-component-contract-hover",
+    status: "known-gap",
+  },
+  {
+    evidence: [
+      {
+        kind: "pending-pr",
+        pr: 4607,
+        reason: "Component v-model navigation needs authored defineModel targets.",
+      },
+    ],
+    followUp: "#4592",
+    id: "lsp-component-v-model-navigation",
+    status: "known-gap",
+  },
+  {
+    evidence: [
+      {
+        kind: "pending-pr",
+        pr: 4609,
+        reason: "Non-VSCode host reactive hover coverage is pending merge.",
+      },
+    ],
+    followUp: "#4589",
+    id: "non-vscode-host-reactive-hover-surface",
+    status: "known-gap",
+  },
+];
+
+test("typed editor oracle matrix covers or explicitly tracks every P0 slice", () => {
+  assert.deepEqual(
+    matrix.map((row) => row.id),
+    [
+      "cli-authored-script-diagnostics",
+      "lsp-authored-script-diagnostics",
+      "cli-fallthrough-template-range",
+      "lsp-fallthrough-template-range",
+      "lsp-hover-definition-template-anchors",
+      "cli-jsx-intrinsic-globals",
+      "vscode-host-reactive-hover-surface",
+      "lsp-imported-component-contract-hover",
+      "lsp-component-v-model-navigation",
+      "non-vscode-host-reactive-hover-surface",
+    ],
+  );
+
+  for (const row of matrix) {
+    assert.match(row.followUp, /^#\d+(?:[,\s]+#\d+)*$/, `${row.id} must point at tracking issues`);
+    if (row.status === "covered") {
+      assert.ok(
+        row.evidence.some((entry) => entry.kind === "file"),
+        `${row.id} needs file proof`,
+      );
+    } else {
+      assert.ok(
+        row.evidence.every((entry) => entry.kind === "pending-pr" && entry.reason.length > 0),
+        `${row.id} known gaps need explicit pending PR rationale`,
+      );
+    }
+  }
+});
+
+test("covered typed editor oracle matrix rows point at live gate files", () => {
+  for (const row of matrix) {
+    for (const evidence of row.evidence) {
+      if (evidence.kind !== "file") continue;
+      const source = fs.readFileSync(path.join(root, evidence.path), "utf8");
+      for (const text of evidence.requiredText) {
+        assert.match(source, new RegExp(escapeRegExp(text)), `${row.id} missing ${text}`);
+      }
+    }
+  }
+});
+
+test("typed editor oracle matrix document mirrors the executable ledger", () => {
+  const doc = fs.readFileSync(
+    path.join(root, "docs/release/typed-editor-oracle-matrix.md"),
+    "utf8",
+  );
+  for (const row of matrix) {
+    for (const issue of row.followUp.match(/#\d+/g) ?? []) {
+      assert.match(doc, new RegExp(escapeRegExp(issue)), `${row.id} missing ${issue}`);
+    }
+    if (row.status === "known-gap") {
+      for (const evidence of row.evidence) {
+        if (evidence.kind === "pending-pr") {
+          assert.match(doc, new RegExp(`pending PR #${evidence.pr}`), `${row.id} missing PR`);
+        }
+      }
+    } else {
+      for (const evidence of row.evidence) {
+        if (evidence.kind === "file") {
+          assert.match(doc, new RegExp(escapeRegExp(evidence.path)), `${row.id} missing file`);
+        }
+      }
+    }
+  }
+});
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
Refs #4585

## Summary

- add a typed editor oracle matrix document for the P0 editor/typecheck surface
- add an executable gate that verifies covered rows point at live test files and required anchors
- mark remaining gaps explicitly against pending PRs #4607, #4608, and #4609 instead of treating the matrix as complete

## Validation

- `node --test tests/tooling/typed-editor-oracle-matrix.test.ts`
- `./node_modules/.bin/vp check tests/tooling/typed-editor-oracle-matrix.test.ts docs/release/typed-editor-oracle-matrix.md`
- `MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790047987&installation_model_id=422833&pr_number=4610&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4610&signature=b87353b4817d91da7be2c1adab8865ae4b6db5e427d83174d4f908aae5b6655c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a typed editor oracle matrix covering CLI, LSP, Vue JSX, and VS Code scenarios.
  * Documented supporting evidence, known gaps, pending work, and follow-up issues.

* **Tests**
  * Added validation to ensure the matrix, evidence references, tracking issues, and pending work remain complete and accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->