### PR TITLE
test(matrix): scope typecheck corpus to the target tsconfig

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -35,6 +35,7 @@
         "packageManagerVersion": "11.5.0",
         "lockfile": "pnpm-lock.yaml",
         "hangTimeoutMs": 300000,
+        "corpusGlobs": ["playground/src/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
       },
@@ -99,6 +100,7 @@
         "packageManagerVersion": "10.33.4",
         "lockfile": "pnpm-lock.yaml",
         "hangTimeoutMs": 300000,
+        "corpusGlobs": ["packages/hoppscotch-common/src/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
       }
@@ -252,6 +254,7 @@
         "packageManagerVersion": "10.13.1",
         "lockfile": "pnpm-lock.yaml",
         "hangTimeoutMs": 300000,
+        "corpusGlobs": ["packages/core/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
       }
@@ -291,6 +294,7 @@
         "packageManagerVersion": "9.6.0",
         "lockfile": "pnpm-lock.yaml",
         "hangTimeoutMs": 300000,
+        "corpusGlobs": ["packages/primevue/src/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
       }

--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -129,8 +129,10 @@ test("fixture tool matrix emits read-only commands with machine-readable diagnos
     assert.match(compilerCommand, /--no-config(?:\s|$)/);
     assert.match(
       runs.typechecker.command,
-      /check .*--format json --no-config --tsconfig playground\/tsconfig\.json/,
+      /check playground\/src\/\*\*\/\*\.vue --format json --no-config --tsconfig playground\/tsconfig\.json/,
     );
+    assert.doesNotMatch(runs.typechecker.command, /apps\/\*\*\/\*\.vue/);
+    assert.match(runs.compiler.command, /apps\/\*\*\/\*\.vue/);
     assert.match(runs.linter.command, /lint .*--format json --preset ecosystem --no-config/);
     assert.match(runs.formatter.command, /fmt .*--check --no-config/);
     for (const entry of Object.values(runs)) {

--- a/tests/tooling/fixture-tool-matrix-typecheck-corpus.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typecheck-corpus.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { toolArgs, typecheckCorpusGlobs } from "../../tools/fixtures/tool-matrix-command.mjs";
+
+const project = {
+  vueGlobs: ["apps/**/*.vue", "playground/src/**/*.vue"],
+  tsconfig: "playground/tsconfig.json",
+  typecheckPerformance: { corpusGlobs: ["playground/src/**/*.vue"] },
+};
+
+test("typechecker args use corpusGlobs and leave compiler on vueGlobs", () => {
+  assert.deepEqual(typecheckCorpusGlobs(project), ["playground/src/**/*.vue"]);
+  assert.deepEqual(toolArgs(project, "typechecker", "out"), [
+    "check",
+    "playground/src/**/*.vue",
+    "--format",
+    "json",
+    "--no-config",
+    "--tsconfig",
+    "playground/tsconfig.json",
+  ]);
+  const compiler = toolArgs(project, "compiler", "out");
+  assert.equal(compiler[0], "build");
+  assert.deepEqual(compiler.slice(1, 3), project.vueGlobs);
+});
+
+test("typechecker args fall back to vueGlobs when corpusGlobs is omitted", () => {
+  const fallback = { vueGlobs: ["src/**/*.vue"], tsconfig: "tsconfig.json" };
+  assert.deepEqual(typecheckCorpusGlobs(fallback), ["src/**/*.vue"]);
+  assert.deepEqual(toolArgs(fallback, "typechecker", "out"), [
+    "check",
+    "src/**/*.vue",
+    "--format",
+    "json",
+    "--no-config",
+    "--tsconfig",
+    "tsconfig.json",
+  ]);
+});

--- a/tests/tooling/fixture-tool-matrix-typecheck-target.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typecheck-target.test.ts
@@ -91,6 +91,19 @@ test("fixture tool matrix requires an exact baseline tsconfig for performance ta
       ),
     );
 
+    assert.doesNotThrow(() =>
+      validateTypecheckPerformanceTarget(
+        {
+          ...project,
+          typecheckPerformance: {
+            ...project.typecheckPerformance,
+            corpusGlobs: ["src/**/*.vue"],
+          },
+        },
+        fixtureRoot,
+      ),
+    );
+
     for (const [candidate, message] of [
       [{ ...project, typecheckPerformance: { enabled: true, compareTo: "tsc" } }, /compareTo/],
       [{ ...project, tsconfig: undefined }, /normalized relative path/],
@@ -139,6 +152,30 @@ test("fixture tool matrix requires an exact baseline tsconfig for performance ta
           typecheckPerformance: { ...project.typecheckPerformance, lockfile: "../pnpm-lock.yaml" },
         },
         /lockfile must be pnpm-lock.yaml/,
+      ],
+      [
+        {
+          ...project,
+          typecheckPerformance: { ...project.typecheckPerformance, corpusGlobs: [] },
+        },
+        /corpusGlobs must be a non-empty array when present/,
+      ],
+      [
+        {
+          ...project,
+          typecheckPerformance: { ...project.typecheckPerformance, corpusGlobs: [""] },
+        },
+        /corpusGlobs entries must be non-empty strings/,
+      ],
+      [
+        {
+          ...project,
+          typecheckPerformance: {
+            ...project.typecheckPerformance,
+            corpusGlobs: ["../src/**/*.vue"],
+          },
+        },
+        /normalized relative path/,
       ],
     ] as const) {
       assert.throws(() => validateTypecheckPerformanceTarget(candidate, fixtureRoot), message);

--- a/tests/tooling/vue-ecosystem-fixtures.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures.test.ts
@@ -37,6 +37,7 @@ interface FixtureProject {
     lockfile: "pnpm-lock.yaml" | "yarn.lock";
     baseline?: { tsconfig: string; prepare?: string[] };
     hangTimeoutMs: number;
+    corpusGlobs?: string[];
     maxFalsePositiveRatio: number;
     maxFalseNegativeRatio: number;
     largeProjectRegressionTarget?: boolean;

--- a/tests/tooling/vue-ecosystem-typecheck-corpus.test.ts
+++ b/tests/tooling/vue-ecosystem-typecheck-corpus.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const registryPath = path.join(root, "tests", "_fixtures", "vue-ecosystem-fixtures.json");
+
+const expectedCorpus = {
+  "vue-vben-admin": ["playground/src/**/*.vue"],
+  hoppscotch: ["packages/hoppscotch-common/src/**/*.vue"],
+  "reka-ui": ["packages/core/**/*.vue"],
+  primevue: ["packages/primevue/src/**/*.vue"],
+} as const;
+
+test("typecheck corpus globs pin the tsconfig-owned Vue sources", () => {
+  const registry = JSON.parse(fs.readFileSync(registryPath, "utf8")) as {
+    projects: Array<{
+      id: string;
+      typecheckPerformance?: { corpusGlobs?: string[] };
+    }>;
+  };
+  const actual = Object.fromEntries(
+    registry.projects
+      .filter((project) => project.typecheckPerformance?.corpusGlobs != null)
+      .map((project) => [project.id, project.typecheckPerformance?.corpusGlobs]),
+  );
+  assert.deepEqual(actual, expectedCorpus);
+});

--- a/tools/fixtures/tool-matrix-command.mjs
+++ b/tools/fixtures/tool-matrix-command.mjs
@@ -1,3 +1,7 @@
+export function typecheckCorpusGlobs(project) {
+  return project.typecheckPerformance?.corpusGlobs ?? project.vueGlobs;
+}
+
 export function toolArgs(project, tool, compilerOutputDir) {
   if (tool === "compiler") {
     return [
@@ -25,7 +29,11 @@ export function toolArgs(project, tool, compilerOutputDir) {
     ];
   }
   if (tool === "typechecker") {
-    const args = ["check", ...project.vueGlobs, "--format", "json", "--no-config"];
+    // One `--tsconfig` cannot answer for sibling apps that `vueGlobs` still
+    // cover for compiler/linter/formatter. Narrow the typecheck corpus to the
+    // files that config owns, or vue-tsc's baseline inherits the same
+    // unresolvable aliases and the comparison reports fake FNs (#4454).
+    const args = ["check", ...typecheckCorpusGlobs(project), "--format", "json", "--no-config"];
     if (project.tsconfig != null) args.push("--tsconfig", project.tsconfig);
     return args;
   }

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -15,7 +15,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { expectedCompilerOutputs } from "./tool-matrix-compiler-paths.mjs";
-import { displayCommand, toolArgs } from "./tool-matrix-command.mjs";
+import { displayCommand, toolArgs, typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
 import { snapshotFormatterInputs, validateFormatterOutput } from "./tool-matrix-formatter.mjs";
 import { collectTypecheckerAuthoredPaths, collectVueInputPaths } from "./tool-matrix-inputs.mjs";
 import { validateLinterOutput } from "./tool-matrix-linter.mjs";
@@ -92,7 +92,7 @@ function prepareToolRun(project, tool, args, launch, outputDir) {
     tool === "formatter" ? snapshotFormatterInputs(cwd, project.vueGlobs) : null;
   const expectedToolFiles =
     tool === "typechecker" || tool === "linter" || tool === "formatter"
-      ? collectVueInputPaths(cwd, project.vueGlobs)
+      ? collectVueInputPaths(cwd, tool === "typechecker" ? typecheckCorpusGlobs(project) : project.vueGlobs)
       : null;
   return {
     base,

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -92,7 +92,10 @@ function prepareToolRun(project, tool, args, launch, outputDir) {
     tool === "formatter" ? snapshotFormatterInputs(cwd, project.vueGlobs) : null;
   const expectedToolFiles =
     tool === "typechecker" || tool === "linter" || tool === "formatter"
-      ? collectVueInputPaths(cwd, tool === "typechecker" ? typecheckCorpusGlobs(project) : project.vueGlobs)
+      ? collectVueInputPaths(
+          cwd,
+          tool === "typechecker" ? typecheckCorpusGlobs(project) : project.vueGlobs,
+        )
       : null;
   return {
     base,

--- a/tools/fixtures/tool-matrix-typecheck-target.mjs
+++ b/tools/fixtures/tool-matrix-typecheck-target.mjs
@@ -11,6 +11,21 @@ export function validateTypecheckPerformanceTarget(
     invalid(project, "compareTo must be vue-tsc");
   }
   requireFile(project, fixtureRoot, project.tsconfig, "tsconfig");
+  // Optional: when shared `vueGlobs` reach past what `tsconfig` owns, the
+  // typechecker corpus is narrowed here so one config is never asked to
+  // answer for files it never included (#4454).
+  const corpus = project.typecheckPerformance.corpusGlobs;
+  if (corpus !== undefined) {
+    if (!Array.isArray(corpus) || corpus.length === 0) {
+      invalid(project, "corpusGlobs must be a non-empty array when present");
+    }
+    for (const glob of corpus) {
+      if (typeof glob !== "string" || glob.length === 0) {
+        invalid(project, "corpusGlobs entries must be non-empty strings");
+      }
+      requireRelativePath(project, glob, "corpusGlobs entry");
+    }
+  }
   const manager = project.typecheckPerformance.packageManager;
   const lockfiles = { npm: "package-lock.json", pnpm: "pnpm-lock.yaml", yarn: "yarn.lock" };
   if (!Object.hasOwn(lockfiles, manager)) {

--- a/tools/fixtures/typecheck-divergence-mutation-runner.mjs
+++ b/tools/fixtures/typecheck-divergence-mutation-runner.mjs
@@ -2,7 +2,7 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 
-import { displayCommand, toolArgs } from "./tool-matrix-command.mjs";
+import { displayCommand, toolArgs, typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
 import { collectTypecheckerAuthoredPaths, collectVueInputPaths } from "./tool-matrix-inputs.mjs";
 import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
 import { compareTypecheckDiagnostics } from "./typecheck-divergence.mjs";
@@ -62,7 +62,7 @@ function runVizeTypecheck(project, fixtureRoot, launch) {
     project,
     parsed,
     result.status,
-    collectVueInputPaths(fixtureRoot, project.vueGlobs),
+    collectVueInputPaths(fixtureRoot, typecheckCorpusGlobs(project)),
     collectTypecheckerAuthoredPaths(fixtureRoot),
   );
   return executionEvidence({

--- a/tools/fixtures/typecheck-divergence-report-inputs.mjs
+++ b/tools/fixtures/typecheck-divergence-report-inputs.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
 import { collectTypecheckerAuthoredPaths, collectVueInputPaths } from "./tool-matrix-inputs.mjs";
 import {
   summarizeTypecheckerCoverage,
@@ -100,7 +101,7 @@ export function readAndValidateVizeRun(reportDir, project, summary) {
     project,
     payload.parsed,
     payload.exitCode,
-    collectVueInputPaths(fixtureRoot, project.vueGlobs),
+    collectVueInputPaths(fixtureRoot, typecheckCorpusGlobs(project)),
     collectTypecheckerAuthoredPaths(fixtureRoot),
   );
   if (canonicalJson(expectedCoverage) !== canonicalJson(payload.typecheckerCoverage)) {


### PR DESCRIPTION
## Summary
- Typecheck is the only matrix tool pinned to a single `--tsconfig`, but it was still given the shared `vueGlobs` (sibling apps, docs, showcases).
- vue-tsc then cannot resolve those files' aliases, so the comparison reports fake false negatives (primevue ~0.155 vs 0.05 budget).
- `typecheckPerformance.corpusGlobs` now narrows that corpus. Compiler/linter/formatter still use full `vueGlobs`. Coverage validation uses the same globs so the matrix does not demand files we stopped checking.

Pinned corpora:
- vue-vben-admin → `playground/src/**/*.vue`
- hoppscotch → `packages/hoppscotch-common/src/**/*.vue`
- reka-ui → `packages/core/**/*.vue`
- primevue → `packages/primevue/src/**/*.vue`

Does not restore the release gate (#4461) and does not isolate fixture type packages.

## Test plan
- [x] `node --test tests/tooling/vue-ecosystem-typecheck-corpus.test.ts tests/tooling/fixture-tool-matrix-typecheck-corpus.test.ts tests/tooling/fixture-tool-matrix-typecheck-target.test.ts tests/tooling/fixture-tool-matrix-report.test.ts`
- [x] related typechecker / divergence / registry tests
- [ ] CI green

Fixes #4454

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790092192&installation_model_id=422833&pr_number=4648&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4648&signature=bfd977919be45932136df2751e0b7f9358b0bd9c250b2899aa4c4632fb8f11bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->