### PR TITLE
fix(matrix): honor array extends in overlay rewrites

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-paths-baseurl.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-paths-baseurl.test.ts
@@ -23,9 +23,7 @@ import { materializeBaselineProject } from "../../tools/fixtures/typecheck-basel
 
 function scaffold() {
   const outer = fs.realpathSync(
-    fs.mkdtempSync(
-      path.join(os.tmpdir(), "vize-baseline-outside-paths-baseurl-"),
-    ),
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-outside-paths-baseurl-")),
   );
   const fixtureRoot = path.join(outer, "fixture");
   fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
@@ -35,10 +33,7 @@ function scaffold() {
   const outsideNuxt = path.join(outer, "node_modules", "nuxt");
   fs.mkdirSync(path.join(outsideNuxt, "dist", "app"), { recursive: true });
   fs.writeFileSync(path.join(outsideNuxt, "package.json"), `{"name":"nuxt"}\n`);
-  fs.writeFileSync(
-    path.join(outsideNuxt, "dist", "app", "index.d.ts"),
-    "export {}\n",
-  );
+  fs.writeFileSync(path.join(outsideNuxt, "dist", "app", "index.d.ts"), "export {}\n");
   return { fixtureRoot, outer, outsideNuxt, outsideVue };
 }
 
@@ -53,17 +48,11 @@ function writeLocalNuxt(fixtureRoot: string) {
   const local = path.join(fixtureRoot, "node_modules", "nuxt");
   fs.mkdirSync(path.join(local, "dist", "app"), { recursive: true });
   fs.writeFileSync(path.join(local, "package.json"), `{"name":"nuxt"}\n`);
-  fs.writeFileSync(
-    path.join(local, "dist", "app", "index.d.ts"),
-    "export {}\n",
-  );
+  fs.writeFileSync(path.join(local, "dist", "app", "index.d.ts"), "export {}\n");
   return local;
 }
 
-function writeNuxtTsconfig(
-  fixtureRoot: string,
-  paths: Record<string, string[]>,
-) {
+function writeNuxtTsconfig(fixtureRoot: string, paths: Record<string, string[]>) {
   const nuxtDir = path.join(fixtureRoot, ".nuxt");
   fs.mkdirSync(nuxtDir, { recursive: true });
   const sourcePath = path.join(nuxtDir, "tsconfig.json");
@@ -83,11 +72,7 @@ test("a Nuxt baseUrl resolves outside package mappings from the fixture root", (
       vue: [path.relative(fixtureRoot, outsideVue)],
     });
     assert.deepEqual(
-      rewriteOutsidePackagePaths(
-        fixtureRoot,
-        sourcePath,
-        path.join(fixtureRoot, ".vize-baseline"),
-      ),
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
       {
         "#imports": ["../src/imports.d.ts"],
         vue: ["../node_modules/vue"],
@@ -107,10 +92,7 @@ test("an isolated overlay pins baseUrl so rewritten paths stay beside the source
       vue: [path.relative(fixtureRoot, outsideVue)],
     });
     const overlay = writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath);
-    assert.equal(
-      overlay.path,
-      path.join(fixtureRoot, ".nuxt", ".vize-isolated-tsconfig.json"),
-    );
+    assert.equal(overlay.path, path.join(fixtureRoot, ".nuxt", ".vize-isolated-tsconfig.json"));
     assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
       extends: "./tsconfig.json",
       compilerOptions: {
@@ -131,16 +113,10 @@ test("a Nuxt baseUrl resolves outside hash aliases from the fixture root", () =>
   try {
     writeLocalNuxt(fixtureRoot);
     const sourcePath = writeNuxtTsconfig(fixtureRoot, {
-      "#app": [
-        path.relative(fixtureRoot, path.join(outsideNuxt, "dist", "app")),
-      ],
+      "#app": [path.relative(fixtureRoot, path.join(outsideNuxt, "dist", "app"))],
     });
     assert.deepEqual(
-      rewriteOutsideAliasPaths(
-        fixtureRoot,
-        sourcePath,
-        path.join(fixtureRoot, ".vize-baseline"),
-      ),
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
       { "#app": ["../node_modules/nuxt/dist/app"] },
     );
     const overlay = applyIsolatedAliasOverlay(fixtureRoot, sourcePath, null);
@@ -198,16 +174,9 @@ test("array extends applies later package paths with an earlier baseUrl", () => 
       })}\n`,
     );
     const sourcePath = path.join(fixtureRoot, "tsconfig.json");
-    fs.writeFileSync(
-      sourcePath,
-      `{ "extends": ["./base-url.json", "./paths.json"] }\n`,
-    );
+    fs.writeFileSync(sourcePath, `{ "extends": ["./base-url.json", "./paths.json"] }\n`);
     assert.deepEqual(
-      rewriteOutsidePackagePaths(
-        fixtureRoot,
-        sourcePath,
-        path.join(fixtureRoot, ".vize-baseline"),
-      ),
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
       { vue: ["../node_modules/vue"] },
     );
   } finally {
@@ -229,24 +198,15 @@ test("array extends applies later hash aliases with an earlier baseUrl", () => {
       `${JSON.stringify({
         compilerOptions: {
           paths: {
-            "#app": [
-              path.relative(sourceRoot, path.join(outsideNuxt, "dist", "app")),
-            ],
+            "#app": [path.relative(sourceRoot, path.join(outsideNuxt, "dist", "app"))],
           },
         },
       })}\n`,
     );
     const sourcePath = path.join(fixtureRoot, "tsconfig.json");
-    fs.writeFileSync(
-      sourcePath,
-      `{ "extends": ["./base-url.json", "./paths.json"] }\n`,
-    );
+    fs.writeFileSync(sourcePath, `{ "extends": ["./base-url.json", "./paths.json"] }\n`);
     assert.deepEqual(
-      rewriteOutsideAliasPaths(
-        fixtureRoot,
-        sourcePath,
-        path.join(fixtureRoot, ".vize-baseline"),
-      ),
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
       { "#app": ["../node_modules/nuxt/dist/app"] },
     );
   } finally {

--- a/tests/tooling/typecheck-baseline-outside-paths-baseurl.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-paths-baseurl.test.ts
@@ -23,7 +23,9 @@ import { materializeBaselineProject } from "../../tools/fixtures/typecheck-basel
 
 function scaffold() {
   const outer = fs.realpathSync(
-    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-outside-paths-baseurl-")),
+    fs.mkdtempSync(
+      path.join(os.tmpdir(), "vize-baseline-outside-paths-baseurl-"),
+    ),
   );
   const fixtureRoot = path.join(outer, "fixture");
   fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
@@ -33,7 +35,10 @@ function scaffold() {
   const outsideNuxt = path.join(outer, "node_modules", "nuxt");
   fs.mkdirSync(path.join(outsideNuxt, "dist", "app"), { recursive: true });
   fs.writeFileSync(path.join(outsideNuxt, "package.json"), `{"name":"nuxt"}\n`);
-  fs.writeFileSync(path.join(outsideNuxt, "dist", "app", "index.d.ts"), "export {}\n");
+  fs.writeFileSync(
+    path.join(outsideNuxt, "dist", "app", "index.d.ts"),
+    "export {}\n",
+  );
   return { fixtureRoot, outer, outsideNuxt, outsideVue };
 }
 
@@ -48,11 +53,17 @@ function writeLocalNuxt(fixtureRoot: string) {
   const local = path.join(fixtureRoot, "node_modules", "nuxt");
   fs.mkdirSync(path.join(local, "dist", "app"), { recursive: true });
   fs.writeFileSync(path.join(local, "package.json"), `{"name":"nuxt"}\n`);
-  fs.writeFileSync(path.join(local, "dist", "app", "index.d.ts"), "export {}\n");
+  fs.writeFileSync(
+    path.join(local, "dist", "app", "index.d.ts"),
+    "export {}\n",
+  );
   return local;
 }
 
-function writeNuxtTsconfig(fixtureRoot: string, paths: Record<string, string[]>) {
+function writeNuxtTsconfig(
+  fixtureRoot: string,
+  paths: Record<string, string[]>,
+) {
   const nuxtDir = path.join(fixtureRoot, ".nuxt");
   fs.mkdirSync(nuxtDir, { recursive: true });
   const sourcePath = path.join(nuxtDir, "tsconfig.json");
@@ -72,7 +83,11 @@ test("a Nuxt baseUrl resolves outside package mappings from the fixture root", (
       vue: [path.relative(fixtureRoot, outsideVue)],
     });
     assert.deepEqual(
-      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      rewriteOutsidePackagePaths(
+        fixtureRoot,
+        sourcePath,
+        path.join(fixtureRoot, ".vize-baseline"),
+      ),
       {
         "#imports": ["../src/imports.d.ts"],
         vue: ["../node_modules/vue"],
@@ -92,7 +107,10 @@ test("an isolated overlay pins baseUrl so rewritten paths stay beside the source
       vue: [path.relative(fixtureRoot, outsideVue)],
     });
     const overlay = writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath);
-    assert.equal(overlay.path, path.join(fixtureRoot, ".nuxt", ".vize-isolated-tsconfig.json"));
+    assert.equal(
+      overlay.path,
+      path.join(fixtureRoot, ".nuxt", ".vize-isolated-tsconfig.json"),
+    );
     assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
       extends: "./tsconfig.json",
       compilerOptions: {
@@ -113,10 +131,16 @@ test("a Nuxt baseUrl resolves outside hash aliases from the fixture root", () =>
   try {
     writeLocalNuxt(fixtureRoot);
     const sourcePath = writeNuxtTsconfig(fixtureRoot, {
-      "#app": [path.relative(fixtureRoot, path.join(outsideNuxt, "dist", "app"))],
+      "#app": [
+        path.relative(fixtureRoot, path.join(outsideNuxt, "dist", "app")),
+      ],
     });
     assert.deepEqual(
-      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      rewriteOutsideAliasPaths(
+        fixtureRoot,
+        sourcePath,
+        path.join(fixtureRoot, ".vize-baseline"),
+      ),
       { "#app": ["../node_modules/nuxt/dist/app"] },
     );
     const overlay = applyIsolatedAliasOverlay(fixtureRoot, sourcePath, null);
@@ -151,6 +175,80 @@ test("materialized baseline pins baseUrl when outside paths were retargeted", ()
     const options = JSON.parse(project.source).compilerOptions;
     assert.equal(options.baseUrl, ".");
     assert.deepEqual(options.paths, { vue: ["../../node_modules/vue"] });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("array extends applies later package paths with an earlier baseUrl", () => {
+  const { outer, fixtureRoot, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourceRoot = path.join(fixtureRoot, "src");
+    fs.writeFileSync(
+      path.join(fixtureRoot, "base-url.json"),
+      `${JSON.stringify({ compilerOptions: { baseUrl: "./src" } })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "paths.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { vue: [path.relative(sourceRoot, outsideVue)] },
+        },
+      })}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `{ "extends": ["./base-url.json", "./paths.json"] }\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(
+        fixtureRoot,
+        sourcePath,
+        path.join(fixtureRoot, ".vize-baseline"),
+      ),
+      { vue: ["../node_modules/vue"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("array extends applies later hash aliases with an earlier baseUrl", () => {
+  const { outer, fixtureRoot, outsideNuxt } = scaffold();
+  try {
+    writeLocalNuxt(fixtureRoot);
+    const sourceRoot = path.join(fixtureRoot, "src");
+    fs.writeFileSync(
+      path.join(fixtureRoot, "base-url.json"),
+      `${JSON.stringify({ compilerOptions: { baseUrl: "./src" } })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "paths.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "#app": [
+              path.relative(sourceRoot, path.join(outsideNuxt, "dist", "app")),
+            ],
+          },
+        },
+      })}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `{ "extends": ["./base-url.json", "./paths.json"] }\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsideAliasPaths(
+        fixtureRoot,
+        sourcePath,
+        path.join(fixtureRoot, ".vize-baseline"),
+      ),
+      { "#app": ["../node_modules/nuxt/dist/app"] },
+    );
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });
   }

--- a/tests/tooling/typecheck-baseline-outside-paths-baseurl.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-paths-baseurl.test.ts
@@ -155,3 +155,61 @@ test("materialized baseline pins baseUrl when outside paths were retargeted", ()
     fs.rmSync(outer, { recursive: true, force: true });
   }
 });
+
+test("array extends applies later package paths with an earlier baseUrl", () => {
+  const { outer, fixtureRoot, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourceRoot = path.join(fixtureRoot, "src");
+    fs.writeFileSync(
+      path.join(fixtureRoot, "base-url.json"),
+      `${JSON.stringify({ compilerOptions: { baseUrl: "./src" } })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "paths.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { vue: [path.relative(sourceRoot, outsideVue)] },
+        },
+      })}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(sourcePath, `{ "extends": ["./base-url.json", "./paths.json"] }\n`);
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { vue: ["../node_modules/vue"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("array extends applies later hash aliases with an earlier baseUrl", () => {
+  const { outer, fixtureRoot, outsideNuxt } = scaffold();
+  try {
+    writeLocalNuxt(fixtureRoot);
+    const sourceRoot = path.join(fixtureRoot, "src");
+    fs.writeFileSync(
+      path.join(fixtureRoot, "base-url.json"),
+      `${JSON.stringify({ compilerOptions: { baseUrl: "./src" } })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "paths.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "#app": [path.relative(sourceRoot, path.join(outsideNuxt, "dist", "app"))],
+          },
+        },
+      })}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(sourcePath, `{ "extends": ["./base-url.json", "./paths.json"] }\n`);
+    assert.deepEqual(
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "#app": ["../node_modules/nuxt/dist/app"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-extends-chain.mjs
+++ b/tools/fixtures/typecheck-baseline-extends-chain.mjs
@@ -5,12 +5,7 @@ import { stripJsonc } from "./typecheck-baseline-jsonc.mjs";
 
 export function loadTsconfigExtendsChain(sourceConfigPath, resolveExtends) {
   const chain = [];
-  appendExtendsChain(
-    chain,
-    new Set(),
-    resolve(sourceConfigPath),
-    resolveExtends,
-  );
+  appendExtendsChain(chain, new Set(), resolve(sourceConfigPath), resolveExtends);
   return chain;
 }
 
@@ -38,7 +33,5 @@ function parseTsconfig(configPath) {
 
 function extendsSpecifiers(value) {
   if (typeof value === "string") return [value];
-  return Array.isArray(value)
-    ? value.filter((entry) => typeof entry === "string")
-    : [];
+  return Array.isArray(value) ? value.filter((entry) => typeof entry === "string") : [];
 }

--- a/tools/fixtures/typecheck-baseline-extends-chain.mjs
+++ b/tools/fixtures/typecheck-baseline-extends-chain.mjs
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import { stripJsonc } from "./typecheck-baseline-jsonc.mjs";
+
+export function loadTsconfigExtendsChain(sourceConfigPath, resolveExtends) {
+  const chain = [];
+  appendExtendsChain(
+    chain,
+    new Set(),
+    resolve(sourceConfigPath),
+    resolveExtends,
+  );
+  return chain;
+}
+
+function appendExtendsChain(chain, seen, current, resolveExtends) {
+  if (seen.has(current)) return;
+  seen.add(current);
+  const config = parseTsconfig(current);
+  if (config == null) return;
+  chain.push({ config, dir: dirname(current) });
+  const resolved = extendsSpecifiers(config.extends)
+    .map((specifier) => resolveExtends(current, specifier))
+    .filter((entry) => entry != null);
+  for (const next of resolved.reverse()) {
+    appendExtendsChain(chain, seen, next, resolveExtends);
+  }
+}
+
+function parseTsconfig(configPath) {
+  try {
+    return JSON.parse(stripJsonc(readFileSync(configPath, "utf8")));
+  } catch {
+    return null;
+  }
+}
+
+function extendsSpecifiers(value) {
+  if (typeof value === "string") return [value];
+  return Array.isArray(value)
+    ? value.filter((entry) => typeof entry === "string")
+    : [];
+}

--- a/tools/fixtures/typecheck-baseline-extends-chain.mjs
+++ b/tools/fixtures/typecheck-baseline-extends-chain.mjs
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import { stripJsonc } from "./typecheck-baseline-jsonc.mjs";
+
+export function loadTsconfigExtendsChain(sourceConfigPath, resolveExtends) {
+  const chain = [];
+  appendExtendsChain(chain, new Set(), resolve(sourceConfigPath), resolveExtends);
+  return chain;
+}
+
+function appendExtendsChain(chain, seen, current, resolveExtends) {
+  if (seen.has(current)) return;
+  seen.add(current);
+  const config = parseTsconfig(current);
+  if (config == null) return;
+  chain.push({ config, dir: dirname(current) });
+  const resolved = extendsSpecifiers(config.extends)
+    .map((specifier) => resolveExtends(current, specifier))
+    .filter((entry) => entry != null);
+  for (const next of resolved.reverse()) {
+    appendExtendsChain(chain, seen, next, resolveExtends);
+  }
+}
+
+function parseTsconfig(configPath) {
+  try {
+    return JSON.parse(stripJsonc(readFileSync(configPath, "utf8")));
+  } catch {
+    return null;
+  }
+}
+
+function extendsSpecifiers(value) {
+  if (typeof value === "string") return [value];
+  return Array.isArray(value) ? value.filter((entry) => typeof entry === "string") : [];
+}

--- a/tools/fixtures/typecheck-baseline-outside-aliases.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-aliases.mjs
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 
+import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs";
 import {
   isolatedOverlayBaseUrl,
   isolatedTsconfigOverlayPath,
@@ -22,9 +23,14 @@ import {
  * package-name overlay. Climbing into Vize would load Vize's `#app` mappings.
  */
 
-const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
+const packageNamePattern =
+  /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
 
-export function rewriteOutsideAliasPaths(fixtureRoot, sourceConfigPath, configDir) {
+export function rewriteOutsideAliasPaths(
+  fixtureRoot,
+  sourceConfigPath,
+  configDir,
+) {
   const root = resolve(fixtureRoot);
   const declared = winningPaths(sourceConfigPath, root);
   if (declared == null) return null;
@@ -33,9 +39,16 @@ export function rewriteOutsideAliasPaths(fixtureRoot, sourceConfigPath, configDi
   let changed = false;
   for (const [name, targets] of Object.entries(declared.paths)) {
     if (!Array.isArray(targets)) continue;
-    rewritten[name] = retargetAliasMapping(root, mapping, configDir, name, targets, () => {
-      changed = true;
-    });
+    rewritten[name] = retargetAliasMapping(
+      root,
+      mapping,
+      configDir,
+      name,
+      targets,
+      () => {
+        changed = true;
+      },
+    );
   }
   return changed ? rewritten : null;
 }
@@ -50,16 +63,25 @@ export function mergePathRewrites(packages, aliases) {
   return merged;
 }
 
-export function applyIsolatedAliasOverlay(fixtureRoot, sourceConfigPath, overlay) {
+export function applyIsolatedAliasOverlay(
+  fixtureRoot,
+  sourceConfigPath,
+  overlay,
+) {
   const sourcePath = resolve(sourceConfigPath);
-  const aliases = rewriteOutsideAliasPaths(fixtureRoot, sourcePath, dirname(sourcePath));
+  const aliases = rewriteOutsideAliasPaths(
+    fixtureRoot,
+    sourcePath,
+    dirname(sourcePath),
+  );
   if (aliases == null) return overlay ?? null;
   const paths = mergePathRewrites(overlay?.paths ?? null, aliases);
   const typeRoots = overlay?.typeRoots ?? null;
   const overlayPath = overlay?.path ?? isolatedTsconfigOverlayPath(sourcePath);
   const compilerOptions = { paths };
   if (typeRoots != null) compilerOptions.typeRoots = typeRoots;
-  if (isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) compilerOptions.baseUrl = ".";
+  if (isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null)
+    compilerOptions.baseUrl = ".";
   writeFileSync(
     overlayPath,
     `${JSON.stringify({ extends: `./${basename(sourcePath)}`, compilerOptions }, null, 2)}\n`,
@@ -67,8 +89,17 @@ export function applyIsolatedAliasOverlay(fixtureRoot, sourceConfigPath, overlay
   return { path: overlayPath, paths, typeRoots };
 }
 
-function retargetAliasMapping(fixtureRoot, sourceDir, configDir, name, targets, markChanged) {
-  const relocated = targets.map((entry) => relocatePathEntry(sourceDir, configDir, entry));
+function retargetAliasMapping(
+  fixtureRoot,
+  sourceDir,
+  configDir,
+  name,
+  targets,
+  markChanged,
+) {
+  const relocated = targets.map((entry) =>
+    relocatePathEntry(sourceDir, configDir, entry),
+  );
   if (isPackageMappingName(name)) return relocated;
   const first = targets.find(
     (entry) => typeof entry === "string" && isExactOrTrailingStarPath(entry),
@@ -88,7 +119,9 @@ function retargetAliasMapping(fixtureRoot, sourceDir, configDir, name, targets, 
   const rewritten = star
     ? `${configRelativePath(configDir, localTarget)}/*`
     : configRelativePath(configDir, localTarget);
-  return relocated.map((entry, index) => (index === targets.indexOf(first) ? rewritten : entry));
+  return relocated.map((entry, index) =>
+    index === targets.indexOf(first) ? rewritten : entry,
+  );
 }
 
 function isPackageMappingName(name) {
@@ -98,12 +131,16 @@ function isPackageMappingName(name) {
 }
 
 function isExactOrTrailingStarPath(entry) {
-  return !entry.includes("*") || (entry.endsWith("/*") && !entry.slice(0, -2).includes("*"));
+  return (
+    !entry.includes("*") ||
+    (entry.endsWith("/*") && !entry.slice(0, -2).includes("*"))
+  );
 }
 
 function relocatePathEntry(sourceDir, configDir, entry) {
   if (typeof entry !== "string") return entry;
-  if (!entry.includes("*")) return configRelativePath(configDir, resolve(sourceDir, entry));
+  if (!entry.includes("*"))
+    return configRelativePath(configDir, resolve(sourceDir, entry));
   if (entry.endsWith("/*") && !entry.slice(0, -2).includes("*")) {
     return `${configRelativePath(configDir, resolve(sourceDir, entry.slice(0, -2)))}/*`;
   }
@@ -130,8 +167,14 @@ function nodeModulePackageName(packageRoot) {
   if (basename(parent) === "node_modules") {
     return { name: basename(packageRoot), root: packageRoot };
   }
-  if (basename(grandparent) === "node_modules" && basename(parent).startsWith("@")) {
-    return { name: `${basename(parent)}/${basename(packageRoot)}`, root: packageRoot };
+  if (
+    basename(grandparent) === "node_modules" &&
+    basename(parent).startsWith("@")
+  ) {
+    return {
+      name: `${basename(parent)}/${basename(packageRoot)}`,
+      root: packageRoot,
+    };
   }
   return null;
 }
@@ -140,7 +183,12 @@ function winningPaths(sourceConfigPath, fixtureRoot) {
   let paths;
   let dir;
   for (const { config, dir: configDir } of [
-    ...loadExtendsChain(sourceConfigPath, fixtureRoot),
+    ...loadTsconfigExtendsChain(
+      sourceConfigPath,
+      (fromConfig, specifier) =>
+        resolveRelativeExtends(fromConfig, specifier, fixtureRoot) ??
+        resolvePackageExtends(fromConfig, specifier, fixtureRoot),
+    ),
   ].reverse()) {
     const candidate = config?.compilerOptions?.paths;
     if (candidate != null && typeof candidate === "object") {
@@ -149,41 +197,6 @@ function winningPaths(sourceConfigPath, fixtureRoot) {
     }
   }
   return paths == null ? null : { paths, dir };
-}
-
-function loadExtendsChain(sourceConfigPath, fixtureRoot) {
-  const chain = [];
-  const seen = new Set();
-  let current = resolve(sourceConfigPath);
-  while (!seen.has(current)) {
-    seen.add(current);
-    const config = parseTsconfig(current);
-    if (config == null) break;
-    chain.push({ config, dir: dirname(current) });
-    let next = null;
-    for (const specifier of extendsSpecifiers(config.extends)) {
-      next =
-        resolveRelativeExtends(current, specifier, fixtureRoot) ??
-        resolvePackageExtends(current, specifier, fixtureRoot);
-      if (next != null) break;
-    }
-    if (next == null) break;
-    current = next;
-  }
-  return chain;
-}
-
-function parseTsconfig(configPath) {
-  try {
-    return JSON.parse(stripJsonc(readFileSync(configPath, "utf8")));
-  } catch {
-    return null;
-  }
-}
-
-function extendsSpecifiers(value) {
-  if (typeof value === "string") return [value];
-  return Array.isArray(value) ? value.filter((entry) => typeof entry === "string") : [];
 }
 
 function resolveRelativeExtends(fromConfig, specifier, fixtureRoot) {
@@ -208,38 +221,4 @@ function configRelativePath(from, to) {
   const path = relative(from, to).replaceAll("\\", "/");
   if (path.startsWith("/") || /^[A-Za-z]:\//u.test(path)) return path;
   return path.startsWith(".") ? path : `./${path}`;
-}
-
-function stripJsonc(text) {
-  let out = "";
-  let inString = false;
-  for (let i = 0; i < text.length; i += 1) {
-    const ch = text[i];
-    if (inString) {
-      out += ch;
-      if (ch === "\\") {
-        out += text[i + 1] ?? "";
-        i += 1;
-      } else if (ch === '"') inString = false;
-      continue;
-    }
-    if (ch === '"') {
-      inString = true;
-      out += ch;
-      continue;
-    }
-    if (ch === "/" && text[i + 1] === "/") {
-      while (i < text.length && text[i] !== "\n") i += 1;
-      out += "\n";
-      continue;
-    }
-    if (ch === "/" && text[i + 1] === "*") {
-      i += 2;
-      while (i + 1 < text.length && !(text[i] === "*" && text[i + 1] === "/")) i += 1;
-      i += 1;
-      continue;
-    }
-    out += ch;
-  }
-  return out.replace(/,(\s*[}\]])/g, "$1");
 }

--- a/tools/fixtures/typecheck-baseline-outside-aliases.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-aliases.mjs
@@ -23,14 +23,9 @@ import {
  * package-name overlay. Climbing into Vize would load Vize's `#app` mappings.
  */
 
-const packageNamePattern =
-  /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
+const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
 
-export function rewriteOutsideAliasPaths(
-  fixtureRoot,
-  sourceConfigPath,
-  configDir,
-) {
+export function rewriteOutsideAliasPaths(fixtureRoot, sourceConfigPath, configDir) {
   const root = resolve(fixtureRoot);
   const declared = winningPaths(sourceConfigPath, root);
   if (declared == null) return null;
@@ -39,16 +34,9 @@ export function rewriteOutsideAliasPaths(
   let changed = false;
   for (const [name, targets] of Object.entries(declared.paths)) {
     if (!Array.isArray(targets)) continue;
-    rewritten[name] = retargetAliasMapping(
-      root,
-      mapping,
-      configDir,
-      name,
-      targets,
-      () => {
-        changed = true;
-      },
-    );
+    rewritten[name] = retargetAliasMapping(root, mapping, configDir, name, targets, () => {
+      changed = true;
+    });
   }
   return changed ? rewritten : null;
 }
@@ -63,25 +51,16 @@ export function mergePathRewrites(packages, aliases) {
   return merged;
 }
 
-export function applyIsolatedAliasOverlay(
-  fixtureRoot,
-  sourceConfigPath,
-  overlay,
-) {
+export function applyIsolatedAliasOverlay(fixtureRoot, sourceConfigPath, overlay) {
   const sourcePath = resolve(sourceConfigPath);
-  const aliases = rewriteOutsideAliasPaths(
-    fixtureRoot,
-    sourcePath,
-    dirname(sourcePath),
-  );
+  const aliases = rewriteOutsideAliasPaths(fixtureRoot, sourcePath, dirname(sourcePath));
   if (aliases == null) return overlay ?? null;
   const paths = mergePathRewrites(overlay?.paths ?? null, aliases);
   const typeRoots = overlay?.typeRoots ?? null;
   const overlayPath = overlay?.path ?? isolatedTsconfigOverlayPath(sourcePath);
   const compilerOptions = { paths };
   if (typeRoots != null) compilerOptions.typeRoots = typeRoots;
-  if (isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null)
-    compilerOptions.baseUrl = ".";
+  if (isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) compilerOptions.baseUrl = ".";
   writeFileSync(
     overlayPath,
     `${JSON.stringify({ extends: `./${basename(sourcePath)}`, compilerOptions }, null, 2)}\n`,
@@ -89,17 +68,8 @@ export function applyIsolatedAliasOverlay(
   return { path: overlayPath, paths, typeRoots };
 }
 
-function retargetAliasMapping(
-  fixtureRoot,
-  sourceDir,
-  configDir,
-  name,
-  targets,
-  markChanged,
-) {
-  const relocated = targets.map((entry) =>
-    relocatePathEntry(sourceDir, configDir, entry),
-  );
+function retargetAliasMapping(fixtureRoot, sourceDir, configDir, name, targets, markChanged) {
+  const relocated = targets.map((entry) => relocatePathEntry(sourceDir, configDir, entry));
   if (isPackageMappingName(name)) return relocated;
   const first = targets.find(
     (entry) => typeof entry === "string" && isExactOrTrailingStarPath(entry),
@@ -119,9 +89,7 @@ function retargetAliasMapping(
   const rewritten = star
     ? `${configRelativePath(configDir, localTarget)}/*`
     : configRelativePath(configDir, localTarget);
-  return relocated.map((entry, index) =>
-    index === targets.indexOf(first) ? rewritten : entry,
-  );
+  return relocated.map((entry, index) => (index === targets.indexOf(first) ? rewritten : entry));
 }
 
 function isPackageMappingName(name) {
@@ -131,16 +99,12 @@ function isPackageMappingName(name) {
 }
 
 function isExactOrTrailingStarPath(entry) {
-  return (
-    !entry.includes("*") ||
-    (entry.endsWith("/*") && !entry.slice(0, -2).includes("*"))
-  );
+  return !entry.includes("*") || (entry.endsWith("/*") && !entry.slice(0, -2).includes("*"));
 }
 
 function relocatePathEntry(sourceDir, configDir, entry) {
   if (typeof entry !== "string") return entry;
-  if (!entry.includes("*"))
-    return configRelativePath(configDir, resolve(sourceDir, entry));
+  if (!entry.includes("*")) return configRelativePath(configDir, resolve(sourceDir, entry));
   if (entry.endsWith("/*") && !entry.slice(0, -2).includes("*")) {
     return `${configRelativePath(configDir, resolve(sourceDir, entry.slice(0, -2)))}/*`;
   }
@@ -167,10 +131,7 @@ function nodeModulePackageName(packageRoot) {
   if (basename(parent) === "node_modules") {
     return { name: basename(packageRoot), root: packageRoot };
   }
-  if (
-    basename(grandparent) === "node_modules" &&
-    basename(parent).startsWith("@")
-  ) {
+  if (basename(grandparent) === "node_modules" && basename(parent).startsWith("@")) {
     return {
       name: `${basename(parent)}/${basename(packageRoot)}`,
       root: packageRoot,

--- a/tools/fixtures/typecheck-baseline-outside-aliases.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-aliases.mjs
@@ -1,6 +1,7 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 
+import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs";
 import {
   isolatedOverlayBaseUrl,
   isolatedTsconfigOverlayPath,
@@ -131,7 +132,10 @@ function nodeModulePackageName(packageRoot) {
     return { name: basename(packageRoot), root: packageRoot };
   }
   if (basename(grandparent) === "node_modules" && basename(parent).startsWith("@")) {
-    return { name: `${basename(parent)}/${basename(packageRoot)}`, root: packageRoot };
+    return {
+      name: `${basename(parent)}/${basename(packageRoot)}`,
+      root: packageRoot,
+    };
   }
   return null;
 }
@@ -140,7 +144,12 @@ function winningPaths(sourceConfigPath, fixtureRoot) {
   let paths;
   let dir;
   for (const { config, dir: configDir } of [
-    ...loadExtendsChain(sourceConfigPath, fixtureRoot),
+    ...loadTsconfigExtendsChain(
+      sourceConfigPath,
+      (fromConfig, specifier) =>
+        resolveRelativeExtends(fromConfig, specifier, fixtureRoot) ??
+        resolvePackageExtends(fromConfig, specifier, fixtureRoot),
+    ),
   ].reverse()) {
     const candidate = config?.compilerOptions?.paths;
     if (candidate != null && typeof candidate === "object") {
@@ -149,41 +158,6 @@ function winningPaths(sourceConfigPath, fixtureRoot) {
     }
   }
   return paths == null ? null : { paths, dir };
-}
-
-function loadExtendsChain(sourceConfigPath, fixtureRoot) {
-  const chain = [];
-  const seen = new Set();
-  let current = resolve(sourceConfigPath);
-  while (!seen.has(current)) {
-    seen.add(current);
-    const config = parseTsconfig(current);
-    if (config == null) break;
-    chain.push({ config, dir: dirname(current) });
-    let next = null;
-    for (const specifier of extendsSpecifiers(config.extends)) {
-      next =
-        resolveRelativeExtends(current, specifier, fixtureRoot) ??
-        resolvePackageExtends(current, specifier, fixtureRoot);
-      if (next != null) break;
-    }
-    if (next == null) break;
-    current = next;
-  }
-  return chain;
-}
-
-function parseTsconfig(configPath) {
-  try {
-    return JSON.parse(stripJsonc(readFileSync(configPath, "utf8")));
-  } catch {
-    return null;
-  }
-}
-
-function extendsSpecifiers(value) {
-  if (typeof value === "string") return [value];
-  return Array.isArray(value) ? value.filter((entry) => typeof entry === "string") : [];
 }
 
 function resolveRelativeExtends(fromConfig, specifier, fixtureRoot) {
@@ -208,38 +182,4 @@ function configRelativePath(from, to) {
   const path = relative(from, to).replaceAll("\\", "/");
   if (path.startsWith("/") || /^[A-Za-z]:\//u.test(path)) return path;
   return path.startsWith(".") ? path : `./${path}`;
-}
-
-function stripJsonc(text) {
-  let out = "";
-  let inString = false;
-  for (let i = 0; i < text.length; i += 1) {
-    const ch = text[i];
-    if (inString) {
-      out += ch;
-      if (ch === "\\") {
-        out += text[i + 1] ?? "";
-        i += 1;
-      } else if (ch === '"') inString = false;
-      continue;
-    }
-    if (ch === '"') {
-      inString = true;
-      out += ch;
-      continue;
-    }
-    if (ch === "/" && text[i + 1] === "/") {
-      while (i < text.length && text[i] !== "\n") i += 1;
-      out += "\n";
-      continue;
-    }
-    if (ch === "/" && text[i + 1] === "*") {
-      i += 2;
-      while (i + 1 < text.length && !(text[i] === "*" && text[i + 1] === "/")) i += 1;
-      i += 1;
-      continue;
-    }
-    out += ch;
-  }
-  return out.replace(/,(\s*[}\]])/g, "$1");
 }

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -1,7 +1,7 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 
-import { stripJsonc } from "./typecheck-baseline-jsonc.mjs";
+import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs";
 
 /**
  * Close the vue-tsc path escape unique isolation cannot see (#4461).
@@ -12,26 +12,21 @@ import { stripJsonc } from "./typecheck-baseline-jsonc.mjs";
  * that link. Nuxt-generated configs bake an absolute-looking relative path to
  * a package *above* the fixture, so the baseline still loads Vize's Vue beside
  * the fixture's.
- *
  * Setting `paths` on the generated baseline replaces the inherited object, so
  * this copies every mapping, re-homes it to the generated config directory, and
  * only then retargets package names whose original target is outside and whose
  * fixture-local `node_modules/<name>` is already a real package. No rewrite
  * means the generated config leaves `paths` unset and inherits.
- *
  * Vize's `check --tsconfig` still reads the fixture config, so a matching
  * untracked overlay is written next to the source when a rewrite exists. Git
  * porcelain uses `--untracked-files=no`, so the overlay does not dirty the
  * fixture. The matrix typechecker prefers that overlay when it is present.
- *
  * Package-name `extends` is followed only inside the fixture. Climbing into
  * Vize's `node_modules` would load Vize's `@vue/tsconfig` and bake its
  * outside `paths` into the overlay.
- *
  * `compilerOptions.typeRoots` is the same class of hole: TypeScript searches
  * those directories instead of the fixture's `node_modules/@types`. An outside
  * `node_modules/@types` is retargeted to the fixture-local copy when it exists.
- *
  * A trailing `/*` on a package mapping is the same walk: TypeScript still
  * loads that outside tree. A mapping named `*` whose target is an outside
  * `node_modules` directory is retargeted to the fixture copy. Interior `*`
@@ -44,9 +39,14 @@ import { stripJsonc } from "./typecheck-baseline-jsonc.mjs";
  * from that directory; a rewrite then pins overlay `baseUrl` to `"."`.
  */
 
-const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
+const packageNamePattern =
+  /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
 
-export function rewriteOutsidePackagePaths(fixtureRoot, sourceConfigPath, configDir) {
+export function rewriteOutsidePackagePaths(
+  fixtureRoot,
+  sourceConfigPath,
+  configDir,
+) {
   const root = resolve(fixtureRoot);
   const declared = winningPaths(sourceConfigPath, root);
   if (declared == null) return null;
@@ -55,9 +55,16 @@ export function rewriteOutsidePackagePaths(fixtureRoot, sourceConfigPath, config
   let changed = false;
   for (const [name, targets] of Object.entries(declared.paths)) {
     if (!Array.isArray(targets)) continue;
-    rewritten[name] = retargetPathMapping(root, mapping, configDir, name, targets, () => {
-      changed = true;
-    });
+    rewritten[name] = retargetPathMapping(
+      root,
+      mapping,
+      configDir,
+      name,
+      targets,
+      () => {
+        changed = true;
+      },
+    );
   }
   return changed ? rewritten : null;
 }
@@ -74,10 +81,16 @@ export function isolatedOverlayBaseUrl(sourceConfigPath, fixtureRoot) {
 export function isolatedTsconfigOverlayPath(sourceConfigPath) {
   const dir = dirname(sourceConfigPath).replaceAll("\\", "/");
   const name = basename(sourceConfigPath);
-  return dir === "." ? `.vize-isolated-${name}` : `${dir}/.vize-isolated-${name}`;
+  return dir === "."
+    ? `.vize-isolated-${name}`
+    : `${dir}/.vize-isolated-${name}`;
 }
 
-export function rewriteOutsideTypeRoots(fixtureRoot, sourceConfigPath, configDir) {
+export function rewriteOutsideTypeRoots(
+  fixtureRoot,
+  sourceConfigPath,
+  configDir,
+) {
   const root = resolve(fixtureRoot);
   const declared = winningTypeRoots(sourceConfigPath, root);
   if (declared == null) return null;
@@ -102,7 +115,10 @@ export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
   const compilerOptions = {};
   if (paths != null) compilerOptions.paths = paths;
   if (typeRoots != null) compilerOptions.typeRoots = typeRoots;
-  if (paths != null && isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) {
+  if (
+    paths != null &&
+    isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null
+  ) {
     compilerOptions.baseUrl = ".";
   }
   const overlayPath = isolatedTsconfigOverlayPath(sourcePath);
@@ -113,23 +129,44 @@ export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
   return { path: overlayPath, paths, typeRoots };
 }
 
-function retargetPathMapping(fixtureRoot, sourceDir, configDir, name, targets, markChanged) {
-  const relocated = targets.map((entry) => relocatePathEntry(sourceDir, configDir, entry));
+function retargetPathMapping(
+  fixtureRoot,
+  sourceDir,
+  configDir,
+  name,
+  targets,
+  markChanged,
+) {
+  const relocated = targets.map((entry) =>
+    relocatePathEntry(sourceDir, configDir, entry),
+  );
   const packageName = packageNameFromPathMapping(name);
   const first = targets.find(
     (entry) => typeof entry === "string" && isExactOrTrailingStarPath(entry),
   );
   if (first == null) return relocated;
-  const original = resolve(sourceDir, first.endsWith("/*") ? first.slice(0, -2) : first);
+  const original = resolve(
+    sourceDir,
+    first.endsWith("/*") ? first.slice(0, -2) : first,
+  );
   if (isInside(fixtureRoot, original)) return relocated;
   let local;
   if (packageName != null) {
-    const localPackage = join(fixtureRoot, "node_modules", ...packageName.split("/"));
+    const localPackage = join(
+      fixtureRoot,
+      "node_modules",
+      ...packageName.split("/"),
+    );
     if (!existsSync(join(localPackage, "package.json"))) return relocated;
     const subpath = packageSubpathAfterNodeModules(original, packageName);
     local = subpath ? join(localPackage, subpath) : localPackage;
-    if (subpath && !existsSync(local) && !existsSync(`${local}.d.ts`)) return relocated;
-  } else if (name === "*" && first.endsWith("/*") && basename(original) === "node_modules") {
+    if (subpath && !existsSync(local) && !existsSync(`${local}.d.ts`))
+      return relocated;
+  } else if (
+    name === "*" &&
+    first.endsWith("/*") &&
+    basename(original) === "node_modules"
+  ) {
     local = join(fixtureRoot, "node_modules");
     if (!existsSync(local)) return relocated;
   } else {
@@ -139,7 +176,9 @@ function retargetPathMapping(fixtureRoot, sourceDir, configDir, name, targets, m
   const rewritten = first.endsWith("/*")
     ? `${configRelativePath(configDir, local)}/*`
     : configRelativePath(configDir, local);
-  return relocated.map((entry, index) => (index === targets.indexOf(first) ? rewritten : entry));
+  return relocated.map((entry, index) =>
+    index === targets.indexOf(first) ? rewritten : entry,
+  );
 }
 
 function packageSubpathAfterNodeModules(original, packageName) {
@@ -158,7 +197,10 @@ function packageNameFromPathMapping(name) {
 }
 
 function isExactOrTrailingStarPath(entry) {
-  return !entry.includes("*") || (entry.endsWith("/*") && !entry.slice(0, -2).includes("*"));
+  return (
+    !entry.includes("*") ||
+    (entry.endsWith("/*") && !entry.slice(0, -2).includes("*"))
+  );
 }
 
 function relocatePathEntry(sourceDir, configDir, entry) {
@@ -166,7 +208,13 @@ function relocatePathEntry(sourceDir, configDir, entry) {
   return configRelativePath(configDir, resolve(sourceDir, entry));
 }
 
-function retargetTypeRoot(fixtureRoot, sourceDir, configDir, entry, markChanged) {
+function retargetTypeRoot(
+  fixtureRoot,
+  sourceDir,
+  configDir,
+  entry,
+  markChanged,
+) {
   if (typeof entry !== "string") return entry;
   const relocated = relocatePathEntry(sourceDir, configDir, entry);
   const original = resolve(sourceDir, entry);
@@ -181,7 +229,11 @@ function retargetTypeRoot(fixtureRoot, sourceDir, configDir, entry, markChanged)
 function winningCompilerOption(sourceConfigPath, fixtureRoot, pick) {
   let value;
   let dir;
-  for (const entry of [...loadExtendsChain(sourceConfigPath, fixtureRoot)].reverse()) {
+  for (const entry of [
+    ...loadTsconfigExtendsChain(sourceConfigPath, (fromConfig, specifier) =>
+      resolveExtends(fromConfig, specifier, fixtureRoot),
+    ),
+  ].reverse()) {
     const candidate = pick(entry.config);
     if (candidate != null) {
       value = candidate;
@@ -201,49 +253,19 @@ function winningPaths(sourceConfigPath, fixtureRoot) {
 
 function winningTypeRoots(sourceConfigPath, fixtureRoot) {
   const won = winningCompilerOption(sourceConfigPath, fixtureRoot, (config) =>
-    Array.isArray(config?.compilerOptions?.typeRoots) ? config.compilerOptions.typeRoots : null,
+    Array.isArray(config?.compilerOptions?.typeRoots)
+      ? config.compilerOptions.typeRoots
+      : null,
   );
   return won == null ? null : { typeRoots: won.value, dir: won.dir };
 }
 
 function winningBaseUrl(sourceConfigPath, fixtureRoot) {
   return winningCompilerOption(sourceConfigPath, fixtureRoot, (config) =>
-    typeof config?.compilerOptions?.baseUrl === "string" ? config.compilerOptions.baseUrl : null,
+    typeof config?.compilerOptions?.baseUrl === "string"
+      ? config.compilerOptions.baseUrl
+      : null,
   );
-}
-
-function loadExtendsChain(sourceConfigPath, fixtureRoot) {
-  const chain = [];
-  const seen = new Set();
-  let current = resolve(sourceConfigPath);
-  while (!seen.has(current)) {
-    seen.add(current);
-    const config = parseTsconfig(current);
-    if (config == null) break;
-    chain.push({ config, dir: dirname(current) });
-    const specifiers = extendsSpecifiers(config.extends);
-    let next = null;
-    for (const specifier of specifiers) {
-      next = resolveExtends(current, specifier, fixtureRoot);
-      if (next != null) break;
-    }
-    if (next == null) break;
-    current = next;
-  }
-  return chain;
-}
-
-function parseTsconfig(configPath) {
-  try {
-    return JSON.parse(stripJsonc(readFileSync(configPath, "utf8")));
-  } catch {
-    return null;
-  }
-}
-
-function extendsSpecifiers(value) {
-  if (typeof value === "string") return [value];
-  return Array.isArray(value) ? value.filter((entry) => typeof entry === "string") : [];
 }
 
 function resolveExtends(fromConfig, specifier, fixtureRoot) {
@@ -251,7 +273,8 @@ function resolveExtends(fromConfig, specifier, fixtureRoot) {
   if (specifier.startsWith("./") || specifier.startsWith("../")) {
     const resolved = resolve(dirname(fromConfig), specifier);
     if (existsSync(resolved)) return resolved;
-    if (!resolved.endsWith(".json") && existsSync(`${resolved}.json`)) return `${resolved}.json`;
+    if (!resolved.endsWith(".json") && existsSync(`${resolved}.json`))
+      return `${resolved}.json`;
     return null;
   }
   return resolvePackageExtends(fromConfig, specifier, fixtureRoot);
@@ -290,7 +313,10 @@ function splitPackageExtends(specifier) {
   if (specifier.includes(":")) return null;
   const slash = specifier.indexOf("/");
   if (slash < 0) return { name: specifier, subpath: null };
-  return { name: specifier.slice(0, slash), subpath: specifier.slice(slash + 1) };
+  return {
+    name: specifier.slice(0, slash),
+    subpath: specifier.slice(slash + 1),
+  };
 }
 
 function packageExtendsFile(pkg, subpath) {
@@ -301,7 +327,8 @@ function packageExtendsFile(pkg, subpath) {
   }
   const file = join(pkg, subpath);
   if (existsSync(file)) return file;
-  if (!file.endsWith(".json") && existsSync(`${file}.json`)) return `${file}.json`;
+  if (!file.endsWith(".json") && existsSync(`${file}.json`))
+    return `${file}.json`;
   return null;
 }
 

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -39,14 +39,9 @@ import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs
  * from that directory; a rewrite then pins overlay `baseUrl` to `"."`.
  */
 
-const packageNamePattern =
-  /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
+const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
 
-export function rewriteOutsidePackagePaths(
-  fixtureRoot,
-  sourceConfigPath,
-  configDir,
-) {
+export function rewriteOutsidePackagePaths(fixtureRoot, sourceConfigPath, configDir) {
   const root = resolve(fixtureRoot);
   const declared = winningPaths(sourceConfigPath, root);
   if (declared == null) return null;
@@ -55,16 +50,9 @@ export function rewriteOutsidePackagePaths(
   let changed = false;
   for (const [name, targets] of Object.entries(declared.paths)) {
     if (!Array.isArray(targets)) continue;
-    rewritten[name] = retargetPathMapping(
-      root,
-      mapping,
-      configDir,
-      name,
-      targets,
-      () => {
-        changed = true;
-      },
-    );
+    rewritten[name] = retargetPathMapping(root, mapping, configDir, name, targets, () => {
+      changed = true;
+    });
   }
   return changed ? rewritten : null;
 }
@@ -81,16 +69,10 @@ export function isolatedOverlayBaseUrl(sourceConfigPath, fixtureRoot) {
 export function isolatedTsconfigOverlayPath(sourceConfigPath) {
   const dir = dirname(sourceConfigPath).replaceAll("\\", "/");
   const name = basename(sourceConfigPath);
-  return dir === "."
-    ? `.vize-isolated-${name}`
-    : `${dir}/.vize-isolated-${name}`;
+  return dir === "." ? `.vize-isolated-${name}` : `${dir}/.vize-isolated-${name}`;
 }
 
-export function rewriteOutsideTypeRoots(
-  fixtureRoot,
-  sourceConfigPath,
-  configDir,
-) {
+export function rewriteOutsideTypeRoots(fixtureRoot, sourceConfigPath, configDir) {
   const root = resolve(fixtureRoot);
   const declared = winningTypeRoots(sourceConfigPath, root);
   if (declared == null) return null;
@@ -115,10 +97,7 @@ export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
   const compilerOptions = {};
   if (paths != null) compilerOptions.paths = paths;
   if (typeRoots != null) compilerOptions.typeRoots = typeRoots;
-  if (
-    paths != null &&
-    isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null
-  ) {
+  if (paths != null && isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) {
     compilerOptions.baseUrl = ".";
   }
   const overlayPath = isolatedTsconfigOverlayPath(sourcePath);
@@ -129,44 +108,23 @@ export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
   return { path: overlayPath, paths, typeRoots };
 }
 
-function retargetPathMapping(
-  fixtureRoot,
-  sourceDir,
-  configDir,
-  name,
-  targets,
-  markChanged,
-) {
-  const relocated = targets.map((entry) =>
-    relocatePathEntry(sourceDir, configDir, entry),
-  );
+function retargetPathMapping(fixtureRoot, sourceDir, configDir, name, targets, markChanged) {
+  const relocated = targets.map((entry) => relocatePathEntry(sourceDir, configDir, entry));
   const packageName = packageNameFromPathMapping(name);
   const first = targets.find(
     (entry) => typeof entry === "string" && isExactOrTrailingStarPath(entry),
   );
   if (first == null) return relocated;
-  const original = resolve(
-    sourceDir,
-    first.endsWith("/*") ? first.slice(0, -2) : first,
-  );
+  const original = resolve(sourceDir, first.endsWith("/*") ? first.slice(0, -2) : first);
   if (isInside(fixtureRoot, original)) return relocated;
   let local;
   if (packageName != null) {
-    const localPackage = join(
-      fixtureRoot,
-      "node_modules",
-      ...packageName.split("/"),
-    );
+    const localPackage = join(fixtureRoot, "node_modules", ...packageName.split("/"));
     if (!existsSync(join(localPackage, "package.json"))) return relocated;
     const subpath = packageSubpathAfterNodeModules(original, packageName);
     local = subpath ? join(localPackage, subpath) : localPackage;
-    if (subpath && !existsSync(local) && !existsSync(`${local}.d.ts`))
-      return relocated;
-  } else if (
-    name === "*" &&
-    first.endsWith("/*") &&
-    basename(original) === "node_modules"
-  ) {
+    if (subpath && !existsSync(local) && !existsSync(`${local}.d.ts`)) return relocated;
+  } else if (name === "*" && first.endsWith("/*") && basename(original) === "node_modules") {
     local = join(fixtureRoot, "node_modules");
     if (!existsSync(local)) return relocated;
   } else {
@@ -176,9 +134,7 @@ function retargetPathMapping(
   const rewritten = first.endsWith("/*")
     ? `${configRelativePath(configDir, local)}/*`
     : configRelativePath(configDir, local);
-  return relocated.map((entry, index) =>
-    index === targets.indexOf(first) ? rewritten : entry,
-  );
+  return relocated.map((entry, index) => (index === targets.indexOf(first) ? rewritten : entry));
 }
 
 function packageSubpathAfterNodeModules(original, packageName) {
@@ -197,10 +153,7 @@ function packageNameFromPathMapping(name) {
 }
 
 function isExactOrTrailingStarPath(entry) {
-  return (
-    !entry.includes("*") ||
-    (entry.endsWith("/*") && !entry.slice(0, -2).includes("*"))
-  );
+  return !entry.includes("*") || (entry.endsWith("/*") && !entry.slice(0, -2).includes("*"));
 }
 
 function relocatePathEntry(sourceDir, configDir, entry) {
@@ -208,13 +161,7 @@ function relocatePathEntry(sourceDir, configDir, entry) {
   return configRelativePath(configDir, resolve(sourceDir, entry));
 }
 
-function retargetTypeRoot(
-  fixtureRoot,
-  sourceDir,
-  configDir,
-  entry,
-  markChanged,
-) {
+function retargetTypeRoot(fixtureRoot, sourceDir, configDir, entry, markChanged) {
   if (typeof entry !== "string") return entry;
   const relocated = relocatePathEntry(sourceDir, configDir, entry);
   const original = resolve(sourceDir, entry);
@@ -253,18 +200,14 @@ function winningPaths(sourceConfigPath, fixtureRoot) {
 
 function winningTypeRoots(sourceConfigPath, fixtureRoot) {
   const won = winningCompilerOption(sourceConfigPath, fixtureRoot, (config) =>
-    Array.isArray(config?.compilerOptions?.typeRoots)
-      ? config.compilerOptions.typeRoots
-      : null,
+    Array.isArray(config?.compilerOptions?.typeRoots) ? config.compilerOptions.typeRoots : null,
   );
   return won == null ? null : { typeRoots: won.value, dir: won.dir };
 }
 
 function winningBaseUrl(sourceConfigPath, fixtureRoot) {
   return winningCompilerOption(sourceConfigPath, fixtureRoot, (config) =>
-    typeof config?.compilerOptions?.baseUrl === "string"
-      ? config.compilerOptions.baseUrl
-      : null,
+    typeof config?.compilerOptions?.baseUrl === "string" ? config.compilerOptions.baseUrl : null,
   );
 }
 
@@ -273,8 +216,7 @@ function resolveExtends(fromConfig, specifier, fixtureRoot) {
   if (specifier.startsWith("./") || specifier.startsWith("../")) {
     const resolved = resolve(dirname(fromConfig), specifier);
     if (existsSync(resolved)) return resolved;
-    if (!resolved.endsWith(".json") && existsSync(`${resolved}.json`))
-      return `${resolved}.json`;
+    if (!resolved.endsWith(".json") && existsSync(`${resolved}.json`)) return `${resolved}.json`;
     return null;
   }
   return resolvePackageExtends(fromConfig, specifier, fixtureRoot);
@@ -327,8 +269,7 @@ function packageExtendsFile(pkg, subpath) {
   }
   const file = join(pkg, subpath);
   if (existsSync(file)) return file;
-  if (!file.endsWith(".json") && existsSync(`${file}.json`))
-    return `${file}.json`;
+  if (!file.endsWith(".json") && existsSync(`${file}.json`)) return `${file}.json`;
   return null;
 }
 

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -1,7 +1,7 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 
-import { stripJsonc } from "./typecheck-baseline-jsonc.mjs";
+import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs";
 
 /**
  * Close the vue-tsc path escape unique isolation cannot see (#4461).
@@ -12,26 +12,21 @@ import { stripJsonc } from "./typecheck-baseline-jsonc.mjs";
  * that link. Nuxt-generated configs bake an absolute-looking relative path to
  * a package *above* the fixture, so the baseline still loads Vize's Vue beside
  * the fixture's.
- *
  * Setting `paths` on the generated baseline replaces the inherited object, so
  * this copies every mapping, re-homes it to the generated config directory, and
  * only then retargets package names whose original target is outside and whose
  * fixture-local `node_modules/<name>` is already a real package. No rewrite
  * means the generated config leaves `paths` unset and inherits.
- *
  * Vize's `check --tsconfig` still reads the fixture config, so a matching
  * untracked overlay is written next to the source when a rewrite exists. Git
  * porcelain uses `--untracked-files=no`, so the overlay does not dirty the
  * fixture. The matrix typechecker prefers that overlay when it is present.
- *
  * Package-name `extends` is followed only inside the fixture. Climbing into
  * Vize's `node_modules` would load Vize's `@vue/tsconfig` and bake its
  * outside `paths` into the overlay.
- *
  * `compilerOptions.typeRoots` is the same class of hole: TypeScript searches
  * those directories instead of the fixture's `node_modules/@types`. An outside
  * `node_modules/@types` is retargeted to the fixture-local copy when it exists.
- *
  * A trailing `/*` on a package mapping is the same walk: TypeScript still
  * loads that outside tree. A mapping named `*` whose target is an outside
  * `node_modules` directory is retargeted to the fixture copy. Interior `*`
@@ -181,7 +176,11 @@ function retargetTypeRoot(fixtureRoot, sourceDir, configDir, entry, markChanged)
 function winningCompilerOption(sourceConfigPath, fixtureRoot, pick) {
   let value;
   let dir;
-  for (const entry of [...loadExtendsChain(sourceConfigPath, fixtureRoot)].reverse()) {
+  for (const entry of [
+    ...loadTsconfigExtendsChain(sourceConfigPath, (fromConfig, specifier) =>
+      resolveExtends(fromConfig, specifier, fixtureRoot),
+    ),
+  ].reverse()) {
     const candidate = pick(entry.config);
     if (candidate != null) {
       value = candidate;
@@ -210,40 +209,6 @@ function winningBaseUrl(sourceConfigPath, fixtureRoot) {
   return winningCompilerOption(sourceConfigPath, fixtureRoot, (config) =>
     typeof config?.compilerOptions?.baseUrl === "string" ? config.compilerOptions.baseUrl : null,
   );
-}
-
-function loadExtendsChain(sourceConfigPath, fixtureRoot) {
-  const chain = [];
-  const seen = new Set();
-  let current = resolve(sourceConfigPath);
-  while (!seen.has(current)) {
-    seen.add(current);
-    const config = parseTsconfig(current);
-    if (config == null) break;
-    chain.push({ config, dir: dirname(current) });
-    const specifiers = extendsSpecifiers(config.extends);
-    let next = null;
-    for (const specifier of specifiers) {
-      next = resolveExtends(current, specifier, fixtureRoot);
-      if (next != null) break;
-    }
-    if (next == null) break;
-    current = next;
-  }
-  return chain;
-}
-
-function parseTsconfig(configPath) {
-  try {
-    return JSON.parse(stripJsonc(readFileSync(configPath, "utf8")));
-  } catch {
-    return null;
-  }
-}
-
-function extendsSpecifiers(value) {
-  if (typeof value === "string") return [value];
-  return Array.isArray(value) ? value.filter((entry) => typeof entry === "string") : [];
 }
 
 function resolveExtends(fromConfig, specifier, fixtureRoot) {
@@ -290,7 +255,10 @@ function splitPackageExtends(specifier) {
   if (specifier.includes(":")) return null;
   const slash = specifier.indexOf("/");
   if (slash < 0) return { name: specifier, subpath: null };
-  return { name: specifier.slice(0, slash), subpath: specifier.slice(slash + 1) };
+  return {
+    name: specifier.slice(0, slash),
+    subpath: specifier.slice(slash + 1),
+  };
 }
 
 function packageExtendsFile(pkg, subpath) {


### PR DESCRIPTION
## Summary
- Follow up on #4702 by processing every resolvable `extends` entry in TypeScript array-extends order instead of stopping at the first entry.
- Share the JSONC-backed chain loader between package path and hash-alias overlay rewrites so both surfaces keep later-entry precedence.
- Add package and hash-alias oracles where a later `paths` entry relies on an earlier `baseUrl`.

Refs #4461

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-outside-paths-baseurl.test.ts tests/tooling/typecheck-baseline-outside-paths.test.ts tests/tooling/typecheck-baseline-outside-aliases.test.ts tests/tooling/typecheck-baseline-outside-typeroots.test.ts tests/tooling/typecheck-baseline-outside-paths-package-extends.test.ts tests/tooling/typecheck-baseline-outside-aliases-package-extends.test.ts`
- [x] `vp check tests/tooling/typecheck-baseline-outside-paths-baseurl.test.ts tools/fixtures/typecheck-baseline-extends-chain.mjs tools/fixtures/typecheck-baseline-outside-aliases.mjs tools/fixtures/typecheck-baseline-outside-paths.mjs`
- [x] pinned MoonBit `source_file_lengths --check --base-ref origin/main --max-lines 350 --limit 10`
- [ ] CI `check-js` / `test-scripts`
