### PR TITLE
fix(matrix): isolate undeclared PrimeVue and Reka UI packages

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueUiLibraryPackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * PrimeVue, Reka UI, and Nuxt UI live in Vize's `tests/package.json`.
+ * TypeScript can climb into those copies and load Vize's Vue beside the
+ * fixture (#4461). Unique isolation links the fixture store copy when an
+ * ancestor is reachable.
+ */
+
+function scaffold(names: string[]) {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-ui-libraries-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const name of names) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+test("ancestor UI libraries with one in-fixture copy each are linked from those copies", () => {
+  const { fixtureRoot, outer } = scaffold(["@nuxt/ui", "primevue", "reka-ui"]);
+  try {
+    writeStoreCopy(fixtureRoot, "@nuxt+ui@4.8.2", "@nuxt/ui");
+    writeStoreCopy(fixtureRoot, "primevue@4.5.5", "primevue");
+    writeStoreCopy(fixtureRoot, "reka-ui@2.9.10", "reka-ui");
+    assert.deepEqual(isolateUniqueUiLibraryPackages(fixtureRoot), [
+      {
+        name: "@nuxt/ui",
+        target: "node_modules/.pnpm/@nuxt+ui@4.8.2/node_modules/@nuxt/ui",
+      },
+      { name: "primevue", target: "node_modules/.pnpm/primevue@4.5.5/node_modules/primevue" },
+      { name: "reka-ui", target: "node_modules/.pnpm/reka-ui@2.9.10/node_modules/reka-ui" },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("UI libraries no ancestor provides are left alone", () => {
+  const { fixtureRoot, outer } = scaffold([]);
+  try {
+    writeStoreCopy(fixtureRoot, "primevue@4.5.5", "primevue");
+    writeStoreCopy(fixtureRoot, "reka-ui@2.9.10", "reka-ui");
+    assert.deepEqual(isolateUniqueUiLibraryPackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "primevue")), false);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "reka-ui")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an already hoisted primevue is left for isolation; this repair does not relink it", () => {
+  const { fixtureRoot, outer } = scaffold(["primevue"]);
+  try {
+    writeStoreCopy(fixtureRoot, "primevue@4.5.5", "primevue");
+    const hoisted = path.join(fixtureRoot, "node_modules", "primevue");
+    fs.mkdirSync(hoisted, { recursive: true });
+    fs.writeFileSync(path.join(hoisted, "package.json"), `{"name":"primevue"}\n`);
+    assert.deepEqual(isolateUniqueUiLibraryPackages(fixtureRoot), []);
+    assert.equal(fs.lstatSync(hoisted).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -213,3 +213,7 @@ export function isolateUniqueVueUsePackages(fixtureRoot) {
 export function isolateUniqueNuxtUiPackages(fixtureRoot) {
   return isolateUniqueNamedLocalTypePackages(fixtureRoot, ["@nuxt/ui"]);
 }
+
+export function isolateUniqueUiLibraryPackages(fixtureRoot) {
+  return isolateUniqueNamedLocalTypePackages(fixtureRoot, ["@nuxt/ui", "primevue", "reka-ui"]);
+}

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -9,7 +9,7 @@ import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-targ
 import { isolateFixtureTypePackages } from "./typecheck-baseline-isolation.mjs";
 import {
   isolateUniqueLocalTypePackages,
-  isolateUniqueNuxtUiPackages,
+  isolateUniqueUiLibraryPackages,
   isolateUniqueVueI18nPackages,
   isolateUniqueVueRuntimePackages,
   isolateUniqueVueUsePackages,
@@ -168,7 +168,7 @@ function isolateFixture(project, fixtureRoot) {
     isolateUniqueVueRuntimePackages,
     isolateUniqueVueI18nPackages,
     isolateUniqueVueUsePackages,
-    isolateUniqueNuxtUiPackages,
+    isolateUniqueUiLibraryPackages,
   ]) {
     for (const entry of isolate(fixtureRoot)) {
       if (seen.has(entry.name)) continue;


### PR DESCRIPTION
## Summary
- `tests/package.json` depends on `primevue` and `reka-ui`. Those fixtures can still climb into Vize's copies, which then load Vize's Vue beside the fixture (#4461).
- Unique isolation now links the fixture's own `primevue` and `reka-ui` when an ancestor copy is reachable. `@nuxt/ui` stays in the same helper so `typecheck-dependency-prepare.mjs` stays at 350 lines.

Does not restore the typecheck divergence gate.

## Test plan
- [x] `node --test` UI-library unique-isolation tests plus existing `@nuxt/ui` tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790115707&installation_model_id=422833&pr_number=4706&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4706&signature=7fc4dcccdeaedd40c596ec6376849bf42e3d974c5ebcfa66933641dbb4764d52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->