### PR TITLE
fix(maestro): show vue import contract hovers

### DIFF
--- a/crates/vize_maestro/src/ide/hover/component_import.rs
+++ b/crates/vize_maestro/src/ide/hover/component_import.rs
@@ -14,6 +14,9 @@ use super::HoverService;
 use crate::ide::IdeContext;
 use crate::ide::markup;
 
+mod fallback;
+pub(super) use fallback::vue_component_import_hover;
+
 pub(super) fn rewrite_vue_component_import_hover(
     ctx: &IdeContext<'_>,
     local_name: &str,
@@ -41,7 +44,10 @@ fn contains_generated_component_marker(markdown: &str) -> bool {
         || markdown.contains("__vize_component__")
 }
 
-fn component_contract_markdown(ctx: &IdeContext<'_>, local_name: &str) -> Option<String> {
+pub(super) fn component_contract_markdown(
+    ctx: &IdeContext<'_>,
+    local_name: &str,
+) -> Option<String> {
     let resolved_path = imported_vue_component_path(ctx, local_name)?;
     let source = component_source(ctx, &resolved_path)?;
     let filename = resolved_path.to_string_lossy();
@@ -304,7 +310,7 @@ fn consume_quoted(source: &str, start: usize, quote: u8) -> usize {
     source.len()
 }
 
-fn authored_token_range(ctx: &IdeContext<'_>) -> Option<Range> {
+pub(super) fn authored_token_range(ctx: &IdeContext<'_>) -> Option<Range> {
     let (start, end) =
         crate::ide::token_span_at_offset(&ctx.content, ctx.offset, HoverService::is_word_char)?;
     let (start_line, start_character) = crate::ide::offset_to_position(&ctx.content, start);

--- a/crates/vize_maestro/src/ide/hover/component_import/fallback.rs
+++ b/crates/vize_maestro/src/ide/hover/component_import/fallback.rs
@@ -1,0 +1,18 @@
+//! Corsa-independent hover fallback for imported Vue SFC components.
+
+use tower_lsp::lsp_types::{Hover, HoverContents};
+
+use super::{authored_token_range, component_contract_markdown};
+use crate::ide::{IdeContext, markup};
+
+pub(in crate::ide::hover) fn vue_component_import_hover(
+    ctx: &IdeContext<'_>,
+    local_name: &str,
+) -> Option<Hover> {
+    Some(Hover {
+        contents: HoverContents::Markup(markup::markdown_content(component_contract_markdown(
+            ctx, local_name,
+        )?)),
+        range: authored_token_range(ctx),
+    })
+}

--- a/crates/vize_maestro/src/ide/hover/script.rs
+++ b/crates/vize_maestro/src/ide/hover/script.rs
@@ -65,12 +65,10 @@ impl HoverService {
             return None;
         }
 
-        // Check for Vue Composition API and macros first
-        if let Some(hover) = Self::hover_vue_api(&word) {
-            return Some(hover);
-        }
-
-        if is_setup && let Some(hover) = Self::hover_vue_macro(&word) {
+        if let Some(hover) = Self::hover_vue_api(&word)
+            .or_else(|| is_setup.then(|| Self::hover_vue_macro(&word)).flatten())
+            .or_else(|| super::component_import::vue_component_import_hover(ctx, &word))
+        {
             return Some(hover);
         }
 

--- a/tests/tooling/lsp-authoring-core.test.ts
+++ b/tests/tooling/lsp-authoring-core.test.ts
@@ -29,9 +29,12 @@ test("vize lsp supports production Vue authoring requests in one editor session"
 
     const source = `<script setup lang="ts">
 import { ref } from 'vue'
+import Child from './Child.vue'
 const count = ref(0)
 const items = [1, 2]
 const row = 'outer'
+
+Child
 </script>
 
 <template>
@@ -56,6 +59,18 @@ const row = 'outer'
 `;
     const filePath = path.join(workspaceDir, "AuthoringCore.vue");
     const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(
+      path.join(workspaceDir, "Child.vue"),
+      [
+        '<script setup lang="ts">',
+        "defineProps<{ label: string; count?: number }>()",
+        "defineEmits<{ save: [value: string] }>()",
+        "defineSlots<{ default(props: { value: string }): unknown }>()",
+        "</script>",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
     fs.writeFileSync(filePath, source, "utf8");
 
     session.notify("textDocument/didOpen", {
@@ -144,6 +159,22 @@ const row = 'outer'
     const forDefinitionLocation = firstLocation(forDefinition as never);
     assert.equal(forDefinitionLocation.uri, uri);
     assert.deepEqual(forDefinitionLocation.range.start, offsetToPosition(source, forAliasOffset));
+
+    const childUsageOffset = source.indexOf("\nChild\n") + "\n".length + "Child".length;
+    const childHover = (await session.request("textDocument/hover", {
+      textDocument: { uri },
+      position: offsetToPosition(source, childUsageOffset),
+    })) as { contents?: unknown } | null;
+    const childHoverText = hoverToText(childHover);
+    assert.match(childHoverText, /const Child: VueComponent/);
+    assert.match(childHoverText, /props: \{ label: string; count\?: number \};/);
+    assert.match(childHoverText, /emits: \{ save: \[value: string\] \};/);
+    assert.match(childHoverText, /slots: \{ default\(props: \{ value: string \}\): unknown \};/);
+    assert.match(childHoverText, /Vue component: Child\.vue/);
+    assert.doesNotMatch(
+      childHoverText,
+      /__vizeComponentMarker|__vizeRawProps|__VizeComponentConstructor/,
+    );
 
     const slotPropOffset = source.indexOf("row.id") + "row".length;
     const slotPropPosition = offsetToPosition(source, slotPropOffset);


### PR DESCRIPTION
## Summary
- add a Corsa-independent fallback for imported Vue SFC hovers
- reuse the authored component contract markdown so imports show props, emits, slots, and the source file instead of generated marker internals
- cover the editor fixture with an imported Child.vue hover assertion

Refs #4592.

## Validation
- cargo fmt --all -- --check
- node --test tests/tooling/lsp-authoring-core.test.ts
- node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/davinci-matrices.test.ts
- cargo clippy -p vize_maestro --tests -- -D warnings
- vp check --no-error-on-unmatched-pattern crates/vize_maestro/src/ide/hover/component_import.rs crates/vize_maestro/src/ide/hover/component_import/fallback.rs crates/vize_maestro/src/ide/hover/script.rs tests/tooling/lsp-authoring-core.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790078323&installation_model_id=422833&pr_number=4631&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4631&signature=db0e9b2e0d5c21e3dde5dcb52346feaee45a3431b929aa834670c36437838342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hover information for imported Vue components.
  * Displays component types, props, emitted events, slots, and readable metadata.
  * Provides fallback hover details when richer information is unavailable.

* **Bug Fixes**
  * Prevents internal implementation markers from appearing in hover results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->