### PR TITLE
feat(davinci): admit Vue 2 sugar at S1→S2 lowering (P2-9 series 7)

### DIFF
--- a/crates/vize_ricalco/src/lib.rs
+++ b/crates/vize_ricalco/src/lib.rs
@@ -59,4 +59,4 @@ extern crate alloc;
 pub mod lower;
 pub mod pass;
 
-pub use lower::{Lowered, lower};
+pub use lower::{LegacyCaps, Lowered, lower, lower_with_caps};

--- a/crates/vize_ricalco/src/lower.rs
+++ b/crates/vize_ricalco/src/lower.rs
@@ -33,6 +33,7 @@ use vize_disegno::scope::ScopeFacts;
 
 mod binding;
 mod bindop;
+mod caps;
 mod cx;
 mod directive;
 mod element;
@@ -41,8 +42,11 @@ mod forop;
 mod leaf;
 mod slot;
 mod structural;
+mod sugar;
 mod text;
 mod vfor;
+
+pub use caps::LegacyCaps;
 
 // The one-scanner rule (#4365): the S2 passes re-derive binding names
 // with exactly the enumeration the lowering used, never a second one.
@@ -83,6 +87,9 @@ pub struct Lowered<'a> {
     /// op's page-order id (P2-9 series 5, [`WrapperKeys`]); folded into
     /// branch-key facts by `pass::vif`.
     pub wrappers: SideTable<WrapperKeys>,
+    /// Vue dialect sugar the lowering (and the legalizing pass) consult.
+    /// [`LegacyCaps::VUE3`] unless the caller used [`lower_with_caps`].
+    pub caps: LegacyCaps,
 }
 
 /// Lower a parsed S1 tree (and the tokenizer errors its parse reported)
@@ -99,7 +106,20 @@ pub fn lower<'a>(
     tree: &SurfaceTree<'a>,
     errors: &[SurfaceError],
 ) -> Lowered<'a> {
-    let mut cx = cx::Cx::new(allocator, tree.source);
+    lower_with_caps(allocator, tree, errors, LegacyCaps::VUE3)
+}
+
+/// Lower with an explicit Vue dialect. Vue 3 is [`LegacyCaps::VUE3`]
+/// (identical to [`lower`]); Vue 2 admits `.sync` / `slot-scope` /
+/// pipe-filter payloads so the legalizing pass can rewrite them.
+#[must_use]
+pub fn lower_with_caps<'a>(
+    allocator: &'a Allocator,
+    tree: &SurfaceTree<'a>,
+    errors: &[SurfaceError],
+    caps: LegacyCaps,
+) -> Lowered<'a> {
+    let mut cx = cx::Cx::with_caps(allocator, tree.source, caps);
     for error in errors {
         cx.diagnostics.push(Diagnostic::new(
             Severity::Error,
@@ -117,5 +137,6 @@ pub fn lower<'a>(
         scopes: cx.scopes,
         texts: cx.texts,
         wrappers: cx.wrappers,
+        caps,
     }
 }

--- a/crates/vize_ricalco/src/lower/bindop.rs
+++ b/crates/vize_ricalco/src/lower/bindop.rs
@@ -22,7 +22,7 @@ use vize_carton::{Box, String, Vec, cstr};
 use vize_sinopia::Element;
 
 use vize_disegno::expr::ExprRef;
-use vize_disegno::op::{BindOp, BindingOp, DynamicName, OnOp};
+use vize_disegno::op::{BindOp, BindingOp, DynamicName, OnOp, VueSyncOp};
 
 use super::cx::{Cx, attr_slice, attr_span};
 use super::directive::{Arg, Directive};
@@ -104,6 +104,43 @@ pub(crate) fn lower_bind<'a>(
             _ => None,
         },
     };
+
+    // Vue 2's bounded `.sync` subset: static name, a value, the
+    // `sync` modifier. Dynamic `:[foo].sync` stays `ui.bind`, matching
+    // the shipped pre-transform's skip. `ExprRef`/`DynamicName` are
+    // `Copy`, so the Bind arm still sees the original positions.
+    if cx.caps.scoped_slot_attrs
+        && let Some(name) = name
+        && matches!(name, DynamicName::Static(_))
+        && let Some(value) = value
+        && modifiers.contains(&"sync")
+    {
+        let mut rest: Vec<'a, &'a str> = Vec::new_in(&cx.allocator);
+        let mut stripped = false;
+        for modifier in &modifiers {
+            if *modifier == "sync" && !stripped {
+                stripped = true;
+                continue;
+            }
+            rest.push(*modifier);
+        }
+        cx.record(
+            "lower.sync",
+            node,
+            attr_slice(cx, attr),
+            name_desc("vue.sync", &Some(name)),
+            span,
+        );
+        return BindingOp::VueSync(Box::new_in(
+            VueSyncOp {
+                name,
+                modifiers: rest,
+                value,
+                span,
+            },
+            &cx.allocator,
+        ));
+    }
 
     cx.record(
         "lower.bind",

--- a/crates/vize_ricalco/src/lower/caps.rs
+++ b/crates/vize_ricalco/src/lower/caps.rs
@@ -1,0 +1,86 @@
+//! Vue dialect capabilities the S1→S2 lowering consults.
+//!
+//! A copy of the three template-sugar bits
+//! [`vize_armature::legacy::LegacyDialectCapabilities`] names, kept
+//! here so this crate never grows an armature edge. Resolved once per
+//! file from [`vize_carton::config::VueVersion`]. Vue 3 is every flag
+//! off — a single field-read short-circuit, the same zero-cost shape
+//! the shipped `desugar_legacy_template` uses.
+
+use vize_carton::config::VueVersion;
+
+/// The three Vue 2 template-sugar surfaces P2-9 installment 7 ports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct LegacyCaps {
+    /// Pipe filters (`{{ msg | capitalize }}`). Every pre-Vue-3 line.
+    pub supports_filters: bool,
+    /// `slot-scope` / `scope` and `:foo.sync`. Vue 2 / 2.7 only.
+    pub scoped_slot_attrs: bool,
+    /// `.native` and numeric keyCodes on `v-on`. Vue 2 / 2.7 only.
+    pub v2_event_sugar: bool,
+}
+
+impl LegacyCaps {
+    /// The default dialect: every sugar surface off.
+    pub const VUE3: Self = Self {
+        supports_filters: false,
+        scoped_slot_attrs: false,
+        v2_event_sugar: false,
+    };
+
+    /// Resolve a config-selected dialect. Vue 3 (and any future
+    /// non-legacy line) is [`Self::VUE3`].
+    #[must_use]
+    pub const fn for_version(version: VueVersion) -> Self {
+        match version {
+            VueVersion::V3 => Self::VUE3,
+            VueVersion::V2 | VueVersion::V2_7 => Self {
+                supports_filters: true,
+                scoped_slot_attrs: true,
+                v2_event_sugar: true,
+            },
+            VueVersion::V1 | VueVersion::V0_11 | VueVersion::V0_10 => Self {
+                supports_filters: true,
+                scoped_slot_attrs: false,
+                v2_event_sugar: false,
+            },
+        }
+    }
+
+    /// Whether the legalizing pass has any work. Vue 3 is a single
+    /// false — the tree is never walked for sugar.
+    #[must_use]
+    pub const fn needs_sugar(self) -> bool {
+        self.supports_filters || self.scoped_slot_attrs || self.v2_event_sugar
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LegacyCaps;
+    use vize_carton::config::VueVersion;
+
+    #[test]
+    fn vue3_is_every_flag_off() {
+        let caps = LegacyCaps::for_version(VueVersion::V3);
+        assert_eq!(caps, LegacyCaps::VUE3);
+        assert!(!caps.needs_sugar());
+    }
+
+    #[test]
+    fn vue2_and_vue2_7_share_the_template_sugar() {
+        let v2 = LegacyCaps::for_version(VueVersion::V2);
+        let v2_7 = LegacyCaps::for_version(VueVersion::V2_7);
+        assert_eq!(v2, v2_7);
+        assert!(v2.supports_filters && v2.scoped_slot_attrs && v2.v2_event_sugar);
+        assert!(v2.needs_sugar());
+    }
+
+    #[test]
+    fn vue1_keeps_filters_only() {
+        let v1 = LegacyCaps::for_version(VueVersion::V1);
+        assert!(v1.supports_filters);
+        assert!(!v1.scoped_slot_attrs && !v1.v2_event_sugar);
+        assert!(v1.needs_sugar());
+    }
+}

--- a/crates/vize_ricalco/src/lower/cx.rs
+++ b/crates/vize_ricalco/src/lower/cx.rs
@@ -41,10 +41,15 @@ pub(crate) struct Cx<'a> {
     pub scopes: SideTable<ScopeFacts>,
     pub texts: SideTable<super::text::TextParts>,
     pub wrappers: SideTable<super::structural::WrapperKeys>,
+    pub caps: super::caps::LegacyCaps,
 }
 
 impl<'a> Cx<'a> {
-    pub(crate) fn new(allocator: &'a Allocator, source: &'a str) -> Self {
+    pub(crate) fn with_caps(
+        allocator: &'a Allocator,
+        source: &'a str,
+        caps: super::caps::LegacyCaps,
+    ) -> Self {
         Self {
             allocator,
             source,
@@ -57,6 +62,7 @@ impl<'a> Cx<'a> {
             scopes: SideTable::new(),
             texts: SideTable::new(),
             wrappers: SideTable::new(),
+            caps,
         }
     }
 

--- a/crates/vize_ricalco/src/lower/element.rs
+++ b/crates/vize_ricalco/src/lower/element.rs
@@ -144,13 +144,32 @@ pub(crate) fn element_core<'a>(
         cx.record("lower.element", node, open_slice, after, span);
     }
 
+    let take_scope = super::sugar::should_take(cx, element, analyzed);
+    let scope_index = take_scope
+        .then(|| super::sugar::scope_attr_index(element, analyzed))
+        .flatten();
+    let companion_slot = take_scope
+        .then(|| super::sugar::companion_slot_index(element, analyzed))
+        .flatten();
+
     let mut attributes: Vec<'a, Attribute<'a>> = Vec::new_in(&cx.allocator);
     let mut bindings: Vec<'a, BindingOp<'a>> = Vec::new_in(&cx.allocator);
     for (index, attr) in element.open.attrs.iter().enumerate() {
         if Some(index) == analyzed.branch.map(|(idx, _)| idx) || Some(index) == analyzed.vfor {
             continue;
         }
+        if Some(index) == companion_slot {
+            continue;
+        }
         match &analyzed.forms[index] {
+            AttrForm::Static if Some(index) == scope_index => {
+                bindings.push(super::sugar::lower_slot_scope(
+                    cx,
+                    element,
+                    index,
+                    companion_slot,
+                ));
+            }
             AttrForm::Static => attributes.push(Attribute {
                 name: attr.name.text,
                 value: attr.value.as_ref().map(|value| value.content.text),

--- a/crates/vize_ricalco/src/lower/expr.rs
+++ b/crates/vize_ricalco/src/lower/expr.rs
@@ -4,13 +4,15 @@
 //! The lowering **never re-derives the admission rule**: text goes
 //! through [`ExprRef::parse_js_in`] — the one shared home of the P1-5
 //! guard → parse → whole-coverage rule — and comes back `Js` when
-//! admitted or `Opaque` with the text-classified reason when not. The
-//! position-classified reasons (`ForValue` here; `MultiStatement` and
+//! admitted or `Opaque` with the text-classified reason when not. Vue 2
+//! pipe filters are an exception that is still total: when the dialect
+//! asks, [`VueFilterExpr::parse_in`] runs first so `|` is not bitwise-OR.
+//! The position-classified reasons (`ForValue` here; `MultiStatement` and
 //! `Compound` have no P2-8 producer, see the record) are assigned by
 //! [`opaque_at`], the only constructor that names a reason directly.
 
 use vize_carton::{Span, String, cstr};
-use vize_disegno::expr::{ExprRef, OpaqueExpr, OpaqueReason};
+use vize_disegno::expr::{ExprRef, OpaqueExpr, OpaqueReason, VueFilterExpr};
 
 use super::cx::Cx;
 
@@ -23,8 +25,15 @@ pub(crate) fn trimmed<'a>(cx: &Cx<'a>, text: &'a str) -> (&'a str, Span) {
 
 /// Lower one expression position: trim, then admit through the shared
 /// rule. Total — refused text comes back as the classified escape.
+/// Vue 2 pipe filters are admitted as [`ExprRef::Filter`] when the
+/// dialect asks for them, *before* a JS parse would read `|` as OR.
 pub(crate) fn expr_at<'a>(cx: &Cx<'a>, text: &'a str) -> ExprRef<'a> {
     let (slice, span) = trimmed(cx, text);
+    if cx.caps.supports_filters
+        && let Some(filter) = VueFilterExpr::parse_in(cx.allocator, slice, span)
+    {
+        return ExprRef::Filter(filter);
+    }
     ExprRef::parse_js_in(cx.allocator, slice, span)
 }
 

--- a/crates/vize_ricalco/src/lower/sugar.rs
+++ b/crates/vize_ricalco/src/lower/sugar.rs
@@ -1,0 +1,116 @@
+//! Vue 2 `slot-scope` / `scope` attribute capture at lowering.
+//!
+//! The shipped pre-transform (`desugar_scoped_slot_attrs`) rewrites
+//! these into a `v-slot` directive before the rest of the lane runs.
+//! S2 keeps the authored sugar as [`BindingOp::VueSlotScope`] so the
+//! legalizing pass can turn it into `ui.slot-content` 1:1 (same
+//! page-order id, same scope-fact key). A carrier that already authors
+//! `v-slot` is left alone — the shipped lane will not emit a
+//! conflicting directive.
+
+use alloc::vec::Vec as StdVec;
+
+use vize_carton::{Box, String, cstr};
+use vize_sinopia::Element;
+
+use vize_disegno::op::{BindingOp, VueSlotScopeOp};
+use vize_disegno::scope::{ScopeBinding, ScopeFacts, ScopeOrigin};
+
+use super::cx::{Cx, attr_slice, attr_span};
+use super::directive::{AttrForm, Head};
+use super::element::{Analyzed, attr_value_text};
+use super::expr::{expr_at, simple_identifier};
+
+/// Whether this element should consume `slot-scope`/`scope` (and the
+/// companion static `slot`) into a dialect binding.
+pub(crate) fn should_take(cx: &Cx<'_>, element: &Element<'_>, analyzed: &Analyzed<'_>) -> bool {
+    cx.caps.scoped_slot_attrs
+        && !has_v_slot(analyzed)
+        && scope_attr_index(element, analyzed).is_some()
+}
+
+/// The first static `slot-scope` or `scope` attribute, in authored
+/// order — Vue 2.6 treated both identically and took the first.
+pub(crate) fn scope_attr_index(element: &Element<'_>, analyzed: &Analyzed<'_>) -> Option<usize> {
+    element
+        .open
+        .attrs
+        .iter()
+        .enumerate()
+        .position(|(index, attr)| {
+            matches!(analyzed.forms.get(index), Some(AttrForm::Static))
+                && (attr.name.text == "slot-scope" || attr.name.text == "scope")
+        })
+}
+
+/// The companion static `slot="name"` attribute, consumed as the
+/// dialect op's slot name. Dynamic `:slot` stays a bind.
+pub(crate) fn companion_slot_index(
+    element: &Element<'_>,
+    analyzed: &Analyzed<'_>,
+) -> Option<usize> {
+    element
+        .open
+        .attrs
+        .iter()
+        .enumerate()
+        .position(|(index, attr)| {
+            matches!(analyzed.forms.get(index), Some(AttrForm::Static)) && attr.name.text == "slot"
+        })
+}
+
+/// Lower the scope attribute into `vue.slot-scope`. Scope facts key
+/// this binding so the 1:1 rewrite to `ui.slot-content` keeps the same
+/// side-table entry.
+pub(crate) fn lower_slot_scope<'a>(
+    cx: &mut Cx<'a>,
+    element: &Element<'a>,
+    index: usize,
+    companion_slot: Option<usize>,
+) -> BindingOp<'a> {
+    let attr = &element.open.attrs[index];
+    let span = attr_span(cx, attr);
+    let node = cx.mint_op();
+    let name = companion_slot.and_then(|slot_index| {
+        attr_value_text(element, slot_index)
+            .map(str::trim)
+            .filter(|text| !text.is_empty())
+    });
+    let params = attr_value_text(element, index)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(|text| expr_at(cx, text));
+    if let Some(expr) = &params {
+        let tag = cx.mint_scope();
+        let mut scope_bindings = StdVec::new();
+        if let Some(bound) = simple_identifier(expr) {
+            scope_bindings.push(ScopeBinding {
+                name: String::from(bound),
+                origin: ScopeOrigin::Authored { span: expr.span() },
+            });
+        }
+        cx.attach_scope(
+            node,
+            ScopeFacts {
+                tag,
+                bindings: scope_bindings,
+            },
+        );
+    }
+    let after = match name {
+        None => String::from("vue.slot-scope"),
+        Some(text) => cstr!("vue.slot-scope \"{text}\""),
+    };
+    cx.record("lower.slot-scope", node, attr_slice(cx, attr), after, span);
+    BindingOp::VueSlotScope(Box::new_in(
+        VueSlotScopeOp { name, params, span },
+        &cx.allocator,
+    ))
+}
+
+fn has_v_slot(analyzed: &Analyzed<'_>) -> bool {
+    analyzed
+        .forms
+        .iter()
+        .any(|form| matches!(form, AttrForm::Directive(directive) if directive.head == Head::Slot))
+}

--- a/crates/vize_ricalco/tests/legacy_lowering.rs
+++ b/crates/vize_ricalco/tests/legacy_lowering.rs
@@ -1,0 +1,211 @@
+//! Vue 2 dialect payloads at S1→S2 lowering (P2-9 installment 7).
+//!
+//! The legalizing pass is a later PR; this suite pins that the
+//! lowering admits `.sync` / `slot-scope` / pipe filters as dialect
+//! ops and expressions under Vue 2, and that Vue 3 stays inert.
+
+mod support;
+
+use support::{artifact, artifact_caps, assert_sound, assert_sound_caps};
+use vize_carton::config::VueVersion;
+use vize_ricalco::LegacyCaps;
+
+fn vue2() -> LegacyCaps {
+    LegacyCaps::for_version(VueVersion::V2)
+}
+
+#[test]
+fn vue3_leaves_sync_as_a_bind_modifier() {
+    let source = r#"<Comp :title.sync="heading"/>"#;
+    let art = artifact(source);
+    assert_eq!(
+        art.folio,
+        "[disegno]\n\
+         ops=2\n\
+         \n\
+         [disegno.ops]\n\
+         ui.component Comp @0:29\n\
+         \x20 ui.bind name=\"title\" mods=\"sync\" value=js(\"heading\" @19:26) @6:27\n\
+         \n"
+    );
+    assert_sound(source, "vue3-sync-inert");
+}
+
+#[test]
+fn vue2_admits_sync_as_the_dialect_op() {
+    let source = r#"<Comp :title.sync="heading"/>"#;
+    let art = artifact_caps(source, vue2());
+    assert_eq!(
+        art.folio,
+        "[disegno]\n\
+         ops=2\n\
+         \n\
+         [disegno.ops]\n\
+         ui.component Comp @0:29\n\
+         \x20 vue.sync name=\"title\" value=js(\"heading\" @19:26) @6:27\n\
+         \n"
+    );
+    assert_sound_caps(source, vue2(), "vue2-sync");
+}
+
+#[test]
+fn vue2_keeps_non_sync_bind_modifiers_on_the_dialect_op() {
+    let source = r#"<Comp :title.sync.camel="heading"/>"#;
+    let art = artifact_caps(source, vue2());
+    assert_eq!(
+        art.folio,
+        "[disegno]\n\
+         ops=2\n\
+         \n\
+         [disegno.ops]\n\
+         ui.component Comp @0:35\n\
+         \x20 vue.sync name=\"title\" mods=\"camel\" value=js(\"heading\" @25:32) @6:33\n\
+         \n"
+    );
+    assert_sound_caps(source, vue2(), "vue2-sync-camel");
+}
+
+#[test]
+fn vue2_leaves_dynamic_sync_as_bind() {
+    let source = r#"<Comp :[foo].sync="heading"/>"#;
+    let art = artifact_caps(source, vue2());
+    assert!(
+        art.folio.contains("ui.bind"),
+        "dynamic .sync must stay ui.bind: {}",
+        art.folio
+    );
+    assert!(
+        !art.folio.contains("vue.sync"),
+        "dynamic .sync must not become vue.sync: {}",
+        art.folio
+    );
+    assert_sound_caps(source, vue2(), "vue2-dynamic-sync");
+}
+
+#[test]
+fn vue3_reads_a_pipe_as_js() {
+    let source = "{{msg | cap}}";
+    let art = artifact(source);
+    assert!(
+        art.folio.contains("js(\"msg | cap\""),
+        "Vue 3 must read `|` as JS: {}",
+        art.folio
+    );
+    assert!(
+        !art.folio.contains("vue.filter"),
+        "Vue 3 must not admit vue.filter: {}",
+        art.folio
+    );
+    assert_sound(source, "vue3-pipe-js");
+}
+
+#[test]
+fn vue2_admits_a_pipe_as_the_filter_expression() {
+    let source = "{{msg | cap}}";
+    let art = artifact_caps(source, vue2());
+    assert_eq!(
+        art.folio,
+        "[disegno]\n\
+         ops=1\n\
+         \n\
+         [disegno.ops]\n\
+         ui.interpolation vue.filter(\"msg | cap\" @2:11) @0:13\n\
+         \n"
+    );
+    assert_sound_caps(source, vue2(), "vue2-filter");
+}
+
+#[test]
+fn vue3_leaves_slot_scope_as_an_attribute() {
+    let source = r#"<Comp><template slot-scope="props">x</template></Comp>"#;
+    let art = artifact(source);
+    assert!(
+        art.folio.contains("attr slot-scope=\"props\""),
+        "Vue 3 must keep slot-scope as an attribute: {}",
+        art.folio
+    );
+    assert!(
+        !art.folio.contains("vue.slot-scope"),
+        "Vue 3 must not emit vue.slot-scope: {}",
+        art.folio
+    );
+    assert_sound(source, "vue3-slot-scope-inert");
+}
+
+#[test]
+fn vue2_admits_slot_scope_as_the_dialect_op() {
+    let source = r#"<Comp><template slot-scope="props">x</template></Comp>"#;
+    let art = artifact_caps(source, vue2());
+    assert_eq!(
+        art.folio,
+        "[disegno]\n\
+         ops=4\n\
+         \n\
+         [disegno.ops]\n\
+         ui.component Comp @0:54\n\
+         \x20 ui.element template @6:47\n\
+         \x20   vue.slot-scope params=js(\"props\" @28:33) @16:34\n\
+         \x20   ui.text \"x\" @35:36\n\
+         \n"
+    );
+    assert_eq!(art.scopes.len(), 1);
+    assert_sound_caps(source, vue2(), "vue2-slot-scope");
+}
+
+#[test]
+fn vue2_consumes_the_companion_slot_attribute() {
+    let source = r#"<Comp><template slot="header" slot-scope="props">x</template></Comp>"#;
+    let art = artifact_caps(source, vue2());
+    assert!(
+        art.folio
+            .contains("vue.slot-scope name=\"header\" params=js(\"props\""),
+        "companion slot must become the dialect op name: {}",
+        art.folio
+    );
+    assert!(
+        !art.folio.contains("attr slot="),
+        "companion slot must not remain an attribute: {}",
+        art.folio
+    );
+    assert_sound_caps(source, vue2(), "vue2-slot-scope-named");
+}
+
+#[test]
+fn vue2_leaves_slot_scope_when_v_slot_is_already_authored() {
+    let source = r#"<Comp><template v-slot:header slot-scope="props">x</template></Comp>"#;
+    let art = artifact_caps(source, vue2());
+    assert!(
+        art.folio.contains("ui.slot-content"),
+        "authored v-slot must still lower: {}",
+        art.folio
+    );
+    assert!(
+        art.folio.contains("attr slot-scope=\"props\""),
+        "conflicting slot-scope must stay an attribute: {}",
+        art.folio
+    );
+    assert!(
+        !art.folio.contains("vue.slot-scope"),
+        "must not emit a conflicting dialect op: {}",
+        art.folio
+    );
+    assert_sound_caps(source, vue2(), "vue2-slot-scope-conflict");
+}
+
+#[test]
+fn vue1_admits_filters_but_not_sync() {
+    let caps = LegacyCaps::for_version(VueVersion::V1);
+    let sync = artifact_caps(r#"<Comp :title.sync="heading"/>"#, caps);
+    assert!(
+        sync.folio.contains("ui.bind") && !sync.folio.contains("vue.sync"),
+        "Vue 1 has no .sync sugar: {}",
+        sync.folio
+    );
+    let filter = artifact_caps("{{msg | cap}}", caps);
+    assert!(
+        filter.folio.contains("vue.filter"),
+        "Vue 1 still has filters: {}",
+        filter.folio
+    );
+    assert_sound_caps("{{msg | cap}}", caps, "vue1-filter");
+}

--- a/crates/vize_ricalco/tests/support/mod.rs
+++ b/crates/vize_ricalco/tests/support/mod.rs
@@ -13,7 +13,7 @@ use vize_disegno::folio::DisegnoFolio;
 use vize_disegno::provenance::ProvenanceRecord;
 use vize_disegno::scope::ScopeFacts;
 use vize_disegno::verify::{Rigor, Violation, verify, verify_table};
-use vize_ricalco::{Lowered, lower};
+use vize_ricalco::{LegacyCaps, Lowered, lower, lower_with_caps};
 use vize_sinopia::parse;
 
 /// The owned snapshot of one lowering, for exact-equality pins.
@@ -33,7 +33,12 @@ pub struct Artifact {
 
 /// Lower `source` and clone everything owned out of the arena's shadow.
 pub fn artifact(source: &str) -> Artifact {
-    with_lowered(source, |lowered, folio| Artifact {
+    artifact_caps(source, LegacyCaps::VUE3)
+}
+
+/// [`artifact`] under an explicit Vue dialect.
+pub fn artifact_caps(source: &str, caps: LegacyCaps) -> Artifact {
+    with_lowered_caps(source, caps, |lowered, folio| Artifact {
         folio: folio.print_to_string(FolioMode::Full),
         op_count: lowered.op_count,
         diagnostics: lowered.diagnostics.clone(),
@@ -50,9 +55,18 @@ pub fn artifact(source: &str) -> Artifact {
 /// Parse + lower `source` and hand the artifact (with its owned folio
 /// mirror) to `f`.
 pub fn with_lowered<R>(source: &str, f: impl FnOnce(&Lowered<'_>, &DisegnoFolio) -> R) -> R {
+    with_lowered_caps(source, LegacyCaps::VUE3, f)
+}
+
+/// [`with_lowered`] under an explicit Vue dialect.
+pub fn with_lowered_caps<R>(
+    source: &str,
+    caps: LegacyCaps,
+    f: impl FnOnce(&Lowered<'_>, &DisegnoFolio) -> R,
+) -> R {
     let allocator = Allocator::new();
     let (tree, errors) = parse(&allocator, source);
-    let lowered = lower(&allocator, &tree, &errors);
+    let lowered = lower_with_caps(&allocator, &tree, &errors, caps);
     let folio = DisegnoFolio::of(&lowered.root.ops);
     f(&lowered, &folio)
 }
@@ -154,7 +168,12 @@ pub fn assert_transformed_sound(source: &str, context: &str) {
 /// 4. **Folio round-trip** — `parse(print(v)) == v` structurally and the
 ///    re-print is byte-identical (TS-16 applied to lowered output).
 pub fn assert_sound(source: &str, context: &str) {
-    with_lowered(source, |lowered, folio| {
+    assert_sound_caps(source, LegacyCaps::VUE3, context);
+}
+
+/// [`assert_sound`] under an explicit Vue dialect.
+pub fn assert_sound_caps(source: &str, caps: LegacyCaps, context: &str) {
+    with_lowered_caps(source, caps, |lowered, folio| {
         assert_eq!(
             u64::from(lowered.op_count),
             folio.op_count(),


### PR DESCRIPTION
## Summary
- Stacked on #4633. S1→S2 lowering now consults `LegacyCaps` (a carton `VueVersion` mapping, no armature edge and no ricalco `_legacy` cargo feature): Vue 3 is every flag off, Vue 2 admits `:foo.sync` as `vue.sync`, `slot-scope`/`scope` as `vue.slot-scope` (companion static `slot` consumed; existing `v-slot` left alone), and pipe filters as `vue.filter` *before* a JS parse would read `|` as OR.
- Vue 3 path is `lower()` → `LegacyCaps::VUE3`; existing snapshots, walks=6, and the 6-pass pipeline are unchanged. Zero-cost is a single field-read short-circuit (`needs_sugar()`), the same shape the shipped `desugar_legacy_template` uses.
- The legalizing pass (expand sync, rewrite slot-scope → `ui.slot-content`, `.native`/keyCodes, filter wrap) is the next stacked PR.

## Test plan
- [x] `cargo test -p vize_ricalco` (includes new `legacy_lowering` pins + soundness/round-trip)
- [x] `cargo clippy -p vize_ricalco --lib --tests -- -D warnings`
- [ ] Vue 3 compile output unchanged (no shipped path touched; ricalco is `publish = false`)


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790083568&installation_model_id=422833&pr_number=4634&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4634&signature=34d36af3084670cd783dfc512a2e201f14066722437bbbe4f0ada8e29e0c7dc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->