### PR TITLE
fix(maestro): resolve v-for template scope hovers

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -33,6 +33,7 @@ pub(crate) mod sfc_region;
 pub mod signature_help;
 pub(crate) mod tag_pair;
 mod template_expression;
+pub(crate) mod template_scope;
 pub(crate) mod tsconfig_paths;
 pub mod type_definition;
 pub mod type_service;

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -6,7 +6,7 @@ use vize_croquis::{Drawer, DrawerOptions};
 use vize_relief::BindingType;
 
 use super::{IdeContext, helpers};
-use crate::ide::{is_component_tag, kebab_to_pascal};
+use crate::ide::{is_component_tag, kebab_to_pascal, template_scope};
 
 /// Find definition for a symbol in template context.
 pub(crate) fn definition_in_template(ctx: &IdeContext) -> Option<GotoDefinitionResponse> {
@@ -36,7 +36,6 @@ pub(crate) fn definition_in_template(ctx: &IdeContext) -> Option<GotoDefinitionR
         return None;
     }
 
-    // Check if this is a props property access (e.g., props.title -> defineProps)
     if let Some(def) = find_props_property_definition(ctx, &word) {
         return Some(def);
     }
@@ -47,8 +46,9 @@ pub(crate) fn definition_in_template(ctx: &IdeContext) -> Option<GotoDefinitionR
         return Some(def);
     }
 
-    // Resolve Options API bindings (when enabled) and class-component members
-    // (auto-detected by AST shape, no flag) to their `<script>` declaration.
+    if let Some(definition) = template_scope::v_for_definition(ctx, &word) {
+        return Some(definition);
+    }
     if let Some(location) = super::script::find_analyzed_binding_location(ctx, &word) {
         return Some(GotoDefinitionResponse::Scalar(location));
     }

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -13,7 +13,7 @@ use vize_croquis::{Drawer, DrawerOptions};
 use vize_relief::BindingType;
 
 use super::{HoverBuilder, HoverService};
-use crate::ide::IdeContext;
+use crate::ide::{IdeContext, template_scope};
 
 impl HoverService {
     /// Get hover for template context.
@@ -54,13 +54,13 @@ impl HoverService {
             return None;
         }
 
-        // petite-vue standalone HTML documents have no SFC `<script>`/`<template>`
-        // split, so the croquis/Corsa paths below find nothing. Resolve the
-        // identifier under the cursor against the `v-scope` scope chain instead.
         if let Some(hover) = Self::hover_petite_vue_scope_binding(ctx, &word) {
             return Some(hover);
         }
 
+        if let Some(hover) = template_scope::v_for_hover(ctx, &word) {
+            return Some(hover);
+        }
         if let Some(hover) = super::backend::binding_type_hover(ctx, &word) {
             return Some(hover);
         }

--- a/crates/vize_maestro/src/ide/template_scope.rs
+++ b/crates/vize_maestro/src/ide/template_scope.rs
@@ -1,0 +1,84 @@
+//! Authored template-scope bindings such as `v-for` aliases.
+#![allow(clippy::disallowed_types)]
+
+mod v_for;
+
+#[cfg(test)]
+mod tests;
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Hover, Location, Position, Range};
+
+use super::{HoverBuilder, IdeContext, offset_to_position};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TemplateScopeBindingKind {
+    Value,
+    Key,
+    Index,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TemplateScopeBinding {
+    pub(crate) name: String,
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+    pub(crate) kind: TemplateScopeBindingKind,
+}
+
+impl TemplateScopeBinding {
+    pub(crate) fn location(&self, ctx: &IdeContext<'_>) -> Location {
+        let (start_line, start_character) = offset_to_position(&ctx.content, self.start);
+        let (end_line, end_character) = offset_to_position(&ctx.content, self.end);
+        Location {
+            uri: ctx.uri.clone(),
+            range: Range {
+                start: Position {
+                    line: start_line,
+                    character: start_character,
+                },
+                end: Position {
+                    line: end_line,
+                    character: end_character,
+                },
+            },
+        }
+    }
+}
+
+pub(crate) fn v_for_binding_at(ctx: &IdeContext<'_>, word: &str) -> Option<TemplateScopeBinding> {
+    v_for::binding_at(ctx, word)
+}
+
+pub(crate) fn v_for_definition(ctx: &IdeContext<'_>, word: &str) -> Option<GotoDefinitionResponse> {
+    v_for_binding_at(ctx, word).map(|binding| GotoDefinitionResponse::Scalar(binding.location(ctx)))
+}
+
+pub(crate) fn v_for_hover(ctx: &IdeContext<'_>, word: &str) -> Option<Hover> {
+    let binding = v_for_binding_at(ctx, word)?;
+    let description = match binding.kind {
+        TemplateScopeBindingKind::Value => {
+            "Loop value alias declared by the nearest `v-for` and available to this template scope."
+        }
+        TemplateScopeBindingKind::Key => {
+            "Loop key/index alias declared by the nearest `v-for` and available to this template scope."
+        }
+        TemplateScopeBindingKind::Index => {
+            "Loop index alias declared by the nearest `v-for` and available to this template scope."
+        }
+    };
+
+    Some(
+        HoverBuilder::new()
+            .title(&binding.name)
+            .meta("v-for scope binding")
+            .description(description)
+            .bullets(
+                "Behavior",
+                &[
+                    "Shadows outer template and script bindings with the same name.",
+                    "Type-backed sessions should refine this with the iterable item type when the backend answers.",
+                ],
+            )
+            .build(),
+    )
+}

--- a/crates/vize_maestro/src/ide/template_scope/tests.rs
+++ b/crates/vize_maestro/src/ide/template_scope/tests.rs
@@ -1,0 +1,72 @@
+use tower_lsp::lsp_types::Url;
+
+use super::{TemplateScopeBindingKind, v_for_binding_at};
+use crate::{ide::IdeContext, server::ServerState};
+
+#[test]
+fn finds_v_for_value_key_and_index_aliases_from_body_usage() {
+    let source = r#"<script setup>
+const rows = []
+</script>
+<template>
+  <li v-for="(row, key, index) in rows" :key="row.id">
+    {{ row.name }} {{ key }} {{ index }}
+  </li>
+</template>
+"#;
+    let uri = Url::parse("file:///ForAliases.vue").unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    for (usage, declaration, kind) in [
+        ("row.name", "(row", TemplateScopeBindingKind::Value),
+        ("{{ key }}", " key", TemplateScopeBindingKind::Key),
+        ("{{ index }}", " index", TemplateScopeBindingKind::Index),
+    ] {
+        let usage_offset =
+            source.rfind(usage).unwrap() + usage.find(|c: char| c.is_alphanumeric()).unwrap();
+        let word = usage
+            .trim_matches(|c: char| !c.is_alphanumeric())
+            .split('.')
+            .next()
+            .unwrap();
+        let ctx = IdeContext::new(&state, &uri, usage_offset).unwrap();
+        let binding = v_for_binding_at(&ctx, word).unwrap();
+        assert_eq!(binding.kind, kind);
+        assert_eq!(&source[binding.start..binding.end], word);
+        assert_eq!(binding.start, source.find(declaration).unwrap() + 1);
+    }
+}
+
+#[test]
+fn prefers_the_nearest_nested_v_for_alias() {
+    let source = r#"<script setup>
+const outer = []
+const inner = []
+</script>
+<template>
+  <div v-for="item in outer">
+    <span v-for="item in inner">{{ item }}</span>
+  </div>
+</template>
+"#;
+    let uri = Url::parse("file:///NestedFor.vue").unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    let usage_offset = source.rfind("{{ item }}").unwrap() + "{{ ".len();
+    let ctx = IdeContext::new(&state, &uri, usage_offset).unwrap();
+    let binding = v_for_binding_at(&ctx, "item").unwrap();
+
+    assert_eq!(
+        binding.start,
+        source.rfind("item in inner").unwrap(),
+        "nested v-for aliases must shadow outer aliases",
+    );
+}

--- a/crates/vize_maestro/src/ide/template_scope/v_for.rs
+++ b/crates/vize_maestro/src/ide/template_scope/v_for.rs
@@ -1,0 +1,322 @@
+//! `v-for` scope alias lookup in authored templates.
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
+
+use vize_relief::{ElementNode, ExpressionNode, PropNode, SourceLocation, TemplateChildNode};
+
+use super::{TemplateScopeBinding, TemplateScopeBindingKind};
+use crate::ide::IdeContext;
+
+pub(super) fn binding_at(ctx: &IdeContext<'_>, word: &str) -> Option<TemplateScopeBinding> {
+    if word.is_empty() {
+        return None;
+    }
+
+    let descriptor = vize_atelier_sfc::parse_sfc(
+        &ctx.content,
+        vize_atelier_sfc::SfcParseOptions {
+            filename: ctx.uri.path().to_string().into(),
+            ..Default::default()
+        },
+    )
+    .ok()?;
+    let template = descriptor.template.as_ref()?;
+    if ctx.offset < template.loc.start || ctx.offset > template.loc.end {
+        return None;
+    }
+
+    let cursor = ctx.offset - template.loc.start;
+    let allocator = vize_carton::Allocator::new();
+    let (ast, _) = vize_armature::parse(&allocator, template.content.as_ref());
+
+    find_in_children(&ast.children, template.loc.start, cursor, word)
+}
+
+fn find_in_children(
+    children: &[TemplateChildNode<'_>],
+    template_start: usize,
+    cursor: usize,
+    word: &str,
+) -> Option<TemplateScopeBinding> {
+    children
+        .iter()
+        .find_map(|child| find_in_child(child, template_start, cursor, word))
+}
+
+fn find_in_child(
+    child: &TemplateChildNode<'_>,
+    template_start: usize,
+    cursor: usize,
+    word: &str,
+) -> Option<TemplateScopeBinding> {
+    match child {
+        TemplateChildNode::Element(element) => {
+            find_in_element(element, template_start, cursor, word)
+        }
+        TemplateChildNode::If(if_node) => {
+            if !contains_subtree(child, cursor) {
+                return None;
+            }
+            if_node.branches.iter().find_map(|branch| {
+                if contains(&branch.loc, cursor) || contains_children(&branch.children, cursor) {
+                    find_in_children(&branch.children, template_start, cursor, word)
+                } else {
+                    None
+                }
+            })
+        }
+        TemplateChildNode::IfBranch(branch) => {
+            if contains(&branch.loc, cursor) || contains_children(&branch.children, cursor) {
+                find_in_children(&branch.children, template_start, cursor, word)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn find_in_element(
+    element: &ElementNode<'_>,
+    template_start: usize,
+    cursor: usize,
+    word: &str,
+) -> Option<TemplateScopeBinding> {
+    if !contains_element_subtree(element, cursor) {
+        return None;
+    }
+
+    find_in_children(&element.children, template_start, cursor, word).or_else(|| {
+        element.props.iter().find_map(|prop| {
+            let PropNode::Directive(directive) = prop else {
+                return None;
+            };
+            if directive.name != "for" {
+                return None;
+            }
+            binding_from_v_for_expression(directive.exp.as_ref()?, template_start, word)
+        })
+    })
+}
+
+fn binding_from_v_for_expression(
+    expr: &ExpressionNode<'_>,
+    template_start: usize,
+    word: &str,
+) -> Option<TemplateScopeBinding> {
+    let ExpressionNode::Simple(simple) = expr else {
+        return None;
+    };
+    let (left_start, left) = v_for_left_side(simple.content)?;
+    split_alias_parts(left, left_start)
+        .into_iter()
+        .enumerate()
+        .find_map(|(index, (part_start, part))| {
+            let kind = match index {
+                0 => TemplateScopeBindingKind::Value,
+                1 => TemplateScopeBindingKind::Key,
+                _ => TemplateScopeBindingKind::Index,
+            };
+            binding_from_text(
+                part,
+                simple.loc.span.start as usize + part_start,
+                template_start,
+                word,
+                kind,
+            )
+        })
+}
+
+fn v_for_left_side(text: &str) -> Option<(usize, &str)> {
+    let separator = find_v_for_separator(text)?;
+    let (start, end) = trim_range(text, 0, separator);
+    if start >= end {
+        return None;
+    }
+
+    let (start, end) = strip_wrapping_parens(text, start, end);
+    Some((start, &text[start..end]))
+}
+
+fn find_v_for_separator(text: &str) -> Option<usize> {
+    let mut depth = 0usize;
+    for (index, ch) in text.char_indices() {
+        match ch {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+        if depth == 0 && (text[index..].starts_with(" in ") || text[index..].starts_with(" of ")) {
+            return Some(index);
+        }
+    }
+    None
+}
+
+fn strip_wrapping_parens(text: &str, start: usize, end: usize) -> (usize, usize) {
+    if text[start..end].starts_with('(') && text[start..end].ends_with(')') {
+        trim_range(text, start + 1, end - 1)
+    } else {
+        (start, end)
+    }
+}
+
+fn split_alias_parts(text: &str, base_start: usize) -> Vec<(usize, &str)> {
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut part_start = 0usize;
+
+    for (index, ch) in text.char_indices() {
+        match ch {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                push_trimmed_part(text, base_start, part_start, index, &mut parts);
+                part_start = index + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    push_trimmed_part(text, base_start, part_start, text.len(), &mut parts);
+
+    parts
+}
+
+fn push_trimmed_part<'a>(
+    text: &'a str,
+    base_start: usize,
+    start: usize,
+    end: usize,
+    parts: &mut Vec<(usize, &'a str)>,
+) {
+    let (trimmed_start, trimmed_end) = trim_range(text, start, end);
+    if trimmed_start < trimmed_end {
+        parts.push((
+            base_start + trimmed_start,
+            &text[trimmed_start..trimmed_end],
+        ));
+    }
+}
+
+fn binding_from_text(
+    text: &str,
+    relative_start: usize,
+    template_start: usize,
+    word: &str,
+    kind: TemplateScopeBindingKind,
+) -> Option<TemplateScopeBinding> {
+    if text.is_empty() {
+        return None;
+    }
+
+    find_identifier(text, word).map(|offset| TemplateScopeBinding {
+        name: word.to_string(),
+        start: template_start + relative_start + offset,
+        end: template_start + relative_start + offset + word.len(),
+        kind,
+    })
+}
+
+fn find_identifier(text: &str, word: &str) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let mut search_start = 0;
+    while let Some(relative) = text[search_start..].find(word) {
+        let start = search_start + relative;
+        let end = start + word.len();
+        if is_identifier_boundary(bytes, start, end) {
+            return Some(start);
+        }
+        search_start = end;
+    }
+    None
+}
+
+fn contains(loc: &SourceLocation, cursor: usize) -> bool {
+    let start = loc.span.start as usize;
+    let end = loc.span.end as usize;
+    start <= cursor && cursor <= end
+}
+
+fn contains_subtree(child: &TemplateChildNode<'_>, cursor: usize) -> bool {
+    child_subtree_span(child).is_some_and(|(start, end)| start <= cursor && cursor <= end)
+}
+
+fn contains_children(children: &[TemplateChildNode<'_>], cursor: usize) -> bool {
+    children.iter().any(|child| contains_subtree(child, cursor))
+}
+
+fn contains_element_subtree(element: &ElementNode<'_>, cursor: usize) -> bool {
+    let (start, end) = element_subtree_span(element);
+    start <= cursor && cursor <= end
+}
+
+fn child_subtree_span(child: &TemplateChildNode<'_>) -> Option<(usize, usize)> {
+    match child {
+        TemplateChildNode::Element(element) => Some(element_subtree_span(element)),
+        TemplateChildNode::If(if_node) => merge_span(
+            loc_span(&if_node.loc),
+            if_node
+                .branches
+                .iter()
+                .filter_map(|branch| {
+                    merge_span(
+                        loc_span(&branch.loc),
+                        children_subtree_span(&branch.children),
+                    )
+                })
+                .reduce(|left, right| (left.0.min(right.0), left.1.max(right.1))),
+        ),
+        TemplateChildNode::IfBranch(branch) => merge_span(
+            loc_span(&branch.loc),
+            children_subtree_span(&branch.children),
+        ),
+        TemplateChildNode::Hoisted(_) => None,
+        _ => Some(loc_span(child.loc())),
+    }
+}
+
+fn element_subtree_span(element: &ElementNode<'_>) -> (usize, usize) {
+    merge_span(
+        loc_span(&element.loc),
+        children_subtree_span(&element.children),
+    )
+    .unwrap_or_else(|| loc_span(&element.loc))
+}
+
+fn children_subtree_span(children: &[TemplateChildNode<'_>]) -> Option<(usize, usize)> {
+    children
+        .iter()
+        .filter_map(child_subtree_span)
+        .reduce(|left, right| (left.0.min(right.0), left.1.max(right.1)))
+}
+
+fn merge_span(left: (usize, usize), right: Option<(usize, usize)>) -> Option<(usize, usize)> {
+    Some(match right {
+        Some(right) => (left.0.min(right.0), left.1.max(right.1)),
+        None => left,
+    })
+}
+
+fn loc_span(loc: &SourceLocation) -> (usize, usize) {
+    (loc.span.start as usize, loc.span.end as usize)
+}
+
+fn is_identifier_boundary(bytes: &[u8], start: usize, end: usize) -> bool {
+    let before = start.checked_sub(1).and_then(|index| bytes.get(index));
+    let after = bytes.get(end);
+    !before.is_some_and(|byte| is_identifier_byte(*byte))
+        && !after.is_some_and(|byte| is_identifier_byte(*byte))
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}
+
+fn trim_range(text: &str, mut start: usize, mut end: usize) -> (usize, usize) {
+    while start < end && text.as_bytes()[start].is_ascii_whitespace() {
+        start += 1;
+    }
+    while end > start && text.as_bytes()[end - 1].is_ascii_whitespace() {
+        end -= 1;
+    }
+    (start, end)
+}

--- a/davinci-road/plan/sourcelocation-inventory.md
+++ b/davinci-road/plan/sourcelocation-inventory.md
@@ -28,7 +28,7 @@ any read — or any deleted carrier — comes back.
 - Reads of `span.start` / `span.end` are **not** inventoried: they are
   the surviving offset representation — the pre-migration
   `start.offset` / `end.offset` reads moved to them verbatim
-  (295 loc-shaped span-read sites across
+  (300 loc-shaped span-read sites across
   8 crates at generation time).
 - `#[cfg(test)]` code inside `src/` is included and reported in the
   "in test code" column: a site counts as test code when its file is a test

--- a/tests/tooling/lsp-authoring-core.test.ts
+++ b/tests/tooling/lsp-authoring-core.test.ts
@@ -118,6 +118,27 @@ const items = [1, 2]
     assert.equal(definitionLocation.uri, uri);
     assert.deepEqual(definitionLocation.range.start, declarationPosition);
 
+    const forAliasOffset = source.indexOf('v-for="item in items"') + 'v-for="'.length;
+    const forUsageOffset = source.lastIndexOf("{{ item }}") + "{{ ".length + "item".length;
+    const forUsagePosition = offsetToPosition(source, forUsageOffset);
+
+    const forHover = (await session.request("textDocument/hover", {
+      textDocument: { uri },
+      position: forUsagePosition,
+    })) as { contents?: unknown } | null;
+    const forHoverText = hoverToText(forHover);
+    assert.match(forHoverText, /item/);
+    assert.match(forHoverText, /v-for scope binding/);
+    assert.match(forHoverText, /nearest `v-for`/);
+
+    const forDefinition = await session.request("textDocument/definition", {
+      textDocument: { uri },
+      position: forUsagePosition,
+    });
+    const forDefinitionLocation = firstLocation(forDefinition as never);
+    assert.equal(forDefinitionLocation.uri, uri);
+    assert.deepEqual(forDefinitionLocation.range.start, offsetToPosition(source, forAliasOffset));
+
     const references = (await session.request("textDocument/references", {
       textDocument: { uri },
       position: countUsagePosition,


### PR DESCRIPTION
## Summary

- add authored v-for scope lookup for template hover and definition fallback
- keep nested v-for aliases shadowed correctly, including value, key, and index aliases
- extend the production LSP authoring fixture to assert v-for alias hover and go-to-definition

Refs #4592

## Verification

- cargo fmt --all -- --check
- node --test tests/tooling/davinci-matrices.test.ts
- node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_maestro template_scope --features native
- node --test tests/tooling/lsp-authoring-core.test.ts
- cargo clippy -p vize_maestro --tests -- -D warnings
- vp check --no-error-on-unmatched-pattern crates/vize_maestro/src/ide.rs crates/vize_maestro/src/ide/template_scope.rs crates/vize_maestro/src/ide/template_scope/v_for.rs crates/vize_maestro/src/ide/template_scope/tests.rs crates/vize_maestro/src/ide/definition/template.rs crates/vize_maestro/src/ide/hover/template.rs tests/tooling/lsp-authoring-core.test.ts davinci-road/plan/sourcelocation-inventory.md
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved template IDE support for `v-for` aliases.
  * Hover information now identifies loop value, key, and index bindings.
  * Definition lookup navigates to the correct alias declaration, including nested loops and shadowed aliases.

* **Bug Fixes**
  * Corrected alias resolution based on cursor location and template scope.
  * Improved handling of aliases in nested conditional and loop structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->