### PR TITLE
fix(matrix): retarget outside hash-alias paths to the fixture package

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-aliases.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-aliases.test.ts
@@ -1,0 +1,215 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  applyIsolatedAliasOverlay,
+  mergePathRewrites,
+  rewriteOutsideAliasPaths,
+} from "../../tools/fixtures/typecheck-baseline-outside-aliases.mjs";
+import { writeIsolatedTsconfigOverlay } from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+
+/**
+ * Non-package `paths` keys still load outside trees (#4461). Overlay retargets
+ * `#app` onto the fixture copy of the owning package. Package-name mappings
+ * stay with the existing package rewrite.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-outside-aliases-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsideNuxt = path.join(outer, "node_modules", "nuxt");
+  fs.mkdirSync(path.join(outsideNuxt, "dist", "app"), { recursive: true });
+  fs.writeFileSync(path.join(outsideNuxt, "package.json"), `{"name":"nuxt"}\n`);
+  fs.writeFileSync(path.join(outsideNuxt, "dist", "app", "index.d.ts"), "export {}\n");
+  const outsideRouter = path.join(outer, "node_modules", "vue-router");
+  fs.mkdirSync(outsideRouter, { recursive: true });
+  fs.writeFileSync(path.join(outsideRouter, "package.json"), `{"name":"vue-router"}\n`);
+  return { outer, fixtureRoot, outsideNuxt, outsideRouter };
+}
+
+function writeLocalPackage(fixtureRoot: string, name: string) {
+  const local = path.join(fixtureRoot, "node_modules", name);
+  fs.mkdirSync(local, { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"${name}"}\n`);
+  return local;
+}
+
+test("an outside hash alias is retargeted to the fixture copy of its package", () => {
+  const { outer, fixtureRoot, outsideNuxt } = scaffold();
+  try {
+    writeLocalPackage(fixtureRoot, "nuxt");
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "#imports": ["./src/imports.d.ts"],
+            "#app": [path.relative(fixtureRoot, path.join(outsideNuxt, "dist", "app"))],
+          },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      {
+        "#app": ["../node_modules/nuxt/dist/app"],
+        "#imports": ["../src/imports.d.ts"],
+      },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside hash alias with a trailing star is retargeted", () => {
+  const { outer, fixtureRoot, outsideNuxt } = scaffold();
+  try {
+    writeLocalPackage(fixtureRoot, "nuxt");
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "#app/*": [`${path.relative(fixtureRoot, path.join(outsideNuxt, "dist", "app"))}/*`],
+          },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "#app/*": ["../node_modules/nuxt/dist/app/*"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("package-name mappings are left for the package rewrite", () => {
+  const { outer, fixtureRoot, outsideRouter } = scaffold();
+  try {
+    writeLocalPackage(fixtureRoot, "vue-router");
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "vue-router": [path.relative(fixtureRoot, outsideRouter)] },
+        },
+      })}\n`,
+    );
+    assert.equal(
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an interior star in a hash alias is not guessed", () => {
+  const { outer, fixtureRoot, outsideNuxt } = scaffold();
+  try {
+    writeLocalPackage(fixtureRoot, "nuxt");
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "#app": [`${path.relative(fixtureRoot, path.dirname(outsideNuxt))}/*/nuxt/dist/app`],
+          },
+        },
+      })}\n`,
+    );
+    assert.equal(
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside hash alias with no fixture-local package is left inherited", () => {
+  const { outer, fixtureRoot, outsideNuxt } = scaffold();
+  try {
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "#app": [path.relative(fixtureRoot, path.join(outsideNuxt, "dist", "app"))],
+          },
+        },
+      })}\n`,
+    );
+    assert.equal(
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("package rewrites win over alias rewrites for the same key", () => {
+  assert.deepEqual(
+    mergePathRewrites(
+      { "vue-router": ["./node_modules/vue-router"], "#app": ["./escaped"] },
+      { "vue-router": ["./wrong"], "#app": ["./node_modules/nuxt/dist/app"] },
+    ),
+    {
+      "#app": ["./node_modules/nuxt/dist/app"],
+      "vue-router": ["./node_modules/vue-router"],
+    },
+  );
+});
+
+test("alias overlay keeps package-path overlay typeRoots and merges paths", () => {
+  const { outer, fixtureRoot, outsideNuxt, outsideRouter } = scaffold();
+  try {
+    writeLocalPackage(fixtureRoot, "nuxt");
+    writeLocalPackage(fixtureRoot, "vue-router");
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "#app": [path.relative(fixtureRoot, path.join(outsideNuxt, "dist", "app"))],
+            "vue-router": [path.relative(fixtureRoot, outsideRouter)],
+          },
+        },
+      })}\n`,
+    );
+    const overlay = applyIsolatedAliasOverlay(
+      fixtureRoot,
+      sourcePath,
+      writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath),
+    );
+    assert.deepEqual(overlay?.paths, {
+      "#app": ["./node_modules/nuxt/dist/app"],
+      "vue-router": ["./node_modules/vue-router"],
+    });
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.json",
+      compilerOptions: {
+        paths: {
+          "#app": ["./node_modules/nuxt/dist/app"],
+          "vue-router": ["./node_modules/vue-router"],
+        },
+      },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-aliases.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-aliases.mjs
@@ -1,0 +1,233 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+
+import { isolatedTsconfigOverlayPath } from "./typecheck-baseline-outside-paths.mjs";
+
+/**
+ * Close the remaining `compilerOptions.paths` escape for keys that are not
+ * package names (#4461). Unique isolation and the package-name overlay only
+ * retarget `vue-router`. Nuxt still writes `#app` / `#imports` onto files
+ * *above* the fixture, so vue-tsc loads Vize's Nuxt and then Vize's Vue.
+ *
+ * A mapping is retargeted only when its target sits under an outside
+ * `node_modules/<name>` (or `@scope/name`) directory and the fixture already
+ * has that package. Interior `*` patterns are not guessed.
+ */
+
+const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
+
+export function rewriteOutsideAliasPaths(fixtureRoot, sourceConfigPath, configDir) {
+  const root = resolve(fixtureRoot);
+  const declared = winningPaths(sourceConfigPath, root);
+  if (declared == null) return null;
+  const rewritten = {};
+  let changed = false;
+  for (const [name, targets] of Object.entries(declared.paths)) {
+    if (!Array.isArray(targets)) continue;
+    rewritten[name] = retargetAliasMapping(root, declared.dir, configDir, name, targets, () => {
+      changed = true;
+    });
+  }
+  return changed ? rewritten : null;
+}
+
+export function mergePathRewrites(packages, aliases) {
+  if (packages == null) return aliases;
+  if (aliases == null) return packages;
+  const merged = { ...packages };
+  for (const [name, targets] of Object.entries(aliases)) {
+    if (!isPackageMappingName(name)) merged[name] = targets;
+  }
+  return merged;
+}
+
+export function applyIsolatedAliasOverlay(fixtureRoot, sourceConfigPath, overlay) {
+  const sourcePath = resolve(sourceConfigPath);
+  const aliases = rewriteOutsideAliasPaths(fixtureRoot, sourcePath, dirname(sourcePath));
+  if (aliases == null) return overlay ?? null;
+  const paths = mergePathRewrites(overlay?.paths ?? null, aliases);
+  const typeRoots = overlay?.typeRoots ?? null;
+  const overlayPath = overlay?.path ?? isolatedTsconfigOverlayPath(sourcePath);
+  const compilerOptions = { paths };
+  if (typeRoots != null) compilerOptions.typeRoots = typeRoots;
+  writeFileSync(
+    overlayPath,
+    `${JSON.stringify({ extends: `./${basename(sourcePath)}`, compilerOptions }, null, 2)}\n`,
+  );
+  return { path: overlayPath, paths, typeRoots };
+}
+
+function retargetAliasMapping(fixtureRoot, sourceDir, configDir, name, targets, markChanged) {
+  const relocated = targets.map((entry) => relocatePathEntry(sourceDir, configDir, entry));
+  if (isPackageMappingName(name)) return relocated;
+  const first = targets.find(
+    (entry) => typeof entry === "string" && isExactOrTrailingStarPath(entry),
+  );
+  if (first == null) return relocated;
+  const star = first.endsWith("/*");
+  const original = resolve(sourceDir, star ? first.slice(0, -2) : first);
+  if (isInside(fixtureRoot, original)) return relocated;
+  const owned = owningNodeModulePackage(original);
+  if (owned == null || isInside(fixtureRoot, owned.root)) return relocated;
+  const local = join(fixtureRoot, "node_modules", ...owned.name.split("/"));
+  if (!existsSync(join(local, "package.json"))) return relocated;
+  const subpath = relative(owned.root, original).replaceAll("\\", "/");
+  if (subpath.startsWith("..") || subpath.startsWith("/")) return relocated;
+  const localTarget = subpath === "" ? local : join(local, subpath);
+  markChanged();
+  const rewritten = star
+    ? `${configRelativePath(configDir, localTarget)}/*`
+    : configRelativePath(configDir, localTarget);
+  return relocated.map((entry, index) => (index === targets.indexOf(first) ? rewritten : entry));
+}
+
+function isPackageMappingName(name) {
+  if (typeof name !== "string") return false;
+  const base = name.endsWith("/*") ? name.slice(0, -2) : name;
+  return packageNamePattern.test(base);
+}
+
+function isExactOrTrailingStarPath(entry) {
+  return !entry.includes("*") || (entry.endsWith("/*") && !entry.slice(0, -2).includes("*"));
+}
+
+function relocatePathEntry(sourceDir, configDir, entry) {
+  if (typeof entry !== "string") return entry;
+  if (!entry.includes("*")) return configRelativePath(configDir, resolve(sourceDir, entry));
+  if (entry.endsWith("/*") && !entry.slice(0, -2).includes("*")) {
+    return `${configRelativePath(configDir, resolve(sourceDir, entry.slice(0, -2)))}/*`;
+  }
+  return entry;
+}
+
+function owningNodeModulePackage(resolvedPath) {
+  let directory = resolvedPath;
+  let previous = null;
+  while (directory !== previous) {
+    if (existsSync(join(directory, "package.json"))) {
+      const owned = nodeModulePackageName(directory);
+      if (owned != null) return owned;
+    }
+    previous = directory;
+    directory = dirname(directory);
+  }
+  return null;
+}
+
+function nodeModulePackageName(packageRoot) {
+  const parent = dirname(packageRoot);
+  const grandparent = dirname(parent);
+  if (basename(parent) === "node_modules") {
+    return { name: basename(packageRoot), root: packageRoot };
+  }
+  if (basename(grandparent) === "node_modules" && basename(parent).startsWith("@")) {
+    return { name: `${basename(parent)}/${basename(packageRoot)}`, root: packageRoot };
+  }
+  return null;
+}
+
+function winningPaths(sourceConfigPath, fixtureRoot) {
+  let paths;
+  let dir;
+  for (const { config, dir: configDir } of [
+    ...loadExtendsChain(sourceConfigPath, fixtureRoot),
+  ].reverse()) {
+    const candidate = config?.compilerOptions?.paths;
+    if (candidate != null && typeof candidate === "object") {
+      paths = candidate;
+      dir = configDir;
+    }
+  }
+  return paths == null ? null : { paths, dir };
+}
+
+function loadExtendsChain(sourceConfigPath, fixtureRoot) {
+  const chain = [];
+  const seen = new Set();
+  let current = resolve(sourceConfigPath);
+  while (!seen.has(current)) {
+    seen.add(current);
+    const config = parseTsconfig(current);
+    if (config == null) break;
+    chain.push({ config, dir: dirname(current) });
+    let next = null;
+    for (const specifier of extendsSpecifiers(config.extends)) {
+      next = resolveRelativeExtends(current, specifier, fixtureRoot);
+      if (next != null) break;
+    }
+    if (next == null) break;
+    current = next;
+  }
+  return chain;
+}
+
+function parseTsconfig(configPath) {
+  try {
+    return JSON.parse(stripJsonc(readFileSync(configPath, "utf8")));
+  } catch {
+    return null;
+  }
+}
+
+function extendsSpecifiers(value) {
+  if (typeof value === "string") return [value];
+  return Array.isArray(value) ? value.filter((entry) => typeof entry === "string") : [];
+}
+
+function resolveRelativeExtends(fromConfig, specifier, fixtureRoot) {
+  if (typeof specifier !== "string") return null;
+  if (!(specifier.startsWith("./") || specifier.startsWith("../"))) return null;
+  const resolved = resolve(dirname(fromConfig), specifier);
+  const file = existsSync(resolved)
+    ? resolved
+    : !resolved.endsWith(".json") && existsSync(`${resolved}.json`)
+      ? `${resolved}.json`
+      : null;
+  if (file == null || !isInside(fixtureRoot, file)) return null;
+  return file;
+}
+
+function isInside(root, target) {
+  const path = relative(root, target);
+  return path !== "" && !path.startsWith("..") && !path.startsWith("/");
+}
+
+function configRelativePath(from, to) {
+  const path = relative(from, to).replaceAll("\\", "/");
+  if (path.startsWith("/") || /^[A-Za-z]:\//u.test(path)) return path;
+  return path.startsWith(".") ? path : `./${path}`;
+}
+
+function stripJsonc(text) {
+  let out = "";
+  let inString = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inString) {
+      out += ch;
+      if (ch === "\\") {
+        out += text[i + 1] ?? "";
+        i += 1;
+      } else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i += 1;
+      out += "\n";
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "*") {
+      i += 2;
+      while (i + 1 < text.length && !(text[i] === "*" && text[i + 1] === "/")) i += 1;
+      i += 1;
+      continue;
+    }
+    out += ch;
+  }
+  return out.replace(/,(\s*[}\]])/g, "$1");
+}

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -2,6 +2,10 @@ import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
 import {
+  mergePathRewrites,
+  rewriteOutsideAliasPaths,
+} from "./typecheck-baseline-outside-aliases.mjs";
+import {
   rewriteOutsidePackagePaths,
   rewriteOutsideTypeRoots,
 } from "./typecheck-baseline-outside-paths.mjs";
@@ -120,7 +124,10 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
 
 function outsideCompilerOptions(fixtureRoot, sourcePath, configDir) {
   const options = {};
-  const paths = rewriteOutsidePackagePaths(fixtureRoot, sourcePath, configDir);
+  const paths = mergePathRewrites(
+    rewriteOutsidePackagePaths(fixtureRoot, sourcePath, configDir),
+    rewriteOutsideAliasPaths(fixtureRoot, sourcePath, configDir),
+  );
   if (paths != null) options.paths = paths;
   const typeRoots = rewriteOutsideTypeRoots(fixtureRoot, sourcePath, configDir);
   if (typeRoots != null) options.typeRoots = typeRoots;

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
 import { isolateFixtureTypePackages } from "./typecheck-baseline-isolation.mjs";
 import { isolateUniqueLocalTypePackages } from "./typecheck-baseline-isolation-unique.mjs";
+import { applyIsolatedAliasOverlay } from "./typecheck-baseline-outside-aliases.mjs";
 import { writeIsolatedTsconfigOverlay } from "./typecheck-baseline-outside-paths.mjs";
 import { selectTypecheckPerformanceProjects } from "./typecheck-performance-shard.mjs";
 
@@ -160,7 +161,12 @@ function isolateFixture(project, fixtureRoot) {
     process.stdout.write(`Linked ${project.id} node_modules/${entry.name} -> ${entry.target}\n`);
   }
   if (typeof project.tsconfig !== "string") return;
-  const overlay = writeIsolatedTsconfigOverlay(fixtureRoot, resolve(fixtureRoot, project.tsconfig));
+  const sourceConfig = resolve(fixtureRoot, project.tsconfig);
+  const overlay = applyIsolatedAliasOverlay(
+    fixtureRoot,
+    sourceConfig,
+    writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfig),
+  );
   if (overlay != null) {
     process.stdout.write(
       `Rewrote ${project.id} tsconfig overlay -> ${relative(fixtureRoot, overlay.path)}\n`,


### PR DESCRIPTION
## Summary
- Package-name `paths` overlay cannot see Nuxt `#app` / `#imports` keys. Those mappings still pointed at trees *above* the fixture, so vue-tsc loaded Vize's Nuxt and then Vize's Vue (#4461).
- Retarget a non-package mapping only when the target sits under an outside `node_modules/<name>` directory and the fixture already has that package. Interior `*` patterns are not guessed.
- Package-name mappings stay with the existing package rewrite; the two maps merge with package keys winning.

## Test plan
- [x] `node --test` alias overlay tests plus existing outside-paths / typeRoots tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790110356&installation_model_id=422833&pr_number=4691&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4691&signature=cd92a90e11e281382ec35ec52f1ac448897d538c36147219e2427d71d486d68c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded TypeScript fixture coverage for path aliases, including wildcard mappings, inherited configurations, rewrite precedence, package mappings, and unsupported patterns.
  - Added validation for configurations with aliases targeting packages outside the fixture.

- **Chores**
  - Improved isolated TypeScript configuration generation to preserve existing settings while safely applying supported path-alias rewrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->