### PR TITLE
feat(davinci): name the P2-11 DOM lane flag (VIZE_DAVINCI_DOM)

### DIFF
--- a/crates/vize_ricalco/src/dom.rs
+++ b/crates/vize_ricalco/src/dom.rs
@@ -1,0 +1,21 @@
+//! The in-phase DOM strangler flag (P2-11, charter #26).
+//!
+//! Named here so the phase-2 exit gate's deletion grep has one home,
+//! matching [`super::pass::TRANSFORM_LANE_FLAG`]. This crate is `no_std`
+//! and reads no environment; the dual-run comparator (atelier_dom test
+//! space, later in the series) is what *reads* the flag. Value `legacy`
+//! leaves the shipped DOM lane alone.
+
+/// The env flag P2-11 runs behind: value `legacy` disarms the S2 DOM
+/// dual-run. Deleted, with the lane it guards, at the phase-2 exit gate.
+pub const DOM_LANE_FLAG: &str = "VIZE_DAVINCI_DOM";
+
+#[cfg(test)]
+mod tests {
+    use super::DOM_LANE_FLAG;
+
+    #[test]
+    fn the_dom_lane_flag_has_its_recorded_name() {
+        assert_eq!(DOM_LANE_FLAG, "VIZE_DAVINCI_DOM");
+    }
+}

--- a/crates/vize_ricalco/src/lib.rs
+++ b/crates/vize_ricalco/src/lib.rs
@@ -56,7 +56,9 @@
 
 extern crate alloc;
 
+pub mod dom;
 pub mod lower;
 pub mod pass;
 
+pub use dom::DOM_LANE_FLAG;
 pub use lower::{Lowered, lower};


### PR DESCRIPTION
## Summary
- First P2-11 PR, independent of the P2-10 stack. Names `VIZE_DAVINCI_DOM` in `vize_ricalco::dom` so the phase-2 exit-gate deletion grep has one home (charter #26), the same shape as `VIZE_DAVINCI_TRANSFORM`.
- This crate is `no_std` and reads no environment. The dual-run comparator that honors value `legacy` lands with the S2 DOM emit; the published `vize_atelier_dom` graph is untouched (the program decision in `phase-2.md` is still open).

## Test plan
- [x] `cargo test -p vize_ricalco --lib dom_lane`
- [x] `cargo clippy -p vize_ricalco --lib -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790085717&installation_model_id=422833&pr_number=4644&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4644&signature=48bb2c209044f2a4faadad49354c5c9498e713e5c70c3201ae1ed07917dc7840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->