### PR TITLE
fix(matrix): resolve array-extends paths against earlier baseUrl

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-array-extends.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-array-extends.test.ts
@@ -103,3 +103,38 @@ test("an earlier array extends entry does not hide a later paths mapping", () =>
     fs.rmSync(outer, { recursive: true, force: true });
   }
 });
+
+test("a later array extends paths mapping still honors an earlier baseUrl", () => {
+  const { outer, fixtureRoot, storeId } = scaffold();
+  try {
+    const nuxtDir = path.join(fixtureRoot, ".nuxt");
+    fs.mkdirSync(nuxtDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(nuxtDir, "base.json"),
+      `${JSON.stringify({ compilerOptions: { baseUrl: ".." } })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(nuxtDir, "tsconfig.app.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "vue-router": [`node_modules/.pnpm/${storeId}/node_modules/vue-router`],
+          },
+        },
+      })}\n`,
+    );
+    const configPath = path.join(nuxtDir, "tsconfig.json");
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({ extends: ["./base.json", "./tsconfig.app.json"] })}\n`,
+    );
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+      {
+        name: "vue-router",
+        target: `node_modules/.pnpm/${storeId}/node_modules/vue-router`,
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -16,6 +16,7 @@ import {
 import { recordCompilerOptionJsxImportSource } from "./typecheck-baseline-isolation-jsx.mjs";
 import { recordCompilerOptionPlugins } from "./typecheck-baseline-isolation-plugins.mjs";
 import { recordCompilerOptionTypes } from "./typecheck-baseline-isolation-types.mjs";
+import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs";
 import { pathMappingRoot } from "./typecheck-baseline-outside-paths.mjs";
 
 /**
@@ -177,25 +178,7 @@ function mergeDeclared(declared, conflicts, local) {
 }
 
 function loadExtendsChain(sourceConfigPath) {
-  const chain = [];
-  appendExtendsChain(chain, new Set(), resolve(sourceConfigPath));
-  return chain;
-}
-
-function appendExtendsChain(chain, seen, current) {
-  if (seen.has(current)) return;
-  seen.add(current);
-  const config = parseTsconfig(current);
-  if (config == null) return;
-  chain.push({ config, dir: dirname(current) });
-  // Later array `extends` entries override earlier ones, matching tsc. Walk them
-  // last-to-first so the reverse last-wins pass still sees the later parent.
-  for (const next of extendsSpecifiers(config.extends)
-    .map((specifier) => resolveExtends(current, specifier))
-    .filter((entry) => entry != null)
-    .reverse()) {
-    appendExtendsChain(chain, seen, next);
-  }
+  return loadTsconfigExtendsChain(sourceConfigPath, resolveExtends);
 }
 
 function parseTsconfig(configPath) {


### PR DESCRIPTION
## Summary
- Isolation reuses `loadTsconfigExtendsChain` so array `extends` last-wins matches the overlay.
- Lock the Nuxt case where a later array entry supplies `paths` and an earlier entry supplies `baseUrl: ".."`.

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-isolation-array-extends.test.ts tests/tooling/typecheck-baseline-isolation-baseurl.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790117289&installation_model_id=422833&pr_number=4710&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4710&signature=93febfa2b9deaa5f4cc055df5d1ae6e880e5b679d177b5ededd5b2e5e922ffd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->