### PR TITLE
fix(matrix): isolate compilerOptions.plugins packages to the fixture

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-plugins.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-plugins.test.ts
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { readDeclaredPackagePaths } from "../../tools/fixtures/typecheck-baseline-isolation.mjs";
+import { isolateUniqueLocalTypePackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+import { pluginPackageNamesFromConfigs } from "../../tools/fixtures/typecheck-baseline-isolation-plugins.mjs";
+
+/**
+ * Language-service plugins resolve by climbing `node_modules` (#4461). Unique
+ * isolation links the fixture copy. Package-name `extends` configs are not
+ * read for plugins; relative `extends` chains union plugin lists.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-plugins-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  const ancestorTsPlugin = path.join(outer, "node_modules", "typescript-plugin-css-modules");
+  fs.mkdirSync(ancestorTsPlugin, { recursive: true });
+  fs.writeFileSync(
+    path.join(ancestorTsPlugin, "package.json"),
+    `{"name":"typescript-plugin-css-modules"}\n`,
+  );
+  const ancestorVuePlugin = path.join(outer, "node_modules", "@vue", "language-plugin-pug");
+  fs.mkdirSync(ancestorVuePlugin, { recursive: true });
+  fs.writeFileSync(
+    path.join(ancestorVuePlugin, "package.json"),
+    `{"name":"@vue/language-plugin-pug"}\n`,
+  );
+  const ancestorVueTsconfig = path.join(outer, "node_modules", "@vue", "tsconfig");
+  fs.mkdirSync(ancestorVueTsconfig, { recursive: true });
+  fs.writeFileSync(path.join(ancestorVueTsconfig, "package.json"), `{"name":"@vue/tsconfig"}\n`);
+  fs.writeFileSync(
+    path.join(ancestorVueTsconfig, "tsconfig.json"),
+    `${JSON.stringify({
+      compilerOptions: { plugins: [{ name: "typescript-plugin-css-modules" }] },
+    })}\n`,
+  );
+  return { ancestorTsPlugin, ancestorVuePlugin, ancestorVueTsconfig, fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+function writeConfig(fixtureRoot: string, config: unknown, fileName = "tsconfig.json") {
+  const configPath = path.join(fixtureRoot, fileName);
+  fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+  return configPath;
+}
+
+test("plugin names come from compilerOptions and vueCompilerOptions", () => {
+  assert.deepEqual(
+    pluginPackageNamesFromConfigs([
+      {
+        compilerOptions: { plugins: [{ name: "typescript-plugin-css-modules" }] },
+        vueCompilerOptions: {
+          plugins: ["@vue/language-plugin-pug", ["./local-plugin.js", { pretty: true }]],
+        },
+      },
+    ]),
+    ["typescript-plugin-css-modules", "@vue/language-plugin-pug"],
+  );
+  assert.deepEqual(pluginPackageNamesFromConfigs([]), []);
+  assert.deepEqual(pluginPackageNamesFromConfigs(undefined), []);
+});
+
+test("compilerOptions.plugins records ancestor packages for unique isolation", () => {
+  const { ancestorTsPlugin, fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: { plugins: [{ name: "typescript-plugin-css-modules" }] },
+    });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "typescript-plugin-css-modules": ancestorTsPlugin,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("vueCompilerOptions.plugins records ancestor packages", () => {
+  const { ancestorVuePlugin, fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, {
+      vueCompilerOptions: { plugins: ["@vue/language-plugin-pug"] },
+    });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "@vue/language-plugin-pug": ancestorVuePlugin,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("unique isolation links the fixture copy of a plugin package", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(
+      fixtureRoot,
+      "typescript-plugin-css-modules@5.0.0",
+      "typescript-plugin-css-modules",
+    );
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: { plugins: [{ name: "typescript-plugin-css-modules" }] },
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      {
+        name: "typescript-plugin-css-modules",
+        target:
+          "node_modules/.pnpm/typescript-plugin-css-modules@5.0.0/node_modules/typescript-plugin-css-modules",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("plugins on a relative extends parent are recorded", () => {
+  const { ancestorTsPlugin, fixtureRoot, outer } = scaffold();
+  try {
+    writeConfig(
+      fixtureRoot,
+      { compilerOptions: { plugins: [{ name: "typescript-plugin-css-modules" }] } },
+      "tsconfig.app.json",
+    );
+    const configPath = writeConfig(fixtureRoot, { extends: "./tsconfig.app.json" });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "typescript-plugin-css-modules": ancestorTsPlugin,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("child and parent plugins are unioned", () => {
+  const { ancestorTsPlugin, ancestorVuePlugin, fixtureRoot, outer } = scaffold();
+  try {
+    writeConfig(
+      fixtureRoot,
+      { compilerOptions: { plugins: [{ name: "typescript-plugin-css-modules" }] } },
+      "tsconfig.app.json",
+    );
+    const configPath = writeConfig(fixtureRoot, {
+      extends: "./tsconfig.app.json",
+      vueCompilerOptions: { plugins: [["@vue/language-plugin-pug", { pretty: true }]] },
+    });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "@vue/language-plugin-pug": ancestorVuePlugin,
+      "typescript-plugin-css-modules": ancestorTsPlugin,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("package-name extends is not walked for plugins", () => {
+  const { ancestorVueTsconfig, fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, { extends: "@vue/tsconfig" });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "@vue/tsconfig": ancestorVueTsconfig,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("paths still win when the same name is also a plugin", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const local = path.join(fixtureRoot, "packages", "typescript-plugin-css-modules");
+    fs.mkdirSync(local, { recursive: true });
+    fs.writeFileSync(
+      path.join(local, "package.json"),
+      `{"name":"typescript-plugin-css-modules"}\n`,
+    );
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: {
+        plugins: [{ name: "typescript-plugin-css-modules" }],
+        paths: { "typescript-plugin-css-modules": ["./packages/typescript-plugin-css-modules"] },
+      },
+    });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "typescript-plugin-css-modules": local,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a plugin package with no fixture copy is left unlinked", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: { plugins: [{ name: "typescript-plugin-css-modules" }] },
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), []);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-plugins.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-plugins.mjs
@@ -1,0 +1,63 @@
+import {
+  ancestorPackagePath,
+  packageNameFromExtendsSpecifier,
+} from "./typecheck-baseline-isolation-package-extends.mjs";
+
+/**
+ * `compilerOptions.plugins` and `vueCompilerOptions.plugins` load by climbing
+ * `node_modules` (#4461). Overlay cannot retarget that require. Recording the
+ * plugin package as an ancestor target lets unique isolation link the
+ * fixture's own copy first.
+ *
+ * Package-name `extends` configs are not read for plugins, matching `paths`
+ * and `types`. Relative `extends` chains are unioned: TypeScript concatenates
+ * plugin lists rather than replacing the parent object.
+ */
+
+export function pluginPackageNamesFromConfigs(configs) {
+  const names = [];
+  const seen = new Set();
+  if (!Array.isArray(configs)) return names;
+  for (const config of configs) {
+    addCompilerPlugins(names, seen, config?.compilerOptions?.plugins);
+    addVueCompilerPlugins(names, seen, config?.vueCompilerOptions?.plugins);
+  }
+  return names;
+}
+
+export function recordCompilerOptionPlugins(declared, conflicts, fixtureRoot, configs) {
+  for (const name of pluginPackageNamesFromConfigs(configs)) {
+    if (conflicts.has(name) || declared.has(name)) continue;
+    const ancestor = ancestorPackagePath(fixtureRoot, name);
+    if (ancestor == null) continue;
+    declared.set(name, ancestor);
+  }
+}
+
+function addCompilerPlugins(names, seen, plugins) {
+  if (!Array.isArray(plugins)) return;
+  for (const plugin of plugins) {
+    if (plugin == null || typeof plugin.name !== "string") continue;
+    addName(names, seen, plugin.name);
+  }
+}
+
+function addVueCompilerPlugins(names, seen, plugins) {
+  if (!Array.isArray(plugins)) return;
+  for (const plugin of plugins) {
+    if (typeof plugin === "string") {
+      addName(names, seen, plugin);
+      continue;
+    }
+    if (Array.isArray(plugin) && typeof plugin[0] === "string") {
+      addName(names, seen, plugin[0]);
+    }
+  }
+}
+
+function addName(names, seen, specifier) {
+  const name = packageNameFromExtendsSpecifier(specifier);
+  if (name == null || seen.has(name)) return;
+  seen.add(name);
+  names.push(name);
+}

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -25,9 +25,10 @@ import { readDeclaredPackagePaths } from "./typecheck-baseline-isolation.mjs";
  * Declared names come from the same `extends` / `references` walk isolation
  * uses, so a check tsconfig that only extends the generated app config still
  * sees the outside mapping (reka-ui's `tsconfig.check.json`). Package-name
- * `extends` specifiers and `compilerOptions.types` entries are included as
- * ancestor targets so this can link the fixture's own `@vue/tsconfig`, `vite`,
- * or `@types/node` before TypeScript climbs into Vize.
+ * `extends` specifiers, `compilerOptions.types` entries, and plugin packages
+ * are included as ancestor targets so this can link the fixture's own
+ * `@vue/tsconfig`, `vite`, `@types/node`, or language plugin before TypeScript
+ * climbs into Vize.
  */
 
 export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -13,6 +13,7 @@ import {
   ancestorPackagePath,
   packageNameFromExtendsSpecifier,
 } from "./typecheck-baseline-isolation-package-extends.mjs";
+import { recordCompilerOptionPlugins } from "./typecheck-baseline-isolation-plugins.mjs";
 import { recordCompilerOptionTypes } from "./typecheck-baseline-isolation-types.mjs";
 
 /**
@@ -53,10 +54,10 @@ import { recordCompilerOptionTypes } from "./typecheck-baseline-isolation-types.
  * from relative `references` when that chain declares none — elk's root
  * `tsconfig.json` is solution-style and parks the real paths on referenced
  * `.nuxt` projects (#4461). Conflicting targets for one name are dropped
- * rather than guessed. Package-name `extends` specifiers and
- * `compilerOptions.types` entries are recorded as ancestor targets so unique
- * isolation can link a fixture-local copy; those package configs are not
- * walked for `paths` or `types`.
+ * rather than guessed. Package-name `extends` specifiers,
+ * `compilerOptions.types` entries, and plugin packages are recorded as
+ * ancestor targets so unique isolation can link a fixture-local copy; those
+ * package configs are not walked for `paths`, `types`, or plugins.
  */
 
 /** `paths` also carries `#imports`-style aliases and `foo/*` patterns, which are not packages. */
@@ -117,12 +118,19 @@ function mergePackageExtends(declared, conflicts, configPaths, fixtureRoot) {
       if (ancestor == null) continue;
       declared.set(name, ancestor);
     }
+    const chain = loadExtendsChain(configPath);
     let types;
-    for (const { config: chained } of [...loadExtendsChain(configPath)].reverse()) {
+    for (const { config: chained } of [...chain].reverse()) {
       const candidate = chained?.compilerOptions?.types;
       if (Array.isArray(candidate)) types = candidate;
     }
     recordCompilerOptionTypes(declared, conflicts, fixtureRoot, types);
+    recordCompilerOptionPlugins(
+      declared,
+      conflicts,
+      fixtureRoot,
+      chain.map(({ config }) => config),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- TypeScript and vue-tsc load `compilerOptions.plugins` / `vueCompilerOptions.plugins` by climbing `node_modules`, so a fixture can execute Vize's language plugin and then Vize's Vue (#4461).
- Record those plugin package names as ancestor targets so unique isolation can link the fixture's own pnpm copy first. Relative `extends` chains union plugin lists; package-name `extends` configs are still not read for plugins.
- Overlay cannot retarget `require` of a plugin; unique-link is the repair, matching `compilerOptions.types`.

## Test plan
- [x] `node --test` plugins isolation tests plus existing isolation / unique / types / package-extends tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790109405&installation_model_id=422833&pr_number=4689&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4689&signature=54b702919db56b839629d0c175640b34bb7b86073106c15edbe729452e25973b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->