### PR TITLE
feat(davinci): emit static HTML attrs from S2 (P2-11)

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
@@ -1,5 +1,6 @@
-//! P2-11 installment 1 witness: static native HTML elements, old DOM
-//! lane vs S2 emit, compared **byte-for-byte** including helper usage.
+//! P2-11 installment 2 witness: static native HTML elements (with
+//! static attributes), old DOM lane vs S2 emit, compared **byte-for-byte**
+//! including helper usage.
 //!
 //! `vize_atelier_dom` is published; the Davinci crates are not. The
 //! comparator therefore rides stripped-on-publish dev-deps (the same
@@ -23,6 +24,14 @@ const BATTERY: &[(&str, &str)] = &[
     ("nested_elements", "<div><span>hello</span></div>"),
     ("paragraph", "<p>hi</p>"),
     ("sibling_spans", "<div><span>a</span><span>b</span></div>"),
+    ("class_attr", r#"<div class="x"></div>"#),
+    (
+        "id_and_class",
+        r#"<div id="app" class="container">static</div>"#,
+    ),
+    ("data_attr", r#"<div data-id="1"></div>"#),
+    ("boolean_attr", "<div disabled></div>"),
+    ("nested_class", r#"<div><span class="x">hello</span></div>"#),
 ];
 
 fn shipped(src: &str) -> String {

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -7,12 +7,13 @@
 //! P2-9 carve-out. This module writes the JS string **directly from
 //! S2 ops** — it does not mint relief codegen-nodes (`NodeType` 13–20).
 //!
-//! Installment 1 emits only **static native HTML elements** whose
-//! children are nested static native elements or a single inlined text
-//! node. Everything else is [`EmitError::Unsupported`]: the comparator
-//! counts those, it does not invent output. The old lane stays the
-//! shipped compile path; [`super::DOM_LANE_FLAG`] is named here and
-//! *read* in the atelier_dom witness.
+//! Installment 2 emits **static native HTML elements** with static
+//! attributes (and nested static native children / a single inlined
+//! text node). Bindings, interpolations, components, and hoist
+//! realization stay [`EmitError::Unsupported`]: the comparator counts
+//! those, it does not invent output. The old lane stays the shipped
+//! compile path; [`super::DOM_LANE_FLAG`] is named here and *read* in
+//! the atelier_dom witness.
 
 #[path = "emit/buf.rs"]
 mod buf;

--- a/crates/vize_ricalco/src/emit/buf.rs
+++ b/crates/vize_ricalco/src/emit/buf.rs
@@ -49,6 +49,8 @@ pub(super) struct Buf {
     pub code: String,
     indent: u32,
     used: u8,
+    /// Compact static-props object hoisted as `_hoisted_1` (root only).
+    hoisted_props: Option<String>,
 }
 
 impl Buf {
@@ -57,6 +59,7 @@ impl Buf {
             code: String::default(),
             indent: 0,
             used: 0,
+            hoisted_props: None,
         }
     }
 
@@ -105,7 +108,17 @@ impl Buf {
         Helper::CreateElementVNode.alias()
     }
 
-    /// Function-mode preamble, helpers in import-rank order.
+    pub(super) fn hoist_root_props(&mut self, object: String) {
+        self.hoisted_props = Some(object);
+    }
+
+    pub(super) fn hoisted_props_alias() -> &'static str {
+        "_hoisted_1"
+    }
+
+    /// Function-mode preamble, helpers in import-rank order, then any
+    /// root static-props hoist (the shipped codegen appends hoists to
+    /// the helper preamble).
     pub(super) fn preamble(&self) -> String {
         let listed: [Helper; 3] = Helper::ALL;
         let mut n = 0;
@@ -132,6 +145,14 @@ impl Buf {
             preamble.push_str(helper.alias());
         }
         preamble.push_str(" } = Vue\n");
+        if let Some(object) = &self.hoisted_props {
+            preamble.push('\n');
+            preamble.push_str("const ");
+            preamble.push_str(Self::hoisted_props_alias());
+            preamble.push_str(" = ");
+            preamble.push_str(object.as_str());
+            preamble.push('\n');
+        }
         preamble
     }
 }

--- a/crates/vize_ricalco/src/emit/js.rs
+++ b/crates/vize_ricalco/src/emit/js.rs
@@ -72,6 +72,16 @@ fn push_hex4(out: &mut String, value: u32) {
     out.push(HEX[(value & 0xF) as usize] as char);
 }
 
+/// Same rule as `vize_atelier_core::codegen::helpers::is_valid_js_identifier`.
+pub(super) fn is_valid_js_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' || c == '$' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+}
+
 /// Escape `s` for a JavaScript double-quoted string literal, matching
 /// `vize_atelier_core::codegen::helpers::escape_js_string`.
 pub(super) fn escape_js_string(s: &str) -> String {

--- a/crates/vize_ricalco/src/emit/vnode.rs
+++ b/crates/vize_ricalco/src/emit/vnode.rs
@@ -1,11 +1,13 @@
 //! Static native HTML element / children emission.
 
-use vize_carton::ensure_sufficient_stack;
-use vize_disegno::op::{ElementOp, Namespace, Op, Region, TextOp};
+use alloc::vec::Vec as StdVec;
+
+use vize_carton::{String, ensure_sufficient_stack};
+use vize_disegno::op::{Attribute, ElementOp, Namespace, Op, Region, TextOp};
 
 use super::EmitError;
 use super::buf::Buf;
-use super::js::escape_js_string;
+use super::js::{escape_js_string, is_valid_js_identifier};
 
 pub(super) fn emit_root(buf: &mut Buf, root: &Region<'_>) -> Result<(), EmitError> {
     let element = unique_root_element(root)?;
@@ -51,7 +53,27 @@ fn emit_call(buf: &mut Buf, element: &ElementOp<'_>, block: bool) -> Result<(), 
     buf.push("(\"");
     buf.push(element.tag);
     buf.push("\"");
-    if !element.children.ops.is_empty() {
+    let has_children = !element.children.ops.is_empty();
+    // Root (block) elements with a fully hoistable static props surface
+    // match the shipped `is_root` + `has_static_props` arm: hoist the
+    // object, do not whole-hoist the vnode. Nested native children keep
+    // inline props (`hoist_static_vnodes` is false without directives).
+    if block && root_props_should_hoist(element) {
+        buf.hoist_root_props(compact_props_object(element.attributes.iter()));
+        buf.push(", ");
+        buf.push(Buf::hoisted_props_alias());
+        if has_children {
+            buf.push(", ");
+            emit_children(buf, &element.children)?;
+        }
+    } else if !element.attributes.is_empty() {
+        buf.push(", ");
+        emit_static_props_inline(buf, element.attributes.iter());
+        if has_children {
+            buf.push(", ");
+            emit_children(buf, &element.children)?;
+        }
+    } else if has_children {
         buf.push(", null, ");
         emit_children(buf, &element.children)?;
     }
@@ -59,11 +81,99 @@ fn emit_call(buf: &mut Buf, element: &ElementOp<'_>, block: bool) -> Result<(), 
     Ok(())
 }
 
+fn root_props_should_hoist(element: &ElementOp<'_>) -> bool {
+    !element.attributes.is_empty()
+        && element
+            .attributes
+            .iter()
+            .all(|attribute| attribute.name != "ref")
+}
+
+/// First-occurrence static attrs as a single-line object, matching
+/// hoisted `JsChildNode::Object` emission.
+fn compact_props_object<'a>(attributes: impl Iterator<Item = &'a Attribute<'a>>) -> String {
+    let unique = unique_attrs(attributes);
+    let mut out = String::from("{ ");
+    for (i, attr) in unique.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        push_attr_pair(&mut out, attr);
+    }
+    out.push_str(" }");
+    out
+}
+
+/// First-occurrence static attrs, matching
+/// `vize_atelier_core::codegen::props::generate::try_generate_static_attrs`.
+fn emit_static_props_inline<'a>(
+    buf: &mut Buf,
+    attributes: impl Iterator<Item = &'a Attribute<'a>>,
+) {
+    let unique = unique_attrs(attributes);
+    let multiline = unique.len() > 1;
+    if multiline {
+        buf.push("{");
+        buf.indent();
+    } else {
+        buf.push("{ ");
+    }
+    for (i, attr) in unique.iter().enumerate() {
+        if i > 0 {
+            buf.push(",");
+        }
+        if multiline {
+            buf.newline();
+        } else if i > 0 {
+            buf.push(" ");
+        }
+        let mut pair = String::default();
+        push_attr_pair(&mut pair, attr);
+        buf.push(pair.as_str());
+    }
+    if multiline {
+        buf.deindent();
+        buf.newline();
+        buf.push("}");
+    } else {
+        buf.push(" }");
+    }
+}
+
+fn unique_attrs<'a>(
+    attributes: impl Iterator<Item = &'a Attribute<'a>>,
+) -> StdVec<&'a Attribute<'a>> {
+    let mut unique: StdVec<&Attribute<'_>> = StdVec::new();
+    for attr in attributes {
+        if unique.iter().any(|seen| seen.name == attr.name) {
+            continue;
+        }
+        unique.push(attr);
+    }
+    unique
+}
+
+fn push_attr_pair(out: &mut String, attr: &Attribute<'_>) {
+    let quoted = !is_valid_js_identifier(attr.name);
+    if quoted {
+        out.push('"');
+    }
+    out.push_str(attr.name);
+    if quoted {
+        out.push('"');
+    }
+    out.push_str(": \"");
+    if let Some(value) = attr.value {
+        out.push_str(escape_js_string(value).as_str());
+    }
+    out.push('"');
+}
+
 fn admit_static_native(element: &ElementOp<'_>) -> Result<(), EmitError> {
     if element.namespace != Namespace::Html {
         return Err(EmitError::Unsupported);
     }
-    if !element.attributes.is_empty() || !element.bindings.is_empty() {
+    if !element.bindings.is_empty() {
         return Err(EmitError::Unsupported);
     }
     Ok(())

--- a/crates/vize_ricalco/tests/emit_static.rs
+++ b/crates/vize_ricalco/tests/emit_static.rs
@@ -1,5 +1,5 @@
-//! P2-11 installment 1: static native HTML elements emit the same
-//! render function the shipped DOM lane does.
+//! P2-11 installment 2: static native HTML elements (with static
+//! attributes) emit the same render function the shipped DOM lane does.
 
 #![allow(
     clippy::disallowed_macros,
@@ -71,8 +71,83 @@ fn emit_dom_source_agrees_with_emit_dom() {
 }
 
 #[test]
-fn static_attributes_are_unsupported_this_installment() {
-    with_transformed(r#"<div class="x"></div>"#, |lowered, _, _, _| {
+fn empty_div_with_class_matches_the_shipped_snapshot() {
+    assert_eq!(
+        assembled(r#"<div class="x"></div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+const _hoisted_1 = { class: \"x\" }
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", _hoisted_1))
+}"
+    );
+}
+
+#[test]
+fn multiple_static_attrs_hoist_as_one_object() {
+    assert_eq!(
+        assembled(r#"<div id="app" class="container">static</div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+const _hoisted_1 = { id: \"app\", class: \"container\" }
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", _hoisted_1, \"static\"))
+}"
+    );
+}
+
+#[test]
+fn hyphenated_attr_names_are_quoted() {
+    assert_eq!(
+        assembled(r#"<div data-id="1"></div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+const _hoisted_1 = { \"data-id\": \"1\" }
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", _hoisted_1))
+}"
+    );
+}
+
+#[test]
+fn boolean_attr_emits_an_empty_string_value() {
+    assert_eq!(
+        assembled("<div disabled></div>"),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+const _hoisted_1 = { disabled: \"\" }
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", _hoisted_1))
+}"
+    );
+}
+
+#[test]
+fn nested_static_attrs_match_the_shipped_snapshot() {
+    assert_eq!(
+        assembled(r#"<div><span class="x">hello</span></div>"#),
+        "\
+const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", null, [
+    _createElementVNode(\"span\", { class: \"x\" }, \"hello\")
+  ]))
+}"
+    );
+}
+
+#[test]
+fn a_bound_attr_is_unsupported_this_installment() {
+    with_transformed(r#"<div :class="x"></div>"#, |lowered, _, _, _| {
         assert_eq!(emit_dom(lowered), Err(EmitError::Unsupported));
     });
 }


### PR DESCRIPTION
## Summary
- Extend the S2 DOM emitter past bare tags: static native attributes, including hyphenated names and boolean empty values.
- Root elements hoist the props object as `_hoisted_1` (shipped `is_root` + `has_static_props`); nested native children keep inline props because `hoist_static_vnodes` is off without directives.
- Dual-run battery vs `compile_template` stays byte-for-byte; bound attrs remain `EmitError::Unsupported`.

## Test plan
- [x] `cargo test -p vize_ricalco --test emit_static`
- [x] `cargo test -p vize_atelier_dom --test davinci_s2_dom`
- [ ] CI check.yml (fmt, clippy-and-test, test-scripts)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4649"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790094941&installation_model_id=422833&pr_number=4649&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4649&signature=b8bea07cf50339c0aaddcf73bfb421366fa7e9e579dae100638f8fef2f633df4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for static attributes on native HTML elements.
  * Supports standard, hyphenated, boolean, and nested-element attributes.
  * Preserves attribute values and handles duplicate names consistently.
* **Bug Fixes**
  * Improved generated output for attribute names that are not valid JavaScript identifiers.
* **Tests**
  * Expanded coverage for root and nested static attributes, including class, ID, data, and boolean attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->