### PR TITLE
fix(matrix): isolate undeclared vue-router packages to the fixture

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-vue-router.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-vue-router.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueVueRuntimePackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * Nuxt's generated `nuxt.d.ts` still `/// <reference types="vue-router" />`
+ * even when no tsconfig declared the package (#4461). Unique isolation links
+ * the fixture copy when an ancestor `vue-router` is reachable.
+ */
+
+function scaffold(names: string[] = ["vue-router"]) {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-vue-router-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const name of names) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+function writeFixtureVue(fixtureRoot: string, version: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", "vue");
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `{"name":"vue","version":"${version}"}\n`,
+  );
+}
+
+test("an ancestor vue-router with exactly one in-fixture copy is linked from that copy", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0", "vue-router");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), [
+      {
+        name: "vue-router",
+        target: "node_modules/.pnpm/vue-router@5.1.0/node_modules/vue-router",
+      },
+    ]);
+    assert.equal(
+      fs.realpathSync(path.join(fixtureRoot, "node_modules", "vue-router")),
+      fs.realpathSync(
+        path.join(
+          fixtureRoot,
+          "node_modules",
+          ".pnpm",
+          "vue-router@5.1.0",
+          "node_modules",
+          "vue-router",
+        ),
+      ),
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a vue-router no ancestor provides is left alone", () => {
+  const { fixtureRoot, outer } = scaffold([]);
+  try {
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0", "vue-router");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-router")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("several vue-router copies whose Vue peers miss a unique match stay unlinked", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.5.13", "vue-router");
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.4.38", "vue-router");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-router")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("several vue-router copies collapse to the one whose Vue peer matches the fixture", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeFixtureVue(fixtureRoot, "3.5.30");
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.5.30", "vue-router");
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0_vue@3.5.13", "vue-router");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), [
+      {
+        name: "vue-router",
+        target: "node_modules/.pnpm/vue-router@5.1.0_vue@3.5.30/node_modules/vue-router",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an already hoisted vue-router is left for isolation; this repair does not relink it", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue-router@5.1.0", "vue-router");
+    const hoisted = path.join(fixtureRoot, "node_modules", "vue-router");
+    fs.mkdirSync(hoisted, { recursive: true });
+    fs.writeFileSync(path.join(hoisted, "package.json"), `{"name":"vue-router"}\n`);
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), []);
+    assert.equal(fs.lstatSync(hoisted).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -32,7 +32,7 @@ import { ancestorPackagePath } from "./typecheck-baseline-isolation-package-exte
  * `vue` JSX runtime before TypeScript climbs into Vize.
  */
 
-const vueRuntimePackages = ["@vue/runtime-core", "@vue/runtime-dom", "vue"];
+const vueRuntimePackages = ["@vue/runtime-core", "@vue/runtime-dom", "vue", "vue-router"];
 
 export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {
   const root = resolve(fixtureRoot);


### PR DESCRIPTION
## Summary
- Nuxt's generated `nuxt.d.ts` still `/// <reference types="vue-router" />` even when no tsconfig declared the package, so TypeScript can climb into Vize's `vue-router` and then Vize's Vue (#4461).
- Unique isolation now links the fixture copy of `vue-router` on the same undeclared walk as `vue` / `@vue/runtime-*`. Declared unique links still win; several copies without a unique Vue peer stay unlinked.

## Test plan
- [x] `node --test` vue-router unique isolation tests plus existing unique / Vue runtime isolation tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790112406&installation_model_id=422833&pr_number=4697&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4697&signature=1f882d4119844800a3776325b870221f47c3edc704efc48ab267fd8190e50f63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->