### PR TITLE
fix(matrix): expand TypeScript ${configDir} in isolation path targets

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-config-dir.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-config-dir.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateFixtureTypePackages } from "../../tools/fixtures/typecheck-baseline-isolation.mjs";
+
+/**
+ * TypeScript 5.5 expands `${configDir}` to the declaring tsconfig directory.
+ * Isolation used to treat the token as a literal path segment, so Nuxt-style
+ * `${configDir}/../node_modules/...` mappings never found the fixture copy
+ * and `vue-router` escaped to Vize (#4461).
+ */
+
+const configDirToken = "${configDir}";
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-config-dir-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  const storeId = "vue-router@5.1.0";
+  const storeCopy = path.join(
+    fixtureRoot,
+    "node_modules",
+    ".pnpm",
+    storeId,
+    "node_modules",
+    "vue-router",
+  );
+  fs.mkdirSync(storeCopy, { recursive: true });
+  fs.writeFileSync(path.join(storeCopy, "package.json"), '{"name":"vue-router"}\n');
+  const ancestor = path.join(outer, "node_modules", "vue-router");
+  fs.mkdirSync(ancestor, { recursive: true });
+  fs.writeFileSync(path.join(ancestor, "package.json"), '{"name":"vue-router"}\n');
+  return { fixtureRoot, outer, storeId };
+}
+
+test("a ${configDir} package mapping resolves to the fixture store copy", () => {
+  const { outer, fixtureRoot, storeId } = scaffold();
+  try {
+    const nuxtDir = path.join(fixtureRoot, ".nuxt");
+    fs.mkdirSync(nuxtDir, { recursive: true });
+    const configPath = path.join(nuxtDir, "tsconfig.json");
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "vue-router": [
+              `${configDirToken}/../node_modules/.pnpm/${storeId}/node_modules/vue-router`,
+            ],
+          },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+      {
+        name: "vue-router",
+        target: `node_modules/.pnpm/${storeId}/node_modules/vue-router`,
+      },
+    ]);
+    assert.equal(
+      fs.realpathSync(path.join(fixtureRoot, "node_modules", "vue-router")),
+      fs.realpathSync(
+        path.join(fixtureRoot, "node_modules", ".pnpm", storeId, "node_modules", "vue-router"),
+      ),
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a ${configDir} mapping still honors last-wins baseUrl", () => {
+  const { outer, fixtureRoot, storeId } = scaffold();
+  try {
+    const nuxtDir = path.join(fixtureRoot, ".nuxt");
+    fs.mkdirSync(nuxtDir, { recursive: true });
+    const configPath = path.join(nuxtDir, "tsconfig.json");
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        compilerOptions: {
+          baseUrl: `${configDirToken}/..`,
+          paths: {
+            "vue-router": [`node_modules/.pnpm/${storeId}/node_modules/vue-router`],
+          },
+        },
+      })}\n`,
+    );
+    assert.deepEqual(isolateFixtureTypePackages(fixtureRoot, configPath), [
+      {
+        name: "vue-router",
+        target: `node_modules/.pnpm/${storeId}/node_modules/vue-router`,
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -16,6 +16,7 @@ import {
 import { recordCompilerOptionJsxImportSource } from "./typecheck-baseline-isolation-jsx.mjs";
 import { recordCompilerOptionPlugins } from "./typecheck-baseline-isolation-plugins.mjs";
 import { recordCompilerOptionTypes } from "./typecheck-baseline-isolation-types.mjs";
+import { resolveWithConfigDir } from "./typecheck-baseline-config-dir.mjs";
 import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs";
 import { pathMappingRoot } from "./typecheck-baseline-outside-paths.mjs";
 
@@ -142,7 +143,7 @@ function mergePackageExtends(declared, conflicts, configPaths, fixtureRoot) {
 function packagePathsFromExtends(fixtureRoot, sourceConfigPath) {
   const declared = new Map();
   // Child `compilerOptions.paths` replace the parent's object, matching tsc.
-  // Targets resolve from last-wins `baseUrl` when set (#4461).
+  // Targets resolve from last-wins `baseUrl`; `${configDir}` expands first (#4461).
   let paths;
   let configDir;
   for (const { config, dir } of [...loadExtendsChain(sourceConfigPath)].reverse()) {
@@ -157,7 +158,14 @@ function packagePathsFromExtends(fixtureRoot, sourceConfigPath) {
     if (!packageNamePattern.test(name) || !Array.isArray(targets)) continue;
     const first = targets.find((entry) => typeof entry === "string" && !entry.includes("*"));
     if (first == null) continue;
-    declared.set(name, resolve(pathMappingRoot(sourceConfigPath, fixtureRoot, configDir), first));
+    declared.set(
+      name,
+      resolveWithConfigDir(
+        pathMappingRoot(sourceConfigPath, fixtureRoot, configDir),
+        configDir,
+        first,
+      ),
+    );
   }
   return declared;
 }


### PR DESCRIPTION
## Summary
- Isolation now expands TypeScript `${configDir}` in declared `paths` before resolving package targets, matching overlay rewrite (#4711).
- Nuxt-style `${configDir}/../node_modules/.pnpm/...` mappings link the fixture store copy instead of letting `vue-router` climb into Vize (#4461).
- `${configDir}` in last-wins `baseUrl` already flowed through `pathMappingRoot`; a regression test locks that together with path-target expansion.

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-isolation-config-dir.test.ts tests/tooling/typecheck-baseline-isolation-baseurl.test.ts tests/tooling/typecheck-baseline-isolation-array-extends.test.ts`
- [ ] CI `check-js` / tooling tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TypeScript path resolution so `${configDir}` references resolve relative to the declaring configuration file.
  * Corrected package lookup behavior for configurations using `${configDir}` in `paths` and `baseUrl` mappings.
* **Tests**
  * Added coverage for configuration-directory expansion, including pnpm-style package layouts and base URL resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->