### PR TITLE
fix(maestro): resolve re-exported component navigation

### DIFF
--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -1,6 +1,7 @@
 //! Go-to-definition for Vue SFC template bindings, components, imports, and Corsa.
 mod art;
 pub mod bindings;
+mod component_import;
 mod component_model;
 #[cfg(all(test, feature = "native"))]
 mod corsa_tests;

--- a/crates/vize_maestro/src/ide/definition/component_import.rs
+++ b/crates/vize_maestro/src/ide/definition/component_import.rs
@@ -1,0 +1,234 @@
+//! Component import resolution beyond direct `.vue` specifiers.
+#![allow(clippy::disallowed_types)]
+
+use std::path::{Path, PathBuf};
+
+use tower_lsp::lsp_types::Url;
+
+use super::{IdeContext, helpers};
+
+const MAX_REEXPORT_DEPTH: usize = 8;
+
+pub(crate) fn resolve_component_file(
+    ctx: &IdeContext<'_>,
+    component_name: &str,
+) -> Option<PathBuf> {
+    let import = find_component_import(ctx, component_name)?;
+    let resolved = helpers::resolve_import_path(ctx.uri, &import.specifier)?;
+    if is_vue_path(&resolved) {
+        return Some(resolved);
+    }
+    resolve_exported_component(&resolved, &import.imported_name, 0)
+}
+
+struct ComponentImport {
+    specifier: String,
+    imported_name: String,
+}
+
+fn find_component_import(ctx: &IdeContext<'_>, component_name: &str) -> Option<ComponentImport> {
+    for (pos, _) in ctx.content.match_indices("import ") {
+        let rest = &ctx.content[pos..];
+        let Some(from_pos) = rest.find(" from") else {
+            continue;
+        };
+        let specifier = helpers::extract_import_path_from_pos(rest, from_pos + " from".len())?;
+        let clause = rest["import ".len()..from_pos].trim();
+        if default_import_name(clause) == Some(component_name) {
+            return Some(ComponentImport {
+                specifier,
+                imported_name: "default".to_string(),
+            });
+        }
+        if let Some(imported_name) = named_import_name(clause, component_name) {
+            return Some(ComponentImport {
+                specifier,
+                imported_name,
+            });
+        }
+    }
+    None
+}
+
+fn default_import_name(clause: &str) -> Option<&str> {
+    let clause = clause.strip_prefix("type ").unwrap_or(clause).trim();
+    if clause.starts_with('{') || clause.starts_with('*') {
+        return None;
+    }
+    ident_at_start(
+        clause
+            .split_once(',')
+            .map_or(clause, |(head, _)| head)
+            .trim(),
+    )
+}
+
+fn named_import_name(clause: &str, local_name: &str) -> Option<String> {
+    let body = brace_body(clause)?;
+    for part in body.split(',') {
+        let (imported, local) = parse_import_binding(part)?;
+        if local == local_name {
+            return Some(imported.to_string());
+        }
+    }
+    None
+}
+
+fn parse_import_binding(part: &str) -> Option<(&str, &str)> {
+    let part = part
+        .trim()
+        .strip_prefix("type ")
+        .unwrap_or(part.trim())
+        .trim();
+    if part.is_empty() {
+        return None;
+    }
+    if let Some((imported, local)) = part.split_once(" as ") {
+        return Some((
+            ident_at_start(imported.trim())?,
+            ident_at_start(local.trim())?,
+        ));
+    }
+    let name = ident_at_start(part)?;
+    Some((name, name))
+}
+
+fn resolve_exported_component(
+    module_path: &Path,
+    export_name: &str,
+    depth: usize,
+) -> Option<PathBuf> {
+    if depth >= MAX_REEXPORT_DEPTH {
+        return None;
+    }
+    let content = std::fs::read_to_string(module_path).ok()?;
+    for export in named_reexports(&content, export_name) {
+        if let Some(resolved) =
+            resolve_reexport(module_path, &export.specifier, &export.imported, depth)
+        {
+            return Some(resolved);
+        }
+    }
+    for specifier in star_reexports(&content) {
+        let Some(target) = resolve_from_module(module_path, &specifier) else {
+            continue;
+        };
+        if is_vue_path(&target) {
+            continue;
+        }
+        if let Some(resolved) = resolve_exported_component(&target, export_name, depth + 1) {
+            return Some(resolved);
+        }
+    }
+    None
+}
+
+struct Reexport {
+    imported: String,
+    specifier: String,
+}
+
+fn named_reexports(content: &str, export_name: &str) -> Vec<Reexport> {
+    let mut exports = Vec::new();
+    for (pos, _) in content.match_indices("export ") {
+        let rest = &content[pos..];
+        let Some(body) = brace_body(rest) else {
+            continue;
+        };
+        let Some(body_start) = rest.find('{') else {
+            continue;
+        };
+        let after_body = &rest[body_start + body.len() + 2..];
+        let Some(from_pos) = after_body.find("from") else {
+            continue;
+        };
+        let Some(specifier) =
+            helpers::extract_import_path_from_pos(after_body, from_pos + "from".len())
+        else {
+            continue;
+        };
+        for part in body.split(',') {
+            let Some((imported, exported)) = parse_export_binding(part) else {
+                continue;
+            };
+            if exported == export_name {
+                exports.push(Reexport {
+                    imported: imported.to_string(),
+                    specifier: specifier.clone(),
+                });
+            }
+        }
+    }
+    exports
+}
+
+fn parse_export_binding(part: &str) -> Option<(&str, &str)> {
+    let part = part
+        .trim()
+        .strip_prefix("type ")
+        .unwrap_or(part.trim())
+        .trim();
+    if part.is_empty() {
+        return None;
+    }
+    if let Some((imported, exported)) = part.split_once(" as ") {
+        return Some((
+            ident_at_start(imported.trim())?,
+            ident_at_start(exported.trim())?,
+        ));
+    }
+    let name = ident_at_start(part)?;
+    Some((name, name))
+}
+
+fn star_reexports(content: &str) -> Vec<String> {
+    let mut specifiers = Vec::new();
+    for (pos, _) in content.match_indices("export *") {
+        let rest = &content[pos + "export *".len()..];
+        let Some(from_pos) = rest.find("from") else {
+            continue;
+        };
+        if let Some(specifier) =
+            helpers::extract_import_path_from_pos(rest, from_pos + "from".len())
+        {
+            specifiers.push(specifier);
+        }
+    }
+    specifiers
+}
+
+fn resolve_reexport(
+    module_path: &Path,
+    specifier: &str,
+    imported: &str,
+    depth: usize,
+) -> Option<PathBuf> {
+    let target = resolve_from_module(module_path, specifier)?;
+    if is_vue_path(&target) {
+        return (imported == "default").then_some(target);
+    }
+    resolve_exported_component(&target, imported, depth + 1)
+}
+
+fn resolve_from_module(module_path: &Path, specifier: &str) -> Option<PathBuf> {
+    let uri = Url::from_file_path(module_path).ok()?;
+    helpers::resolve_import_path(&uri, specifier)
+}
+
+fn brace_body(value: &str) -> Option<&str> {
+    let start = value.find('{')?;
+    let end = value[start + 1..].find('}')? + start + 1;
+    Some(&value[start + 1..end])
+}
+
+fn ident_at_start(value: &str) -> Option<&str> {
+    let end = value
+        .bytes()
+        .position(|byte| !(byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'))
+        .unwrap_or(value.len());
+    (end > 0).then_some(&value[..end])
+}
+
+fn is_vue_path(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "vue")
+}

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -402,9 +402,11 @@ pub(crate) fn find_component_prop_definition(
         return None;
     }
 
-    let import_path = helpers::find_import_path(ctx, &component_name)
-        .or_else(|| super::art::component_path(ctx, &component_name))?;
-    let resolved_path = helpers::resolve_import_path(ctx.uri, &import_path)?;
+    let resolved_path = super::component_import::resolve_component_file(ctx, &component_name)
+        .or_else(|| {
+            let import_path = super::art::component_path(ctx, &component_name)?;
+            helpers::resolve_import_path(ctx.uri, &import_path)
+        })?;
     let component_content = std::fs::read_to_string(&resolved_path).ok()?;
 
     let options = vize_atelier_sfc::SfcParseOptions {
@@ -553,8 +555,7 @@ pub(crate) fn find_component_definition(
     let names_to_try = [tag_name.to_string(), pascal_name];
 
     for name in &names_to_try {
-        if let Some(import_path) = helpers::find_import_path(ctx, name)
-            && let Some(resolved) = helpers::resolve_import_path(ctx.uri, &import_path)
+        if let Some(resolved) = super::component_import::resolve_component_file(ctx, name)
             && let Some(location) = component_file_location(ctx, &resolved)
         {
             return Some(GotoDefinitionResponse::Scalar(location));
@@ -562,8 +563,7 @@ pub(crate) fn find_component_definition(
 
         if let Some(binding_type) = summary.get_binding_type(name)
             && binding_type == BindingType::ExternalModule
-            && let Some(import_path) = helpers::find_import_path(ctx, name)
-            && let Some(resolved) = helpers::resolve_import_path(ctx.uri, &import_path)
+            && let Some(resolved) = super::component_import::resolve_component_file(ctx, name)
             && let Some(location) = component_file_location(ctx, &resolved)
         {
             return Some(GotoDefinitionResponse::Scalar(location));

--- a/tests/tooling/lsp-component-reexport-navigation.test.ts
+++ b/tests/tooling/lsp-component-reexport-navigation.test.ts
@@ -1,0 +1,186 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { firstLocation, offsetToPosition } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+const appSource = `<script setup lang="ts">
+import { BarrelChild, StarChild } from './components'
+import { PackageChild as UiChild } from '@fixture/ui'
+</script>
+
+<template>
+  <BarrelChild :label="'barrel'" />
+  <StarChild mode="wide" />
+  <UiChild tone="info" />
+</template>
+`;
+
+const barrelChildSource = `<script setup lang="ts">
+defineProps<{ label: string }>()
+</script>
+<template><span>{{ label }}</span></template>
+`;
+
+const packageChildSource = `<script setup lang="ts">
+defineProps<{ tone: 'info' | 'warn' }>()
+</script>
+<template><span>{{ tone }}</span></template>
+`;
+
+const starChildSource = `<script setup lang="ts">
+defineProps<{ mode: 'wide' | 'narrow' }>()
+</script>
+<template><span>{{ mode }}</span></template>
+`;
+
+test("component definition follows re-exported barrel and package component tags", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-component-reexport-navigation");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+  let initialized = false;
+
+  try {
+    const srcDir = path.join(workspaceDir, "src");
+    const componentsDir = path.join(srcDir, "components");
+    const packageDir = path.join(workspaceDir, "node_modules/@fixture/ui");
+    fs.mkdirSync(componentsDir, { recursive: true });
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(path.join(workspaceDir, "tsconfig.json"), JSON.stringify({}));
+    fs.writeFileSync(path.join(workspaceDir, "vize.config.json"), JSON.stringify({}));
+
+    const appPath = path.join(srcDir, "App.vue");
+    const barrelChildPath = path.join(componentsDir, "BarrelChild.vue");
+    const starChildPath = path.join(componentsDir, "StarChild.vue");
+    const packageChildPath = path.join(packageDir, "PackageChild.vue");
+    fs.writeFileSync(appPath, appSource, "utf8");
+    fs.writeFileSync(barrelChildPath, barrelChildSource, "utf8");
+    fs.writeFileSync(starChildPath, starChildSource, "utf8");
+    fs.writeFileSync(packageChildPath, packageChildSource, "utf8");
+    fs.writeFileSync(
+      path.join(componentsDir, "index.ts"),
+      [
+        "export { default as BarrelChild } from './BarrelChild.vue'",
+        "export * from './nested'",
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(componentsDir, "nested.ts"),
+      "export { default as StarChild } from './StarChild.vue'\n",
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(packageDir, "package.json"),
+      JSON.stringify({ name: "@fixture/ui", exports: { ".": "./index.ts" } }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(packageDir, "index.ts"),
+      "export { default as PackageChild } from './PackageChild.vue'\n",
+      "utf8",
+    );
+
+    const uri = pathToFileURL(appPath).href;
+    const barrelChildUri = pathToFileURL(barrelChildPath).href;
+    const starChildUri = pathToFileURL(starChildPath).href;
+    const packageChildUri = pathToFileURL(packageChildPath).href;
+    await session.initialize(workspaceDir, { editor: true, typecheck: false, lint: false });
+    initialized = true;
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: appSource },
+    });
+
+    await assertDefinitionUri(session, uri, positionOf("<BarrelChild") + 1, barrelChildUri);
+    await assertDefinitionRange(
+      session,
+      uri,
+      positionOf(":label") + 1,
+      barrelChildUri,
+      rangeForIn(barrelChildSource, "label", barrelChildSource.indexOf("defineProps")),
+    );
+    await assertDefinitionUri(session, uri, positionOf("<StarChild") + 1, starChildUri);
+    await assertDefinitionRange(
+      session,
+      uri,
+      positionOf("mode="),
+      starChildUri,
+      rangeForIn(starChildSource, "mode", starChildSource.indexOf("defineProps")),
+    );
+    await assertDefinitionUri(session, uri, positionOf("<UiChild") + 1, packageChildUri);
+    await assertDefinitionRange(
+      session,
+      uri,
+      positionOf("tone="),
+      packageChildUri,
+      rangeForIn(packageChildSource, "tone", packageChildSource.indexOf("defineProps")),
+    );
+  } finally {
+    if (initialized) {
+      await session.shutdown();
+    } else {
+      await session.kill().catch(() => undefined);
+    }
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+async function assertDefinitionUri(
+  session: LspSession,
+  uri: string,
+  offset: number,
+  expectedUri: string,
+): Promise<void> {
+  const response = await requestDefinition(session, uri, offset);
+  assert.equal(firstLocation(response).uri, expectedUri);
+}
+
+async function assertDefinitionRange(
+  session: LspSession,
+  uri: string,
+  offset: number,
+  expectedUri: string,
+  expectedRange: Range,
+): Promise<void> {
+  const response = await requestDefinition(session, uri, offset);
+  assert.deepEqual(firstLocation(response), { range: expectedRange, uri: expectedUri });
+}
+
+async function requestDefinition(
+  session: LspSession,
+  uri: string,
+  offset: number,
+): Promise<Parameters<typeof firstLocation>[0]> {
+  return (await session.request(
+    "textDocument/definition",
+    {
+      textDocument: { uri },
+      position: offsetToPosition(appSource, offset),
+    },
+    120_000,
+  )) as Parameters<typeof firstLocation>[0];
+}
+
+type Position = { line: number; character: number };
+type Range = { start: Position; end: Position };
+
+function positionOf(marker: string): number {
+  const offset = appSource.indexOf(marker);
+  assert.ok(offset >= 0, `missing marker ${marker}`);
+  return offset;
+}
+
+function rangeForIn(document: string, symbol: string, nearOffset: number): Range {
+  const startOffset = document.indexOf(symbol, nearOffset);
+  assert.ok(startOffset >= 0, `missing ${symbol} near ${nearOffset}`);
+  return {
+    start: offsetToPosition(document, startOffset),
+    end: offsetToPosition(document, startOffset + symbol.length),
+  };
+}


### PR DESCRIPTION
## Summary

- resolve template component tag and prop definitions through component barrel exports
- follow package exports that land on a component barrel before selecting the authored `.vue` file
- add an LSP oracle covering direct barrel, star barrel, package export, and aliased named imports

Refs #4592

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p vize_maestro --tests -- -D warnings`
- `MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts`
- `cargo build -p vize`
- `VIZE_LSP_BIN=/private/tmp/vize-p0-tag-nav.0AO3Cq/target/debug/vize node --test tests/tooling/lsp-component-reexport-navigation.test.ts tests/tooling/lsp-hover-type-backed.test.ts`
- `./node_modules/.bin/vp check tests/tooling/lsp-component-reexport-navigation.test.ts crates/vize_maestro/src/ide/definition/component_import.rs crates/vize_maestro/src/ide/definition/template.rs crates/vize_maestro/src/ide/definition.rs`
- post-rebase source-length check
- post-rebase `VIZE_LSP_BIN=/private/tmp/vize-p0-tag-nav.0AO3Cq/target/debug/vize node --test tests/tooling/lsp-component-reexport-navigation.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790049068&installation_model_id=422833&pr_number=4611&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4611&signature=36d4239c714f3dfe7b2a72dd5e23bba66636f4fbd20ddd784657634d7a86967b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved go-to-definition navigation for Vue components imported through direct imports, aliases, barrel files, wildcard re-exports, and package exports.
  * Added more reliable navigation to component prop definitions.

* **Bug Fixes**
  * Improved handling of malformed, unresolved, or unsupported component imports without breaking navigation.

* **Tests**
  * Added end-to-end coverage for component re-export navigation and prop-definition ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->