### PR TITLE
fix(matrix): isolate undeclared @vueuse packages to the fixture

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-vueuse.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-vueuse.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueVueUsePackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * Elk loses @vueuse augmentations when TypeScript climbs into Vize's
+ * `@vueuse/core`, which then loads Vize's Vue beside the fixture (#4461).
+ * Unique isolation links the fixture copy when an ancestor copy is reachable.
+ */
+
+function scaffold(names: string[] = ["@vueuse/core"]) {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-vueuse-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const name of names) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+function writeFixtureVue(fixtureRoot: string, version: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", "vue");
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `{"name":"vue","version":"${version}"}\n`,
+  );
+}
+
+test("an ancestor @vueuse/core with exactly one in-fixture copy is linked from that copy", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "@vueuse+core@13.1.0", "@vueuse/core");
+    assert.deepEqual(isolateUniqueVueUsePackages(fixtureRoot), [
+      {
+        name: "@vueuse/core",
+        target: "node_modules/.pnpm/@vueuse+core@13.1.0/node_modules/@vueuse/core",
+      },
+    ]);
+    assert.equal(
+      fs.realpathSync(path.join(fixtureRoot, "node_modules", "@vueuse", "core")),
+      fs.realpathSync(
+        path.join(
+          fixtureRoot,
+          "node_modules",
+          ".pnpm",
+          "@vueuse+core@13.1.0",
+          "node_modules",
+          "@vueuse",
+          "core",
+        ),
+      ),
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a @vueuse/core no ancestor provides is left alone", () => {
+  const { fixtureRoot, outer } = scaffold([]);
+  try {
+    writeStoreCopy(fixtureRoot, "@vueuse+core@13.1.0", "@vueuse/core");
+    assert.deepEqual(isolateUniqueVueUsePackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "@vueuse", "core")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("several @vueuse/core copies whose Vue peers miss a unique match stay unlinked", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "@vueuse+core@13.1.0_vue@3.5.13", "@vueuse/core");
+    writeStoreCopy(fixtureRoot, "@vueuse+core@13.1.0_vue@3.4.38", "@vueuse/core");
+    assert.deepEqual(isolateUniqueVueUsePackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "@vueuse", "core")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("several @vueuse/core copies collapse to the one whose Vue peer matches the fixture", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeFixtureVue(fixtureRoot, "3.5.30");
+    writeStoreCopy(fixtureRoot, "@vueuse+core@13.1.0_vue@3.5.30", "@vueuse/core");
+    writeStoreCopy(fixtureRoot, "@vueuse+core@13.1.0_vue@3.5.13", "@vueuse/core");
+    assert.deepEqual(isolateUniqueVueUsePackages(fixtureRoot), [
+      {
+        name: "@vueuse/core",
+        target: "node_modules/.pnpm/@vueuse+core@13.1.0_vue@3.5.30/node_modules/@vueuse/core",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an already hoisted @vueuse/core is left for isolation; this repair does not relink it", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "@vueuse+core@13.1.0", "@vueuse/core");
+    const hoisted = path.join(fixtureRoot, "node_modules", "@vueuse", "core");
+    fs.mkdirSync(hoisted, { recursive: true });
+    fs.writeFileSync(path.join(hoisted, "package.json"), `{"name":"@vueuse/core"}\n`);
+    assert.deepEqual(isolateUniqueVueUsePackages(fixtureRoot), []);
+    assert.equal(fs.lstatSync(hoisted).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -185,3 +185,14 @@ function isDanglingLink(link) {
 function compare(left, right) {
   return left < right ? -1 : left > right ? 1 : 0;
 }
+
+export function isolateUniqueVueUsePackages(fixtureRoot) {
+  const root = resolve(fixtureRoot);
+  const declared = new Map();
+  for (const name of ["@vueuse/core", "@vueuse/shared"]) {
+    const ancestor = ancestorPackagePath(root, name);
+    if (ancestor == null) continue;
+    declared.set(name, ancestor);
+  }
+  return isolateUniqueDeclaredLocalTypePackages(root, declared);
+}

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -10,6 +10,7 @@ import { isolateFixtureTypePackages } from "./typecheck-baseline-isolation.mjs";
 import {
   isolateUniqueLocalTypePackages,
   isolateUniqueVueRuntimePackages,
+  isolateUniqueVueUsePackages,
 } from "./typecheck-baseline-isolation-unique.mjs";
 import { applyIsolatedAliasOverlay } from "./typecheck-baseline-outside-aliases.mjs";
 import { writeIsolatedTsconfigOverlay } from "./typecheck-baseline-outside-paths.mjs";
@@ -166,6 +167,11 @@ function isolateFixture(project, fixtureRoot) {
     shadowed.push(entry);
   }
   for (const entry of shadowed) {
+    process.stdout.write(`Linked ${project.id} node_modules/${entry.name} -> ${entry.target}\n`);
+  }
+  for (const entry of isolateUniqueVueUsePackages(fixtureRoot)) {
+    if (seen.has(entry.name)) continue;
+    seen.add(entry.name);
     process.stdout.write(`Linked ${project.id} node_modules/${entry.name} -> ${entry.target}\n`);
   }
   if (typeof project.tsconfig !== "string") return;


### PR DESCRIPTION
## Summary
- Elk loses `@vueuse` augmentations when TypeScript climbs into Vize's `@vueuse/core`, which then loads Vize's Vue beside the fixture (#4461).
- Unique isolation now links the fixture copies of `@vueuse/core` and `@vueuse/shared` when an ancestor copy is reachable. Declared unique links still win; several copies without a unique Vue peer stay unlinked.

Independent of #4697 (`vue-router`) and #4698 (`vue-i18n`) on the same undeclared walk.

## Test plan
- [x] `node --test` @vueuse unique isolation tests plus existing unique / Vue runtime isolation tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790113287&installation_model_id=422833&pr_number=4699&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4699&signature=0498245172d11c436af0fd5cd042eb080542755f9dce82f4b2a50d89fd249870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->