### PR TITLE
fix(matrix): isolate undeclared Swiper Vue bindings

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts
@@ -9,7 +9,8 @@ import { isolateUniqueUiLibraryPackages } from "../../tools/fixtures/typecheck-b
 /**
  * Vue UI libraries in Vize's `tests/package.json` still climb out of a
  * fixture that does not declare them (#4461). Unique isolation links the
- * fixture store copy when an ancestor is reachable.
+ * fixture store copy when an ancestor is reachable. Swiper is included
+ * because `swiper/vue` types load Vue from the answering copy.
  */
 
 function scaffold(names: string[]) {
@@ -43,6 +44,7 @@ test("ancestor UI libraries with one in-fixture copy each are linked from those 
     ["primevue", "primevue@4.5.5"],
     ["quasar", "quasar@2.19.3"],
     ["reka-ui", "reka-ui@2.9.10"],
+    ["swiper", "swiper@12.2.0"],
     ["vant", "vant@4.9.24"],
     ["vue-select", "vue-select@4.0.0-beta.6"],
     ["vue-virtual-scroller", "vue-virtual-scroller@3.0.4"],

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -227,6 +227,7 @@ export function isolateUniqueUiLibraryPackages(fixtureRoot) {
     "primevue",
     "quasar",
     "reka-ui",
+    "swiper",
     "vant",
     "vue-select",
     "vue-virtual-scroller",


### PR DESCRIPTION
## Summary
- `swiper` is in Vize's `tests/package.json`; `swiper/vue` types resolve Vue from whichever copy answers the climb (#4461).
- Unique isolation already unique-links the other UI libraries from that tree. Add Swiper to the same list so fixtures get their store copy first.

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts`
- [ ] CI `check-js` / tooling tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790120393&installation_model_id=422833&pr_number=4722&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4722&signature=493ccc24fd714d583569a72fefa0b1f96e9b42df9c8cba353e103b70f7705921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->