### PR TITLE
fix(matrix): isolate undeclared vue-select and vue-virtual-scroller

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts
@@ -44,6 +44,8 @@ test("ancestor UI libraries with one in-fixture copy each are linked from those 
     ["quasar", "quasar@2.19.3"],
     ["reka-ui", "reka-ui@2.9.10"],
     ["vant", "vant@4.9.24"],
+    ["vue-select", "vue-select@4.0.0-beta.6"],
+    ["vue-virtual-scroller", "vue-virtual-scroller@3.0.4"],
   ];
   const { fixtureRoot, outer } = scaffold(libraries.map(([name]) => name));
   try {

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -225,6 +225,8 @@ export function isolateUniqueUiLibraryPackages(fixtureRoot) {
     "quasar",
     "reka-ui",
     "vant",
+    "vue-select",
+    "vue-virtual-scroller",
   ]);
 }
 


### PR DESCRIPTION
## Summary
- Unique-link undeclared `vue-select` and `vue-virtual-scroller` through the existing UI library isolator (#4461).
- No `prepare.mjs` change: that isolator is already invoked after install.

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts`
- [ ] CI `check-js` / tooling tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790119109&installation_model_id=422833&pr_number=4716&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4716&signature=83954d872cca493658d063081a064fab91570160988d3009d2b78d5ac30fe10d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved isolation for the `vue-select` and `vue-virtual-scroller` UI libraries.
  * Updated validation coverage to ensure these libraries are correctly linked when provided by an ancestor project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->