### PR TITLE
fix(matrix): isolate package-name tsconfig extends to the fixture

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-package-extends.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-package-extends.test.ts
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { readDeclaredPackagePaths } from "../../tools/fixtures/typecheck-baseline-isolation.mjs";
+import {
+  ancestorPackagePath,
+  packageNameFromExtendsSpecifier,
+} from "../../tools/fixtures/typecheck-baseline-isolation-package-extends.mjs";
+import { isolateUniqueLocalTypePackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * Relative `extends` is already followed for `paths`. A package-name specifier
+ * is a different walk: TypeScript climbs `node_modules` and can load Vize's
+ * `@vue/tsconfig` (or `nuxt`) instead of the fixture's copy (#4461).
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-package-extends-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  const ancestor = path.join(outer, "node_modules", "@vue", "tsconfig");
+  fs.mkdirSync(ancestor, { recursive: true });
+  fs.writeFileSync(path.join(ancestor, "package.json"), `{"name":"@vue/tsconfig"}\n`);
+  return { ancestor, fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string) {
+  const packageRoot = path.join(
+    fixtureRoot,
+    "node_modules",
+    ".pnpm",
+    "@vue+tsconfig@0.5.0",
+    "node_modules",
+    "@vue",
+    "tsconfig",
+  );
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"@vue/tsconfig"}\n`);
+  return packageRoot;
+}
+
+test("package-name extends specifiers resolve to the package, not a subpath", () => {
+  assert.equal(packageNameFromExtendsSpecifier("@vue/tsconfig"), "@vue/tsconfig");
+  assert.equal(
+    packageNameFromExtendsSpecifier("@vue/tsconfig/tsconfig.dom.json"),
+    "@vue/tsconfig",
+  );
+  assert.equal(packageNameFromExtendsSpecifier("nuxt"), "nuxt");
+  assert.equal(packageNameFromExtendsSpecifier("nuxt/tsconfig"), "nuxt");
+  assert.equal(packageNameFromExtendsSpecifier("./tsconfig.app.json"), null);
+  assert.equal(packageNameFromExtendsSpecifier("../tsconfig.json"), null);
+});
+
+test("an ancestor package-name extends is recorded as the ancestor directory", () => {
+  const { ancestor, fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(configPath, `{ "extends": "@vue/tsconfig" }\n`);
+    assert.equal(ancestorPackagePath(fixtureRoot, "@vue/tsconfig"), ancestor);
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "@vue/tsconfig": ancestor,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a subpath package-name extends still names the package", () => {
+  const { ancestor, fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(configPath, `{ "extends": "@vue/tsconfig/tsconfig.dom.json" }\n`);
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "@vue/tsconfig": ancestor,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("unique isolation links the fixture copy of a package-name extends", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot);
+    const configPath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(configPath, `{ "extends": "@vue/tsconfig" }\n`);
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      {
+        name: "@vue/tsconfig",
+        target: "node_modules/.pnpm/@vue+tsconfig@0.5.0/node_modules/@vue/tsconfig",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("paths still win when the same name is also a package-name extends", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const local = path.join(fixtureRoot, "packages", "tsconfig");
+    fs.mkdirSync(local, { recursive: true });
+    fs.writeFileSync(path.join(local, "package.json"), `{"name":"@vue/tsconfig"}\n`);
+    const configPath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        extends: "@vue/tsconfig",
+        compilerOptions: { paths: { "@vue/tsconfig": ["./packages/tsconfig"] } },
+      })}\n`,
+    );
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "@vue/tsconfig": local,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a package-name extends with no fixture copy is left unlinked", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(configPath, `{ "extends": "@vue/tsconfig" }\n`);
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), []);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/typecheck-baseline-isolation-package-extends.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-package-extends.test.ts
@@ -46,10 +46,7 @@ function writeStoreCopy(fixtureRoot: string) {
 
 test("package-name extends specifiers resolve to the package, not a subpath", () => {
   assert.equal(packageNameFromExtendsSpecifier("@vue/tsconfig"), "@vue/tsconfig");
-  assert.equal(
-    packageNameFromExtendsSpecifier("@vue/tsconfig/tsconfig.dom.json"),
-    "@vue/tsconfig",
-  );
+  assert.equal(packageNameFromExtendsSpecifier("@vue/tsconfig/tsconfig.dom.json"), "@vue/tsconfig");
   assert.equal(packageNameFromExtendsSpecifier("nuxt"), "nuxt");
   assert.equal(packageNameFromExtendsSpecifier("nuxt/tsconfig"), "nuxt");
   assert.equal(packageNameFromExtendsSpecifier("./tsconfig.app.json"), null);

--- a/tools/fixtures/typecheck-baseline-isolation-package-extends.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-package-extends.mjs
@@ -21,7 +21,8 @@ export function packageNameFromExtendsSpecifier(specifier) {
     if (slash < 0) return null;
     const rest = specifier.slice(slash + 1);
     const second = rest.indexOf("/");
-    const name = second < 0 ? specifier : `${specifier.slice(0, slash + 1)}${rest.slice(0, second)}`;
+    const name =
+      second < 0 ? specifier : `${specifier.slice(0, slash + 1)}${rest.slice(0, second)}`;
     return packageNamePattern.test(name) ? name : null;
   }
   const name = specifier.split("/")[0];

--- a/tools/fixtures/typecheck-baseline-isolation-package-extends.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-package-extends.mjs
@@ -1,0 +1,43 @@
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+/**
+ * Package-name `extends` is a second walk out of the fixture (#4461).
+ *
+ * Isolation follows only relative `extends` for `paths`, so TypeScript still
+ * resolves `@vue/tsconfig` by climbing `node_modules` and can load Vize's copy.
+ * Recording the ancestor package lets unique isolation link the fixture's own
+ * pnpm copy first. The package config is not read for `paths` — that would
+ * load Vize's files.
+ */
+
+const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
+
+export function packageNameFromExtendsSpecifier(specifier) {
+  if (typeof specifier !== "string") return null;
+  if (specifier.startsWith("./") || specifier.startsWith("../")) return null;
+  if (specifier.startsWith("@")) {
+    const slash = specifier.indexOf("/", 1);
+    if (slash < 0) return null;
+    const rest = specifier.slice(slash + 1);
+    const second = rest.indexOf("/");
+    const name = second < 0 ? specifier : `${specifier.slice(0, slash + 1)}${rest.slice(0, second)}`;
+    return packageNamePattern.test(name) ? name : null;
+  }
+  const name = specifier.split("/")[0];
+  return packageNamePattern.test(name) ? name : null;
+}
+
+export function ancestorPackagePath(fixtureRoot, name) {
+  const root = resolve(fixtureRoot);
+  const segments = name.split("/");
+  let directory = dirname(root);
+  let previous = null;
+  while (directory !== previous) {
+    const candidate = join(directory, "node_modules", ...segments);
+    if (existsSync(join(candidate, "package.json"))) return candidate;
+    previous = directory;
+    directory = dirname(directory);
+  }
+  return null;
+}

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -24,7 +24,9 @@ import { readDeclaredPackagePaths } from "./typecheck-baseline-isolation.mjs";
  *
  * Declared names come from the same `extends` / `references` walk isolation
  * uses, so a check tsconfig that only extends the generated app config still
- * sees the outside mapping (reka-ui's `tsconfig.check.json`).
+ * sees the outside mapping (reka-ui's `tsconfig.check.json`). Package-name
+ * `extends` specifiers are included as ancestor targets so this can link the
+ * fixture's own `@vue/tsconfig` (or `nuxt`) before TypeScript climbs into Vize.
  */
 
 export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -9,6 +9,11 @@ import {
 } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 
+import {
+  ancestorPackagePath,
+  packageNameFromExtendsSpecifier,
+} from "./typecheck-baseline-isolation-package-extends.mjs";
+
 /**
  * Keep the fixture's type environment inside the fixture (run 31979524200).
  *
@@ -47,7 +52,9 @@ import { dirname, join, relative, resolve } from "node:path";
  * from relative `references` when that chain declares none — elk's root
  * `tsconfig.json` is solution-style and parks the real paths on referenced
  * `.nuxt` projects (#4461). Conflicting targets for one name are dropped
- * rather than guessed. Package-name specifiers are ignored, matching `extends`.
+ * rather than guessed. Package-name `extends` specifiers are recorded as
+ * ancestor targets so unique isolation can link a fixture-local copy; those
+ * package configs are not walked for `paths`.
  */
 
 /** `paths` also carries `#imports`-style aliases and `foo/*` patterns, which are not packages. */
@@ -93,7 +100,22 @@ export function readDeclaredPackagePaths(fixtureRoot, sourceConfigPath) {
       queue.push(next);
     }
   }
+  mergePackageExtends(declared, conflicts, seen, fixtureRoot);
   return declared;
+}
+
+function mergePackageExtends(declared, conflicts, configPaths, fixtureRoot) {
+  for (const configPath of configPaths) {
+    const config = parseTsconfig(configPath);
+    if (config == null) continue;
+    for (const specifier of extendsSpecifiers(config.extends)) {
+      const name = packageNameFromExtendsSpecifier(specifier);
+      if (name == null || conflicts.has(name) || declared.has(name)) continue;
+      const ancestor = ancestorPackagePath(fixtureRoot, name);
+      if (ancestor == null) continue;
+      declared.set(name, ancestor);
+    }
+  }
 }
 
 function packagePathsFromExtends(sourceConfigPath) {


### PR DESCRIPTION
## Summary
- Isolation already follows relative `extends` for `compilerOptions.paths`. A package-name specifier (`@vue/tsconfig`, `nuxt/tsconfig`) is a different walk: TypeScript climbs `node_modules` and can load Vize's copy.
- Record those specifiers as ancestor targets so unique isolation can link the fixture's own pnpm copy. The package config is not read for `paths` (that would load Vize's files). `paths` still win when the same name is already mapped.

## Test plan
- [x] `node --test` package-extends isolation tests plus existing isolation / unique-extends / references tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790106224&installation_model_id=422833&pr_number=4681&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4681&signature=af18581face3fb2c3c6097087a22dea9b2229151df3230253dd103f90366e543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TypeScript configuration isolation for package-based `extends` references.
  - Local configuration packages, including scoped and nested packages, are now resolved more reliably.
  - Existing path mappings and configuration precedence are preserved during resolution.
  - Unavailable packages are safely ignored instead of causing incorrect links or resolution failures.

- **Tests**
  - Added coverage for package discovery, nested paths, precedence handling, temporary package layouts, and missing-package scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->