### PR TITLE
fix(matrix): typecheck PrimeVue Volt and Showcase under their own Nuxt tsconfigs

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -300,6 +300,44 @@
       }
     },
     {
+      "id": "primevue-volt",
+      "displayName": "PrimeVue Volt",
+      "kind": "component-library",
+      "fixturePath": "tests/_fixtures/_git/primevue",
+      "repository": "https://github.com/primefaces/primevue",
+      "revision": "d4374cb7c1267f35eba7cee5d0a266f50ca8ec84",
+      "license": {
+        "spdx": "MIT",
+        "files": ["LICENSE.md"]
+      },
+      "vueGlobs": ["apps/volt/**/*.vue"],
+      "tsconfig": "apps/volt/tsconfig.json",
+      "coverage": [
+        "compiler",
+        "linter",
+        "typechecker",
+        "formatter",
+        "syntax-highlighter",
+        "lsp"
+      ],
+      "diff": "curator-compare",
+      "typecheckPerformance": {
+        "enabled": true,
+        "compareTo": "vue-tsc",
+        "packageManager": "pnpm",
+        "packageManagerVersion": "9.6.0",
+        "lockfile": "pnpm-lock.yaml",
+        "baseline": {
+          "tsconfig": "apps/volt/.nuxt/tsconfig.json",
+          "prepare": ["pnpm", "--filter", "volt", "exec", "nuxt", "prepare"]
+        },
+        "hangTimeoutMs": 300000,
+        "corpusGlobs": ["apps/volt/**/*.vue"],
+        "maxFalsePositiveRatio": 0.05,
+        "maxFalseNegativeRatio": 0.05
+      }
+    },
+    {
       "id": "vuetify",
       "displayName": "Vuetify",
       "kind": "component-library",

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -338,6 +338,44 @@
       }
     },
     {
+      "id": "primevue-showcase",
+      "displayName": "PrimeVue Showcase",
+      "kind": "component-library",
+      "fixturePath": "tests/_fixtures/_git/primevue",
+      "repository": "https://github.com/primefaces/primevue",
+      "revision": "d4374cb7c1267f35eba7cee5d0a266f50ca8ec84",
+      "license": {
+        "spdx": "MIT",
+        "files": ["LICENSE.md"]
+      },
+      "vueGlobs": ["apps/showcase/**/*.vue"],
+      "tsconfig": "apps/showcase/tsconfig.json",
+      "coverage": [
+        "compiler",
+        "linter",
+        "typechecker",
+        "formatter",
+        "syntax-highlighter",
+        "lsp"
+      ],
+      "diff": "curator-compare",
+      "typecheckPerformance": {
+        "enabled": true,
+        "compareTo": "vue-tsc",
+        "packageManager": "pnpm",
+        "packageManagerVersion": "9.6.0",
+        "lockfile": "pnpm-lock.yaml",
+        "baseline": {
+          "tsconfig": "apps/showcase/.nuxt/tsconfig.json",
+          "prepare": ["pnpm", "--filter", "showcase", "exec", "nuxt", "prepare"]
+        },
+        "hangTimeoutMs": 300000,
+        "corpusGlobs": ["apps/showcase/**/*.vue"],
+        "maxFalsePositiveRatio": 0.05,
+        "maxFalseNegativeRatio": 0.05
+      }
+    },
+    {
       "id": "vuetify",
       "displayName": "Vuetify",
       "kind": "component-library",

--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -57,11 +57,11 @@ test("fixture tool matrix plans every registered project across all four require
     assert.match(markdown, /Machine: [^/]+\/[^,]+, \d+ logical CPUs, \d+ bytes memory/);
     assert.match(markdown, /\bRequested\b/);
     assert.match(markdown, /\bTransitive\b/);
-    assert.equal(report.summary.projectCount, 143);
+    assert.equal(report.summary.projectCount, 144);
     assert.equal(report.summary.toolCount, 4);
-    assert.equal(report.summary.runCount, 572);
-    assert.equal(report.summary.plannedRuns, 572);
-    assert.equal(report.projects.length, 143);
+    assert.equal(report.summary.runCount, 576);
+    assert.equal(report.summary.plannedRuns, 576);
+    assert.equal(report.projects.length, 144);
     for (const project of report.projects) {
       assert.deepEqual(
         project.runs.map((entry: { tool: string }) => entry.tool),
@@ -291,14 +291,14 @@ test("fixture tool matrix shards every project exactly once with balanced sizes"
       fs.rmSync(outputDir, { recursive: true, force: true });
     }
   }
-  assert.equal(projectIds.size, 143);
+  assert.equal(projectIds.size, 144);
   assert.deepEqual(
     [...new Set(shardSizes)].sort((a, b) => a - b),
-    [13],
+    [13, 14],
   );
   assert.equal(
     shardSizes.reduce((sum, size) => sum + size, 0),
-    143,
+    144,
   );
 });
 

--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -57,11 +57,11 @@ test("fixture tool matrix plans every registered project across all four require
     assert.match(markdown, /Machine: [^/]+\/[^,]+, \d+ logical CPUs, \d+ bytes memory/);
     assert.match(markdown, /\bRequested\b/);
     assert.match(markdown, /\bTransitive\b/);
-    assert.equal(report.summary.projectCount, 142);
+    assert.equal(report.summary.projectCount, 143);
     assert.equal(report.summary.toolCount, 4);
-    assert.equal(report.summary.runCount, 568);
-    assert.equal(report.summary.plannedRuns, 568);
-    assert.equal(report.projects.length, 142);
+    assert.equal(report.summary.runCount, 572);
+    assert.equal(report.summary.plannedRuns, 572);
+    assert.equal(report.projects.length, 143);
     for (const project of report.projects) {
       assert.deepEqual(
         project.runs.map((entry: { tool: string }) => entry.tool),
@@ -291,14 +291,14 @@ test("fixture tool matrix shards every project exactly once with balanced sizes"
       fs.rmSync(outputDir, { recursive: true, force: true });
     }
   }
-  assert.equal(projectIds.size, 142);
+  assert.equal(projectIds.size, 143);
   assert.deepEqual(
     [...new Set(shardSizes)].sort((a, b) => a - b),
-    [12, 13],
+    [13],
   );
   assert.equal(
     shardSizes.reduce((sum, size) => sum + size, 0),
-    142,
+    143,
   );
 });
 

--- a/tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts
@@ -22,6 +22,7 @@ interface TypecheckPerformance {
   lockfile: "pnpm-lock.yaml" | "yarn.lock";
   baseline?: { tsconfig: string; prepare?: string[] };
   hangTimeoutMs: number;
+  corpusGlobs?: string[];
   maxFalsePositiveRatio: number;
   maxFalseNegativeRatio: number;
   largeProjectRegressionTarget?: boolean;
@@ -29,6 +30,8 @@ interface TypecheckPerformance {
 
 interface FixtureProject {
   id: string;
+  fixturePath?: string;
+  tsconfig?: string;
   typecheckPerformance?: TypecheckPerformance;
 }
 
@@ -45,7 +48,7 @@ test("typecheck baselines have complete budgets and bounded release coverage", (
     return true;
   });
 
-  assert.equal(targets.length, 11);
+  assert.equal(targets.length, 12);
   for (const project of targets) {
     const performance = project.typecheckPerformance!;
     assert.equal(performance.compareTo, "vue-tsc", `${project.id} baseline`);
@@ -81,4 +84,22 @@ test("large typechecker fixtures have performance safeguards and bench wiring", 
     ?.baseline;
   assert.equal(baseline?.tsconfig, ".nuxt/tsconfig.app.json");
   assert.deepEqual(baseline?.prepare, ["pnpm", "exec", "nuxt", "prepare"]);
+});
+
+test("PrimeVue Volt is measured under the app tsconfig, sharing the PrimeVue fixture", () => {
+  const registry = readRegistry();
+  const library = registry.projects.find((project) => project.id === "primevue");
+  const volt = registry.projects.find((project) => project.id === "primevue-volt");
+  assert.equal(volt?.fixturePath, library?.fixturePath);
+  assert.equal(volt?.tsconfig, "apps/volt/tsconfig.json");
+  assert.deepEqual(volt?.typecheckPerformance?.corpusGlobs, ["apps/volt/**/*.vue"]);
+  assert.equal(volt?.typecheckPerformance?.baseline?.tsconfig, "apps/volt/.nuxt/tsconfig.json");
+  assert.deepEqual(volt?.typecheckPerformance?.baseline?.prepare, [
+    "pnpm",
+    "--filter",
+    "volt",
+    "exec",
+    "nuxt",
+    "prepare",
+  ]);
 });

--- a/tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts
@@ -48,7 +48,7 @@ test("typecheck baselines have complete budgets and bounded release coverage", (
     return true;
   });
 
-  assert.equal(targets.length, 12);
+  assert.equal(targets.length, 13);
   for (const project of targets) {
     const performance = project.typecheckPerformance!;
     assert.equal(performance.compareTo, "vue-tsc", `${project.id} baseline`);
@@ -98,6 +98,27 @@ test("PrimeVue Volt is measured under the app tsconfig, sharing the PrimeVue fix
     "pnpm",
     "--filter",
     "volt",
+    "exec",
+    "nuxt",
+    "prepare",
+  ]);
+});
+
+test("PrimeVue Showcase is measured under the app tsconfig, sharing the PrimeVue fixture", () => {
+  const registry = readRegistry();
+  const library = registry.projects.find((project) => project.id === "primevue");
+  const showcase = registry.projects.find((project) => project.id === "primevue-showcase");
+  assert.equal(showcase?.fixturePath, library?.fixturePath);
+  assert.equal(showcase?.tsconfig, "apps/showcase/tsconfig.json");
+  assert.deepEqual(showcase?.typecheckPerformance?.corpusGlobs, ["apps/showcase/**/*.vue"]);
+  assert.equal(
+    showcase?.typecheckPerformance?.baseline?.tsconfig,
+    "apps/showcase/.nuxt/tsconfig.json",
+  );
+  assert.deepEqual(showcase?.typecheckPerformance?.baseline?.prepare, [
+    "pnpm",
+    "--filter",
+    "showcase",
     "exec",
     "nuxt",
     "prepare",

--- a/tests/tooling/vue-ecosystem-typecheck-corpus.test.ts
+++ b/tests/tooling/vue-ecosystem-typecheck-corpus.test.ts
@@ -13,6 +13,7 @@ const expectedCorpus = {
   "reka-ui": ["packages/core/**/*.vue"],
   primevue: ["packages/primevue/src/**/*.vue"],
   "primevue-volt": ["apps/volt/**/*.vue"],
+  "primevue-showcase": ["apps/showcase/**/*.vue"],
 } as const;
 
 test("typecheck corpus globs pin the tsconfig-owned Vue sources", () => {

--- a/tests/tooling/vue-ecosystem-typecheck-corpus.test.ts
+++ b/tests/tooling/vue-ecosystem-typecheck-corpus.test.ts
@@ -12,6 +12,7 @@ const expectedCorpus = {
   hoppscotch: ["packages/hoppscotch-common/src/**/*.vue"],
   "reka-ui": ["packages/core/**/*.vue"],
   primevue: ["packages/primevue/src/**/*.vue"],
+  "primevue-volt": ["apps/volt/**/*.vue"],
 } as const;
 
 test("typecheck corpus globs pin the tsconfig-owned Vue sources", () => {

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -332,10 +332,13 @@ function validateRatchets(oracles, fixtureMap, context) {
   );
   deepEqual(
     [...oracles.get("vue-tsc-parity")].sort(compareCodepoints),
-    context.registry.projects
-      .filter((project) => project.typecheckPerformance?.enabled === true)
-      .map((project) => project.fixturePath)
-      .sort(compareCodepoints),
+    [
+      ...new Set(
+        context.registry.projects
+          .filter((project) => project.typecheckPerformance?.enabled === true)
+          .map((project) => project.fixturePath),
+      ),
+    ].sort(compareCodepoints),
     "vue-tsc parity membership drifted",
   );
 }


### PR DESCRIPTION
## Summary
- Add `primevue-volt` and `primevue-showcase` registry entries that share the PrimeVue fixture.
- Each app typechecks under `apps/<app>/.nuxt/tsconfig.json` after `pnpm --filter <app> exec nuxt prepare`.
- The library corpus stays on `packages/primevue/src/**/*.vue`.
- vue-tsc parity membership is de-duplicated by fixture path so two typecheck programs may share one checkout.
- Part of #4461 (does not restore the typecheck divergence gate).

## Test plan
- [x] `node --test tests/tooling/vue-ecosystem-typecheck-corpus.test.ts tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/vue-ecosystem-tsconfig-coverage.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/fixture-tool-matrix-report.test.ts`
- [ ] CI green
- [ ] squash auto-merge