### PR TITLE
fix(matrix): isolate undeclared Vue compiler packages to the fixture

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-vue-runtime.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-vue-runtime.test.ts
@@ -89,6 +89,50 @@ test("an already hoisted vue is left for isolation; this repair does not relink 
   }
 });
 
+test("an ancestor @vue/compiler-sfc with exactly one in-fixture copy is linked", () => {
+  const { fixtureRoot, outer } = scaffold(["@vue/compiler-sfc"]);
+  try {
+    writeStoreCopy(fixtureRoot, "@vue+compiler-sfc@3.5.30", "@vue/compiler-sfc");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), [
+      {
+        name: "@vue/compiler-sfc",
+        target: "node_modules/.pnpm/@vue+compiler-sfc@3.5.30/node_modules/@vue/compiler-sfc",
+      },
+    ]);
+    assert.equal(
+      fs.realpathSync(path.join(fixtureRoot, "node_modules", "@vue", "compiler-sfc")),
+      fs.realpathSync(
+        path.join(
+          fixtureRoot,
+          "node_modules",
+          ".pnpm",
+          "@vue+compiler-sfc@3.5.30",
+          "node_modules",
+          "@vue",
+          "compiler-sfc",
+        ),
+      ),
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an ancestor @vue/compiler-dom with exactly one in-fixture copy is linked", () => {
+  const { fixtureRoot, outer } = scaffold(["@vue/compiler-dom"]);
+  try {
+    writeStoreCopy(fixtureRoot, "@vue+compiler-dom@3.5.30", "@vue/compiler-dom");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), [
+      {
+        name: "@vue/compiler-dom",
+        target: "node_modules/.pnpm/@vue+compiler-dom@3.5.30/node_modules/@vue/compiler-dom",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
 test("an ancestor @vue/runtime-core with exactly one in-fixture copy is linked", () => {
   const { fixtureRoot, outer } = scaffold(["@vue/runtime-core"]);
   try {

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -30,9 +30,21 @@ import { ancestorPackagePath } from "./typecheck-baseline-isolation-package-exte
  * `jsxImportSource` are included as ancestor targets so this can link the
  * fixture's own `@vue/tsconfig`, `vite`, `@types/node`, language plugin, or
  * `vue` JSX runtime before TypeScript climbs into Vize.
+ *
+ * Undeclared Vue compiler packages (`@vue/compiler-sfc` and friends) live in
+ * Vize's `tests/package.json`, so TypeScript can still climb into them and
+ * load Vize's Vue beside the fixture.
  */
 
-const vueRuntimePackages = ["@vue/runtime-core", "@vue/runtime-dom", "vue", "vue-router"];
+const vueRuntimePackages = [
+  "@vue/compiler-core",
+  "@vue/compiler-dom",
+  "@vue/compiler-sfc",
+  "@vue/runtime-core",
+  "@vue/runtime-dom",
+  "vue",
+  "vue-router",
+];
 
 export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {
   const root = resolve(fixtureRoot);


### PR DESCRIPTION
## Summary
- `tests/package.json` installs `@vue/compiler-sfc` and `@vue/compiler-dom`, so TypeScript can climb into Vize's copies and load Vize's Vue beside the fixture (#4461).
- Unique isolation now links the fixture copies of `@vue/compiler-core`, `@vue/compiler-dom`, and `@vue/compiler-sfc` on the same undeclared walk as `vue` / `vue-router`. No prepare change: they ride `isolateUniqueVueRuntimePackages`.

Independent of #4699 (`@vueuse`) and #4700 (baseline tsconfig overlay).

## Test plan
- [x] `node --test` Vue runtime unique isolation tests (compiler-sfc / compiler-dom oracles plus existing unique / vue-i18n tests)
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790113850&installation_model_id=422833&pr_number=4701&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4701&signature=dc6e536955b8bbb56667e578c97e66ece8cb3f3a2343604e81927dd557176707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->