### PR TITLE
fix(matrix): resolve overlay paths against compilerOptions.baseUrl

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-paths-baseurl.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-paths-baseurl.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  applyIsolatedAliasOverlay,
+  rewriteOutsideAliasPaths,
+} from "../../tools/fixtures/typecheck-baseline-outside-aliases.mjs";
+import {
+  rewriteOutsidePackagePaths,
+  writeIsolatedTsconfigOverlay,
+} from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+import { materializeBaselineProject } from "../../tools/fixtures/typecheck-baseline-project.mjs";
+
+/**
+ * Nuxt writes `baseUrl: ".."` on `.nuxt/tsconfig.json` and `paths` relative to
+ * that directory. Resolving mappings from the tsconfig file itself treats a
+ * fixture-local unique-link as interior and never retargets, while vue-tsc still
+ * walks above the fixture (#4461).
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-outside-paths-baseurl-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsideVue = path.join(outer, "node_modules", "vue");
+  fs.mkdirSync(outsideVue, { recursive: true });
+  fs.writeFileSync(path.join(outsideVue, "package.json"), `{"name":"vue"}\n`);
+  const outsideNuxt = path.join(outer, "node_modules", "nuxt");
+  fs.mkdirSync(path.join(outsideNuxt, "dist", "app"), { recursive: true });
+  fs.writeFileSync(path.join(outsideNuxt, "package.json"), `{"name":"nuxt"}\n`);
+  fs.writeFileSync(path.join(outsideNuxt, "dist", "app", "index.d.ts"), "export {}\n");
+  return { fixtureRoot, outer, outsideNuxt, outsideVue };
+}
+
+function writeLocalVue(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "vue");
+  fs.mkdirSync(local, { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue"}\n`);
+  return local;
+}
+
+function writeLocalNuxt(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "nuxt");
+  fs.mkdirSync(path.join(local, "dist", "app"), { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"nuxt"}\n`);
+  fs.writeFileSync(path.join(local, "dist", "app", "index.d.ts"), "export {}\n");
+  return local;
+}
+
+function writeNuxtTsconfig(fixtureRoot: string, paths: Record<string, string[]>) {
+  const nuxtDir = path.join(fixtureRoot, ".nuxt");
+  fs.mkdirSync(nuxtDir, { recursive: true });
+  const sourcePath = path.join(nuxtDir, "tsconfig.json");
+  fs.writeFileSync(
+    sourcePath,
+    `${JSON.stringify({ compilerOptions: { baseUrl: "..", paths } })}\n`,
+  );
+  return sourcePath;
+}
+
+test("a Nuxt baseUrl resolves outside package mappings from the fixture root", () => {
+  const { outer, fixtureRoot, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourcePath = writeNuxtTsconfig(fixtureRoot, {
+      "#imports": ["./src/imports.d.ts"],
+      vue: [path.relative(fixtureRoot, outsideVue)],
+    });
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      {
+        "#imports": ["../src/imports.d.ts"],
+        vue: ["../node_modules/vue"],
+      },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an isolated overlay pins baseUrl so rewritten paths stay beside the source", () => {
+  const { outer, fixtureRoot, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourcePath = writeNuxtTsconfig(fixtureRoot, {
+      "#imports": ["./src/imports.d.ts"],
+      vue: [path.relative(fixtureRoot, outsideVue)],
+    });
+    const overlay = writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath);
+    assert.equal(overlay.path, path.join(fixtureRoot, ".nuxt", ".vize-isolated-tsconfig.json"));
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.json",
+      compilerOptions: {
+        baseUrl: ".",
+        paths: {
+          "#imports": ["../src/imports.d.ts"],
+          vue: ["../node_modules/vue"],
+        },
+      },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a Nuxt baseUrl resolves outside hash aliases from the fixture root", () => {
+  const { outer, fixtureRoot, outsideNuxt } = scaffold();
+  try {
+    writeLocalNuxt(fixtureRoot);
+    const sourcePath = writeNuxtTsconfig(fixtureRoot, {
+      "#app": [path.relative(fixtureRoot, path.join(outsideNuxt, "dist", "app"))],
+    });
+    assert.deepEqual(
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "#app": ["../node_modules/nuxt/dist/app"] },
+    );
+    const overlay = applyIsolatedAliasOverlay(fixtureRoot, sourcePath, null);
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.json",
+      compilerOptions: {
+        baseUrl: ".",
+        paths: { "#app": ["../node_modules/nuxt/dist/app"] },
+      },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("materialized baseline pins baseUrl when outside paths were retargeted", () => {
+  const { outer, fixtureRoot, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    fs.writeFileSync(path.join(fixtureRoot, "src/App.vue"), "<template />\n");
+    writeNuxtTsconfig(fixtureRoot, {
+      vue: [path.relative(fixtureRoot, outsideVue)],
+    });
+    const reportDir = path.join(outer, "report");
+    fs.mkdirSync(reportDir);
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      { id: "fixture", tsconfig: ".nuxt/tsconfig.json" },
+      { fileCount: 1, files: [{ file: "src/App.vue" }] },
+    );
+    const options = JSON.parse(project.source).compilerOptions;
+    assert.equal(options.baseUrl, ".");
+    assert.deepEqual(options.paths, { vue: ["../../node_modules/vue"] });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-jsonc.mjs
+++ b/tools/fixtures/typecheck-baseline-jsonc.mjs
@@ -1,0 +1,39 @@
+/**
+ * Strip comments and trailing commas from a tsconfig-shaped JSONC string.
+ * Shared so overlay parsers stay under the source-length budget.
+ */
+export function stripJsonc(text) {
+  let out = "";
+  let inString = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (inString) {
+      out += ch;
+      if (ch === "\\") {
+        out += text[i + 1] ?? "";
+        i += 1;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "/") {
+      while (i < text.length && text[i] !== "\n") i += 1;
+      out += "\n";
+      continue;
+    }
+    if (ch === "/" && text[i + 1] === "*") {
+      i += 2;
+      while (i + 1 < text.length && !(text[i] === "*" && text[i + 1] === "/")) i += 1;
+      i += 1;
+      continue;
+    }
+    out += ch;
+  }
+  return out.replace(/,(\s*[}\]])/g, "$1");
+}

--- a/tools/fixtures/typecheck-baseline-outside-aliases.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-aliases.mjs
@@ -2,7 +2,9 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 
 import {
+  isolatedOverlayBaseUrl,
   isolatedTsconfigOverlayPath,
+  pathMappingRoot,
   resolvePackageExtends,
 } from "./typecheck-baseline-outside-paths.mjs";
 
@@ -26,11 +28,12 @@ export function rewriteOutsideAliasPaths(fixtureRoot, sourceConfigPath, configDi
   const root = resolve(fixtureRoot);
   const declared = winningPaths(sourceConfigPath, root);
   if (declared == null) return null;
+  const mapping = pathMappingRoot(sourceConfigPath, root, declared.dir);
   const rewritten = {};
   let changed = false;
   for (const [name, targets] of Object.entries(declared.paths)) {
     if (!Array.isArray(targets)) continue;
-    rewritten[name] = retargetAliasMapping(root, declared.dir, configDir, name, targets, () => {
+    rewritten[name] = retargetAliasMapping(root, mapping, configDir, name, targets, () => {
       changed = true;
     });
   }
@@ -56,6 +59,7 @@ export function applyIsolatedAliasOverlay(fixtureRoot, sourceConfigPath, overlay
   const overlayPath = overlay?.path ?? isolatedTsconfigOverlayPath(sourcePath);
   const compilerOptions = { paths };
   if (typeRoots != null) compilerOptions.typeRoots = typeRoots;
+  if (isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) compilerOptions.baseUrl = ".";
   writeFileSync(
     overlayPath,
     `${JSON.stringify({ extends: `./${basename(sourcePath)}`, compilerOptions }, null, 2)}\n`,

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -1,6 +1,8 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 
+import { stripJsonc } from "./typecheck-baseline-jsonc.mjs";
+
 /**
  * Close the vue-tsc path escape unique isolation cannot see (#4461).
  *
@@ -37,6 +39,9 @@ import { basename, dirname, join, relative, resolve } from "node:path";
  *
  * A package mapping whose outside target sits under `node_modules/<name>/...`
  * keeps that subpath on the fixture copy (Nuxt's `vue/dist/vue` JSX entry).
+ *
+ * `compilerOptions.baseUrl` is last-wins on the extends chain. Mappings resolve
+ * from that directory; a rewrite then pins overlay `baseUrl` to `"."`.
  */
 
 const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
@@ -45,15 +50,25 @@ export function rewriteOutsidePackagePaths(fixtureRoot, sourceConfigPath, config
   const root = resolve(fixtureRoot);
   const declared = winningPaths(sourceConfigPath, root);
   if (declared == null) return null;
+  const mapping = pathMappingRoot(sourceConfigPath, root, declared.dir);
   const rewritten = {};
   let changed = false;
   for (const [name, targets] of Object.entries(declared.paths)) {
     if (!Array.isArray(targets)) continue;
-    rewritten[name] = retargetPathMapping(root, declared.dir, configDir, name, targets, () => {
+    rewritten[name] = retargetPathMapping(root, mapping, configDir, name, targets, () => {
       changed = true;
     });
   }
   return changed ? rewritten : null;
+}
+
+export function pathMappingRoot(sourceConfigPath, fixtureRoot, pathsDir) {
+  const base = winningBaseUrl(sourceConfigPath, fixtureRoot);
+  return base == null ? pathsDir : resolve(base.dir, base.value);
+}
+
+export function isolatedOverlayBaseUrl(sourceConfigPath, fixtureRoot) {
+  return winningBaseUrl(sourceConfigPath, fixtureRoot) == null ? null : ".";
 }
 
 export function isolatedTsconfigOverlayPath(sourceConfigPath) {
@@ -87,6 +102,9 @@ export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
   const compilerOptions = {};
   if (paths != null) compilerOptions.paths = paths;
   if (typeRoots != null) compilerOptions.typeRoots = typeRoots;
+  if (paths != null && isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) {
+    compilerOptions.baseUrl = ".";
+  }
   const overlayPath = isolatedTsconfigOverlayPath(sourcePath);
   writeFileSync(
     overlayPath,
@@ -160,34 +178,38 @@ function retargetTypeRoot(fixtureRoot, sourceDir, configDir, entry, markChanged)
   return configRelativePath(configDir, local);
 }
 
-function winningPaths(sourceConfigPath, fixtureRoot) {
-  let paths;
+function winningCompilerOption(sourceConfigPath, fixtureRoot, pick) {
+  let value;
   let dir;
-  for (const { config, dir: configDir } of [
-    ...loadExtendsChain(sourceConfigPath, fixtureRoot),
-  ].reverse()) {
-    const candidate = config?.compilerOptions?.paths;
-    if (candidate != null && typeof candidate === "object") {
-      paths = candidate;
-      dir = configDir;
+  for (const entry of [...loadExtendsChain(sourceConfigPath, fixtureRoot)].reverse()) {
+    const candidate = pick(entry.config);
+    if (candidate != null) {
+      value = candidate;
+      dir = entry.dir;
     }
   }
-  return paths == null ? null : { paths, dir };
+  return value == null ? null : { value, dir };
+}
+
+function winningPaths(sourceConfigPath, fixtureRoot) {
+  const won = winningCompilerOption(sourceConfigPath, fixtureRoot, (config) => {
+    const value = config?.compilerOptions?.paths;
+    return value != null && typeof value === "object" ? value : null;
+  });
+  return won == null ? null : { paths: won.value, dir: won.dir };
 }
 
 function winningTypeRoots(sourceConfigPath, fixtureRoot) {
-  let typeRoots;
-  let dir;
-  for (const { config, dir: configDir } of [
-    ...loadExtendsChain(sourceConfigPath, fixtureRoot),
-  ].reverse()) {
-    const candidate = config?.compilerOptions?.typeRoots;
-    if (Array.isArray(candidate)) {
-      typeRoots = candidate;
-      dir = configDir;
-    }
-  }
-  return typeRoots == null ? null : { typeRoots, dir };
+  const won = winningCompilerOption(sourceConfigPath, fixtureRoot, (config) =>
+    Array.isArray(config?.compilerOptions?.typeRoots) ? config.compilerOptions.typeRoots : null,
+  );
+  return won == null ? null : { typeRoots: won.value, dir: won.dir };
+}
+
+function winningBaseUrl(sourceConfigPath, fixtureRoot) {
+  return winningCompilerOption(sourceConfigPath, fixtureRoot, (config) =>
+    typeof config?.compilerOptions?.baseUrl === "string" ? config.compilerOptions.baseUrl : null,
+  );
 }
 
 function loadExtendsChain(sourceConfigPath, fixtureRoot) {
@@ -297,40 +319,4 @@ function configRelativePath(from, to) {
   const path = relative(from, to).replaceAll("\\", "/");
   if (path.startsWith("/") || /^[A-Za-z]:\//u.test(path)) return path;
   return path.startsWith(".") ? path : `./${path}`;
-}
-
-function stripJsonc(text) {
-  let out = "";
-  let inString = false;
-  for (let i = 0; i < text.length; i += 1) {
-    const ch = text[i];
-    if (inString) {
-      out += ch;
-      if (ch === "\\") {
-        out += text[i + 1] ?? "";
-        i += 1;
-      } else if (ch === '"') {
-        inString = false;
-      }
-      continue;
-    }
-    if (ch === '"') {
-      inString = true;
-      out += ch;
-      continue;
-    }
-    if (ch === "/" && text[i + 1] === "/") {
-      while (i < text.length && text[i] !== "\n") i += 1;
-      out += "\n";
-      continue;
-    }
-    if (ch === "/" && text[i + 1] === "*") {
-      i += 2;
-      while (i + 1 < text.length && !(text[i] === "*" && text[i + 1] === "/")) i += 1;
-      i += 1;
-      continue;
-    }
-    out += ch;
-  }
-  return out.replace(/,(\s*[}\]])/g, "$1");
 }

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -6,6 +6,7 @@ import {
   rewriteOutsideAliasPaths,
 } from "./typecheck-baseline-outside-aliases.mjs";
 import {
+  isolatedOverlayBaseUrl,
   rewriteOutsidePackagePaths,
   rewriteOutsideTypeRoots,
 } from "./typecheck-baseline-outside-paths.mjs";
@@ -129,6 +130,9 @@ function outsideCompilerOptions(fixtureRoot, sourcePath, configDir) {
     rewriteOutsideAliasPaths(fixtureRoot, sourcePath, configDir),
   );
   if (paths != null) options.paths = paths;
+  if (paths != null && isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) {
+    options.baseUrl = ".";
+  }
   const typeRoots = rewriteOutsideTypeRoots(fixtureRoot, sourcePath, configDir);
   if (typeRoots != null) options.typeRoots = typeRoots;
   return options;


### PR DESCRIPTION
## Summary
- Nuxt-generated configs set `compilerOptions.baseUrl` to `".."` on `.nuxt/tsconfig.json`. Overlay used to resolve `paths` from the tsconfig directory, so a unique-linked fixture copy looked interior while vue-tsc still walked above the fixture (#4461).
- Rewrites now resolve mappings from the last-wins `baseUrl` directory. When a baseUrl is in play, the overlay and materialized baseline pin `baseUrl` to `"."` so overlay-relative strings keep that meaning. Configs without a baseUrl are unchanged.
- JSONC stripping is extracted so the overlay module stays under the 350-line source budget.

Does not restore the typecheck divergence gate.

## Test plan
- [x] `node --test` overlay path/alias tests including Nuxt-shaped `baseUrl: ".."` oracles
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790114629&installation_model_id=422833&pr_number=4702&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4702&signature=20c218dbb384c497f85c057965a6f2ce1d09e529a89e874a518708f38afa3784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript baseline handling for configurations with aliases targeting packages outside the fixture.
  * Corrected path resolution across inherited configuration files, including `baseUrl`, `paths`, and `typeRoots`.
  * Ensured generated isolated configurations preserve rewritten aliases and use the correct base URL.
* **Tests**
  * Added coverage for package aliases, hash aliases, generated configuration overlays, and materialized baseline projects.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->