### PR TITLE
fix(musea): resolve previewCss package specifiers through Vite

### DIFF
--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -36,6 +36,7 @@ import {
 import { resolveMuseaSharedConfig } from "./config.js";
 import { processMuseaArtFile } from "./art-processing.js";
 import { transformMuseaVirtualModule } from "./virtual-transform.js";
+import { resolvePreviewCssPath } from "./preview-css.js";
 import { resolveStaticPreviewVueVersion } from "./static-preview.js";
 
 export function musea(options: MuseaOptions = {}): Plugin[] {
@@ -128,7 +129,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
       virtualState.basePath = basePath;
 
       resolvedPreviewCss = previewCss.map((cssPath) =>
-        path.isAbsolute(cssPath) ? cssPath : path.resolve(resolvedConfig.root, cssPath),
+        resolvePreviewCssPath(resolvedConfig.root, cssPath),
       );
 
       if (previewSetup) {

--- a/npm/builder/vite-musea/src/plugin/preview-css.test.ts
+++ b/npm/builder/vite-musea/src/plugin/preview-css.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { resolvePreviewCssPath } from "./preview-css.js";
+
+void test("package specifiers stay unresolved for the bundler", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "musea-preview-css-"));
+  try {
+    assert.equal(resolvePreviewCssPath(root, "normalize.css"), "normalize.css");
+    assert.equal(
+      resolvePreviewCssPath(root, "@fontsource/inter/index.css"),
+      "@fontsource/inter/index.css",
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+void test("dot-relative paths resolve against the project root", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "musea-preview-css-"));
+  try {
+    assert.equal(
+      resolvePreviewCssPath(root, "./src/styles/tokens.css"),
+      path.resolve(root, "./src/styles/tokens.css"),
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+void test("existing project-relative files resolve against the project root", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "musea-preview-css-"));
+  try {
+    const relative = path.join("src", "styles", "main.css");
+    const absolute = path.join(root, relative);
+    fs.mkdirSync(path.dirname(absolute), { recursive: true });
+    fs.writeFileSync(absolute, "button{color:red}");
+    assert.equal(resolvePreviewCssPath(root, relative), absolute);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+void test("absolute paths are unchanged", () => {
+  const absolute = path.resolve("/tmp/musea-preview.css");
+  assert.equal(resolvePreviewCssPath("/other-root", absolute), absolute);
+});

--- a/npm/builder/vite-musea/src/plugin/preview-css.ts
+++ b/npm/builder/vite-musea/src/plugin/preview-css.ts
@@ -1,0 +1,21 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Resolve a `previewCss` entry.
+ *
+ * Relative and project-root files stay filesystem paths. Bare specifiers
+ * (`normalize.css`, `@fontsource/inter/index.css`) are left for Vite.
+ */
+export function resolvePreviewCssPath(root: string, cssPath: string): string {
+  if (path.isAbsolute(cssPath)) {
+    return cssPath;
+  }
+
+  const rooted = path.resolve(root, cssPath);
+  if (cssPath.startsWith(".") || fs.existsSync(rooted)) {
+    return rooted;
+  }
+
+  return cssPath;
+}

--- a/npm/builder/vite-musea/src/types/plugin.ts
+++ b/npm/builder/vite-musea/src/types/plugin.ts
@@ -127,8 +127,10 @@ export interface MuseaOptions {
    * Useful for loading global styles (custom properties, resets, fonts, etc.)
    * that components depend on.
    *
-   * Paths are resolved relative to the project root.
-   * @example ['app/assets/styles/main.css']
+   * Project-relative and `./` paths resolve against the project root.
+   * Bare specifiers (`normalize.css`, `@fontsource/inter/index.css`) are
+   * left for Vite to resolve.
+   * @example ['app/assets/styles/main.css', 'normalize.css']
    */
   previewCss?: string[];
 


### PR DESCRIPTION
## Summary
- `previewCss` entries that are not absolute and do not exist as project files are left as bundler specifiers.
- `./` paths and files that exist under the project root still resolve against the root.
- This lets gallery CSS load from packages such as `normalize.css` and `@fontsource/*`.

Fixes #4466

## Test plan
- [x] `pnpm exec tsx --test src/plugin/preview-css.test.ts` in `@vizejs/vite-plugin-musea`
- [ ] CI green
- [ ] squash auto-merge

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790098858&installation_model_id=422833&pr_number=4661&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4661&signature=98a7057a7f0060bce3ec48f4f0421876e7fd225b514d301dfc48bc8e0d3da6ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->