### PR TITLE
fix(matrix): follow in-fixture package-name extends when rewriting paths

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-paths-package-extends.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-paths-package-extends.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { rewriteOutsidePackagePaths } from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+
+/**
+ * Overlay rewrite used to follow only relative `extends`. A package-name
+ * specifier is a different walk: TypeScript climbs `node_modules` and can load
+ * Vize's `@vue/tsconfig`, whose `paths` still point above the fixture (#4461).
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-overlay-package-extends-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsideRouter = path.join(outer, "node_modules", "vue-router");
+  fs.mkdirSync(outsideRouter, { recursive: true });
+  fs.writeFileSync(path.join(outsideRouter, "package.json"), `{"name":"vue-router"}\n`);
+  return { fixtureRoot, outer, outsideRouter };
+}
+
+function writeLocalRouter(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "vue-router");
+  fs.mkdirSync(local, { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue-router"}\n`);
+  return local;
+}
+
+function writeVueTsconfig(packageRoot: string, outsideRouter: string, fileName = "tsconfig.json") {
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"@vue/tsconfig"}\n`);
+  fs.writeFileSync(
+    path.join(packageRoot, fileName),
+    `${JSON.stringify({
+      compilerOptions: {
+        paths: { "vue-router": [path.relative(packageRoot, outsideRouter)] },
+      },
+    })}\n`,
+  );
+}
+
+test("an outside mapping reached only through a fixture package-name extends is retargeted", () => {
+  const { fixtureRoot, outer, outsideRouter } = scaffold();
+  try {
+    writeLocalRouter(fixtureRoot);
+    writeVueTsconfig(path.join(fixtureRoot, "node_modules", "@vue", "tsconfig"), outsideRouter);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(sourcePath, `{ "extends": "@vue/tsconfig" }\n`);
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "vue-router": ["../node_modules/vue-router"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a subpath package-name extends still contributes its outside mapping", () => {
+  const { fixtureRoot, outer, outsideRouter } = scaffold();
+  try {
+    writeLocalRouter(fixtureRoot);
+    writeVueTsconfig(
+      path.join(fixtureRoot, "node_modules", "@vue", "tsconfig"),
+      outsideRouter,
+      "tsconfig.dom.json",
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(sourcePath, `{ "extends": "@vue/tsconfig/tsconfig.dom.json" }\n`);
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "vue-router": ["../node_modules/vue-router"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a package-name extends that lives only above the fixture is not followed", () => {
+  const { fixtureRoot, outer, outsideRouter } = scaffold();
+  try {
+    writeLocalRouter(fixtureRoot);
+    writeVueTsconfig(path.join(outer, "node_modules", "@vue", "tsconfig"), outsideRouter);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(sourcePath, `{ "extends": "@vue/tsconfig" }\n`);
+    assert.equal(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -21,13 +21,17 @@ import { basename, dirname, join, relative, resolve } from "node:path";
  * untracked overlay is written next to the source when a rewrite exists. Git
  * porcelain uses `--untracked-files=no`, so the overlay does not dirty the
  * fixture. The matrix typechecker prefers that overlay when it is present.
+ *
+ * Package-name `extends` is followed only inside the fixture. Climbing into
+ * Vize's `node_modules` would load Vize's `@vue/tsconfig` and bake its
+ * outside `paths` into the overlay.
  */
 
 const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
 
 export function rewriteOutsidePackagePaths(fixtureRoot, sourceConfigPath, configDir) {
   const root = resolve(fixtureRoot);
-  const declared = winningPaths(sourceConfigPath);
+  const declared = winningPaths(sourceConfigPath, root);
   if (declared == null) return null;
   const rewritten = {};
   let changed = false;
@@ -82,10 +86,12 @@ function relocatePathEntry(sourceDir, configDir, entry) {
   return configRelativePath(configDir, resolve(sourceDir, entry));
 }
 
-function winningPaths(sourceConfigPath) {
+function winningPaths(sourceConfigPath, fixtureRoot) {
   let paths;
   let dir;
-  for (const { config, dir: configDir } of [...loadExtendsChain(sourceConfigPath)].reverse()) {
+  for (const { config, dir: configDir } of [
+    ...loadExtendsChain(sourceConfigPath, fixtureRoot),
+  ].reverse()) {
     const candidate = config?.compilerOptions?.paths;
     if (candidate != null && typeof candidate === "object") {
       paths = candidate;
@@ -95,7 +101,7 @@ function winningPaths(sourceConfigPath) {
   return paths == null ? null : { paths, dir };
 }
 
-function loadExtendsChain(sourceConfigPath) {
+function loadExtendsChain(sourceConfigPath, fixtureRoot) {
   const chain = [];
   const seen = new Set();
   let current = resolve(sourceConfigPath);
@@ -107,7 +113,7 @@ function loadExtendsChain(sourceConfigPath) {
     const specifiers = extendsSpecifiers(config.extends);
     let next = null;
     for (const specifier of specifiers) {
-      next = resolveExtends(current, specifier);
+      next = resolveExtends(current, specifier, fixtureRoot);
       if (next != null) break;
     }
     if (next == null) break;
@@ -129,12 +135,62 @@ function extendsSpecifiers(value) {
   return Array.isArray(value) ? value.filter((entry) => typeof entry === "string") : [];
 }
 
-function resolveExtends(fromConfig, specifier) {
+function resolveExtends(fromConfig, specifier, fixtureRoot) {
   if (typeof specifier !== "string") return null;
-  if (!(specifier.startsWith("./") || specifier.startsWith("../"))) return null;
-  const resolved = resolve(dirname(fromConfig), specifier);
-  if (existsSync(resolved)) return resolved;
-  if (!resolved.endsWith(".json") && existsSync(`${resolved}.json`)) return `${resolved}.json`;
+  if (specifier.startsWith("./") || specifier.startsWith("../")) {
+    const resolved = resolve(dirname(fromConfig), specifier);
+    if (existsSync(resolved)) return resolved;
+    if (!resolved.endsWith(".json") && existsSync(`${resolved}.json`)) return `${resolved}.json`;
+    return null;
+  }
+  return resolvePackageExtends(fromConfig, specifier, fixtureRoot);
+}
+
+function resolvePackageExtends(fromConfig, specifier, fixtureRoot) {
+  const parsed = splitPackageExtends(specifier);
+  if (parsed == null) return null;
+  const root = resolve(fixtureRoot);
+  let directory = dirname(resolve(fromConfig));
+  let previous = null;
+  while (directory !== previous) {
+    if (!(directory === root || isInside(root, directory))) break;
+    const pkg = join(directory, "node_modules", ...parsed.name.split("/"));
+    const file = packageExtendsFile(pkg, parsed.subpath);
+    if (file != null) return file;
+    if (directory === root) break;
+    previous = directory;
+    directory = dirname(directory);
+  }
+  return null;
+}
+
+function splitPackageExtends(specifier) {
+  if (specifier.startsWith("@")) {
+    const slash = specifier.indexOf("/");
+    if (slash < 0) return null;
+    const rest = specifier.slice(slash + 1);
+    const second = rest.indexOf("/");
+    if (second < 0) return { name: specifier, subpath: null };
+    return {
+      name: `${specifier.slice(0, slash + 1)}${rest.slice(0, second)}`,
+      subpath: rest.slice(second + 1),
+    };
+  }
+  if (specifier.includes(":")) return null;
+  const slash = specifier.indexOf("/");
+  if (slash < 0) return { name: specifier, subpath: null };
+  return { name: specifier.slice(0, slash), subpath: specifier.slice(slash + 1) };
+}
+
+function packageExtendsFile(pkg, subpath) {
+  if (!existsSync(join(pkg, "package.json"))) return null;
+  if (subpath == null) {
+    const main = join(pkg, "tsconfig.json");
+    return existsSync(main) ? main : null;
+  }
+  const file = join(pkg, subpath);
+  if (existsSync(file)) return file;
+  if (!file.endsWith(".json") && existsSync(`${file}.json`)) return `${file}.json`;
   return null;
 }
 


### PR DESCRIPTION
## Summary
- Overlay / vue-tsc path rewrite followed only relative `extends`. A package-name specifier (`@vue/tsconfig`) is a different walk: TypeScript climbs `node_modules` and can load Vize's copy, whose `paths` still point above the fixture.
- Resolve package-name `extends` only inside the fixture (including subpaths like `@vue/tsconfig/tsconfig.dom.json`). Ancestor copies are not followed, so Vize's `@vue/tsconfig` cannot bake outside mappings into the overlay.

## Test plan
- [x] `node --test` overlay rewrite tests (existing + package-name extends)
- [x] `vp check` on the touched files
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790106925&installation_model_id=422833&pr_number=4683&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4683&signature=babf35654ebe7ef698322fcf5c784a703cdd64adb740d88a677f8c8b906c9db0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->