### PR TITLE
fix(matrix): retarget outside tsconfig paths to fixture-local packages

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-paths.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-paths.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { rewriteOutsidePackagePaths } from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+import { materializeBaselineProject } from "../../tools/fixtures/typecheck-baseline-project.mjs";
+
+/**
+ * Unique isolation can link a fixture-local copy, but vue-tsc still honors
+ * `compilerOptions.paths`. When those mappings point above the fixture, the
+ * baseline loads Vize's Vue beside the fixture's (#4461).
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-outside-paths-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsideRouter = path.join(outer, "node_modules", "vue-router");
+  fs.mkdirSync(outsideRouter, { recursive: true });
+  fs.writeFileSync(path.join(outsideRouter, "package.json"), `{"name":"vue-router"}\n`);
+  return { outer, fixtureRoot, outsideRouter };
+}
+
+function writeLocalRouter(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "vue-router");
+  fs.mkdirSync(local, { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue-router"}\n`);
+  return local;
+}
+
+test("an outside package path is retargeted to the fixture-local copy", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    writeLocalRouter(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "#imports": ["./src/imports.d.ts"],
+            "vue-router": [path.relative(fixtureRoot, outsideRouter)],
+          },
+        },
+      })}\n`,
+    );
+    const configDir = path.join(fixtureRoot, ".vize-baseline");
+    assert.deepEqual(rewriteOutsidePackagePaths(fixtureRoot, sourcePath, configDir), {
+      "#imports": ["../src/imports.d.ts"],
+      "vue-router": ["../node_modules/vue-router"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside mapping reached only through extends is still retargeted", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    writeLocalRouter(fixtureRoot);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.app.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "vue-router": [path.relative(fixtureRoot, outsideRouter)] },
+        },
+      })}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.check.json");
+    fs.writeFileSync(sourcePath, `{ "extends": "./tsconfig.app.json" }\n`);
+    const configDir = path.join(fixtureRoot, ".vize-baseline");
+    assert.deepEqual(rewriteOutsidePackagePaths(fixtureRoot, sourcePath, configDir), {
+      "vue-router": ["../node_modules/vue-router"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside path with no fixture-local copy is left inherited", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "vue-router": [path.relative(fixtureRoot, outsideRouter)] },
+        },
+      })}\n`,
+    );
+    assert.equal(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("materialized baseline writes the retargeted paths onto the generated config", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    writeLocalRouter(fixtureRoot);
+    fs.writeFileSync(path.join(fixtureRoot, "src/App.vue"), "<template />\n");
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "vue-router": [path.relative(fixtureRoot, outsideRouter)] },
+        },
+      })}\n`,
+    );
+    const reportDir = path.join(outer, "report");
+    fs.mkdirSync(reportDir);
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      { id: "fixture", tsconfig: "tsconfig.json" },
+      { fileCount: 1, files: [{ file: "src/App.vue" }] },
+    );
+    assert.deepEqual(JSON.parse(project.source).compilerOptions.paths, {
+      "vue-router": ["../node_modules/vue-router"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -1,0 +1,159 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+/**
+ * Close the vue-tsc path escape unique isolation cannot see (#4461).
+ *
+ * Unique isolation links a fixture-local copy so `/// <reference types />`
+ * stops walking into Vize's `node_modules`. `compilerOptions.paths` is a
+ * different resolver: TypeScript uses the declared mapping and never consults
+ * that link. Nuxt-generated configs bake an absolute-looking relative path to
+ * a package *above* the fixture, so the baseline still loads Vize's Vue beside
+ * the fixture's.
+ *
+ * Setting `paths` on the generated baseline replaces the inherited object, so
+ * this copies every mapping, re-homes it to the generated config directory, and
+ * only then retargets package names whose original target is outside and whose
+ * fixture-local `node_modules/<name>` is already a real package. No rewrite
+ * means the generated config leaves `paths` unset and inherits.
+ */
+
+const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
+
+export function rewriteOutsidePackagePaths(fixtureRoot, sourceConfigPath, configDir) {
+  const root = resolve(fixtureRoot);
+  const declared = winningPaths(sourceConfigPath);
+  if (declared == null) return null;
+  const rewritten = {};
+  let changed = false;
+  for (const [name, targets] of Object.entries(declared.paths)) {
+    if (!Array.isArray(targets)) continue;
+    rewritten[name] = retargetPathMapping(root, declared.dir, configDir, name, targets, () => {
+      changed = true;
+    });
+  }
+  return changed ? rewritten : null;
+}
+
+function retargetPathMapping(fixtureRoot, sourceDir, configDir, name, targets, markChanged) {
+  const relocated = targets.map((entry) => relocatePathEntry(sourceDir, configDir, entry));
+  if (!packageNamePattern.test(name)) return relocated;
+  const first = targets.find((entry) => typeof entry === "string" && !entry.includes("*"));
+  if (first == null) return relocated;
+  const original = resolve(sourceDir, first);
+  if (isInside(fixtureRoot, original)) return relocated;
+  const local = join(fixtureRoot, "node_modules", ...name.split("/"));
+  if (!existsSync(join(local, "package.json"))) return relocated;
+  markChanged();
+  return relocated.map((entry, index) =>
+    index === targets.indexOf(first) ? configRelativePath(configDir, local) : entry,
+  );
+}
+
+function relocatePathEntry(sourceDir, configDir, entry) {
+  if (typeof entry !== "string" || entry.includes("*")) return entry;
+  return configRelativePath(configDir, resolve(sourceDir, entry));
+}
+
+function winningPaths(sourceConfigPath) {
+  let paths;
+  let dir;
+  for (const { config, dir: configDir } of [...loadExtendsChain(sourceConfigPath)].reverse()) {
+    const candidate = config?.compilerOptions?.paths;
+    if (candidate != null && typeof candidate === "object") {
+      paths = candidate;
+      dir = configDir;
+    }
+  }
+  return paths == null ? null : { paths, dir };
+}
+
+function loadExtendsChain(sourceConfigPath) {
+  const chain = [];
+  const seen = new Set();
+  let current = resolve(sourceConfigPath);
+  while (!seen.has(current)) {
+    seen.add(current);
+    const config = parseTsconfig(current);
+    if (config == null) break;
+    chain.push({ config, dir: dirname(current) });
+    const specifiers = extendsSpecifiers(config.extends);
+    let next = null;
+    for (const specifier of specifiers) {
+      next = resolveExtends(current, specifier);
+      if (next != null) break;
+    }
+    if (next == null) break;
+    current = next;
+  }
+  return chain;
+}
+
+function parseTsconfig(configPath) {
+  try {
+    return JSON.parse(stripJsonc(readFileSync(configPath, "utf8")));
+  } catch {
+    return null;
+  }
+}
+
+function extendsSpecifiers(value) {
+  if (typeof value === "string") return [value];
+  return Array.isArray(value) ? value.filter((entry) => typeof entry === "string") : [];
+}
+
+function resolveExtends(fromConfig, specifier) {
+  if (typeof specifier !== "string") return null;
+  if (!(specifier.startsWith("./") || specifier.startsWith("../"))) return null;
+  const resolved = resolve(dirname(fromConfig), specifier);
+  if (existsSync(resolved)) return resolved;
+  if (!resolved.endsWith(".json") && existsSync(`${resolved}.json`)) return `${resolved}.json`;
+  return null;
+}
+
+function isInside(root, target) {
+  const path = relative(root, target);
+  return path !== "" && !path.startsWith("..") && !path.startsWith("/");
+}
+
+function configRelativePath(from, to) {
+  const path = relative(from, to).replaceAll("\\", "/");
+  if (path.startsWith("/") || /^[A-Za-z]:\//u.test(path)) return path;
+  return path.startsWith(".") ? path : `./${path}`;
+}
+
+function stripJsonc(text) {
+  let out = "";
+  let inString = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inString) {
+      out += ch;
+      if (ch === "\\") {
+        out += text[i + 1] ?? "";
+        i += 1;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i += 1;
+      out += "\n";
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "*") {
+      i += 2;
+      while (i + 1 < text.length && !(text[i] === "*" && text[i + 1] === "/")) i += 1;
+      i += 1;
+      continue;
+    }
+    out += ch;
+  }
+  return out.replace(/,(\s*[}\]])/g, "$1");
+}

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
+import { rewriteOutsidePackagePaths } from "./typecheck-baseline-outside-paths.mjs";
 import { typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
 
 /**
@@ -94,6 +95,7 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
       // that directory becomes TS6059 noise and the baseline stops measuring
       // Vize. Pin it to the fixture corpus root instead.
       rootDir: configRelativePath(configDir, fixtureRoot),
+      ...outsidePackagePaths(fixtureRoot, sourcePath, configDir),
     },
     files: vizeReport.files
       .slice(0, vizeReport.fileCount)
@@ -111,6 +113,11 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
   writeFileSync(outputPath, source);
   writeFileSync(artifactPath, source);
   return { path: outputPath, source, sourceProject };
+}
+
+function outsidePackagePaths(fixtureRoot, sourcePath, configDir) {
+  const paths = rewriteOutsidePackagePaths(fixtureRoot, sourcePath, configDir);
+  return paths == null ? {} : { paths };
 }
 
 function configRelativePath(from, to) {


### PR DESCRIPTION
## Summary
- Unique isolation can link a fixture-local package so type-reference walks stop escaping. vue-tsc still uses `compilerOptions.paths`, and Nuxt-generated configs bake mappings that point *above* the fixture — that still loads Vize's Vue beside the fixture's.
- The materialized baseline now copies inherited `paths`, re-homes them to the generated config, and retargets package names whose original target is outside when `node_modules/<name>` is already a real local package. No local copy means `paths` stay inherited.
- Part of #4461. Does not restore `typecheck_divergence_mode` to enforce.

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-outside-paths.test.ts tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-baseline-project-composite.test.ts`
- [ ] CI `test-scripts` / Check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790104709&installation_model_id=422833&pr_number=4679&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4679&signature=096ba454070e5f39e2bcb876baff0bff2f783ab79007b5ca0a5e4440802b644a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->