### PR TITLE
fix(matrix): isolate undeclared FormKit and VeeValidate packages

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-vue-form.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-vue-form.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueVueFormPackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * FormKit and VeeValidate live in Vize's `tests/package.json`. TypeScript can
+ * climb into those copies and load Vize's Vue beside the fixture (#4461).
+ * Unique isolation links the fixture store copy when an ancestor is reachable.
+ */
+
+function scaffold(names: string[]) {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-vue-form-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const name of names) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+test("ancestor form packages with one in-fixture copy each are linked from those copies", () => {
+  const { fixtureRoot, outer } = scaffold(["@formkit/vue", "vee-validate"]);
+  try {
+    writeStoreCopy(fixtureRoot, "@formkit+vue@2.1.0", "@formkit/vue");
+    writeStoreCopy(fixtureRoot, "vee-validate@4.15.1", "vee-validate");
+    assert.deepEqual(isolateUniqueVueFormPackages(fixtureRoot), [
+      {
+        name: "@formkit/vue",
+        target: "node_modules/.pnpm/@formkit+vue@2.1.0/node_modules/@formkit/vue",
+      },
+      {
+        name: "vee-validate",
+        target: "node_modules/.pnpm/vee-validate@4.15.1/node_modules/vee-validate",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("form packages no ancestor provides are left alone", () => {
+  const { fixtureRoot, outer } = scaffold([]);
+  try {
+    writeStoreCopy(fixtureRoot, "@formkit+vue@2.1.0", "@formkit/vue");
+    writeStoreCopy(fixtureRoot, "vee-validate@4.15.1", "vee-validate");
+    assert.deepEqual(isolateUniqueVueFormPackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "@formkit", "vue")), false);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vee-validate")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an already hoisted vee-validate is left for isolation; this repair does not relink it", () => {
+  const { fixtureRoot, outer } = scaffold(["vee-validate"]);
+  try {
+    writeStoreCopy(fixtureRoot, "vee-validate@4.15.1", "vee-validate");
+    const hoisted = path.join(fixtureRoot, "node_modules", "vee-validate");
+    fs.mkdirSync(hoisted, { recursive: true });
+    fs.writeFileSync(path.join(hoisted, "package.json"), `{"name":"vee-validate"}\n`);
+    assert.deepEqual(isolateUniqueVueFormPackages(fixtureRoot), []);
+    assert.equal(fs.lstatSync(hoisted).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -217,3 +217,7 @@ export function isolateUniqueNuxtUiPackages(fixtureRoot) {
 export function isolateUniqueUiLibraryPackages(fixtureRoot) {
   return isolateUniqueNamedLocalTypePackages(fixtureRoot, ["@nuxt/ui", "primevue", "reka-ui"]);
 }
+
+export function isolateUniqueVueFormPackages(fixtureRoot) {
+  return isolateUniqueNamedLocalTypePackages(fixtureRoot, ["@formkit/vue", "vee-validate"]);
+}

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -10,6 +10,7 @@ import { isolateFixtureTypePackages } from "./typecheck-baseline-isolation.mjs";
 import {
   isolateUniqueLocalTypePackages,
   isolateUniqueUiLibraryPackages,
+  isolateUniqueVueFormPackages,
   isolateUniqueVueI18nPackages,
   isolateUniqueVueRuntimePackages,
   isolateUniqueVueUsePackages,
@@ -129,15 +130,11 @@ function prepareProjectDependencies({ args, commitSha, project }) {
 }
 
 /**
- * Link the packages the fixture's own config maps but its package manager did
- * not hoist, so a `/// <reference types="..." />` inside the fixture cannot be
- * answered by Vize's own `node_modules` further up the tree (run 31979524200).
- * When Vize's `--tsconfig` and vue-tsc's baseline config differ (Nuxt Volt:
- * `apps/volt/tsconfig.json` vs `apps/volt/.nuxt/tsconfig.json`), both are
- * walked and both receive an overlay. Reported on stdout rather than into the
- * artifact: what the run has to prove is the outcome, and
- * `typecheck-baseline-ambient.mjs` proves that from the program listing
- * regardless of how the tree got there.
+ * Link packages the fixture config maps but its package manager did not hoist,
+ * so a `/// <reference types="..." />` cannot be answered by Vize's
+ * `node_modules` further up the tree (run 31979524200). When Vize's
+ * `--tsconfig` and vue-tsc's baseline differ (Nuxt Volt), both are walked and
+ * overlaid. Reported on stdout; `typecheck-baseline-ambient.mjs` proves it.
  */
 export function isolationTsconfigPaths(project) {
   const paths = [];
@@ -169,6 +166,7 @@ function isolateFixture(project, fixtureRoot) {
     isolateUniqueVueI18nPackages,
     isolateUniqueVueUsePackages,
     isolateUniqueUiLibraryPackages,
+    isolateUniqueVueFormPackages,
   ]) {
     for (const entry of isolate(fixtureRoot)) {
       if (seen.has(entry.name)) continue;


### PR DESCRIPTION
## Summary
- Unique-link undeclared `@formkit/vue` and `vee-validate` from Vize's `tests/package.json` into the fixture store copy so TypeScript cannot climb into Vize's Vue (#4461).
- Keep `prepare.mjs` at 348/350 by tightening the isolation comment.

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-isolation-vue-form.test.ts`
- [x] existing UI library and vue-i18n isolation tests still pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790117040&installation_model_id=422833&pr_number=4709&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4709&signature=a3d9a7b89c5cd5f39b6684766806bfde86f79fad15f3714e3c629554598e6d4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->