### PR TITLE
feat(davinci): emit mixed text siblings as createTextVNode (P2-11)

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
@@ -1,6 +1,6 @@
-//! P2-11 installment 3 witness: static native HTML plus interpolations,
-//! old DOM lane vs S2 emit, compared **byte-for-byte** including helper
-//! usage.
+//! P2-11 installment 4 witness: static native HTML, interpolations,
+//! and mixed element+text siblings, old DOM lane vs S2 emit, compared
+//! **byte-for-byte** including helper usage.
 //!
 //! `vize_atelier_dom` is published; the Davinci crates are not. The
 //! comparator therefore rides stripped-on-publish dev-deps (the same
@@ -39,6 +39,12 @@ const BATTERY: &[(&str, &str)] = &[
     ("nested_interp", "<div><span>{{ msg }}</span></div>"),
     ("compound_two_dyn", "<p>Hi {{ name }}!</p>"),
     ("multiline_root_compound", "<div>Hi {{ name }}</div>\n"),
+    ("interp_then_span", "<div>{{ msg }}<span></span></div>"),
+    ("text_then_span", "<div>hello<span></span></div>"),
+    (
+        "space_between_spans",
+        "<div><span></span> <span></span></div>",
+    ),
 ];
 
 fn shipped(src: &str) -> String {

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -7,10 +7,10 @@
 //! P2-9 carve-out. This module writes the JS string **directly from
 //! S2 ops** — it does not mint relief codegen-nodes (`NodeType` 13–20).
 //!
-//! Installment 3 emits **static native HTML** plus **Js interpolations**
-//! (and mixed text+interpolation compounds compiled from [`TextFacts`],
-//! never from the opaque source). Bindings, filters, components, and
-//! mixed element+text siblings stay [`EmitError::Unsupported`]: the
+//! Installment 4 emits **static native HTML**, **Js interpolations**
+//! (compounds from [`TextFacts`], never the opaque source), and
+//! **mixed element+text siblings** as `_createTextVNode`. Bindings,
+//! filters, and components stay [`EmitError::Unsupported`]: the
 //! comparator counts those, it does not invent output. The old lane
 //! stays the shipped compile path; [`super::DOM_LANE_FLAG`] is named
 //! here and *read* in the atelier_dom witness.

--- a/crates/vize_ricalco/src/emit/buf.rs
+++ b/crates/vize_ricalco/src/emit/buf.rs
@@ -4,21 +4,24 @@ use vize_carton::String;
 
 /// Vue helpers this installment can mention, ranked the way
 /// `vue_helper_import_rank` orders the shipped preamble (`toDisplayString`
-/// before vnode creates before `openBlock` before block creates).
+/// before vnode creates before `openBlock` before block creates before
+/// `createTextVNode`).
 #[derive(Clone, Copy)]
 enum Helper {
     ToDisplayString,
     CreateElementVNode,
     OpenBlock,
     CreateElementBlock,
+    CreateText,
 }
 
 impl Helper {
-    const ALL: [Self; 4] = [
+    const ALL: [Self; 5] = [
         Self::ToDisplayString,
         Self::CreateElementVNode,
         Self::OpenBlock,
         Self::CreateElementBlock,
+        Self::CreateText,
     ];
 
     const fn bit(self) -> u8 {
@@ -27,6 +30,7 @@ impl Helper {
             Self::CreateElementVNode => 2,
             Self::OpenBlock => 4,
             Self::CreateElementBlock => 8,
+            Self::CreateText => 16,
         }
     }
 
@@ -36,6 +40,7 @@ impl Helper {
             Self::CreateElementVNode => "createElementVNode",
             Self::OpenBlock => "openBlock",
             Self::CreateElementBlock => "createElementBlock",
+            Self::CreateText => "createTextVNode",
         }
     }
 
@@ -45,6 +50,7 @@ impl Helper {
             Self::CreateElementVNode => "_createElementVNode",
             Self::OpenBlock => "_openBlock",
             Self::CreateElementBlock => "_createElementBlock",
+            Self::CreateText => "_createTextVNode",
         }
     }
 }
@@ -105,6 +111,10 @@ impl Buf {
         self.used |= Helper::CreateElementVNode.bit();
     }
 
+    pub(super) fn use_create_text(&mut self) {
+        self.used |= Helper::CreateText.bit();
+    }
+
     pub(super) fn to_display_string_alias() -> &'static str {
         Helper::ToDisplayString.alias()
     }
@@ -121,6 +131,10 @@ impl Buf {
         Helper::CreateElementVNode.alias()
     }
 
+    pub(super) fn create_text_alias() -> &'static str {
+        Helper::CreateText.alias()
+    }
+
     pub(super) fn hoist_root_props(&mut self, object: String) {
         self.hoisted_props = Some(object);
     }
@@ -133,7 +147,7 @@ impl Buf {
     /// root static-props hoist (the shipped codegen appends hoists to
     /// the helper preamble).
     pub(super) fn preamble(&self) -> String {
-        let listed: [Helper; 4] = Helper::ALL;
+        let listed: [Helper; 5] = Helper::ALL;
         let mut n = 0;
         for helper in listed {
             if self.used & helper.bit() != 0 {

--- a/crates/vize_ricalco/src/emit/children.rs
+++ b/crates/vize_ricalco/src/emit/children.rs
@@ -97,3 +97,28 @@ fn emit_to_display_string(cx: &mut EmitCx<'_>, source: &str) {
     cx.buf.push(source);
     cx.buf.push(")");
 }
+
+/// Array-form text run: `_createTextVNode(...)`, matching
+/// `codegen/children.rs`'s consecutive-run grouping.
+pub(super) fn emit_create_text_vnode(cx: &mut EmitCx<'_>, ops: &[Op<'_>]) -> Result<(), EmitError> {
+    if ops.is_empty() {
+        return Err(EmitError::Unsupported);
+    }
+    let has_interp = ops.iter().any(|op| matches!(op, Op::Interpolation(_)));
+    let is_single_space =
+        !has_interp && ops.len() == 1 && matches!(&ops[0], Op::Text(text) if text.content == " ");
+    cx.buf.use_create_text();
+    cx.buf.push(Buf::create_text_alias());
+    if is_single_space {
+        let _id = cx.walk.mint();
+        cx.buf.push("()");
+        return Ok(());
+    }
+    cx.buf.push("(");
+    emit_text_like(cx, ops)?;
+    if has_interp {
+        cx.buf.push(", 1 /* TEXT */");
+    }
+    cx.buf.push(")");
+    Ok(())
+}

--- a/crates/vize_ricalco/src/emit/vnode.rs
+++ b/crates/vize_ricalco/src/emit/vnode.rs
@@ -8,7 +8,9 @@ use vize_disegno::op::{Attribute, ElementOp, Namespace, Op, Region, TextOp};
 use super::EmitCx;
 use super::EmitError;
 use super::buf::Buf;
-use super::children::{children_need_text_flag, emit_interpolation, emit_text_like};
+use super::children::{
+    children_need_text_flag, emit_create_text_vnode, emit_interpolation, emit_text_like,
+};
 use super::js::{escape_js_string, is_valid_js_identifier};
 
 pub(super) fn emit_root(cx: &mut EmitCx<'_>, root: &Region<'_>) -> Result<(), EmitError> {
@@ -215,12 +217,29 @@ fn emit_children(cx: &mut EmitCx<'_>, children: &Region<'_>) -> Result<(), EmitE
     }
     cx.buf.push("[");
     cx.buf.indent();
-    for (i, op) in ops.iter().enumerate() {
-        if i > 0 {
+    let mut i = 0;
+    let mut first = true;
+    while i < ops.len() {
+        if matches!(ops[i], Op::Text(_) | Op::Interpolation(_)) {
+            let start = i;
+            while i < ops.len() && matches!(ops[i], Op::Text(_) | Op::Interpolation(_)) {
+                i += 1;
+            }
+            if !first {
+                cx.buf.push(",");
+            }
+            cx.buf.newline();
+            first = false;
+            emit_create_text_vnode(cx, &ops[start..i])?;
+            continue;
+        }
+        if !first {
             cx.buf.push(",");
         }
         cx.buf.newline();
-        emit_array_child(cx, op)?;
+        first = false;
+        emit_array_child(cx, &ops[i])?;
+        i += 1;
     }
     cx.buf.deindent();
     cx.buf.newline();

--- a/crates/vize_ricalco/tests/emit_static.rs
+++ b/crates/vize_ricalco/tests/emit_static.rs
@@ -1,5 +1,6 @@
-//! P2-11 installment 3: static native HTML plus interpolations emit
-//! the same render function the shipped DOM lane does.
+//! P2-11 installment 4: static native HTML, interpolations, and
+//! mixed element+text siblings emit the same render function the
+//! shipped DOM lane does.
 
 #![allow(
     clippy::disallowed_macros,
@@ -242,11 +243,50 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
-fn mixed_element_and_interpolation_siblings_are_unsupported_this_installment() {
-    with_transformed(
-        "<div>{{ msg }}<span></span></div>",
-        |lowered, _, facts, _| {
-            assert_eq!(emit_dom(lowered, facts), Err(EmitError::Unsupported));
-        },
+fn mixed_element_and_interpolation_siblings_use_create_text_vnode() {
+    assert_eq!(
+        assembled("<div>{{ msg }}<span></span></div>"),
+        "\
+const { toDisplayString: _toDisplayString, createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, createTextVNode: _createTextVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", null, [
+    _createTextVNode(_toDisplayString(msg), 1 /* TEXT */),
+    _createElementVNode(\"span\")
+  ]))
+}"
+    );
+}
+
+#[test]
+fn mixed_static_text_and_element_siblings_use_create_text_vnode() {
+    assert_eq!(
+        assembled("<div>hello<span></span></div>"),
+        "\
+const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, createTextVNode: _createTextVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", null, [
+    _createTextVNode(\"hello\"),
+    _createElementVNode(\"span\")
+  ]))
+}"
+    );
+}
+
+#[test]
+fn a_single_space_between_elements_is_create_text_vnode_with_no_args() {
+    assert_eq!(
+        assembled("<div><span></span> <span></span></div>"),
+        "\
+const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, createTextVNode: _createTextVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", null, [
+    _createElementVNode(\"span\"),
+    _createTextVNode(),
+    _createElementVNode(\"span\")
+  ]))
+}"
     );
 }


### PR DESCRIPTION
## Summary
- Mixed element+text siblings now emit `_createTextVNode`, including the Vue single-space `()` convention.
- Dual-run battery covers interp-then-span, static-text-then-span, and space-between-spans.
- Stacked on #4651 (interpolation emit). Retarget to `main` after that lands.

## Test plan
- [x] `cargo test -p vize_ricalco --test emit_static`
- [x] `cargo test -p vize_atelier_dom --test davinci_s2_dom`
- [ ] CI green after #4651 merge / retarget

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790096077&installation_model_id=422833&pr_number=4652&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4652&signature=d81c937211d77eb68776be943c0c42ee028444805d7b0f02d2c9740d8adf7730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->