### PR TITLE
feat(cli): expose compiler.customElements on vize build

### DIFF
--- a/crates/vize/src/commands/build.rs
+++ b/crates/vize/src/commands/build.rs
@@ -89,6 +89,14 @@ pub struct BuildArgs {
     #[arg(long)]
     pub custom_renderer: bool,
 
+    /// Tag patterns compiled as custom elements instead of Vue components
+    ///
+    /// Repeat the flag for multiple patterns. `Tres*` matches PascalCase
+    /// renderer tags such as `<TresMesh>` without treating imported
+    /// components as elements.
+    #[arg(long, value_name = "PATTERN")]
+    pub custom_elements: Vec<String>,
+
     /// Template syntax compatibility mode
     #[arg(long, value_enum)]
     pub template_syntax: Option<TemplateSyntaxArg>,

--- a/crates/vize/src/commands/build/runner/settings.rs
+++ b/crates/vize/src/commands/build/runner/settings.rs
@@ -113,7 +113,7 @@ impl CompileFileSettings {
             ssr,
             vapor,
             custom_renderer: args.custom_renderer,
-            custom_elements: build_config.custom_elements,
+            custom_elements: resolve_custom_elements(args, build_config.custom_elements),
             template_syntax: args
                 .template_syntax
                 .map(Into::into)
@@ -169,6 +169,17 @@ impl CompileFileSettings {
             bytes.extend_from_slice(pattern.as_bytes());
         }
         hash_bytes(&bytes)
+    }
+}
+
+fn resolve_custom_elements(args: &BuildArgs, from_config: Vec<String>) -> Vec<String> {
+    if args.custom_elements.is_empty() {
+        from_config
+    } else {
+        args.custom_elements
+            .iter()
+            .map(|pattern| String::from(pattern.as_str()))
+            .collect()
     }
 }
 

--- a/crates/vize/src/commands/ready.rs
+++ b/crates/vize/src/commands/ready.rs
@@ -127,6 +127,7 @@ pub fn run(args: ReadyArgs) {
         ssr: args.ssr,
         vapor: false,
         custom_renderer: false,
+        custom_elements: Vec::new(),
         template_syntax: None,
         script_ext: args.script_ext,
         declaration: false,

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_build_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_build_help.snap
@@ -45,6 +45,11 @@ Options:
       --custom-renderer
           Target a custom renderer instead of DOM runtime helpers
 
+      --custom-elements <PATTERN>
+          Tag patterns compiled as custom elements instead of Vue components
+
+          Repeat the flag for multiple patterns. `Tres*` matches PascalCase renderer tags such as `<TresMesh>` without treating imported components as elements.
+
       --template-syntax <TEMPLATE_SYNTAX>
           Template syntax compatibility mode
 

--- a/crates/vize/tests/build_custom_elements_cli.rs
+++ b/crates/vize/tests/build_custom_elements_cli.rs
@@ -1,0 +1,148 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+const TRES_SCENE: &str = r#"<script setup lang="ts">
+import { TresCanvas } from '@tresjs/core'
+const visible = true
+</script>
+
+<template>
+  <TresCanvas>
+    <TresMesh v-if="visible">
+      <TresSpotLight />
+    </TresMesh>
+  </TresCanvas>
+</template>
+"#;
+
+fn temp_project_dir(test_name: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "vize-build-custom-elements-cli-{}-{}-{}",
+        std::process::id(),
+        test_name,
+        nonce
+    ))
+}
+
+fn write_project_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+fn output_details(output: &std::process::Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn needle_count(source: &str, needle: &str) -> usize {
+    source.match_indices(needle).count()
+}
+
+fn build_js(project_root: &Path, extra_args: &[&str]) -> String {
+    write_project_file(project_root, "src/Scene.vue", TRES_SCENE);
+    let mut args = vec![
+        "build",
+        "--format",
+        "js",
+        "src/Scene.vue",
+        "--output",
+        "dist",
+    ];
+    args.extend_from_slice(extra_args);
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root)
+        .args(&args)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", output_details(&output));
+    fs::read_to_string(project_root.join("dist/Scene.js")).unwrap()
+}
+
+#[test]
+fn custom_renderer_alone_still_resolves_pascal_case_renderer_tags() {
+    let project_root = temp_project_dir("custom-renderer-only");
+    let js = build_js(&project_root, &["--no-config", "--custom-renderer"]);
+    assert_eq!(
+        needle_count(&js, r#"_resolveComponent("TresMesh")"#),
+        1,
+        "{js}"
+    );
+    let _ = fs::remove_dir_all(project_root);
+}
+
+#[test]
+fn custom_elements_flag_compiles_matched_pascal_case_tags_as_elements() {
+    let project_root = temp_project_dir("custom-elements-flag");
+    let js = build_js(
+        &project_root,
+        &[
+            "--no-config",
+            "--custom-renderer",
+            "--custom-elements",
+            "Tres*",
+        ],
+    );
+    assert_eq!(
+        needle_count(&js, r#"_resolveComponent("TresMesh")"#),
+        0,
+        "{js}"
+    );
+    assert_eq!(
+        needle_count(&js, r#"_resolveComponent("TresSpotLight")"#),
+        0,
+        "{js}"
+    );
+    assert_eq!(
+        needle_count(&js, r#"_createElementBlock("TresMesh""#),
+        1,
+        "{js}"
+    );
+    assert_eq!(
+        needle_count(&js, r#"_createElementVNode("TresSpotLight""#),
+        1,
+        "{js}"
+    );
+    assert_eq!(needle_count(&js, "import { TresCanvas }"), 1, "{js}");
+    let _ = fs::remove_dir_all(project_root);
+}
+
+#[test]
+fn custom_elements_config_compiles_matched_pascal_case_tags_as_elements() {
+    let project_root = temp_project_dir("custom-elements-config");
+    write_project_file(
+        &project_root,
+        "vize.config.json",
+        r#"{
+  "compiler": {
+    "customRenderer": true,
+    "customElements": ["Tres*"]
+  }
+}
+"#,
+    );
+    let js = build_js(&project_root, &[]);
+    assert_eq!(
+        needle_count(&js, r#"_resolveComponent("TresMesh")"#),
+        0,
+        "{js}"
+    );
+    assert_eq!(
+        needle_count(&js, r#"_createElementBlock("TresMesh""#),
+        1,
+        "{js}"
+    );
+    let _ = fs::remove_dir_all(project_root);
+}

--- a/crates/vize/tests/build_custom_elements_cli.rs
+++ b/crates/vize/tests/build_custom_elements_cli.rs
@@ -116,6 +116,21 @@ fn custom_elements_flag_compiles_matched_pascal_case_tags_as_elements() {
         "{js}"
     );
     assert_eq!(needle_count(&js, "import { TresCanvas }"), 1, "{js}");
+    assert_eq!(
+        needle_count(&js, r#"_createBlock(_unref(TresCanvas)"#),
+        1,
+        "{js}"
+    );
+    assert_eq!(
+        needle_count(&js, r#"_createElementBlock("TresCanvas""#),
+        0,
+        "{js}"
+    );
+    assert_eq!(
+        needle_count(&js, r#"_createElementVNode("TresCanvas""#),
+        0,
+        "{js}"
+    );
     let _ = fs::remove_dir_all(project_root);
 }
 

--- a/crates/vize/tests/build_custom_elements_cli.rs
+++ b/crates/vize/tests/build_custom_elements_cli.rs
@@ -92,6 +92,10 @@ fn custom_elements_flag_compiles_matched_pascal_case_tags_as_elements() {
             "--no-config",
             "--custom-renderer",
             "--custom-elements",
+            "TresMesh",
+            "--custom-elements",
+            "TresSpotLight",
+            "--custom-elements",
             "Tres*",
         ],
     );
@@ -142,7 +146,6 @@ fn custom_elements_config_compiles_matched_pascal_case_tags_as_elements() {
         "vize.config.json",
         r#"{
   "compiler": {
-    "customRenderer": true,
     "customElements": ["Tres*"]
   }
 }

--- a/docs/content/fr/guide/cli.md
+++ b/docs/content/fr/guide/cli.md
@@ -108,19 +108,19 @@ vize build --profile src
 
 Options clés :
 
-| Option                | Description                                                                                   |
-| --------------------- | --------------------------------------------------------------------------------------------- |
-| `-o, --output`        | Sortie relative à la source en dessous de la racine d’entrée commune ; rejette les collisions |
-| `-f, --format`        | Format de sortie : `js`, `json`, `stats`                                                      |
-| `--ssr`               | Activer la compilation SSR                                                                    |
-| `--custom-renderer`   | Considérer les balises minuscules non HTML comme des éléments de rendu personnalisés          |
-| `--custom-elements`   | Motifs de balises compilés comme éléments personnalisés ; répétable                           |
-| `--script-ext`        | `preserve` ou `downcompile`                                                                   |
-| `--declaration`       | Émettre `.d.ts` fichiers pour les SFC construits (alias : `--dts`)                            |
-| `--declaration-dir`   | Dossier de sortie de déclaration (par défaut : le répertoire de sortie de compilation)        |
-| `-j, --threads`       | Remplacement du nombre de fils                                                                |
-| `--profile`           | Profil de timing d’impression                                                                 |
-| `--continue-on-error` | Continuez à compiler et signalez les échecs à la fin                                          |
+| Option                        | Description                                                                                   |
+| ----------------------------- | --------------------------------------------------------------------------------------------- |
+| `-o, --output`                | Sortie relative à la source en dessous de la racine d’entrée commune ; rejette les collisions |
+| `-f, --format`                | Format de sortie : `js`, `json`, `stats`                                                      |
+| `--ssr`                       | Activer la compilation SSR                                                                    |
+| `--custom-renderer`           | Considérer les balises minuscules non HTML comme des éléments de rendu personnalisés          |
+| `--custom-elements <PATTERN>` | Motifs de balises compilés comme éléments personnalisés ; répétable                           |
+| `--script-ext`                | `preserve` ou `downcompile`                                                                   |
+| `--declaration`               | Émettre `.d.ts` fichiers pour les SFC construits (alias : `--dts`)                            |
+| `--declaration-dir`           | Dossier de sortie de déclaration (par défaut : le répertoire de sortie de compilation)        |
+| `-j, --threads`               | Remplacement du nombre de fils                                                                |
+| `--profile`                   | Profil de timing d’impression                                                                 |
+| `--continue-on-error`         | Continuez à compiler et signalez les échecs à la fin                                          |
 
 ## Format
 

--- a/docs/content/fr/guide/cli.md
+++ b/docs/content/fr/guide/cli.md
@@ -113,6 +113,8 @@ Options clés :
 | `-o, --output`        | Sortie relative à la source en dessous de la racine d’entrée commune ; rejette les collisions |
 | `-f, --format`        | Format de sortie : `js`, `json`, `stats`                                                      |
 | `--ssr`               | Activer la compilation SSR                                                                    |
+| `--custom-renderer`   | Considérer les balises minuscules non HTML comme des éléments de rendu personnalisés          |
+| `--custom-elements`   | Motifs de balises compilés comme éléments personnalisés ; répétable                           |
 | `--script-ext`        | `preserve` ou `downcompile`                                                                   |
 | `--declaration`       | Émettre `.d.ts` fichiers pour les SFC construits (alias : `--dts`)                            |
 | `--declaration-dir`   | Dossier de sortie de déclaration (par défaut : le répertoire de sortie de compilation)        |

--- a/docs/content/fr/guide/configuration.md
+++ b/docs/content/fr/guide/configuration.md
@@ -196,6 +196,7 @@ chaque intégration consomme tous les domaines pour l’instant.
 | `vapor`             | `boolean`                             | Activer la compilation en mode Vapor                                                                        |
 | `jsxMode`           | `"vdom"` ou `"vapor"`                 | Backend de sortie par défaut pour les composants `.jsx`/`.tsx`                                              |
 | `customRenderer`    | `boolean`                             | Considérez les balises minuscules non HTML comme des éléments de rendu personnalisés                        |
+| `customElements`    | `string[]`                            | Motifs de balises compilés comme éléments personnalisés (`Tres*` pour TresJS)                               |
 | `templateSyntax`    | `"standard"`, `"strict"`ou `"quirks"` | Choisissez la gestion des avertissements, des erreurs ou des particularités Vue pour la syntaxe des modèles |
 | `scriptExt`         | `"ts"` ou `"js"`                      | Conserver la sortie TS ou décompiler vers JS dans la commande de compilation npm                            |
 | `mode`              | `"module"` ou `"function"`            | Mode de sortie de compilateur de bas niveau                                                                 |

--- a/docs/content/fr/guide/vite-plugin.md
+++ b/docs/content/fr/guide/vite-plugin.md
@@ -189,7 +189,8 @@ vize({
 | `ssr`                  | `compiler.ssr` ou `vize({ ssr })`                       | Force la compilation SSR quand le drapeau de compilation SSR de Vite ne suffit pas.                                                         |
 | `vapor`                | `compiler.vapor` ou `vize({ vapor })`                   | Compile les modèles via le backend Vapor.                                                                                                   |
 | `jsxMode`              | `compiler.jsxMode` ou `vize({ jsxMode })`               | Backend de sortie par défaut (`"vdom"` / `"vapor"`) pour `.jsx`/`.tsx` composants. Les directives `"use vue:*"` par composant l’emportent.  |
-| `customRenderer`       | `compiler.customRenderer` ou `vize({ customRenderer })` | Considérez les balises minuscules non HTML comme des éléments de rendu personnalisés. Utile pour les écosystèmes de rendu tels que TresJS.  |
+| `customRenderer`       | `compiler.customRenderer` ou `vize({ customRenderer })` | Considérez les balises minuscules non HTML comme des éléments de rendu personnalisés. Ne correspond pas aux balises PascalCase telles que `<TresMesh>`. |
+| `customElements`       | `compiler.customElements` ou `vize({ customElements })` | Motifs de balises compilés comme éléments personnalisés. Utilisez `["Tres*"]` pour les balises PascalCase TresJS.                            |
 | `templateSyntax`       | `compiler.templateSyntax` ou `vize({ templateSyntax })` | Choisissez `"standard"`, `"strict"`ou `"quirks"` gestion de la syntaxe du modèle.                                                           |
 | `include`              | `vite.include` ou `vize({ include })`                   | Des fichiers que le plugin devrait compiler.                                                                                                |
 | `exclude`              | `vite.exclude` ou `vize({ exclude })`                   | Des fichiers que le plugin devrait ignorer.                                                                                                 |
@@ -207,8 +208,11 @@ Recettes courantes :
 // Vapor-oriented build
 vize({ vapor: true });
 
-// TresJS or another custom renderer
-vize({ customRenderer: true });
+// Balises PascalCase TresJS
+vize({
+  customRenderer: true,
+  customElements: ["Tres*", "primitive"],
+});
 
 // Existing templates that rely on parser edge cases, such as
 // v-for alias edge parens or `<div />` as a self-closing leaf

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -108,6 +108,8 @@ Key options:
 | `-o, --output`        | Source-relative output below the common input root; rejects collisions |
 | `-f, --format`        | Output format: `js`, `json`, `stats`                                   |
 | `--ssr`               | Enable SSR compilation                                                 |
+| `--custom-renderer`   | Treat lowercase non-HTML tags as custom renderer elements              |
+| `--custom-elements`   | Tag patterns compiled as custom elements; repeat for multiple patterns |
 | `--script-ext`        | `preserve` or `downcompile`                                            |
 | `--declaration`       | Emit `.d.ts` files for the built SFCs (alias: `--dts`)                 |
 | `--declaration-dir`   | Declaration output directory (default: the build output directory)     |

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -4,8 +4,6 @@ title: CLI
 
 # CLI Reference
 
-> **⚠️ Work in Progress:** Vize is under active development and the CLI surface is still evolving.
-
 Most application workflows should install the `vize` npm package and run it through `package.json`
 scripts. This page describes the lower-level Rust-native `vize` binary for LSP, IDE management,
 `check-server`, profiling, and other direct CLI workflows. The npm package exposes shared config
@@ -76,22 +74,22 @@ vize [COMMAND]
 
 When invoked without a command, `vize` defaults to `build`.
 
-| Command          | Description                                     |
-| ---------------- | ----------------------------------------------- |
-| `build`          | Compile Vue SFC files                           |
-| `fmt`            | Format Vue SFC files                            |
-| `lint`           | Lint Vue SFC files                              |
-| `check`          | Type check Vue SFC, TS, TSX, and `.d.ts` inputs |
-| `doctor`         | Analyze whole-application health                |
-| `inspector`      | Create playground compiler inspector payloads   |
-| `clean`          | Remove Vize-generated cache artifacts           |
-| `ready`          | Run `fmt`, `lint`, `check`, and `build`         |
-| `upgrade`        | Update the installed CLI                        |
-| `check-server`   | Start the Unix JSON-RPC typecheck server        |
+| Command          | Description                                                       |
+| ---------------- | ----------------------------------------------------------------- |
+| `build`          | Compile Vue SFC files                                             |
+| `fmt`            | Format Vue SFC files                                              |
+| `lint`           | Lint Vue SFC files                                                |
+| `check`          | Type check Vue SFC, TS, TSX, and `.d.ts` inputs                   |
+| `doctor`         | Analyze whole-application health                                  |
+| `inspector`      | Create playground compiler inspector payloads                     |
+| `clean`          | Remove Vize-generated cache artifacts                             |
+| `ready`          | Run `fmt`, `lint`, `check`, and `build`                           |
+| `upgrade`        | Update the installed CLI                                          |
+| `check-server`   | Start the Unix JSON-RPC typecheck server                          |
 | `content-mapper` | Start the [TypeScript content-mapper](./content-mapper.md) server |
-| `musea`          | Musea subcommands and scaffolding               |
-| `lsp`            | Start the language server                       |
-| `ide`            | Install or manage editor integrations           |
+| `musea`          | Musea subcommands and scaffolding                                 |
+| `lsp`            | Start the language server                                         |
+| `ide`            | Install or manage editor integrations                             |
 
 ## Build
 
@@ -103,19 +101,19 @@ vize build --profile src
 
 Key options:
 
-| Option                | Description                                                            |
-| --------------------- | ---------------------------------------------------------------------- |
-| `-o, --output`        | Source-relative output below the common input root; rejects collisions |
-| `-f, --format`        | Output format: `js`, `json`, `stats`                                   |
-| `--ssr`               | Enable SSR compilation                                                 |
-| `--custom-renderer`   | Treat lowercase non-HTML tags as custom renderer elements              |
-| `--custom-elements`   | Tag patterns compiled as custom elements; repeat for multiple patterns |
-| `--script-ext`        | `preserve` or `downcompile`                                            |
-| `--declaration`       | Emit `.d.ts` files for the built SFCs (alias: `--dts`)                 |
-| `--declaration-dir`   | Declaration output directory (default: the build output directory)     |
-| `-j, --threads`       | Thread count override                                                  |
-| `--profile`           | Print timing profile                                                   |
-| `--continue-on-error` | Keep compiling and report failures at the end                          |
+| Option                        | Description                                                            |
+| ----------------------------- | ---------------------------------------------------------------------- |
+| `-o, --output`                | Source-relative output below the common input root; rejects collisions |
+| `-f, --format`                | Output format: `js`, `json`, `stats`                                   |
+| `--ssr`                       | Enable SSR compilation                                                 |
+| `--custom-renderer`           | Treat lowercase non-HTML tags as custom renderer elements              |
+| `--custom-elements <PATTERN>` | Tag patterns compiled as custom elements; repeat for multiple patterns |
+| `--script-ext`                | `preserve` or `downcompile`                                            |
+| `--declaration`               | Emit `.d.ts` files for the built SFCs (alias: `--dts`)                 |
+| `--declaration-dir`           | Declaration output directory (default: the build output directory)     |
+| `-j, --threads`               | Thread count override                                                  |
+| `--profile`                   | Print timing profile                                                   |
+| `--continue-on-error`         | Keep compiling and report failures at the end                          |
 
 ## Format
 

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -5,9 +5,7 @@ title: CLI
 # CLI Reference
 
 Most application workflows should install the `vize` npm package and run it through `package.json`
-scripts. This page describes the lower-level Rust-native `vize` binary for LSP, IDE management,
-`check-server`, profiling, and other direct CLI workflows. The npm package exposes shared config
-helpers plus NAPI-backed `build`, `fmt`, `lint`, `check`, `clean`, `ready`, and `upgrade` commands.
+scripts. This page describes the lower-level Rust-native `vize` binary for LSP, IDE management, `check-server`, profiling, and other direct CLI workflows. The npm package exposes shared config helpers plus NAPI-backed `build`, `fmt`, `lint`, `check`, `clean`, `ready`, and `upgrade` commands.
 
 For a higher-level explanation of the analysis pipeline, see [Static Analysis](./static-analysis.md).
 

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -8,8 +8,7 @@ Vize uses `vize.config.*` for shared npm package commands, Vite plugin, and Rust
 
 ## Config Files
 
-The npm package commands and `@vizejs/vite-plugin` load these files from the project root in this
-priority order:
+The npm package commands and `@vizejs/vite-plugin` load these files from the project root in this priority order:
 
 - `vize.config.pkl`
 - `vize.config.ts`

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -184,8 +184,7 @@ lsp {
 
 ## Compiler Options
 
-These options live under `compiler`. They are schema-backed and shared through `defineConfig`; not
-every integration consumes every field yet.
+These options live under `compiler` in `defineConfig`; not every integration consumes every field.
 
 | Option              | Values                                  | Common use                                                       |
 | ------------------- | --------------------------------------- | ---------------------------------------------------------------- |

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -194,6 +194,7 @@ every integration consumes every field yet.
 | `vapor`             | `boolean`                               | Enable Vapor-mode compilation                                    |
 | `jsxMode`           | `"vdom"` or `"vapor"`                   | Default output backend for `.jsx`/`.tsx` components              |
 | `customRenderer`    | `boolean`                               | Treat lowercase non-HTML tags as custom renderer elements        |
+| `customElements`    | `string[]`                              | Tag patterns compiled as custom elements (`Tres*` for TresJS)    |
 | `templateSyntax`    | `"standard"`, `"strict"`, or `"quirks"` | Choose warning, error, or Vue-quirk handling for template syntax |
 | `scriptExt`         | `"ts"` or `"js"`                        | Preserve TS output or downcompile to JS in the npm build command |
 | `mode`              | `"module"` or `"function"`              | Lower-level compiler output mode                                 |

--- a/docs/content/guide/vite-plugin.md
+++ b/docs/content/guide/vite-plugin.md
@@ -205,7 +205,8 @@ vize({
 | `ssr`                  | `compiler.ssr` or `vize({ ssr })`                       | Force SSR compilation when Vite's SSR build flag is not enough.                                                                                 |
 | `vapor`                | `compiler.vapor` or `vize({ vapor })`                   | Compile templates through the Vapor backend.                                                                                                    |
 | `jsxMode`              | `compiler.jsxMode` or `vize({ jsxMode })`               | Default output backend (`"vdom"` / `"vapor"`) for `.jsx`/`.tsx` components. Per-component `"use vue:*"` directives override it.                 |
-| `customRenderer`       | `compiler.customRenderer` or `vize({ customRenderer })` | Treat lowercase non-HTML tags as custom renderer elements. Useful for renderer ecosystems such as TresJS.                                       |
+| `customRenderer`       | `compiler.customRenderer` or `vize({ customRenderer })` | Treat lowercase non-HTML tags as custom renderer elements. Does not match PascalCase tags such as `<TresMesh>`.                                 |
+| `customElements`       | `compiler.customElements` or `vize({ customElements })` | Tag patterns compiled as custom elements instead of Vue components. Use `["Tres*"]` for TresJS PascalCase renderer tags.                        |
 | `templateSyntax`       | `compiler.templateSyntax` or `vize({ templateSyntax })` | Choose `"standard"`, `"strict"`, or `"quirks"` template syntax handling.                                                                        |
 | `include`              | `vite.include` or `vize({ include })`                   | Files that the plugin should compile.                                                                                                           |
 | `exclude`              | `vite.exclude` or `vize({ exclude })`                   | Files that the plugin should ignore.                                                                                                            |
@@ -223,8 +224,11 @@ Common recipes:
 // Vapor-oriented build
 vize({ vapor: true });
 
-// TresJS or another custom renderer
-vize({ customRenderer: true });
+// TresJS PascalCase renderer tags
+vize({
+  customRenderer: true,
+  customElements: ["Tres*", "primitive"],
+});
 
 // Existing templates that rely on parser edge cases, such as
 // v-for alias edge parens or `<div />` as a self-closing leaf

--- a/docs/content/ja/guide/cli.md
+++ b/docs/content/ja/guide/cli.md
@@ -210,18 +210,18 @@ vize check --profile src
 
 主なオプション:
 
-| オプション | 説明 |
-| ------------------- | --------------------------------------------------------------- | ------------------------ |
-| `-s, --socket` | 実行中の `check-server` | に接続します。 |
-| `--tsconfig` | `tsconfig.json` | をオーバーライドします。 |
-| `-f, --format` | 出力形式: `text` または `json` |
-| `--show-virtual-ts` | 生成された仮想 TypeScript を印刷する |
-| `-q, --quiet` | 概要のみを表示 |
-| `--profile` | プロファイル アーティファクトを `node_modules/.vize` に書き込む |
-| `--corsa-path` | Corsa 実行可能ファイルのパスをオーバーライドする |
-| `--servers` | 予約済み Corsa サーバー数。 `1` のみがサポートされています。 |
-| `--declaration` | `.d.ts` 出力を出力する |
-| `--declaration-dir` | 発行された宣言の出力ディレクトリ |
+| オプション          | 説明                                                            |
+| ------------------- | --------------------------------------------------------------- |
+| `-s, --socket`      | 実行中の `check-server` に接続します。                          |
+| `--tsconfig`        | `tsconfig.json` をオーバーライドします。                        |
+| `-f, --format`      | 出力形式: `text` または `json`                                  |
+| `--show-virtual-ts` | 生成された仮想 TypeScript を印刷する                            |
+| `-q, --quiet`       | 概要のみを表示                                                  |
+| `--profile`         | プロファイル アーティファクトを `node_modules/.vize` に書き込む |
+| `--corsa-path`      | Corsa 実行可能ファイルのパスをオーバーライドする                |
+| `--servers`         | 予約済み Corsa サーバー数。 `1` のみがサポートされています。    |
+| `--declaration`     | `.d.ts` 出力を出力する                                          |
+| `--declaration-dir` | 発行された宣言の出力ディレクトリ                                |
 
 Vize の開発中またはテスト中にカスタム Corsa 実行可能ファイルを固定したい場合は、`--corsa-path` を使用します。
 ローカル `corsa-bind` チェックアウト。共有構成キーは `typeChecker.corsaPath` です。 `typeChecker.tsgoPath`

--- a/docs/content/ja/guide/cli.md
+++ b/docs/content/ja/guide/cli.md
@@ -113,6 +113,8 @@ vize build --profile src
 | `-o, --output`        | 共通入力ルートの下のソース相対出力。衝突を拒否します             |
 | `-f, --format`        | 出力形式: `js`、`json`、`stats`                                  |
 | `--ssr`               | SSR コンパイルを有効にする                                       |
+| `--custom-renderer`   | 小文字の非 HTML タグをカスタム レンダラー要素として扱う          |
+| `--custom-elements`   | カスタム要素としてコンパイルするタグパターン。複数回指定可能     |
 | `--script-ext`        | `preserve` または `downcompile`                                  |
 | `--declaration`       | ビルドされた SFC の `.d.ts` ファイルを出力 (エイリアス: `--dts`) |
 | `--declaration-dir`   | 宣言出力ディレクトリ (デフォルト: ビルド出力ディレクトリ)        |

--- a/docs/content/ja/guide/cli.md
+++ b/docs/content/ja/guide/cli.md
@@ -108,19 +108,19 @@ vize build --profile src
 
 主なオプション:
 
-| オプション            | 説明                                                             |
-| --------------------- | ---------------------------------------------------------------- |
-| `-o, --output`        | 共通入力ルートの下のソース相対出力。衝突を拒否します             |
-| `-f, --format`        | 出力形式: `js`、`json`、`stats`                                  |
-| `--ssr`               | SSR コンパイルを有効にする                                       |
-| `--custom-renderer`   | 小文字の非 HTML タグをカスタム レンダラー要素として扱う          |
-| `--custom-elements`   | カスタム要素としてコンパイルするタグパターン。複数回指定可能     |
-| `--script-ext`        | `preserve` または `downcompile`                                  |
-| `--declaration`       | ビルドされた SFC の `.d.ts` ファイルを出力 (エイリアス: `--dts`) |
-| `--declaration-dir`   | 宣言出力ディレクトリ (デフォルト: ビルド出力ディレクトリ)        |
-| `-j, --threads`       | スレッド数のオーバーライド                                       |
-| `--profile`           | 印刷タイミング プロファイル                                      |
-| `--continue-on-error` | コンパイルを続けて最後に失敗を報告する                           |
+| オプション                    | 説明                                                             |
+| ----------------------------- | ---------------------------------------------------------------- |
+| `-o, --output`                | 共通入力ルートの下のソース相対出力。衝突を拒否します             |
+| `-f, --format`                | 出力形式: `js`、`json`、`stats`                                  |
+| `--ssr`                       | SSR コンパイルを有効にする                                       |
+| `--custom-renderer`           | 小文字の非 HTML タグをカスタム レンダラー要素として扱う          |
+| `--custom-elements <PATTERN>` | カスタム要素としてコンパイルするタグパターン。複数回指定可能     |
+| `--script-ext`                | `preserve` または `downcompile`                                  |
+| `--declaration`               | ビルドされた SFC の `.d.ts` ファイルを出力 (エイリアス: `--dts`) |
+| `--declaration-dir`           | 宣言出力ディレクトリ (デフォルト: ビルド出力ディレクトリ)        |
+| `-j, --threads`               | スレッド数のオーバーライド                                       |
+| `--profile`                   | 印刷タイミング プロファイル                                      |
+| `--continue-on-error`         | コンパイルを続けて最後に失敗を報告する                           |
 
 ## フォーマット
 
@@ -210,18 +210,18 @@ vize check --profile src
 
 主なオプション:
 
-| オプション          | 説明                                                            |
+| オプション | 説明 |
 | ------------------- | --------------------------------------------------------------- | ------------------------ |
-| `-s, --socket`      | 実行中の `check-server`                                         | に接続します。           |
-| `--tsconfig`        | `tsconfig.json`                                                 | をオーバーライドします。 |
-| `-f, --format`      | 出力形式: `text` または `json`                                  |
-| `--show-virtual-ts` | 生成された仮想 TypeScript を印刷する                            |
-| `-q, --quiet`       | 概要のみを表示                                                  |
-| `--profile`         | プロファイル アーティファクトを `node_modules/.vize` に書き込む |
-| `--corsa-path`      | Corsa 実行可能ファイルのパスをオーバーライドする                |
-| `--servers`         | 予約済み Corsa サーバー数。 `1` のみがサポートされています。    |
-| `--declaration`     | `.d.ts` 出力を出力する                                          |
-| `--declaration-dir` | 発行された宣言の出力ディレクトリ                                |
+| `-s, --socket` | 実行中の `check-server` | に接続します。 |
+| `--tsconfig` | `tsconfig.json` | をオーバーライドします。 |
+| `-f, --format` | 出力形式: `text` または `json` |
+| `--show-virtual-ts` | 生成された仮想 TypeScript を印刷する |
+| `-q, --quiet` | 概要のみを表示 |
+| `--profile` | プロファイル アーティファクトを `node_modules/.vize` に書き込む |
+| `--corsa-path` | Corsa 実行可能ファイルのパスをオーバーライドする |
+| `--servers` | 予約済み Corsa サーバー数。 `1` のみがサポートされています。 |
+| `--declaration` | `.d.ts` 出力を出力する |
+| `--declaration-dir` | 発行された宣言の出力ディレクトリ |
 
 Vize の開発中またはテスト中にカスタム Corsa 実行可能ファイルを固定したい場合は、`--corsa-path` を使用します。
 ローカル `corsa-bind` チェックアウト。共有構成キーは `typeChecker.corsaPath` です。 `typeChecker.tsgoPath`

--- a/docs/content/ja/guide/configuration.md
+++ b/docs/content/ja/guide/configuration.md
@@ -196,6 +196,7 @@ lsp {
 | `vapor`             | `boolean`                                   | Vapor モードのコンパイルを有効にする                                    |
 | `jsxMode`           | `"vdom"` または `"vapor"`                   | `.jsx`/`.tsx` コンポーネントのデフォルトの出力バックエンド              |
 | `customRenderer`    | `boolean`                                   | 小文字の非 HTML タグをカスタム レンダラー要素として扱う                 |
+| `customElements`    | `string[]`                                  | カスタム要素としてコンパイルするタグパターン（TresJS は `Tres*`）       |
 | `templateSyntax`    | `"standard"`、`"strict"`、または `"quirks"` | テンプレート構文の警告、エラー、または Vue-quirk 処理を選択します。     |
 | `scriptExt`         | `"ts"` または `"js"`                        | npm build コマンドで TS 出力を保存するか、JS にダウンコンパイルします。 |
 | `mode`              | `"module"` または `"function"`              | 下位レベルのコンパイラ出力モード                                        |

--- a/docs/content/ja/guide/vite-plugin.md
+++ b/docs/content/ja/guide/vite-plugin.md
@@ -189,7 +189,8 @@ vize({
 | `ssr`                  | `compiler.ssr` または `vize({ ssr })`                       | Vite の SSR ビルド フラグが不十分な場合に SSR を強制的にコンパイルします。                                                                                         |
 | `vapor`                | `compiler.vapor` または `vize({ vapor })`                   | Vapor バックエンドを通じてテンプレートをコンパイルします。                                                                                                         |
 | `jsxMode`              | `compiler.jsxMode` または `vize({ jsxMode })`               | `.jsx`/`.tsx` コンポーネントのデフォルトの出力バックエンド (`"vdom"` / `"vapor"`)。コンポーネントごとの `"use vue:*"` ディレクティブはこれをオーバーライドします。 |
-| `customRenderer`       | `compiler.customRenderer` または `vize({ customRenderer })` | 小文字の非 HTML タグをカスタム レンダラー要素として扱います。 TresJS などのレンダラー エコシステムに役立ちます。                                                   |
+| `customRenderer`       | `compiler.customRenderer` または `vize({ customRenderer })` | 小文字の非 HTML タグをカスタム レンダラー要素として扱います。 `<TresMesh>` のような PascalCase タグには一致しません。                                                 |
+| `customElements`       | `compiler.customElements` または `vize({ customElements })` | カスタム要素としてコンパイルするタグパターン。 TresJS の PascalCase レンダラータグには `["Tres*"]` を使います。                                                     |
 | `templateSyntax`       | `compiler.templateSyntax` または `vize({ templateSyntax })` | `"standard"`、`"strict"`、または `"quirks"` テンプレート構文処理を選択します。                                                                                     |
 | `include`              | `vite.include` または `vize({ include })`                   | プラグインがコンパイルする必要があるファイル。                                                                                                                     |
 | `exclude`              | `vite.exclude` または `vize({ exclude })`                   | プラグインが無視する必要があるファイル。                                                                                                                           |
@@ -207,8 +208,11 @@ vize({
 // Vapor-oriented build
 vize({ vapor: true });
 
-// TresJS or another custom renderer
-vize({ customRenderer: true });
+// TresJS PascalCase レンダラータグ
+vize({
+  customRenderer: true,
+  customElements: ["Tres*", "primitive"],
+});
 
 // Existing templates that rely on parser edge cases, such as
 // v-for alias edge parens or `<div />` as a self-closing leaf

--- a/docs/content/pt-BR/guide/cli.md
+++ b/docs/content/pt-BR/guide/cli.md
@@ -108,19 +108,19 @@ vize build --profile src
 
 Principais opções:
 
-| Opção                 | Descrição                                                                     |
-| --------------------- | ----------------------------------------------------------------------------- |
-| `-o, --output`        | Saída relativa à fonte abaixo da raiz de entrada comum; rejeita colisões      |
-| `-f, --format`        | Formato de saída: `js`, `json`, `stats`                                       |
-| `--ssr`               | Habilitar compilação SSR                                                      |
-| `--custom-renderer`   | Tratar tags minúsculas não HTML como elementos de renderização personalizados |
-| `--custom-elements`   | Padrões de tag compilados como custom elements; repetir para vários padrões   |
-| `--script-ext`        | `preserve` ou `downcompile`                                                   |
-| `--declaration`       | Emitir `.d.ts` arquivos para os SFCs construídos (alias: `--dts`)             |
-| `--declaration-dir`   | Diretório de saída de declaração (padrão: o diretório de saída da compilação) |
-| `-j, --threads`       | Substituição da contagem de threads                                           |
-| `--profile`           | Perfil de tempo de impressão                                                  |
-| `--continue-on-error` | Continue compilando e reporte falhas no final                                 |
+| Opção                         | Descrição                                                                     |
+| ----------------------------- | ----------------------------------------------------------------------------- |
+| `-o, --output`                | Saída relativa à fonte abaixo da raiz de entrada comum; rejeita colisões      |
+| `-f, --format`                | Formato de saída: `js`, `json`, `stats`                                       |
+| `--ssr`                       | Habilitar compilação SSR                                                      |
+| `--custom-renderer`           | Tratar tags minúsculas não HTML como elementos de renderização personalizados |
+| `--custom-elements <PATTERN>` | Padrões de tag compilados como custom elements; repetir para vários padrões   |
+| `--script-ext`                | `preserve` ou `downcompile`                                                   |
+| `--declaration`               | Emitir `.d.ts` arquivos para os SFCs construídos (alias: `--dts`)             |
+| `--declaration-dir`           | Diretório de saída de declaração (padrão: o diretório de saída da compilação) |
+| `-j, --threads`               | Substituição da contagem de threads                                           |
+| `--profile`                   | Perfil de tempo de impressão                                                  |
+| `--continue-on-error`         | Continue compilando e reporte falhas no final                                 |
 
 ## Formato
 

--- a/docs/content/pt-BR/guide/cli.md
+++ b/docs/content/pt-BR/guide/cli.md
@@ -113,6 +113,8 @@ Principais opções:
 | `-o, --output`        | Saída relativa à fonte abaixo da raiz de entrada comum; rejeita colisões      |
 | `-f, --format`        | Formato de saída: `js`, `json`, `stats`                                       |
 | `--ssr`               | Habilitar compilação SSR                                                      |
+| `--custom-renderer`   | Tratar tags minúsculas não HTML como elementos de renderização personalizados |
+| `--custom-elements`   | Padrões de tag compilados como custom elements; repetir para vários padrões   |
 | `--script-ext`        | `preserve` ou `downcompile`                                                   |
 | `--declaration`       | Emitir `.d.ts` arquivos para os SFCs construídos (alias: `--dts`)             |
 | `--declaration-dir`   | Diretório de saída de declaração (padrão: o diretório de saída da compilação) |

--- a/docs/content/pt-BR/guide/configuration.md
+++ b/docs/content/pt-BR/guide/configuration.md
@@ -196,6 +196,7 @@ toda integração consome todos os campos ainda.
 | `vapor`             | `boolean`                             | Ativar compilação em modo vapor                                                        |
 | `jsxMode`           | `"vdom"` ou `"vapor"`                 | Backend de saída padrão para componentes `.jsx`/`.tsx`                                 |
 | `customRenderer`    | `boolean`                             | Trate tags minúsculas que não sejam HTML como elementos de renderização personalizados |
+| `customElements`    | `string[]`                            | Padrões de tag compilados como custom elements (`Tres*` para TresJS)                   |
 | `templateSyntax`    | `"standard"`, `"strict"`ou `"quirks"` | Escolha o tratamento de aviso, erro ou peculiaridade do Vue para a sintaxe do modelo   |
 | `scriptExt`         | `"ts"` ou `"js"`                      | Preserve a saída do TS ou faça downcompile para JS no comando de build npm             |
 | `mode`              | `"module"` ou `"function"`            | Modo de saída de compilador de nível inferior                                          |

--- a/docs/content/pt-BR/guide/vite-plugin.md
+++ b/docs/content/pt-BR/guide/vite-plugin.md
@@ -189,7 +189,8 @@ vize({
 | `ssr`                  | `compiler.ssr` ou `vize({ ssr })`                       | Forçar a compilação do SSR quando a flag de build do SSR do Vite não é suficiente.                                                                         |
 | `vapor`                | `compiler.vapor` ou `vize({ vapor })`                   | Compilar templates pelo backend do Vapor.                                                                                                                  |
 | `jsxMode`              | `compiler.jsxMode` ou `vize({ jsxMode })`               | Backend de saída padrão (`"vdom"` / `"vapor"`) para componentes `.jsx`/`.tsx` . Diretivas `"use vue:*"` por componente prevalecem sobre isso.              |
-| `customRenderer`       | `compiler.customRenderer` ou `vize({ customRenderer })` | Trate tags minúsculas que não sejam HTML como elementos personalizados de renderização. Útil para ecossistemas de renderizadores como TresJS.              |
+| `customRenderer`       | `compiler.customRenderer` ou `vize({ customRenderer })` | Trate tags minúsculas que não sejam HTML como elementos personalizados de renderização. Não corresponde a tags PascalCase como `<TresMesh>`.               |
+| `customElements`       | `compiler.customElements` ou `vize({ customElements })` | Padrões de tag compilados como custom elements. Use `["Tres*"]` para tags PascalCase do TresJS.                                                            |
 | `templateSyntax`       | `compiler.templateSyntax` ou `vize({ templateSyntax })` | Escolha `"standard"`, `"strict"`ou `"quirks"` tratamento de sintaxe de template.                                                                           |
 | `include`              | `vite.include` ou `vize({ include })`                   | Arquivos que o plugin deve compilar.                                                                                                                       |
 | `exclude`              | `vite.exclude` ou `vize({ exclude })`                   | Arquivos que o plugin deveria ignorar.                                                                                                                     |
@@ -207,8 +208,11 @@ Receitas comuns:
 // Vapor-oriented build
 vize({ vapor: true });
 
-// TresJS or another custom renderer
-vize({ customRenderer: true });
+// Tags PascalCase do TresJS
+vize({
+  customRenderer: true,
+  customElements: ["Tres*", "primitive"],
+});
 
 // Existing templates that rely on parser edge cases, such as
 // v-for alias edge parens or `<div />` as a self-closing leaf

--- a/docs/content/zh-CN/guide/cli.md
+++ b/docs/content/zh-CN/guide/cli.md
@@ -108,19 +108,19 @@ vize build --profile src
 
 关键选项：
 
-| 选项                  | 描述                                         |
-| --------------------- | -------------------------------------------- |
-| `-o, --output`        | 低于公共输入根的源相对输出;拒绝碰撞          |
-| `-f, --format`        | 输出格式：`js`、`json`、`stats`              |
-| `--ssr`               | 启用SSR编译                                  |
-| `--custom-renderer`   | 将小写非HTML标签视为自定义渲染器元素         |
-| `--custom-elements`   | 作为自定义元素编译的标签模式；可重复指定     |
-| `--script-ext`        | `preserve`或`downcompile`                    |
-| `--declaration`       | 为构建的SFCs（别名：`--dts`）发布`.d.ts`文件 |
-| `--declaration-dir`   | 声明输出目录（默认：构建输出目录）           |
-| `-j, --threads`       | 线数覆盖                                     |
-| `--profile`           | 打印时序配置文件                             |
-| `--continue-on-error` | 继续编译并在最后报告失败                     |
+| 选项                          | 描述                                         |
+| ----------------------------- | -------------------------------------------- |
+| `-o, --output`                | 低于公共输入根的源相对输出;拒绝碰撞          |
+| `-f, --format`                | 输出格式：`js`、`json`、`stats`              |
+| `--ssr`                       | 启用SSR编译                                  |
+| `--custom-renderer`           | 将小写非HTML标签视为自定义渲染器元素         |
+| `--custom-elements <PATTERN>` | 作为自定义元素编译的标签模式；可重复指定     |
+| `--script-ext`                | `preserve`或`downcompile`                    |
+| `--declaration`               | 为构建的SFCs（别名：`--dts`）发布`.d.ts`文件 |
+| `--declaration-dir`           | 声明输出目录（默认：构建输出目录）           |
+| `-j, --threads`               | 线数覆盖                                     |
+| `--profile`                   | 打印时序配置文件                             |
+| `--continue-on-error`         | 继续编译并在最后报告失败                     |
 
 ## 节目形式
 

--- a/docs/content/zh-CN/guide/cli.md
+++ b/docs/content/zh-CN/guide/cli.md
@@ -113,6 +113,8 @@ vize build --profile src
 | `-o, --output`        | 低于公共输入根的源相对输出;拒绝碰撞          |
 | `-f, --format`        | 输出格式：`js`、`json`、`stats`              |
 | `--ssr`               | 启用SSR编译                                  |
+| `--custom-renderer`   | 将小写非HTML标签视为自定义渲染器元素         |
+| `--custom-elements`   | 作为自定义元素编译的标签模式；可重复指定     |
 | `--script-ext`        | `preserve`或`downcompile`                    |
 | `--declaration`       | 为构建的SFCs（别名：`--dts`）发布`.d.ts`文件 |
 | `--declaration-dir`   | 声明输出目录（默认：构建输出目录）           |

--- a/docs/content/zh-CN/guide/configuration.md
+++ b/docs/content/zh-CN/guide/configuration.md
@@ -196,6 +196,7 @@ lsp {
 | `vapor`             | `boolean`                            | 启用蒸汽模式编译                        |
 | `jsxMode`           | `"vdom"`或`"vapor"`                  | `.jsx`/`.tsx`组件的默认输出后端         |
 | `customRenderer`    | `boolean`                            | 将小写非HTML标签视为自定义渲染器元素    |
+| `customElements`    | `string[]`                           | 作为自定义元素编译的标签模式（TresJS 用 `Tres*`） |
 | `templateSyntax`    | `"standard"`、`"strict"`或`"quirks"` | 模板语法选择警告、错误或Vue-quirk处理   |
 | `scriptExt`         | `"ts"`或`"js"`                       | 保留TS输出或在npm build命令中下编译为JS |
 | `mode`              | `"module"`或`"function"`             | 低级别编译器输出模式                    |

--- a/docs/content/zh-CN/guide/vite-plugin.md
+++ b/docs/content/zh-CN/guide/vite-plugin.md
@@ -189,7 +189,8 @@ vize({
 | `ssr`                  | `compiler.ssr`或`vize({ ssr })`                       | 当Vite的SSR构建旗帜不够时，强制SSR汇编。                                                           |
 | `vapor`                | `compiler.vapor`或`vize({ vapor })`                   | 通过Vapor后端编译模板。                                                                            |
 | `jsxMode`              | `compiler.jsxMode`或`vize({ jsxMode })`               | `.jsx`/`.tsx`组件的默认输出后端（`"vdom"` / `"vapor"`）。每个组件的 `"use vue:*"` 指令覆盖了它。   |
-| `customRenderer`       | `compiler.customRenderer`或`vize({ customRenderer })` | 把小写非HTML标签当作自定义渲染器元素。对于像 TresJS 这样的渲染器生态系统非常有用。                 |
+| `customRenderer`       | `compiler.customRenderer`或`vize({ customRenderer })` | 把小写非HTML标签当作自定义渲染器元素。不匹配 `<TresMesh>` 这类 PascalCase 标签。                   |
+| `customElements`       | `compiler.customElements`或`vize({ customElements })` | 作为自定义元素编译的标签模式。TresJS 的 PascalCase 渲染器标签使用 `["Tres*"]`。                    |
 | `templateSyntax`       | `compiler.templateSyntax`或`vize({ templateSyntax })` | 选择`"standard"`、`"strict"`或`"quirks"`模板语法处理。                                             |
 | `include`              | `vite.include`或`vize({ include })`                   | 插件应该编译的文件。                                                                               |
 | `exclude`              | `vite.exclude`或`vize({ exclude })`                   | 这些文件是插件应该忽略的。                                                                         |
@@ -207,8 +208,11 @@ vize({
 // Vapor-oriented build
 vize({ vapor: true });
 
-// TresJS or another custom renderer
-vize({ customRenderer: true });
+// TresJS PascalCase 渲染器标签
+vize({
+  customRenderer: true,
+  customElements: ["Tres*", "primitive"],
+});
 
 // Existing templates that rely on parser edge cases, such as
 // v-for alias edge parens or `<div />` as a self-closing leaf

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -238,25 +238,25 @@ extension so both TypeScript and embedded JSX parse correctly. See the
 
 Important shared fields:
 
-| Field                            | Used by                        | Purpose                                                   |
-| -------------------------------- | ------------------------------ | --------------------------------------------------------- |
-| `compiler.sourceMap`             | Vite plugin                    | Enable source maps                                        |
-| `compiler.ssr`                   | npm build, Vite plugin         | Force SSR compilation                                     |
-| `compiler.vapor`                 | npm build, Vite plugin         | Enable Vapor compilation                                  |
-| `compiler.customRenderer`        | npm build, Vite plugin         | Treat lowercase non-HTML tags as custom renderer elements |
+| Field                            | Used by                        | Purpose                                                            |
+| -------------------------------- | ------------------------------ | ------------------------------------------------------------------ |
+| `compiler.sourceMap`             | Vite plugin                    | Enable source maps                                                 |
+| `compiler.ssr`                   | npm build, Vite plugin         | Force SSR compilation                                              |
+| `compiler.vapor`                 | npm build, Vite plugin         | Enable Vapor compilation                                           |
+| `compiler.customRenderer`        | npm build, Vite plugin         | Treat lowercase non-HTML tags as custom renderer elements          |
 | `compiler.customElements`        | npm build, Vite plugin         | Tag patterns compiled as custom elements instead of Vue components |
-| `compiler.templateSyntax`        | npm build, Vite plugin         | Choose standard, strict, or quirks template syntax mode   |
-| `experimentals.vapor`            | npm build, Vite plugin         | Opt into experimental SFC Vapor before compiler support   |
-| `experimentals.jsxVapor`         | Vite plugin                    | Opt into experimental JSX Vapor by default                |
-| `experimentals.intagComment`     | npm build, Vite plugin, syntax | Opt into in-tag `//` comments                             |
-| `experimentals.pattenedTemplate` | npm build, Vite plugin         | Opt into `v-match` / `v-case` templates                   |
-| `experimentals.serverScript`     | npm build, Vite plugin         | Preserve server-script RFC opt-in surface                 |
-| `compiler.compatibility`         | integrations                   | Opt into legacy Vue, Nuxt, CDN, Vapor, or Webpack bridges |
-| `compiler.scriptExt`             | npm build                      | Preserve TypeScript output or downcompile to JavaScript   |
-| `vite.scanPatterns`              | Vite plugin                    | Pre-compile matching Vue files                            |
-| `linter.preset`                  | npm lint                       | Select the Patina lint preset                             |
-| `typeChecker.strict`             | npm check                      | Enable strict checks                                      |
-| `formatter.printWidth`           | npm fmt                        | Set formatting width                                      |
+| `compiler.templateSyntax`        | npm build, Vite plugin         | Choose standard, strict, or quirks template syntax mode            |
+| `experimentals.vapor`            | npm build, Vite plugin         | Opt into experimental SFC Vapor before compiler support            |
+| `experimentals.jsxVapor`         | Vite plugin                    | Opt into experimental JSX Vapor by default                         |
+| `experimentals.intagComment`     | npm build, Vite plugin, syntax | Opt into in-tag `//` comments                                      |
+| `experimentals.pattenedTemplate` | npm build, Vite plugin         | Opt into `v-match` / `v-case` templates                            |
+| `experimentals.serverScript`     | npm build, Vite plugin         | Preserve server-script RFC opt-in surface                          |
+| `compiler.compatibility`         | integrations                   | Opt into legacy Vue, Nuxt, CDN, Vapor, or Webpack bridges          |
+| `compiler.scriptExt`             | npm build                      | Preserve TypeScript output or downcompile to JavaScript            |
+| `vite.scanPatterns`              | Vite plugin                    | Pre-compile matching Vue files                                     |
+| `linter.preset`                  | npm lint                       | Select the Patina lint preset                                      |
+| `typeChecker.strict`             | npm check                      | Enable strict checks                                               |
+| `formatter.printWidth`           | npm fmt                        | Set formatting width                                               |
 
 ### Template syntax
 

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -243,7 +243,8 @@ Important shared fields:
 | `compiler.sourceMap`             | Vite plugin                    | Enable source maps                                        |
 | `compiler.ssr`                   | npm build, Vite plugin         | Force SSR compilation                                     |
 | `compiler.vapor`                 | npm build, Vite plugin         | Enable Vapor compilation                                  |
-| `compiler.customRenderer`        | npm build, Vite plugin         | Support custom renderer element semantics                 |
+| `compiler.customRenderer`        | npm build, Vite plugin         | Treat lowercase non-HTML tags as custom renderer elements |
+| `compiler.customElements`        | npm build, Vite plugin         | Tag patterns compiled as custom elements instead of Vue components |
 | `compiler.templateSyntax`        | npm build, Vite plugin         | Choose standard, strict, or quirks template syntax mode   |
 | `experimentals.vapor`            | npm build, Vite plugin         | Opt into experimental SFC Vapor before compiler support   |
 | `experimentals.jsxVapor`         | Vite plugin                    | Opt into experimental JSX Vapor by default                |


### PR DESCRIPTION
## Summary
- `vize build --custom-elements PATTERN` (repeatable) now threads compiler custom-element patterns; when the flag is omitted, `compiler.customElements` from config is used.
- `--custom-renderer` is unchanged: it still only matches lowercase non-HTML tags. PascalCase TresJS tags such as `<TresMesh>` need `Tres*`.
- Vite plugin / config docs (en, ja, zh-CN, fr, pt-BR) and the npm CLI README now document that recipe instead of implying `customRenderer` is enough.

## Test plan
- [x] `cargo test -p vize --test build_custom_elements_cli`
- [x] `cargo test -p vize --lib -- build_help_snapshot`
- [x] `cargo clippy -p vize -- -D warnings`
- [ ] CI green on the PR

Fixes #3946

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790090895&installation_model_id=422833&pr_number=4646&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4646&signature=98ebe495046da2b85ca8efb65542d3aeaab5ef60157df0d7ad4d3f65fd90fd41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added repeatable `--custom-elements` build options for compiling matching tag patterns as custom elements.
  - Added `compiler.customElements` configuration support, including patterns such as `Tres*`.
  - CLI settings take precedence over configuration when both are provided.

- **Documentation**
  - Updated CLI, configuration, and Vite plugin guides across supported languages.
  - Clarified `customRenderer` behavior and PascalCase custom-element configuration.
  - Updated the TresJS integration example.

- **Tests**
  - Added coverage for CLI and configuration-based custom-element patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->