### PR TITLE
fix(maestro): infer literal ref fallback types

### DIFF
--- a/crates/vize_maestro/src/ide/type_service.rs
+++ b/crates/vize_maestro/src/ide/type_service.rs
@@ -138,7 +138,10 @@ impl TypeService {
             .and_then(Self::infer_literal_value_type)
             .unwrap_or("unknown");
 
-        vize_canon::TypeInfo::new(format!("Ref<{inner}>"), vize_canon::TypeKind::Ref)
+        vize_canon::TypeInfo::new(
+            vize_carton::cstr!("Ref<{inner}>"),
+            vize_canon::TypeKind::Ref,
+        )
     }
 
     fn infer_literal_value_type(value: &str) -> Option<&'static str> {

--- a/crates/vize_maestro/src/ide/type_service.rs
+++ b/crates/vize_maestro/src/ide/type_service.rs
@@ -131,6 +131,37 @@ impl TypeService {
         let checker = vize_canon::TypeChecker::new();
         checker.get_completions(&template.content, template_offset as u32, &type_ctx)
     }
+
+    fn infer_ref_call_type(value: &str) -> vize_canon::TypeInfo {
+        let inner = value
+            .strip_prefix("ref(")
+            .and_then(Self::infer_literal_value_type)
+            .unwrap_or("unknown");
+
+        vize_canon::TypeInfo::new(format!("Ref<{inner}>"), vize_canon::TypeKind::Ref)
+    }
+
+    fn infer_literal_value_type(value: &str) -> Option<&'static str> {
+        let value = value.trim_start();
+
+        if value.starts_with('"') || value.starts_with('\'') || value.starts_with('`') {
+            Some("string")
+        } else if value.starts_with("true") || value.starts_with("false") {
+            Some("boolean")
+        } else if value.starts_with(|c: char| c.is_ascii_digit() || c == '-') {
+            Some("number")
+        } else if value.starts_with('[') {
+            Some("unknown[]")
+        } else if value.starts_with('{') {
+            Some("object")
+        } else if value.starts_with("null") {
+            Some("null")
+        } else if value.starts_with("undefined") {
+            Some("undefined")
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(test)]
@@ -167,5 +198,14 @@ mod tests {
 
         let t = TypeService::infer_binding_type("= ref(0)", "count");
         assert_eq!(t.kind, vize_canon::TypeKind::Ref);
+        assert_eq!(t.display, "Ref<number>");
+
+        let t = TypeService::infer_binding_type("= ref('hello')", "message");
+        assert_eq!(t.kind, vize_canon::TypeKind::Ref);
+        assert_eq!(t.display, "Ref<string>");
+
+        let t = TypeService::infer_binding_type("= ref<boolean>(false)", "flag");
+        assert_eq!(t.kind, vize_canon::TypeKind::Ref);
+        assert_eq!(t.display, "Ref<boolean>");
     }
 }

--- a/crates/vize_maestro/src/ide/type_service/type_context.rs
+++ b/crates/vize_maestro/src/ide/type_service/type_context.rs
@@ -100,7 +100,7 @@ impl TypeService {
                 if let Some(binding_name) = Self::find_binding_before(script, abs_fn_pos) {
                     let type_info = match kind {
                         vize_canon::BindingKind::Ref => {
-                            vize_canon::TypeInfo::new("Ref<unknown>", vize_canon::TypeKind::Ref)
+                            Self::infer_ref_call_type(&script[abs_fn_pos..])
                         }
                         vize_canon::BindingKind::Computed => vize_canon::TypeInfo::new(
                             "ComputedRef<unknown>",
@@ -221,8 +221,17 @@ impl TypeService {
             }
 
             // ref()
+            if let Some(type_arg) = value
+                .strip_prefix("ref<")
+                .and_then(|rest| rest.split_once('>').map(|(type_arg, _)| type_arg.trim()))
+            {
+                return vize_canon::TypeInfo::new(
+                    format!("Ref<{type_arg}>"),
+                    vize_canon::TypeKind::Ref,
+                );
+            }
             if value.starts_with("ref(") {
-                return vize_canon::TypeInfo::new("Ref<unknown>", vize_canon::TypeKind::Ref);
+                return Self::infer_ref_call_type(value);
             }
 
             // computed()

--- a/crates/vize_maestro/src/ide/type_service/type_context.rs
+++ b/crates/vize_maestro/src/ide/type_service/type_context.rs
@@ -226,7 +226,7 @@ impl TypeService {
                 .and_then(|rest| rest.split_once('>').map(|(type_arg, _)| type_arg.trim()))
             {
                 return vize_canon::TypeInfo::new(
-                    format!("Ref<{type_arg}>"),
+                    vize_carton::cstr!("Ref<{type_arg}>"),
                     vize_canon::TypeKind::Ref,
                 );
             }


### PR DESCRIPTION
## Summary

- infer literal `ref()` fallback types as `Ref<number>`, `Ref<string>`, and related primitive/container shapes instead of `Ref<unknown>`
- preserve generic `ref<T>()` display in the fallback type context
- tighten the TypeService regression so `ref()` display text is pinned

## Validation

- cargo fmt --all -- --check
- cargo test -p vize_maestro ide::type_service::tests::test_infer_binding_type -- --nocapture
- MOON_HOME=/private/tmp/vize-moonbit.wocUWA/moonbit PATH="/private/tmp/vize-moonbit.wocUWA/moonbit-shims:/private/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts
- vp check --no-error-on-unmatched-pattern crates/vize_maestro/src/ide/type_service.rs crates/vize_maestro/src/ide/type_service/type_context.rs
- git diff --check

Refs #4592

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790062036&installation_model_id=422833&pr_number=4626&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4626&signature=8c03ea07b338b472548748832d71ba8b322f81a5beeebfabea7dbfb4a56d5baf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for `ref()` bindings.
  * Numeric and string values now retain their inferred types.
  * Explicit generic types such as `ref<T>(...)` are represented accurately.
  * Unresolved `ref()` values safely fall back to `Ref<unknown>`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->