### PR TITLE
fix(matrix): typecheck the baseline tsconfig, not the solution root

### DIFF
--- a/tests/tooling/fixture-tool-matrix-typecheck-tsconfig.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typecheck-tsconfig.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  toolArgs,
+  typecheckSourceTsconfig,
+  typecheckTsconfigPath,
+} from "../../tools/fixtures/tool-matrix-command.mjs";
+import { isolatedTsconfigOverlayPath } from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+
+/**
+ * Elk's root tsconfig is a Nuxt 4 solution (`files: []` + `references`). vue-tsc
+ * already measures `.nuxt/tsconfig.app.json`. Vize must use that same program,
+ * and the isolated overlay of that file, not the empty solution (#4461).
+ */
+
+const elk = {
+  vueGlobs: ["app/**/*.vue"],
+  tsconfig: "tsconfig.json",
+  typecheckPerformance: { baseline: { tsconfig: ".nuxt/tsconfig.app.json" } },
+};
+
+test("typecheck uses the baseline tsconfig when it differs from the root config", () => {
+  assert.equal(typecheckSourceTsconfig(elk), ".nuxt/tsconfig.app.json");
+  assert.equal(typecheckTsconfigPath(elk), ".nuxt/tsconfig.app.json");
+  assert.deepEqual(toolArgs(elk, "typechecker", "out"), [
+    "check",
+    "app/**/*.vue",
+    "--format",
+    "json",
+    "--no-config",
+    "--tsconfig",
+    ".nuxt/tsconfig.app.json",
+  ]);
+});
+
+test("typecheck falls back to the root tsconfig when no baseline is pinned", () => {
+  const project = { vueGlobs: ["src/**/*.vue"], tsconfig: "tsconfig.json" };
+  assert.equal(typecheckSourceTsconfig(project), "tsconfig.json");
+  assert.equal(typecheckTsconfigPath(project), "tsconfig.json");
+});
+
+test("typecheck prefers the isolated overlay of the baseline tsconfig", () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typecheck-tsconfig-"));
+  try {
+    const overlayRel = isolatedTsconfigOverlayPath(".nuxt/tsconfig.app.json");
+    fs.mkdirSync(path.join(fixtureRoot, path.dirname(overlayRel)), { recursive: true });
+    fs.writeFileSync(path.join(fixtureRoot, overlayRel), "{}\n");
+    const project = { ...elk, fixturePath: fixtureRoot };
+    assert.equal(typecheckTsconfigPath(project), overlayRel);
+    assert.deepEqual(toolArgs(project, "typechecker", "out"), [
+      "check",
+      "app/**/*.vue",
+      "--format",
+      "json",
+      "--no-config",
+      "--tsconfig",
+      overlayRel,
+    ]);
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("typecheck does not use the root overlay when a baseline tsconfig is pinned", () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typecheck-tsconfig-root-"));
+  try {
+    const rootOverlay = isolatedTsconfigOverlayPath("tsconfig.json");
+    fs.writeFileSync(path.join(fixtureRoot, rootOverlay), "{}\n");
+    assert.equal(
+      typecheckTsconfigPath({ ...elk, fixturePath: fixtureRoot }),
+      ".nuxt/tsconfig.app.json",
+    );
+  } finally {
+    fs.rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/tool-matrix-command.mjs
+++ b/tools/fixtures/tool-matrix-command.mjs
@@ -10,14 +10,24 @@ export function typecheckCorpusGlobs(project) {
   return project.typecheckPerformance?.corpusGlobs ?? project.vueGlobs;
 }
 
+export function typecheckSourceTsconfig(project) {
+  const baseline = project.typecheckPerformance?.baseline?.tsconfig;
+  if (typeof baseline === "string") return baseline;
+  return typeof project.tsconfig === "string" ? project.tsconfig : null;
+}
+
 export function typecheckTsconfigPath(project) {
-  if (typeof project.tsconfig !== "string") return null;
-  const overlayRel = isolatedTsconfigOverlayPath(project.tsconfig);
+  // vue-tsc measures `baseline.tsconfig` when it is set. Elk's root config is
+  // a solution (`files: []` + `references`); using it would compare a different
+  // program than the baseline (#4461).
+  const source = typecheckSourceTsconfig(project);
+  if (source == null) return null;
+  const overlayRel = isolatedTsconfigOverlayPath(source);
   const overlayAbs =
     typeof project.fixturePath === "string"
       ? resolve(repoRoot, project.fixturePath, overlayRel)
       : resolve(overlayRel);
-  return existsSync(overlayAbs) ? overlayRel : project.tsconfig;
+  return existsSync(overlayAbs) ? overlayRel : source;
 }
 
 export function toolArgs(project, tool, compilerOutputDir) {

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -132,9 +132,10 @@ function prepareProjectDependencies({ args, commitSha, project }) {
  * answered by Vize's own `node_modules` further up the tree (run 31979524200).
  * When Vize's `--tsconfig` and vue-tsc's baseline config differ (Nuxt Volt:
  * `apps/volt/tsconfig.json` vs `apps/volt/.nuxt/tsconfig.json`), both are
- * walked. Reported on stdout rather than into the artifact: what the run has
- * to prove is the outcome, and `typecheck-baseline-ambient.mjs` proves that
- * from the program listing regardless of how the tree got there.
+ * walked and both receive an overlay. Reported on stdout rather than into the
+ * artifact: what the run has to prove is the outcome, and
+ * `typecheck-baseline-ambient.mjs` proves that from the program listing
+ * regardless of how the tree got there.
  */
 export function isolationTsconfigPaths(project) {
   const paths = [];
@@ -161,30 +162,28 @@ function isolateFixture(project, fixtureRoot) {
       shadowed.push(entry);
     }
   }
-  for (const entry of isolateUniqueVueRuntimePackages(fixtureRoot)) {
-    if (seen.has(entry.name)) continue;
-    seen.add(entry.name);
-    shadowed.push(entry);
-  }
-  for (const entry of isolateUniqueVueI18nPackages(fixtureRoot)) {
-    if (seen.has(entry.name)) continue;
-    seen.add(entry.name);
-    shadowed.push(entry);
+  for (const isolate of [isolateUniqueVueRuntimePackages, isolateUniqueVueI18nPackages]) {
+    for (const entry of isolate(fixtureRoot)) {
+      if (seen.has(entry.name)) continue;
+      seen.add(entry.name);
+      shadowed.push(entry);
+    }
   }
   for (const entry of shadowed) {
     process.stdout.write(`Linked ${project.id} node_modules/${entry.name} -> ${entry.target}\n`);
   }
-  if (typeof project.tsconfig !== "string") return;
-  const sourceConfig = resolve(fixtureRoot, project.tsconfig);
-  const overlay = applyIsolatedAliasOverlay(
-    fixtureRoot,
-    sourceConfig,
-    writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfig),
-  );
-  if (overlay != null) {
-    process.stdout.write(
-      `Rewrote ${project.id} tsconfig overlay -> ${relative(fixtureRoot, overlay.path)}\n`,
+  for (const relativeConfig of isolationTsconfigPaths(project)) {
+    const sourceConfig = resolve(fixtureRoot, relativeConfig);
+    const overlay = applyIsolatedAliasOverlay(
+      fixtureRoot,
+      sourceConfig,
+      writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfig),
     );
+    if (overlay != null) {
+      process.stdout.write(
+        `Rewrote ${project.id} tsconfig overlay -> ${relative(fixtureRoot, overlay.path)}\n`,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Elk's root `tsconfig.json` is a Nuxt 4 solution (`files: []` + `references` to `.nuxt/tsconfig.app.json`). vue-tsc already measures that app config; Vize was still passed the empty root (#4461).
- Typecheck now uses `typecheckPerformance.baseline.tsconfig` when it is set, and prefers the isolated overlay of *that* file.
- Isolation writes overlays for every walked tsconfig (baseline and root), so the app config's outside `paths` are rewritten the same way vue-tsc's materialized baseline already is.

Does not restore the typecheck divergence gate.

## Test plan
- [x] `node --test` typecheck tsconfig selection tests plus overlay / isolation tsconfig tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790113694&installation_model_id=422833&pr_number=4700&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4700&signature=e8b9caf785ad447795dc5cbc2b564b88caba8b2e489e5487981f0ab91444cad2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->