### PR TITLE
fix(matrix): isolate compilerOptions.jsxImportSource to the fixture

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-jsx.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-jsx.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { readDeclaredPackagePaths } from "../../tools/fixtures/typecheck-baseline-isolation.mjs";
+import { isolateUniqueLocalTypePackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+import { jsxImportSourcePackageName } from "../../tools/fixtures/typecheck-baseline-isolation-jsx.mjs";
+
+/**
+ * `compilerOptions.jsxImportSource` resolves `<name>/jsx-runtime` by climbing
+ * `node_modules` (#4461). Unique isolation links the fixture copy. Child
+ * replaces parent. Package-name `extends` configs are not read.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-jsx-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  const ancestorVue = path.join(outer, "node_modules", "vue");
+  fs.mkdirSync(ancestorVue, { recursive: true });
+  fs.writeFileSync(path.join(ancestorVue, "package.json"), `{"name":"vue"}\n`);
+  const ancestorPreact = path.join(outer, "node_modules", "preact");
+  fs.mkdirSync(ancestorPreact, { recursive: true });
+  fs.writeFileSync(path.join(ancestorPreact, "package.json"), `{"name":"preact"}\n`);
+  const ancestorVueTsconfig = path.join(outer, "node_modules", "@vue", "tsconfig");
+  fs.mkdirSync(ancestorVueTsconfig, { recursive: true });
+  fs.writeFileSync(path.join(ancestorVueTsconfig, "package.json"), `{"name":"@vue/tsconfig"}\n`);
+  fs.writeFileSync(
+    path.join(ancestorVueTsconfig, "tsconfig.json"),
+    `${JSON.stringify({ compilerOptions: { jsxImportSource: "vue" } })}\n`,
+  );
+  return { ancestorPreact, ancestorVue, ancestorVueTsconfig, fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+function writeConfig(fixtureRoot: string, config: unknown, fileName = "tsconfig.json") {
+  const configPath = path.join(fixtureRoot, fileName);
+  fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`);
+  return configPath;
+}
+
+test("jsxImportSource names the package, not a relative path", () => {
+  assert.equal(jsxImportSourcePackageName("vue"), "vue");
+  assert.equal(jsxImportSourcePackageName("preact"), "preact");
+  assert.equal(jsxImportSourcePackageName("./jsx"), null);
+  assert.equal(jsxImportSourcePackageName(undefined), null);
+});
+
+test("compilerOptions.jsxImportSource records ancestor packages for unique isolation", () => {
+  const { ancestorVue, fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: { jsxImportSource: "vue" },
+    });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      vue: ancestorVue,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("unique isolation links the fixture copy of a jsxImportSource package", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue@3.5.13", "vue");
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: { jsxImportSource: "vue" },
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      { name: "vue", target: "node_modules/.pnpm/vue@3.5.13/node_modules/vue" },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("jsxImportSource on a relative extends parent is recorded", () => {
+  const { ancestorVue, fixtureRoot, outer } = scaffold();
+  try {
+    writeConfig(fixtureRoot, { compilerOptions: { jsxImportSource: "vue" } }, "tsconfig.app.json");
+    const configPath = writeConfig(fixtureRoot, { extends: "./tsconfig.app.json" });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      vue: ancestorVue,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("child jsxImportSource replaces parent jsxImportSource", () => {
+  const { ancestorPreact, fixtureRoot, outer } = scaffold();
+  try {
+    writeConfig(fixtureRoot, { compilerOptions: { jsxImportSource: "vue" } }, "tsconfig.app.json");
+    const configPath = writeConfig(fixtureRoot, {
+      extends: "./tsconfig.app.json",
+      compilerOptions: { jsxImportSource: "preact" },
+    });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      preact: ancestorPreact,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("package-name extends is not walked for jsxImportSource", () => {
+  const { ancestorVueTsconfig, fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, { extends: "@vue/tsconfig" });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      "@vue/tsconfig": ancestorVueTsconfig,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("paths still win when the same name is also jsxImportSource", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const local = path.join(fixtureRoot, "packages", "vue");
+    fs.mkdirSync(local, { recursive: true });
+    fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue"}\n`);
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: {
+        jsxImportSource: "vue",
+        paths: { vue: ["./packages/vue"] },
+      },
+    });
+    assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
+      vue: local,
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a jsxImportSource package with no fixture copy is left unlinked", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const configPath = writeConfig(fixtureRoot, {
+      compilerOptions: { jsxImportSource: "vue" },
+    });
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), []);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-jsx.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-jsx.mjs
@@ -1,0 +1,34 @@
+import {
+  ancestorPackagePath,
+  packageNameFromExtendsSpecifier,
+} from "./typecheck-baseline-isolation-package-extends.mjs";
+
+/**
+ * `compilerOptions.jsxImportSource` is a module walk out of the fixture (#4461).
+ *
+ * TypeScript loads `<name>/jsx-runtime` by climbing `node_modules`. Overlay
+ * cannot retarget that require. Recording the package as an ancestor target
+ * lets unique isolation link the fixture's own `vue` before Vize's copy.
+ *
+ * Child `jsxImportSource` replaces the parent, matching tsc. Package-name
+ * `extends` configs are not read for it, matching `paths` and `types`.
+ */
+
+export function jsxImportSourcePackageName(specifier) {
+  return packageNameFromExtendsSpecifier(specifier);
+}
+
+export function recordCompilerOptionJsxImportSource(declared, conflicts, fixtureRoot, chain) {
+  if (!Array.isArray(chain)) return;
+  let specifier;
+  for (const entry of [...chain].reverse()) {
+    const candidate =
+      entry?.config?.compilerOptions?.jsxImportSource ?? entry?.compilerOptions?.jsxImportSource;
+    if (typeof candidate === "string") specifier = candidate;
+  }
+  const name = packageNameFromExtendsSpecifier(specifier);
+  if (name == null || conflicts.has(name) || declared.has(name)) return;
+  const ancestor = ancestorPackagePath(fixtureRoot, name);
+  if (ancestor == null) return;
+  declared.set(name, ancestor);
+}

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -25,10 +25,10 @@ import { readDeclaredPackagePaths } from "./typecheck-baseline-isolation.mjs";
  * Declared names come from the same `extends` / `references` walk isolation
  * uses, so a check tsconfig that only extends the generated app config still
  * sees the outside mapping (reka-ui's `tsconfig.check.json`). Package-name
- * `extends` specifiers, `compilerOptions.types` entries, and plugin packages
- * are included as ancestor targets so this can link the fixture's own
- * `@vue/tsconfig`, `vite`, `@types/node`, or language plugin before TypeScript
- * climbs into Vize.
+ * `extends` specifiers, `compilerOptions.types` entries, plugin packages, and
+ * `jsxImportSource` are included as ancestor targets so this can link the
+ * fixture's own `@vue/tsconfig`, `vite`, `@types/node`, language plugin, or
+ * `vue` JSX runtime before TypeScript climbs into Vize.
  */
 
 export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -13,6 +13,7 @@ import {
   ancestorPackagePath,
   packageNameFromExtendsSpecifier,
 } from "./typecheck-baseline-isolation-package-extends.mjs";
+import { recordCompilerOptionJsxImportSource } from "./typecheck-baseline-isolation-jsx.mjs";
 import { recordCompilerOptionPlugins } from "./typecheck-baseline-isolation-plugins.mjs";
 import { recordCompilerOptionTypes } from "./typecheck-baseline-isolation-types.mjs";
 
@@ -55,9 +56,10 @@ import { recordCompilerOptionTypes } from "./typecheck-baseline-isolation-types.
  * `tsconfig.json` is solution-style and parks the real paths on referenced
  * `.nuxt` projects (#4461). Conflicting targets for one name are dropped
  * rather than guessed. Package-name `extends` specifiers,
- * `compilerOptions.types` entries, and plugin packages are recorded as
- * ancestor targets so unique isolation can link a fixture-local copy; those
- * package configs are not walked for `paths`, `types`, or plugins.
+ * `compilerOptions.types` entries, plugin packages, and `jsxImportSource`
+ * are recorded as ancestor targets so unique isolation can link a
+ * fixture-local copy; those package configs are not walked for `paths`,
+ * `types`, plugins, or `jsxImportSource`.
  */
 
 /** `paths` also carries `#imports`-style aliases and `foo/*` patterns, which are not packages. */
@@ -131,6 +133,7 @@ function mergePackageExtends(declared, conflicts, configPaths, fixtureRoot) {
       fixtureRoot,
       chain.map(({ config }) => config),
     );
+    recordCompilerOptionJsxImportSource(declared, conflicts, fixtureRoot, chain);
   }
 }
 


### PR DESCRIPTION
## Summary
- TypeScript resolves `compilerOptions.jsxImportSource` as `<name>/jsx-runtime` by climbing `node_modules`, so a Vue JSX fixture can load Vize's `vue` beside its own (#4461). Overlay cannot retarget that require.
- Record the package as an ancestor target so unique isolation can link the fixture's own copy first. Child `jsxImportSource` replaces the parent; package-name `extends` configs are not read for it.

## Test plan
- [x] `node --test` jsxImportSource isolation tests plus existing isolation / types / plugins tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790110590&installation_model_id=422833&pr_number=4692&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4692&signature=d3acdfd364f8559ae05e02445a7abbeddfe79dc15ba1c413d1b81acc609dc3bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript JSX configuration handling so fixture-specific Vue JSX runtimes resolve correctly.
  * Added support for inherited and overridden `jsxImportSource` settings, including package-name extensions and path mappings.
  * Improved isolation when fixture package copies are missing or located through ancestor packages.

* **Tests**
  * Added comprehensive coverage for JSX import-source resolution, configuration inheritance, overrides, linking, and missing fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->