### PR TITLE
fix(matrix): isolate both Vize and vue-tsc tsconfigs when they differ

### DIFF
--- a/tests/tooling/typecheck-dependency-prepare-isolation-tsconfigs.test.ts
+++ b/tests/tooling/typecheck-dependency-prepare-isolation-tsconfigs.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { isolationTsconfigPaths } from "../../tools/fixtures/typecheck-dependency-prepare.mjs";
+
+/**
+ * Vize's `--tsconfig` and vue-tsc's baseline config can differ (Nuxt Volt).
+ * Isolation used to walk only the baseline, so packages declared only on
+ * Vize's config still escaped into Vize's `node_modules` (#4461).
+ */
+
+test("isolation walks the baseline tsconfig and Vize's tsconfig when they differ", () => {
+  assert.deepEqual(
+    isolationTsconfigPaths({
+      tsconfig: "apps/volt/tsconfig.json",
+      typecheckPerformance: { baseline: { tsconfig: "apps/volt/.nuxt/tsconfig.json" } },
+    }),
+    ["apps/volt/.nuxt/tsconfig.json", "apps/volt/tsconfig.json"],
+  );
+});
+
+test("isolation does not walk the same tsconfig twice", () => {
+  assert.deepEqual(isolationTsconfigPaths({ tsconfig: "tsconfig.json" }), ["tsconfig.json"]);
+});
+
+test("isolation follows the baseline tsconfig when Vize's is omitted", () => {
+  assert.deepEqual(
+    isolationTsconfigPaths({
+      typecheckPerformance: { baseline: { tsconfig: ".nuxt/tsconfig.app.json" } },
+    }),
+    [".nuxt/tsconfig.app.json"],
+  );
+});

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -125,18 +125,37 @@ function prepareProjectDependencies({ args, commitSha, project }) {
  * Link the packages the fixture's own config maps but its package manager did
  * not hoist, so a `/// <reference types="..." />` inside the fixture cannot be
  * answered by Vize's own `node_modules` further up the tree (run 31979524200).
- * Reported on
- * stdout rather than into the artifact: what the run has to prove is the
- * outcome, and `typecheck-baseline-ambient.mjs` proves that from the program
- * listing regardless of how the tree got there.
+ * When Vize's `--tsconfig` and vue-tsc's baseline config differ (Nuxt Volt:
+ * `apps/volt/tsconfig.json` vs `apps/volt/.nuxt/tsconfig.json`), both are
+ * walked. Reported on stdout rather than into the artifact: what the run has
+ * to prove is the outcome, and `typecheck-baseline-ambient.mjs` proves that
+ * from the program listing regardless of how the tree got there.
  */
+export function isolationTsconfigPaths(project) {
+  const paths = [];
+  const seen = new Set();
+  for (const candidate of [project.typecheckPerformance?.baseline?.tsconfig, project.tsconfig]) {
+    if (typeof candidate !== "string" || seen.has(candidate)) continue;
+    seen.add(candidate);
+    paths.push(candidate);
+  }
+  return paths;
+}
+
 function isolateFixture(project, fixtureRoot) {
-  const sourceProject = project.typecheckPerformance.baseline?.tsconfig ?? project.tsconfig;
-  const sourceConfig = resolve(fixtureRoot, sourceProject);
-  const shadowed = [
-    ...isolateFixtureTypePackages(fixtureRoot, sourceConfig),
-    ...isolateUniqueLocalTypePackages(fixtureRoot, sourceConfig),
-  ];
+  const shadowed = [];
+  const seen = new Set();
+  for (const relativeConfig of isolationTsconfigPaths(project)) {
+    const sourceConfig = resolve(fixtureRoot, relativeConfig);
+    for (const entry of [
+      ...isolateFixtureTypePackages(fixtureRoot, sourceConfig),
+      ...isolateUniqueLocalTypePackages(fixtureRoot, sourceConfig),
+    ]) {
+      if (seen.has(entry.name)) continue;
+      seen.add(entry.name);
+      shadowed.push(entry);
+    }
+  }
   for (const entry of shadowed) {
     process.stdout.write(`Linked ${project.id} node_modules/${entry.name} -> ${entry.target}\n`);
   }


### PR DESCRIPTION
## Summary
- After #4680, Vize and vue-tsc can still use different tsconfigs (Nuxt Volt: `apps/volt/tsconfig.json` vs `apps/volt/.nuxt/tsconfig.json`). Isolation walked only the baseline, so packages declared only on Vize's config could still resolve from Vize's `node_modules`.
- Walk both configs (once each) before writing the untracked overlay. Same path is not isolated twice.

## Test plan
- [x] `node --test` isolation tsconfig path selection
- [x] `vp check` on the touched files
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790106677&installation_model_id=422833&pr_number=4682&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4682&signature=273ce65d099b82bbdc698a0273932cda5885765aecc8bcf2e4400af0027c0324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript dependency isolation when projects use multiple configuration files.
  * Ensured packages declared in any applicable configuration are isolated correctly.
  * Prevented duplicate processing when the same configuration is referenced more than once.

* **Tests**
  * Added coverage for multiple configuration files, single-configuration setups, and baseline-only scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->