### PR TITLE
fix(matrix): isolate undeclared Vue runtime packages to the fixture

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-vue-runtime.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-vue-runtime.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueVueRuntimePackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * `vue-router` (and other Vue packages) still climb `node_modules` for `vue`
+ * even when no tsconfig declared it (#4461). Unique isolation links the
+ * fixture copy of the Vue runtime packages when an ancestor copy is reachable.
+ */
+
+function scaffold(names: string[] = ["vue", "@vue/runtime-core", "@vue/runtime-dom"]) {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-vue-rt-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const name of names) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string, version = "3.5.30") {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `{"name":"${name}","version":"${version}"}\n`,
+  );
+  return packageRoot;
+}
+
+test("an ancestor vue with exactly one in-fixture copy is linked from that copy", () => {
+  const { fixtureRoot, outer } = scaffold(["vue"]);
+  try {
+    writeStoreCopy(fixtureRoot, "vue@3.5.30", "vue");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), [
+      { name: "vue", target: "node_modules/.pnpm/vue@3.5.30/node_modules/vue" },
+    ]);
+    assert.equal(
+      fs.realpathSync(path.join(fixtureRoot, "node_modules", "vue")),
+      fs.realpathSync(
+        path.join(fixtureRoot, "node_modules", ".pnpm", "vue@3.5.30", "node_modules", "vue"),
+      ),
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a vue runtime name no ancestor provides is left alone", () => {
+  const { fixtureRoot, outer } = scaffold([]);
+  try {
+    writeStoreCopy(fixtureRoot, "vue@3.5.30", "vue");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("several vue copies whose Vue peers miss a unique match stay unlinked", () => {
+  const { fixtureRoot, outer } = scaffold(["vue"]);
+  try {
+    writeStoreCopy(fixtureRoot, "vue@3.5.13", "vue", "3.5.13");
+    writeStoreCopy(fixtureRoot, "vue@3.4.38", "vue", "3.4.38");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an already hoisted vue is left for isolation; this repair does not relink it", () => {
+  const { fixtureRoot, outer } = scaffold(["vue"]);
+  try {
+    writeStoreCopy(fixtureRoot, "vue@3.5.30", "vue");
+    const hoisted = path.join(fixtureRoot, "node_modules", "vue");
+    fs.mkdirSync(hoisted, { recursive: true });
+    fs.writeFileSync(path.join(hoisted, "package.json"), `{"name":"vue","version":"3.5.30"}\n`);
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), []);
+    assert.equal(fs.lstatSync(hoisted).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an ancestor @vue/runtime-core with exactly one in-fixture copy is linked", () => {
+  const { fixtureRoot, outer } = scaffold(["@vue/runtime-core"]);
+  try {
+    writeStoreCopy(fixtureRoot, "@vue+runtime-core@3.5.30", "@vue/runtime-core");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), [
+      {
+        name: "@vue/runtime-core",
+        target: "node_modules/.pnpm/@vue+runtime-core@3.5.30/node_modules/@vue/runtime-core",
+      },
+    ]);
+    assert.equal(
+      fs.realpathSync(path.join(fixtureRoot, "node_modules", "@vue", "runtime-core")),
+      fs.realpathSync(
+        path.join(
+          fixtureRoot,
+          "node_modules",
+          ".pnpm",
+          "@vue+runtime-core@3.5.30",
+          "node_modules",
+          "@vue",
+          "runtime-core",
+        ),
+      ),
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -10,6 +10,7 @@ import {
 import { dirname, join, relative, resolve } from "node:path";
 
 import { readDeclaredPackagePaths } from "./typecheck-baseline-isolation.mjs";
+import { ancestorPackagePath } from "./typecheck-baseline-isolation-package-extends.mjs";
 
 /**
  * Close the remaining type-reference escape when Nuxt (or another generator)
@@ -31,9 +32,28 @@ import { readDeclaredPackagePaths } from "./typecheck-baseline-isolation.mjs";
  * climbs into Vize.
  */
 
+const vueRuntimePackages = ["@vue/runtime-core", "@vue/runtime-dom", "vue"];
+
 export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {
   const root = resolve(fixtureRoot);
-  const declared = readDeclaredPackagePaths(root, sourceConfigPath);
+  return isolateUniqueDeclaredLocalTypePackages(
+    root,
+    readDeclaredPackagePaths(root, sourceConfigPath),
+  );
+}
+
+export function isolateUniqueVueRuntimePackages(fixtureRoot) {
+  const root = resolve(fixtureRoot);
+  const declared = new Map();
+  for (const name of vueRuntimePackages) {
+    const ancestor = ancestorPackagePath(root, name);
+    if (ancestor == null) continue;
+    declared.set(name, ancestor);
+  }
+  return isolateUniqueDeclaredLocalTypePackages(root, declared);
+}
+
+function isolateUniqueDeclaredLocalTypePackages(root, declared) {
   if (declared.size === 0) return [];
   const reachable = collectAncestorPackageNames(root);
   const shadowed = [];

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -7,7 +7,10 @@ import { fileURLToPath } from "node:url";
 
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
 import { isolateFixtureTypePackages } from "./typecheck-baseline-isolation.mjs";
-import { isolateUniqueLocalTypePackages } from "./typecheck-baseline-isolation-unique.mjs";
+import {
+  isolateUniqueLocalTypePackages,
+  isolateUniqueVueRuntimePackages,
+} from "./typecheck-baseline-isolation-unique.mjs";
 import { applyIsolatedAliasOverlay } from "./typecheck-baseline-outside-aliases.mjs";
 import { writeIsolatedTsconfigOverlay } from "./typecheck-baseline-outside-paths.mjs";
 import { selectTypecheckPerformanceProjects } from "./typecheck-performance-shard.mjs";
@@ -156,6 +159,11 @@ function isolateFixture(project, fixtureRoot) {
       seen.add(entry.name);
       shadowed.push(entry);
     }
+  }
+  for (const entry of isolateUniqueVueRuntimePackages(fixtureRoot)) {
+    if (seen.has(entry.name)) continue;
+    seen.add(entry.name);
+    shadowed.push(entry);
   }
   for (const entry of shadowed) {
     process.stdout.write(`Linked ${project.id} node_modules/${entry.name} -> ${entry.target}\n`);


### PR DESCRIPTION
## Summary
- `vue-router` still climbs `node_modules` for `vue` even when no tsconfig declared it, so a fixture can load Vize's Vue beside its own (#4461). Overlay cannot close that require.
- Unique isolation now links the fixture copies of `vue`, `@vue/runtime-core`, and `@vue/runtime-dom` when an ancestor copy is reachable. Declared unique links still win; several copies without a unique Vue peer stay unlinked.

## Test plan
- [x] `node --test` Vue runtime unique isolation tests plus existing unique isolation tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790111521&installation_model_id=422833&pr_number=4694&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4694&signature=894e666534bddbe552660f4e8a85f00a6253220883ead24301c9f9b0c8886ce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->