### PR TITLE
test(matrix): unique-link relative node_modules plugins, types, and jsxImportSource

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-jsx.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-jsx.test.ts
@@ -51,6 +51,7 @@ test("jsxImportSource names the package, not a relative path", () => {
   assert.equal(jsxImportSourcePackageName("vue"), "vue");
   assert.equal(jsxImportSourcePackageName("preact"), "preact");
   assert.equal(jsxImportSourcePackageName("./jsx"), null);
+  assert.equal(jsxImportSourcePackageName("../node_modules/vue"), "vue");
   assert.equal(jsxImportSourcePackageName(undefined), null);
 });
 
@@ -63,6 +64,24 @@ test("compilerOptions.jsxImportSource records ancestor packages for unique isola
     assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
       vue: ancestorVue,
     });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("unique isolation links a relative node_modules jsxImportSource specifier", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "vue@3.5.13", "vue");
+    const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({ compilerOptions: { jsxImportSource: "../node_modules/vue" } })}\n`,
+    );
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      { name: "vue", target: "node_modules/.pnpm/vue@3.5.13/node_modules/vue" },
+    ]);
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });
   }

--- a/tests/tooling/typecheck-baseline-isolation-plugins.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-plugins.test.ts
@@ -61,7 +61,11 @@ test("plugin names come from compilerOptions and vueCompilerOptions", () => {
       {
         compilerOptions: { plugins: [{ name: "typescript-plugin-css-modules" }] },
         vueCompilerOptions: {
-          plugins: ["@vue/language-plugin-pug", ["./local-plugin.js", { pretty: true }]],
+          plugins: [
+            "@vue/language-plugin-pug",
+            ["./local-plugin.js", { pretty: true }],
+            "../node_modules/@vue/language-plugin-pug",
+          ],
         },
       },
     ]),
@@ -94,6 +98,30 @@ test("vueCompilerOptions.plugins records ancestor packages", () => {
     assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
       "@vue/language-plugin-pug": ancestorVuePlugin,
     });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("unique isolation links a relative node_modules vue plugin specifier", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "@vue+language-plugin-pug@1.8.27", "@vue/language-plugin-pug");
+    const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        vueCompilerOptions: { plugins: ["../node_modules/@vue/language-plugin-pug"] },
+      })}\n`,
+    );
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      {
+        name: "@vue/language-plugin-pug",
+        target:
+          "node_modules/.pnpm/@vue+language-plugin-pug@1.8.27/node_modules/@vue/language-plugin-pug",
+      },
+    ]);
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });
   }

--- a/tests/tooling/typecheck-baseline-isolation-types.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-types.test.ts
@@ -52,6 +52,11 @@ test("types entries resolve to the package and @types package for unscoped names
   assert.deepEqual(typePackageNamesFromTypes(["vite/client"]), ["vite", "@types/vite"]);
   assert.deepEqual(typePackageNamesFromTypes(["node"]), ["node", "@types/node"]);
   assert.deepEqual(typePackageNamesFromTypes(["@vue/runtime-dom"]), ["@vue/runtime-dom"]);
+  assert.deepEqual(typePackageNamesFromTypes(["../node_modules/@types/node"]), ["@types/node"]);
+  assert.deepEqual(typePackageNamesFromTypes(["../node_modules/vite/client"]), [
+    "vite",
+    "@types/vite",
+  ]);
   assert.deepEqual(typePackageNamesFromTypes([]), []);
   assert.deepEqual(typePackageNamesFromTypes(undefined), []);
 });
@@ -93,6 +98,27 @@ test("unique isolation links the fixture copy of a types package", () => {
     });
     assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
       { name: "vite", target: "node_modules/.pnpm/vite@6.0.0/node_modules/vite" },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("unique isolation links a relative node_modules types specifier", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot, "@types+node@22.0.0", "@types/node");
+    const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({ compilerOptions: { types: ["../node_modules/@types/node"] } })}\n`,
+    );
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      {
+        name: "@types/node",
+        target: "node_modules/.pnpm/@types+node@22.0.0/node_modules/@types/node",
+      },
     ]);
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Generated Nuxt-style configs write `../node_modules/<pkg>` for `vueCompilerOptions.plugins`, `compilerOptions.types`, and `compilerOptions.jsxImportSource`.
- `#4717` already extracts those package names; these tests lock unique isolation to link the fixture store copy instead of climbing into Vize (#4461).

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-isolation-plugins.test.ts tests/tooling/typecheck-baseline-isolation-types.test.ts tests/tooling/typecheck-baseline-isolation-jsx.test.ts`
- [ ] CI `check-js` / tooling tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790120140&installation_model_id=422833&pr_number=4721&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4721&signature=dd7a0237c9111c4f2a760716b441b6a5a0f40fb97a82d767f4c6041f8660c7be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->