### PR TITLE
fix(matrix): retarget outside vueCompilerOptions globalTypesPath and typesRoot

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-vue-compiler.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-vue-compiler.test.ts
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { applyIsolatedAliasOverlay } from "../../tools/fixtures/typecheck-baseline-outside-aliases.mjs";
+import { writeIsolatedTsconfigOverlay } from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+import { rewriteOutsideVueCompilerOptions } from "../../tools/fixtures/typecheck-baseline-outside-vue-compiler.mjs";
+import { materializeBaselineProject } from "../../tools/fixtures/typecheck-baseline-project.mjs";
+
+/**
+ * Unique isolation cannot retarget `vueCompilerOptions.globalTypesPath` or
+ * `typesRoot`. An outside `@vue/language-core` path lets vue-tsc load Vize's
+ * Vue beside the fixture (#4461). Overlay rewrite is the repair, and the
+ * vue-tsc baseline must apply the same rewrite so both tools measure one
+ * program. Overlay replaces `vueCompilerOptions`, so other keys stay.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-vue-compiler-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsideCore = path.join(outer, "node_modules", "@vue", "language-core");
+  fs.mkdirSync(path.join(outsideCore, "types"), { recursive: true });
+  fs.writeFileSync(path.join(outsideCore, "package.json"), `{"name":"@vue/language-core"}\n`);
+  fs.writeFileSync(path.join(outsideCore, "vue-global-types.d.ts"), "export {};\n");
+  fs.writeFileSync(path.join(outsideCore, "types", "index.d.ts"), "export {};\n");
+  return { fixtureRoot, outer, outsideCore };
+}
+
+function writeLocalCore(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "@vue", "language-core");
+  fs.mkdirSync(path.join(local, "types"), { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"@vue/language-core"}\n`);
+  fs.writeFileSync(path.join(local, "vue-global-types.d.ts"), "export {};\n");
+  fs.writeFileSync(path.join(local, "types", "index.d.ts"), "export {};\n");
+  return local;
+}
+
+test("an outside globalTypesPath is retargeted to the fixture copy and other keys are kept", () => {
+  const { fixtureRoot, outer, outsideCore } = scaffold();
+  try {
+    writeLocalCore(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: {
+          strictTemplates: true,
+          globalTypesPath: path.relative(
+            fixtureRoot,
+            path.join(outsideCore, "vue-global-types.d.ts"),
+          ),
+        },
+      })}\n`,
+    );
+    assert.deepEqual(rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, fixtureRoot), {
+      strictTemplates: true,
+      globalTypesPath: "./node_modules/@vue/language-core/vue-global-types.d.ts",
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a typesRoot package specifier is retargeted to the fixture copy", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalCore(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({ vueCompilerOptions: { typesRoot: "@vue/language-core/types" } })}\n`,
+    );
+    assert.deepEqual(rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, fixtureRoot), {
+      typesRoot: "./node_modules/@vue/language-core/types",
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("vueCompilerOptions reached only through relative extends are still retargeted", () => {
+  const { fixtureRoot, outer, outsideCore } = scaffold();
+  try {
+    writeLocalCore(fixtureRoot);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.app.json"),
+      `${JSON.stringify({
+        vueCompilerOptions: {
+          globalTypesPath: path.relative(
+            fixtureRoot,
+            path.join(outsideCore, "vue-global-types.d.ts"),
+          ),
+        },
+      })}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.check.json");
+    fs.writeFileSync(sourcePath, `{ "extends": "./tsconfig.app.json" }\n`);
+    const overlay = applyIsolatedAliasOverlay(
+      fixtureRoot,
+      sourcePath,
+      writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath),
+    );
+    assert.equal(overlay.path, path.join(fixtureRoot, ".vize-isolated-tsconfig.check.json"));
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.check.json",
+      vueCompilerOptions: {
+        globalTypesPath: "./node_modules/@vue/language-core/vue-global-types.d.ts",
+      },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an inside globalTypesPath is left for inheritance", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalCore(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: {
+          globalTypesPath: "./node_modules/@vue/language-core/vue-global-types.d.ts",
+        },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, fixtureRoot), null);
+    assert.equal(applyIsolatedAliasOverlay(fixtureRoot, sourcePath, null), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside globalTypesPath is left alone when the fixture has no local package", () => {
+  const { fixtureRoot, outer, outsideCore } = scaffold();
+  try {
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: {
+          globalTypesPath: path.relative(
+            fixtureRoot,
+            path.join(outsideCore, "vue-global-types.d.ts"),
+          ),
+        },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("alias overlay keeps vueCompilerOptions when it also rewrites #app", () => {
+  const { fixtureRoot, outer, outsideCore } = scaffold();
+  try {
+    writeLocalCore(fixtureRoot);
+    const outsideNuxt = path.join(outer, "node_modules", "nuxt");
+    fs.mkdirSync(path.join(outsideNuxt, "dist", "app"), { recursive: true });
+    fs.writeFileSync(path.join(outsideNuxt, "package.json"), `{"name":"nuxt"}\n`);
+    const localNuxt = path.join(fixtureRoot, "node_modules", "nuxt");
+    fs.mkdirSync(path.join(localNuxt, "dist", "app"), { recursive: true });
+    fs.writeFileSync(path.join(localNuxt, "package.json"), `{"name":"nuxt"}\n`);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "#app": [path.relative(fixtureRoot, path.join(outsideNuxt, "dist", "app"))] },
+        },
+        vueCompilerOptions: {
+          globalTypesPath: path.relative(
+            fixtureRoot,
+            path.join(outsideCore, "vue-global-types.d.ts"),
+          ),
+        },
+      })}\n`,
+    );
+    const overlay = applyIsolatedAliasOverlay(
+      fixtureRoot,
+      sourcePath,
+      writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath),
+    );
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.json",
+      compilerOptions: { paths: { "#app": ["./node_modules/nuxt/dist/app"] } },
+      vueCompilerOptions: {
+        globalTypesPath: "./node_modules/@vue/language-core/vue-global-types.d.ts",
+      },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("materialized baseline retargets outside globalTypesPath with the overlay", () => {
+  const { outer, fixtureRoot, outsideCore } = scaffold();
+  try {
+    writeLocalCore(fixtureRoot);
+    fs.writeFileSync(path.join(fixtureRoot, "src/App.vue"), "<template />\n");
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: {
+          globalTypesPath: path.relative(
+            fixtureRoot,
+            path.join(outsideCore, "vue-global-types.d.ts"),
+          ),
+        },
+      })}\n`,
+    );
+    const reportDir = path.join(outer, "report");
+    fs.mkdirSync(reportDir);
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      { id: "fixture", tsconfig: "tsconfig.json" },
+      { fileCount: 1, files: [{ file: "src/App.vue" }] },
+    );
+    const parsed = JSON.parse(project.source);
+    assert.deepEqual(parsed.vueCompilerOptions, {
+      globalTypesPath: "../node_modules/@vue/language-core/vue-global-types.d.ts",
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-aliases.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-aliases.mjs
@@ -9,6 +9,7 @@ import {
   pathMappingRoot,
   resolvePackageExtends,
 } from "./typecheck-baseline-outside-paths.mjs";
+import { rewriteOutsideVueCompilerOptions } from "./typecheck-baseline-outside-vue-compiler.mjs";
 
 /**
  * Close the remaining `compilerOptions.paths` escape for keys that are not
@@ -62,21 +63,26 @@ export function mergePathRewrites(packages, aliases) {
 
 export function applyIsolatedAliasOverlay(fixtureRoot, sourceConfigPath, overlay) {
   const sourcePath = resolve(sourceConfigPath);
-  const aliases = rewriteOutsideAliasPaths(fixtureRoot, sourcePath, dirname(sourcePath));
-  if (aliases == null) return overlay ?? null;
+  const configDir = dirname(sourcePath);
+  const aliases = rewriteOutsideAliasPaths(fixtureRoot, sourcePath, configDir);
+  const vueCompilerOptions = rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, configDir);
+  if (aliases == null && vueCompilerOptions == null) return overlay ?? null;
   const paths = mergePathRewrites(overlay?.paths ?? null, aliases);
   const typeRoots = overlay?.typeRoots ?? null;
   const rootDirs = overlay?.rootDirs ?? null;
   const overlayPath = overlay?.path ?? isolatedTsconfigOverlayPath(sourcePath);
-  const compilerOptions = { paths };
+  const compilerOptions = {};
+  if (paths != null) compilerOptions.paths = paths;
   if (typeRoots != null) compilerOptions.typeRoots = typeRoots;
   if (rootDirs != null) compilerOptions.rootDirs = rootDirs;
-  if (isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) compilerOptions.baseUrl = ".";
-  writeFileSync(
-    overlayPath,
-    `${JSON.stringify({ extends: `./${basename(sourcePath)}`, compilerOptions }, null, 2)}\n`,
-  );
-  return { path: overlayPath, paths, typeRoots, rootDirs };
+  if (paths != null && isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) {
+    compilerOptions.baseUrl = ".";
+  }
+  const document = { extends: `./${basename(sourcePath)}` };
+  if (Object.keys(compilerOptions).length > 0) document.compilerOptions = compilerOptions;
+  if (vueCompilerOptions != null) document.vueCompilerOptions = vueCompilerOptions;
+  writeFileSync(overlayPath, `${JSON.stringify(document, null, 2)}\n`);
+  return { path: overlayPath, paths, typeRoots, rootDirs, vueCompilerOptions };
 }
 
 function retargetAliasMapping(

--- a/tools/fixtures/typecheck-baseline-outside-vue-compiler.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-vue-compiler.mjs
@@ -1,0 +1,145 @@
+import { existsSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+
+import { resolveWithConfigDir } from "./typecheck-baseline-config-dir.mjs";
+import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs";
+import { packageNameFromExtendsSpecifier } from "./typecheck-baseline-isolation-package-extends.mjs";
+import { resolvePackageExtends } from "./typecheck-baseline-outside-paths.mjs";
+
+/**
+ * Close the vue-tsc option escape unique isolation cannot see (#4461).
+ *
+ * `vueCompilerOptions.globalTypesPath` and `typesRoot` are filesystem or
+ * package walks. Overlay `compilerOptions` cannot retarget them. An outside
+ * path still loads Vize's `@vue/language-core` beside the fixture Vue.
+ * When the fixture already has that package, this copies every winning
+ * `vueCompilerOptions` key and retargets only those two paths. Overlay
+ * replaces the object, so other keys must be preserved.
+ */
+
+const pathOptionKeys = ["globalTypesPath", "typesRoot"];
+
+export function rewriteOutsideVueCompilerOptions(fixtureRoot, sourceConfigPath, configDir) {
+  const root = resolve(fixtureRoot);
+  const declared = winningVueCompilerOptions(sourceConfigPath, root);
+  if (declared == null) return null;
+  const rewritten = { ...declared.options };
+  let changed = false;
+  for (const key of pathOptionKeys) {
+    const entry = declared.options[key];
+    if (typeof entry !== "string") continue;
+    const retargeted = retargetVueCompilerPath(root, declared.dirs[key], configDir, entry);
+    if (retargeted == null) continue;
+    rewritten[key] = retargeted;
+    changed = true;
+  }
+  return changed ? rewritten : null;
+}
+
+function retargetVueCompilerPath(fixtureRoot, sourceDir, configDir, entry) {
+  if (isPathSpecifier(entry)) {
+    const original = resolveWithConfigDir(sourceDir, sourceDir, entry);
+    if (isInside(fixtureRoot, original)) return null;
+    const owned = owningNodeModulePackage(original);
+    if (owned == null) return null;
+    return localPackageTarget(fixtureRoot, configDir, owned.name, relative(owned.root, original));
+  }
+  const name = packageNameFromExtendsSpecifier(entry);
+  if (name == null) return null;
+  const rest = entry.startsWith(`${name}/`) ? entry.slice(name.length + 1) : "";
+  return localPackageTarget(fixtureRoot, configDir, name, rest);
+}
+
+function localPackageTarget(fixtureRoot, configDir, name, subpath) {
+  const local = join(fixtureRoot, "node_modules", ...name.split("/"));
+  if (!existsSync(join(local, "package.json"))) return null;
+  const nested = typeof subpath === "string" ? subpath.replaceAll("\\", "/") : "";
+  if (nested.startsWith("..") || nested.startsWith("/")) return null;
+  const target = nested === "" ? local : join(local, nested);
+  if (nested !== "" && !existsSync(target)) return null;
+  return configRelativePath(configDir, target);
+}
+
+function isPathSpecifier(entry) {
+  return (
+    entry.startsWith("./") ||
+    entry.startsWith("../") ||
+    entry.startsWith("/") ||
+    entry.includes("/node_modules/") ||
+    entry.includes("${configDir}")
+  );
+}
+
+function winningVueCompilerOptions(sourceConfigPath, fixtureRoot) {
+  const options = {};
+  const dirs = {};
+  for (const { config, dir } of [
+    ...loadTsconfigExtendsChain(
+      sourceConfigPath,
+      (fromConfig, specifier) =>
+        resolveRelativeExtends(fromConfig, specifier, fixtureRoot) ??
+        resolvePackageExtends(fromConfig, specifier, fixtureRoot),
+    ),
+  ].reverse()) {
+    const current = config?.vueCompilerOptions;
+    if (current == null || typeof current !== "object" || Array.isArray(current)) continue;
+    for (const [key, value] of Object.entries(current)) {
+      options[key] = value;
+      dirs[key] = dir;
+    }
+  }
+  return Object.keys(options).length === 0 ? null : { options, dirs };
+}
+
+function resolveRelativeExtends(fromConfig, specifier, fixtureRoot) {
+  if (typeof specifier !== "string") return null;
+  if (!(specifier.startsWith("./") || specifier.startsWith("../"))) return null;
+  const resolved = resolve(dirname(fromConfig), specifier);
+  const file = existsSync(resolved)
+    ? resolved
+    : !resolved.endsWith(".json") && existsSync(`${resolved}.json`)
+      ? `${resolved}.json`
+      : null;
+  if (file == null || !isInside(fixtureRoot, file)) return null;
+  return file;
+}
+
+function owningNodeModulePackage(resolvedPath) {
+  let directory = resolvedPath;
+  let previous = null;
+  while (directory !== previous) {
+    if (existsSync(join(directory, "package.json"))) {
+      const owned = nodeModulePackageName(directory);
+      if (owned != null) return owned;
+    }
+    previous = directory;
+    directory = dirname(directory);
+  }
+  return null;
+}
+
+function nodeModulePackageName(packageRoot) {
+  const parent = dirname(packageRoot);
+  const grandparent = dirname(parent);
+  if (basename(parent) === "node_modules") {
+    return { name: basename(packageRoot), root: packageRoot };
+  }
+  if (basename(grandparent) === "node_modules" && basename(parent).startsWith("@")) {
+    return {
+      name: `${basename(parent)}/${basename(packageRoot)}`,
+      root: packageRoot,
+    };
+  }
+  return null;
+}
+
+function isInside(root, target) {
+  const path = relative(root, target);
+  return path !== "" && !path.startsWith("..") && !path.startsWith("/");
+}
+
+function configRelativePath(from, to) {
+  const path = relative(from, to).replaceAll("\\", "/");
+  if (path.startsWith("/") || /^[A-Za-z]:\//u.test(path)) return path;
+  return path.startsWith(".") ? path : `./${path}`;
+}

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -11,6 +11,7 @@ import {
   rewriteOutsideRootDirs,
   rewriteOutsideTypeRoots,
 } from "./typecheck-baseline-outside-paths.mjs";
+import { rewriteOutsideVueCompilerOptions } from "./typecheck-baseline-outside-vue-compiler.mjs";
 import { typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
 
 /**
@@ -117,6 +118,8 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
     exclude: ambientRoots.flatMap((root) => [`${root}/**/node_modules/**`, `${root}/**/dist/**`]),
     references: [],
   };
+  const vueCompilerOptions = rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, configDir);
+  if (vueCompilerOptions != null) config.vueCompilerOptions = vueCompilerOptions;
   const source = `${JSON.stringify(config, null, 2)}\n`;
   mkdirSync(configDir, { recursive: true });
   writeFileSync(outputPath, source);


### PR DESCRIPTION
## Summary
- `vueCompilerOptions.globalTypesPath` and `typesRoot` are filesystem/package walks. Overlay `compilerOptions` cannot retarget them, so vue-tsc can still load Vize's `@vue/language-core` beside the fixture Vue (#4461).
- Rewrite those paths onto the isolated overlay and the vue-tsc baseline when the fixture already has the package. Copy the rest of `vueCompilerOptions` because overlay replaces that object.

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-outside-vue-compiler.test.ts tests/tooling/typecheck-baseline-outside-aliases.test.ts tests/tooling/typecheck-baseline-outside-rootdirs.test.ts tests/tooling/typecheck-baseline-outside-paths.test.ts tests/tooling/typecheck-baseline-outside-typeroots.test.ts tests/tooling/typecheck-baseline-outside-paths-baseurl.test.ts`
- [ ] CI `check-js` / tooling tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790120923&installation_model_id=422833&pr_number=4723&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4723&signature=8c185db25dac247a5dd70ec6f95a79c17c5ce35fc2c2244aa834035ae7c10e98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->