### PR TITLE
fix(matrix): give Vize the same retargeted tsconfig paths as vue-tsc

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-paths.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-paths.test.ts
@@ -4,7 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
-import { rewriteOutsidePackagePaths } from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+import { toolArgs } from "../../tools/fixtures/tool-matrix-command.mjs";
+import {
+  isolatedTsconfigOverlayPath,
+  rewriteOutsidePackagePaths,
+  writeIsolatedTsconfigOverlay,
+} from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
 import { materializeBaselineProject } from "../../tools/fixtures/typecheck-baseline-project.mjs";
 
 /**
@@ -126,6 +131,139 @@ test("materialized baseline writes the retargeted paths onto the generated confi
     assert.deepEqual(JSON.parse(project.source).compilerOptions.paths, {
       "vue-router": ["../node_modules/vue-router"],
     });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("isolated overlay path sits beside the source tsconfig", () => {
+  assert.equal(isolatedTsconfigOverlayPath("tsconfig.json"), ".vize-isolated-tsconfig.json");
+  assert.equal(
+    isolatedTsconfigOverlayPath("playground/tsconfig.json"),
+    "playground/.vize-isolated-tsconfig.json",
+  );
+  assert.equal(
+    isolatedTsconfigOverlayPath("packages/core/tsconfig.check.json"),
+    "packages/core/.vize-isolated-tsconfig.check.json",
+  );
+});
+
+test("an untracked overlay retargets outside paths next to the source tsconfig", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    writeLocalRouter(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "#imports": ["./src/imports.d.ts"],
+            "vue-router": [path.relative(fixtureRoot, outsideRouter)],
+          },
+        },
+      })}\n`,
+    );
+    const overlay = writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath);
+    assert.equal(overlay.path, path.join(fixtureRoot, ".vize-isolated-tsconfig.json"));
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.json",
+      compilerOptions: {
+        paths: {
+          "#imports": ["./src/imports.d.ts"],
+          "vue-router": ["./node_modules/vue-router"],
+        },
+      },
+    });
+    assert.deepEqual(
+      toolArgs(
+        { vueGlobs: ["src/**/*.vue"], tsconfig: "tsconfig.json", fixturePath: fixtureRoot },
+        "typechecker",
+        "out",
+      ),
+      [
+        "check",
+        "src/**/*.vue",
+        "--format",
+        "json",
+        "--no-config",
+        "--tsconfig",
+        ".vize-isolated-tsconfig.json",
+      ],
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a nested overlay keeps rewritten paths relative to the source directory", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    writeLocalRouter(fixtureRoot);
+    const playground = path.join(fixtureRoot, "playground");
+    fs.mkdirSync(playground);
+    const sourcePath = path.join(playground, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "vue-router": [path.relative(playground, outsideRouter)] },
+        },
+      })}\n`,
+    );
+    const overlay = writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath);
+    assert.equal(overlay.path, path.join(playground, ".vize-isolated-tsconfig.json"));
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.json",
+      compilerOptions: { paths: { "vue-router": ["../node_modules/vue-router"] } },
+    });
+    assert.deepEqual(
+      toolArgs(
+        {
+          vueGlobs: ["playground/src/**/*.vue"],
+          tsconfig: "playground/tsconfig.json",
+          fixturePath: fixtureRoot,
+        },
+        "typechecker",
+        "out",
+      ),
+      [
+        "check",
+        "playground/src/**/*.vue",
+        "--format",
+        "json",
+        "--no-config",
+        "--tsconfig",
+        "playground/.vize-isolated-tsconfig.json",
+      ],
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("no overlay is written when there is no fixture-local package to retarget", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "vue-router": [path.relative(fixtureRoot, outsideRouter)] },
+        },
+      })}\n`,
+    );
+    assert.equal(writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath), null);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, ".vize-isolated-tsconfig.json")), false);
+    assert.deepEqual(
+      toolArgs(
+        { vueGlobs: ["src/**/*.vue"], tsconfig: "tsconfig.json", fixturePath: fixtureRoot },
+        "typechecker",
+        "out",
+      ),
+      ["check", "src/**/*.vue", "--format", "json", "--no-config", "--tsconfig", "tsconfig.json"],
+    );
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });
   }

--- a/tools/fixtures/tool-matrix-command.mjs
+++ b/tools/fixtures/tool-matrix-command.mjs
@@ -1,5 +1,23 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { isolatedTsconfigOverlayPath } from "./typecheck-baseline-outside-paths.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
 export function typecheckCorpusGlobs(project) {
   return project.typecheckPerformance?.corpusGlobs ?? project.vueGlobs;
+}
+
+export function typecheckTsconfigPath(project) {
+  if (typeof project.tsconfig !== "string") return null;
+  const overlayRel = isolatedTsconfigOverlayPath(project.tsconfig);
+  const overlayAbs =
+    typeof project.fixturePath === "string"
+      ? resolve(repoRoot, project.fixturePath, overlayRel)
+      : resolve(overlayRel);
+  return existsSync(overlayAbs) ? overlayRel : project.tsconfig;
 }
 
 export function toolArgs(project, tool, compilerOutputDir) {
@@ -34,7 +52,8 @@ export function toolArgs(project, tool, compilerOutputDir) {
     // files that config owns, or vue-tsc's baseline inherits the same
     // unresolvable aliases and the comparison reports fake FNs (#4454).
     const args = ["check", ...typecheckCorpusGlobs(project), "--format", "json", "--no-config"];
-    if (project.tsconfig != null) args.push("--tsconfig", project.tsconfig);
+    const tsconfig = typecheckTsconfigPath(project);
+    if (tsconfig != null) args.push("--tsconfig", tsconfig);
     return args;
   }
   return ["fmt", ...project.vueGlobs, "--check", "--no-config"];

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
 
 /**
  * Close the vue-tsc path escape unique isolation cannot see (#4461).
@@ -16,6 +16,11 @@ import { dirname, join, relative, resolve } from "node:path";
  * only then retargets package names whose original target is outside and whose
  * fixture-local `node_modules/<name>` is already a real package. No rewrite
  * means the generated config leaves `paths` unset and inherits.
+ *
+ * Vize's `check --tsconfig` still reads the fixture config, so a matching
+ * untracked overlay is written next to the source when a rewrite exists. Git
+ * porcelain uses `--untracked-files=no`, so the overlay does not dirty the
+ * fixture. The matrix typechecker prefers that overlay when it is present.
  */
 
 const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
@@ -33,6 +38,28 @@ export function rewriteOutsidePackagePaths(fixtureRoot, sourceConfigPath, config
     });
   }
   return changed ? rewritten : null;
+}
+
+export function isolatedTsconfigOverlayPath(sourceConfigPath) {
+  const dir = dirname(sourceConfigPath).replaceAll("\\", "/");
+  const name = basename(sourceConfigPath);
+  return dir === "." ? `.vize-isolated-${name}` : `${dir}/.vize-isolated-${name}`;
+}
+
+export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
+  const sourcePath = resolve(sourceConfigPath);
+  const rewritten = rewriteOutsidePackagePaths(fixtureRoot, sourcePath, dirname(sourcePath));
+  if (rewritten == null) return null;
+  const overlayPath = isolatedTsconfigOverlayPath(sourcePath);
+  writeFileSync(
+    overlayPath,
+    `${JSON.stringify(
+      { extends: `./${basename(sourcePath)}`, compilerOptions: { paths: rewritten } },
+      null,
+      2,
+    )}\n`,
+  );
+  return { path: overlayPath, paths: rewritten };
 }
 
 function retargetPathMapping(fixtureRoot, sourceDir, configDir, name, targets, markChanged) {

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
 import { isolateFixtureTypePackages } from "./typecheck-baseline-isolation.mjs";
 import { isolateUniqueLocalTypePackages } from "./typecheck-baseline-isolation-unique.mjs";
+import { writeIsolatedTsconfigOverlay } from "./typecheck-baseline-outside-paths.mjs";
 import { selectTypecheckPerformanceProjects } from "./typecheck-performance-shard.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -138,6 +139,13 @@ function isolateFixture(project, fixtureRoot) {
   ];
   for (const entry of shadowed) {
     process.stdout.write(`Linked ${project.id} node_modules/${entry.name} -> ${entry.target}\n`);
+  }
+  if (typeof project.tsconfig !== "string") return;
+  const overlay = writeIsolatedTsconfigOverlay(fixtureRoot, resolve(fixtureRoot, project.tsconfig));
+  if (overlay != null) {
+    process.stdout.write(
+      `Rewrote ${project.id} tsconfig paths -> ${relative(fixtureRoot, overlay.path)}\n`,
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Unique isolation can link a fixture-local copy, but Vize still honors `compilerOptions.paths` on the tracked tsconfig. After #4679, vue-tsc's generated baseline is retargeted; Vize was not.
- Write an untracked overlay beside the source tsconfig (git porcelain uses `--untracked-files=no`, so the fixture stays clean) and point `check --tsconfig` at that overlay when it exists.

## Test plan
- [x] `node --test` outside-paths overlay tests and typecheck corpus args
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790105805&installation_model_id=422833&pr_number=4680&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4680&signature=475b76da0d3966416c4c8635f9c945dcd3b2f0a3e1e32aeff74051698e02701d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->