### PR TITLE
fix(patina): make vue/no-undefined-refs reachable from config

### DIFF
--- a/crates/vize/tests/lint_undefined_refs_cli.rs
+++ b/crates/vize/tests/lint_undefined_refs_cli.rs
@@ -1,0 +1,80 @@
+use std::{fs, path::Path, process::Command};
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+fn output_details(output: &std::process::Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn lint_config_can_enable_undefined_template_refs() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "rules": {
+      "vue/no-undefined-refs": "warn"
+    }
+  }
+}"#,
+    );
+    write_file(
+        project_root.path(),
+        "src/App.vue",
+        r#"<script setup>
+const known = 1
+</script>
+<template>
+  <p>{{ known }} {{ missing }}</p>
+</template>
+"#,
+    );
+
+    let enabled = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "src/App.vue",
+        ])
+        .output()
+        .unwrap();
+    let enabled_stdout = String::from_utf8_lossy(&enabled.stdout);
+    assert!(
+        enabled_stdout.contains("vue/no-undefined-refs"),
+        "config-enable must report the undefined template ref: {}",
+        output_details(&enabled)
+    );
+    assert!(
+        enabled_stdout.contains("missing"),
+        "{}",
+        output_details(&enabled)
+    );
+
+    let default = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args(["lint", "--no-config", "--format", "json", "src/App.vue"])
+        .output()
+        .unwrap();
+    let default_stdout = String::from_utf8_lossy(&default.stdout);
+    assert!(
+        !default_stdout.contains("vue/no-undefined-refs"),
+        "default preset must stay silent: {}",
+        output_details(&default)
+    );
+}

--- a/crates/vize/tests/lint_undefined_refs_cli.rs
+++ b/crates/vize/tests/lint_undefined_refs_cli.rs
@@ -54,14 +54,31 @@ const known = 1
         ])
         .output()
         .unwrap();
-    let enabled_stdout = String::from_utf8_lossy(&enabled.stdout);
     assert!(
-        enabled_stdout.contains("vue/no-undefined-refs"),
-        "config-enable must report the undefined template ref: {}",
+        enabled.status.success(),
+        "config-enable must keep the warning exit: {}",
         output_details(&enabled)
     );
-    assert!(
-        enabled_stdout.contains("missing"),
+    let enabled_json: serde_json::Value = serde_json::from_slice(&enabled.stdout)
+        .unwrap_or_else(|_| panic!("config-enable must emit JSON: {}", output_details(&enabled)));
+    assert_eq!(
+        enabled_json,
+        serde_json::json!([{
+            "file": "src/App.vue",
+            "messages": [{
+                "ruleId": "vue/no-undefined-refs",
+                "ruleDocsPath": "docs/content/rules/vue.md",
+                "severity": 1,
+                "message": "[vize:vue/no-undefined-refs] Variable 'missing' is not defined",
+                "line": 5,
+                "column": 21,
+                "endLine": 5,
+                "endColumn": 28,
+                "help": "Define in <script setup> or ensure it's imported"
+            }],
+            "errorCount": 0,
+            "warningCount": 1
+        }]),
         "{}",
         output_details(&enabled)
     );
@@ -71,10 +88,27 @@ const known = 1
         .args(["lint", "--no-config", "--format", "json", "src/App.vue"])
         .output()
         .unwrap();
-    let default_stdout = String::from_utf8_lossy(&default.stdout);
     assert!(
-        !default_stdout.contains("vue/no-undefined-refs"),
+        default.status.success(),
         "default preset must stay silent: {}",
+        output_details(&default)
+    );
+    let default_json: serde_json::Value =
+        serde_json::from_slice(&default.stdout).unwrap_or_else(|_| {
+            panic!(
+                "default preset must emit JSON: {}",
+                output_details(&default)
+            )
+        });
+    assert_eq!(
+        default_json,
+        serde_json::json!([{
+            "file": "src/App.vue",
+            "messages": [],
+            "errorCount": 0,
+            "warningCount": 0
+        }]),
+        "{}",
         output_details(&default)
     );
 }

--- a/crates/vize_patina/src/linter/engine/rule_sets.rs
+++ b/crates/vize_patina/src/linter/engine/rule_sets.rs
@@ -55,14 +55,16 @@ mod tests {
                 .iter()
                 .copied(),
         );
-        for name in SEMANTIC_TEMPLATE_RULES
+        let missing: Vec<&str> = SEMANTIC_TEMPLATE_RULES
             .iter()
             .chain(SHARED_SFC_DESCRIPTOR_RULES)
-        {
-            assert!(
-                available.contains(name),
-                "{name} is named in an engine rule-name set but no registry can instantiate it"
-            );
-        }
+            .copied()
+            .filter(|name| !available.contains(name))
+            .collect();
+        assert_eq!(
+            missing,
+            Vec::<&str>::new(),
+            "engine rule-name sets must only name rules a registry can instantiate"
+        );
     }
 }

--- a/crates/vize_patina/src/linter/engine/rule_sets.rs
+++ b/crates/vize_patina/src/linter/engine/rule_sets.rs
@@ -34,3 +34,35 @@ pub(super) const SHARED_SFC_DESCRIPTOR_RULES: &[&str] = &[
     "ecosystem/void-link-require-href",
     "ecosystem/void-link-valid-method",
 ];
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use super::{SEMANTIC_TEMPLATE_RULES, SHARED_SFC_DESCRIPTOR_RULES};
+    use crate::rule::RuleRegistry;
+
+    #[test]
+    fn engine_rule_name_sets_only_name_dispatchable_rules() {
+        let mut available: BTreeSet<_> = RuleRegistry::with_all()
+            .rule_names()
+            .iter()
+            .copied()
+            .collect();
+        available.extend(
+            RuleRegistry::with_opt_in_rules()
+                .rule_names()
+                .iter()
+                .copied(),
+        );
+        for name in SEMANTIC_TEMPLATE_RULES
+            .iter()
+            .chain(SHARED_SFC_DESCRIPTOR_RULES)
+        {
+            assert!(
+                available.contains(name),
+                "{name} is named in an engine rule-name set but no registry can instantiate it"
+            );
+        }
+    }
+}

--- a/crates/vize_patina/src/preset/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/preset/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -544,6 +544,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "petite-vue/no-unsupported-directive",
     "petite-vue/valid-v-effect",
     "petite-vue/valid-v-scope",
+    "vue/no-undefined-refs",
     "vue/no-multiple-template-root",
     "vue/no-use-v-else-with-v-for",
     "vue/no-deprecated-v-on-native-modifier",

--- a/crates/vize_patina/src/preset/tests.rs
+++ b/crates/vize_patina/src/preset/tests.rs
@@ -66,7 +66,9 @@ fn happy_path_keeps_opinionated_rules_opt_in() {
     assert!(!happy_path.has_rule("type/no-reactivity-loss"));
     assert!(happy_path.has_rule("html/no-empty-palpable-content"));
     assert!(!happy_path.has_rule("vue/multi-word-component-names"));
+    assert!(!happy_path.has_rule("vue/no-undefined-refs"));
     assert!(!happy_path.has_rule("a11y/use-list"));
+    assert!(RuleRegistry::with_opt_in_rules().has_rule("vue/no-undefined-refs"));
     assert!(opinionated.has_rule("vue/attribute-order"));
     assert!(opinionated.has_rule("vue/component-definition-name-casing"));
     assert!(opinionated.has_rule("vue/html-quotes"));

--- a/crates/vize_patina/src/rules/vue.rs
+++ b/crates/vize_patina/src/rules/vue.rs
@@ -231,10 +231,16 @@ pub(crate) fn register_security(registry: &mut crate::rule::RuleRegistry) {
 
 /// Register Vue rules that require explicit opt-in.
 ///
-/// This includes contextual contracts such as Nuxt's single-root pages and
-/// migration checks for deprecated Vue 2 syntax. Keeping them outside every
+/// This includes contextual contracts such as Nuxt's single-root pages,
+/// migration checks for deprecated Vue 2 syntax, and documented semantic
+/// checks that are not in the default preset. Keeping them outside every
 /// preset avoids imposing those narrower contracts on general Vue 3 projects.
+/// A documented rule still has to be instantiable here: config-enabling a
+/// name that no registry entry owns is a silent false negative (#4636).
 pub(crate) fn register_opt_in(registry: &mut crate::rule::RuleRegistry) {
+    if !registry.has_rule("vue/no-undefined-refs") {
+        registry.register(Box::new(NoUndefinedRefs));
+    }
     if !registry.has_rule("vue/no-multiple-template-root") {
         registry.register(Box::new(NoMultipleTemplateRoot));
     }

--- a/crates/vize_patina/src/rules/vue/no_undefined_refs.rs
+++ b/crates/vize_patina/src/rules/vue/no_undefined_refs.rs
@@ -57,14 +57,4 @@ impl Rule for NoUndefinedRefs {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::NoUndefinedRefs;
-    use crate::rule::{Rule, RuleCategory};
-
-    #[test]
-    fn test_meta() {
-        let rule = NoUndefinedRefs;
-        assert_eq!(rule.meta().name, "vue/no-undefined-refs");
-        assert_eq!(rule.meta().category, RuleCategory::Recommended);
-    }
-}
+mod tests;

--- a/crates/vize_patina/src/rules/vue/no_undefined_refs/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_undefined_refs/tests.rs
@@ -115,12 +115,16 @@ const known = 1
     let result = Linter::new()
         .with_additional_rules(vec![RULE.into()])
         .lint_sfc(sfc, "Probe.vue");
-    assert!(
-        result.diagnostics.iter().any(|diagnostic| {
-            diagnostic.rule_name == RULE && diagnostic.message.as_str().contains("missing")
-        }),
-        "config-enable must instantiate the rule: {:#?}",
-        result.diagnostics
+    let expected = undefined_at(sfc, "missing");
+    assert_eq!(
+        findings(&result)
+            .into_iter()
+            .filter(|(rule, _, _, _, _)| *rule == RULE)
+            .map(|(rule, severity, start, end, message)| {
+                (rule, severity, start, end, message.to_string())
+            })
+            .collect::<Vec<_>>(),
+        vec![expected]
     );
 }
 

--- a/crates/vize_patina/src/rules/vue/no_undefined_refs/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_undefined_refs/tests.rs
@@ -1,0 +1,160 @@
+use super::NoUndefinedRefs;
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleCategory, RuleRegistry};
+
+const RULE: &str = "vue/no-undefined-refs";
+
+/// Lint a full SFC with only this rule enabled.
+///
+/// `vue/no-undefined-refs` is a member of `SEMANTIC_TEMPLATE_RULES`, so
+/// enabling it alone still produces the croquis analysis the rule reads.
+fn lint_sfc(sfc: &str) -> LintResult {
+    Linter::new()
+        .with_enabled_rules(Some(vec![RULE.into()]))
+        .lint_sfc(sfc, "Probe.vue")
+}
+
+fn findings(result: &LintResult) -> Vec<(&'static str, Severity, u32, u32, &str)> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.rule_name,
+                diagnostic.severity,
+                diagnostic.start,
+                diagnostic.end,
+                diagnostic.message.as_str(),
+            )
+        })
+        .collect()
+}
+
+fn none() -> Vec<(&'static str, Severity, u32, u32, &'static str)> {
+    Vec::new()
+}
+
+fn undefined_at(sfc: &str, name: &str) -> (&'static str, Severity, u32, u32, std::string::String) {
+    let start = sfc.rfind(name).expect("undefined identifier") as u32;
+    (
+        RULE,
+        Severity::Warning,
+        start,
+        start + name.len() as u32,
+        format!("Variable '{name}' is not defined"),
+    )
+}
+
+#[test]
+fn test_meta() {
+    let rule = NoUndefinedRefs;
+    assert_eq!(rule.meta().name, RULE);
+    assert_eq!(rule.meta().category, RuleCategory::Recommended);
+    assert_eq!(rule.meta().default_severity, Severity::Warning);
+}
+
+#[test]
+fn opt_in_registry_owns_the_rule_and_default_presets_do_not() {
+    assert!(RuleRegistry::with_opt_in_rules().has_rule(RULE));
+    assert!(!RuleRegistry::with_preset(crate::preset::LintPreset::HappyPath).has_rule(RULE));
+    assert!(!RuleRegistry::with_preset(crate::preset::LintPreset::Ecosystem).has_rule(RULE));
+    assert!(!RuleRegistry::with_preset(crate::preset::LintPreset::Opinionated).has_rule(RULE));
+}
+
+#[test]
+fn default_preset_stays_silent_on_an_undefined_template_ref() {
+    let sfc = r#"<script setup>
+const known = 1
+</script>
+<template>
+  <p>{{ known }} {{ missing }}</p>
+</template>
+"#;
+    let result = Linter::new().lint_sfc(sfc, "Probe.vue");
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.rule_name != RULE),
+        "default preset must not fire the opt-in rule: {:#?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn reports_an_undefined_interpolation_identifier() {
+    let sfc = r#"<script setup>
+const known = 1
+</script>
+<template>
+  <p>{{ known }} {{ missing }}</p>
+</template>
+"#;
+    let expected = undefined_at(sfc, "missing");
+    assert_eq!(
+        findings(&lint_sfc(sfc))
+            .into_iter()
+            .map(|(rule, severity, start, end, message)| {
+                (rule, severity, start, end, message.to_string())
+            })
+            .collect::<Vec<_>>(),
+        vec![expected]
+    );
+}
+
+#[test]
+fn additional_rules_can_enable_the_rule_without_replacing_the_preset() {
+    let sfc = r#"<script setup>
+const known = 1
+</script>
+<template>
+  <p>{{ known }} {{ missing }}</p>
+</template>
+"#;
+    let result = Linter::new()
+        .with_additional_rules(vec![RULE.into()])
+        .lint_sfc(sfc, "Probe.vue");
+    assert!(
+        result.diagnostics.iter().any(|diagnostic| {
+            diagnostic.rule_name == RULE && diagnostic.message.as_str().contains("missing")
+        }),
+        "config-enable must instantiate the rule: {:#?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn ignores_a_script_setup_binding() {
+    let sfc = r#"<script setup>
+const known = 1
+</script>
+<template>
+  <p>{{ known }}</p>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_v_for_alias() {
+    let sfc = r#"<script setup>
+const items = ['a']
+</script>
+<template>
+  <span v-for="item in items" :key="item">{{ item }}</span>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_javascript_global() {
+    let sfc = r#"<script setup>
+</script>
+<template>
+  <span>{{ Math.max(1, 2) }}</span>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}

--- a/davinci-road/plan/ledger-fn.md
+++ b/davinci-road/plan/ledger-fn.md
@@ -50,13 +50,18 @@ _mechanism_ is proven green both ways in CI (a synthetic diagnostic set
 matching the manifest passes; a same-count wrong-location set fails listing
 the exact miss).
 
-**Disposition:** `deferred-with-issue` — registering the rule in a preset
-changes default lint behavior, which the phase-0 exit gate (corpus-diff
-empty, zero behavior change) forbids in this phase; needs a charter-level
-preset-placement decision. The CI expectation
-(`tests/_fixtures/davinci-fpfn/expected/assert-report.json`) pins the
-measured 0/3 so the day the rule gains a consumer the pilot test fails
-loudly and this entry must flip in the same change.
+**Disposition:** `justified-with-witness` for default-preset recall;
+config-enable is fixed.
+
+- Default presets still do not instantiate the rule, so the seeded-defect
+  pilot remains 0/3 (`tests/_fixtures/davinci-fpfn/expected/assert-report.json`).
+  Putting it on a default preset is a separate FP-audit change.
+- `#4636` / `fix/patina-undefined-refs-dispatch` registers the rule on the
+  opt-in path. `"vue/no-undefined-refs": "warn"` now instantiates and runs
+  the rule. The engine rule-name set is no longer a dead gate entry.
+
+The CI expectation still pins the measured default-preset 0/3. Flip that
+pin in the same change that adds the rule to a default preset.
 
 ## FN-2 — class (b) unused-binding: `unused_bindings` has no lint consumer
 

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -26,17 +26,17 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 ## File accounting
 
-- `.rs` files under `crates/vize_patina/src/rules/**`: **356**
+- `.rs` files under `crates/vize_patina/src/rules/**`: **357**
 - rule-defining files (exactly one `static META` each): **245** → **245 rules**
-- non-rule files: **111** — 27 module organizers (a `<name>.rs` with a `<name>/` directory beside it), 17 `*_tests.rs` companions, 67 helper/data files (rule submodules, shared tables, private utilities)
+- non-rule files: **112** — 27 module organizers (a `<name>.rs` with a `<name>/` directory beside it), 17 `*_tests.rs` companions, 68 helper/data files (rule submodules, shared tables, private utilities)
 
 ## Summary
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
 - by surface (a rule can have several): `css-text` 10, `markup-facade` 13, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
-- path membership: SFC `lint_sfc` 238 · JSX `lint_jsx` 146 · **SFC∩JSX 146** · SFC-only 92 · JSX-only 0 · neither 7 (6 musea + 1 unregistered)
-- JSX lanes: `fallback` 133, `ir` 12, `ir-lowered` 1, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (13 = 13 `markup-facade` rules)
+- path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
+- JSX lanes: `fallback` 134, `ir` 12, `ir-lowered` 1, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (13 = 13 `markup-facade` rules)
 - classification: neutral-core-candidate **85** · vue-dialect-bound **138** · container-bound **22** (0 overridden)
 - croquis adoption: **24** rules touch vize_croquis (19 direct imports, 12 via context analysis)
 
@@ -237,7 +237,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `vue/no-template-shadow`                        | template-family | `opinionated/vue/no_template_shadow.rs`                | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-template-target-blank`                  | template-family | `vue/no_template_target_blank.rs`                      | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-textarea-mustache`                      | template-family | `vue/no_textarea_mustache.rs`                          | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
-| `vue/no-undefined-refs`                         | template-family | `vue/no_undefined_refs.rs`                             | template-ast                   | no                               | no                          | ctx 1                                                                                               | neutral-core-candidate |
+| `vue/no-undefined-refs`                         | template-family | `vue/no_undefined_refs.rs`                             | template-ast                   | yes (template-visitor)           | yes (fallback)              | ctx 1                                                                                               | neutral-core-candidate |
 | `vue/no-unsafe-url`                             | template-family | `vue/no_unsafe_url.rs`                                 | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-unsandboxed-iframe`                     | template-family | `vue/no_unsandboxed_iframe.rs`                         | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-unused-components`                      | template-family | `vue/no_unused_components.rs`                          | template-ast                   | yes (template-visitor)           | yes (fallback)              | direct 6: `Croquis`, `ScopeData`, `naming::is_pascal_case`, +2; ctx 2                               | container-bound        |
@@ -298,8 +298,8 @@ None. Hand-corrections go in `davinci-road/plan/rule-parity-overrides.toml`, nev
 
 ## Cross-checks
 
-- Rules defined but registered on no dispatch path (dead or host-only until wired): `vue/no-undefined-refs`
-- Engine rule-name sets referencing rules outside the registered set (gate entries that can never activate): `SEMANTIC_TEMPLATE_RULES` names `vue/no-undefined-refs`, which no preset registers
+- Every non-musea rule is registered on at least one dispatch path.
+- Every engine rule-name set entry resolves to a registered rule.
 - `SEMANTIC_TEMPLATE_RULES` (engine-side croquis gate, `linter/engine/rule_sets.rs`) lists 9 rules; all of them show croquis usage above.
 - Context-lane croquis users outside that gate (their template pass runs without analysis unless another path supplies it): `type/require-typed-emits`, `type/require-typed-props`, `vue/use-unique-element-ids`
 - Script registry: 71 dispatch entries vs 71 names in `ALL_BUILTIN_SCRIPT_RULE_NAMES` (agree).

--- a/npm/cli/src/types/rules.ts
+++ b/npm/cli/src/types/rules.ts
@@ -187,6 +187,7 @@ export const LINT_RULE_NAMES = [
   "vue/no-template-shadow",
   "vue/no-template-target-blank",
   "vue/no-textarea-mustache",
+  "vue/no-undefined-refs",
   "vue/no-unsafe-url",
   "vue/no-unsandboxed-iframe",
   "vue/no-unused-components",


### PR DESCRIPTION
## Summary
- `vue/no-undefined-refs` was implemented and documented but never registered, so `"vue/no-undefined-refs": "warn"` was a silent no-op (#4636, FN-1).
- Register the rule on the opt-in path only. Default presets stay unchanged.
- Add isolated lint tests, a CLI config oracle, and an engine rule-name-set dispatch check so a named-but-unreachable rule cannot land again.

## Test plan
- [x] `cargo test -p vize_patina --lib -- no_undefined`
- [x] `cargo test -p vize_patina --lib -- engine_rule_name_sets`
- [x] `cargo test -p vize --test lint_undefined_refs_cli`
- [x] `cargo clippy -p vize_patina --lib -- -D warnings`
- [x] `node --test tests/tooling/davinci-matrices.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790084631&installation_model_id=422833&pr_number=4639&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4639&signature=48beb2421d77ea23a96f7c1946253a78367a8d1b6d2cfdcf86558e8bce606caa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enabling the `vue/no-undefined-refs` lint rule through opt-in configuration.
  * The rule now detects undefined template references while ignoring valid bindings and globals.
* **Bug Fixes**
  * Improved rule registration and availability across supported template types.
* **Tests**
  * Added comprehensive coverage for configuration, diagnostics, presets, and valid reference handling.
* **Documentation**
  * Updated rule parity and preset tracking to reflect the new opt-in rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->