### PR TITLE
fix(matrix): follow corpusGlobs when materializing baseline include roots

### DIFF
--- a/tests/tooling/typecheck-baseline-project-composite.test.ts
+++ b/tests/tooling/typecheck-baseline-project-composite.test.ts
@@ -125,6 +125,36 @@ test(
   },
 );
 
+test("materialized baseline include roots follow corpusGlobs instead of sibling vueGlobs", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "vize-corpus-globs-baseline-"));
+  const fixtureRoot = path.join(temp, "fixture");
+  const reportDir = path.join(temp, "report");
+  fs.mkdirSync(path.join(fixtureRoot, "packages/lib"), { recursive: true });
+  fs.mkdirSync(path.join(fixtureRoot, "apps/volt"), { recursive: true });
+  fs.mkdirSync(reportDir);
+  fs.writeFileSync(path.join(fixtureRoot, "tsconfig.json"), "{}\n");
+  fs.writeFileSync(path.join(fixtureRoot, "packages/lib/Button.vue"), "<template />\n");
+  fs.writeFileSync(path.join(fixtureRoot, "apps/volt/Page.vue"), "<template />\n");
+  try {
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      {
+        id: "fixture",
+        tsconfig: "tsconfig.json",
+        vueGlobs: ["packages/lib/**/*.vue", "apps/volt/**/*.vue"],
+        typecheckPerformance: { corpusGlobs: ["packages/lib/**/*.vue"] },
+      },
+      { fileCount: 1, files: [{ file: "packages/lib/Button.vue" }] },
+    );
+    const config = JSON.parse(project.source);
+    assert.equal(config.include.includes("../packages/lib/**/*.ts"), true);
+    assert.equal(config.include.includes("../apps/volt/**/*.ts"), false);
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
 function runVueTsc(project: string, cwd: string) {
   return spawnSync(vueTsc, ["--noEmit", "--pretty", "false", "--listFiles", "-p", project], {
     cwd,

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -1,6 +1,8 @@
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
+import { typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
+
 /**
  * Materialize the exact Vue corpus Vize checked as a vue-tsc project.
  *
@@ -118,8 +120,9 @@ function configRelativePath(from, to) {
 }
 
 function vueGlobSourceRoots(fixtureRoot, project) {
-  if (!Array.isArray(project.vueGlobs)) return [];
-  return project.vueGlobs.map((glob) => resolve(fixtureRoot, literalGlobRoot(glob)));
+  const globs = typecheckCorpusGlobs(project);
+  if (!Array.isArray(globs)) return [];
+  return globs.map((glob) => resolve(fixtureRoot, literalGlobRoot(glob)));
 }
 
 function literalGlobRoot(glob) {


### PR DESCRIPTION
## Summary
- The materialized vue-tsc baseline used every `vueGlobs` tree as include roots, even when typecheck already narrows to `corpusGlobs`.
- PrimeVue still lists Volt and Showcase in `vueGlobs` for compiler/linter coverage; those apps now have their own typecheck entries. The library baseline should not pull those trees into include.
- Part of #4461. Does not restore `typecheck_divergence_mode` to enforce.

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-project-composite.test.ts tests/tooling/typecheck-baseline-project.test.ts`
- [ ] CI `test-scripts` / Check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790103637&installation_model_id=422833&pr_number=4676&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4676&signature=3f62174a02480c3ebced860349e3b5d43075100028d096a35858fbae80359477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected generated typecheck baselines to include only files matching the configured performance corpus.
  - Prevented unrelated application directories from being included when generating baseline configurations.

- **Tests**
  - Added coverage verifying that baseline include paths follow the configured corpus scope and exclude unrelated project areas.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->