### PR TITLE
fix(matrix): expand TypeScript ${configDir} in overlay path rewrites

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-paths-config-dir.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-paths-config-dir.test.ts
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { expandConfigDir } from "../../tools/fixtures/typecheck-baseline-config-dir.mjs";
+import { rewriteOutsideAliasPaths } from "../../tools/fixtures/typecheck-baseline-outside-aliases.mjs";
+import {
+  pathMappingRoot,
+  rewriteOutsidePackagePaths,
+  rewriteOutsideTypeRoots,
+} from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+
+/**
+ * TypeScript 5.5 expands `${configDir}` to the declaring tsconfig directory.
+ * Overlay rewrite used to treat the token as a literal segment, so Nuxt-style
+ * mappings never resolved above the fixture and never retargeted (#4461).
+ */
+
+const configDirToken = "${configDir}";
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-outside-config-dir-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, ".nuxt"), { recursive: true });
+  const outsideVue = path.join(outer, "node_modules", "vue");
+  fs.mkdirSync(outsideVue, { recursive: true });
+  fs.writeFileSync(path.join(outsideVue, "package.json"), `{"name":"vue"}\n`);
+  const outsideNuxt = path.join(outer, "node_modules", "nuxt");
+  fs.mkdirSync(path.join(outsideNuxt, "dist", "app"), { recursive: true });
+  fs.writeFileSync(path.join(outsideNuxt, "package.json"), `{"name":"nuxt"}\n`);
+  const outsideTypes = path.join(outer, "node_modules", "@types");
+  fs.mkdirSync(outsideTypes, { recursive: true });
+  return { fixtureRoot, outer, outsideNuxt, outsideTypes, outsideVue };
+}
+
+function writeLocal(fixtureRoot: string, name: string) {
+  const local = path.join(fixtureRoot, "node_modules", name);
+  fs.mkdirSync(local, { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"${name}"}\n`);
+  return local;
+}
+
+test("expandConfigDir substitutes the declaring tsconfig directory", () => {
+  assert.equal(expandConfigDir("vue", "/abs/.nuxt"), "vue");
+  assert.equal(
+    expandConfigDir(`${configDirToken}/../node_modules/vue`, "/abs/.nuxt"),
+    "/abs/.nuxt/../node_modules/vue",
+  );
+});
+
+test("a ${configDir} package mapping that resolves outside is retargeted", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocal(fixtureRoot, "vue");
+    const sourcePath = path.join(fixtureRoot, ".nuxt", "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { vue: [`${configDirToken}/../../node_modules/vue`] },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { vue: ["../node_modules/vue"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a ${configDir} baseUrl still resolves outside package mappings from the fixture root", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    writeLocal(fixtureRoot, "vue");
+    const nuxtDir = path.join(fixtureRoot, ".nuxt");
+    const sourcePath = path.join(nuxtDir, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          baseUrl: `${configDirToken}/..`,
+          paths: { vue: [path.relative(fixtureRoot, outsideVue)] },
+        },
+      })}\n`,
+    );
+    assert.equal(pathMappingRoot(sourcePath, fixtureRoot, nuxtDir), fixtureRoot);
+    assert.deepEqual(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { vue: ["../node_modules/vue"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a ${configDir} hash alias that resolves outside is retargeted", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocal(fixtureRoot, "nuxt");
+    const sourcePath = path.join(fixtureRoot, ".nuxt", "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "#app": [`${configDirToken}/../../node_modules/nuxt/dist/app`],
+          },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      { "#app": ["../node_modules/nuxt/dist/app"] },
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a ${configDir} typeRoots mapping that resolves outside is retargeted", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    fs.mkdirSync(path.join(fixtureRoot, "node_modules", "@types"), { recursive: true });
+    const sourcePath = path.join(fixtureRoot, ".nuxt", "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          typeRoots: [`${configDirToken}/../../node_modules/@types`],
+        },
+      })}\n`,
+    );
+    assert.deepEqual(
+      rewriteOutsideTypeRoots(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
+      ["../node_modules/@types"],
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-config-dir.mjs
+++ b/tools/fixtures/typecheck-baseline-config-dir.mjs
@@ -1,0 +1,20 @@
+import { resolve } from "node:path";
+
+/**
+ * TypeScript 5.5 substitutes `${configDir}` with the directory of the tsconfig
+ * that declared the option, then resolves the result. Overlay rewrite used to
+ * treat the token as a literal path segment, so Nuxt-style
+ * `${configDir}/../node_modules/vue` never looked outside and never retargeted
+ * (#4461).
+ */
+
+const token = "${configDir}";
+
+export function expandConfigDir(entry, tsconfigDir) {
+  if (typeof entry !== "string" || !entry.includes(token)) return entry;
+  return entry.replaceAll(token, tsconfigDir.replaceAll("\\", "/"));
+}
+
+export function resolveWithConfigDir(mappingRoot, tsconfigDir, entry) {
+  return resolve(mappingRoot, expandConfigDir(entry, tsconfigDir));
+}

--- a/tools/fixtures/typecheck-baseline-outside-aliases.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-aliases.mjs
@@ -1,6 +1,7 @@
 import { existsSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 
+import { resolveWithConfigDir } from "./typecheck-baseline-config-dir.mjs";
 import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs";
 import {
   isolatedOverlayBaseUrl,
@@ -34,9 +35,17 @@ export function rewriteOutsideAliasPaths(fixtureRoot, sourceConfigPath, configDi
   let changed = false;
   for (const [name, targets] of Object.entries(declared.paths)) {
     if (!Array.isArray(targets)) continue;
-    rewritten[name] = retargetAliasMapping(root, mapping, configDir, name, targets, () => {
-      changed = true;
-    });
+    rewritten[name] = retargetAliasMapping(
+      root,
+      mapping,
+      declared.dir,
+      configDir,
+      name,
+      targets,
+      () => {
+        changed = true;
+      },
+    );
   }
   return changed ? rewritten : null;
 }
@@ -68,15 +77,25 @@ export function applyIsolatedAliasOverlay(fixtureRoot, sourceConfigPath, overlay
   return { path: overlayPath, paths, typeRoots };
 }
 
-function retargetAliasMapping(fixtureRoot, sourceDir, configDir, name, targets, markChanged) {
-  const relocated = targets.map((entry) => relocatePathEntry(sourceDir, configDir, entry));
+function retargetAliasMapping(
+  fixtureRoot,
+  sourceDir,
+  tsconfigDir,
+  configDir,
+  name,
+  targets,
+  markChanged,
+) {
+  const relocated = targets.map((entry) =>
+    relocatePathEntry(sourceDir, tsconfigDir, configDir, entry),
+  );
   if (isPackageMappingName(name)) return relocated;
   const first = targets.find(
     (entry) => typeof entry === "string" && isExactOrTrailingStarPath(entry),
   );
   if (first == null) return relocated;
   const star = first.endsWith("/*");
-  const original = resolve(sourceDir, star ? first.slice(0, -2) : first);
+  const original = resolveWithConfigDir(sourceDir, tsconfigDir, star ? first.slice(0, -2) : first);
   if (isInside(fixtureRoot, original)) return relocated;
   const owned = owningNodeModulePackage(original);
   if (owned == null || isInside(fixtureRoot, owned.root)) return relocated;
@@ -102,11 +121,16 @@ function isExactOrTrailingStarPath(entry) {
   return !entry.includes("*") || (entry.endsWith("/*") && !entry.slice(0, -2).includes("*"));
 }
 
-function relocatePathEntry(sourceDir, configDir, entry) {
+function relocatePathEntry(sourceDir, tsconfigDir, configDir, entry) {
   if (typeof entry !== "string") return entry;
-  if (!entry.includes("*")) return configRelativePath(configDir, resolve(sourceDir, entry));
+  if (!entry.includes("*")) {
+    return configRelativePath(configDir, resolveWithConfigDir(sourceDir, tsconfigDir, entry));
+  }
   if (entry.endsWith("/*") && !entry.slice(0, -2).includes("*")) {
-    return `${configRelativePath(configDir, resolve(sourceDir, entry.slice(0, -2)))}/*`;
+    return `${configRelativePath(
+      configDir,
+      resolveWithConfigDir(sourceDir, tsconfigDir, entry.slice(0, -2)),
+    )}/*`;
   }
   return entry;
 }

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -1,6 +1,7 @@
 import { existsSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, relative, resolve } from "node:path";
 
+import { expandConfigDir, resolveWithConfigDir } from "./typecheck-baseline-config-dir.mjs";
 import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs";
 
 /**
@@ -37,6 +38,8 @@ import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs
  *
  * `compilerOptions.baseUrl` is last-wins on the extends chain. Mappings resolve
  * from that directory; a rewrite then pins overlay `baseUrl` to `"."`.
+ * `${configDir}` in `baseUrl`, `paths`, and `typeRoots` expands to the tsconfig
+ * directory that declared the option, matching tsc, before those paths resolve.
  */
 
 const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
@@ -50,16 +53,24 @@ export function rewriteOutsidePackagePaths(fixtureRoot, sourceConfigPath, config
   let changed = false;
   for (const [name, targets] of Object.entries(declared.paths)) {
     if (!Array.isArray(targets)) continue;
-    rewritten[name] = retargetPathMapping(root, mapping, configDir, name, targets, () => {
-      changed = true;
-    });
+    rewritten[name] = retargetPathMapping(
+      root,
+      mapping,
+      declared.dir,
+      configDir,
+      name,
+      targets,
+      () => {
+        changed = true;
+      },
+    );
   }
   return changed ? rewritten : null;
 }
 
 export function pathMappingRoot(sourceConfigPath, fixtureRoot, pathsDir) {
   const base = winningBaseUrl(sourceConfigPath, fixtureRoot);
-  return base == null ? pathsDir : resolve(base.dir, base.value);
+  return base == null ? pathsDir : resolve(base.dir, expandConfigDir(base.value, base.dir));
 }
 
 export function isolatedOverlayBaseUrl(sourceConfigPath, fixtureRoot) {
@@ -108,14 +119,28 @@ export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
   return { path: overlayPath, paths, typeRoots };
 }
 
-function retargetPathMapping(fixtureRoot, sourceDir, configDir, name, targets, markChanged) {
-  const relocated = targets.map((entry) => relocatePathEntry(sourceDir, configDir, entry));
+function retargetPathMapping(
+  fixtureRoot,
+  sourceDir,
+  tsconfigDir,
+  configDir,
+  name,
+  targets,
+  markChanged,
+) {
+  const relocated = targets.map((entry) =>
+    relocatePathEntry(sourceDir, tsconfigDir, configDir, entry),
+  );
   const packageName = packageNameFromPathMapping(name);
   const first = targets.find(
     (entry) => typeof entry === "string" && isExactOrTrailingStarPath(entry),
   );
   if (first == null) return relocated;
-  const original = resolve(sourceDir, first.endsWith("/*") ? first.slice(0, -2) : first);
+  const original = resolveWithConfigDir(
+    sourceDir,
+    tsconfigDir,
+    first.endsWith("/*") ? first.slice(0, -2) : first,
+  );
   if (isInside(fixtureRoot, original)) return relocated;
   let local;
   if (packageName != null) {
@@ -156,15 +181,15 @@ function isExactOrTrailingStarPath(entry) {
   return !entry.includes("*") || (entry.endsWith("/*") && !entry.slice(0, -2).includes("*"));
 }
 
-function relocatePathEntry(sourceDir, configDir, entry) {
+function relocatePathEntry(sourceDir, tsconfigDir, configDir, entry) {
   if (typeof entry !== "string" || entry.includes("*")) return entry;
-  return configRelativePath(configDir, resolve(sourceDir, entry));
+  return configRelativePath(configDir, resolveWithConfigDir(sourceDir, tsconfigDir, entry));
 }
 
 function retargetTypeRoot(fixtureRoot, sourceDir, configDir, entry, markChanged) {
   if (typeof entry !== "string") return entry;
-  const relocated = relocatePathEntry(sourceDir, configDir, entry);
-  const original = resolve(sourceDir, entry);
+  const relocated = relocatePathEntry(sourceDir, sourceDir, configDir, entry);
+  const original = resolveWithConfigDir(sourceDir, sourceDir, entry);
   if (isInside(fixtureRoot, original)) return relocated;
   if (!isTypesPackageRoot(original)) return relocated;
   const local = join(fixtureRoot, "node_modules", "@types");


### PR DESCRIPTION
## Summary
- Expand TypeScript 5.5 `${configDir}` in overlay `baseUrl`, `paths`, `typeRoots`, and hash aliases before resolving, matching tsc.
- Retarget Nuxt-style `${configDir}/../node_modules/vue` onto the fixture copy so vue-tsc does not load Vize's Vue (#4461).

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-outside-paths-config-dir.test.ts`
- [x] existing outside-paths, baseUrl, alias, and typeRoots overlay tests still pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790117639&installation_model_id=422833&pr_number=4711&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4711&signature=bbd282e21b28ff56abe7390561e8d296c3975fdb54fbc4307c794f0d5439a0e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->