### PR TITLE
fix(matrix): unique-link relative node_modules package extends

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-package-extends.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-package-extends.test.ts
@@ -51,6 +51,11 @@ test("package-name extends specifiers resolve to the package, not a subpath", ()
   assert.equal(packageNameFromExtendsSpecifier("nuxt/tsconfig"), "nuxt");
   assert.equal(packageNameFromExtendsSpecifier("./tsconfig.app.json"), null);
   assert.equal(packageNameFromExtendsSpecifier("../tsconfig.json"), null);
+  assert.equal(
+    packageNameFromExtendsSpecifier("../node_modules/@vue/tsconfig/tsconfig.json"),
+    "@vue/tsconfig",
+  );
+  assert.equal(packageNameFromExtendsSpecifier("../../node_modules/nuxt/tsconfig"), "nuxt");
 });
 
 test("an ancestor package-name extends is recorded as the ancestor directory", () => {
@@ -75,6 +80,24 @@ test("a subpath package-name extends still names the package", () => {
     assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
       "@vue/tsconfig": ancestor,
     });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("unique isolation links a relative node_modules package-name extends", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot);
+    const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, `{ "extends": "../node_modules/@vue/tsconfig/tsconfig.json" }\n`);
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      {
+        name: "@vue/tsconfig",
+        target: "node_modules/.pnpm/@vue+tsconfig@0.5.0/node_modules/@vue/tsconfig",
+      },
+    ]);
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });
   }

--- a/tools/fixtures/typecheck-baseline-isolation-package-extends.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-package-extends.mjs
@@ -6,6 +6,8 @@ import { dirname, join, resolve } from "node:path";
  *
  * Isolation follows only relative `extends` for `paths`, so TypeScript still
  * resolves `@vue/tsconfig` by climbing `node_modules` and can load Vize's copy.
+ * Generated configs also write `../node_modules/@vue/tsconfig/...`; that is the
+ * same package walk and is recorded the same way.
  * Recording the ancestor package lets unique isolation link the fixture's own
  * pnpm copy first. The package config is not read for `paths` — that would
  * load Vize's files.
@@ -15,6 +17,8 @@ const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u
 
 export function packageNameFromExtendsSpecifier(specifier) {
   if (typeof specifier !== "string") return null;
+  const fromNodeModules = packageNameFromNodeModulesSpecifier(specifier);
+  if (fromNodeModules != null) return fromNodeModules;
   if (specifier.startsWith("./") || specifier.startsWith("../")) return null;
   if (specifier.startsWith("@")) {
     const slash = specifier.indexOf("/", 1);
@@ -26,6 +30,28 @@ export function packageNameFromExtendsSpecifier(specifier) {
     return packageNamePattern.test(name) ? name : null;
   }
   const name = specifier.split("/")[0];
+  return packageNamePattern.test(name) ? name : null;
+}
+
+function packageNameFromNodeModulesSpecifier(specifier) {
+  const normalized = specifier.replaceAll("\\", "/");
+  const marker = "/node_modules/";
+  const index = normalized.lastIndexOf(marker);
+  const rest =
+    index >= 0
+      ? normalized.slice(index + marker.length)
+      : normalized.startsWith("node_modules/")
+        ? normalized.slice("node_modules/".length)
+        : null;
+  if (rest == null || rest === "") return null;
+  if (rest.startsWith("@")) {
+    const slash = rest.indexOf("/");
+    if (slash < 0) return null;
+    const second = rest.indexOf("/", slash + 1);
+    const name = second < 0 ? rest : rest.slice(0, second);
+    return packageNamePattern.test(name) ? name : null;
+  }
+  const name = rest.split("/")[0];
   return packageNamePattern.test(name) ? name : null;
 }
 


### PR DESCRIPTION
## Summary
- `packageNameFromExtendsSpecifier` now treats `../node_modules/<pkg>/...` as the same package walk as a bare `@vue/tsconfig` specifier (#4461).
- Unique isolation can therefore link the fixture store copy when generated Nuxt-style configs extend a relative `node_modules` path.

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-isolation-package-extends.test.ts tests/tooling/typecheck-baseline-isolation-plugins.test.ts`
- [ ] CI `check-js` / tooling tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790119221&installation_model_id=422833&pr_number=4717&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4717&signature=22d4b54c8a189e4147d30cb6b9878b8add5dc39f3ddb1d73a03cf685681eafc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of TypeScript configuration inheritance from packages in relative `node_modules` paths.
  - Added support for scoped packages, nested paths, and Windows-style path separators.
  - Ensured isolated package resolution uses the correct package copy.

- **Tests**
  - Added integration coverage for relative package-name inheritance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->