### PR TITLE
fix(matrix): resolve isolation package paths against compilerOptions.baseUrl

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-baseurl.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-baseurl.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateFixtureTypePackages } from "../../tools/fixtures/typecheck-baseline-isolation.mjs";
+
+/**
+ * Nuxt writes `baseUrl: ".."` on `.nuxt/tsconfig.json` and `paths` relative to
+ * that directory. Isolation used to resolve those targets from `.nuxt`, so the
+ * fixture store copy looked missing and `vue-router` escaped to Vize (#4461).
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-baseurl-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  const storeId = "vue-router@5.1.0";
+  const storeCopy = path.join(
+    fixtureRoot,
+    "node_modules",
+    ".pnpm",
+    storeId,
+    "node_modules",
+    "vue-router",
+  );
+  fs.mkdirSync(storeCopy, { recursive: true });
+  fs.writeFileSync(path.join(storeCopy, "package.json"), '{"name":"vue-router"}\n');
+  const ancestor = path.join(outer, "node_modules", "vue-router");
+  fs.mkdirSync(ancestor, { recursive: true });
+  fs.writeFileSync(path.join(ancestor, "package.json"), '{"name":"vue-router"}\n');
+  return { fixtureRoot, outer, storeId };
+}
+
+test("a Nuxt baseUrl resolves declared package paths from the fixture root", () => {
+  const { outer, fixtureRoot, storeId } = scaffold();
+  try {
+    const nuxtDir = path.join(fixtureRoot, ".nuxt");
+    fs.mkdirSync(nuxtDir, { recursive: true });
+    const configPath = path.join(nuxtDir, "tsconfig.json");
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        compilerOptions: {
+          baseUrl: "..",
+          paths: {
+            "vue-router": [`./node_modules/.pnpm/${storeId}/node_modules/vue-router`],
+          },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+      {
+        name: "vue-router",
+        target: `node_modules/.pnpm/${storeId}/node_modules/vue-router`,
+      },
+    ]);
+    assert.equal(
+      fs.realpathSync(path.join(fixtureRoot, "node_modules", "vue-router")),
+      fs.realpathSync(
+        path.join(fixtureRoot, "node_modules", ".pnpm", storeId, "node_modules", "vue-router"),
+      ),
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("paths without a baseUrl still resolve from the declaring tsconfig directory", () => {
+  const { outer, fixtureRoot, storeId } = scaffold();
+  try {
+    const nuxtDir = path.join(fixtureRoot, ".nuxt");
+    fs.mkdirSync(nuxtDir, { recursive: true });
+    const configPath = path.join(nuxtDir, "tsconfig.json");
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "vue-router": [`../node_modules/.pnpm/${storeId}/node_modules/vue-router`],
+          },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+      {
+        name: "vue-router",
+        target: `node_modules/.pnpm/${storeId}/node_modules/vue-router`,
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -16,6 +16,7 @@ import {
 import { recordCompilerOptionJsxImportSource } from "./typecheck-baseline-isolation-jsx.mjs";
 import { recordCompilerOptionPlugins } from "./typecheck-baseline-isolation-plugins.mjs";
 import { recordCompilerOptionTypes } from "./typecheck-baseline-isolation-types.mjs";
+import { pathMappingRoot } from "./typecheck-baseline-outside-paths.mjs";
 
 /**
  * Keep the fixture's type environment inside the fixture (run 31979524200).
@@ -92,7 +93,7 @@ export function readDeclaredPackagePaths(fixtureRoot, sourceConfigPath) {
     const current = queue.shift();
     if (seen.has(current)) continue;
     seen.add(current);
-    const local = packagePathsFromExtends(current);
+    const local = packagePathsFromExtends(fixtureRoot, current);
     if (local.size > 0) {
       mergeDeclared(declared, conflicts, local);
       continue;
@@ -137,11 +138,10 @@ function mergePackageExtends(declared, conflicts, configPaths, fixtureRoot) {
   }
 }
 
-function packagePathsFromExtends(sourceConfigPath) {
+function packagePathsFromExtends(fixtureRoot, sourceConfigPath) {
   const declared = new Map();
   // Child `compilerOptions.paths` replace the parent's object, matching tsc.
-  // Relative `extends` is followed so reka-ui's `tsconfig.check.json` still
-  // sees the paths one hop away in `tsconfig.app.json` (#4461).
+  // Targets resolve from last-wins `baseUrl` when set (#4461).
   let paths;
   let configDir;
   for (const { config, dir } of [...loadExtendsChain(sourceConfigPath)].reverse()) {
@@ -156,7 +156,7 @@ function packagePathsFromExtends(sourceConfigPath) {
     if (!packageNamePattern.test(name) || !Array.isArray(targets)) continue;
     const first = targets.find((entry) => typeof entry === "string" && !entry.includes("*"));
     if (first == null) continue;
-    declared.set(name, resolve(configDir, first));
+    declared.set(name, resolve(pathMappingRoot(sourceConfigPath, fixtureRoot, configDir), first));
   }
   return declared;
 }


### PR DESCRIPTION
## Summary
- Overlay rewrite already honors last-wins `compilerOptions.baseUrl` (#4702). Isolation still resolved `paths` targets from the tsconfig directory, so a Nuxt `baseUrl: ".."` mapping to the fixture store looked missing and `vue-router` escaped to Vize (#4461).
- Declared package paths now resolve from `pathMappingRoot`, the same mapping root the overlay uses. Configs without a baseUrl still resolve from the declaring file.

Does not restore the typecheck divergence gate.

## Test plan
- [x] `node --test` isolation tests, including Nuxt-shaped `baseUrl: ".."` oracles
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790115480&installation_model_id=422833&pr_number=4704&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4704&signature=6001d02494a82fca67708a501a6aa2bfa0410288039b521b601828f68fe8efff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript path alias resolution for isolated fixtures.
  * Ensured path mappings correctly honor `baseUrl` and resolve relative to the appropriate configuration location.
  * Prevented package resolution from incorrectly escaping to unrelated ancestor dependencies.

* **Tests**
  * Added coverage for path mappings with and without a configured `baseUrl`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->