### PR TITLE
feat(davinci): emit v-on modifiers from S2 (P2-11)

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
@@ -1,6 +1,7 @@
 //! P2-11 installment 5 witness: static native HTML, interpolations,
-//! mixed text siblings, static-name binds, static-name events, and native v-if,
-//! compared **byte-for-byte** including helper usage.
+//! mixed text siblings, static-name binds, static-name events including
+//! event/key/option modifiers, and native v-if, compared **byte-for-byte**
+//! including helper usage.
 //!
 //! `vize_atelier_dom` is published; the Davinci crates are not. The
 //! comparator therefore rides stripped-on-publish dev-deps (the same
@@ -62,6 +63,30 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<div @click="handler">{{ msg }}</div>"#,
     ),
     ("inline_click", r#"<div @click="count++"></div>"#),
+    ("click_stop", r#"<div @click.stop="handler"></div>"#),
+    (
+        "click_prevent_stop",
+        r#"<div @click.prevent.stop="handler"></div>"#,
+    ),
+    ("click_capture", r#"<div @click.capture="handler"></div>"#),
+    ("click_once", r#"<div @click.once="handler"></div>"#),
+    ("click_passive", r#"<div @click.passive="handler"></div>"#),
+    ("click_right", r#"<div @click.right="handler"></div>"#),
+    ("click_middle", r#"<div @click.middle="handler"></div>"#),
+    ("click_left", r#"<div @click.left="handler"></div>"#),
+    ("keyup_enter", r#"<div @keyup.enter="handler"></div>"#),
+    ("keyup_left", r#"<div @keyup.left="handler"></div>"#),
+    (
+        "keyup_enter_stop",
+        r#"<div @keyup.enter.stop="handler"></div>"#,
+    ),
+    ("inline_click_stop", r#"<div @click.stop="count++"></div>"#),
+    ("bare_submit_prevent", r#"<div @submit.prevent></div>"#),
+    (
+        "click_once_capture",
+        r#"<div @click.once.capture="handler"></div>"#,
+    ),
+    ("unknown_click_key", r#"<div @click.foo="handler"></div>"#),
     ("simple_v_if", r#"<div v-if="ok">hello</div>"#),
     (
         "v_if_else",

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -8,12 +8,12 @@
 //! S2 ops** — it does not mint relief codegen-nodes (`NodeType` 13–20).
 //!
 //! Installment 5 emits **static native HTML**, interpolations,
-//! mixed text siblings, static-name `ui.bind`, static-name `ui.on`,
-//! and **native `ui.if`** (root and nested `v-if`/`v-else` on HTML
-//! elements). Object-spread `v-bind`/`v-on`, modifiers, fragments,
-//! filters, and components stay [`EmitError::Unsupported`]. The old lane
-//! stays the shipped compile path; [`super::DOM_LANE_FLAG`] is named
-//! here and *read* in the atelier_dom witness.
+//! mixed text siblings, static-name `ui.bind`, static-name `ui.on`
+//! (including event/key/option modifiers), and **native `ui.if`**.
+//! Object-spread `v-bind`/`v-on`, `.native`, fragments, filters, and
+//! components stay [`EmitError::Unsupported`]. The old lane stays the
+//! shipped compile path; [`super::DOM_LANE_FLAG`] is named here and
+//! *read* in the atelier_dom witness.
 
 #[path = "emit/buf.rs"]
 mod buf;

--- a/crates/vize_ricalco/src/emit/buf.rs
+++ b/crates/vize_ricalco/src/emit/buf.rs
@@ -3,23 +3,29 @@
 use vize_carton::String;
 
 /// Vue helpers this installment can mention, ranked the way
-/// `vue_helper_import_rank` orders the shipped preamble (`toDisplayString`
-/// before vnode creates before class/style normalizers before `openBlock`
-/// before block creates before `createTextVNode` / `createCommentVNode`).
+/// `vue_helper_import_rank` orders the shipped preamble (`withKeys` /
+/// `withModifiers` before `toDisplayString` before vnode creates before
+/// class/style normalizers before `openBlock` before block creates
+/// before `createTextVNode` / `createCommentVNode`). Same-rank helpers
+/// keep this array order (`withKeys` before `withModifiers`).
 #[derive(Clone, Copy)]
 enum Helper {
+    WithKeys,
+    WithModifiers,
     ToDisplayString,
     CreateElementVNode,
     NormalizeClass,
     NormalizeStyle,
     OpenBlock,
     CreateElementBlock,
-    CreateText,
     CreateComment,
+    CreateText,
 }
 
 impl Helper {
-    const ALL: [Self; 8] = [
+    const ALL: [Self; 10] = [
+        Self::WithKeys,
+        Self::WithModifiers,
         Self::ToDisplayString,
         Self::CreateElementVNode,
         Self::NormalizeClass,
@@ -30,7 +36,7 @@ impl Helper {
         Self::CreateText,
     ];
 
-    const fn bit(self) -> u8 {
+    const fn bit(self) -> u16 {
         match self {
             Self::ToDisplayString => 1,
             Self::CreateElementVNode => 2,
@@ -39,12 +45,16 @@ impl Helper {
             Self::CreateText => 16,
             Self::NormalizeClass => 32,
             Self::NormalizeStyle => 64,
-            Self::CreateComment => 128,
+            Self::WithKeys => 128,
+            Self::WithModifiers => 256,
+            Self::CreateComment => 512,
         }
     }
 
     const fn name(self) -> &'static str {
         match self {
+            Self::WithKeys => "withKeys",
+            Self::WithModifiers => "withModifiers",
             Self::ToDisplayString => "toDisplayString",
             Self::CreateElementVNode => "createElementVNode",
             Self::NormalizeClass => "normalizeClass",
@@ -58,6 +68,8 @@ impl Helper {
 
     const fn alias(self) -> &'static str {
         match self {
+            Self::WithKeys => "_withKeys",
+            Self::WithModifiers => "_withModifiers",
             Self::ToDisplayString => "_toDisplayString",
             Self::CreateElementVNode => "_createElementVNode",
             Self::NormalizeClass => "_normalizeClass",
@@ -74,7 +86,7 @@ impl Helper {
 pub(super) struct Buf {
     pub code: String,
     indent: u32,
-    used: u8,
+    used: u16,
     /// Compact static-props object hoisted as `_hoisted_1` (root only).
     hoisted_props: Option<String>,
 }
@@ -114,6 +126,14 @@ impl Buf {
         self.used |= Helper::ToDisplayString.bit();
     }
 
+    pub(super) fn use_with_keys(&mut self) {
+        self.used |= Helper::WithKeys.bit();
+    }
+
+    pub(super) fn use_with_modifiers(&mut self) {
+        self.used |= Helper::WithModifiers.bit();
+    }
+
     pub(super) fn use_open_block(&mut self) {
         self.used |= Helper::OpenBlock.bit();
     }
@@ -144,6 +164,14 @@ impl Buf {
 
     pub(super) fn to_display_string_alias() -> &'static str {
         Helper::ToDisplayString.alias()
+    }
+
+    pub(super) fn with_keys_alias() -> &'static str {
+        Helper::WithKeys.alias()
+    }
+
+    pub(super) fn with_modifiers_alias() -> &'static str {
+        Helper::WithModifiers.alias()
     }
 
     pub(super) fn open_block_alias() -> &'static str {
@@ -186,7 +214,7 @@ impl Buf {
     /// root static-props hoist (the shipped codegen appends hoists to
     /// the helper preamble).
     pub(super) fn preamble(&self) -> String {
-        let listed: [Helper; 8] = Helper::ALL;
+        let listed: [Helper; 10] = Helper::ALL;
         let mut n = 0;
         for helper in listed {
             if self.used & helper.bit() != 0 {

--- a/crates/vize_ricalco/src/emit/on.rs
+++ b/crates/vize_ricalco/src/emit/on.rs
@@ -1,4 +1,5 @@
-//! Static-name `ui.on` (`@click` / `v-on:click`) without modifiers.
+//! Static-name `ui.on` (`@click` / `v-on:click`), including event / key /
+//! option modifiers (`withModifiers` / `withKeys`, `onClickOnce`, …).
 
 use alloc::vec::Vec as StdVec;
 
@@ -9,21 +10,26 @@ use vize_disegno::op::{DynamicName, OnOp};
 
 use super::EmitCx;
 use super::EmitError;
+use super::buf::Buf;
 use super::js::is_valid_js_identifier;
 
+struct Classified<'a> {
+    options: StdVec<&'a str>,
+    event: StdVec<&'a str>,
+    keys: StdVec<&'a str>,
+}
+
 pub(super) fn admit_on(on: &OnOp<'_>, seen: &mut StdVec<String>) -> Result<(), EmitError> {
-    if !on.modifiers.is_empty() {
-        return Err(EmitError::Unsupported);
-    }
     let name = static_on_name(on)?;
     if name.contains(':') {
         return Err(EmitError::Unsupported);
     }
+    classify(on)?;
     match on.handler {
         None | Some(ExprRef::Js(_)) => {}
         Some(_) => return Err(EmitError::Unsupported),
     }
-    let key = event_key(name);
+    let key = event_key_for(on)?;
     if seen.contains(&key) {
         return Err(EmitError::Unsupported);
     }
@@ -53,8 +59,21 @@ pub(super) fn event_key(raw: &str) -> String {
     }
 }
 
-pub(super) fn needs_hydration(raw: &str) -> bool {
-    raw != "click"
+pub(super) fn event_key_for(on: &OnOp<'_>) -> Result<String, EmitError> {
+    let classified = classify(on)?;
+    let mut key = event_key(remapped_name(static_on_name(on)?, &classified.event));
+    for option in &classified.options {
+        key.push_str(capitalize(option).as_str());
+    }
+    Ok(key)
+}
+
+pub(super) fn needs_hydration(key: &str, on: &OnOp<'_>) -> bool {
+    key != "onClick" || classify(on).is_ok_and(|classified| !classified.keys.is_empty())
+}
+
+pub(super) fn wraps_on(on: &OnOp<'_>) -> bool {
+    classify(on).is_ok_and(|classified| !classified.event.is_empty() || !classified.keys.is_empty())
 }
 
 pub(super) fn is_inline_handler_source(source: &str) -> bool {
@@ -66,7 +85,8 @@ pub(super) fn is_inline_handler_source(source: &str) -> bool {
 }
 
 pub(super) fn emit_on_pair(cx: &mut EmitCx<'_>, on: &OnOp<'_>) -> Result<(), EmitError> {
-    let key = event_key(static_on_name(on)?);
+    let classified = classify(on)?;
+    let key = event_key_for(on)?;
     if !is_valid_js_identifier(key.as_str()) {
         cx.buf.push("\"");
         cx.buf.push(key.as_str());
@@ -75,12 +95,53 @@ pub(super) fn emit_on_pair(cx: &mut EmitCx<'_>, on: &OnOp<'_>) -> Result<(), Emi
         cx.buf.push(key.as_str());
     }
     cx.buf.push(": ");
+    emit_wrapped_handler(cx, on, &classified)
+}
+
+fn emit_wrapped_handler(
+    cx: &mut EmitCx<'_>,
+    on: &OnOp<'_>,
+    classified: &Classified<'_>,
+) -> Result<(), EmitError> {
+    if !classified.keys.is_empty() {
+        cx.buf.use_with_keys();
+        cx.buf.push(Buf::with_keys_alias());
+        cx.buf.push("(");
+    }
+    if !classified.event.is_empty() {
+        cx.buf.use_with_modifiers();
+        cx.buf.push(Buf::with_modifiers_alias());
+        cx.buf.push("(");
+    }
     match on.handler {
         Some(ExprRef::Js(js)) => emit_handler(cx, js),
         None => cx.buf.push("() => {}"),
         Some(_) => return Err(EmitError::Unsupported),
     }
+    if !classified.event.is_empty() {
+        cx.buf.push(", ");
+        emit_mod_array(cx, &classified.event);
+        cx.buf.push(")");
+    }
+    if !classified.keys.is_empty() {
+        cx.buf.push(", ");
+        emit_mod_array(cx, &classified.keys);
+        cx.buf.push(")");
+    }
     Ok(())
+}
+
+fn emit_mod_array(cx: &mut EmitCx<'_>, mods: &[&str]) {
+    cx.buf.push("[");
+    for (i, modifier) in mods.iter().enumerate() {
+        if i > 0 {
+            cx.buf.push(",");
+        }
+        cx.buf.push("\"");
+        cx.buf.push(modifier);
+        cx.buf.push("\"");
+    }
+    cx.buf.push("]");
 }
 
 fn emit_handler(cx: &mut EmitCx<'_>, js: &JsExpr<'_>) {
@@ -96,6 +157,39 @@ fn emit_handler(cx: &mut EmitCx<'_>, js: &JsExpr<'_>) {
         cx.buf.push("$event => (");
         cx.buf.push(js.source);
         cx.buf.push(")");
+    }
+}
+
+fn classify<'a>(on: &'a OnOp<'a>) -> Result<Classified<'a>, EmitError> {
+    let name = static_on_name(on)?;
+    let keyboard = matches!(name, "keydown" | "keyup" | "keypress");
+    let mut options = StdVec::new();
+    let mut event = StdVec::new();
+    let mut keys = StdVec::new();
+    for modifier in on.modifiers.iter() {
+        match *modifier {
+            "native" => return Err(EmitError::Unsupported),
+            "capture" | "once" | "passive" => options.push(*modifier),
+            "left" | "right" if keyboard => keys.push(*modifier),
+            "stop" | "prevent" | "self" | "ctrl" | "shift" | "alt" | "meta" | "middle"
+            | "exact" | "left" | "right" => event.push(*modifier),
+            _ => keys.push(*modifier),
+        }
+    }
+    Ok(Classified {
+        options,
+        event,
+        keys,
+    })
+}
+
+fn remapped_name<'a>(raw: &'a str, event: &[&str]) -> &'a str {
+    if raw == "click" && event.contains(&"right") {
+        "contextmenu"
+    } else if raw == "click" && event.contains(&"middle") {
+        "mouseup"
+    } else {
+        raw
     }
 }
 

--- a/crates/vize_ricalco/src/emit/props.rs
+++ b/crates/vize_ricalco/src/emit/props.rs
@@ -11,7 +11,7 @@ use super::EmitError;
 use super::buf::Buf;
 use super::js::{escape_js_string, is_valid_js_identifier};
 use super::on::{
-    admit_on, emit_on_pair, event_key, is_inline_handler_source, needs_hydration, static_on_name,
+    admit_on, emit_on_pair, event_key_for, is_inline_handler_source, needs_hydration, wraps_on,
 };
 
 pub(super) struct Patch {
@@ -75,15 +75,14 @@ pub(super) fn bind_patch(element: &ElementOp<'_>) -> Patch {
                 }
             }
             BindingOp::On(on) => {
-                let Ok(name) = static_on_name(on) else {
+                let Ok(key) = event_key_for(on) else {
                     continue;
                 };
-                let key = event_key(name);
                 flag |= 8;
                 if !dynamic_props.contains(&key) {
-                    dynamic_props.push(key);
+                    dynamic_props.push(key.clone());
                 }
-                if needs_hydration(name) {
+                if needs_hydration(key.as_str(), on) {
                     flag |= 32;
                 }
             }
@@ -233,10 +232,13 @@ fn static_bind_name<'a>(bind: &'a BindOp<'a>) -> Result<&'a str, EmitError> {
 
 fn has_inline_on(element: &ElementOp<'_>) -> bool {
     element.bindings.iter().any(|binding| match binding {
-        BindingOp::On(on) => match on.handler {
-            Some(ExprRef::Js(js)) => is_inline_handler_source(js.source),
-            _ => false,
-        },
+        BindingOp::On(on) => {
+            wraps_on(on)
+                || match on.handler {
+                    Some(ExprRef::Js(js)) => is_inline_handler_source(js.source),
+                    _ => false,
+                }
+        }
         _ => false,
     })
 }

--- a/crates/vize_ricalco/tests/emit_on.rs
+++ b/crates/vize_ricalco/tests/emit_on.rs
@@ -68,9 +68,97 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
-fn a_click_modifier_is_unsupported_this_installment() {
+fn a_click_stop_wraps_with_modifiers() {
     assert_eq!(
-        refused(r#"<div @click.stop="handler"></div>"#),
+        assembled(r#"<div @click.stop="handler"></div>"#),
+        "\
+const { withModifiers: _withModifiers, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", {
+    onClick: _withModifiers(handler, [\"stop\"])
+  }, null, 8 /* PROPS */, [\"onClick\"]))
+}"
+    );
+}
+
+#[test]
+fn a_click_prevent_stop_keeps_author_order() {
+    assert_eq!(
+        assembled(r#"<div @click.prevent.stop="handler"></div>"#),
+        "\
+const { withModifiers: _withModifiers, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", {
+    onClick: _withModifiers(handler, [\"prevent\",\"stop\"])
+  }, null, 8 /* PROPS */, [\"onClick\"]))
+}"
+    );
+}
+
+#[test]
+fn a_click_capture_suffixes_the_event_key() {
+    assert_eq!(
+        assembled(r#"<div @click.capture="handler"></div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", { onClickCapture: handler }, null, 40 /* PROPS, NEED_HYDRATION */, [\"onClickCapture\"]))
+}"
+    );
+}
+
+#[test]
+fn a_click_right_remaps_to_contextmenu() {
+    assert_eq!(
+        assembled(r#"<div @click.right="handler"></div>"#),
+        "\
+const { withModifiers: _withModifiers, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", {
+    onContextmenu: _withModifiers(handler, [\"right\"])
+  }, null, 40 /* PROPS, NEED_HYDRATION */, [\"onContextmenu\"]))
+}"
+    );
+}
+
+#[test]
+fn a_keyup_enter_wraps_with_keys() {
+    assert_eq!(
+        assembled(r#"<div @keyup.enter="handler"></div>"#),
+        "\
+const { withKeys: _withKeys, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", {
+    onKeyup: _withKeys(handler, [\"enter\"])
+  }, null, 40 /* PROPS, NEED_HYDRATION */, [\"onKeyup\"]))
+}"
+    );
+}
+
+#[test]
+fn a_keyup_enter_stop_nests_keys_outside_modifiers() {
+    assert_eq!(
+        assembled(r#"<div @keyup.enter.stop="handler"></div>"#),
+        "\
+const { withKeys: _withKeys, withModifiers: _withModifiers, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", {
+    onKeyup: _withKeys(_withModifiers(handler, [\"stop\"]), [\"enter\"])
+  }, null, 40 /* PROPS, NEED_HYDRATION */, [\"onKeyup\"]))
+}"
+    );
+}
+
+#[test]
+fn a_click_native_is_unsupported_this_installment() {
+    assert_eq!(
+        refused(r#"<div @click.native="handler"></div>"#),
         EmitError::Unsupported
     );
 }


### PR DESCRIPTION
## Summary
- Emit static-name `v-on` event/key/option modifiers from S2 to match the shipped DOM lane: `_withModifiers` / `_withKeys`, `onClickCapture`/`Once`/`Passive` suffixes, `@click.right` → `onContextmenu`, `@click.middle` → `onMouseup`.
- Hydration stays `onClick`-only unless `withKeys` is used; `.native`, object-spread `v-on`, and duplicate handlers stay `Unsupported`.
- Dual-run battery extended; exact byte match against the shipped lane (including native `v-if` cases already on main).

This PR targets `main` now that v-if (#4669) has landed. It is **not** stacked on a parent feature branch.

## Test plan
- [ ] `cargo test -p vize_ricalco --test emit_on --test emit_if`
- [ ] `cargo test -p vize_atelier_dom --test davinci_s2_dom`
- [ ] `cargo clippy -p vize_ricalco --tests -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790102811&installation_model_id=422833&pr_number=4673&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4673&signature=3ac8c72c4ee05f50fecbcda39d138bc47f55462484cf5626a6d8d3f0f7bb15cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->