### PR TITLE
fix(musea): parse CLI art files with native status

### DIFF
--- a/npm/builder/vite-musea/src/cli/utils.test.ts
+++ b/npm/builder/vite-musea/src/cli/utils.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { scanArtFiles } from "./utils.ts";
+import { parseArtFile, scanArtFiles } from "./utils.ts";
 
 void test("scanArtFiles skips unreadable directories", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-musea-scan-"));
@@ -20,6 +20,91 @@ void test("scanArtFiles skips unreadable directories", async () => {
     assert.deepEqual(files, [path.join(root, "Button.art.vue")]);
   } finally {
     fs.chmodSync(locked, 0o700);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function writeArtFile(root: string, source: string): string {
+  const artPath = path.join(root, "Button.art.vue");
+  fs.writeFileSync(artPath, source);
+  return artPath;
+}
+
+void test("parseArtFile reports native draft for unknown art status", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-musea-parse-wip-"));
+  const warnings: string[] = [];
+  const warn = console.warn;
+  console.warn = (message: string) => {
+    warnings.push(String(message));
+  };
+
+  try {
+    const artPath = writeArtFile(
+      root,
+      `<art title="Button" component="Button" status="wip">
+  <variant name="Default" default>
+    <Button />
+  </variant>
+</art>
+`,
+    );
+    const parsed = await parseArtFile(artPath);
+    assert.equal(parsed?.metadata.status, "draft");
+    assert.deepEqual(warnings, [
+      `[musea] ${artPath}: unknown status "wip"; falling back to "draft" (expected "draft" | "ready" | "deprecated")`,
+    ]);
+  } finally {
+    console.warn = warn;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+void test("parseArtFile keeps native ready status", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-musea-parse-ready-"));
+  const warnings: string[] = [];
+  const warn = console.warn;
+  console.warn = (message: string) => {
+    warnings.push(String(message));
+  };
+
+  try {
+    const artPath = writeArtFile(
+      root,
+      `<art title="Button" component="Button" status="ready">
+  <variant name="Default" default>
+    <Button />
+  </variant>
+</art>
+`,
+    );
+    const parsed = await parseArtFile(artPath);
+    assert.equal(parsed?.metadata.status, "ready");
+    assert.deepEqual(warnings, []);
+  } finally {
+    console.warn = warn;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+void test("parseArtFile returns null when native parse fails", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-musea-parse-bad-"));
+  const errors: string[] = [];
+  const error = console.error;
+  console.error = (message: string) => {
+    errors.push(String(message));
+  };
+
+  try {
+    const artPath = writeArtFile(root, "<art></art>");
+    const parsed = await parseArtFile(artPath);
+    assert.equal(parsed, null);
+    assert.equal(errors.length, 1);
+    assert.equal(
+      errors[0],
+      `[musea] Failed to process Button.art.vue: Missing required 'title' attribute in <art> block`,
+    );
+  } finally {
+    console.error = error;
     fs.rmSync(root, { recursive: true, force: true });
   }
 });

--- a/npm/builder/vite-musea/src/cli/utils.ts
+++ b/npm/builder/vite-musea/src/cli/utils.ts
@@ -7,6 +7,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { processMuseaArtFile } from "../plugin/art-processing.js";
 import type { ArtFileInfo } from "../types/index.js";
 
 /** Recursively scan a directory for .art.vue files. */
@@ -46,52 +47,8 @@ export async function scanArtFiles(root: string): Promise<string[]> {
 
 /** Parse a single .art.vue file into an ArtFileInfo structure. */
 export async function parseArtFile(filePath: string): Promise<ArtFileInfo | null> {
-  try {
-    const source = await fs.promises.readFile(filePath, "utf-8");
-
-    // Simple parsing - in production, use @vizejs/native
-    const titleMatch = source.match(/<art[^>]*\stitle=["']([^"']+)["']/);
-    const componentMatch = source.match(/<art[^>]*\scomponent=["']([^"']+)["']/);
-    const categoryMatch = source.match(/<art[^>]*\scategory=["']([^"']+)["']/);
-
-    const variants: ArtFileInfo["variants"] = [];
-    const variantRegex = /<variant\s+([^>]*)>([\s\S]*?)<\/variant>/g;
-    let match;
-
-    while ((match = variantRegex.exec(source)) !== null) {
-      const attrs = match[1];
-      const template = match[2].trim();
-
-      const nameMatch = attrs.match(/name=["']([^"']+)["']/);
-      const isDefault = /\bdefault\b/.test(attrs);
-      const skipVrt = /\bskip-vrt\b/.test(attrs);
-
-      if (nameMatch) {
-        variants.push({
-          name: nameMatch[1],
-          template,
-          isDefault,
-          skipVrt,
-        });
-      }
-    }
-
-    return {
-      path: filePath,
-      metadata: {
-        title: titleMatch?.[1] || path.basename(filePath, ".art.vue"),
-        component: componentMatch?.[1],
-        category: categoryMatch?.[1],
-        tags: [],
-        status: "ready",
-      },
-      variants,
-      hasScriptSetup: /<script\s+setup/.test(source),
-      hasScript: /<script(?!\s+setup)/.test(source),
-      styleCount: (source.match(/<style/g) || []).length,
-    };
-  } catch (error) {
-    console.error(`Failed to parse ${filePath}:`, error);
-    return null;
-  }
+  return processMuseaArtFile(filePath, {
+    root: path.dirname(filePath),
+    command: "serve",
+  });
 }


### PR DESCRIPTION
## Summary
- Musea VRT CLI parsed `.art.vue` with a regex stub that always set `status: "ready"`, so unknown statuses never became `draft` and never warned.
- Reuse the Vite plugin's native `processMuseaArtFile` path so CLI status and unknown-status warnings match the gallery.

## Test plan
- [x] CLI utils tests for unknown → draft + warning, ready unchanged, parse failure → null
- [ ] CI `check-js` / `test-js-packages` (native binding required)

Refs #4467

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790108413&installation_model_id=422833&pr_number=4686&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4686&signature=2627927f6766c1030bbe5182b34c81d9e07cd5ecb6f6eebd6626fb1248017cab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->