### PR TITLE
fix(matrix): follow in-fixture package-name extends for hash-alias overlay

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-aliases-package-extends.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-aliases-package-extends.test.ts
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { rewriteOutsideAliasPaths } from "../../tools/fixtures/typecheck-baseline-outside-aliases.mjs";
+
+/**
+ * Hash-alias overlay used to follow only relative `extends`. A package-name
+ * specifier is a different walk: TypeScript climbs `node_modules` and can load
+ * Vize's generated Nuxt config, whose `#app` still points above the fixture
+ * (#4461).
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-overlay-alias-package-extends-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsideNuxt = path.join(outer, "node_modules", "nuxt");
+  fs.mkdirSync(path.join(outsideNuxt, "dist", "app"), { recursive: true });
+  fs.writeFileSync(path.join(outsideNuxt, "package.json"), `{"name":"nuxt"}\n`);
+  fs.writeFileSync(path.join(outsideNuxt, "dist", "app", "index.d.ts"), "export {}\n");
+  return { fixtureRoot, outer, outsideNuxt };
+}
+
+function writeLocalNuxt(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "nuxt");
+  fs.mkdirSync(path.join(local, "dist", "app"), { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"nuxt"}\n`);
+  fs.writeFileSync(path.join(local, "dist", "app", "index.d.ts"), "export {}\n");
+  return local;
+}
+
+function writeNuxtTsconfig(packageRoot: string, outsideNuxt: string, fileName = "tsconfig.json") {
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"nuxt"}\n`);
+  fs.writeFileSync(
+    path.join(packageRoot, fileName),
+    `${JSON.stringify({
+      compilerOptions: {
+        paths: { "#app": [path.relative(packageRoot, path.join(outsideNuxt, "dist", "app"))] },
+      },
+    })}\n`,
+  );
+}
+
+test("an outside hash alias reached only through a fixture package-name extends is retargeted", () => {
+  const { fixtureRoot, outer, outsideNuxt } = scaffold();
+  try {
+    writeLocalNuxt(fixtureRoot);
+    writeNuxtTsconfig(
+      path.join(fixtureRoot, "node_modules", "@nuxt", "typescript-config"),
+      outsideNuxt,
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "node_modules", "@nuxt", "typescript-config", "package.json"),
+      `{"name":"@nuxt/typescript-config"}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(sourcePath, `{ "extends": "@nuxt/typescript-config" }\n`);
+    assert.deepEqual(
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "#app": ["../node_modules/nuxt/dist/app"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a subpath package-name extends still contributes its outside hash alias", () => {
+  const { fixtureRoot, outer, outsideNuxt } = scaffold();
+  try {
+    writeLocalNuxt(fixtureRoot);
+    writeNuxtTsconfig(
+      path.join(fixtureRoot, "node_modules", "@nuxt", "typescript-config"),
+      outsideNuxt,
+      "tsconfig.app.json",
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "node_modules", "@nuxt", "typescript-config", "package.json"),
+      `{"name":"@nuxt/typescript-config"}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(sourcePath, `{ "extends": "@nuxt/typescript-config/tsconfig.app.json" }\n`);
+    assert.deepEqual(
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "#app": ["../node_modules/nuxt/dist/app"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a package-name extends that lives only above the fixture is not followed", () => {
+  const { fixtureRoot, outer, outsideNuxt } = scaffold();
+  try {
+    writeLocalNuxt(fixtureRoot);
+    writeNuxtTsconfig(path.join(outer, "node_modules", "@nuxt", "typescript-config"), outsideNuxt);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(sourcePath, `{ "extends": "@nuxt/typescript-config" }\n`);
+    assert.equal(
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-aliases.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-aliases.mjs
@@ -1,7 +1,10 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 
-import { isolatedTsconfigOverlayPath } from "./typecheck-baseline-outside-paths.mjs";
+import {
+  isolatedTsconfigOverlayPath,
+  resolvePackageExtends,
+} from "./typecheck-baseline-outside-paths.mjs";
 
 /**
  * Close the remaining `compilerOptions.paths` escape for keys that are not
@@ -12,6 +15,9 @@ import { isolatedTsconfigOverlayPath } from "./typecheck-baseline-outside-paths.
  * A mapping is retargeted only when its target sits under an outside
  * `node_modules/<name>` (or `@scope/name`) directory and the fixture already
  * has that package. Interior `*` patterns are not guessed.
+ *
+ * Package-name `extends` is followed only inside the fixture, matching the
+ * package-name overlay. Climbing into Vize would load Vize's `#app` mappings.
  */
 
 const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
@@ -152,7 +158,9 @@ function loadExtendsChain(sourceConfigPath, fixtureRoot) {
     chain.push({ config, dir: dirname(current) });
     let next = null;
     for (const specifier of extendsSpecifiers(config.extends)) {
-      next = resolveRelativeExtends(current, specifier, fixtureRoot);
+      next =
+        resolveRelativeExtends(current, specifier, fixtureRoot) ??
+        resolvePackageExtends(current, specifier, fixtureRoot);
       if (next != null) break;
     }
     if (next == null) break;

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -220,7 +220,7 @@ function resolveExtends(fromConfig, specifier, fixtureRoot) {
   return resolvePackageExtends(fromConfig, specifier, fixtureRoot);
 }
 
-function resolvePackageExtends(fromConfig, specifier, fixtureRoot) {
+export function resolvePackageExtends(fromConfig, specifier, fixtureRoot) {
   const parsed = splitPackageExtends(specifier);
   if (parsed == null) return null;
   const root = resolve(fixtureRoot);


### PR DESCRIPTION
## Summary
- Hash-alias overlay (`#app` / `#imports`) followed only relative `extends`, so a fixture-local package-name tsconfig could still bake Nuxt aliases that point above the fixture (#4461).
- Follow in-fixture package-name `extends` the same way the package-path overlay already does. Ancestor package configs above the fixture are still not read.

## Test plan
- [x] `node --test` alias package-name extends overlay tests plus existing alias / package-extends overlay tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790111994&installation_model_id=422833&pr_number=4695&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4695&signature=947821c7935315c3a8248e2b4e47b7d98b43748c7f4ceb868c02e218705585e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->