### PR TITLE
fix(matrix): isolate undeclared Element Plus, Naive UI, and related UI packages

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts
@@ -7,10 +7,9 @@ import { test } from "node:test";
 import { isolateUniqueUiLibraryPackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
 
 /**
- * PrimeVue, Reka UI, and Nuxt UI live in Vize's `tests/package.json`.
- * TypeScript can climb into those copies and load Vize's Vue beside the
- * fixture (#4461). Unique isolation links the fixture store copy when an
- * ancestor is reachable.
+ * Vue UI libraries in Vize's `tests/package.json` still climb out of a
+ * fixture that does not declare them (#4461). Unique isolation links the
+ * fixture store copy when an ancestor is reachable.
  */
 
 function scaffold(names: string[]) {
@@ -35,19 +34,26 @@ function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
 }
 
 test("ancestor UI libraries with one in-fixture copy each are linked from those copies", () => {
-  const { fixtureRoot, outer } = scaffold(["@nuxt/ui", "primevue", "reka-ui"]);
+  const libraries = [
+    ["@nuxt/ui", "@nuxt+ui@4.8.2"],
+    ["ant-design-vue", "ant-design-vue@4.2.6"],
+    ["element-plus", "element-plus@2.14.1"],
+    ["naive-ui", "naive-ui@2.44.1"],
+    ["primevue", "primevue@4.5.5"],
+    ["quasar", "quasar@2.19.3"],
+    ["reka-ui", "reka-ui@2.9.10"],
+    ["vant", "vant@4.9.24"],
+  ];
+  const { fixtureRoot, outer } = scaffold(libraries.map(([name]) => name));
   try {
-    writeStoreCopy(fixtureRoot, "@nuxt+ui@4.8.2", "@nuxt/ui");
-    writeStoreCopy(fixtureRoot, "primevue@4.5.5", "primevue");
-    writeStoreCopy(fixtureRoot, "reka-ui@2.9.10", "reka-ui");
-    assert.deepEqual(isolateUniqueUiLibraryPackages(fixtureRoot), [
-      {
-        name: "@nuxt/ui",
-        target: "node_modules/.pnpm/@nuxt+ui@4.8.2/node_modules/@nuxt/ui",
-      },
-      { name: "primevue", target: "node_modules/.pnpm/primevue@4.5.5/node_modules/primevue" },
-      { name: "reka-ui", target: "node_modules/.pnpm/reka-ui@2.9.10/node_modules/reka-ui" },
-    ]);
+    for (const [name, id] of libraries) writeStoreCopy(fixtureRoot, id, name);
+    assert.deepEqual(
+      isolateUniqueUiLibraryPackages(fixtureRoot),
+      libraries.map(([name, id]) => ({
+        name,
+        target: `node_modules/.pnpm/${id}/node_modules/${name}`,
+      })),
+    );
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });
   }

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -215,5 +215,14 @@ export function isolateUniqueNuxtUiPackages(fixtureRoot) {
 }
 
 export function isolateUniqueUiLibraryPackages(fixtureRoot) {
-  return isolateUniqueNamedLocalTypePackages(fixtureRoot, ["@nuxt/ui", "primevue", "reka-ui"]);
+  return isolateUniqueNamedLocalTypePackages(fixtureRoot, [
+    "@nuxt/ui",
+    "ant-design-vue",
+    "element-plus",
+    "naive-ui",
+    "primevue",
+    "quasar",
+    "reka-ui",
+    "vant",
+  ]);
 }


### PR DESCRIPTION
## Summary
- `tests/package.json` also depends on `ant-design-vue`, `element-plus`, `naive-ui`, `quasar`, and `vant`. Those fixtures can climb into Vize's copies and load Vize's Vue beside the fixture (#4461).
- Unique isolation now links those names through the existing UI-library helper from #4706. `prepare.mjs` stays at 350 lines.

Does not restore the typecheck divergence gate.

## Test plan
- [x] `node --test` UI-library unique-isolation tests
- [ ] CI `check-js` / `test-scripts`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790116341&installation_model_id=422833&pr_number=4708&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4708&signature=93d049824ca8c480265cdf32b7db6fc4e33bd3054d8f92dfc12b6e66a620a1fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->