### PR TITLE
test(maestro): gate SFC TSX script diagnostics

### DIFF
--- a/tests/tooling/lsp-sfc-tsx-script-typecheck.test.ts
+++ b/tests/tooling/lsp-sfc-tsx-script-typecheck.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
+
+const source = `<script setup lang="tsx">
+const label: string = "ready"
+const vnode = <button class="primary">{label}</button>
+const mismatch: string = 1
+void vnode
+void mismatch
+</script>
+`;
+
+test("SFC TSX script typecheck reports script errors without intrinsic JSX noise", async (t) => {
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTsgoBinary(),
+    "tsgo binary for the SFC TSX typecheck gate",
+    "tsgo binary not found; skipping SFC TSX typecheck test",
+  );
+  if (corsaPath == null) return;
+
+  const testRootDir = path.join(testOutputRoot, "lsp-sfc-tsx-script-typecheck");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    fs.mkdirSync(path.join(workspaceDir, "src"), { recursive: true });
+    linkVuePackage(workspaceDir);
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify({ lsp: { lint: false, typecheck: true }, typeChecker: { corsaPath } }),
+      "utf8",
+    );
+    fs.writeFileSync(
+      path.join(workspaceDir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          jsx: "preserve",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src/**/*"],
+      }),
+      "utf8",
+    );
+
+    const filePath = path.join(workspaceDir, "src/App.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+    await session.initialize(workspaceDir, { editor: true, lint: false, typecheck: true });
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: source },
+    });
+
+    const publish = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, uri) &&
+        params.diagnostics.some((diagnostic) =>
+          diagnostic.message?.includes("Type 'number' is not assignable to type 'string'"),
+        ),
+      120_000,
+    )) as PublishDiagnosticsParams;
+    const messages = publish.diagnostics.map((diagnostic) => diagnostic.message ?? "");
+    assert.equal(
+      messages.some((message) => message.includes("JSX.IntrinsicElements")),
+      false,
+      messages.join("\n"),
+    );
+
+    const mismatchOffset = source.indexOf("mismatch: string");
+    assert.notEqual(mismatchOffset, -1);
+    assert.deepEqual(publish.diagnostics, [
+      {
+        code: 2322,
+        message: "Type 'number' is not assignable to type 'string'.",
+        range: {
+          start: offsetToPosition(source, mismatchOffset),
+          end: offsetToPosition(source, mismatchOffset + "mismatch".length),
+        },
+        severity: 1,
+        source: "vize/types",
+      },
+    ]);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+function resolveTsgoBinary(): string | undefined {
+  return [
+    process.env.CORSA_BIN,
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ].find((candidate) => candidate != null && fs.existsSync(candidate));
+}
+
+function linkVuePackage(workspaceDir: string): void {
+  const vuePackage = [
+    path.join(root, "node_modules/vue"),
+    path.join(root, "tests/node_modules/vue"),
+  ].find((candidate) => fs.existsSync(candidate));
+  assert.ok(vuePackage, "Vue package is required for SFC TSX typecheck");
+  const nodeModules = path.join(workspaceDir, "node_modules");
+  fs.mkdirSync(nodeModules, { recursive: true });
+  fs.symlinkSync(vuePackage, path.join(nodeModules, "vue"), dirLinkType());
+  const vueNamespace = path.join(path.dirname(vuePackage), "@vue");
+  if (fs.existsSync(vueNamespace)) {
+    fs.symlinkSync(vueNamespace, path.join(nodeModules, "@vue"), dirLinkType());
+  }
+}
+
+function dirLinkType(): fs.symlink.Type {
+  return process.platform === "win32" ? "junction" : "dir";
+}


### PR DESCRIPTION
## Summary

- add an SFC TSX editor oracle for `<script setup lang="tsx">`
- assert Vue JSX intrinsic elements are wired so TS7026 noise stays absent
- assert real script type errors still publish on the authored SFC range

## Verification

- `MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts`
- `CORSA_BIN=/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.bin/tsgo VIZE_LSP_BIN=/private/tmp/vize-p0-jsx-sfc.OYTP0v/target/debug/vize node --test tests/tooling/lsp-sfc-tsx-script-typecheck.test.ts`
- `./node_modules/.bin/vp check tests/tooling/lsp-sfc-tsx-script-typecheck.test.ts`

Refs #4585
Refs #3957

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790049901&installation_model_id=422833&pr_number=4612&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4612&signature=d101c69c65016e79417a72ca09be40f4476c981d455c6e1c00539b99ef2f07dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->