### PR TITLE
test(lsp): add Vue Fes authored oracle

### DIFF
--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -767,7 +767,8 @@
           "tests/_fixtures/_git/reka-ui",
           "tests/_fixtures/_git/elk",
           "tests/_fixtures/_git/misskey",
-          "tests/_fixtures/_git/create-vue"
+          "tests/_fixtures/_git/create-vue",
+          "tests/_fixtures/_git/vuefes-japan-speakers"
         ]
       },
       "evidence": {

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 7,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 4,
+    "minimumProjectCount": 5,
     "trackingIssue": 3952
   },
   "projects": [
@@ -3399,7 +3399,156 @@
         "syntax-highlighter",
         "lsp"
       ],
-      "diff": "e2e-vrt"
+      "diff": "e2e-vrt",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "app/components/DirectoryView.vue",
+          "symbol": "toggleNameSort",
+          "usageAnchor": "@click=\"toggleNameSort()\"",
+          "declarationAnchor": "function toggleNameSort() {",
+          "hoverContains": ["function toggleNameSort(): void"],
+          "renameTo": "__vizeRenamedToggleNameSort"
+        },
+        "componentBoundary": {
+          "importerFile": "app/islands/HomePageIsland.vue",
+          "componentFile": "app/components/AppMasthead.vue",
+          "tagName": "AppMasthead",
+          "tagAnchor": "<AppMasthead ",
+          "completionItemCount": 29,
+          "completionItems": [
+            {
+              "label": "v-if",
+              "rank": 0
+            },
+            {
+              "label": "v-else-if",
+              "rank": 1
+            },
+            {
+              "label": "v-else",
+              "rank": 2
+            },
+            {
+              "label": "v-for",
+              "rank": 3
+            },
+            {
+              "label": "v-on",
+              "rank": 4
+            },
+            {
+              "label": "v-bind",
+              "rank": 5
+            },
+            {
+              "label": "v-model",
+              "rank": 6
+            },
+            {
+              "label": "v-slot",
+              "rank": 7
+            },
+            {
+              "label": "v-show",
+              "rank": 8
+            },
+            {
+              "label": "v-pre",
+              "rank": 9
+            },
+            {
+              "label": "v-once",
+              "rank": 10
+            },
+            {
+              "label": "v-memo",
+              "rank": 11
+            },
+            {
+              "label": "v-cloak",
+              "rank": 12
+            },
+            {
+              "label": "v-text",
+              "rank": 13
+            },
+            {
+              "label": "v-html",
+              "rank": 14
+            },
+            {
+              "label": "@",
+              "rank": 15
+            },
+            {
+              "label": ":",
+              "rank": 16
+            },
+            {
+              "label": "#",
+              "rank": 17
+            },
+            {
+              "label": "@click",
+              "rank": 18
+            },
+            {
+              "label": "@input",
+              "rank": 19
+            },
+            {
+              "label": "@change",
+              "rank": 20
+            },
+            {
+              "label": "@submit",
+              "rank": 21
+            },
+            {
+              "label": "@keydown",
+              "rank": 22
+            },
+            {
+              "label": "@keyup",
+              "rank": 23
+            },
+            {
+              "label": "@focus",
+              "rank": 24
+            },
+            {
+              "label": "@blur",
+              "rank": 25
+            },
+            {
+              "label": "@mouseenter",
+              "rank": 26
+            },
+            {
+              "label": "@mouseleave",
+              "rank": 27
+            },
+            {
+              "label": "stats",
+              "rank": 28
+            }
+          ],
+          "dependencyEdit": {
+            "anchor": "  stats: { speakers: number; talks: number; years: number };\n",
+            "replacement": "  stats: { speakers: number; talks: number; years: number };\n  vizeOracleProbe?: boolean;\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "app/components/__VizeOracleAppMasthead.vue",
+          "renamedFile": "app/components/__VizeOracleRenamedAppMasthead.vue",
+          "originalImportSpecifier": "../components/AppMasthead.vue",
+          "copiedImportSpecifier": "../components/__VizeOracleAppMasthead.vue",
+          "renamedImportSpecifier": "../components/__VizeOracleRenamedAppMasthead.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizeVueFesFileLifecycleMarker__"
+        }
+      }
     },
     {
       "id": "mobile-web-best-practice",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 4,
+      "authored-lsp": 5,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 4, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 5, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
Refs #3952.

## Summary

- add Vue Fes Japan Speakers as the fifth authored real-project LSP oracle
- raise the authored LSP ratchet from 4 to 5 projects
- pin script-setup template hover/definition/references/rename, component-boundary completion ranks, unsaved dependency completion refresh, and create/rename/delete lifecycle for the fixture

## Validation

- `node --test tests/tooling/real-project-lsp-authored-registry.test.ts`
- `FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=134 VIZE_LSP_BIN=target/ci/vize CORSA_PATH="$PWD/node_modules/.bin/tsgo" REAL_PROJECT_LSP_TIMEOUT_MS=600000 node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts`
- `./node_modules/.bin/vp check tests/_fixtures/vue-ecosystem-fixtures.json tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/real-project-lsp.test.ts`
- `node --test tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts tests/tooling/vue-ecosystem-tsconfig-coverage.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts`
- `git diff --check`

## Follow-up

- Vue 2 Options API references still need a separate P0 slice before `vue2-elm` can join this authored-oracle ratchet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790125866&installation_model_id=422833&pr_number=4727&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4727&signature=d42aa5af2b155b4bd42190c5f8c17e87d5157af4c6e1d58fc6b47c2c4994e941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded Vue ecosystem coverage for language-service scenarios, including template bindings, component-boundary completions, dependency editing, and file lifecycle operations.
  * Raised the minimum project coverage required for the language-service validation gate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->