### PR TITLE
fix(matrix): follow every array extends entry in typecheck isolation

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-array-extends.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-array-extends.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateFixtureTypePackages } from "../../tools/fixtures/typecheck-baseline-isolation.mjs";
+
+/**
+ * TypeScript array `extends` walks every entry; later files win. Isolation used
+ * to follow only the first specifier, so a Nuxt-style
+ * `extends: ["./empty.json", "./tsconfig.app.json"]` never saw the app `paths`
+ * and `vue-router` escaped to Vize (#4461).
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-array-extends-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  const storeId = "vue-router@5.1.0";
+  const storeCopy = path.join(
+    fixtureRoot,
+    "node_modules",
+    ".pnpm",
+    storeId,
+    "node_modules",
+    "vue-router",
+  );
+  fs.mkdirSync(storeCopy, { recursive: true });
+  fs.writeFileSync(path.join(storeCopy, "package.json"), '{"name":"vue-router"}\n');
+  const ancestor = path.join(outer, "node_modules", "vue-router");
+  fs.mkdirSync(ancestor, { recursive: true });
+  fs.writeFileSync(path.join(ancestor, "package.json"), '{"name":"vue-router"}\n');
+  return { fixtureRoot, outer, storeId };
+}
+
+test("a later array extends entry still isolates declared package paths", () => {
+  const { outer, fixtureRoot, storeId } = scaffold();
+  try {
+    const nuxtDir = path.join(fixtureRoot, ".nuxt");
+    fs.mkdirSync(nuxtDir, { recursive: true });
+    fs.writeFileSync(path.join(nuxtDir, "empty.json"), "{}\n");
+    fs.writeFileSync(
+      path.join(nuxtDir, "tsconfig.app.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "vue-router": [`../node_modules/.pnpm/${storeId}/node_modules/vue-router`],
+          },
+        },
+      })}\n`,
+    );
+    const configPath = path.join(nuxtDir, "tsconfig.json");
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({ extends: ["./empty.json", "./tsconfig.app.json"] })}\n`,
+    );
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+      {
+        name: "vue-router",
+        target: `node_modules/.pnpm/${storeId}/node_modules/vue-router`,
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an earlier array extends entry does not hide a later paths mapping", () => {
+  const { outer, fixtureRoot, storeId } = scaffold();
+  try {
+    const nuxtDir = path.join(fixtureRoot, ".nuxt");
+    fs.mkdirSync(nuxtDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nuxtDir, "stale.json"),
+      `${JSON.stringify({
+        compilerOptions: { paths: { "vue-router": ["./missing-vue-router"] } },
+      })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(nuxtDir, "tsconfig.app.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "vue-router": [`../node_modules/.pnpm/${storeId}/node_modules/vue-router`],
+          },
+        },
+      })}\n`,
+    );
+    const configPath = path.join(nuxtDir, "tsconfig.json");
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({ extends: ["./stale.json", "./tsconfig.app.json"] })}\n`,
+    );
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+      {
+        name: "vue-router",
+        target: `node_modules/.pnpm/${storeId}/node_modules/vue-router`,
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -178,23 +178,24 @@ function mergeDeclared(declared, conflicts, local) {
 
 function loadExtendsChain(sourceConfigPath) {
   const chain = [];
-  const seen = new Set();
-  let current = resolve(sourceConfigPath);
-  while (!seen.has(current)) {
-    seen.add(current);
-    const config = parseTsconfig(current);
-    if (config == null) break;
-    chain.push({ config, dir: dirname(current) });
-    const specifiers = extendsSpecifiers(config.extends);
-    let next = null;
-    for (const specifier of specifiers) {
-      next = resolveExtends(current, specifier);
-      if (next != null) break;
-    }
-    if (next == null) break;
-    current = next;
-  }
+  appendExtendsChain(chain, new Set(), resolve(sourceConfigPath));
   return chain;
+}
+
+function appendExtendsChain(chain, seen, current) {
+  if (seen.has(current)) return;
+  seen.add(current);
+  const config = parseTsconfig(current);
+  if (config == null) return;
+  chain.push({ config, dir: dirname(current) });
+  // Later array `extends` entries override earlier ones, matching tsc. Walk them
+  // last-to-first so the reverse last-wins pass still sees the later parent.
+  for (const next of extendsSpecifiers(config.extends)
+    .map((specifier) => resolveExtends(current, specifier))
+    .filter((entry) => entry != null)
+    .reverse()) {
+    appendExtendsChain(chain, seen, next);
+  }
 }
 
 function parseTsconfig(configPath) {


### PR DESCRIPTION
## Summary
- Overlay rewrite is learning array `extends` separately (#4705). Isolation still followed only the first specifier, so `extends: [\"./empty.json\", \"./tsconfig.app.json\"]` never saw the app `paths` and `vue-router` escaped to Vize (#4461).
- The isolation extends walk now visits every relative array entry, later files winning, matching tsc. `isolation.mjs` stays at 350 lines.

Does not restore the typecheck divergence gate.

## Test plan
- [x] `node --test` isolation tests, including later-wins array `extends` oracles
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790116286&installation_model_id=422833&pr_number=4707&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4707&signature=60e152c17b94ead9b1bf89abd071f515c5c84bdafa6f7fc1239be4206f6bbdda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->