### PR TITLE
fix(matrix): isolate undeclared Ionic Vue packages

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts
@@ -35,6 +35,7 @@ function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
 
 test("ancestor UI libraries with one in-fixture copy each are linked from those copies", () => {
   const libraries = [
+    ["@ionic/vue", "@ionic+vue@8.8.9"],
     ["@nuxt/ui", "@nuxt+ui@4.8.2"],
     ["ant-design-vue", "ant-design-vue@4.2.6"],
     ["element-plus", "element-plus@2.14.1"],

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -216,6 +216,7 @@ export function isolateUniqueNuxtUiPackages(fixtureRoot) {
 
 export function isolateUniqueUiLibraryPackages(fixtureRoot) {
   return isolateUniqueNamedLocalTypePackages(fixtureRoot, [
+    "@ionic/vue",
     "@nuxt/ui",
     "ant-design-vue",
     "element-plus",


### PR DESCRIPTION
## Summary
- Unique-link undeclared `@ionic/vue` from Vize's `tests/package.json` into the fixture store copy so TypeScript cannot climb into Vize's Vue (#4461).
- No `prepare.mjs` change: Ionic is included in the existing UI-library isolation pass.

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790117723&installation_model_id=422833&pr_number=4712&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4712&signature=dfc76ba29f57c111b2b3cecc969666fc3f3454ed3d96cb1912099d912540f970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->