### PR TITLE
fix(release): wait for hidden staged npm publishes

### DIFF
--- a/tests/tooling/moonbit-publish-staged.test.ts
+++ b/tests/tooling/moonbit-publish-staged.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+
+import { runMoonScript } from "./_helpers/moonbit.ts";
+import { writeFakeCommand } from "./support/fake-command.ts";
+
+test("publish_npm_package waits instead of retrying a hidden staged npm publish", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "moonbit-publish-staged-"));
+  const packageDir = path.join(tempDir, "pkg");
+  const binDir = path.join(tempDir, "bin");
+  const statePath = path.join(tempDir, "vp-state.json");
+
+  try {
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.mkdirSync(binDir, { recursive: true });
+    writeFileSync(
+      path.join(packageDir, "package.json"),
+      `${JSON.stringify({ name: "@vizejs/example", version: "1.2.3" }, null, 2)}\n`,
+    );
+    writeFakeCommand(
+      binDir,
+      "vp",
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "const state = fs.existsSync(process.env.VP_STATE_PATH)",
+        "  ? JSON.parse(fs.readFileSync(process.env.VP_STATE_PATH, 'utf8'))",
+        "  : { publishCalls: 0, tagChecks: 0, versionChecks: 0 };",
+        "function save() {",
+        "  fs.writeFileSync(process.env.VP_STATE_PATH, JSON.stringify(state));",
+        "}",
+        "if (args[0] === 'pm' && args[1] === 'view' && args[3] === 'version') {",
+        "  state.versionChecks += 1;",
+        "  save();",
+        "  if (state.publishCalls === 1 && state.versionChecks >= 3) {",
+        "    process.stdout.write(JSON.stringify('1.2.3'));",
+        "    process.exit(0);",
+        "  }",
+        "  process.exit(1);",
+        "}",
+        "if (args[0] === 'pm' && args[1] === 'view' && args[3] === 'dist-tags') {",
+        "  state.tagChecks += 1;",
+        "  save();",
+        "  if (state.publishCalls === 1) {",
+        "    process.stdout.write(JSON.stringify({ latest: '1.2.3' }));",
+        "    process.exit(0);",
+        "  }",
+        "  process.exit(1);",
+        "}",
+        "if (args[0] === 'pm' && args[1] === 'publish') {",
+        "  state.publishCalls += 1;",
+        "  save();",
+        "  process.stderr.write(",
+        "    'Cannot publish over previously staged version \"1.2.3\".',",
+        "  );",
+        "  process.exit(1);",
+        "}",
+        "process.exit(1);",
+      ].join("\n"),
+    );
+
+    const result = runMoonScript("publish_npm_package", [packageDir], {
+      env: {
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        VP_STATE_PATH: statePath,
+        PUBLISH_RETRY_LIMIT: "6",
+        PUBLISH_RETRY_DELAY: "1",
+        PUBLISH_RESOLUTION_RETRY_LIMIT: "3",
+        PUBLISH_RESOLUTION_RETRY_DELAY: "1",
+      },
+    });
+
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
+    assert.match(result.stdout, /staged in npm but not yet visible/i);
+    assert.match(result.stdout, /visible in npm with dist-tag latest/i);
+    const state = JSON.parse(fs.readFileSync(statePath, "utf8")) as {
+      publishCalls: number;
+      tagChecks: number;
+      versionChecks: number;
+    };
+    assert.equal(state.publishCalls, 1);
+    assert.equal(state.tagChecks, 1);
+    assert.equal(state.versionChecks, 3);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tools/moon/cmd/publish_npm_package/main.mbt
+++ b/tools/moon/cmd/publish_npm_package/main.mbt
@@ -1,24 +1,6 @@
-/// Publishes a single npm package directory in a rerun-safe way.
-/// The script is intentionally defensive because GitHub Actions releases often
-/// fail in the gap between "the registry accepted the publish" and "the version
-/// is visible from registry reads". To make the workflow resilient, the script:
-/// 1. Reads the package name and version from `package.json`.
-/// 2. Checks whether the exact version is already visible in the registry.
-/// 3. Runs `vp pm publish` with retry/backoff when needed.
-/// 4. Treats "publish returned non-zero but the version is now visible" as a
-///    success, because that usually means the server-side publish completed.
-/// 5. Normalizes publish manifests so detached release artifacts do not retain
-///    unresolved `workspace:*` or `catalog:*` dependency specs.
-/// 6. Waits for both the published version and the expected dist-tag to become
-///    readable before reporting success.
-/// This makes the script suitable for trusted publishing flows where the most
-/// common failures are transient registry propagation issues rather than actual
-/// package content problems.
+/// Publishes one npm package with rerun-safe registry visibility checks.
 
-/// Minimal package metadata that we need to reason about registry state.
-/// Keeping the data in a small struct makes the retry / visibility helpers read
-/// more clearly and avoids repeatedly recomputing name, version, and dist-tag
-/// from the package manifest.
+/// Minimal package metadata for registry checks.
 struct NpmPackageInfo {
   name : String
   version : String
@@ -113,10 +95,7 @@ fn find_repo_root(start : String) -> String? {
   }
 }
 
-/// Reads and parses a `package.json` file, returning `None` on any failure.
-/// We intentionally collapse IO and JSON parsing failures into a single
-/// optional result because the caller only needs to know whether manifest
-/// discovery succeeded before producing a human-readable CLI error.
+/// Reads and parses a `package.json`, returning `None` on failure.
 fn read_package_json(path : String) -> Json? {
   try {
     Some(@json.parse(@xfs.read_file_to_string(path)))
@@ -139,10 +118,7 @@ fn package_version(json : Json) -> String? {
   Some(version)
 }
 
-/// Parses a positive integer from a string and falls back on invalid input.
-/// Retry and delay settings are user-configurable through environment
-/// variables and CLI flags, so we keep the parser forgiving and preserve a
-/// safe default instead of aborting on malformed values.
+/// Parses a positive integer and falls back on invalid input.
 fn positive_int_or(value : String, fallback : Int) -> Int {
   try {
     let parsed = @string.parse_int(value)
@@ -156,7 +132,6 @@ fn positive_int_or(value : String, fallback : Int) -> Int {
   }
 }
 
-/// Reads a retry-related integer from the environment with a validated default.
 fn env_positive_int(name : String, fallback : Int) -> Int {
   match @env.get_env_var(name) {
     Some(value) if value != "" => positive_int_or(value, fallback)
@@ -165,9 +140,6 @@ fn env_positive_int(name : String, fallback : Int) -> Int {
 }
 
 /// Derives the npm dist-tag for a package version.
-/// `NPM_TAG` is allowed to override the heuristic so the workflow can force a
-/// tag explicitly. Otherwise, prerelease suffixes map to the conventional
-/// `alpha`, `beta`, and `rc` tags, while stable releases use `latest`.
 fn npm_tag(version : String) -> String {
   match @env.get_env_var("NPM_TAG") {
     Some(value) if value != "" => value
@@ -477,7 +449,19 @@ async fn run_app() -> Int {
     println(
       "Attempt \{attempt}/\{max_attempts}: publish \{info.name}@\{info.version} with \{vp_bin} \{command_display}",
     )
-    let exit_code = @process.run(vp_bin, publish_args, cwd=directory)
+    let (exit_code, stdout, stderr) = @process.collect_output(
+      vp_bin,
+      publish_args,
+      cwd=directory,
+    )
+    let stdout_text = stdout.text().trim()
+    let stderr_text = stderr.text().trim()
+    if stdout_text != "" {
+      println(stdout_text)
+    }
+    if stderr_text != "" {
+      @stdio.stderr.write(stderr_text + "\n")
+    }
     if exit_code == 0 {
       return wait_for_registry_visibility(
         vp_bin,
@@ -489,6 +473,18 @@ async fn run_app() -> Int {
     if npm_version_is_visible(vp_bin, info.name, info.version) {
       println(
         "\{info.name}@\{info.version} appears in npm despite a non-zero publish exit. Verifying registry visibility.",
+      )
+      return wait_for_registry_visibility(
+        vp_bin,
+        info,
+        resolution_retries,
+        resolution_delay_seconds,
+      )
+    }
+    let publish_detail = stdout_text + "\n" + stderr_text
+    if publish_detail.contains("Cannot publish over previously staged version") {
+      println(
+        "\{info.name}@\{info.version} is staged in npm but not yet visible. Waiting for registry visibility before retrying.",
       )
       return wait_for_registry_visibility(
         vp_bin,


### PR DESCRIPTION
## Summary
- capture failed `vp pm publish` output so npm staged-version conflicts can be detected
- treat `Cannot publish over previously staged version` as an accepted hidden publish and wait for version/dist-tag visibility
- add a regression test proving the staged path does not hammer publish retries

## Verification
- `MOON_HOME=/private/tmp/vize-moonbit.wocUWA/moonbit PATH="/private/tmp/vize-moonbit.wocUWA/moonbit-shims:/private/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/moonbit-publish-staged.test.ts`
- `MOON_HOME=/private/tmp/vize-moonbit.wocUWA/moonbit PATH="/private/tmp/vize-moonbit.wocUWA/moonbit-shims:/private/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/moonbit-publish.test.ts`
- `MOON_HOME=/private/tmp/vize-moonbit.wocUWA/moonbit PATH="/private/tmp/vize-moonbit.wocUWA/moonbit-shims:/private/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" node --test tests/tooling/source-file-lengths.test.ts`
- `MOON_HOME=/private/tmp/vize-moonbit.wocUWA/moonbit PATH="/private/tmp/vize-moonbit.wocUWA/moonbit-shims:/private/tmp/vize-moonbit.wocUWA/moonbit/bin:$PATH" vp check --no-error-on-unmatched-pattern tools/moon/cmd/publish_npm_package/main.mbt tests/tooling/moonbit-publish-staged.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4627"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790065488&installation_model_id=422833&pr_number=4627&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4627&signature=93031ce4e8023dcf152e7ea85374f4fefd8c1d2c49c870839a9a5b3348e2e67e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staged npm publishing by waiting for the package to become visible in the registry instead of retrying publication unnecessarily.
  * Added clearer handling and reporting of publishing output and staged-version errors.
  * Publishing now confirms the package is available with the expected `latest` tag before completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->