### PR TITLE
test(editor): pin VS Code template ref hovers

### DIFF
--- a/editors/vscode/test/suite/real-scenario-expected.cjs
+++ b/editors/vscode/test/suite/real-scenario-expected.cjs
@@ -30,14 +30,15 @@ const renamedSource = formattedSource
 
 const refSurfaceSource = [
   '<script setup lang="ts">',
-  'import { computed, ref } from "vue";',
+  'import { computed, ref, useTemplateRef } from "vue";',
   "",
   "const count = ref(1);",
   "const doubled = computed(() => count.value * 2);",
+  'const button = useTemplateRef<HTMLButtonElement>("button");',
   "</script>",
   "",
   "<template>",
-  "  <p>{{ count }} {{ doubled }}</p>",
+  '  <button ref="button">{{ count }} {{ doubled }} {{ button }}</button>',
   "</template>",
   "",
 ].join("\n");
@@ -55,16 +56,30 @@ const refSurfaceHovers = {
       range: [4, 6, 4, 13],
     },
   ],
+  scriptButton: [
+    {
+      contents: [
+        "```typescript\nconst button: Readonly<ShallowRef<HTMLButtonElement | null, HTMLButtonElement | null>>\n```",
+      ],
+      range: [5, 6, 5, 12],
+    },
+  ],
   templateCount: [
     {
       contents: ["```typescript\nconst count: number\n```"],
-      range: [8, 8, 8, 13],
+      range: [9, 26, 9, 31],
     },
   ],
   templateDoubled: [
     {
       contents: ["```typescript\nconst doubled: number\n```"],
-      range: [8, 20, 8, 27],
+      range: [9, 38, 9, 45],
+    },
+  ],
+  templateButton: [
+    {
+      contents: ["```typescript\nconst button: HTMLButtonElement | null\n```"],
+      range: [9, 52, 9, 58],
     },
   ],
 };

--- a/editors/vscode/test/suite/real-scenario.cjs
+++ b/editors/vscode/test/suite/real-scenario.cjs
@@ -124,8 +124,10 @@ async function stepTypedRefHoverSurfaces() {
   const hovers = {
     scriptCount: await hoverAt(uri, 3, 8),
     scriptDoubled: await hoverAt(uri, 4, 8),
-    templateCount: await hoverAt(uri, 8, 10),
-    templateDoubled: await hoverAt(uri, 8, 22),
+    scriptButton: await hoverAt(uri, 5, 8),
+    templateCount: await hoverAt(uri, 9, 28),
+    templateDoubled: await hoverAt(uri, 9, 40),
+    templateButton: await hoverAt(uri, 9, 54),
   };
   assert.deepEqual(hovers, expected.refSurfaceHovers);
   for (const value of Object.values(hovers).flatMap((hover) =>


### PR DESCRIPTION
## Summary

- extend the packaged VS Code real-server scenario to cover `useTemplateRef`
- pin script and template hover responses for template refs, matching the Neovim host gate
- keep the `Ref<unknown>` / `ComputedRef<unknown>` / `MaybeRef<unknown>` degradation guard on every captured hover

## Verification

- `MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts`
- `node --test tests/tooling/editor-real-server-e2e.test.ts tests/tooling/typed-editor-oracle-matrix.test.ts`
- `./node_modules/.bin/vp check editors/vscode/test/suite/real-scenario.cjs editors/vscode/test/suite/real-scenario-expected.cjs tests/tooling/editor-real-server-e2e.test.ts tests/tooling/typed-editor-oracle-matrix.test.ts`

Refs #4589

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790050091&installation_model_id=422833&pr_number=4613&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4613&signature=068ecd094d8b3f0db83118f306778709c21cdf3c3bea275da2fcea1ee703f247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded editor validation for hover information on template references and script bindings.
  * Updated hover-position checks to reflect the latest reference-surface layout.
  * Added coverage confirming typed button references and their rendered template usage display the expected information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->