### PR TITLE
fix(matrix): retarget outside rootDirs in overlay and vue-tsc baseline

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-rootdirs.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-rootdirs.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { materializeBaselineProject } from "../../tools/fixtures/typecheck-baseline-project.mjs";
+import {
+  rewriteOutsideRootDirs,
+  writeIsolatedTsconfigOverlay,
+} from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+
+/**
+ * Unique isolation cannot retarget `compilerOptions.rootDirs`. An outside
+ * `node_modules/vue` root lets TypeScript load Vize's Vue beside the fixture
+ * (#4461). Overlay rewrite is the repair, and the vue-tsc baseline must apply
+ * the same rewrite so the two tools still measure one program.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-rootdirs-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsideVue = path.join(outer, "node_modules", "vue");
+  fs.mkdirSync(outsideVue, { recursive: true });
+  fs.writeFileSync(path.join(outsideVue, "package.json"), `{"name":"vue"}\n`);
+  return { fixtureRoot, outer, outsideVue };
+}
+
+function writeLocalVue(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "vue");
+  fs.mkdirSync(local, { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue"}\n`);
+  return local;
+}
+
+test("an outside node_modules/vue rootDir is retargeted to the fixture copy", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { rootDirs: [path.relative(fixtureRoot, outsideVue)] },
+      })}\n`,
+    );
+    const configDir = path.join(fixtureRoot, ".vize-baseline");
+    assert.deepEqual(rewriteOutsideRootDirs(fixtureRoot, sourcePath, configDir), [
+      "../node_modules/vue",
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("rootDirs reached only through relative extends are still retargeted", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.app.json"),
+      `${JSON.stringify({
+        compilerOptions: { rootDirs: [path.relative(fixtureRoot, outsideVue)] },
+      })}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.check.json");
+    fs.writeFileSync(sourcePath, `{ "extends": "./tsconfig.app.json" }\n`);
+    const overlay = writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath);
+    assert.equal(overlay.path, path.join(fixtureRoot, ".vize-isolated-tsconfig.check.json"));
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.check.json",
+      compilerOptions: { rootDirs: ["./node_modules/vue"] },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an inside rootDir is left for inheritance", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const generated = path.join(fixtureRoot, "generated");
+    fs.mkdirSync(generated);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({ compilerOptions: { rootDirs: ["./generated"] } })}\n`,
+    );
+    assert.equal(rewriteOutsideRootDirs(fixtureRoot, sourcePath, fixtureRoot), null);
+    assert.equal(writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside rootDir is left alone when the fixture has no local package", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { rootDirs: [path.relative(fixtureRoot, outsideVue)] },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideRootDirs(fixtureRoot, sourcePath, fixtureRoot), null);
+    assert.equal(writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a custom outside rootDir that is not a node_modules package is not guessed", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const outsideGenerated = path.join(outer, "generated");
+    fs.mkdirSync(outsideGenerated);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { rootDirs: [path.relative(fixtureRoot, outsideGenerated)] },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideRootDirs(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("materialized baseline retargets outside rootDirs with the overlay", () => {
+  const { outer, fixtureRoot, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    fs.writeFileSync(path.join(fixtureRoot, "src/App.vue"), "<template />\n");
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { rootDirs: [path.relative(fixtureRoot, outsideVue)] },
+      })}\n`,
+    );
+    const reportDir = path.join(outer, "report");
+    fs.mkdirSync(reportDir);
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      { id: "fixture", tsconfig: "tsconfig.json" },
+      { fileCount: 1, files: [{ file: "src/App.vue" }] },
+    );
+    const options = JSON.parse(project.source).compilerOptions;
+    assert.deepEqual(options.rootDirs, ["../node_modules/vue"]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-aliases.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-aliases.mjs
@@ -66,15 +66,17 @@ export function applyIsolatedAliasOverlay(fixtureRoot, sourceConfigPath, overlay
   if (aliases == null) return overlay ?? null;
   const paths = mergePathRewrites(overlay?.paths ?? null, aliases);
   const typeRoots = overlay?.typeRoots ?? null;
+  const rootDirs = overlay?.rootDirs ?? null;
   const overlayPath = overlay?.path ?? isolatedTsconfigOverlayPath(sourcePath);
   const compilerOptions = { paths };
   if (typeRoots != null) compilerOptions.typeRoots = typeRoots;
+  if (rootDirs != null) compilerOptions.rootDirs = rootDirs;
   if (isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) compilerOptions.baseUrl = ".";
   writeFileSync(
     overlayPath,
     `${JSON.stringify({ extends: `./${basename(sourcePath)}`, compilerOptions }, null, 2)}\n`,
   );
-  return { path: overlayPath, paths, typeRoots };
+  return { path: overlayPath, paths, typeRoots, rootDirs };
 }
 
 function retargetAliasMapping(

--- a/tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -25,21 +25,15 @@ import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs
  * Package-name `extends` is followed only inside the fixture. Climbing into
  * Vize's `node_modules` would load Vize's `@vue/tsconfig` and bake its
  * outside `paths` into the overlay.
- * `compilerOptions.typeRoots` is the same class of hole: TypeScript searches
- * those directories instead of the fixture's `node_modules/@types`. An outside
- * `node_modules/@types` is retargeted to the fixture-local copy when it exists.
- * A trailing `/*` on a package mapping is the same walk: TypeScript still
- * loads that outside tree. A mapping named `*` whose target is an outside
- * `node_modules` directory is retargeted to the fixture copy. Interior `*`
- * patterns and `#alias/*` keys are not guessed.
- *
- * A package mapping whose outside target sits under `node_modules/<name>/...`
- * keeps that subpath on the fixture copy (Nuxt's `vue/dist/vue` JSX entry).
- *
- * `compilerOptions.baseUrl` is last-wins on the extends chain. Mappings resolve
- * from that directory; a rewrite then pins overlay `baseUrl` to `"."`.
- * `${configDir}` in `baseUrl`, `paths`, and `typeRoots` expands to the tsconfig
- * directory that declared the option, matching tsc, before those paths resolve.
+ * `compilerOptions.typeRoots` and `rootDirs` are the same walk: an outside
+ * `node_modules/@types` or `node_modules/<name>` is retargeted to the fixture
+ * copy when that directory already exists locally. A trailing `/*` on a package
+ * mapping, or a `*` mapping onto an outside `node_modules` directory, is
+ * retargeted the same way. Interior `*` patterns and `#alias/*` keys are not
+ * guessed. Package mappings keep `node_modules/<name>/...` subpaths (Nuxt's
+ * `vue/dist/vue` JSX entry). `baseUrl` is last-wins; a rewrite pins it to `"."`.
+ * `${configDir}` in `baseUrl`, `paths`, `typeRoots`, and `rootDirs` expands to
+ * the declaring tsconfig directory, matching tsc, before those paths resolve.
  */
 
 const packageNamePattern = /^(?:@[a-z0-9][a-z0-9-._]*\/)?[a-z0-9][a-z0-9-._]*$/u;
@@ -84,19 +78,23 @@ export function isolatedTsconfigOverlayPath(sourceConfigPath) {
 }
 
 export function rewriteOutsideTypeRoots(fixtureRoot, sourceConfigPath, configDir) {
-  const root = resolve(fixtureRoot);
-  const declared = winningTypeRoots(sourceConfigPath, root);
-  if (declared == null) return null;
-  const rewritten = [];
-  let changed = false;
-  for (const entry of declared.typeRoots) {
-    rewritten.push(
-      retargetTypeRoot(root, declared.dir, configDir, entry, () => {
-        changed = true;
-      }),
-    );
-  }
-  return changed ? rewritten : null;
+  return rewriteOutsideDirList(
+    fixtureRoot,
+    sourceConfigPath,
+    configDir,
+    "typeRoots",
+    retargetTypeRoot,
+  );
+}
+
+export function rewriteOutsideRootDirs(fixtureRoot, sourceConfigPath, configDir) {
+  return rewriteOutsideDirList(
+    fixtureRoot,
+    sourceConfigPath,
+    configDir,
+    "rootDirs",
+    retargetRootDir,
+  );
 }
 
 export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
@@ -104,10 +102,12 @@ export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
   const configDir = dirname(sourcePath);
   const paths = rewriteOutsidePackagePaths(fixtureRoot, sourcePath, configDir);
   const typeRoots = rewriteOutsideTypeRoots(fixtureRoot, sourcePath, configDir);
-  if (paths == null && typeRoots == null) return null;
+  const rootDirs = rewriteOutsideRootDirs(fixtureRoot, sourcePath, configDir);
+  if (paths == null && typeRoots == null && rootDirs == null) return null;
   const compilerOptions = {};
   if (paths != null) compilerOptions.paths = paths;
   if (typeRoots != null) compilerOptions.typeRoots = typeRoots;
+  if (rootDirs != null) compilerOptions.rootDirs = rootDirs;
   if (paths != null && isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) {
     compilerOptions.baseUrl = ".";
   }
@@ -116,7 +116,7 @@ export function writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath) {
     overlayPath,
     `${JSON.stringify({ extends: `./${basename(sourcePath)}`, compilerOptions }, null, 2)}\n`,
   );
-  return { path: overlayPath, paths, typeRoots };
+  return { path: overlayPath, paths, typeRoots, rootDirs };
 }
 
 function retargetPathMapping(
@@ -186,6 +186,46 @@ function relocatePathEntry(sourceDir, tsconfigDir, configDir, entry) {
   return configRelativePath(configDir, resolveWithConfigDir(sourceDir, tsconfigDir, entry));
 }
 
+function rewriteOutsideDirList(fixtureRoot, sourceConfigPath, configDir, option, retarget) {
+  const root = resolve(fixtureRoot);
+  const won = winningCompilerOption(sourceConfigPath, root, (config) =>
+    Array.isArray(config?.compilerOptions?.[option]) ? config.compilerOptions[option] : null,
+  );
+  if (won == null) return null;
+  let changed = false;
+  const rewritten = won.value.map((entry) =>
+    retarget(root, won.dir, configDir, entry, () => {
+      changed = true;
+    }),
+  );
+  return changed ? rewritten : null;
+}
+
+function retargetRootDir(fixtureRoot, sourceDir, configDir, entry, markChanged) {
+  if (typeof entry !== "string") return entry;
+  const relocated = relocatePathEntry(sourceDir, sourceDir, configDir, entry);
+  const original = resolveWithConfigDir(sourceDir, sourceDir, entry);
+  if (isInside(fixtureRoot, original)) return relocated;
+  const owned = ownedNodeModulePackage(original);
+  if (owned == null) return relocated;
+  const local = join(fixtureRoot, "node_modules", ...owned.name.split("/"));
+  if (!existsSync(join(local, "package.json"))) return relocated;
+  const dir = owned.subpath === "" ? local : join(local, owned.subpath);
+  if (owned.subpath !== "" && !existsSync(dir)) return relocated;
+  markChanged();
+  return configRelativePath(configDir, dir);
+}
+
+function ownedNodeModulePackage(target) {
+  const normalized = target.replaceAll("\\", "/");
+  const index = normalized.lastIndexOf("/node_modules/");
+  if (index < 0) return null;
+  const rest = normalized.slice(index + "/node_modules/".length);
+  const name = rest.startsWith("@") ? rest.split("/").slice(0, 2).join("/") : rest.split("/")[0];
+  if (!packageNamePattern.test(name)) return null;
+  return { name, subpath: rest.slice(name.length).replace(/^\//, "") };
+}
+
 function retargetTypeRoot(fixtureRoot, sourceDir, configDir, entry, markChanged) {
   if (typeof entry !== "string") return entry;
   const relocated = relocatePathEntry(sourceDir, sourceDir, configDir, entry);
@@ -221,13 +261,6 @@ function winningPaths(sourceConfigPath, fixtureRoot) {
     return value != null && typeof value === "object" ? value : null;
   });
   return won == null ? null : { paths: won.value, dir: won.dir };
-}
-
-function winningTypeRoots(sourceConfigPath, fixtureRoot) {
-  const won = winningCompilerOption(sourceConfigPath, fixtureRoot, (config) =>
-    Array.isArray(config?.compilerOptions?.typeRoots) ? config.compilerOptions.typeRoots : null,
-  );
-  return won == null ? null : { typeRoots: won.value, dir: won.dir };
 }
 
 function winningBaseUrl(sourceConfigPath, fixtureRoot) {

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -8,6 +8,7 @@ import {
 import {
   isolatedOverlayBaseUrl,
   rewriteOutsidePackagePaths,
+  rewriteOutsideRootDirs,
   rewriteOutsideTypeRoots,
 } from "./typecheck-baseline-outside-paths.mjs";
 import { typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
@@ -135,6 +136,8 @@ function outsideCompilerOptions(fixtureRoot, sourcePath, configDir) {
   }
   const typeRoots = rewriteOutsideTypeRoots(fixtureRoot, sourcePath, configDir);
   if (typeRoots != null) options.typeRoots = typeRoots;
+  const rootDirs = rewriteOutsideRootDirs(fixtureRoot, sourcePath, configDir);
+  if (rootDirs != null) options.rootDirs = rootDirs;
   return options;
 }
 


### PR DESCRIPTION
## Summary
- Overlay rewrite now retargets `compilerOptions.rootDirs` that resolve to an outside `node_modules/<name>` onto the fixture copy when that package is already local (#4461).
- The same rewrite is applied when materializing the vue-tsc baseline, so Vize and vue-tsc still typecheck one program.
- Alias overlay preserves rewritten `rootDirs` when it merges hash-alias paths.

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-outside-rootdirs.test.ts tests/tooling/typecheck-baseline-outside-typeroots.test.ts`
- [ ] CI `check-js` / tooling tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790119570&installation_model_id=422833&pr_number=4718&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4718&signature=a90b92939cd4eebdb66077f1ee410f0f429ef1ffc6f53373d9fa9b9781d5d86f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TypeScript fixture isolation so `rootDirs` entries referencing external packages are correctly redirected to local fixture packages.
  * Preserved valid in-project paths and safely handled missing packages and non-package paths.
  * Applied consistent handling across extended and generated baseline configurations.

* **Tests**
  * Added coverage for relative configuration inheritance, generated projects, unchanged paths, and temporary fixture cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->