### PR TITLE
fix(lsp): keep workspace symbols responsive after file events

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -27,6 +27,8 @@ pub struct CorsaBridge {
     worker: BoundedWorker<Option<CorsaProjectClient>>,
     /// Whether the bridge is initialized
     initialized: AtomicBool,
+    /// Whether the reusable editor LSP session may have read stale disk state.
+    disk_project_state_dirty: AtomicBool,
     /// Profiler for performance tracking
     profiler: Profiler,
     /// Cache statistics
@@ -72,6 +74,7 @@ impl CorsaBridge {
             ),
             config,
             initialized: AtomicBool::new(false),
+            disk_project_state_dirty: AtomicBool::new(false),
             profiler,
             cache_stats: CacheStats::new(),
             package_route_resolver,

--- a/crates/vize_canon/src/corsa_bridge/bridge/documents.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge/documents.rs
@@ -1,5 +1,7 @@
 //! Open-document lifecycle and diagnostic requests.
 
+use std::sync::atomic::Ordering;
+
 use vize_carton::{String, cstr};
 
 use super::CorsaBridge;
@@ -110,6 +112,20 @@ impl CorsaBridge {
                 .map_err(CorsaBridgeError::CommunicationError)
         })
         .await
+    }
+
+    /// Record an external disk project-shape change without touching the
+    /// backend on the foreground LSP notification path.
+    pub fn mark_disk_project_state_dirty(&self) {
+        self.disk_project_state_dirty.store(true, Ordering::SeqCst);
+    }
+
+    /// Flush a deferred disk-state invalidation just before a Corsa request.
+    pub async fn flush_disk_project_state_if_dirty(&self) -> Result<(), CorsaBridgeError> {
+        if !self.disk_project_state_dirty.swap(false, Ordering::SeqCst) {
+            return Ok(());
+        }
+        self.invalidate_disk_project_state().await
     }
 
     pub async fn get_diagnostics(&self, uri: &str) -> Result<Vec<LspDiagnostic>, CorsaBridgeError> {

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -283,6 +283,26 @@ impl EditorLspSession {
                 "Failed to gracefully close editor LSP process: {error}"
             ));
         }
+        self.finish_close(first_error)
+    }
+
+    /// Tear down the editor process without waiting for a protocol shutdown
+    /// response. Workspace file events use this path when the reusable editor
+    /// project view has to be discarded before the next semantic request; a
+    /// stuck old server must not block the foreground LSP notification queue.
+    fn discard(&mut self) -> Result<(), String> {
+        if self.closed {
+            return Ok(());
+        }
+
+        let mut first_error = None;
+        if let Err(error) = block_on(self.client.close()) {
+            first_error = Some(cstr!("Failed to close editor LSP process: {error}"));
+        }
+        self.finish_close(first_error)
+    }
+
+    fn finish_close(&mut self, mut first_error: Option<String>) -> Result<(), String> {
         self.stop.store(true, Ordering::Relaxed);
         if let Some(responder) = self.responder.take()
             && responder.join().is_err()

--- a/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
@@ -241,6 +241,20 @@ impl CorsaProjectClient {
         self.editor_lsp_documents_dirty = true;
         result
     }
+
+    /// Drop the editor session immediately after an external project-shape
+    /// change. Unlike [`Self::retire_editor_lsp`], this does not wait for a
+    /// protocol `shutdown` response from the stale process, so file-operation
+    /// notifications cannot hold the foreground LSP queue hostage.
+    pub(in crate::lsp_client) fn discard_editor_lsp(&mut self) -> Result<(), String> {
+        let result = match self.editor_lsp.as_mut() {
+            Some(session) => session.discard(),
+            None => Ok(()),
+        };
+        self.editor_lsp = None;
+        self.editor_lsp_documents_dirty = true;
+        result
+    }
 }
 
 fn document_maps_equal(lhs: &FxHashMap<String, String>, rhs: &FxHashMap<String, String>) -> bool {

--- a/crates/vize_canon/src/lsp_client/lifecycle.rs
+++ b/crates/vize_canon/src/lsp_client/lifecycle.rs
@@ -262,7 +262,7 @@ impl CorsaProjectClient {
     /// freshly spawned session to see the current workspace.
     pub fn invalidate_disk_project_state(&mut self) -> Result<(), String> {
         self.clear_diagnostics_cache();
-        self.retire_editor_lsp()
+        self.discard_editor_lsp()
     }
 
     pub(crate) fn diagnostics_cache_len(&self) -> usize {

--- a/crates/vize_maestro/src/document/store.rs
+++ b/crates/vize_maestro/src/document/store.rs
@@ -245,6 +245,27 @@ impl DocumentStore {
         self.documents.iter().map(|r| r.key().clone()).collect()
     }
 
+    /// Owned snapshots of open Vue documents, holding no shard guard on return.
+    ///
+    /// Workspace-wide editor features parse these snapshots after the map read
+    /// has finished. Keeping a `DashMap` guard alive while parsing is not an
+    /// `.await`, but it can still stall other LSP handlers that need the same
+    /// shard's write lock and then make later readers wait behind that writer.
+    pub fn vue_texts(&self) -> Vec<(Url, String)> {
+        let mut snapshots = self
+            .documents
+            .iter()
+            .filter_map(|document| {
+                let uri = document.key();
+                uri.path()
+                    .ends_with(".vue")
+                    .then(|| (uri.clone(), document.value().text()))
+            })
+            .collect::<Vec<_>>();
+        snapshots.sort_by(|(left, _), (right, _)| left.as_str().cmp(right.as_str()));
+        snapshots
+    }
+
     /// Get the number of open documents.
     pub fn len(&self) -> usize {
         self.documents.len()
@@ -261,6 +282,8 @@ impl DocumentStore {
     }
 }
 
+#[cfg(test)]
+mod snapshot_tests;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]

--- a/crates/vize_maestro/src/document/store/snapshot_tests.rs
+++ b/crates/vize_maestro/src/document/store/snapshot_tests.rs
@@ -1,0 +1,36 @@
+use super::DocumentStore;
+use tower_lsp::lsp_types::{TextDocumentContentChangeEvent, Url};
+
+fn full_change(text: impl Into<String>) -> TextDocumentContentChangeEvent {
+    TextDocumentContentChangeEvent {
+        range: None,
+        range_length: None,
+        text: text.into(),
+    }
+}
+
+#[test]
+fn vue_texts_snapshot_holds_no_shard_lock() {
+    let store = DocumentStore::new();
+    let vue_uri = Url::parse("file:///test.vue").unwrap();
+    let ts_uri = Url::parse("file:///test.ts").unwrap();
+    store.open(
+        vue_uri.clone(),
+        "<template>before</template>".to_string(),
+        1,
+        "vue".to_string(),
+    );
+    store.open(ts_uri, "export {}".to_string(), 1, "typescript".to_string());
+
+    let snapshots = store.vue_texts();
+    store.apply_changes(&vue_uri, vec![full_change("<template>after</template>")], 2);
+
+    assert_eq!(
+        snapshots,
+        vec![(vue_uri.clone(), "<template>before</template>".to_string())]
+    );
+    assert_eq!(
+        store.text(&vue_uri).as_deref(),
+        Some("<template>after</template>")
+    );
+}

--- a/crates/vize_maestro/src/ide/diagnostics/service.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/service.rs
@@ -48,12 +48,11 @@ pub struct DiagnosticService;
 impl DiagnosticService {
     /// Collect all diagnostics for a document.
     pub fn collect(state: &ServerState, uri: &Url) -> Vec<Diagnostic> {
-        let Some(doc) = state.documents.get(uri) else {
+        let Some(content) = state.documents.text(uri) else {
             tracing::warn!("collect: document not found for {}", uri);
             return vec![];
         };
 
-        let content = doc.text();
         let mut diagnostics = Vec::new();
         let features = state.lsp_features();
 
@@ -218,11 +217,10 @@ impl DiagnosticService {
     /// returned set is byte-for-byte the lint/musea subset of `collect`'s
     /// output for every document shape (Art file, standalone HTML, SFC).
     pub fn collect_lint_only(state: &ServerState, uri: &Url) -> Vec<Diagnostic> {
-        let Some(doc) = state.documents.get(uri) else {
+        let Some(content) = state.documents.text(uri) else {
             return vec![];
         };
 
-        let content = doc.text();
         let features = state.lsp_features();
         let mut diagnostics = Vec::new();
 

--- a/crates/vize_maestro/src/ide/type_service/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/type_service/diagnostics.rs
@@ -45,11 +45,9 @@ impl TypeService {
         uri: &Url,
         lsp_options: &LspTypeCheckOptions,
     ) -> Vec<Diagnostic> {
-        let Some(doc) = state.documents.get(uri) else {
+        let Some(content) = state.documents.text(uri) else {
             return vec![];
         };
-
-        let content = doc.text();
 
         // Use vize_canon's strict type checker
         let options = TypeCheckOptions {
@@ -178,11 +176,9 @@ impl TypeService {
     /// This is kept for backwards compatibility and can be removed later.
     #[deprecated(note = "Use collect_diagnostics which uses the stricter vize_canon type checker")]
     pub fn collect_diagnostics_legacy(state: &ServerState, uri: &Url) -> Vec<Diagnostic> {
-        let Some(doc) = state.documents.get(uri) else {
+        let Some(content) = state.documents.text(uri) else {
             return vec![];
         };
-
-        let content = doc.text();
 
         let options = vize_atelier_sfc::SfcParseOptions {
             filename: uri.path().to_string().into(),

--- a/crates/vize_maestro/src/ide/workspace_symbols.rs
+++ b/crates/vize_maestro/src/ide/workspace_symbols.rs
@@ -22,18 +22,11 @@ impl WorkspaceSymbolsService {
         let mut symbols = Vec::new();
         let query_lower = query.to_lowercase();
 
-        // Search in all open documents
-        for entry in state.documents.iter() {
-            let uri = entry.key();
-            let doc = entry.value();
-            let content = doc.text();
-
-            // Only process .vue files
-            if !uri.path().ends_with(".vue") {
-                continue;
-            }
-
-            Self::collect_symbols_from_document(uri, &content, &query_lower, &mut symbols);
+        // Search in all open documents. Snapshot the text before parsing so a
+        // workspace-wide request never keeps a DashMap document guard alive
+        // while doing SFC work (#3952).
+        for (uri, content) in state.documents.vue_texts() {
+            Self::collect_symbols_from_document(&uri, &content, &query_lower, &mut symbols);
         }
 
         #[cfg(feature = "native")]

--- a/crates/vize_maestro/src/server/state/corsa.rs
+++ b/crates/vize_maestro/src/server/state/corsa.rs
@@ -42,8 +42,12 @@ impl ServerState {
         }
 
         // If already initialized successfully, return it
-        if let Some(bridge) = self.corsa_bridge.read().clone() {
-            return Some(bridge);
+        let existing_bridge = { self.corsa_bridge.read().clone() };
+        if let Some(bridge) = existing_bridge {
+            if self.flush_corsa_disk_state_if_dirty(&bridge).await {
+                return Some(bridge);
+            }
+            self.retire_corsa_bridge(&bridge);
         }
 
         // If initialization already failed, don't retry
@@ -54,8 +58,12 @@ impl ServerState {
         let _guard = self.corsa_init_lock.lock().await;
 
         // Another request may have completed initialization while we were waiting.
-        if let Some(bridge) = self.corsa_bridge.read().clone() {
-            return Some(bridge);
+        let existing_bridge = { self.corsa_bridge.read().clone() };
+        if let Some(bridge) = existing_bridge {
+            if self.flush_corsa_disk_state_if_dirty(&bridge).await {
+                return Some(bridge);
+            }
+            self.retire_corsa_bridge(&bridge);
         }
 
         if self.corsa_init_failed.load(Ordering::SeqCst) {
@@ -98,7 +106,12 @@ impl ServerState {
                 tracing::info!("corsa bridge initialized successfully");
                 let bridge = Arc::new(bridge);
                 *self.corsa_bridge.write() = Some(bridge.clone());
-                Some(bridge)
+                if self.flush_corsa_disk_state_if_dirty(&bridge).await {
+                    Some(bridge)
+                } else {
+                    self.retire_corsa_bridge(&bridge);
+                    None
+                }
             }
             Err(CorsaBridgeError::Timeout) => {
                 let reason = vize_carton::cstr!(
@@ -115,6 +128,32 @@ impl ServerState {
                 tracing::warn!("corsa bridge {}", reason);
                 self.record_corsa_init_failure(reason.as_str());
                 None
+            }
+        }
+    }
+
+    /// Mark the reusable editor-side project view dirty without touching the
+    /// backend from the file-operation notification itself.
+    ///
+    /// `workspace/didCreateFiles`, `didRenameFiles`, and watched declaration
+    /// changes run on the same foreground LSP queue as ordinary requests. A
+    /// direct Corsa call there can park `workspace/symbol` or completion behind
+    /// a backend timeout even though those requests do not need the
+    /// invalidation to answer. The next Corsa-using request flushes this bit
+    /// instead.
+    pub(crate) fn mark_corsa_disk_state_dirty(&self) {
+        let bridge = { self.corsa_bridge.read().clone() };
+        if let Some(bridge) = bridge {
+            bridge.mark_disk_project_state_dirty();
+        }
+    }
+
+    async fn flush_corsa_disk_state_if_dirty(&self, bridge: &Arc<CorsaBridge>) -> bool {
+        match bridge.flush_disk_project_state_if_dirty().await {
+            Ok(()) => true,
+            Err(error) => {
+                tracing::warn!("failed to invalidate cached Corsa disk project state: {error}");
+                false
             }
         }
     }

--- a/crates/vize_maestro/src/server/workspace_files.rs
+++ b/crates/vize_maestro/src/server/workspace_files.rs
@@ -100,7 +100,7 @@ pub(super) async fn did_change_watched_files(
             return;
         }
         if changes_invalidate_disk_project_state(&server.state, &changes) {
-            invalidate_corsa_disk_state(&server.state).await;
+            invalidate_corsa_disk_state(&server.state);
         }
         // Any watched change can affect an open importer; declaration changes
         // additionally invalidate the discoverable global-component cache.
@@ -173,7 +173,7 @@ pub(super) async fn invalidate_changed_document_disk_project_state(
             typ: FileChangeType::CHANGED,
         }],
     ) {
-        invalidate_corsa_disk_state(&server.state).await;
+        invalidate_corsa_disk_state(&server.state);
     }
 }
 
@@ -185,7 +185,7 @@ pub(super) async fn did_create_files(server: &MaestroServer, params: &CreateFile
             params.files.iter().map(|file| file.uri.as_str()),
         );
         record_created_files(&server.state, params);
-        invalidate_corsa_disk_state(&server.state).await;
+        invalidate_corsa_disk_state(&server.state);
         publish_versioned_dependents(server, dependents).await;
     }
     #[cfg(not(feature = "native"))]
@@ -221,7 +221,7 @@ pub(super) async fn did_delete_files(server: &MaestroServer, params: &DeleteFile
         );
         record_deleted_files(&server.state, params);
         forget_corsa_vue_files(&server.state, &deleted_paths).await;
-        invalidate_corsa_disk_state(&server.state).await;
+        invalidate_corsa_disk_state(&server.state);
         publish_versioned_dependents(server, dependents).await;
     }
     #[cfg(not(feature = "native"))]
@@ -284,7 +284,7 @@ pub(super) async fn did_rename_files(server: &MaestroServer, params: &RenameFile
         }
         server.state.invalidate_batch_cache();
         forget_corsa_vue_files(&server.state, &renamed_paths).await;
-        invalidate_corsa_disk_state(&server.state).await;
+        invalidate_corsa_disk_state(&server.state);
         publish_versioned_dependents(server, dependents).await;
     }
     if !server.state.lsp_features().file_rename {

--- a/crates/vize_maestro/src/server/workspace_files/dependents.rs
+++ b/crates/vize_maestro/src/server/workspace_files/dependents.rs
@@ -51,24 +51,20 @@ pub(super) fn affected_vue_source_paths<'a>(
     sources
 }
 
-/// Drop the on-disk project view the reusable Corsa editor session cached.
+/// Mark the on-disk project view cached by the reusable Corsa editor session stale.
 ///
 /// The session keeps one long-lived type-checker process, so files it read from
 /// disk while building its program stay pinned until the session is retired.
 /// Declaration edits and file create, delete, or rename events change that view
 /// without touching any synchronized virtual document, so the change is only
-/// visible to the next request once the cached view is dropped.
-pub(super) async fn invalidate_corsa_disk_state(state: &ServerState) {
-    if !state.has_corsa_bridge() {
-        return;
-    }
-    let Some(bridge) = state.get_corsa_bridge().await else {
-        return;
-    };
-    if let Err(error) = bridge.invalidate_disk_project_state().await {
-        tracing::warn!("failed to invalidate cached Corsa disk project state: {error}");
-        state.retire_corsa_bridge(&bridge);
-    }
+/// visible to the next Corsa-using request once the cached view is dropped.
+///
+/// The file-operation notification itself must stay non-blocking for
+/// Corsa-free editor requests. In particular, the authored fixture asks
+/// `workspace/symbol` immediately after `workspace/didCreateFiles`; that
+/// request only needs the tracked file URI, not a TypeScript backend flush.
+pub(super) fn invalidate_corsa_disk_state(state: &ServerState) {
+    state.mark_corsa_disk_state_dirty();
 }
 
 pub(super) async fn forget_corsa_vue_files(state: &ServerState, deleted: &[PathBuf]) {

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -766,7 +766,8 @@
         "fixturePaths": [
           "tests/_fixtures/_git/reka-ui",
           "tests/_fixtures/_git/elk",
-          "tests/_fixtures/_git/misskey"
+          "tests/_fixtures/_git/misskey",
+          "tests/_fixtures/_git/create-vue"
         ]
       },
       "evidence": {

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 7,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 3,
+    "minimumProjectCount": 4,
     "trackingIssue": 3952
   },
   "projects": [
@@ -815,7 +815,69 @@
       "vueGlobs": ["template/**/*.vue"],
       "tsconfig": "tsconfig.json",
       "coverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "template/code/typescript-default/src/components/TheWelcome.vue",
+          "symbol": "openReadmeInEditor",
+          "usageAnchor": "@click=\"openReadmeInEditor\"",
+          "declarationAnchor": "const openReadmeInEditor = () => fetch('/__open-in-editor?file=README.md')",
+          "hoverContains": ["const openReadmeInEditor: () => Promise<Response>"],
+          "renameTo": "__vizeRenamedOpenReadmeInEditor"
+        },
+        "componentBoundary": {
+          "importerFile": "template/code/typescript-default/src/App.vue",
+          "componentFile": "template/code/typescript-default/src/components/HelloWorld.vue",
+          "tagName": "HelloWorld",
+          "tagAnchor": "<HelloWorld ",
+          "completionItemCount": 29,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "msg", "rank": 28 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  msg: string\n",
+            "replacement": "  msg: string\n  vizeOracleProbe?: boolean\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "template/code/typescript-default/src/components/__VizeOracleHelloWorld.vue",
+          "renamedFile": "template/code/typescript-default/src/components/__VizeOracleRenamedHelloWorld.vue",
+          "originalImportSpecifier": "./components/HelloWorld.vue",
+          "copiedImportSpecifier": "./components/__VizeOracleHelloWorld.vue",
+          "renamedImportSpecifier": "./components/__VizeOracleRenamedHelloWorld.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizeCreateVueFileLifecycleMarker__"
+        }
+      }
     },
     {
       "id": "vue-router",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 3,
+      "authored-lsp": 4,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 3, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 4, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
## Summary
- add create-vue to the authored real-project LSP oracle ratchet
- cover template binding hover/definition/references/rename, component boundary completion, and create/rename/delete file lifecycle behavior
- prevent file-operation events and workspace symbol search from stalling on stale Corsa editor sessions or long-lived document-store guards

## Verification
- cargo fmt --check
- cargo test -p vize_maestro document_store --lib
- cargo test -p vize_maestro workspace_symbols --lib
- cargo test -p vize_canon lsp_client --lib
- cargo build --profile ci -p vize
- NODE_OPTIONS='--disable-warning=DEP0040 --disable-warning=DEP0169' CORSA_PATH=/private/tmp/vize-p0-lsp-authored-create-vue.MjYRcf/node_modules/.bin/tsgo VIZE_LSP_BIN=/private/tmp/vize-p0-lsp-authored-create-vue.MjYRcf/target/ci/vize FIXTURE_SHARD_INDEX=20 FIXTURE_SHARD_COUNT=144 REAL_PROJECT_LSP_TIMEOUT_MS=180000 node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts
- NODE_OPTIONS='--disable-warning=DEP0040 --disable-warning=DEP0169' node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts
- vp check --no-error-on-unmatched-pattern tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/_fixtures/vue-ecosystem-fixtures.json tests/_fixtures/fixture-compatibility-ledger.json tools/fixtures/fixture-compatibility-ledger.mjs crates/vize_canon/src/lsp_client/editor_lsp.rs crates/vize_canon/src/lsp_client/editor_lsp/client.rs crates/vize_canon/src/lsp_client/lifecycle.rs crates/vize_maestro/src/document/store.rs crates/vize_maestro/src/document/store/tests.rs crates/vize_maestro/src/ide/workspace_symbols.rs crates/vize_maestro/src/ide/diagnostics/service.rs crates/vize_maestro/src/ide/type_service/diagnostics.rs
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved editor language-service shutdown and recovery when project files change.
  - Reduced the risk of stale document locks during diagnostics and workspace symbol searches.
  - Preserved expected behavior when document content is unavailable.

- **Improvements**
  - Workspace symbol searches now use stable snapshots of open Vue files.
  - Added coverage for Vue project compatibility, including completions, template bindings, dependency edits, and file lifecycle operations.

- **Tests**
  - Expanded language-service validation to include an additional Vue project fixture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->