### PR TITLE
fix(matrix): unique-link vueCompilerOptions plugins that use object names

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-vue-plugin-objects.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-vue-plugin-objects.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { isolateUniqueLocalTypePackages } from "../../tools/fixtures/typecheck-baseline-isolation-unique.mjs";
+import { pluginPackageNamesFromConfigs } from "../../tools/fixtures/typecheck-baseline-isolation-plugins.mjs";
+
+/**
+ * Some Vue language-plugin configs use the TypeScript `{ name }` object shape
+ * instead of a string or `[name, options]` tuple (#4461). Unique isolation
+ * must still extract the package and link the fixture copy.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-isolation-vue-plugin-objects-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(fixtureRoot, { recursive: true });
+  const ancestor = path.join(outer, "node_modules", "@vue", "language-plugin-pug");
+  fs.mkdirSync(ancestor, { recursive: true });
+  fs.writeFileSync(path.join(ancestor, "package.json"), `{"name":"@vue/language-plugin-pug"}\n`);
+  return { fixtureRoot, outer };
+}
+
+function writeStoreCopy(fixtureRoot: string) {
+  const packageRoot = path.join(
+    fixtureRoot,
+    "node_modules",
+    ".pnpm",
+    "@vue+language-plugin-pug@1.8.27",
+    "node_modules",
+    "@vue",
+    "language-plugin-pug",
+  );
+  fs.mkdirSync(packageRoot, { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), `{"name":"@vue/language-plugin-pug"}\n`);
+}
+
+test("vueCompilerOptions.plugins objects contribute the name field", () => {
+  assert.deepEqual(
+    pluginPackageNamesFromConfigs([
+      {
+        vueCompilerOptions: {
+          plugins: [
+            { name: "@vue/language-plugin-pug" },
+            { name: "../node_modules/@vue/language-plugin-pug" },
+          ],
+        },
+      },
+    ]),
+    ["@vue/language-plugin-pug"],
+  );
+});
+
+test("unique isolation links a vue plugin object with a relative node_modules name", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot);
+    const configPath = path.join(fixtureRoot, ".nuxt", "tsconfig.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        vueCompilerOptions: {
+          plugins: [{ name: "../node_modules/@vue/language-plugin-pug" }],
+        },
+      })}\n`,
+    );
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      {
+        name: "@vue/language-plugin-pug",
+        target:
+          "node_modules/.pnpm/@vue+language-plugin-pug@1.8.27/node_modules/@vue/language-plugin-pug",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-plugins.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-plugins.mjs
@@ -51,6 +51,10 @@ function addVueCompilerPlugins(names, seen, plugins) {
     }
     if (Array.isArray(plugin) && typeof plugin[0] === "string") {
       addName(names, seen, plugin[0]);
+      continue;
+    }
+    if (plugin != null && typeof plugin.name === "string") {
+      addName(names, seen, plugin.name);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Some Vue language-plugin configs write `vueCompilerOptions.plugins` as `{ name: "<pkg>" }` instead of a string or `[name, options]` tuple.
- Unique isolation now extracts that package name, including generated `../node_modules/<pkg>` specifiers, and links the fixture store copy (#4461).

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-isolation-plugins.test.ts tests/tooling/typecheck-baseline-isolation-vue-plugin-objects.test.ts`
- [ ] CI `check-js` / tooling tests

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790121212&installation_model_id=422833&pr_number=4725&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4725&signature=05f2196abe764481772672cedd2b4b045785b69a1ac33dd9dd73f5d8bd22ab3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->