### PR TITLE
fix(matrix): pick the in-fixture copy whose Vue peer matches the fixture

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-unique.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-unique.test.ts
@@ -45,7 +45,10 @@ function writeConfig(fixtureRoot: string, paths: Record<string, string[]>) {
 function writeFixtureVue(fixtureRoot: string, version: string) {
   const packageRoot = path.join(fixtureRoot, "node_modules", "vue");
   fs.mkdirSync(packageRoot, { recursive: true });
-  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"vue","version":"${version}"}\n`);
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `{"name":"vue","version":"${version}"}\n`,
+  );
 }
 
 test("an outside target with exactly one in-fixture copy is linked from that copy", () => {

--- a/tests/tooling/typecheck-baseline-isolation-unique.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-unique.test.ts
@@ -9,8 +9,9 @@ import { isolateUniqueLocalTypePackages } from "../../tools/fixtures/typecheck-b
 /**
  * Nuxt writes `paths` to a package it resolved above the fixture. Isolation
  * will not link that target in. If the fixture's pnpm store holds exactly one
- * copy of the name, this repair uses that copy; if it holds several, it does
- * not guess (#4461).
+ * copy of the name, this repair uses that copy. If it holds several, it uses
+ * the fixture's own `vue` version to pick the matching peer suffix, and still
+ * does not guess when that does not select exactly one copy (#4461).
  */
 
 function scaffold() {
@@ -39,6 +40,12 @@ function writeConfig(fixtureRoot: string, paths: Record<string, string[]>) {
     `// generated\n${JSON.stringify({ compilerOptions: { paths } }, null, 2)}\n`,
   );
   return configPath;
+}
+
+function writeFixtureVue(fixtureRoot: string, version: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", "vue");
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"vue","version":"${version}"}\n`);
 }
 
 test("an outside target with exactly one in-fixture copy is linked from that copy", () => {
@@ -97,6 +104,59 @@ test("a name no ancestor provides is left alone", () => {
     });
     assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), []);
     assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "defu")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("several copies collapse to the one whose Vue peer matches the fixture", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeFixtureVue(fixtureRoot, "3.5.30");
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.5.30", "vue-router");
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.5.13", "vue-router");
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.4.38", "vue-router");
+    const configPath = writeConfig(fixtureRoot, {
+      "vue-router": ["../../node_modules/vue-router"],
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      {
+        name: "vue-router",
+        target: "node_modules/.pnpm/vue-router@5.1.0_vue@3.5.30/node_modules/vue-router",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("several copies whose Vue peers miss the fixture stay unlinked", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeFixtureVue(fixtureRoot, "3.5.30");
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.5.13", "vue-router");
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.4.38", "vue-router");
+    const configPath = writeConfig(fixtureRoot, {
+      "vue-router": ["../../node_modules/vue-router"],
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-router")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("several copies that share the fixture Vue peer are still not guessed between", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeFixtureVue(fixtureRoot, "3.5.30");
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.5.30", "vue-router");
+    writeStoreCopy(fixtureRoot, "vue-router@4.5.1_vue@3.5.30", "vue-router");
+    const configPath = writeConfig(fixtureRoot, {
+      "vue-router": ["../../node_modules/vue-router"],
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-router")), false);
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });
   }

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -16,8 +16,9 @@ import { dirname, join, relative, resolve } from "node:path";
  * `typecheck-baseline-isolation.mjs` will not materialize an outside target —
  * that would import the contamination. If the fixture's own pnpm store holds
  * exactly one copy of that name, this links that copy instead of walking out to
- * Vize's. Multiple copies are different peer suffixes; this does not guess
- * which Vue they were built against.
+ * Vize's. Several copies are different Vue peer suffixes: this then picks the
+ * copy whose pnpm id matches the fixture's own `vue` version, and still does
+ * not guess when zero or several copies match.
  */
 
 const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
@@ -34,8 +35,8 @@ export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {
     if (existsSync(link) || isDanglingLink(link)) continue;
     if (isPackageDirectory(target) && isInside(root, target)) continue;
     const copies = findLocalCopies(root, name);
-    if (copies.length !== 1) continue;
-    const local = copies[0];
+    const local = selectLocalCopy(root, name, copies);
+    if (local == null) continue;
     mkdirSync(dirname(link), { recursive: true });
     symlinkSync(relative(dirname(link), local), link);
     shadowed.push({ name, target: relative(root, local).replaceAll("\\", "/") });
@@ -76,6 +77,45 @@ function findLocalCopies(fixtureRoot, name) {
     copies.set(real, packageDir);
   }
   return [...copies.values()].sort(compare);
+}
+
+function selectLocalCopy(fixtureRoot, name, copies) {
+  if (copies.length === 1) return copies[0];
+  if (copies.length === 0) return null;
+  const vueVersion = readFixtureVueVersion(fixtureRoot);
+  if (vueVersion == null) return null;
+  const matched = copies.filter((copy) => copyMatchesVue(fixtureRoot, name, copy, vueVersion));
+  return matched.length === 1 ? matched[0] : null;
+}
+
+function readFixtureVueVersion(fixtureRoot) {
+  const hoisted = readPackageVersion(join(fixtureRoot, "node_modules", "vue"));
+  if (hoisted != null) return hoisted;
+  const copies = findLocalCopies(fixtureRoot, "vue");
+  if (copies.length !== 1) return null;
+  return readPackageVersion(copies[0]);
+}
+
+function readPackageVersion(packageDir) {
+  try {
+    const pkg = JSON.parse(readFileSync(join(packageDir, "package.json"), "utf8"));
+    return typeof pkg.version === "string" && pkg.version !== "" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+function copyMatchesVue(fixtureRoot, name, packageDir, vueVersion) {
+  const store = join(fixtureRoot, "node_modules", ".pnpm");
+  const relativePath = relative(store, packageDir);
+  if (relativePath.startsWith("..") || relativePath.startsWith("/")) return false;
+  const id = relativePath.split(/[\\/]/)[0];
+  const marker = name === "vue" ? `vue@${vueVersion}` : `_vue@${vueVersion}`;
+  const index = id.indexOf(marker);
+  if (index === -1) return false;
+  if (name === "vue" && index !== 0) return false;
+  const end = index + marker.length;
+  return end === id.length || id[end] === "_" || id[end] === "(";
 }
 
 function parseTsconfig(configPath) {


### PR DESCRIPTION
## Summary
- When a fixture tsconfig maps a package outside the fixture and the local pnpm store holds **several** copies, pick the copy whose pnpm id matches the fixture's own `vue` version.
- Unique copies stay as they were. Zero or several matches still skip rather than guessing between router versions that share the same Vue peer.
- Part of #4461. Does not restore `typecheck_divergence_mode` to enforce.

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-isolation-unique.test.ts`
- [ ] CI `test-scripts` / Check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790103157&installation_model_id=422833&pr_number=4675&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4675&signature=d784728e8f12126114069c66ec67a03353cc648791d6c798371cd20c99de5f28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->