### PR TITLE
fix(matrix): isolate undeclared TipTap Vue and Vue Flow packages

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-vue-editor.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-vue-editor.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueVueEditorPackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * TipTap Vue and Vue Flow live in Vize's `tests/package.json`. TypeScript can
+ * climb into those copies and load Vize's Vue beside the fixture (#4461).
+ * Unique isolation links the fixture store copy when an ancestor is reachable.
+ */
+
+function scaffold(names: string[]) {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-vue-editor-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const name of names) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+test("ancestor editor packages with one in-fixture copy each are linked from those copies", () => {
+  const { fixtureRoot, outer } = scaffold(["@tiptap/vue-3", "@vue-flow/core"]);
+  try {
+    writeStoreCopy(fixtureRoot, "@tiptap+vue-3@3.26.0", "@tiptap/vue-3");
+    writeStoreCopy(fixtureRoot, "@vue-flow+core@1.48.2", "@vue-flow/core");
+    assert.deepEqual(isolateUniqueVueEditorPackages(fixtureRoot), [
+      {
+        name: "@tiptap/vue-3",
+        target: "node_modules/.pnpm/@tiptap+vue-3@3.26.0/node_modules/@tiptap/vue-3",
+      },
+      {
+        name: "@vue-flow/core",
+        target: "node_modules/.pnpm/@vue-flow+core@1.48.2/node_modules/@vue-flow/core",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("editor packages no ancestor provides are left alone", () => {
+  const { fixtureRoot, outer } = scaffold([]);
+  try {
+    writeStoreCopy(fixtureRoot, "@tiptap+vue-3@3.26.0", "@tiptap/vue-3");
+    writeStoreCopy(fixtureRoot, "@vue-flow+core@1.48.2", "@vue-flow/core");
+    assert.deepEqual(isolateUniqueVueEditorPackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "@tiptap", "vue-3")), false);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "@vue-flow", "core")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an already hoisted @tiptap/vue-3 is left for isolation; this repair does not relink it", () => {
+  const { fixtureRoot, outer } = scaffold(["@tiptap/vue-3"]);
+  try {
+    writeStoreCopy(fixtureRoot, "@tiptap+vue-3@3.26.0", "@tiptap/vue-3");
+    const hoisted = path.join(fixtureRoot, "node_modules", "@tiptap", "vue-3");
+    fs.mkdirSync(hoisted, { recursive: true });
+    fs.writeFileSync(path.join(hoisted, "package.json"), `{"name":"@tiptap/vue-3"}\n`);
+    assert.deepEqual(isolateUniqueVueEditorPackages(fixtureRoot), []);
+    assert.equal(fs.lstatSync(hoisted).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -238,3 +238,7 @@ export function isolateUniqueVueQueryPackages(fixtureRoot) {
     "@vue/apollo-composable",
   ]);
 }
+
+export function isolateUniqueVueEditorPackages(fixtureRoot) {
+  return isolateUniqueNamedLocalTypePackages(fixtureRoot, ["@tiptap/vue-3", "@vue-flow/core"]);
+}

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -10,6 +10,7 @@ import { isolateFixtureTypePackages } from "./typecheck-baseline-isolation.mjs";
 import {
   isolateUniqueLocalTypePackages,
   isolateUniqueUiLibraryPackages,
+  isolateUniqueVueEditorPackages,
   isolateUniqueVueFormPackages,
   isolateUniqueVueI18nPackages,
   isolateUniqueVueQueryPackages,
@@ -131,10 +132,8 @@ function prepareProjectDependencies({ args, commitSha, project }) {
 }
 
 /**
- * Link packages the fixture config maps but its package manager did not hoist,
- * so `/// <reference types />` cannot climb into Vize's `node_modules`
- * (run 31979524200). Differing Vize `--tsconfig` and vue-tsc baselines are
- * both walked and overlaid. Proven by `typecheck-baseline-ambient.mjs`.
+ * Overlay unhoisted declared packages from both Vize and vue-tsc configs so
+ * type-reference walks cannot climb into Vize (run 31979524200).
  */
 export function isolationTsconfigPaths(project) {
   const paths = [];
@@ -168,6 +167,7 @@ function isolateFixture(project, fixtureRoot) {
     isolateUniqueUiLibraryPackages,
     isolateUniqueVueFormPackages,
     isolateUniqueVueQueryPackages,
+    isolateUniqueVueEditorPackages,
   ]) {
     for (const entry of isolate(fixtureRoot)) {
       if (seen.has(entry.name)) continue;


### PR DESCRIPTION
## Summary
- Unique-link undeclared `@tiptap/vue-3` and `@vue-flow/core` when an ancestor copy is reachable, matching the Vue Query / UI library isolators (#4461).
- Compact the prepare isolator comment by two lines so the new import and call stay inside the 350-line budget.

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-isolation-vue-editor.test.ts tests/tooling/typecheck-baseline-isolation-vue-query.test.ts`
- [ ] CI `check-js` / tooling tests