### PR TITLE
fix(content-mapper): track TypeScript round two protocol

### DIFF
--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -104,7 +104,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  CONTENT_MAPPER_TSGO_SHA: "01b9e721f3d7f8037d700daff94f5808c1afb97e"
+  CONTENT_MAPPER_TYPESCRIPT_SHA: "d6c4afddb2c55f4a9dea7b59293a99a8fdea1799"
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
@@ -119,18 +119,20 @@ jobs:
       - name: Checkout exact TypeScript Content Mapper revision
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          repository: microsoft/typescript-go
-          ref: ${{ env.CONTENT_MAPPER_TSGO_SHA }}
-          path: typescript-go-content-mapper
+          repository: microsoft/TypeScript
+          ref: ${{ env.CONTENT_MAPPER_TYPESCRIPT_SHA }}
+          path: typescript-content-mapper
           persist-credentials: false
       - name: Setup Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:
-          go-version-file: typescript-go-content-mapper/go.mod
-          cache-dependency-path: typescript-go-content-mapper/go.sum
-      - name: Verify upstream watcher close regression
-        working-directory: typescript-go-content-mapper
-        run: go test ./internal/lsp/lspwatcher -run '^TestWatcher_CloseWhileWatchFilesReconciles$' -count=1
+          go-version-file: typescript-content-mapper/tsc/go.mod
+          cache-dependency-path: typescript-content-mapper/tsc/go.sum
+      - name: Verify upstream content mapper protocol regressions
+        working-directory: typescript-content-mapper/tsc
+        run: |
+          go test ./internal/contentmapper -run '^(TestRunnerTransform|TestRunnerTransformResponseValidation)$' -count=1
+          go test ./internal/spanmap -run '^(TestOriginalToVirtualOverlappingSpans|TestValidateOriginalOverlapAndFeatures)$' -count=1
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
@@ -149,9 +151,9 @@ jobs:
       - name: Install JavaScript dependencies
         run: vp install --frozen-lockfile --prefer-offline
       - name: Build exact upstream tsgo
-        working-directory: typescript-go-content-mapper
+        working-directory: typescript-content-mapper/tsc
         run: |
-          go build -tags=noembed -trimpath -o "$RUNNER_TEMP/tsgo" ./cmd/tsgo
+          go build -tags=noembed -trimpath -o "$RUNNER_TEMP/tsgo" ./cmd/tsc
           cp internal/bundled/libs/*.d.ts "$RUNNER_TEMP/"
       - name: Build packed Content Mapper runtime
         run: |

--- a/crates/vize/src/commands/content_mapper.rs
+++ b/crates/vize/src/commands/content_mapper.rs
@@ -1,7 +1,7 @@
 //! TypeScript content-mapper protocol server.
 //!
 //! Speaks the TypeScript content-mapper protocol:
-//! `initialize` negotiates the position encoding, `openProject` and
+//! `initialize` negotiates capabilities and the position encoding, `openProject` and
 //! `closeProject` bracket each TypeScript project's mapper options and
 //! compiler options, and `transform` projects one Vue SFC into virtual
 //! TypeScript for an opened project handle.
@@ -115,13 +115,10 @@ fn serve<R: BufRead, W: Write>(reader: &mut R, writer: &mut W) -> io::Result<()>
                 }
 
                 initialized = true;
-                let mut result = json!({
+                let result = json!({
                     "positionEncoding": "utf-8",
                     "diagnosticSource": "vize",
                 });
-                if params.protocol_version.is_some() {
-                    result["protocolVersion"] = json!(PROTOCOL_VERSION);
-                }
                 write_result(writer, id, result)?;
             }
             "openProject" | "closeProject" | "transform" if !initialized => {

--- a/crates/vize/src/commands/content_mapper/tests.rs
+++ b/crates/vize/src/commands/content_mapper/tests.rs
@@ -5,7 +5,7 @@ use super::test_support::{
 };
 
 #[test]
-fn negotiates_utf8_and_transforms_vue_sfc() {
+fn accepts_legacy_initialize_version_without_echoing_it() {
     let input = frames(&[
         json!({
             "jsonrpc": "2.0",
@@ -25,7 +25,7 @@ fn negotiates_utf8_and_transforms_vue_sfc() {
     ]);
     let responses = exchange(&input);
 
-    assert_eq!(responses[0]["result"]["protocolVersion"], 1);
+    assert!(responses[0]["result"].get("protocolVersion").is_none());
     assert_eq!(responses[0]["result"]["positionEncoding"], "utf-8");
     assert_eq!(responses[0]["result"]["diagnosticSource"], "vize");
     assert!(responses[2]["result"].get("scriptKind").is_none());
@@ -57,7 +57,7 @@ fn negotiates_utf8_without_legacy_protocol_version() {
     })]);
     let responses = exchange(&input);
 
-    assert_eq!(responses[0]["result"]["protocolVersion"], Value::Null);
+    assert!(responses[0]["result"].get("protocolVersion").is_none());
     assert_eq!(responses[0]["result"]["positionEncoding"], "utf-8");
     assert_eq!(responses[0]["result"]["diagnosticSource"], "vize");
 }

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -5,10 +5,12 @@ import { parse } from "yaml";
 
 import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
 
-const UPSTREAM_SHA = "01b9e721f3d7f8037d700daff94f5808c1afb97e";
-const WATCHER_CLOSE_TEST = "TestWatcher_CloseWhileWatchFilesReconciles";
-const WATCHER_COMMAND = `go test ./internal/lsp/lspwatcher -run '^${WATCHER_CLOSE_TEST}$' -count=1`;
-const TSGO_BUILD_COMMAND = 'go build -tags=noembed -trimpath -o "$RUNNER_TEMP/tsgo" ./cmd/tsgo';
+const UPSTREAM_SHA = "d6c4afddb2c55f4a9dea7b59293a99a8fdea1799";
+const CONTENT_MAPPER_PROTOCOL_COMMAND =
+  "go test ./internal/contentmapper -run '^(TestRunnerTransform|TestRunnerTransformResponseValidation)$' -count=1";
+const SPANMAP_PROTOCOL_COMMAND =
+  "go test ./internal/spanmap -run '^(TestOriginalToVirtualOverlappingSpans|TestValidateOriginalOverlapAndFeatures)$' -count=1";
+const TSGO_BUILD_COMMAND = 'go build -tags=noembed -trimpath -o "$RUNNER_TEMP/tsgo" ./cmd/tsc';
 const MAESTRO_COMMAND = "cargo test -p vize_maestro -- --quiet";
 const MAESTRO_LOOP = "for iteration in $(seq 1 20); do";
 const MAESTRO_SUCCESS_LOG = 'echo "Content Mapper Maestro lifecycle cycle $iteration/20 passed"';
@@ -74,23 +76,40 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
     assert.match(workflow, new RegExp(relevantPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
 
-  assert.match(workflow, new RegExp(`CONTENT_MAPPER_TSGO_SHA: "${UPSTREAM_SHA}"`));
-  assert.match(job, /repository: microsoft\/typescript-go/);
-  assert.match(job, /ref: \$\{\{ env\.CONTENT_MAPPER_TSGO_SHA \}\}/);
+  assert.match(workflow, new RegExp(`CONTENT_MAPPER_TYPESCRIPT_SHA: "${UPSTREAM_SHA}"`));
+  assert.match(job, /repository: microsoft\/TypeScript/);
+  assert.match(job, /ref: \$\{\{ env\.CONTENT_MAPPER_TYPESCRIPT_SHA \}\}/);
   assert.match(job, /uses: actions\/setup-go@[0-9a-f]{40}\s+# v6\.1\.0/);
   assert.match(
     job,
     /uses: \.\/\.github\/actions\/setup-rust-sticky-cache\n\s+with:\n\s+key: content-mapper-conformance\n\s+cache-key-suffix: \$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}/,
   );
-  assert.match(job, /go-version-file: typescript-go-content-mapper\/go\.mod/);
-  const watcherSteps = stepsRunning(steps, WATCHER_COMMAND);
+  assert.match(job, /go-version-file: typescript-content-mapper\/tsc\/go\.mod/);
+  const contentMapperProtocolSteps = stepsRunning(steps, CONTENT_MAPPER_PROTOCOL_COMMAND);
+  const spanmapProtocolSteps = stepsRunning(steps, SPANMAP_PROTOCOL_COMMAND);
   const buildSteps = stepsRunning(steps, TSGO_BUILD_COMMAND);
-  assert.equal(watcherSteps.length, 1, "expected exactly one watcher regression step");
+  assert.equal(
+    contentMapperProtocolSteps.length,
+    1,
+    "expected exactly one upstream content mapper protocol regression step",
+  );
+  assert.equal(
+    spanmapProtocolSteps.length,
+    1,
+    "expected exactly one upstream spanmap regression step",
+  );
   assert.equal(buildSteps.length, 1, "expected exactly one exact tsgo build step");
-  assert.equal(steps[watcherSteps[0]]["working-directory"], "typescript-go-content-mapper");
+  assert.equal(
+    steps[contentMapperProtocolSteps[0]]["working-directory"],
+    "typescript-content-mapper/tsc",
+  );
+  assert.equal(
+    steps[spanmapProtocolSteps[0]]["working-directory"],
+    "typescript-content-mapper/tsc",
+  );
   assert.ok(
-    watcherSteps[0] < buildSteps[0],
-    "watcher regression must run before the exact tsgo build",
+    contentMapperProtocolSteps[0] < buildSteps[0] && spanmapProtocolSteps[0] < buildSteps[0],
+    "upstream protocol regressions must run before the exact tsgo build",
   );
   assert.match(job, /cp internal\/bundled\/libs\/\*\.d\.ts "\$RUNNER_TEMP\/"/);
   assert.match(job, /VIZE_TEST_CONTENT_MAPPER_TSGO: \$\{\{ runner\.temp \}\}\/tsgo/);


### PR DESCRIPTION
## Summary

- track the merged TypeScript content mapper round-two commit in the exact conformance workflow
- build the upstream binary from the TypeScript monorepo `tsc/cmd/tsc` entry point
- stop echoing the removed `protocolVersion` field from Vize content mapper initialize responses while keeping legacy input accepted

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize commands::content_mapper -- --nocapture`
- `cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture`
- `vp check .github/workflows/content-mapper-conformance.yml tests/tooling/content-mapper-workflow.test.ts crates/vize/src/commands/content_mapper.rs crates/vize/src/commands/content_mapper/tests.rs`
- `node --test tests/tooling/content-mapper-workflow.test.ts`
- `MOON_HOME=/tmp/vize-moonbit.wocUWA/moonbit PATH="/tmp/vize-moonbit.wocUWA/moonbit-shims:/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts`
- upstream TypeScript `d6c4afddb2c55f4a9dea7b59293a99a8fdea1799`: `go test ./internal/contentmapper -run '^(TestRunnerTransform|TestRunnerTransformResponseValidation)$' -count=1`
- upstream TypeScript `d6c4afddb2c55f4a9dea7b59293a99a8fdea1799`: `go test ./internal/spanmap -run '^(TestOriginalToVirtualOverlappingSpans|TestValidateOriginalOverlapAndFeatures)$' -count=1`
- upstream TypeScript `d6c4afddb2c55f4a9dea7b59293a99a8fdea1799`: `go build -tags=noembed -trimpath -o <temp>/tsgo ./cmd/tsc`

Refs microsoft/TypeScript#63936.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4616"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790051828&installation_model_id=422833&pr_number=4616&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4616&signature=ca724132636b229ab6b0c96271720ba64a56f3e4e74decc664bc3a3efc63eae2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Content Mapper protocol compatibility during initialization.
  - Legacy protocol version inputs are now accepted without being echoed in responses.
  - Updated UTF-8 position encoding negotiation behavior.

- **Tests**
  - Expanded conformance coverage for transforms, response validation, span mapping, and overlap handling.
  - Updated regression checks to validate Content Mapper protocol behavior and TypeScript integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->