### PR TITLE
fix(matrix): isolate undeclared @nuxt/ui packages to the fixture

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-nuxt-ui.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-nuxt-ui.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueNuxtUiPackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * Elk and Nuxt UI apps lose `@nuxt/ui` augmentations when TypeScript climbs
+ * into Vize's copy, which then loads Vize's Vue beside the fixture (#4461).
+ * Unique isolation links the fixture copy when an ancestor copy is reachable.
+ */
+
+function scaffold(names: string[] = ["@nuxt/ui"]) {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-nuxt-ui-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const name of names) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+test("an ancestor @nuxt/ui with exactly one in-fixture copy is linked from that copy", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "@nuxt+ui@4.8.2", "@nuxt/ui");
+    assert.deepEqual(isolateUniqueNuxtUiPackages(fixtureRoot), [
+      {
+        name: "@nuxt/ui",
+        target: "node_modules/.pnpm/@nuxt+ui@4.8.2/node_modules/@nuxt/ui",
+      },
+    ]);
+    assert.equal(
+      fs.realpathSync(path.join(fixtureRoot, "node_modules", "@nuxt", "ui")),
+      fs.realpathSync(
+        path.join(
+          fixtureRoot,
+          "node_modules",
+          ".pnpm",
+          "@nuxt+ui@4.8.2",
+          "node_modules",
+          "@nuxt",
+          "ui",
+        ),
+      ),
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a @nuxt/ui no ancestor provides is left alone", () => {
+  const { fixtureRoot, outer } = scaffold([]);
+  try {
+    writeStoreCopy(fixtureRoot, "@nuxt+ui@4.8.2", "@nuxt/ui");
+    assert.deepEqual(isolateUniqueNuxtUiPackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "@nuxt", "ui")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an already hoisted @nuxt/ui is left for isolation; this repair does not relink it", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "@nuxt+ui@4.8.2", "@nuxt/ui");
+    const hoisted = path.join(fixtureRoot, "node_modules", "@nuxt", "ui");
+    fs.mkdirSync(hoisted, { recursive: true });
+    fs.writeFileSync(path.join(hoisted, "package.json"), `{"name":"@nuxt/ui"}\n`);
+    assert.deepEqual(isolateUniqueNuxtUiPackages(fixtureRoot), []);
+    assert.equal(fs.lstatSync(hoisted).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -207,12 +207,9 @@ function compare(left, right) {
 }
 
 export function isolateUniqueVueUsePackages(fixtureRoot) {
-  const root = resolve(fixtureRoot);
-  const declared = new Map();
-  for (const name of ["@vueuse/core", "@vueuse/shared"]) {
-    const ancestor = ancestorPackagePath(root, name);
-    if (ancestor == null) continue;
-    declared.set(name, ancestor);
-  }
-  return isolateUniqueDeclaredLocalTypePackages(root, declared);
+  return isolateUniqueNamedLocalTypePackages(fixtureRoot, ["@vueuse/core", "@vueuse/shared"]);
+}
+
+export function isolateUniqueNuxtUiPackages(fixtureRoot) {
+  return isolateUniqueNamedLocalTypePackages(fixtureRoot, ["@nuxt/ui"]);
 }

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -9,6 +9,7 @@ import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-targ
 import { isolateFixtureTypePackages } from "./typecheck-baseline-isolation.mjs";
 import {
   isolateUniqueLocalTypePackages,
+  isolateUniqueNuxtUiPackages,
   isolateUniqueVueI18nPackages,
   isolateUniqueVueRuntimePackages,
   isolateUniqueVueUsePackages,
@@ -167,6 +168,7 @@ function isolateFixture(project, fixtureRoot) {
     isolateUniqueVueRuntimePackages,
     isolateUniqueVueI18nPackages,
     isolateUniqueVueUsePackages,
+    isolateUniqueNuxtUiPackages,
   ]) {
     for (const entry of isolate(fixtureRoot)) {
       if (seen.has(entry.name)) continue;


### PR DESCRIPTION
## Summary
- `tests/package.json` depends on `@nuxt/ui`. Elk and Nuxt UI fixtures can still climb into that ancestor, which then loads Vize's Vue beside the fixture (#4461).
- Unique isolation now links the fixture's own `@nuxt/ui` when an ancestor copy is reachable and the fixture has not already hoisted one.
- `isolateUniqueVueUsePackages` now shares the named-package helper so `prepare.mjs` stays at the 350-line budget.

Does not restore the typecheck divergence gate.

## Test plan
- [x] `node --test` `@nuxt/ui` unique-isolation tests plus existing vueuse / vue-i18n tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790114981&installation_model_id=422833&pr_number=4703&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4703&signature=9aeabb31315c528784f43cd5ec0d44ed06458728420fc8a22fc0543c9210f30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved package isolation for Nuxt UI dependencies in prepared type-checking fixtures.
  - Prevented unnecessary relinking when a package is already correctly hoisted.
  - Preserved package state when no ancestor dependency is available.

- **Tests**
  - Added coverage for unique package linking, existing hoisted packages, missing ancestors, filesystem links, and temporary directory cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->