### PR TITLE
fix(native): lower gnu glibc release floor

### DIFF
--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -29,10 +29,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: blacksmith-32vcpu-ubuntu-2404
+          - runner: ubuntu-22.04
             target: linux-x64-gnu
             msvc_arch: amd64
-          - runner: blacksmith-32vcpu-ubuntu-2404-arm
+          - runner: ubuntu-22.04-arm
             target: linux-arm64-gnu
             msvc_arch: amd64
           - runner: macos-15-intel
@@ -95,6 +95,9 @@ jobs:
           fi
       - name: Build @vizejs/native
         run: vp run --filter './npm/native' build:ci
+      - name: Verify GNU native glibc compatibility
+        if: runner.os == 'Linux' && endsWith(matrix.target, '-gnu')
+        run: node tools/github/verify-glibc-symbols.mjs --max 2.36 npm/native/*.linux-*-gnu.node
       - name: Smoke @vizejs/native
         run: node -e "const native = require('./npm/native'); if (typeof native.compileSfc !== 'function') throw new Error('compileSfc missing')"
       - name: Package-install smoke for host native package
@@ -114,10 +117,10 @@ jobs:
         # known-limitation policy in docs/content/stability.md in sync when
         # containerized musl tarball staging is added.
         platform:
-          - runner: blacksmith-32vcpu-ubuntu-2404
+          - runner: ubuntu-22.04
             target: linux-x64-gnu
             msvc_arch: amd64
-          - runner: blacksmith-32vcpu-ubuntu-2404-arm
+          - runner: ubuntu-22.04-arm
             target: linux-arm64-gnu
             msvc_arch: amd64
           - runner: macos-15-intel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -415,10 +415,7 @@ jobs:
         run: moon run --target native tools/moon/cmd/github/clean_node_binaries -- npm/native npm/fresco-native
       - name: Build vize-native
         shell: bash
-        run: moon run --target native tools/moon/cmd/github/build_napi_package -- npm/native ../../crates/vize_vitrine/Cargo.toml vize_vitrine ${{ matrix.settings.target }} ${{ matrix.settings.cross_compile == true && '--cross-compile' || '' }}
-      - name: Verify vize-native GNU glibc compatibility
-        if: runner.os == 'Linux' && endsWith(matrix.settings.target, '-gnu')
-        run: node tools/github/verify-glibc-symbols.mjs --max 2.36 npm/native/*.linux-*-gnu.node
+        run: moon run --target native tools/moon/cmd/github/build_napi_package -- npm/native ../../crates/vize_vitrine/Cargo.toml vize_vitrine ${{ matrix.settings.target }} ${{ matrix.settings.cross_compile == true && '--cross-compile' || '' }} && if [[ "$RUNNER_OS" == Linux && "${{ matrix.settings.target }}" == *-gnu ]]; then node tools/github/verify-glibc-symbols.mjs --max 2.36 npm/native/*.linux-*-gnu.node; fi
       - name: Collect vize-native artifact
         shell: bash
         run: moon run --target native tools/moon/cmd/github/collect_native_artifacts -- npm/native .artifacts/vize-native vize-native
@@ -431,10 +428,7 @@ jobs:
           compression-level: 0
       - name: Build fresco-native
         shell: bash
-        run: moon run --target native tools/moon/cmd/github/build_napi_package -- npm/fresco-native ../../crates/vize_fresco/Cargo.toml vize_fresco ${{ matrix.settings.target }} ${{ matrix.settings.cross_compile == true && '--cross-compile' || '' }}
-      - name: Verify fresco-native GNU glibc compatibility
-        if: runner.os == 'Linux' && endsWith(matrix.settings.target, '-gnu')
-        run: node tools/github/verify-glibc-symbols.mjs --max 2.36 npm/fresco-native/*.linux-*-gnu.node
+        run: moon run --target native tools/moon/cmd/github/build_napi_package -- npm/fresco-native ../../crates/vize_fresco/Cargo.toml vize_fresco ${{ matrix.settings.target }} ${{ matrix.settings.cross_compile == true && '--cross-compile' || '' }} && if [[ "$RUNNER_OS" == Linux && "${{ matrix.settings.target }}" == *-gnu ]]; then node tools/github/verify-glibc-symbols.mjs --max 2.36 npm/fresco-native/*.linux-*-gnu.node; fi
       - name: Collect fresco-native artifact
         shell: bash
         run: moon run --target native tools/moon/cmd/github/collect_native_artifacts -- npm/fresco-native .artifacts/fresco-native fresco-native

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,6 +416,9 @@ jobs:
       - name: Build vize-native
         shell: bash
         run: moon run --target native tools/moon/cmd/github/build_napi_package -- npm/native ../../crates/vize_vitrine/Cargo.toml vize_vitrine ${{ matrix.settings.target }} ${{ matrix.settings.cross_compile == true && '--cross-compile' || '' }}
+      - name: Verify vize-native GNU glibc compatibility
+        if: runner.os == 'Linux' && endsWith(matrix.settings.target, '-gnu')
+        run: node tools/github/verify-glibc-symbols.mjs --max 2.36 npm/native/*.linux-*-gnu.node
       - name: Collect vize-native artifact
         shell: bash
         run: moon run --target native tools/moon/cmd/github/collect_native_artifacts -- npm/native .artifacts/vize-native vize-native
@@ -429,6 +432,9 @@ jobs:
       - name: Build fresco-native
         shell: bash
         run: moon run --target native tools/moon/cmd/github/build_napi_package -- npm/fresco-native ../../crates/vize_fresco/Cargo.toml vize_fresco ${{ matrix.settings.target }} ${{ matrix.settings.cross_compile == true && '--cross-compile' || '' }}
+      - name: Verify fresco-native GNU glibc compatibility
+        if: runner.os == 'Linux' && endsWith(matrix.settings.target, '-gnu')
+        run: node tools/github/verify-glibc-symbols.mjs --max 2.36 npm/fresco-native/*.linux-*-gnu.node
       - name: Collect fresco-native artifact
         shell: bash
         run: moon run --target native tools/moon/cmd/github/collect_native_artifacts -- npm/fresco-native .artifacts/fresco-native fresco-native

--- a/tests/tooling/github-workflows-release-build.test.ts
+++ b/tests/tooling/github-workflows-release-build.test.ts
@@ -173,15 +173,32 @@ test("release workflow builds native targets on MoonBit-supported runners", () =
   for (const [host, target] of [
     [hostedOrBlacksmith("macos-15"), "x86_64-apple-darwin"],
     [hostedOrBlacksmith("macos-15"), "aarch64-apple-darwin"],
-    [hostedOrBlacksmith("ubuntu-24.04"), "x86_64-unknown-linux-gnu"],
+    [hostedOrBlacksmith("ubuntu-22.04"), "x86_64-unknown-linux-gnu"],
     [hostedOrBlacksmith("ubuntu-24.04"), "x86_64-unknown-linux-musl"],
-    [hostedOrBlacksmith("ubuntu-24.04-arm"), "aarch64-unknown-linux-gnu"],
+    [hostedOrBlacksmith("ubuntu-22.04-arm"), "aarch64-unknown-linux-gnu"],
     [hostedOrBlacksmith("ubuntu-24.04"), "aarch64-unknown-linux-musl"],
     [hostedOrBlacksmith("windows-2025"), "x86_64-pc-windows-msvc"],
     ["windows-11-arm", "aarch64-pc-windows-msvc"],
   ] as const) {
     assert.match(releasePlatforms, new RegExp(`host:\\s*"${host}"[\\s\\S]*target:\\s*"${target}"`));
   }
+});
+
+test("release workflow gates GNU native binaries against the Debian bookworm glibc ceiling", () => {
+  const workflow = readRepoFile(".github", "workflows", "release.yml");
+  const buildNativeJob = workflowJobBody(workflow, "build-native-all");
+  const nativeHosts = new Map(nativeReleasePlatforms.map(({ host, target }) => [target, host]));
+
+  assert.equal(nativeHosts.get("x86_64-unknown-linux-gnu"), "ubuntu-22.04");
+  assert.equal(nativeHosts.get("aarch64-unknown-linux-gnu"), "ubuntu-22.04-arm");
+  assert.match(
+    buildNativeJob,
+    /name:\s*Verify vize-native GNU glibc compatibility[\s\S]*verify-glibc-symbols\.mjs --max 2\.36 npm\/native\/\*\.linux-\*-gnu\.node/,
+  );
+  assert.match(
+    buildNativeJob,
+    /name:\s*Verify fresco-native GNU glibc compatibility[\s\S]*verify-glibc-symbols\.mjs --max 2\.36 npm\/fresco-native\/\*\.linux-\*-gnu\.node/,
+  );
 });
 
 test("release workflow keeps the Windows ARM64 CLI cross build on a compatible hosted runner", () => {

--- a/tests/tooling/github-workflows-release-build.test.ts
+++ b/tests/tooling/github-workflows-release-build.test.ts
@@ -182,22 +182,9 @@ test("release workflow builds native targets on MoonBit-supported runners", () =
   ] as const) {
     assert.match(releasePlatforms, new RegExp(`host:\\s*"${host}"[\\s\\S]*target:\\s*"${target}"`));
   }
-});
-
-test("release workflow gates GNU native binaries against the Debian bookworm glibc ceiling", () => {
-  const workflow = readRepoFile(".github", "workflows", "release.yml");
-  const buildNativeJob = workflowJobBody(workflow, "build-native-all");
-  const nativeHosts = new Map(nativeReleasePlatforms.map(({ host, target }) => [target, host]));
-
-  assert.equal(nativeHosts.get("x86_64-unknown-linux-gnu"), "ubuntu-22.04");
-  assert.equal(nativeHosts.get("aarch64-unknown-linux-gnu"), "ubuntu-22.04-arm");
   assert.match(
-    buildNativeJob,
-    /name:\s*Verify vize-native GNU glibc compatibility[\s\S]*verify-glibc-symbols\.mjs --max 2\.36 npm\/native\/\*\.linux-\*-gnu\.node/,
-  );
-  assert.match(
-    buildNativeJob,
-    /name:\s*Verify fresco-native GNU glibc compatibility[\s\S]*verify-glibc-symbols\.mjs --max 2\.36 npm\/fresco-native\/\*\.linux-\*-gnu\.node/,
+    workflowJobBody(readRepoFile(".github", "workflows", "release.yml"), "build-native-all"),
+    /verify-glibc-symbols\.mjs --max 2\.36 npm\/native\/\*\.linux-\*-gnu\.node[\s\S]*verify-glibc-symbols\.mjs --max 2\.36 npm\/fresco-native\/\*\.linux-\*-gnu\.node/,
   );
 });
 

--- a/tests/tooling/github-workflows-release-build.test.ts
+++ b/tests/tooling/github-workflows-release-build.test.ts
@@ -182,10 +182,6 @@ test("release workflow builds native targets on MoonBit-supported runners", () =
   ] as const) {
     assert.match(releasePlatforms, new RegExp(`host:\\s*"${host}"[\\s\\S]*target:\\s*"${target}"`));
   }
-  assert.match(
-    workflowJobBody(readRepoFile(".github", "workflows", "release.yml"), "build-native-all"),
-    /verify-glibc-symbols\.mjs --max 2\.36 npm\/native\/\*\.linux-\*-gnu\.node[\s\S]*verify-glibc-symbols\.mjs --max 2\.36 npm\/fresco-native\/\*\.linux-\*-gnu\.node/,
-  );
 });
 
 test("release workflow keeps the Windows ARM64 CLI cross build on a compatible hosted runner", () => {

--- a/tests/tooling/github-workflows-setup.test.ts
+++ b/tests/tooling/github-workflows-setup.test.ts
@@ -194,8 +194,8 @@ test("native smoke workflow covers host platforms before release tags", () => {
     /Full native\/fresh-install smoke is release evidence, not a per-push gate/,
   );
   for (const [runner, target] of [
-    [hostedOrBlacksmith("ubuntu-24.04"), "linux-x64-gnu"],
-    [hostedOrBlacksmith("ubuntu-24.04-arm"), "linux-arm64-gnu"],
+    [hostedOrBlacksmith("ubuntu-22.04"), "linux-x64-gnu"],
+    [hostedOrBlacksmith("ubuntu-22.04-arm"), "linux-arm64-gnu"],
     ["macos-15-intel", "darwin-x64"],
     [hostedOrBlacksmith("macos-15"), "darwin-arm64"],
     [hostedOrBlacksmith("windows-2025"), "win32-x64-msvc"],
@@ -205,6 +205,7 @@ test("native smoke workflow covers host platforms before release tags", () => {
   }
   assert.match(job, /cargo build --profile ci -p vize/);
   assert.match(job, /vp run --filter '\.\/npm\/native' build:ci/);
+  assert.match(job, /verify-glibc-symbols\.mjs --max 2\.36 npm\/native\/\*\.linux-\*-gnu\.node/);
   assert.match(job, /require\('\.\/npm\/native'\)/);
   assert.match(job, /smoke-release-install\.mjs --prepare-manifests npm\/native/);
 });
@@ -214,8 +215,8 @@ test("native smoke workflow fresh-installs runtime tarballs across supported tar
   const job = workflowJobBody(workflow, "fresh-install-smoke");
 
   for (const [runner, target] of [
-    [hostedOrBlacksmith("ubuntu-24.04"), "linux-x64-gnu"],
-    [hostedOrBlacksmith("ubuntu-24.04-arm"), "linux-arm64-gnu"],
+    [hostedOrBlacksmith("ubuntu-22.04"), "linux-x64-gnu"],
+    [hostedOrBlacksmith("ubuntu-22.04-arm"), "linux-arm64-gnu"],
     ["macos-15-intel", "darwin-x64"],
     [hostedOrBlacksmith("macos-15"), "darwin-arm64"],
     [hostedOrBlacksmith("windows-2025"), "win32-x64-msvc"],

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -97,7 +97,7 @@ test("GitHub workflows declare the expected cross-platform runner matrix", () =>
   // `github.event_name == 'pull_request' && 'ubuntu-latest' || 'ubuntu-24.04'`)
   // and is asserted shape-by-shape further down.
   const allowedRunnerPattern =
-    /^(?:ubuntu-(?:latest|24\.04)(?:-arm)?|blacksmith-\d+vcpu-ubuntu-2404(?:-arm)?|macos-15(?:-intel)?|blacksmith-(?:6|12)vcpu-macos-15|windows-(?:2025|11-arm)|blacksmith-\d+vcpu-windows-2025)$/;
+    /^(?:ubuntu-(?:latest|2[24]\.04)(?:-arm)?|blacksmith-\d+vcpu-ubuntu-2404(?:-arm)?|macos-15(?:-intel)?|blacksmith-(?:6|12)vcpu-macos-15|windows-(?:2025|11-arm)|blacksmith-\d+vcpu-windows-2025)$/;
   const matrixRunnerPattern = /(?:runner|host):\s*([A-Za-z0-9._-]+)/g;
   const violations: string[] = [];
 
@@ -120,12 +120,12 @@ test("GitHub workflows declare the expected cross-platform runner matrix", () =>
   // GitHub-hosted label or any Blacksmith Ubuntu SKU so changing vCPU size
   // (or temporarily reverting to GitHub-hosted) doesn't churn this test.
   assert.match(checkWorkflow, new RegExp(`runs-on:\\s*${hostedOrBlacksmith("ubuntu-24.04")}`));
-  assert.match(nativeWorkflow, new RegExp(`runner:\\s*${hostedOrBlacksmith("ubuntu-24.04-arm")}`));
+  assert.match(nativeWorkflow, new RegExp(`runner:\\s*${hostedOrBlacksmith("ubuntu-22.04-arm")}`));
   assert.match(nativeWorkflow, new RegExp(`runner:\\s*${hostedOrBlacksmith("macos-15")}`));
   assert.match(nativeWorkflow, new RegExp(`runner:\\s*${hostedOrBlacksmith("windows-2025")}`));
   assert.match(
     releasePlatforms,
-    new RegExp(`host:\\s*"${hostedOrBlacksmith("ubuntu-24.04-arm")}"`),
+    new RegExp(`host:\\s*"${hostedOrBlacksmith("ubuntu-22.04-arm")}"`),
   );
   assert.match(releasePlatforms, new RegExp(`host:\\s*"${hostedOrBlacksmith("macos-15")}"`));
   assert.match(releasePlatforms, new RegExp(`host:\\s*"${hostedOrBlacksmith("windows-2025")}"`));

--- a/tests/tooling/glibc-symbols.test.ts
+++ b/tests/tooling/glibc-symbols.test.ts
@@ -7,6 +7,7 @@ import {
   parseGlibcVersion,
   parseGlibcVersions,
 } from "../../tools/github/verify-glibc-symbols.mjs";
+import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
 
 test("glibc symbol parser deduplicates and sorts required versions", () => {
   const versions = parseGlibcVersions(`
@@ -42,4 +43,11 @@ test("glibc verifier accepts binaries at the Debian bookworm ceiling", () => {
   `);
 
   assert.deepEqual(glibcVersionsAbove(versions, parseGlibcVersion("2.36")), []);
+});
+
+test("release workflow gates GNU native binaries against the Debian bookworm glibc ceiling", () => {
+  assert.match(
+    workflowJobBody(readRepoFile(".github", "workflows", "release.yml"), "build-native-all"),
+    /verify-glibc-symbols\.mjs --max 2\.36 npm\/native\/\*\.linux-\*-gnu\.node[\s\S]*verify-glibc-symbols\.mjs --max 2\.36 npm\/fresco-native\/\*\.linux-\*-gnu\.node/,
+  );
 });

--- a/tests/tooling/glibc-symbols.test.ts
+++ b/tests/tooling/glibc-symbols.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  glibcVersionsAbove,
+  highestGlibcVersion,
+  parseGlibcVersion,
+  parseGlibcVersions,
+} from "../../tools/github/verify-glibc-symbols.mjs";
+
+test("glibc symbol parser deduplicates and sorts required versions", () => {
+  const versions = parseGlibcVersions(`
+    0x0010:   Name: GLIBC_2.2.5  Flags: none  Version: 7
+    0x0020:   Name: GLIBC_2.36   Flags: none  Version: 6
+    0x0030:   Name: GLIBC_2.17   Flags: none  Version: 5
+    0x0040:   Name: GLIBC_2.36   Flags: none  Version: 6
+  `);
+
+  assert.deepEqual(
+    versions.map((version) => version.text),
+    ["2.2.5", "2.17", "2.36"],
+  );
+  assert.equal(highestGlibcVersion(versions)?.text, "2.36");
+});
+
+test("glibc verifier flags native binaries newer than the Debian bookworm ceiling", () => {
+  const versions = parseGlibcVersions(`
+    0x0010:   Name: GLIBC_2.2.5  Flags: none  Version: 7
+    0x0020:   Name: GLIBC_2.39   Flags: none  Version: 6
+  `);
+
+  assert.deepEqual(
+    glibcVersionsAbove(versions, parseGlibcVersion("2.36")).map((version) => version.text),
+    ["2.39"],
+  );
+});
+
+test("glibc verifier accepts binaries at the Debian bookworm ceiling", () => {
+  const versions = parseGlibcVersions(`
+    0x0010:   Name: GLIBC_2.2.5  Flags: none  Version: 7
+    0x0020:   Name: GLIBC_2.36   Flags: none  Version: 6
+  `);
+
+  assert.deepEqual(glibcVersionsAbove(versions, parseGlibcVersion("2.36")), []);
+});

--- a/tests/tooling/release-platforms.test.ts
+++ b/tests/tooling/release-platforms.test.ts
@@ -35,6 +35,14 @@ test("release platform plan includes slow targets outside fifth minors", () => {
   assert.ok(plan.nativeMatrix.some((platform) => platform.target === "aarch64-pc-windows-msvc"));
 });
 
+test("release platform plan builds GNU native packages on the Debian bookworm floor", () => {
+  const plan = releasePlatformPlan("v1.201.0");
+  const hosts = new Map(plan.nativeMatrix.map(({ host, target }) => [target, host]));
+
+  assert.equal(hosts.get("x86_64-unknown-linux-gnu"), "ubuntu-22.04");
+  assert.equal(hosts.get("aarch64-unknown-linux-gnu"), "ubuntu-22.04-arm");
+});
+
 test("release platform cadence preserves native manifest entries when all platforms are included", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-platforms-"));
   const packageDir = path.join(tempDir, "npm", "native");

--- a/tests/tooling/support/github-workflows.ts
+++ b/tests/tooling/support/github-workflows.ts
@@ -81,6 +81,12 @@ const LABEL_BOUNDARY = "(?![\\w.-])";
 // runner-pool vendor; switching back to GitHub-hosted shouldn't break the test
 // and vice versa.
 export function hostedOrBlacksmith(hostedLabel: string): string {
+  if (hostedLabel === "ubuntu-22.04") {
+    return `ubuntu-22\\.04${LABEL_BOUNDARY}`;
+  }
+  if (hostedLabel === "ubuntu-22.04-arm") {
+    return `ubuntu-22\\.04-arm${LABEL_BOUNDARY}`;
+  }
   if (hostedLabel === "ubuntu-24.04") {
     return `(?:ubuntu-24\\.04|blacksmith-\\d+vcpu-ubuntu-2404)${LABEL_BOUNDARY}`;
   }

--- a/tools/github/release-platforms.mjs
+++ b/tools/github/release-platforms.mjs
@@ -79,7 +79,7 @@ export const nativeReleasePlatforms = [
     cross_compile: false,
   },
   {
-    host: "blacksmith-32vcpu-ubuntu-2404",
+    host: "ubuntu-22.04",
     target: "x86_64-unknown-linux-gnu",
     cross_compile: false,
   },
@@ -89,7 +89,7 @@ export const nativeReleasePlatforms = [
     cross_compile: true,
   },
   {
-    host: "blacksmith-32vcpu-ubuntu-2404-arm",
+    host: "ubuntu-22.04-arm",
     target: "aarch64-unknown-linux-gnu",
     cross_compile: false,
   },

--- a/tools/github/verify-glibc-symbols.mjs
+++ b/tools/github/verify-glibc-symbols.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_MAX_GLIBC = "2.36";
+
+export function parseGlibcVersions(text) {
+  const versions = new Map();
+  for (const match of text.matchAll(/\bGLIBC_(\d+)\.(\d+)(?:\.(\d+))?\b/g)) {
+    const patch = match[3] == null ? 0 : Number(match[3]);
+    const version = {
+      major: Number(match[1]),
+      minor: Number(match[2]),
+      patch,
+      text: `${Number(match[1])}.${Number(match[2])}${patch === 0 ? "" : `.${patch}`}`,
+    };
+    versions.set(version.text, version);
+  }
+  return [...versions.values()].sort(compareGlibcVersions);
+}
+
+export function parseGlibcVersion(value) {
+  const match = /^(\d+)\.(\d+)(?:\.(\d+))?$/.exec(value);
+  if (!match) {
+    throw new Error(`glibc version must look like MAJOR.MINOR[.PATCH], got ${value}`);
+  }
+  const patch = match[3] == null ? 0 : Number(match[3]);
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch,
+    text: `${Number(match[1])}.${Number(match[2])}${patch === 0 ? "" : `.${patch}`}`,
+  };
+}
+
+export function compareGlibcVersions(left, right) {
+  return left.major - right.major || left.minor - right.minor || left.patch - right.patch;
+}
+
+export function highestGlibcVersion(versions) {
+  return versions.at(-1) ?? null;
+}
+
+export function glibcVersionsAbove(versions, maxVersion) {
+  return versions.filter((version) => compareGlibcVersions(version, maxVersion) > 0);
+}
+
+function readElfVersionInfo(filePath) {
+  const result = spawnSync("readelf", ["--version-info", filePath], {
+    encoding: "utf8",
+  });
+  if (result.error != null) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `readelf --version-info failed for ${filePath}\n${result.stderr}${result.stdout}`.trim(),
+    );
+  }
+  return `${result.stdout}\n${result.stderr}`;
+}
+
+function parseArgs(args) {
+  let max = DEFAULT_MAX_GLIBC;
+  const files = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--max") {
+      const value = args[index + 1];
+      if (!value) {
+        throw new Error("--max requires a value");
+      }
+      max = value;
+      index += 1;
+      continue;
+    }
+    files.push(arg);
+  }
+  return { files, max: parseGlibcVersion(max) };
+}
+
+function reportError(message) {
+  console.error(`::error::${message}`);
+}
+
+function main() {
+  const { files, max } = parseArgs(process.argv.slice(2));
+  if (files.length === 0) {
+    throw new Error(
+      "Usage: node tools/github/verify-glibc-symbols.mjs [--max 2.36] <file.node>...",
+    );
+  }
+
+  let failed = false;
+  for (const file of files) {
+    if (!fs.existsSync(file)) {
+      reportError(`native binary does not exist: ${file}`);
+      failed = true;
+      continue;
+    }
+
+    const versions = parseGlibcVersions(readElfVersionInfo(file));
+    if (versions.length === 0) {
+      reportError(`native binary has no GLIBC_* version records: ${file}`);
+      failed = true;
+      continue;
+    }
+
+    const tooNew = glibcVersionsAbove(versions, max);
+    if (tooNew.length > 0) {
+      const highest = highestGlibcVersion(versions);
+      reportError(
+        `${file} requires GLIBC_${highest.text}, above the supported ceiling GLIBC_${max.text}`,
+      );
+      failed = true;
+      continue;
+    }
+
+    const highest = highestGlibcVersion(versions);
+    console.log(`${file}: GLIBC_${highest.text} <= GLIBC_${max.text}`);
+  }
+
+  if (failed) {
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] != null && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}


### PR DESCRIPTION
## Summary
- build GNU Linux native package release artifacts on Ubuntu 22.04 / 22.04-arm so the emitted N-API binaries stay compatible with Debian bookworm's glibc floor
- add a release/native-smoke verifier that fails if shipped GNU `.node` binaries require a GLIBC symbol newer than 2.36
- keep the workflow shape tests pinned to the bookworm-compatible native runner plan

The loader diagnostic side of #4453 is already covered on main by the native loader failure tests; this slice closes the remaining release artifact ABI gap.

Fixes #4453

## Validation
- `node --test tests/tooling/glibc-symbols.test.ts tests/tooling/release-platforms.test.ts tests/tooling/github-workflows-release-build.test.ts tests/tooling/github-workflows-setup.test.ts tests/tooling/github-workflows.test.ts tests/tooling/native-loader-errors.test.ts tests/tooling/native-loader-failures.test.ts`
- `MOON_HOME=/private/tmp/vize-moonbit.wocUWA/moonbit PATH="/private/tmp/vize-moonbit.wocUWA/moonbit-shims:/private/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts`
- `vp check tools/github/verify-glibc-symbols.mjs tools/github/release-platforms.mjs .github/workflows/native-smoke.yml .github/workflows/release.yml tests/tooling/glibc-symbols.test.ts tests/tooling/release-platforms.test.ts tests/tooling/github-workflows-release-build.test.ts tests/tooling/github-workflows-setup.test.ts tests/tooling/github-workflows.test.ts tests/tooling/support/github-workflows.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790057390&installation_model_id=422833&pr_number=4622&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4622&signature=2ad130683210593b9dbe7e2dbe1b2590ef4c616fd03a9c28c62094e61d6c2c6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->