### PR TITLE
fix(matrix): isolate undeclared vue-i18n packages to the fixture

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-vue-i18n.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-vue-i18n.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueVueI18nPackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * Elk's components lose vue-i18n augmentations when TypeScript climbs into
+ * Vize's `vue-i18n`, which then loads Vize's Vue beside the fixture (#4461).
+ * Unique isolation links the fixture copy when an ancestor copy is reachable.
+ */
+
+function scaffold(names: string[] = ["vue-i18n"]) {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-vue-i18n-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const name of names) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+function writeFixtureVue(fixtureRoot: string, version: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", "vue");
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `{"name":"vue","version":"${version}"}\n`,
+  );
+}
+
+test("an ancestor vue-i18n with exactly one in-fixture copy is linked from that copy", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue-i18n@11.1.11", "vue-i18n");
+    assert.deepEqual(isolateUniqueVueI18nPackages(fixtureRoot), [
+      { name: "vue-i18n", target: "node_modules/.pnpm/vue-i18n@11.1.11/node_modules/vue-i18n" },
+    ]);
+    assert.equal(
+      fs.realpathSync(path.join(fixtureRoot, "node_modules", "vue-i18n")),
+      fs.realpathSync(
+        path.join(
+          fixtureRoot,
+          "node_modules",
+          ".pnpm",
+          "vue-i18n@11.1.11",
+          "node_modules",
+          "vue-i18n",
+        ),
+      ),
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a vue-i18n no ancestor provides is left alone", () => {
+  const { fixtureRoot, outer } = scaffold([]);
+  try {
+    writeStoreCopy(fixtureRoot, "vue-i18n@11.1.11", "vue-i18n");
+    assert.deepEqual(isolateUniqueVueI18nPackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-i18n")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("several vue-i18n copies whose Vue peers miss a unique match stay unlinked", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue-i18n@11.1.11_vue@3.5.13", "vue-i18n");
+    writeStoreCopy(fixtureRoot, "vue-i18n@11.1.11_vue@3.4.38", "vue-i18n");
+    assert.deepEqual(isolateUniqueVueI18nPackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-i18n")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("several vue-i18n copies collapse to the one whose Vue peer matches the fixture", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeFixtureVue(fixtureRoot, "3.5.30");
+    writeStoreCopy(fixtureRoot, "vue-i18n@11.1.11_vue@3.5.30", "vue-i18n");
+    writeStoreCopy(fixtureRoot, "vue-i18n@11.1.11_vue@3.5.13", "vue-i18n");
+    assert.deepEqual(isolateUniqueVueI18nPackages(fixtureRoot), [
+      {
+        name: "vue-i18n",
+        target: "node_modules/.pnpm/vue-i18n@11.1.11_vue@3.5.30/node_modules/vue-i18n",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an already hoisted vue-i18n is left for isolation; this repair does not relink it", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue-i18n@11.1.11", "vue-i18n");
+    const hoisted = path.join(fixtureRoot, "node_modules", "vue-i18n");
+    fs.mkdirSync(hoisted, { recursive: true });
+    fs.writeFileSync(path.join(hoisted, "package.json"), `{"name":"vue-i18n"}\n`);
+    assert.deepEqual(isolateUniqueVueI18nPackages(fixtureRoot), []);
+    assert.equal(fs.lstatSync(hoisted).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -43,9 +43,17 @@ export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {
 }
 
 export function isolateUniqueVueRuntimePackages(fixtureRoot) {
+  return isolateUniqueNamedLocalTypePackages(fixtureRoot, vueRuntimePackages);
+}
+
+export function isolateUniqueVueI18nPackages(fixtureRoot) {
+  return isolateUniqueNamedLocalTypePackages(fixtureRoot, ["vue-i18n"]);
+}
+
+function isolateUniqueNamedLocalTypePackages(fixtureRoot, names) {
   const root = resolve(fixtureRoot);
   const declared = new Map();
-  for (const name of vueRuntimePackages) {
+  for (const name of names) {
     const ancestor = ancestorPackagePath(root, name);
     if (ancestor == null) continue;
     declared.set(name, ancestor);

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -9,6 +9,7 @@ import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-targ
 import { isolateFixtureTypePackages } from "./typecheck-baseline-isolation.mjs";
 import {
   isolateUniqueLocalTypePackages,
+  isolateUniqueVueI18nPackages,
   isolateUniqueVueRuntimePackages,
 } from "./typecheck-baseline-isolation-unique.mjs";
 import { applyIsolatedAliasOverlay } from "./typecheck-baseline-outside-aliases.mjs";
@@ -161,6 +162,11 @@ function isolateFixture(project, fixtureRoot) {
     }
   }
   for (const entry of isolateUniqueVueRuntimePackages(fixtureRoot)) {
+    if (seen.has(entry.name)) continue;
+    seen.add(entry.name);
+    shadowed.push(entry);
+  }
+  for (const entry of isolateUniqueVueI18nPackages(fixtureRoot)) {
     if (seen.has(entry.name)) continue;
     seen.add(entry.name);
     shadowed.push(entry);


### PR DESCRIPTION
## Summary
- Elk's components lose vue-i18n augmentations when TypeScript climbs into Vize's `vue-i18n`, which then loads Vize's Vue beside the fixture (#4461).
- Unique isolation now links the fixture copy of `vue-i18n` when an ancestor copy is reachable. Declared unique links still win; several copies without a unique Vue peer stay unlinked.

Independent of #4697 (`vue-router` on the same undeclared walk).

## Test plan
- [x] `node --test` vue-i18n unique isolation tests plus existing unique / Vue runtime isolation tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790112729&installation_model_id=422833&pr_number=4698&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4698&signature=0c099394b835c0ab8446f746298c16c2b069f973933263ccf9adefc659a4ff0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->