### PR TITLE
fix(matrix): isolate undeclared TresJS and vue-chartjs packages

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-vue-viz.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-vue-viz.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueVueVisualizationPackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * TresJS and vue-chartjs live in Vize's `tests/package.json`. TypeScript can
+ * climb into those copies and load Vize's Vue beside the fixture (#4461).
+ * Unique isolation links the fixture store copy when an ancestor is reachable.
+ */
+
+function scaffold(names: string[]) {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-vue-viz-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const name of names) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+test("ancestor visualization packages with one in-fixture copy each are linked from those copies", () => {
+  const { fixtureRoot, outer } = scaffold(["@tresjs/core", "vue-chartjs"]);
+  try {
+    writeStoreCopy(fixtureRoot, "@tresjs+core@5.8.1", "@tresjs/core");
+    writeStoreCopy(fixtureRoot, "vue-chartjs@5.3.3", "vue-chartjs");
+    assert.deepEqual(isolateUniqueVueVisualizationPackages(fixtureRoot), [
+      {
+        name: "@tresjs/core",
+        target: "node_modules/.pnpm/@tresjs+core@5.8.1/node_modules/@tresjs/core",
+      },
+      {
+        name: "vue-chartjs",
+        target: "node_modules/.pnpm/vue-chartjs@5.3.3/node_modules/vue-chartjs",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("visualization packages no ancestor provides are left alone", () => {
+  const { fixtureRoot, outer } = scaffold([]);
+  try {
+    writeStoreCopy(fixtureRoot, "@tresjs+core@5.8.1", "@tresjs/core");
+    writeStoreCopy(fixtureRoot, "vue-chartjs@5.3.3", "vue-chartjs");
+    assert.deepEqual(isolateUniqueVueVisualizationPackages(fixtureRoot), []);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "@tresjs", "core")), false);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-chartjs")), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an already hoisted vue-chartjs is left for isolation; this repair does not relink it", () => {
+  const { fixtureRoot, outer } = scaffold(["vue-chartjs"]);
+  try {
+    writeStoreCopy(fixtureRoot, "vue-chartjs@5.3.3", "vue-chartjs");
+    const hoisted = path.join(fixtureRoot, "node_modules", "vue-chartjs");
+    fs.mkdirSync(hoisted, { recursive: true });
+    fs.writeFileSync(path.join(hoisted, "package.json"), `{"name":"vue-chartjs"}\n`);
+    assert.deepEqual(isolateUniqueVueVisualizationPackages(fixtureRoot), []);
+    assert.equal(fs.lstatSync(hoisted).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -55,7 +55,10 @@ export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {
 }
 
 export function isolateUniqueVueRuntimePackages(fixtureRoot) {
-  return isolateUniqueNamedLocalTypePackages(fixtureRoot, vueRuntimePackages);
+  return [
+    ...isolateUniqueNamedLocalTypePackages(fixtureRoot, vueRuntimePackages),
+    ...isolateUniqueVueVisualizationPackages(fixtureRoot),
+  ];
 }
 
 export function isolateUniqueVueI18nPackages(fixtureRoot) {
@@ -241,4 +244,8 @@ export function isolateUniqueVueQueryPackages(fixtureRoot) {
 
 export function isolateUniqueVueEditorPackages(fixtureRoot) {
   return isolateUniqueNamedLocalTypePackages(fixtureRoot, ["@tiptap/vue-3", "@vue-flow/core"]);
+}
+
+export function isolateUniqueVueVisualizationPackages(fixtureRoot) {
+  return isolateUniqueNamedLocalTypePackages(fixtureRoot, ["@tresjs/core", "vue-chartjs"]);
 }


### PR DESCRIPTION
## Summary
- Unique-link undeclared `@tresjs/core` and `vue-chartjs` when an ancestor copy is reachable (#4461).
- The new isolator is invoked from the existing Vue runtime isolator, so `prepare.mjs` does not need another import.

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-isolation-vue-viz.test.ts tests/tooling/typecheck-baseline-isolation-vue-runtime.test.ts`
- [ ] CI `check-js` / tooling tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790119696&installation_model_id=422833&pr_number=4719&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4719&signature=601371deb9c65707ae93ae57435e7da861d7b2b0816f2e002950e2025357bc09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->