### PR TITLE
test(matrix): unique-link relative node_modules compiler plugin names

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-plugins.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-plugins.test.ts
@@ -59,7 +59,12 @@ test("plugin names come from compilerOptions and vueCompilerOptions", () => {
   assert.deepEqual(
     pluginPackageNamesFromConfigs([
       {
-        compilerOptions: { plugins: [{ name: "typescript-plugin-css-modules" }] },
+        compilerOptions: {
+          plugins: [
+            { name: "typescript-plugin-css-modules" },
+            { name: "../node_modules/typescript-plugin-css-modules" },
+          ],
+        },
         vueCompilerOptions: {
           plugins: [
             "@vue/language-plugin-pug",
@@ -98,6 +103,36 @@ test("vueCompilerOptions.plugins records ancestor packages", () => {
     assert.deepEqual(Object.fromEntries(readDeclaredPackagePaths(fixtureRoot, configPath)), {
       "@vue/language-plugin-pug": ancestorVuePlugin,
     });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("unique isolation links a relative node_modules compiler plugin name", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(
+      fixtureRoot,
+      "typescript-plugin-css-modules@5.0.0",
+      "typescript-plugin-css-modules",
+    );
+    const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        compilerOptions: {
+          plugins: [{ name: "../node_modules/typescript-plugin-css-modules" }],
+        },
+      })}\n`,
+    );
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      {
+        name: "typescript-plugin-css-modules",
+        target:
+          "node_modules/.pnpm/typescript-plugin-css-modules@5.0.0/node_modules/typescript-plugin-css-modules",
+      },
+    ]);
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Generated configs write `compilerOptions.plugins` as `{ name: "../node_modules/<pkg>" }`.
- `#4717` already extracts that package name; these tests lock unique isolation to link the fixture store copy instead of climbing into Vize (#4461).

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-isolation-plugins.test.ts`
- [ ] CI `check-js` / tooling tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790121062&installation_model_id=422833&pr_number=4724&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4724&signature=77c2bbe38b8af6dae8c5e6c048af19ccb62409842a5d686678970859715bdcd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->