### PR TITLE
fix(matrix): isolate undeclared vue-class-component packages

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-vue-class.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-vue-class.test.ts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueVueRuntimePackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+
+/**
+ * vue-class-component and vue-property-decorator live in Vize's
+ * `tests/package.json`. TypeScript can climb into those copies and load
+ * Vize's Vue beside the fixture (#4461). Unique isolation links the fixture
+ * store copy when an ancestor is reachable.
+ */
+
+function scaffold(names: string[]) {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-vue-class-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  for (const name of names) {
+    const packageRoot = path.join(outer, "node_modules", name);
+    fs.mkdirSync(packageRoot, { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  }
+  return { fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string, id: string, name: string) {
+  const packageRoot = path.join(fixtureRoot, "node_modules", ".pnpm", id, "node_modules", name);
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"${name}"}\n`);
+  return packageRoot;
+}
+
+test("ancestor class-component packages with one in-fixture copy each are linked from those copies", () => {
+  const { fixtureRoot, outer } = scaffold(["vue-class-component", "vue-property-decorator"]);
+  try {
+    writeStoreCopy(fixtureRoot, "vue-class-component@8.0.0-rc.1", "vue-class-component");
+    writeStoreCopy(fixtureRoot, "vue-property-decorator@10.0.0-rc.3", "vue-property-decorator");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), [
+      {
+        name: "vue-class-component",
+        target:
+          "node_modules/.pnpm/vue-class-component@8.0.0-rc.1/node_modules/vue-class-component",
+      },
+      {
+        name: "vue-property-decorator",
+        target:
+          "node_modules/.pnpm/vue-property-decorator@10.0.0-rc.3/node_modules/vue-property-decorator",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("class-component packages no ancestor provides are left alone", () => {
+  const { fixtureRoot, outer } = scaffold([]);
+  try {
+    writeStoreCopy(fixtureRoot, "vue-class-component@8.0.0-rc.1", "vue-class-component");
+    writeStoreCopy(fixtureRoot, "vue-property-decorator@10.0.0-rc.3", "vue-property-decorator");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), []);
+    assert.equal(
+      fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-class-component")),
+      false,
+    );
+    assert.equal(
+      fs.existsSync(path.join(fixtureRoot, "node_modules", "vue-property-decorator")),
+      false,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an already hoisted vue-class-component is left for isolation; this repair does not relink it", () => {
+  const { fixtureRoot, outer } = scaffold(["vue-class-component"]);
+  try {
+    writeStoreCopy(fixtureRoot, "vue-class-component@8.0.0-rc.1", "vue-class-component");
+    const hoisted = path.join(fixtureRoot, "node_modules", "vue-class-component");
+    fs.mkdirSync(hoisted, { recursive: true });
+    fs.writeFileSync(path.join(hoisted, "package.json"), `{"name":"vue-class-component"}\n`);
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), []);
+    assert.equal(fs.lstatSync(hoisted).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -31,9 +31,9 @@ import { ancestorPackagePath } from "./typecheck-baseline-isolation-package-exte
  * fixture's own `@vue/tsconfig`, `vite`, `@types/node`, language plugin, or
  * `vue` JSX runtime before TypeScript climbs into Vize.
  *
- * Undeclared Vue compiler packages (`@vue/compiler-sfc` and friends) live in
- * Vize's `tests/package.json`, so TypeScript can still climb into them and
- * load Vize's Vue beside the fixture.
+ * Undeclared Vue compiler packages (`@vue/compiler-sfc` and friends) and
+ * class-component helpers live in Vize's `tests/package.json`, so TypeScript
+ * can still climb into them and load Vize's Vue beside the fixture.
  */
 
 const vueRuntimePackages = [
@@ -43,6 +43,8 @@ const vueRuntimePackages = [
   "@vue/runtime-core",
   "@vue/runtime-dom",
   "vue",
+  "vue-class-component",
+  "vue-property-decorator",
   "vue-router",
 ];
 


### PR DESCRIPTION
## Summary
- Unique-link undeclared `vue-class-component` and `vue-property-decorator` through the existing Vue runtime isolator (#4461).
- No `prepare.mjs` change: that isolator is already invoked after install.

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-isolation-vue-class.test.ts tests/tooling/typecheck-baseline-isolation-vue-runtime.test.ts`
- [ ] CI `check-js` / tooling tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790119846&installation_model_id=422833&pr_number=4720&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4720&signature=221861b3c483da5b0544d7ceaf1cd7b000779ea06add7541f13dece46c8a0885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->