### PR TITLE
test(vscode): pin template component host navigation

### DIFF
--- a/editors/vscode/test/suite/real-scenario-expected.cjs
+++ b/editors/vscode/test/suite/real-scenario-expected.cjs
@@ -136,7 +136,33 @@ const componentContractHovers = {
       range: [3, 0, 3, 13],
     },
   ],
+  templateTag: [
+    {
+      contents: [
+        [
+          "**ContractChild**",
+          "",
+          "_Component usage_",
+          "",
+          "**Passed props**",
+          '- `label="ready"`',
+          "",
+          "[Vue Component Props](https://vuejs.org/guide/components/props.html)",
+        ].join("\n"),
+      ],
+      range: [7, 3, 7, 16],
+    },
+  ],
 };
+
+function componentContractTemplateDefinitions(childUri) {
+  return [
+    {
+      range: [0, 0, 0, 0],
+      uri: childUri,
+    },
+  ];
+}
 
 // The authored `<Child  :count="total" />` carries two independent authored
 // bugs on one line: two spaces after the tag name (a fixable lint warning) and
@@ -243,6 +269,7 @@ module.exports = {
   componentContractChildSource,
   componentContractHostSource,
   componentContractHovers,
+  componentContractTemplateDefinitions,
   diagnostics,
   formattedSource,
   formattingEdits,

--- a/editors/vscode/test/suite/real-scenario.cjs
+++ b/editors/vscode/test/suite/real-scenario.cjs
@@ -155,6 +155,7 @@ async function stepComponentContractHoverSurfaces() {
     async () => ({
       importBinding: await hoverAt(uri, 1, 8),
       scriptUsage: await hoverAt(uri, 3, 1),
+      templateTag: await hoverAt(uri, 7, 5),
     }),
     (next) => deepEqual(next, expected.componentContractHovers),
     "component contract hovers",
@@ -166,6 +167,19 @@ async function stepComponentContractHoverSurfaces() {
   )) {
     assert.doesNotMatch(value, /__vizeComponentMarker|__vizeRawProps|__VizeComponentConstructor/);
   }
+
+  const definitions = await vscode.commands.executeCommand(
+    "vscode.executeDefinitionProvider",
+    uri,
+    new vscode.Position(7, 5),
+  );
+  const childUri = vscode.Uri.file(
+    path.join(getWorkspaceFolderPath(), "src", "ContractChild.vue"),
+  ).toString();
+  assert.deepEqual(
+    definitions.map(describeDefinition),
+    expected.componentContractTemplateDefinitions(childUri),
+  );
 }
 
 /** Step 2: the quick fix the server offers on the lint warning's own span. */
@@ -270,6 +284,15 @@ function describeHover(hover) {
       return String(content);
     }),
     range: hover.range === undefined ? undefined : describeRange(hover.range),
+  };
+}
+
+function describeDefinition(definition) {
+  const uri = definition.uri ?? definition.targetUri;
+  const range = definition.range ?? definition.targetSelectionRange ?? definition.targetRange;
+  return {
+    range: describeRange(range),
+    uri: uri.toString(),
   };
 }
 

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -295,10 +295,12 @@ test("the Neovim real-server scenario drains post-save diagnostics before rename
   assert.ok(waitAt >= 0 && semanticTokensAt > waitAt && renameAt > semanticTokensAt);
 });
 
-test("the VS Code real-server suite drives all five scorecard steps", () => {
+test("the VS Code real-server suite drives the packaged type-aware scorecard", () => {
   const scenario = readRepoFile("editors", "vscode", "test", "suite", "real-scenario.cjs");
+  const expected = readRepoFile("editors", "vscode", "test", "suite", "real-scenario-expected.cjs");
 
   assert.match(scenario, /vscode\.executeCodeActionProvider/);
+  assert.match(scenario, /vscode\.executeDefinitionProvider/);
   assert.match(scenario, /vscode\.executeFormatDocumentProvider/);
   assert.match(scenario, /vscode\.provideDocumentSemanticTokens/);
   assert.match(scenario, /vscode\.executeDocumentRenameProvider/);
@@ -319,4 +321,9 @@ test("the VS Code real-server suite drives all five scorecard steps", () => {
 
   // Rule for this suite: complete-response assertions only.
   assert.doesNotMatch(scenario, /\.includes\(|\.contains\(/);
+
+  assert.match(expected, /templateTag: \[/);
+  assert.match(expected, /componentContractTemplateDefinitions/);
+  assert.match(expected, /_Component usage_/);
+  assert.match(expected, /range: \[7, 3, 7, 16\]/);
 });


### PR DESCRIPTION
## Summary

- harden the packaged VS Code real-server scenario for P0 #4592
- pin the template component tag hover response, including authored template range
- pin template component definition navigation to the imported child SFC

## Verification

- node --test tests/tooling/editor-real-server-e2e.test.ts
- vp check --no-error-on-unmatched-pattern editors/vscode/test/suite/real-scenario.cjs editors/vscode/test/suite/real-scenario-expected.cjs tests/tooling/editor-real-server-e2e.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790091843&installation_model_id=422833&pr_number=4647&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4647&signature=d262c2217baa77fe1728d2871fe4fb9b4b4ac7a5c22e215f569a700c8791066e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded editor integration coverage for component contract hover information.
  * Added validation that imported component template tags resolve to the correct component definition.
  * Enhanced scorecard checks to verify template tags, component usage text, definition support, and expected source ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->