### PR TITLE
fix(matrix): keep package-path overlay subpaths on the fixture copy

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-paths-subpath.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-paths-subpath.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { rewriteOutsidePackagePaths } from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+
+/**
+ * Package overlay used to retarget `vue` onto the fixture package root and
+ * drop `dist/vue`. Nuxt still points `paths` at that JSX entry above the
+ * fixture, so vue-tsc would load Vize's `vue/jsx-runtime` (#4461).
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-outside-paths-subpath-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsideVue = path.join(outer, "node_modules", "vue");
+  fs.mkdirSync(path.join(outsideVue, "dist"), { recursive: true });
+  fs.writeFileSync(path.join(outsideVue, "package.json"), `{"name":"vue"}\n`);
+  fs.writeFileSync(path.join(outsideVue, "dist", "vue.d.ts"), "export {}\n");
+  const outsideRuntime = path.join(outer, "node_modules", "@vue", "runtime-dom");
+  fs.mkdirSync(path.join(outsideRuntime, "dist"), { recursive: true });
+  fs.writeFileSync(path.join(outsideRuntime, "package.json"), `{"name":"@vue/runtime-dom"}\n`);
+  fs.writeFileSync(path.join(outsideRuntime, "dist", "runtime-dom.d.ts"), "export {}\n");
+  return { fixtureRoot, outer, outsideRuntime, outsideVue };
+}
+
+function writeLocalVue(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "vue");
+  fs.mkdirSync(path.join(local, "dist"), { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue"}\n`);
+  fs.writeFileSync(path.join(local, "dist", "vue.d.ts"), "export {}\n");
+  return local;
+}
+
+function writeLocalRuntimeDom(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "@vue", "runtime-dom");
+  fs.mkdirSync(path.join(local, "dist"), { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"@vue/runtime-dom"}\n`);
+  fs.writeFileSync(path.join(local, "dist", "runtime-dom.d.ts"), "export {}\n");
+  return local;
+}
+
+test("an outside vue mapping that points at dist/vue keeps that subpath", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { vue: [path.relative(fixtureRoot, path.join(outsideVue, "dist", "vue"))] },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { vue: ["../node_modules/vue/dist/vue"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside scoped mapping keeps its dist subpath", () => {
+  const { fixtureRoot, outer, outsideRuntime } = scaffold();
+  try {
+    writeLocalRuntimeDom(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "@vue/runtime-dom": [
+              path.relative(fixtureRoot, path.join(outsideRuntime, "dist", "runtime-dom")),
+            ],
+          },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "@vue/runtime-dom": ["../node_modules/@vue/runtime-dom/dist/runtime-dom"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a trailing-star mapping under dist keeps that directory", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "vue/*": [`${path.relative(fixtureRoot, path.join(outsideVue, "dist"))}/*`] },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "vue/*": ["../node_modules/vue/dist/*"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a missing fixture subpath is left inherited", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    const local = path.join(fixtureRoot, "node_modules", "vue");
+    fs.mkdirSync(local, { recursive: true });
+    fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue"}\n`);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { vue: [path.relative(fixtureRoot, path.join(outsideVue, "dist", "vue"))] },
+        },
+      })}\n`,
+    );
+    assert.equal(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      null,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -34,6 +34,9 @@ import { basename, dirname, join, relative, resolve } from "node:path";
  * loads that outside tree. A mapping named `*` whose target is an outside
  * `node_modules` directory is retargeted to the fixture copy. Interior `*`
  * patterns and `#alias/*` keys are not guessed.
+ *
+ * A package mapping whose outside target sits under `node_modules/<name>/...`
+ * keeps that subpath on the fixture copy (Nuxt's `vue/dist/vue` JSX entry).
  */
 
 const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
@@ -103,8 +106,11 @@ function retargetPathMapping(fixtureRoot, sourceDir, configDir, name, targets, m
   if (isInside(fixtureRoot, original)) return relocated;
   let local;
   if (packageName != null) {
-    local = join(fixtureRoot, "node_modules", ...packageName.split("/"));
-    if (!existsSync(join(local, "package.json"))) return relocated;
+    const localPackage = join(fixtureRoot, "node_modules", ...packageName.split("/"));
+    if (!existsSync(join(localPackage, "package.json"))) return relocated;
+    const subpath = packageSubpathAfterNodeModules(original, packageName);
+    local = subpath ? join(localPackage, subpath) : localPackage;
+    if (subpath && !existsSync(local) && !existsSync(`${local}.d.ts`)) return relocated;
   } else if (name === "*" && first.endsWith("/*") && basename(original) === "node_modules") {
     local = join(fixtureRoot, "node_modules");
     if (!existsSync(local)) return relocated;
@@ -116,6 +122,15 @@ function retargetPathMapping(fixtureRoot, sourceDir, configDir, name, targets, m
     ? `${configRelativePath(configDir, local)}/*`
     : configRelativePath(configDir, local);
   return relocated.map((entry, index) => (index === targets.indexOf(first) ? rewritten : entry));
+}
+
+function packageSubpathAfterNodeModules(original, packageName) {
+  const normalized = original.replaceAll("\\", "/");
+  const folder = `/node_modules/${packageName}`;
+  const nested = `${folder}/`;
+  const index = normalized.lastIndexOf(nested);
+  if (index !== -1) return normalized.slice(index + nested.length);
+  return normalized.endsWith(folder) ? "" : null;
 }
 
 function packageNameFromPathMapping(name) {


### PR DESCRIPTION
## Summary
- Package-path overlay retargeted `vue` onto the fixture package root and dropped `dist/vue`. Nuxt still points that mapping at the JSX entry above the fixture, so vue-tsc loaded Vize's Vue (#4461).
- Keep the `node_modules/<name>/...` subpath on the fixture copy when that file or `.d.ts` exists. Missing subpaths stay inherited.

## Test plan
- [x] `node --test` package-path subpath overlay tests plus existing outside-paths / star tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790112275&installation_model_id=422833&pr_number=4696&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4696&signature=24d30cadcbeb9651fb10c89ee84526be17a846769d6dc53e1a7826815302daaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->