### PR TITLE
fix(musea): surface unknown art status warnings in Vite

### DIFF
--- a/crates/vize_musea/src/lib.rs
+++ b/crates/vize_musea/src/lib.rs
@@ -72,6 +72,7 @@ pub mod autogen;
 pub mod docs;
 pub mod palette;
 pub mod parse;
+mod status_warnings;
 pub mod tokens;
 pub mod transform;
 pub mod types;
@@ -79,6 +80,7 @@ pub mod vrt;
 
 // Re-exports for convenience
 pub use parse::parse_art;
+pub use status_warnings::parse_art_status_warnings;
 pub use tokens::{
     build_token_map, find_dependent_tokens, flatten_token_categories, generate_tokens_markdown,
     parse_tokens_from_json, parse_tokens_from_path, parse_tokens_from_value,

--- a/crates/vize_musea/src/parse.rs
+++ b/crates/vize_musea/src/parse.rs
@@ -3,7 +3,7 @@
 //! High-performance zero-copy parser using arena allocation.
 //! All string data is borrowed directly from the source.
 
-mod art_block;
+pub(crate) mod art_block;
 mod status;
 mod variant;
 

--- a/crates/vize_musea/src/status_warnings.rs
+++ b/crates/vize_musea/src/status_warnings.rs
@@ -1,0 +1,62 @@
+//! Unknown `status` diagnostics for Art files.
+//!
+//! `parse_art` keeps `ArtDescriptor` field-stable, so these warnings are
+//! collected through a separate entry rather than a new descriptor field.
+
+use crate::parse::art_block::{find_art_block, parse_metadata};
+use vize_carton::{Allocator, Vec};
+
+/// Return unknown-status warnings for `source`, or an empty list if the Art
+/// block is missing or metadata cannot be parsed.
+pub fn parse_art_status_warnings<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    filename: &str,
+) -> Vec<'a, &'a str> {
+    let Ok(block) = find_art_block(source.as_bytes(), source) else {
+        return Vec::new_in(&allocator);
+    };
+    match parse_metadata(allocator, &block, None, filename) {
+        Ok((_, warnings)) => warnings,
+        Err(_) => Vec::new_in(&allocator),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_art_status_warnings;
+    use vize_carton::Allocator;
+
+    #[test]
+    fn unknown_status_returns_the_shared_warning() {
+        let allocator = Allocator::new();
+        let source = r#"<art title="Button" status="wip"></art>"#;
+        assert_eq!(
+            parse_art_status_warnings(&allocator, source, "button.art.vue").as_slice(),
+            [
+                "button.art.vue: unknown status \"wip\"; falling back to \"draft\" (expected \"draft\" | \"ready\" | \"deprecated\")"
+            ]
+        );
+    }
+
+    #[test]
+    fn known_status_and_missing_art_return_no_warnings() {
+        let allocator = Allocator::new();
+        let ready = r#"<art title="Button" status="ready"></art>"#;
+        assert_eq!(
+            parse_art_status_warnings(&allocator, ready, "button.art.vue").as_slice(),
+            [] as [&str; 0]
+        );
+        assert_eq!(
+            parse_art_status_warnings(&allocator, "<div></div>", "button.art.vue").as_slice(),
+            [] as [&str; 0]
+        );
+        assert_eq!(
+            parse_art_status_warnings(&allocator, r#"<art title="Button" status="wip"></art>"#, "")
+                .as_slice(),
+            [
+                "anonymous.art.vue: unknown status \"wip\"; falling back to \"draft\" (expected \"draft\" | \"ready\" | \"deprecated\")"
+            ]
+        );
+    }
+}

--- a/crates/vize_vitrine/src/napi.rs
+++ b/crates/vize_vitrine/src/napi.rs
@@ -9,6 +9,7 @@
 //! - `config`: Public config normalization helpers
 
 mod art;
+mod art_status;
 mod cli;
 mod config;
 mod format;
@@ -26,6 +27,7 @@ mod napi_typecheck;
 pub use napi_typecheck::*;
 
 pub use art::*;
+pub use art_status::*;
 pub use cli::*;
 pub use config::*;
 pub use format::*;

--- a/crates/vize_vitrine/src/napi/art_status.rs
+++ b/crates/vize_vitrine/src/napi/art_status.rs
@@ -1,0 +1,30 @@
+//! NAPI bindings for Art status diagnostics.
+//!
+//! FFI boundary code: uses std types for JavaScript interop.
+#![allow(
+    clippy::disallowed_types,
+    clippy::disallowed_methods,
+    clippy::disallowed_macros
+)]
+
+use napi_derive::napi;
+
+use super::art::ArtParseOptionsNapi;
+
+/// Return unknown-status warnings for an Art file (`*.art.vue`).
+#[napi(js_name = "parseArtStatusWarnings")]
+pub fn parse_art_status_warnings(
+    source: String,
+    options: Option<ArtParseOptionsNapi>,
+) -> Vec<String> {
+    use vize_musea::{Allocator, parse_art_status_warnings as musea_warnings};
+
+    let allocator = Allocator::new();
+    let filename = options
+        .and_then(|opts| opts.filename)
+        .unwrap_or_else(|| "anonymous.art.vue".to_string());
+    musea_warnings(&allocator, &source, &filename)
+        .iter()
+        .map(|warning| (*warning).to_string())
+        .collect()
+}

--- a/npm/builder/vite-musea/src/native-loader.ts
+++ b/npm/builder/vite-musea/src/native-loader.ts
@@ -11,10 +11,7 @@ import { extractWithDefaults } from "./with-defaults.js";
 
 // Native binding types
 export interface NativeBinding {
-  parseArtStatusWarnings?: (
-    source: string,
-    options?: { filename?: string },
-  ) => string[];
+  parseArtStatusWarnings?: (source: string, options?: { filename?: string }) => string[];
   parseArt: (
     source: string,
     options?: { filename?: string },

--- a/npm/builder/vite-musea/src/native-loader.ts
+++ b/npm/builder/vite-musea/src/native-loader.ts
@@ -11,6 +11,10 @@ import { extractWithDefaults } from "./with-defaults.js";
 
 // Native binding types
 export interface NativeBinding {
+  parseArtStatusWarnings?: (
+    source: string,
+    options?: { filename?: string },
+  ) => string[];
   parseArt: (
     source: string,
     options?: { filename?: string },

--- a/npm/builder/vite-musea/src/plugin/art-processing.test.ts
+++ b/npm/builder/vite-musea/src/plugin/art-processing.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { processMuseaArtFile } from "./art-processing.js";
+import { processMuseaArtFile, reportArtStatusWarnings } from "./art-processing.js";
 
 void test("processMuseaArtFile forwards parser diagnostics during build", async () => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-bad-art-"));
@@ -54,4 +54,31 @@ void test("processMuseaArtFile keeps dev processing non-fatal", async () => {
   } finally {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   }
+});
+
+void test("reportArtStatusWarnings prints native unknown-status diagnostics", () => {
+  const messages: string[] = [];
+  reportArtStatusWarnings(
+    {
+      parseArtStatusWarnings: (source, options) => {
+        assert.equal(source, '<art title="Button" status="wip"></art>');
+        assert.equal(options?.filename, "button.art.vue");
+        return [
+          'button.art.vue: unknown status "wip"; falling back to "draft" (expected "draft" | "ready" | "deprecated")',
+        ];
+      },
+    },
+    '<art title="Button" status="wip"></art>',
+    "button.art.vue",
+    (message) => messages.push(message),
+  );
+  assert.deepEqual(messages, [
+    '[musea] button.art.vue: unknown status "wip"; falling back to "draft" (expected "draft" | "ready" | "deprecated")',
+  ]);
+});
+
+void test("reportArtStatusWarnings is a no-op when the native export is missing", () => {
+  const messages: string[] = [];
+  reportArtStatusWarnings({}, "<art></art>", "button.art.vue", (message) => messages.push(message));
+  assert.deepEqual(messages, []);
 });

--- a/npm/builder/vite-musea/src/plugin/art-processing.ts
+++ b/npm/builder/vite-musea/src/plugin/art-processing.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 import { extractScriptSetupContent, extractScriptSetupIsolated } from "../art-module.js";
 import { loadNative } from "../native-loader.js";
+import type { NativeBinding } from "../native-loader.js";
 import type { ArtFileInfo, ArtMetadata } from "../types/index.js";
 
 export interface ArtProcessingContext {
@@ -92,6 +93,19 @@ function stringifyUnknown(value: unknown): string {
   }
 }
 
+export function reportArtStatusWarnings(
+  binding: Pick<NativeBinding, "parseArtStatusWarnings">,
+  source: string,
+  filename: string,
+  warn: (message: string) => void = console.warn,
+): void {
+  const warnings = binding.parseArtStatusWarnings?.(source, { filename });
+  if (warnings == null) return;
+  for (const warning of warnings) {
+    warn(`[musea] ${warning}`);
+  }
+}
+
 export async function processMuseaArtFile(
   filePath: string,
   ctx: ArtProcessingContext,
@@ -100,6 +114,7 @@ export async function processMuseaArtFile(
     const source = await fs.promises.readFile(filePath, "utf-8");
     const binding = loadNative();
     const parsed = binding.parseArt(source, { filename: filePath });
+    reportArtStatusWarnings(binding, source, filePath);
     const customMetadata = extractCustomArtMetadata(source);
 
     if (!parsed.variants || parsed.variants.length === 0) return null;

--- a/npm/native/index.d.ts
+++ b/npm/native/index.d.ts
@@ -784,6 +784,12 @@ export declare function parseArt(
   options?: ArtParseOptionsNapi | undefined | null,
 ): ArtDescriptorNapi;
 
+/** Return unknown-status warnings for an Art file (`*.art.vue`). */
+export declare function parseArtStatusWarnings(
+  source: string,
+  options?: ArtParseOptionsNapi | undefined | null,
+): Array<string>;
+
 export declare function parseCssAst(
   source: string,
   options?: CssCompileOptionsNapi | undefined | null,

--- a/npm/native/index.js
+++ b/npm/native/index.js
@@ -61,6 +61,7 @@ module.exports.normalizeViteResolvedVuePath = nativeBinding.normalizeViteResolve
 module.exports.normalizeViteVirtualVueModuleId = nativeBinding.normalizeViteVirtualVueModuleId;
 module.exports.normalizeVizeConfig = nativeBinding.normalizeVizeConfig;
 module.exports.parseArt = nativeBinding.parseArt;
+module.exports.parseArtStatusWarnings = nativeBinding.parseArtStatusWarnings;
 module.exports.parseCssAst = nativeBinding.parseCssAst;
 module.exports.parseDesignTokensFromJson = nativeBinding.parseDesignTokensFromJson;
 module.exports.parseDesignTokensFromPath = nativeBinding.parseDesignTokensFromPath;


### PR DESCRIPTION
## Summary
- Unknown Art `status` already falls back to `draft` without changing `ArtDescriptor`. This adds `parse_art_status_warnings` so that warning text is no longer discarded.
- NAPI `parseArtStatusWarnings` and the Musea Vite plugin print those warnings (`[musea] …`) while processing Art files.
- Follow-up to #4467. Does not restore the typecheck release gate (#4461).

## Test plan
- [x] `cargo test -p vize_musea --lib status_warnings`
- [x] `cargo check -p vize_vitrine --features napi`
- [x] `reportArtStatusWarnings` unit tests in `art-processing.test.ts`
- [ ] CI Check / test-scripts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790102779&installation_model_id=422833&pr_number=4672&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4672&signature=1da601c4304a0c3e9d804f6603f462bfc72439954819389adda381687f35c4b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection of unknown Art statuses during file processing.
  * Exposed `parseArtStatusWarnings` through the native and JavaScript APIs.
  * Warning messages include the `[musea]` prefix and support optional filenames.
  * Processing remains compatible when the warning parser is unavailable.

* **Bug Fixes**
  * Unknown status warnings are now surfaced instead of being silently overlooked.

* **Tests**
  * Added coverage for unknown and recognized statuses, missing Art blocks, default filenames, and unavailable parser support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->