### PR TITLE
fix(matrix): isolate undeclared Vue Query and Apollo packages

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-vue-query.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-vue-query.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueVueQueryPackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * Vue Query and Apollo Composable live in Vize's `tests/package.json`.
+ * TypeScript can climb into those copies and load Vize's Vue beside the
+ * fixture (#4461). Unique isolation links the fixture store copy when an
+ * ancestor is reachable.
+ */
+
+function scaffold(names: string[]) {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-vue-query-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const name of names) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+test("ancestor query packages with one in-fixture copy each are linked from those copies", () => {
+  const { fixtureRoot, outer } = scaffold(["@tanstack/vue-query", "@vue/apollo-composable"]);
+  try {
+    writeStoreCopy(fixtureRoot, "@tanstack+vue-query@5.101.0", "@tanstack/vue-query");
+    writeStoreCopy(fixtureRoot, "@vue+apollo-composable@4.2.2", "@vue/apollo-composable");
+    assert.deepEqual(isolateUniqueVueQueryPackages(fixtureRoot), [
+      {
+        name: "@tanstack/vue-query",
+        target: "node_modules/.pnpm/@tanstack+vue-query@5.101.0/node_modules/@tanstack/vue-query",
+      },
+      {
+        name: "@vue/apollo-composable",
+        target:
+          "node_modules/.pnpm/@vue+apollo-composable@4.2.2/node_modules/@vue/apollo-composable",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("query packages no ancestor provides are left alone", () => {
+  const { fixtureRoot, outer } = scaffold([]);
+  try {
+    writeStoreCopy(fixtureRoot, "@tanstack+vue-query@5.101.0", "@tanstack/vue-query");
+    writeStoreCopy(fixtureRoot, "@vue+apollo-composable@4.2.2", "@vue/apollo-composable");
+    assert.deepEqual(isolateUniqueVueQueryPackages(fixtureRoot), []);
+    assert.equal(
+      fs.existsSync(path.join(fixtureRoot, "node_modules", "@tanstack", "vue-query")),
+      false,
+    );
+    assert.equal(
+      fs.existsSync(path.join(fixtureRoot, "node_modules", "@vue", "apollo-composable")),
+      false,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an already hoisted vue-query is left for isolation; this repair does not relink it", () => {
+  const { fixtureRoot, outer } = scaffold(["@tanstack/vue-query"]);
+  try {
+    writeStoreCopy(fixtureRoot, "@tanstack+vue-query@5.101.0", "@tanstack/vue-query");
+    const hoisted = path.join(fixtureRoot, "node_modules", "@tanstack", "vue-query");
+    fs.mkdirSync(hoisted, { recursive: true });
+    fs.writeFileSync(path.join(hoisted, "package.json"), `{"name":"@tanstack/vue-query"}\n`);
+    assert.deepEqual(isolateUniqueVueQueryPackages(fixtureRoot), []);
+    assert.equal(fs.lstatSync(hoisted).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -230,3 +230,10 @@ export function isolateUniqueUiLibraryPackages(fixtureRoot) {
 export function isolateUniqueVueFormPackages(fixtureRoot) {
   return isolateUniqueNamedLocalTypePackages(fixtureRoot, ["@formkit/vue", "vee-validate"]);
 }
+
+export function isolateUniqueVueQueryPackages(fixtureRoot) {
+  return isolateUniqueNamedLocalTypePackages(fixtureRoot, [
+    "@tanstack/vue-query",
+    "@vue/apollo-composable",
+  ]);
+}

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -12,6 +12,7 @@ import {
   isolateUniqueUiLibraryPackages,
   isolateUniqueVueFormPackages,
   isolateUniqueVueI18nPackages,
+  isolateUniqueVueQueryPackages,
   isolateUniqueVueRuntimePackages,
   isolateUniqueVueUsePackages,
 } from "./typecheck-baseline-isolation-unique.mjs";
@@ -131,10 +132,9 @@ function prepareProjectDependencies({ args, commitSha, project }) {
 
 /**
  * Link packages the fixture config maps but its package manager did not hoist,
- * so a `/// <reference types="..." />` cannot be answered by Vize's
- * `node_modules` further up the tree (run 31979524200). When Vize's
- * `--tsconfig` and vue-tsc's baseline differ (Nuxt Volt), both are walked and
- * overlaid. Reported on stdout; `typecheck-baseline-ambient.mjs` proves it.
+ * so `/// <reference types />` cannot climb into Vize's `node_modules`
+ * (run 31979524200). Differing Vize `--tsconfig` and vue-tsc baselines are
+ * both walked and overlaid. Proven by `typecheck-baseline-ambient.mjs`.
  */
 export function isolationTsconfigPaths(project) {
   const paths = [];
@@ -167,6 +167,7 @@ function isolateFixture(project, fixtureRoot) {
     isolateUniqueVueUsePackages,
     isolateUniqueUiLibraryPackages,
     isolateUniqueVueFormPackages,
+    isolateUniqueVueQueryPackages,
   ]) {
     for (const entry of isolate(fixtureRoot)) {
       if (seen.has(entry.name)) continue;


### PR DESCRIPTION
## Summary
- Unique-link undeclared `@tanstack/vue-query` and `@vue/apollo-composable` from Vize's `tests/package.json` into the fixture store copy so TypeScript cannot climb into Vize's Vue (#4461).
- Keep `prepare.mjs` at 349/350.

## Test plan
- [x] `node --test tests/tooling/typecheck-baseline-isolation-vue-query.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790117876&installation_model_id=422833&pr_number=4713&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4713&signature=df9f50565de98bb156ac0ce896495c11df27ab476dc43dfb0a9ca2dd4573bc1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->