### PR TITLE
feat(davinci): lower SFC style v-bind() into vue.css-bind (P2-10)

### DIFF
--- a/crates/vize_ricalco/src/lib.rs
+++ b/crates/vize_ricalco/src/lib.rs
@@ -59,4 +59,4 @@ extern crate alloc;
 pub mod lower;
 pub mod pass;
 
-pub use lower::{Lowered, lower};
+pub use lower::{Lowered, lower, lower_style_block};

--- a/crates/vize_ricalco/src/lower.rs
+++ b/crates/vize_ricalco/src/lower.rs
@@ -33,6 +33,7 @@ use vize_disegno::scope::ScopeFacts;
 
 mod binding;
 mod bindop;
+mod css;
 mod cx;
 mod directive;
 mod element;
@@ -49,6 +50,7 @@ mod vfor;
 pub(crate) use expr::simple_identifier;
 // The wrapper-key channel (P2-9 series 5): captured `<template v-if>`
 // keys, folded into branch-key facts by the v-if pass.
+pub use css::lower_style_block;
 pub use structural::{WrapperKey, WrapperKeys};
 // The one-rebuild rule (the same discipline): the text pass re-derives a
 // compound's source with exactly the spelling the lowering minted.

--- a/crates/vize_ricalco/src/lower/css.rs
+++ b/crates/vize_ricalco/src/lower/css.rs
@@ -1,0 +1,69 @@
+//! SFC style-block `v-bind()` → [`BindingOp::VueCssBind`] (P2-10).
+//!
+//! Style blocks never enter the template [`SurfaceTree`], so this is a
+//! parallel admission: CSS in, a carrier [`ElementOp`] whose bindings
+//! are the calls. The carrier is not a DOM vnode — P2-11 must skip it.
+//! Spans are **block-relative** via [`Span::to_block_relative`].
+
+use vize_carton::{Allocator, Box, Span, Vec};
+use vize_disegno::expr::ExprRef;
+use vize_disegno::op::{BindingOp, ElementOp, Namespace, Op, Region, VueCssBindOp};
+
+mod scan;
+
+/// Lower one style block's `v-bind()` calls onto a carrier `ui.element style`.
+///
+/// `css` is the style block's **content** (not the wrapping `<style>`
+/// tags). `block_start` is that content's file-absolute start; every
+/// span on the result is relative to it.
+#[must_use]
+pub fn lower_style_block<'a>(allocator: &'a Allocator, css: &'a str, block_start: u32) -> Op<'a> {
+    let mut bindings = Vec::new_in(&allocator);
+    let mut pos = 0;
+    while let Some(hit) = scan::next(css, pos) {
+        let call = rebase(block_start, hit.call_start, hit.call_end);
+        let expr = rebase_slice(css, hit.expr, block_start);
+        bindings.push(BindingOp::VueCssBind(Box::new_in(
+            VueCssBindOp {
+                value: ExprRef::parse_js_in(allocator, hit.expr, expr),
+                span: call,
+            },
+            &allocator,
+        )));
+        pos = hit.call_end;
+    }
+    let block = rebase(block_start, 0, css.len());
+    Op::Element(Box::new_in(
+        ElementOp {
+            tag: "style",
+            namespace: Namespace::Html,
+            attributes: Vec::new_in(&allocator),
+            bindings,
+            children: Region {
+                ops: Vec::new_in(&allocator),
+            },
+            span: block,
+        },
+        &allocator,
+    ))
+}
+
+fn rebase(block_start: u32, start: usize, end: usize) -> Span {
+    Span::new(
+        block_start.saturating_add(start as u32),
+        block_start.saturating_add(end as u32),
+    )
+    .to_block_relative(block_start)
+}
+
+/// File-absolute span of `slice` inside `css`, then block-relative.
+fn rebase_slice(css: &str, slice: &str, block_start: u32) -> Span {
+    let base = css.as_ptr() as usize;
+    let ptr = slice.as_ptr() as usize;
+    let start = if ptr >= base && ptr + slice.len() <= base + css.len() {
+        ptr - base
+    } else {
+        0
+    };
+    rebase(block_start, start, start + slice.len())
+}

--- a/crates/vize_ricalco/src/lower/css/scan.rs
+++ b/crates/vize_ricalco/src/lower/css/scan.rs
@@ -1,0 +1,176 @@
+//! Locate CSS `v-bind()` calls the way the shipped extractor does
+//! (`vize_atelier_sfc::css::transform`): strings and comments are not
+//! calls, `my-v-bind(` / `-webkit-v-bind(` need a left boundary, and an
+//! unmatched `(` stops the scan. Kept as a conversion-local copy so
+//! ricalco never grows an atelier_sfc edge (that crate is published;
+//! this one is not).
+
+/// One `v-bind(...)` whose argument survived trim + outer-quote strip.
+pub(super) struct Hit<'a> {
+    /// Byte offset of the `v` in `v-bind`.
+    pub call_start: usize,
+    /// Byte offset after the matching `)`.
+    pub call_end: usize,
+    /// Argument text, a slice of the CSS (quotes stripped).
+    pub expr: &'a str,
+}
+
+pub(super) fn next<'a>(css: &'a str, from: usize) -> Option<Hit<'a>> {
+    let start = find_next_v_bind(css, from)?;
+    let inner = start + 7;
+    let after_open = css.get(inner..)?;
+    let end = find_matching_paren(after_open)?;
+    let inside = after_open.get(..end)?;
+    let expr = trim_outer_quotes(inside.trim());
+    Some(Hit {
+        call_start: start,
+        call_end: inner + end + 1,
+        expr,
+    })
+}
+
+fn trim_outer_quotes(expr: &str) -> &str {
+    let bytes = expr.as_bytes();
+    if bytes.len() >= 2
+        && matches!(bytes.first(), Some(b'"' | b'\''))
+        && bytes.first() == bytes.last()
+    {
+        &expr[1..expr.len() - 1]
+    } else {
+        expr
+    }
+}
+
+fn find_matching_paren(s: &str) -> Option<usize> {
+    let mut depth = 1u32;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut in_block_comment = false;
+    let mut in_line_comment = false;
+    let mut chars = s.char_indices().peekable();
+
+    while let Some((i, c)) = chars.next() {
+        if in_block_comment {
+            if c == '*' && chars.peek().is_some_and(|(_, next)| *next == '/') {
+                chars.next();
+                in_block_comment = false;
+            }
+            continue;
+        }
+        if in_line_comment {
+            if c == '\n' || c == '\r' {
+                in_line_comment = false;
+            }
+            continue;
+        }
+        if let Some(quote_char) = quote {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            if c == '\\' {
+                escaped = true;
+                continue;
+            }
+            if c == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+        match c {
+            '/' if chars.peek().is_some_and(|(_, next)| *next == '*') => {
+                chars.next();
+                in_block_comment = true;
+            }
+            '/' if chars.peek().is_some_and(|(_, next)| *next == '/') => {
+                chars.next();
+                in_line_comment = true;
+            }
+            '"' | '\'' | '`' => quote = Some(c),
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn find_next_v_bind(css: &str, start: usize) -> Option<usize> {
+    let bytes = css.as_bytes();
+    let mut pos = start;
+    let mut quote: Option<u8> = None;
+    let mut escaped = false;
+    let mut in_block_comment = false;
+    let mut in_line_comment = false;
+
+    while pos < bytes.len() {
+        let byte = bytes[pos];
+        if in_block_comment {
+            if byte == b'*' && bytes.get(pos + 1) == Some(&b'/') {
+                in_block_comment = false;
+                pos += 2;
+            } else {
+                pos += 1;
+            }
+            continue;
+        }
+        if in_line_comment {
+            if byte == b'\n' || byte == b'\r' {
+                in_line_comment = false;
+            }
+            pos += 1;
+            continue;
+        }
+        if let Some(quote_byte) = quote {
+            if escaped {
+                escaped = false;
+                pos += 1;
+                continue;
+            }
+            if byte == b'\\' {
+                escaped = true;
+                pos += 1;
+                continue;
+            }
+            if byte == quote_byte {
+                quote = None;
+            }
+            pos += 1;
+            continue;
+        }
+        match byte {
+            b'"' | b'\'' | b'`' => {
+                quote = Some(byte);
+                pos += 1;
+            }
+            b'/' if bytes.get(pos + 1) == Some(&b'*') => {
+                in_block_comment = true;
+                pos += 2;
+            }
+            b'/' if bytes.get(pos + 1) == Some(&b'/') => {
+                in_line_comment = true;
+                pos += 2;
+            }
+            b'v' if bytes[pos..].starts_with(b"v-bind(")
+                && has_v_bind_left_boundary(bytes, pos) =>
+            {
+                return Some(pos);
+            }
+            _ => pos += 1,
+        }
+    }
+    None
+}
+
+fn has_v_bind_left_boundary(bytes: &[u8], pos: usize) -> bool {
+    pos == 0 || !is_css_identifier_byte(bytes[pos - 1])
+}
+
+fn is_css_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')
+}

--- a/crates/vize_ricalco/tests/css_bind_lowering.rs
+++ b/crates/vize_ricalco/tests/css_bind_lowering.rs
@@ -1,0 +1,111 @@
+//! P2-10: style-block `v-bind()` lowers to `vue.css-bind` on a carrier
+//! `ui.element style`. Spans are block-relative.
+
+use vize_carton::Allocator;
+use vize_davinci::folio::{Folio, FolioMode};
+use vize_disegno::folio::{DisegnoFolio, FolioBinding, FolioElement, FolioExpr, FolioOp};
+use vize_disegno::op::Op;
+use vize_ricalco::lower_style_block;
+
+fn folio(css: &str, block_start: u32) -> DisegnoFolio {
+    let arena = Allocator::default();
+    let op = lower_style_block(&arena, css, block_start);
+    DisegnoFolio::of(core::slice::from_ref(&op))
+}
+
+#[test]
+fn two_calls_round_trip_on_the_carrier() {
+    let css = ".foo { color: v-bind(color); background: v-bind('bgColor'); }";
+    let value = folio(css, 0);
+    assert_eq!(value.op_count(), 3);
+    assert_eq!(
+        value.print_to_string(FolioMode::Full).as_str(),
+        "\
+[disegno]
+ops=3
+
+[disegno.ops]
+ui.element style @0:61
+  vue.css-bind value=js(\"color\" @21:26) @14:27
+  vue.css-bind value=js(\"bgColor\" @49:56) @41:58
+
+"
+    );
+}
+
+#[test]
+fn block_start_rebases_spans_without_changing_relative_offsets() {
+    let css = ".foo { color: v-bind(color); }";
+    let at_zero = folio(css, 0).print_to_string(FolioMode::Full);
+    let shifted = folio(css, 90).print_to_string(FolioMode::Full);
+    assert_eq!(at_zero.as_str(), shifted.as_str());
+    let FolioOp::Element(FolioElement { bindings, span, .. }) = &folio(css, 90).ops[0] else {
+        panic!("carrier is ui.element");
+    };
+    assert_eq!(span.start, 0);
+    let FolioBinding::VueCssBind(bind) = &bindings[0] else {
+        panic!("first binding is vue.css-bind");
+    };
+    assert_eq!(bind.span.start, 14);
+    assert_eq!(bind.span.end, 27);
+    let FolioExpr::Js { span, source } = &bind.value else {
+        panic!("color is admitted js");
+    };
+    assert_eq!(source.as_str(), "color");
+    assert_eq!((span.start, span.end), (21, 26));
+}
+
+#[test]
+fn strings_comments_and_prefixed_names_are_not_calls() {
+    let css = r#"
+.icon::before {
+  content: "v-bind(icon)";
+  color: v-bind(color /* keep ) inside comments */);
+}
+/* background: v-bind(bg); */
+// width: v-bind(width);
+.label { background: 'v-bind(bg)'; }
+.foo { transition: my-v-bind(x); animation: -webkit-v-bind(y); }
+"#;
+    let FolioOp::Element(FolioElement { bindings, .. }) = &folio(css, 0).ops[0] else {
+        panic!("carrier is ui.element");
+    };
+    assert_eq!(bindings.len(), 1);
+    let FolioBinding::VueCssBind(bind) = &bindings[0] else {
+        panic!("only real v-bind(color)");
+    };
+    // Shipped extractor keeps the comment in the var text.
+    let FolioExpr::Opaque { reason, source, .. } = &bind.value else {
+        panic!("comment-bearing argument is not one JS expression");
+    };
+    assert_eq!(source.as_str(), "color /* keep ) inside comments */");
+    assert_eq!(*reason, vize_disegno::expr::OpaqueReason::ParseRejected);
+}
+
+#[test]
+fn quoted_expressions_keep_inner_parentheses() {
+    let css = r#".header { background: v-bind("parentBg ?? 'var(--bg)'"); }"#;
+    assert_eq!(
+        folio(css, 0).print_to_string(FolioMode::Full).as_str(),
+        "\
+[disegno]
+ops=2
+
+[disegno.ops]
+ui.element style @0:58
+  vue.css-bind value=js(\"parentBg ?? 'var(--bg)'\" @30:53) @22:55
+
+"
+    );
+}
+
+#[test]
+fn an_empty_block_is_a_carrier_with_no_binds() {
+    let arena = Allocator::default();
+    let op = lower_style_block(&arena, "/* no binds */", 0);
+    let Op::Element(element) = &op else {
+        panic!("carrier");
+    };
+    assert!(element.bindings.is_empty());
+    assert_eq!(DisegnoFolio::of(core::slice::from_ref(&op)).op_count(), 1);
+}


### PR DESCRIPTION
## Summary
- Stacked on #4640. `lower_style_block` scans CSS the way the shipped extractor does (strings/comments are not calls; `my-v-bind(` needs a left boundary) and emits `vue.css-bind` on a carrier `ui.element style`.
- Spans go through `Span::to_block_relative` (a shifted `block_start` prints identically). Arguments ride `ExprRef::parse_js_in` — comment-bearing text is `opaque(parse-rejected)`, matching P2-5b.
- atelier_sfc is not touched (published compile path / css-var names stay frozen). The carrier is not a DOM vnode; P2-11 must skip it. SFC fixture wiring is the next PR.

## Test plan
- [x] `cargo test -p vize_ricalco --test css_bind_lowering`
- [x] `cargo test -p vize_ricalco`
- [x] `cargo clippy -p vize_ricalco --lib --tests -- -D warnings`
- [ ] Compile output unchanged (no atelier_sfc / setup_emit edit)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790085420&installation_model_id=422833&pr_number=4641&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4641&signature=aa0fe84ef8cae55c22a75f60155cf67809d4ffa92f7791fa413134929a347092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->