### PR TITLE
fix(matrix): retarget outside typeRoots to the fixture @types tree

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-typeroots.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-typeroots.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  rewriteOutsideTypeRoots,
+  writeIsolatedTsconfigOverlay,
+} from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+
+/**
+ * Unique isolation cannot retarget `compilerOptions.typeRoots`. An outside
+ * `node_modules/@types` lets TypeScript load Vize's ambient packages beside
+ * the fixture's Vue (#4461). Overlay rewrite is the repair.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-typeroots-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsideTypes = path.join(outer, "node_modules", "@types");
+  fs.mkdirSync(outsideTypes, { recursive: true });
+  return { fixtureRoot, outer, outsideTypes };
+}
+
+function writeLocalTypes(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "@types");
+  fs.mkdirSync(local, { recursive: true });
+  return local;
+}
+
+test("an outside node_modules/@types typeRoot is retargeted to the fixture copy", () => {
+  const { fixtureRoot, outer, outsideTypes } = scaffold();
+  try {
+    writeLocalTypes(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { typeRoots: [path.relative(fixtureRoot, outsideTypes)] },
+      })}\n`,
+    );
+    const configDir = path.join(fixtureRoot, ".vize-baseline");
+    assert.deepEqual(rewriteOutsideTypeRoots(fixtureRoot, sourcePath, configDir), [
+      "../node_modules/@types",
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("typeRoots reached only through relative extends are still retargeted", () => {
+  const { fixtureRoot, outer, outsideTypes } = scaffold();
+  try {
+    writeLocalTypes(fixtureRoot);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.app.json"),
+      `${JSON.stringify({
+        compilerOptions: { typeRoots: [path.relative(fixtureRoot, outsideTypes)] },
+      })}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.check.json");
+    fs.writeFileSync(sourcePath, `{ "extends": "./tsconfig.app.json" }\n`);
+    const overlay = writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath);
+    assert.equal(overlay.path, path.join(fixtureRoot, ".vize-isolated-tsconfig.check.json"));
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.check.json",
+      compilerOptions: { typeRoots: ["./node_modules/@types"] },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an inside typeRoot is left for inheritance", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const typings = path.join(fixtureRoot, "typings");
+    fs.mkdirSync(typings);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({ compilerOptions: { typeRoots: ["./typings"] } })}\n`,
+    );
+    assert.equal(rewriteOutsideTypeRoots(fixtureRoot, sourcePath, fixtureRoot), null);
+    assert.equal(writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside typeRoot is left alone when the fixture has no local @types", () => {
+  const { fixtureRoot, outer, outsideTypes } = scaffold();
+  try {
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { typeRoots: [path.relative(fixtureRoot, outsideTypes)] },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideTypeRoots(fixtureRoot, sourcePath, fixtureRoot), null);
+    assert.equal(writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a custom outside typeRoot that is not node_modules/@types is not guessed", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalTypes(fixtureRoot);
+    const outsideTypings = path.join(outer, "typings");
+    fs.mkdirSync(outsideTypings);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { typeRoots: [path.relative(fixtureRoot, outsideTypings)] },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideTypeRoots(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -25,6 +25,10 @@ import { basename, dirname, join, relative, resolve } from "node:path";
  * Package-name `extends` is followed only inside the fixture. Climbing into
  * Vize's `node_modules` would load Vize's `@vue/tsconfig` and bake its
  * outside `paths` into the overlay.
+ *
+ * `compilerOptions.typeRoots` is the same class of hole: TypeScript searches
+ * those directories instead of the fixture's `node_modules/@types`. An outside
+ * `node_modules/@types` is retargeted to the fixture-local copy when it exists.
  */
 
 const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
@@ -50,20 +54,37 @@ export function isolatedTsconfigOverlayPath(sourceConfigPath) {
   return dir === "." ? `.vize-isolated-${name}` : `${dir}/.vize-isolated-${name}`;
 }
 
+export function rewriteOutsideTypeRoots(fixtureRoot, sourceConfigPath, configDir) {
+  const root = resolve(fixtureRoot);
+  const declared = winningTypeRoots(sourceConfigPath, root);
+  if (declared == null) return null;
+  const rewritten = [];
+  let changed = false;
+  for (const entry of declared.typeRoots) {
+    rewritten.push(
+      retargetTypeRoot(root, declared.dir, configDir, entry, () => {
+        changed = true;
+      }),
+    );
+  }
+  return changed ? rewritten : null;
+}
+
 export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
   const sourcePath = resolve(sourceConfigPath);
-  const rewritten = rewriteOutsidePackagePaths(fixtureRoot, sourcePath, dirname(sourcePath));
-  if (rewritten == null) return null;
+  const configDir = dirname(sourcePath);
+  const paths = rewriteOutsidePackagePaths(fixtureRoot, sourcePath, configDir);
+  const typeRoots = rewriteOutsideTypeRoots(fixtureRoot, sourcePath, configDir);
+  if (paths == null && typeRoots == null) return null;
+  const compilerOptions = {};
+  if (paths != null) compilerOptions.paths = paths;
+  if (typeRoots != null) compilerOptions.typeRoots = typeRoots;
   const overlayPath = isolatedTsconfigOverlayPath(sourcePath);
   writeFileSync(
     overlayPath,
-    `${JSON.stringify(
-      { extends: `./${basename(sourcePath)}`, compilerOptions: { paths: rewritten } },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify({ extends: `./${basename(sourcePath)}`, compilerOptions }, null, 2)}\n`,
   );
-  return { path: overlayPath, paths: rewritten };
+  return { path: overlayPath, paths, typeRoots };
 }
 
 function retargetPathMapping(fixtureRoot, sourceDir, configDir, name, targets, markChanged) {
@@ -86,6 +107,18 @@ function relocatePathEntry(sourceDir, configDir, entry) {
   return configRelativePath(configDir, resolve(sourceDir, entry));
 }
 
+function retargetTypeRoot(fixtureRoot, sourceDir, configDir, entry, markChanged) {
+  if (typeof entry !== "string") return entry;
+  const relocated = relocatePathEntry(sourceDir, configDir, entry);
+  const original = resolve(sourceDir, entry);
+  if (isInside(fixtureRoot, original)) return relocated;
+  if (!isTypesPackageRoot(original)) return relocated;
+  const local = join(fixtureRoot, "node_modules", "@types");
+  if (!existsSync(local)) return relocated;
+  markChanged();
+  return configRelativePath(configDir, local);
+}
+
 function winningPaths(sourceConfigPath, fixtureRoot) {
   let paths;
   let dir;
@@ -99,6 +132,21 @@ function winningPaths(sourceConfigPath, fixtureRoot) {
     }
   }
   return paths == null ? null : { paths, dir };
+}
+
+function winningTypeRoots(sourceConfigPath, fixtureRoot) {
+  let typeRoots;
+  let dir;
+  for (const { config, dir: configDir } of [
+    ...loadExtendsChain(sourceConfigPath, fixtureRoot),
+  ].reverse()) {
+    const candidate = config?.compilerOptions?.typeRoots;
+    if (Array.isArray(candidate)) {
+      typeRoots = candidate;
+      dir = configDir;
+    }
+  }
+  return typeRoots == null ? null : { typeRoots, dir };
 }
 
 function loadExtendsChain(sourceConfigPath, fixtureRoot) {
@@ -197,6 +245,11 @@ function packageExtendsFile(pkg, subpath) {
 function isInside(root, target) {
   const path = relative(root, target);
   return path !== "" && !path.startsWith("..") && !path.startsWith("/");
+}
+
+function isTypesPackageRoot(directory) {
+  const normalized = directory.replaceAll("\\", "/");
+  return normalized.endsWith("/node_modules/@types");
 }
 
 function configRelativePath(from, to) {

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -1,7 +1,10 @@
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
-import { rewriteOutsidePackagePaths } from "./typecheck-baseline-outside-paths.mjs";
+import {
+  rewriteOutsidePackagePaths,
+  rewriteOutsideTypeRoots,
+} from "./typecheck-baseline-outside-paths.mjs";
 import { typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
 
 /**
@@ -95,7 +98,7 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
       // that directory becomes TS6059 noise and the baseline stops measuring
       // Vize. Pin it to the fixture corpus root instead.
       rootDir: configRelativePath(configDir, fixtureRoot),
-      ...outsidePackagePaths(fixtureRoot, sourcePath, configDir),
+      ...outsideCompilerOptions(fixtureRoot, sourcePath, configDir),
     },
     files: vizeReport.files
       .slice(0, vizeReport.fileCount)
@@ -115,9 +118,13 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
   return { path: outputPath, source, sourceProject };
 }
 
-function outsidePackagePaths(fixtureRoot, sourcePath, configDir) {
+function outsideCompilerOptions(fixtureRoot, sourcePath, configDir) {
+  const options = {};
   const paths = rewriteOutsidePackagePaths(fixtureRoot, sourcePath, configDir);
-  return paths == null ? {} : { paths };
+  if (paths != null) options.paths = paths;
+  const typeRoots = rewriteOutsideTypeRoots(fixtureRoot, sourcePath, configDir);
+  if (typeRoots != null) options.typeRoots = typeRoots;
+  return options;
 }
 
 function configRelativePath(from, to) {

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -163,7 +163,7 @@ function isolateFixture(project, fixtureRoot) {
   const overlay = writeIsolatedTsconfigOverlay(fixtureRoot, resolve(fixtureRoot, project.tsconfig));
   if (overlay != null) {
     process.stdout.write(
-      `Rewrote ${project.id} tsconfig paths -> ${relative(fixtureRoot, overlay.path)}\n`,
+      `Rewrote ${project.id} tsconfig overlay -> ${relative(fixtureRoot, overlay.path)}\n`,
     );
   }
 }


### PR DESCRIPTION
## Summary
- `compilerOptions.typeRoots` that resolve to a parent `node_modules/@types` let vue-tsc/Vize load Vize's ambient packages beside the fixture Vue (#4461). Unique isolation cannot retarget a directory list.
- Overlay and generated baseline now retarget that `@types` root to the fixture-local copy when it exists. Custom outside typeRoots are not guessed.

## Test plan
- [x] `node --test` typeRoots overlay tests plus existing outside-paths / package-extends / baseline-project tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790108887&installation_model_id=422833&pr_number=4688&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4688&signature=bc9d69cd9d2e1c7482bacb4c6fcb82263e8f6d7a12395172e7908340ea595034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->