### PR TITLE
fix(matrix): follow extends and references when linking unique type copies

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-unique-extends.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-unique-extends.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueLocalTypePackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * Isolation already follows `extends` / `references`. Unique repair used to
+ * read only the source config's own `paths`, so a check tsconfig that merely
+ * extends the generated app config never saw an outside mapping (#4461).
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-unique-extends-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, ".nuxt"), { recursive: true });
+  for (const name of ["vue-router", "@vue/runtime-core"]) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { outer, fixtureRoot };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+function writeAppPaths(fixtureRoot: string) {
+  const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.app.json");
+  fs.writeFileSync(
+    configPath,
+    `// generated\n${JSON.stringify(
+      { compilerOptions: { paths: { "vue-router": ["../../node_modules/vue-router"] } } },
+      null,
+      2,
+    )}\n`,
+  );
+  return configPath;
+}
+
+test("an outside mapping reached only through extends still links the unique copy", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0", "vue-router");
+    writeAppPaths(fixtureRoot);
+    const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.check.json");
+    fs.writeFileSync(configPath, `// check-only\n{ "extends": "./tsconfig.app.json", }\n`);
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      { name: "vue-router", target: "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router" },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside mapping reached only through references still links the unique copy", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0", "vue-router");
+    writeAppPaths(fixtureRoot);
+    const configPath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        files: [],
+        references: [{ path: "@vue/tsconfig" }, { path: "./.nuxt/tsconfig.app.json" }],
+      })}\n`,
+    );
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      { name: "vue-router", target: "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router" },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("several copies reached through extends are still not guessed between", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.5.30", "vue-router");
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.5.13", "vue-router");
+    writeAppPaths(fixtureRoot);
+    const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.check.json");
+    fs.writeFileSync(configPath, `{ "extends": "./tsconfig.app.json" }\n`);
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-router")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -1,13 +1,7 @@
-import {
-  existsSync,
-  lstatSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  realpathSync,
-  symlinkSync,
-} from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readdirSync, realpathSync, symlinkSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
+
+import { readDeclaredPackagePaths } from "./typecheck-baseline-isolation.mjs";
 
 /**
  * Close the remaining type-reference escape when Nuxt (or another generator)
@@ -18,13 +12,15 @@ import { dirname, join, relative, resolve } from "node:path";
  * exactly one copy of that name, this links that copy instead of walking out to
  * Vize's. Multiple copies are different peer suffixes; this does not guess
  * which Vue they were built against.
+ *
+ * Declared names come from the same `extends` / `references` walk isolation
+ * uses, so a check tsconfig that only extends the generated app config still
+ * sees the outside mapping (reka-ui's `tsconfig.check.json`).
  */
-
-const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
 
 export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {
   const root = resolve(fixtureRoot);
-  const declared = readOwnPackagePaths(sourceConfigPath);
+  const declared = readDeclaredPackagePaths(root, sourceConfigPath);
   if (declared.size === 0) return [];
   const reachable = collectAncestorPackageNames(root);
   const shadowed = [];
@@ -41,21 +37,6 @@ export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {
     shadowed.push({ name, target: relative(root, local).replaceAll("\\", "/") });
   }
   return shadowed;
-}
-
-function readOwnPackagePaths(sourceConfigPath) {
-  const declared = new Map();
-  const config = parseTsconfig(sourceConfigPath);
-  const paths = config?.compilerOptions?.paths;
-  if (paths == null || typeof paths !== "object") return declared;
-  const configDir = dirname(resolve(sourceConfigPath));
-  for (const [name, targets] of Object.entries(paths)) {
-    if (!packageNamePattern.test(name) || !Array.isArray(targets)) continue;
-    const first = targets.find((entry) => typeof entry === "string" && !entry.includes("*"));
-    if (first == null) continue;
-    declared.set(name, resolve(configDir, first));
-  }
-  return declared;
 }
 
 function findLocalCopies(fixtureRoot, name) {
@@ -76,14 +57,6 @@ function findLocalCopies(fixtureRoot, name) {
     copies.set(real, packageDir);
   }
   return [...copies.values()].sort(compare);
-}
-
-function parseTsconfig(configPath) {
-  try {
-    return JSON.parse(stripJsonc(readFileSync(configPath, "utf8")));
-  } catch {
-    return null;
-  }
 }
 
 function collectAncestorPackageNames(fixtureRoot) {
@@ -139,40 +112,4 @@ function isDanglingLink(link) {
 
 function compare(left, right) {
   return left < right ? -1 : left > right ? 1 : 0;
-}
-
-function stripJsonc(text) {
-  let out = "";
-  let inString = false;
-  for (let i = 0; i < text.length; i += 1) {
-    const ch = text[i];
-    if (inString) {
-      out += ch;
-      if (ch === "\\") {
-        out += text[i + 1] ?? "";
-        i += 1;
-      } else if (ch === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (ch === '"') {
-      inString = true;
-      out += ch;
-      continue;
-    }
-    if (ch === "/" && text[i + 1] === "/") {
-      while (i < text.length && text[i] !== "\n") i += 1;
-      out += "\n";
-      continue;
-    }
-    if (ch === "/" && text[i + 1] === "*") {
-      i += 2;
-      while (i + 1 < text.length && !(text[i] === "*" && text[i + 1] === "/")) i += 1;
-      i += 1;
-      continue;
-    }
-    out += ch;
-  }
-  return out.replace(/,(\s*[}\]])/g, "$1");
 }

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -71,7 +71,7 @@ export function isolateFixtureTypePackages(fixtureRoot, sourceConfigPath) {
   return shadowed;
 }
 
-function readDeclaredPackagePaths(fixtureRoot, sourceConfigPath) {
+export function readDeclaredPackagePaths(fixtureRoot, sourceConfigPath) {
   const declared = new Map();
   const conflicts = new Set();
   const seen = new Set();


### PR DESCRIPTION
## Summary
- Unique isolation used to read only the source tsconfig's own `paths`. Isolation already follows relative `extends` and `references`; unique repair now uses that same declared set.
- A check tsconfig that only extends the generated app config (reka-ui) can still link a unique in-fixture copy when the mapping points outside. Several copies are still not guessed between.
- Part of #4461. Does not restore `typecheck_divergence_mode` to enforce.

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-isolation-unique.test.ts tests/tooling/typecheck-baseline-isolation-unique-extends.test.ts tests/tooling/typecheck-baseline-isolation.test.ts`
- [ ] CI `test-scripts` / Check