### PR TITLE
fix(matrix): follow relative tsconfig references when isolating fixture types

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-references.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-references.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateFixtureTypePackages } from "../../tools/fixtures/typecheck-baseline-isolation.mjs";
+
+/**
+ * `references` walk the project graph; they do not merge programs. A leaf that
+ * already has `paths` must not absorb another project's packages, a directory
+ * reference must resolve `tsconfig.json`, and two referenced copies of one
+ * name must not be guessed between (#4461).
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-refs-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  const store = path.join(fixtureRoot, "node_modules", ".pnpm");
+  fs.mkdirSync(path.join(fixtureRoot, ".nuxt"), { recursive: true });
+  for (const [name, id] of [
+    ["vue-router", "vue-router@5.1.0"],
+    ["defu", "defu@6.1.4"],
+    ["vue-router", "vue-router@4.5.1"],
+  ] as const) {
+    const packageRoot = path.join(store, id, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  for (const name of ["vue-router", "defu"]) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { outer, fixtureRoot };
+}
+
+function writeJson(filePath: string, value: unknown) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value)}\n`);
+}
+
+test("a config that already declares paths does not absorb packages from its references", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    const app = path.join(fixtureRoot, ".nuxt", "tsconfig.app.json");
+    const node = path.join(fixtureRoot, ".nuxt", "tsconfig.node.json");
+    writeJson(app, {
+      compilerOptions: {
+        paths: {
+          "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
+        },
+      },
+      references: [{ path: "./tsconfig.node.json" }],
+    });
+    writeJson(node, {
+      compilerOptions: {
+        paths: { defu: ["../node_modules/.pnpm/defu@6.1.4/node_modules/defu"] },
+      },
+    });
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, app), [
+      { name: "vue-router", target: "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router" },
+    ]);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "defu")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a relative directory reference isolates packages from that project's tsconfig.json", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeJson(path.join(fixtureRoot, ".nuxt", "tsconfig.json"), {
+      compilerOptions: {
+        paths: {
+          "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
+        },
+      },
+    });
+    const configPath = path.join(fixtureRoot, "tsconfig.json");
+    writeJson(configPath, { files: [], references: [{ path: "./.nuxt" }] });
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+      { name: "vue-router", target: "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router" },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("conflicting referenced targets for one name are dropped rather than guessed", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeJson(path.join(fixtureRoot, ".nuxt", "tsconfig.app.json"), {
+      compilerOptions: {
+        paths: {
+          "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
+        },
+      },
+    });
+    writeJson(path.join(fixtureRoot, ".nuxt", "tsconfig.node.json"), {
+      compilerOptions: {
+        paths: {
+          "vue-router": ["../node_modules/.pnpm/vue-router@4.5.1/node_modules/vue-router"],
+        },
+      },
+    });
+    const configPath = path.join(fixtureRoot, "tsconfig.json");
+    writeJson(configPath, {
+      files: [],
+      references: [{ path: "./.nuxt/tsconfig.app.json" }, { path: "./.nuxt/tsconfig.node.json" }],
+    });
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-router")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/typecheck-baseline-isolation.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation.test.ts
@@ -294,6 +294,33 @@ test("a JSONC config that extends another still isolates the parent's packages",
   }
 });
 
+test("a solution-style config still isolates packages declared in relative referenced projects", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeConfig(fixtureRoot, declaredPaths);
+    // elk's root tsconfig is a solution: `files: []` and `references`, with the
+    // real `paths` on `.nuxt/tsconfig.app.json`. Package-name references are
+    // not relative and must not be invented as configs.
+    const configPath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        files: [],
+        references: [{ path: "@vue/tsconfig" }, { path: "./.nuxt/tsconfig.app.json" }],
+      })}\n`,
+    );
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+      {
+        name: "@vue/runtime-core",
+        target: "node_modules/.pnpm/@vue+runtime-core@3.5.30/node_modules/@vue/runtime-core",
+      },
+      { name: "vue-router", target: "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router" },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
 test("a config that declares nothing, or cannot be read, links nothing", () => {
   const { outer, fixtureRoot } = scaffold();
   try {

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -1,4 +1,12 @@
-import { existsSync, lstatSync, mkdirSync, readdirSync, readFileSync, symlinkSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  symlinkSync,
+} from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 
 /**
@@ -34,6 +42,12 @@ import { dirname, join, relative, resolve } from "node:path";
  * fixture. Everything else is left alone, and the ambient-environment gate in
  * `typecheck-baseline-ambient.mjs` is what proves the outcome — this is the
  * repair, not the check.
+ *
+ * Declaration comes from `compilerOptions.paths` after relative `extends`, and
+ * from relative `references` when that chain declares none — elk's root
+ * `tsconfig.json` is solution-style and parks the real paths on referenced
+ * `.nuxt` projects (#4461). Conflicting targets for one name are dropped
+ * rather than guessed. Package-name specifiers are ignored, matching `extends`.
  */
 
 /** `paths` also carries `#imports`-style aliases and `foo/*` patterns, which are not packages. */
@@ -41,7 +55,7 @@ const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u
 
 export function isolateFixtureTypePackages(fixtureRoot, sourceConfigPath) {
   const root = resolve(fixtureRoot);
-  const declared = readDeclaredPackagePaths(sourceConfigPath);
+  const declared = readDeclaredPackagePaths(root, sourceConfigPath);
   if (declared.size === 0) return [];
   const reachable = collectAncestorPackageNames(root);
   const shadowed = [];
@@ -57,7 +71,32 @@ export function isolateFixtureTypePackages(fixtureRoot, sourceConfigPath) {
   return shadowed;
 }
 
-function readDeclaredPackagePaths(sourceConfigPath) {
+function readDeclaredPackagePaths(fixtureRoot, sourceConfigPath) {
+  const declared = new Map();
+  const conflicts = new Set();
+  const seen = new Set();
+  const queue = [resolve(sourceConfigPath)];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (seen.has(current)) continue;
+    seen.add(current);
+    const local = packagePathsFromExtends(current);
+    if (local.size > 0) {
+      mergeDeclared(declared, conflicts, local);
+      continue;
+    }
+    const config = parseTsconfig(current);
+    if (config == null) continue;
+    for (const specifier of referenceSpecifiers(config.references)) {
+      const next = resolveReference(current, specifier);
+      if (next == null || !isInside(fixtureRoot, next)) continue;
+      queue.push(next);
+    }
+  }
+  return declared;
+}
+
+function packagePathsFromExtends(sourceConfigPath) {
   const declared = new Map();
   // Child `compilerOptions.paths` replace the parent's object, matching tsc.
   // Relative `extends` is followed so reka-ui's `tsconfig.check.json` still
@@ -79,6 +118,21 @@ function readDeclaredPackagePaths(sourceConfigPath) {
     declared.set(name, resolve(configDir, first));
   }
   return declared;
+}
+
+function mergeDeclared(declared, conflicts, local) {
+  for (const [name, target] of local) {
+    if (conflicts.has(name)) continue;
+    const existing = declared.get(name);
+    if (existing === undefined) {
+      declared.set(name, target);
+      continue;
+    }
+    if (existing !== target) {
+      declared.delete(name);
+      conflicts.add(name);
+    }
+  }
 }
 
 function loadExtendsChain(sourceConfigPath) {
@@ -122,6 +176,34 @@ function resolveExtends(fromConfig, specifier) {
   if (existsSync(resolved)) return resolved;
   if (!resolved.endsWith(".json") && existsSync(`${resolved}.json`)) return `${resolved}.json`;
   return null;
+}
+
+function referenceSpecifiers(value) {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((entry) =>
+    entry != null && typeof entry.path === "string" ? [entry.path] : [],
+  );
+}
+
+function resolveReference(fromConfig, specifier) {
+  if (typeof specifier !== "string") return null;
+  if (!(specifier.startsWith("./") || specifier.startsWith("../"))) return null;
+  const resolved = resolve(dirname(fromConfig), specifier);
+  if (isDirectory(resolved)) {
+    const nested = join(resolved, "tsconfig.json");
+    return existsSync(nested) ? nested : null;
+  }
+  if (existsSync(resolved)) return resolved;
+  if (!resolved.endsWith(".json") && existsSync(`${resolved}.json`)) return `${resolved}.json`;
+  return null;
+}
+
+function isDirectory(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Walk relative `references` when a tsconfig (after relative `extends`) declares no `compilerOptions.paths`, so solution-style roots such as elk's still isolate packages their referenced projects already mapped.
- Directory references resolve `tsconfig.json`; package-name specifiers are ignored; conflicting targets for one name are dropped rather than guessed. A leaf that already has `paths` does not absorb another project's packages.
- Part of #4461. Does not restore `typecheck_divergence_mode` to enforce.

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-isolation.test.ts tests/tooling/typecheck-baseline-isolation-references.test.ts`
- [ ] CI `test-scripts` / Check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790101749&installation_model_id=422833&pr_number=4668&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4668&signature=87047775d7d860d1f0d9f3954318b0a2c6abb3edfbed1209e31ad598e5e5731e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->