### PR TITLE
fix(matrix): retarget outside * paths that point at node_modules

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-catchall.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-catchall.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { rewriteOutsidePackagePaths } from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+
+/**
+ * A `paths` mapping named `*` whose target is an outside `node_modules`
+ * directory still loads Vize's Vue (#4461). Overlay retargets that catch-all
+ * to the fixture copy. Other outside directories are not guessed.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-outside-catchall-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsideModules = path.join(outer, "node_modules");
+  fs.mkdirSync(outsideModules, { recursive: true });
+  return { fixtureRoot, outer, outsideModules };
+}
+
+test("an outside node_modules catch-all is retargeted to the fixture copy", () => {
+  const { fixtureRoot, outer, outsideModules } = scaffold();
+  try {
+    fs.mkdirSync(path.join(fixtureRoot, "node_modules"), { recursive: true });
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "*": [`${path.relative(fixtureRoot, outsideModules)}/*`] },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "*": ["../node_modules/*"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside catch-all with no fixture node_modules is left inherited", () => {
+  const { fixtureRoot, outer, outsideModules } = scaffold();
+  try {
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "*": [`${path.relative(fixtureRoot, outsideModules)}/*`] },
+        },
+      })}\n`,
+    );
+    assert.equal(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside catch-all that is not node_modules is not guessed", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    fs.mkdirSync(path.join(fixtureRoot, "node_modules"), { recursive: true });
+    const outsideSrc = path.join(outer, "src");
+    fs.mkdirSync(outsideSrc, { recursive: true });
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "*": [`${path.relative(fixtureRoot, outsideSrc)}/*`] },
+        },
+      })}\n`,
+    );
+    assert.equal(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an inside node_modules catch-all is left inherited", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    fs.mkdirSync(path.join(fixtureRoot, "node_modules"), { recursive: true });
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "*": ["./node_modules/*"] },
+        },
+      })}\n`,
+    );
+    assert.equal(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -31,8 +31,9 @@ import { basename, dirname, join, relative, resolve } from "node:path";
  * `node_modules/@types` is retargeted to the fixture-local copy when it exists.
  *
  * A trailing `/*` on a package mapping is the same walk: TypeScript still
- * loads that outside tree. Interior `*` patterns and `#alias/*` keys are not
- * guessed.
+ * loads that outside tree. A mapping named `*` whose target is an outside
+ * `node_modules` directory is retargeted to the fixture copy. Interior `*`
+ * patterns and `#alias/*` keys are not guessed.
  */
 
 const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
@@ -94,15 +95,22 @@ export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
 function retargetPathMapping(fixtureRoot, sourceDir, configDir, name, targets, markChanged) {
   const relocated = targets.map((entry) => relocatePathEntry(sourceDir, configDir, entry));
   const packageName = packageNameFromPathMapping(name);
-  if (packageName == null) return relocated;
   const first = targets.find(
     (entry) => typeof entry === "string" && isExactOrTrailingStarPath(entry),
   );
   if (first == null) return relocated;
   const original = resolve(sourceDir, first.endsWith("/*") ? first.slice(0, -2) : first);
   if (isInside(fixtureRoot, original)) return relocated;
-  const local = join(fixtureRoot, "node_modules", ...packageName.split("/"));
-  if (!existsSync(join(local, "package.json"))) return relocated;
+  let local;
+  if (packageName != null) {
+    local = join(fixtureRoot, "node_modules", ...packageName.split("/"));
+    if (!existsSync(join(local, "package.json"))) return relocated;
+  } else if (name === "*" && first.endsWith("/*") && basename(original) === "node_modules") {
+    local = join(fixtureRoot, "node_modules");
+    if (!existsSync(local)) return relocated;
+  } else {
+    return relocated;
+  }
   markChanged();
   const rewritten = first.endsWith("/*")
     ? `${configRelativePath(configDir, local)}/*`


### PR DESCRIPTION
## Summary
- A `compilerOptions.paths` catch-all named `*` that points at an ancestor `node_modules` still loads Vize's Vue beside the fixture (#4461). Package-name overlay cannot see that key.
- Retarget `*: ["../node_modules/*"]` to the fixture's `node_modules` when that directory exists. Outside directories that are not `node_modules`, interior `*` patterns, and `#alias/*` keys are not guessed.

## Test plan
- [x] `node --test` catch-all overlay tests plus existing outside-paths / trailing-star / typeRoots tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790110835&installation_model_id=422833&pr_number=4693&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4693&signature=1bfbe28182ec6baa29b55866481cfe5c904ec2e85ff10d11f103a48d550ba403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->