### PR TITLE
fix(matrix): link a unique in-fixture copy when tsconfig paths escape

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-unique.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-unique.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueLocalTypePackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * Nuxt writes `paths` to a package it resolved above the fixture. Isolation
+ * will not link that target in. If the fixture's pnpm store holds exactly one
+ * copy of the name, this repair uses that copy; if it holds several, it does
+ * not guess (#4461).
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-unique-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, ".nuxt"), { recursive: true });
+  for (const name of ["vue-router", "@vue/runtime-core"]) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { outer, fixtureRoot };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+function writeConfig(fixtureRoot: string, paths: Record<string, string[]>) {
+  const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.app.json");
+  fs.writeFileSync(
+    configPath,
+    `// generated\n${JSON.stringify({ compilerOptions: { paths } }, null, 2)}\n`,
+  );
+  return configPath;
+}
+
+test("an outside target with exactly one in-fixture copy is linked from that copy", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0", "vue-router");
+    const configPath = writeConfig(fixtureRoot, {
+      "vue-router": ["../../node_modules/vue-router"],
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      { name: "vue-router", target: "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router" },
+    ]);
+    const linked = fs.realpathSync(path.join(fixtureRoot, "node_modules", "vue-router"));
+    assert.equal(linked.startsWith(fs.realpathSync(fixtureRoot) + path.sep), true);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside target with several in-fixture copies is left unlinked", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.5.30", "vue-router");
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.5.13", "vue-router");
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.4.38", "vue-router");
+    const configPath = writeConfig(fixtureRoot, {
+      "vue-router": ["../../node_modules/vue-router"],
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-router")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an inside target is left for isolation; this repair does not relink it", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0", "vue-router");
+    const configPath = writeConfig(fixtureRoot, {
+      "vue-router": ["../node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router"],
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-router")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a name no ancestor provides is left alone", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "defu@6.1.4", "defu");
+    const configPath = writeConfig(fixtureRoot, {
+      defu: ["../../node_modules/defu"],
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "defu")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -1,0 +1,178 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  symlinkSync,
+} from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+/**
+ * Close the remaining type-reference escape when Nuxt (or another generator)
+ * bakes `compilerOptions.paths` to a package *outside* the fixture (#4461).
+ *
+ * `typecheck-baseline-isolation.mjs` will not materialize an outside target —
+ * that would import the contamination. If the fixture's own pnpm store holds
+ * exactly one copy of that name, this links that copy instead of walking out to
+ * Vize's. Multiple copies are different peer suffixes; this does not guess
+ * which Vue they were built against.
+ */
+
+const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
+
+export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {
+  const root = resolve(fixtureRoot);
+  const declared = readOwnPackagePaths(sourceConfigPath);
+  if (declared.size === 0) return [];
+  const reachable = collectAncestorPackageNames(root);
+  const shadowed = [];
+  for (const [name, target] of [...declared].sort(([left], [right]) => compare(left, right))) {
+    if (!reachable.has(name)) continue;
+    const link = join(root, "node_modules", name);
+    if (existsSync(link) || isDanglingLink(link)) continue;
+    if (isPackageDirectory(target) && isInside(root, target)) continue;
+    const copies = findLocalCopies(root, name);
+    if (copies.length !== 1) continue;
+    const local = copies[0];
+    mkdirSync(dirname(link), { recursive: true });
+    symlinkSync(relative(dirname(link), local), link);
+    shadowed.push({ name, target: relative(root, local).replaceAll("\\", "/") });
+  }
+  return shadowed;
+}
+
+function readOwnPackagePaths(sourceConfigPath) {
+  const declared = new Map();
+  const config = parseTsconfig(sourceConfigPath);
+  const paths = config?.compilerOptions?.paths;
+  if (paths == null || typeof paths !== "object") return declared;
+  const configDir = dirname(resolve(sourceConfigPath));
+  for (const [name, targets] of Object.entries(paths)) {
+    if (!packageNamePattern.test(name) || !Array.isArray(targets)) continue;
+    const first = targets.find((entry) => typeof entry === "string" && !entry.includes("*"));
+    if (first == null) continue;
+    declared.set(name, resolve(configDir, first));
+  }
+  return declared;
+}
+
+function findLocalCopies(fixtureRoot, name) {
+  const copies = new Map();
+  const store = join(fixtureRoot, "node_modules", ".pnpm");
+  const segments = name.split("/");
+  for (const entry of readDirectory(store)) {
+    if (entry.name.startsWith(".")) continue;
+    const packageDir = join(store, entry.name, "node_modules", ...segments);
+    if (!isPackageDirectory(packageDir) || !isInside(fixtureRoot, packageDir)) continue;
+    let real;
+    try {
+      real = realpathSync(packageDir);
+    } catch {
+      continue;
+    }
+    if (!isInside(fixtureRoot, real)) continue;
+    copies.set(real, packageDir);
+  }
+  return [...copies.values()].sort(compare);
+}
+
+function parseTsconfig(configPath) {
+  try {
+    return JSON.parse(stripJsonc(readFileSync(configPath, "utf8")));
+  } catch {
+    return null;
+  }
+}
+
+function collectAncestorPackageNames(fixtureRoot) {
+  const names = new Set();
+  let directory = dirname(fixtureRoot);
+  let previous = null;
+  while (directory !== previous) {
+    collectPackageNames(join(directory, "node_modules"), names);
+    previous = directory;
+    directory = dirname(directory);
+  }
+  return names;
+}
+
+function collectPackageNames(nodeModules, names) {
+  for (const entry of readDirectory(nodeModules)) {
+    if (entry.name.startsWith(".")) continue;
+    if (!entry.name.startsWith("@")) {
+      names.add(entry.name);
+      continue;
+    }
+    for (const scoped of readDirectory(join(nodeModules, entry.name))) {
+      names.add(`${entry.name}/${scoped.name}`);
+    }
+  }
+}
+
+function readDirectory(directory) {
+  try {
+    return readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+function isPackageDirectory(target) {
+  return existsSync(join(target, "package.json"));
+}
+
+function isInside(root, target) {
+  const path = relative(root, target);
+  return path !== "" && !path.startsWith("..") && !path.startsWith("/");
+}
+
+function isDanglingLink(link) {
+  try {
+    lstatSync(link);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function compare(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function stripJsonc(text) {
+  let out = "";
+  let inString = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inString) {
+      out += ch;
+      if (ch === "\\") {
+        out += text[i + 1] ?? "";
+        i += 1;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i += 1;
+      out += "\n";
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "*") {
+      i += 2;
+      while (i + 1 < text.length && !(text[i] === "*" && text[i + 1] === "/")) i += 1;
+      i += 1;
+      continue;
+    }
+    out += ch;
+  }
+  return out.replace(/,(\s*[}\]])/g, "$1");
+}

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
 import { isolateFixtureTypePackages } from "./typecheck-baseline-isolation.mjs";
+import { isolateUniqueLocalTypePackages } from "./typecheck-baseline-isolation-unique.mjs";
 import { selectTypecheckPerformanceProjects } from "./typecheck-performance-shard.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -130,7 +131,11 @@ function prepareProjectDependencies({ args, commitSha, project }) {
  */
 function isolateFixture(project, fixtureRoot) {
   const sourceProject = project.typecheckPerformance.baseline?.tsconfig ?? project.tsconfig;
-  const shadowed = isolateFixtureTypePackages(fixtureRoot, resolve(fixtureRoot, sourceProject));
+  const sourceConfig = resolve(fixtureRoot, sourceProject);
+  const shadowed = [
+    ...isolateFixtureTypePackages(fixtureRoot, sourceConfig),
+    ...isolateUniqueLocalTypePackages(fixtureRoot, sourceConfig),
+  ];
   for (const entry of shadowed) {
     process.stdout.write(`Linked ${project.id} node_modules/${entry.name} -> ${entry.target}\n`);
   }


### PR DESCRIPTION
## Summary
- When a fixture tsconfig maps a package to a path *outside* the fixture, isolation will not materialize that target (it would import Vize's copy and split Vue identities).
- If the fixture's own pnpm store holds **exactly one** copy of that name, link that copy at the fixture root. Several copies (different Vue peer suffixes) are left alone rather than guessed.
- Wired into typecheck dependency prepare after the existing isolation pass. Part of #4461. Does not restore `typecheck_divergence_mode` to enforce.

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-isolation-unique.test.ts`
- [x] `node --test tests/tooling/typecheck-dependency-prepare.test.ts`
- [ ] CI `test-scripts` / Check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790102142&installation_model_id=422833&pr_number=4671&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4671&signature=ef8c2ba388d23b169f86ac5a972582f7ddf2cb8f14a97aa0727d05c6daf72209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->