### PR TITLE
fix(matrix): retarget trailing-star outside package paths

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-paths-star.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-paths-star.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { rewriteOutsidePackagePaths } from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+
+/**
+ * Trailing `/*` on a package `paths` mapping still loads that outside tree
+ * (#4461). Overlay retargets it to the fixture copy. Interior `*` and
+ * `#alias/*` keys are not guessed.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-outside-paths-star-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsideRouter = path.join(outer, "node_modules", "vue-router");
+  fs.mkdirSync(outsideRouter, { recursive: true });
+  fs.writeFileSync(path.join(outsideRouter, "package.json"), `{"name":"vue-router"}\n`);
+  return { outer, fixtureRoot, outsideRouter };
+}
+
+function writeLocalRouter(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "vue-router");
+  fs.mkdirSync(local, { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue-router"}\n`);
+  return local;
+}
+
+test("an outside package path with a trailing star is retargeted", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    writeLocalRouter(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "vue-router": [`${path.relative(fixtureRoot, outsideRouter)}/*`],
+          },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "vue-router": ["../node_modules/vue-router/*"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside package/* mapping is retargeted", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    writeLocalRouter(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "vue-router/*": [`${path.relative(fixtureRoot, outsideRouter)}/*`],
+          },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "vue-router/*": ["../node_modules/vue-router/*"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside hash alias with a trailing star is left inherited", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    writeLocalRouter(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "#app/*": [`${path.relative(fixtureRoot, outsideRouter)}/*`],
+          },
+        },
+      })}\n`,
+    );
+    assert.equal(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an interior star in a package path is not guessed", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    writeLocalRouter(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "vue-router": [
+              `${path.relative(fixtureRoot, path.dirname(outsideRouter))}/*/vue-router`,
+            ],
+          },
+        },
+      })}\n`,
+    );
+    assert.equal(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a trailing-star package with no fixture-local copy is left inherited", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "vue-router": [`${path.relative(fixtureRoot, outsideRouter)}/*`],
+          },
+        },
+      })}\n`,
+    );
+    assert.equal(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -29,6 +29,10 @@ import { basename, dirname, join, relative, resolve } from "node:path";
  * `compilerOptions.typeRoots` is the same class of hole: TypeScript searches
  * those directories instead of the fixture's `node_modules/@types`. An outside
  * `node_modules/@types` is retargeted to the fixture-local copy when it exists.
+ *
+ * A trailing `/*` on a package mapping is the same walk: TypeScript still
+ * loads that outside tree. Interior `*` patterns and `#alias/*` keys are not
+ * guessed.
  */
 
 const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
@@ -89,17 +93,31 @@ export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
 
 function retargetPathMapping(fixtureRoot, sourceDir, configDir, name, targets, markChanged) {
   const relocated = targets.map((entry) => relocatePathEntry(sourceDir, configDir, entry));
-  if (!packageNamePattern.test(name)) return relocated;
-  const first = targets.find((entry) => typeof entry === "string" && !entry.includes("*"));
+  const packageName = packageNameFromPathMapping(name);
+  if (packageName == null) return relocated;
+  const first = targets.find(
+    (entry) => typeof entry === "string" && isExactOrTrailingStarPath(entry),
+  );
   if (first == null) return relocated;
-  const original = resolve(sourceDir, first);
+  const original = resolve(sourceDir, first.endsWith("/*") ? first.slice(0, -2) : first);
   if (isInside(fixtureRoot, original)) return relocated;
-  const local = join(fixtureRoot, "node_modules", ...name.split("/"));
+  const local = join(fixtureRoot, "node_modules", ...packageName.split("/"));
   if (!existsSync(join(local, "package.json"))) return relocated;
   markChanged();
-  return relocated.map((entry, index) =>
-    index === targets.indexOf(first) ? configRelativePath(configDir, local) : entry,
-  );
+  const rewritten = first.endsWith("/*")
+    ? `${configRelativePath(configDir, local)}/*`
+    : configRelativePath(configDir, local);
+  return relocated.map((entry, index) => (index === targets.indexOf(first) ? rewritten : entry));
+}
+
+function packageNameFromPathMapping(name) {
+  if (typeof name !== "string") return null;
+  const base = name.endsWith("/*") ? name.slice(0, -2) : name;
+  return packageNamePattern.test(base) ? base : null;
+}
+
+function isExactOrTrailingStarPath(entry) {
+  return !entry.includes("*") || (entry.endsWith("/*") && !entry.slice(0, -2).includes("*"));
 }
 
 function relocatePathEntry(sourceDir, configDir, entry) {


### PR DESCRIPTION
## Summary
- Overlay already retargets outside `compilerOptions.paths` package mappings, but skipped any target containing `*`. Nuxt-style `vue-router: [\"../../node_modules/vue-router/*\"]` therefore still loaded Vize's Vue beside the fixture (#4461).
- Retarget trailing `/*` on package names (and `package/*` keys) to the fixture-local copy when it exists.
- Interior `*` patterns and `#alias/*` keys are not guessed.

## Test plan
- [x] `node --test` star-path overlay tests plus existing outside-paths / typeRoots / package-extends overlay tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790109733&installation_model_id=422833&pr_number=4690&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4690&signature=a861417f270f07f4318d825bb0434eb4dc70d3cf4f9a0b5125b9a795332be827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->