### PR TITLE
fix(release): defer manual crates publish handoffs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,7 +86,6 @@ jobs:
           - vize_armature
           - vize_atelier_core
           - vize_atelier_dom
-          - vize_atelier_jsx
           - vize_atelier_sfc
           - vize_atelier_ssr
           - vize_atelier_vapor
@@ -94,7 +93,6 @@ jobs:
           - vize_croquis
           - vize_fresco
           - vize_musea
-          - vize_patina
           - vize_relief
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/tests/tooling/moonbit-publish-crates.test.ts
+++ b/tests/tooling/moonbit-publish-crates.test.ts
@@ -37,9 +37,9 @@ function getScriptCrateArray(variableName: string): string[] {
 }
 
 const getPublishedCrates = () => getScriptCrateArray("published_crates");
-const getPendingFirstPublishCrates = () => getScriptCrateArray("pending_first_publish_crates");
-const getBlockedByPendingFirstPublishCrates = () =>
-  getScriptCrateArray("blocked_by_pending_first_publish_crates");
+const getManualPublishCrates = () => getScriptCrateArray("manual_publish_crates");
+const getBlockedByManualPublishCrates = () =>
+  getScriptCrateArray("blocked_by_manual_publish_crates");
 
 function getMetadata(): CargoMetadata {
   return JSON.parse(
@@ -80,8 +80,8 @@ test("publish_crates script keeps publishable workspace dependencies ordered", (
 test("publish_crates exactly partitions every publishable workspace crate", () => {
   const releaseCrates = [
     ...getPublishedCrates(),
-    ...getPendingFirstPublishCrates(),
-    ...getBlockedByPendingFirstPublishCrates(),
+    ...getManualPublishCrates(),
+    ...getBlockedByManualPublishCrates(),
   ];
   const publishableCrates = getMetadata()
     .packages.filter((pkg) =>
@@ -94,16 +94,17 @@ test("publish_crates exactly partitions every publishable workspace crate", () =
   assert.deepEqual(releaseCrates.toSorted(), publishableCrates.toSorted());
 });
 
-test("publish_crates only defers crates that have not been created on crates.io", () => {
-  assert.deepEqual(getPendingFirstPublishCrates(), [
+test("publish_crates defers crates that still need manual crates.io handoff", () => {
+  assert.deepEqual(getManualPublishCrates(), [
     "vize_croquis_cf",
+    "vize_atelier_jsx",
     "vize_marquette",
     "vize_doctor",
   ]);
 });
 
-test("publish_crates only blocks crates that depend on first-publish exclusions", () => {
-  assert.deepEqual(getBlockedByPendingFirstPublishCrates(), ["vize_canon"]);
+test("publish_crates only blocks crates that depend on manual-publish exclusions", () => {
+  assert.deepEqual(getBlockedByManualPublishCrates(), ["vize_canon", "vize_patina"]);
 });
 
 test("publish_crates native script covers publish and idempotent dry-run modes", () => {

--- a/tools/moon/cmd/publish_crates/main.mbt
+++ b/tools/moon/cmd/publish_crates/main.mbt
@@ -9,9 +9,11 @@
 /// The order matters because many of these crates depend on previously
 /// published workspace crates via exact-version dependencies. The accompanying
 /// test asserts that this list remains topologically valid.
-/// Crates in `pending_first_publish_crates` are intentionally omitted here:
-/// crates.io Trusted Publishing can publish new versions of existing crates,
-/// but it cannot create a crate on its first release.
+/// Crates in `manual_publish_crates` are intentionally omitted here:
+/// crates.io Trusted Publishing can publish only crates whose trusted-publisher
+/// handoff is configured for this repository/workflow/environment. First
+/// publishes and crates whose handoff has not been completed yet must be
+/// published manually once before this job can own subsequent versions.
 let published_crates : Array[String] = [
   "vize_carton",
   "vize_relief",
@@ -22,24 +24,24 @@ let published_crates : Array[String] = [
   "vize_atelier_vapor",
   "vize_atelier_ssr",
   "vize_atelier_sfc",
-  "vize_atelier_jsx",
-  "vize_patina",
   "vize_musea",
   "vize_fresco",
 ]
 
-/// Publishable crates that need one manual owner-token publish before GitHub
-/// Trusted Publishing can take over subsequent versions.
-let pending_first_publish_crates : Array[String] = [
+/// Publishable crates that need manual owner-token work before GitHub Trusted
+/// Publishing can publish them from the release workflow.
+let manual_publish_crates : Array[String] = [
   "vize_croquis_cf",
+  "vize_atelier_jsx",
   "vize_marquette",
   "vize_doctor",
 ]
 
-/// Existing crates whose current version depends on a crate that still needs
-/// its manual first publish.
-let blocked_by_pending_first_publish_crates : Array[String] = [
+/// Existing crates whose current version depends on a crate that still needs a
+/// manual publish handoff.
+let blocked_by_manual_publish_crates : Array[String] = [
   "vize_canon",
+  "vize_patina",
 ]
 
 /// Parses a positive integer from a string and falls back on invalid input.
@@ -128,14 +130,14 @@ async fn run_app() -> Int {
     delay_seconds,
   )
   println("Expected version: \{version}")
-  if !pending_first_publish_crates.is_empty() {
+  if !manual_publish_crates.is_empty() {
     println(
-      "Deferred first-publish crates: " + pending_first_publish_crates.join(", "),
+      "Deferred manual-publish crates: " + manual_publish_crates.join(", "),
     )
   }
-  if !blocked_by_pending_first_publish_crates.is_empty() {
+  if !blocked_by_manual_publish_crates.is_empty() {
     println(
-      "Deferred dependent crates: " + blocked_by_pending_first_publish_crates.join(", "),
+      "Deferred dependent crates: " + blocked_by_manual_publish_crates.join(", "),
     )
   }
 


### PR DESCRIPTION
Summary

- defer crates.io publishes that require manual owner-token or trusted-publishing handoff
- block dependent publishable crates from the automated release plan
- keep the semver matrix aligned with the automated publish plan

Validation

- MOON_HOME=/private/tmp/vize-moonbit.wocUWA/moonbit PATH="/private/tmp/vize-moonbit.wocUWA/moonbit-shims:/private/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/moonbit-publish-crates.test.ts tests/tooling/github-workflows-check.test.ts tests/tooling/github-workflows-semver.test.ts tests/tooling/github-workflows-check-gate.test.ts
- vp check tools/moon/cmd/publish_crates/main.mbt .github/workflows/check.yml tests/tooling/moonbit-publish-crates.test.ts tests/tooling/github-workflows-check.test.ts tests/tooling/github-workflows-semver.test.ts tests/tooling/github-workflows-check-gate.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790057882&installation_model_id=422833&pr_number=4623&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4623&signature=24d263afef525beac6837d7fcbd764073fd795f16d728fddfebe622be3c28723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->