### PR TITLE
fix(matrix): parse JSONC and relative extends when isolating fixture types

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation.test.ts
@@ -275,27 +275,13 @@ test(
   },
 );
 
-test("a JSONC config with comments and trailing commas still isolates declared packages", () => {
+test("a JSONC config that extends another still isolates the parent's packages", () => {
   const { outer, fixtureRoot } = scaffold();
   try {
+    writeConfig(fixtureRoot, declaredPaths);
     const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.check.json");
-    // reka-ui's check config starts with `//` and JSON.parse used to drop `paths`.
-    fs.writeFileSync(
-      configPath,
-      `// check-only
-{
-  "compilerOptions": {
-    "paths": {
-      "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
-      "@vue/runtime-core": [
-        "../node_modules/.pnpm/@vue+runtime-core@3.5.30/node_modules/@vue/runtime-core"
-      ],
-      "src/**/*": ["src/**/*"],
-    },
-  },
-}
-`,
-    );
+    // reka-ui's check config is JSONC with `extends` and no `paths` of its own.
+    fs.writeFileSync(configPath, `// check-only\n{ "extends": "./tsconfig.app.json", }\n`);
     assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
       {
         name: "@vue/runtime-core",

--- a/tests/tooling/typecheck-baseline-isolation.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation.test.ts
@@ -275,14 +275,49 @@ test(
   },
 );
 
+test("a JSONC config with comments and trailing commas still isolates declared packages", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.check.json");
+    // reka-ui's check config starts with `//` and JSON.parse used to drop `paths`.
+    fs.writeFileSync(
+      configPath,
+      `// check-only
+{
+  "compilerOptions": {
+    "paths": {
+      "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
+      "@vue/runtime-core": [
+        "../node_modules/.pnpm/@vue+runtime-core@3.5.30/node_modules/@vue/runtime-core"
+      ],
+      "src/**/*": ["src/**/*"],
+    },
+  },
+}
+`,
+    );
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+      {
+        name: "@vue/runtime-core",
+        target: "node_modules/.pnpm/@vue+runtime-core@3.5.30/node_modules/@vue/runtime-core",
+      },
+      { name: "vue-router", target: "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router" },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
 test("a config that declares nothing, or cannot be read, links nothing", () => {
   const { outer, fixtureRoot } = scaffold();
   try {
     const missing = path.join(fixtureRoot, "tsconfig.json");
     assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, missing), []);
-    fs.writeFileSync(missing, "{ /* JSONC the harness does not parse */ }\n");
+    fs.writeFileSync(missing, "{ /* JSONC with no paths still declares nothing */ }\n");
     assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, missing), []);
     fs.writeFileSync(missing, '{"compilerOptions":{}}\n');
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, missing), []);
+    fs.writeFileSync(missing, "{ this is not json\n");
     assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, missing), []);
     assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-router")), false);
   } finally {

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -59,18 +59,19 @@ export function isolateFixtureTypePackages(fixtureRoot, sourceConfigPath) {
 
 function readDeclaredPackagePaths(sourceConfigPath) {
   const declared = new Map();
-  let config;
-  try {
-    config = JSON.parse(stripJsonc(readFileSync(sourceConfigPath, "utf8")));
-  } catch {
-    // Missing or invalid JSON still declares nothing. JSONC comments and
-    // trailing commas are stripped first so configs like reka-ui's
-    // `tsconfig.check.json` keep their `paths` (#4461).
-    return declared;
+  // Child `compilerOptions.paths` replace the parent's object, matching tsc.
+  // Relative `extends` is followed so reka-ui's `tsconfig.check.json` still
+  // sees the paths one hop away in `tsconfig.app.json` (#4461).
+  let paths;
+  let configDir;
+  for (const { config, dir } of [...loadExtendsChain(sourceConfigPath)].reverse()) {
+    const candidate = config?.compilerOptions?.paths;
+    if (candidate != null && typeof candidate === "object") {
+      paths = candidate;
+      configDir = dir;
+    }
   }
-  const paths = config?.compilerOptions?.paths;
-  if (paths == null || typeof paths !== "object") return declared;
-  const configDir = dirname(resolve(sourceConfigPath));
+  if (paths == null) return declared;
   for (const [name, targets] of Object.entries(paths)) {
     if (!packageNamePattern.test(name) || !Array.isArray(targets)) continue;
     const first = targets.find((entry) => typeof entry === "string" && !entry.includes("*"));
@@ -78,6 +79,49 @@ function readDeclaredPackagePaths(sourceConfigPath) {
     declared.set(name, resolve(configDir, first));
   }
   return declared;
+}
+
+function loadExtendsChain(sourceConfigPath) {
+  const chain = [];
+  const seen = new Set();
+  let current = resolve(sourceConfigPath);
+  while (!seen.has(current)) {
+    seen.add(current);
+    const config = parseTsconfig(current);
+    if (config == null) break;
+    chain.push({ config, dir: dirname(current) });
+    const specifiers = extendsSpecifiers(config.extends);
+    let next = null;
+    for (const specifier of specifiers) {
+      next = resolveExtends(current, specifier);
+      if (next != null) break;
+    }
+    if (next == null) break;
+    current = next;
+  }
+  return chain;
+}
+
+function parseTsconfig(configPath) {
+  try {
+    return JSON.parse(stripJsonc(readFileSync(configPath, "utf8")));
+  } catch {
+    return null;
+  }
+}
+
+function extendsSpecifiers(value) {
+  if (typeof value === "string") return [value];
+  return Array.isArray(value) ? value.filter((entry) => typeof entry === "string") : [];
+}
+
+function resolveExtends(fromConfig, specifier) {
+  if (typeof specifier !== "string") return null;
+  if (!(specifier.startsWith("./") || specifier.startsWith("../"))) return null;
+  const resolved = resolve(dirname(fromConfig), specifier);
+  if (existsSync(resolved)) return resolved;
+  if (!resolved.endsWith(".json") && existsSync(`${resolved}.json`)) return `${resolved}.json`;
+  return null;
 }
 
 /**

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -61,10 +61,11 @@ function readDeclaredPackagePaths(sourceConfigPath) {
   const declared = new Map();
   let config;
   try {
-    config = JSON.parse(readFileSync(sourceConfigPath, "utf8"));
+    config = JSON.parse(stripJsonc(readFileSync(sourceConfigPath, "utf8")));
   } catch {
-    // A config this cannot parse — JSONC, or missing — simply declares nothing.
-    // The ambient gate still fails the run if that leaves the program split.
+    // Missing or invalid JSON still declares nothing. JSONC comments and
+    // trailing commas are stripped first so configs like reka-ui's
+    // `tsconfig.check.json` keep their `paths` (#4461).
     return declared;
   }
   const paths = config?.compilerOptions?.paths;
@@ -138,4 +139,44 @@ function isDanglingLink(link) {
 
 function compare(left, right) {
   return left < right ? -1 : left > right ? 1 : 0;
+}
+
+/**
+ * Strip JSONC comments and trailing commas, string-aware. A regex pass would
+ * treat `"src/**\/*"` as a block comment and rewrite the config.
+ */
+function stripJsonc(text) {
+  let out = "";
+  let inString = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inString) {
+      out += ch;
+      if (ch === "\\") {
+        out += text[i + 1] ?? "";
+        i += 1;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i += 1;
+      out += "\n";
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "*") {
+      i += 2;
+      while (i + 1 < text.length && !(text[i] === "*" && text[i + 1] === "/")) i += 1;
+      i += 1;
+      continue;
+    }
+    out += ch;
+  }
+  return out.replace(/,(\s*[}\]])/g, "$1");
 }


### PR DESCRIPTION
## Summary
- `isolateFixtureTypePackages` strips JSONC comments and trailing commas before `JSON.parse`.
- Relative `extends` is followed so configs like reka-ui's `tsconfig.check.json` inherit `paths` from `tsconfig.app.json`.
- Missing or invalid JSON still declares nothing. Package-name `extends` and `references` are not followed in this slice.
- Part of #4461 (does not restore the typecheck divergence gate).

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-isolation.test.ts`
- [ ] CI green
- [ ] squash auto-merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of TypeScript configurations that inherit settings from other configuration files.
  * Correctly supports comments and trailing commas in JSONC configuration files.
  * Ensures inherited package path declarations are isolated and child settings take precedence.
  * Invalid, unresolved, or cyclic configuration chains now fail safely without producing incorrect links.

* **Tests**
  * Added coverage for configuration inheritance, malformed JSONC, and no-op scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->