### PR TITLE
fix(matrix): isolate compilerOptions.types packages to the fixture

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-types.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-types.test.ts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { readDeclaredPackagePaths } from "../../tools/fixtures/typecheck-baseline-isolation.mjs";
+import { isolateUniqueLocalTypePackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+import { typePackageNamesFromTypes } from "../../tools/fixtures/typecheck-baseline-isolation-types.mjs";
+
+/**
+ * `compilerOptions.types` is a type-reference walk out of the fixture (#4461).
+ * Overlay cannot retarget it; unique isolation links the fixture copy of each
+ * named package (and `@types/<name>` for unscoped entries). Package-name
+ * `extends` configs are not read for `types`.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-types-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  const ancestorVite = path.join(outer, "node_modules", "vite");
+  fs.mkdirSync(ancestorVite, { recursive: true });
+  fs.writeFileSync(path.join(ancestorVite, "package.json"), `{"name":"vite"}\n`);
+  const ancestorNode = path.join(outer, "node_modules", "@types", "node");
+  fs.mkdirSync(ancestorNode, { recursive: true });
+  fs.writeFileSync(path.join(ancestorNode, "package.json"), `{"name":"@types/node"}\n`);
+  const ancestorVueTsconfig = path.join(outer, "node_modules", "@vue", "tsconfig");
+  fs.mkdirSync(ancestorVueTsconfig, { recursive: true });
+  fs.writeFileSync(path.join(ancestorVueTsconfig, "package.json"), `{"name":"@vue/tsconfig"}\n`);
+  fs.writeFileSync(
+    path.join(ancestorVueTsconfig, "tsconfig.json"),
+    `${JSON.stringify({ compilerOptions: { types: ["vite/client"] } })}\n`,
+  );
+  return { ancestorNode, ancestorVite, ancestorVueTsconfig, fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+function writeConfig(fixtureRoot: string, config: unknown, fileName = "tsconfig.json") {
+  const configPath = path.join(fixtureRoot, fileName);
+  fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+  return configPath;
+}
+
+test("types entries resolve to the package and @types package for unscoped names", () => {
+  assert.deepEqual(typePackageNamesFromTypes(["vite/client"]), ["vite", "@types/vite"]);
+  assert.deepEqual(typePackageNamesFromTypes(["node"]), ["node", "@types/node"]);
+  assert.deepEqual(typePackageNamesFromTypes(["@vue/runtime-dom"]), ["@vue/runtime-dom"]);
+  assert.deepEqual(typePackageNamesFromTypes([]), []);
+  assert.deepEqual(typePackageNamesFromTypes(undefined), []);
+});
+
+test("compilerOptions.types records ancestor packages for unique isolation", () => {
+  const { ancestorVite, fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: { types: ["vite/client"] },
+    });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      vite: ancestorVite,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("compilerOptions.types node records the ancestor @types/node package", () => {
+  const { ancestorNode, fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: { types: ["node"] },
+    });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "@types/node": ancestorNode,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("unique isolation links the fixture copy of a types package", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vite@6.0.0", "vite");
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: { types: ["vite/client"] },
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      { name: "vite", target: "node_modules/.pnpm/vite@6.0.0/node_modules/vite" },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("types on a relative extends parent are recorded", () => {
+  const { ancestorVite, fixtureRoot, outer } = scaffold();
+  try {
+    writeConfig(fixtureRoot, { compilerOptions: { types: ["vite/client"] } }, "tsconfig.app.json");
+    const configPath = writeConfig(fixtureRoot, { extends: "./tsconfig.app.json" });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      vite: ancestorVite,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("child types replace parent types", () => {
+  const { ancestorNode, fixtureRoot, outer } = scaffold();
+  try {
+    writeConfig(fixtureRoot, { compilerOptions: { types: ["vite/client"] } }, "tsconfig.app.json");
+    const configPath = writeConfig(fixtureRoot, {
+      extends: "./tsconfig.app.json",
+      compilerOptions: { types: ["node"] },
+    });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "@types/node": ancestorNode,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("package-name extends is not walked for types", () => {
+  const { ancestorVueTsconfig, fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, { extends: "@vue/tsconfig" });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "@vue/tsconfig": ancestorVueTsconfig,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("paths still win when the same name is also a types entry", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const local = path.join(fixtureRoot, "packages", "vite");
+    fs.mkdirSync(local, { recursive: true });
+    fs.writeFileSync(path.join(local, "package.json"), `{"name":"vite"}\n`);
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: {
+        types: ["vite/client"],
+        paths: { vite: ["./packages/vite"] },
+      },
+    });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      vite: local,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("typeRoots directories are not recorded as packages", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: { typeRoots: ["./typings"] },
+    });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {});
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a types package with no fixture copy is left unlinked", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: { types: ["vite/client"] },
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), []);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-types.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-types.mjs
@@ -1,0 +1,45 @@
+import {
+  ancestorPackagePath,
+  packageNameFromExtendsSpecifier,
+} from "./typecheck-baseline-isolation-package-extends.mjs";
+
+/**
+ * `compilerOptions.types` is another walk out of the fixture (#4461).
+ *
+ * TypeScript resolves each entry as a type-reference directive: it looks in
+ * `typeRoots` (default `node_modules/@types`) and in `node_modules/<name>`,
+ * climbing out of the fixture. Overlay cannot retarget that walk. Recording
+ * the package — and `@types/<name>` for unscoped entries — as ancestor
+ * targets lets unique isolation link the fixture's own copy first.
+ *
+ * Package-name `extends` configs are not read for `types`, matching `paths`.
+ * `typeRoots` is a directory list, not a package name; outside `typeRoots`
+ * belong to overlay rewrite, not unique-link.
+ */
+
+export function typePackageNamesFromTypes(types) {
+  const names = [];
+  const seen = new Set();
+  if (!Array.isArray(types)) return names;
+  for (const entry of types) {
+    const name = packageNameFromExtendsSpecifier(entry);
+    if (name == null || seen.has(name)) continue;
+    seen.add(name);
+    names.push(name);
+    if (name.startsWith("@")) continue;
+    const ambient = `@types/${name}`;
+    if (seen.has(ambient)) continue;
+    seen.add(ambient);
+    names.push(ambient);
+  }
+  return names;
+}
+
+export function recordCompilerOptionTypes(declared, conflicts, fixtureRoot, types) {
+  for (const name of typePackageNamesFromTypes(types)) {
+    if (conflicts.has(name) || declared.has(name)) continue;
+    const ancestor = ancestorPackagePath(fixtureRoot, name);
+    if (ancestor == null) continue;
+    declared.set(name, ancestor);
+  }
+}

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -25,8 +25,9 @@ import { readDeclaredPackagePaths } from "./typecheck-baseline-isolation.mjs";
  * Declared names come from the same `extends` / `references` walk isolation
  * uses, so a check tsconfig that only extends the generated app config still
  * sees the outside mapping (reka-ui's `tsconfig.check.json`). Package-name
- * `extends` specifiers are included as ancestor targets so this can link the
- * fixture's own `@vue/tsconfig` (or `nuxt`) before TypeScript climbs into Vize.
+ * `extends` specifiers and `compilerOptions.types` entries are included as
+ * ancestor targets so this can link the fixture's own `@vue/tsconfig`, `vite`,
+ * or `@types/node` before TypeScript climbs into Vize.
  */
 
 export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -13,6 +13,7 @@ import {
   ancestorPackagePath,
   packageNameFromExtendsSpecifier,
 } from "./typecheck-baseline-isolation-package-extends.mjs";
+import { recordCompilerOptionTypes } from "./typecheck-baseline-isolation-types.mjs";
 
 /**
  * Keep the fixture's type environment inside the fixture (run 31979524200).
@@ -52,9 +53,10 @@ import {
  * from relative `references` when that chain declares none — elk's root
  * `tsconfig.json` is solution-style and parks the real paths on referenced
  * `.nuxt` projects (#4461). Conflicting targets for one name are dropped
- * rather than guessed. Package-name `extends` specifiers are recorded as
- * ancestor targets so unique isolation can link a fixture-local copy; those
- * package configs are not walked for `paths`.
+ * rather than guessed. Package-name `extends` specifiers and
+ * `compilerOptions.types` entries are recorded as ancestor targets so unique
+ * isolation can link a fixture-local copy; those package configs are not
+ * walked for `paths` or `types`.
  */
 
 /** `paths` also carries `#imports`-style aliases and `foo/*` patterns, which are not packages. */
@@ -115,6 +117,12 @@ function mergePackageExtends(declared, conflicts, configPaths, fixtureRoot) {
       if (ancestor == null) continue;
       declared.set(name, ancestor);
     }
+    let types;
+    for (const { config: chained } of [...loadExtendsChain(configPath)].reverse()) {
+      const candidate = chained?.compilerOptions?.types;
+      if (Array.isArray(candidate)) types = candidate;
+    }
+    recordCompilerOptionTypes(declared, conflicts, fixtureRoot, types);
   }
 }
 


### PR DESCRIPTION
## Summary
- TypeScript resolves `compilerOptions.types` by climbing `node_modules` (`typeRoots`, then `@types/<name>` / `<name>`), so a fixture can load Vize's `vite` or `@types/node` and then Vize's Vue.
- Record those package names as ancestor targets so unique isolation can link the fixture's own pnpm copy first. Package-name `extends` configs are still not read for `types`. Overlay cannot retarget this walk.
- `typeRoots` is a directory list, not a package name; this slice does not unique-link it.

## Test plan
- [x] `node --test` types isolation tests plus existing isolation / unique / package-extends / references tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790107917&installation_model_id=422833&pr_number=4684&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4684&signature=117558a45d2d8fc93edbbc25c66d03ca7c37e37557b02d13ebf9de9396416b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript fixture isolation by correctly resolving packages declared through `compilerOptions.types`.
  * Added support for inherited configuration and child configuration overrides.
  * Improved handling of scoped packages, `@types` packages, path mappings, ignored type roots, and missing local fixtures.

* **Tests**
  * Added comprehensive coverage for type-package discovery, package linking, configuration inheritance, resolution precedence, and cleanup scenarios.

* **Documentation**
  * Clarified how package extensions and declared type packages are handled during fixture isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->