### PR TITLE
fix(release): add crates handoff recovery

### DIFF
--- a/.github/workflows/release-crates-handoff.yml
+++ b/.github/workflows/release-crates-handoff.yml
@@ -1,0 +1,74 @@
+name: Publish crates.io handoff crates
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: Published GitHub Release tag that contains the handoff command
+        required: true
+        type: string
+      crate_set:
+        description: Manual handoff crate set to publish
+        required: true
+        default: jsx-patina
+        type: choice
+        options:
+          - jsx-patina
+
+run-name: Publish crates.io handoff crates for ${{ inputs.tag_name }} (${{ inputs.crate_set }})
+
+concurrency:
+  group: crates-handoff-${{ inputs.tag_name }}-${{ inputs.crate_set }}
+  cancel-in-progress: false
+
+permissions: { contents: read }
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  publish-crates-handoff:
+    name: Publish crates.io handoff crates
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 30
+    environment: crates-io
+    permissions: { contents: read, id-token: write }
+    steps:
+      - name: Resolve published release tag
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG_NAME: ${{ inputs.tag_name }}
+        run: |
+          test -n "$RELEASE_TAG_NAME"
+          resolved_tag=$(gh release view "$RELEASE_TAG_NAME" --repo "$GITHUB_REPOSITORY" --json isDraft,tagName --jq 'select(.isDraft == false) | .tagName')
+          test "$resolved_tag" = "$RELEASE_TAG_NAME"
+          printf 'tag_name=%s\n' "$resolved_tag" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.release.outputs.tag_name }}
+          persist-credentials: false
+
+      - uses: ./.github/actions/setup-moonbit
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: ./.github/actions/setup-rust-sticky-cache
+        with:
+          key: release-crates-handoff
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ inputs.crate_set }}
+
+      - name: Get crates.io token via Trusted Publishing
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
+
+      - name: Publish JSX and Patina handoff crates
+        if: ${{ inputs.crate_set == 'jsx-patina' }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+        run: |
+          moon run --target native tools/moon/cmd/publish_crates -- \
+            --crate vize_atelier_jsx \
+            --crate vize_patina

--- a/tests/tooling/github-workflows-crates-handoff.test.ts
+++ b/tests/tooling/github-workflows-crates-handoff.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import { readRepoFile } from "./support/github-workflows.ts";
+
+type WorkflowStep = {
+  env?: Record<string, string>;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+};
+
+type WorkflowJob = {
+  environment?: string;
+  permissions?: Record<string, string>;
+  "runs-on"?: string;
+  steps?: WorkflowStep[];
+  "timeout-minutes"?: number;
+};
+
+test("crates.io handoff workflow recovers the JSX and Patina release set", () => {
+  const source = readRepoFile(".github", "workflows", "release-crates-handoff.yml");
+  const workflow = parse(source) as {
+    jobs?: Record<string, WorkflowJob>;
+    on?: Record<string, unknown>;
+    permissions?: Record<string, string>;
+  };
+
+  const dispatch = workflow.on?.workflow_dispatch as
+    | { inputs?: Record<string, { options?: string[]; type?: string }> }
+    | undefined;
+  assert.ok(dispatch);
+  assert.equal(dispatch.inputs?.tag_name?.type, "string");
+  assert.deepEqual(dispatch.inputs?.crate_set?.options, ["jsx-patina"]);
+  assert.deepEqual(workflow.permissions, { contents: "read" });
+
+  const job = workflow.jobs?.["publish-crates-handoff"];
+  assert.ok(job);
+  assert.equal(job.environment, "crates-io");
+  assert.deepEqual(job.permissions, { contents: "read", "id-token": "write" });
+  assert.match(job["runs-on"] ?? "", /^blacksmith-32vcpu-ubuntu-2404$/);
+  assert.equal(job["timeout-minutes"], 30);
+
+  const checkout = job.steps?.find((step) => step.uses?.startsWith("actions/checkout@"));
+  assert.ok(checkout);
+  assert.equal(checkout.with?.ref, "${{ steps.release.outputs.tag_name }}");
+  assert.equal(checkout.with?.["persist-credentials"], false);
+  assert.ok(job.steps?.some((step) => step.uses?.startsWith("rust-lang/crates-io-auth-action@")));
+  assert.ok(
+    job.steps?.some((step) =>
+      /--crate vize_atelier_jsx[\s\S]*--crate vize_patina/.test(step.run ?? ""),
+    ),
+  );
+  assert.doesNotMatch(source, /CARGO_REGISTRY_TOKEN:\s*\$\{\{\s*secrets\./);
+});

--- a/tests/tooling/moonbit-publish-crates-selected.test.ts
+++ b/tests/tooling/moonbit-publish-crates-selected.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs, { mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+
+import { repoRoot, runMoonScript } from "./_helpers/moonbit.ts";
+import { writeFakeCommand } from "./support/fake-command.ts";
+
+function workspaceVersion(): string {
+  const metadata = JSON.parse(
+    execFileSync("cargo", ["metadata", "--no-deps", "--format-version", "1"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }),
+  ) as { packages: Array<{ name: string; version: string }> };
+  return metadata.packages.find((pkg) => pkg.name === "vize_atelier_jsx")?.version ?? "";
+}
+
+test("publish_crates can target the JSX and Patina handoff set", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "moonbit-publish-crates-selected-"));
+  const binDir = path.join(tempDir, "bin");
+  const cargoLogPath = path.join(tempDir, "cargo.log");
+  const curlLogPath = path.join(tempDir, "curl.log");
+  const version = workspaceVersion();
+  assert.ok(version);
+
+  try {
+    fs.mkdirSync(binDir, { recursive: true });
+    writeFakeCommand(
+      binDir,
+      "cargo",
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "fs.appendFileSync(process.env.CARGO_LOG, args.join(' ') + '\\n');",
+        "if (['package', 'publish', 'info'].includes(args[0])) process.exit(0);",
+        "process.exit(1);",
+      ].join("\n"),
+    );
+    writeFakeCommand(
+      binDir,
+      "curl",
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "if (process.env.CURL_LOG) fs.appendFileSync(process.env.CURL_LOG, args.join(' ') + '\\n');",
+        "const endpoint = args.at(-1).split('/');",
+        "const crateName = endpoint.at(-2);",
+        "const version = endpoint.at(-1);",
+        "const published = (process.env.TEST_PUBLISHED_CRATES || '').split(',').includes(crateName);",
+        "const body = published ? { version: { crate: crateName, num: version } } : { errors: [{ detail: 'Not Found' }] };",
+        "fs.writeSync(1, JSON.stringify(body) + 'VIZE_HTTP_STATUS:' + (published ? '200' : '404'));",
+        "process.exit(published ? 0 : 22);",
+      ].join("\n"),
+    );
+
+    const env = {
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      CARGO_LOG: cargoLogPath,
+      PUBLISH_RETRY_LIMIT: "1",
+      PUBLISH_RETRY_DELAY: "1",
+    };
+    const selectedPublish = runMoonScript(
+      "publish_crates",
+      ["--crate", "vize_atelier_jsx", "--crate", "vize_patina"],
+      { cwd: repoRoot, env },
+    );
+    assert.equal(selectedPublish.status, 0, selectedPublish.stderr);
+    assert.match(
+      selectedPublish.stdout,
+      /Selected crate publish plan: vize_atelier_jsx, vize_patina/,
+    );
+    assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
+      "publish --locked -p vize_atelier_jsx",
+      `info --registry crates-io vize_atelier_jsx@${version}`,
+      "publish --locked -p vize_patina",
+      `info --registry crates-io vize_patina@${version}`,
+    ]);
+
+    fs.writeFileSync(cargoLogPath, "");
+    fs.writeFileSync(curlLogPath, "");
+    const selectedDryRun = runMoonScript(
+      "publish_crates",
+      ["--dry-run", "--crate", "vize_atelier_jsx", "--crate", "vize_patina"],
+      {
+        cwd: repoRoot,
+        env: {
+          ...env,
+          CURL_LOG: curlLogPath,
+          TEST_PUBLISHED_CRATES: "vize_atelier_jsx",
+        },
+      },
+    );
+    assert.equal(selectedDryRun.status, 0, selectedDryRun.stderr);
+    assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
+      ["package", "--locked", "--no-verify", "-p", "vize_atelier_jsx", "-p", "vize_patina"].join(
+        " ",
+      ),
+      `info --registry crates-io vize_atelier_jsx@${version}`,
+      "publish --dry-run --locked -p vize_patina",
+    ]);
+    assert.match(selectedDryRun.stdout, /registry-resolvable frontier vize_patina/i);
+
+    for (const invalidArgs of [
+      ["--crate"],
+      ["--crate", "unknown_crate"],
+      ["--crate", "vize_patina", "--crate", "vize_patina"],
+    ]) {
+      fs.writeFileSync(cargoLogPath, "");
+      const invalid = runMoonScript("publish_crates", invalidArgs, {
+        cwd: repoRoot,
+        env,
+      });
+      assert.notEqual(invalid.status, 0);
+      assert.match(invalid.stderr, /Usage: .*publish_crates.*--crate <crate>/);
+      assert.equal(fs.readFileSync(cargoLogPath, "utf8"), "");
+    }
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tools/moon/cmd/publish_crates/main.mbt
+++ b/tools/moon/cmd/publish_crates/main.mbt
@@ -44,6 +44,29 @@ let blocked_by_manual_publish_crates : Array[String] = [
   "vize_patina",
 ]
 
+fn includes_string(items : Array[String], value : String) -> Bool {
+  for item in items {
+    if item == value {
+      return true
+    }
+  }
+  false
+}
+
+fn known_release_crates() -> Array[String] {
+  let crates : Array[String] = []
+  for crate_name in published_crates {
+    crates.push(crate_name)
+  }
+  for crate_name in manual_publish_crates {
+    crates.push(crate_name)
+  }
+  for crate_name in blocked_by_manual_publish_crates {
+    crates.push(crate_name)
+  }
+  crates
+}
+
 /// Parses a positive integer from a string and falls back on invalid input.
 fn positive_int_or(value : String, fallback : Int) -> Int {
   try {
@@ -99,12 +122,53 @@ fn workspace_version_from_content(content : String) -> String? {
 /// before crates.io index propagation catches up.
 async fn run_app() -> Int {
   let args = @tool.cli_args()
-  let dry_run = args.length() == 1 && args[0] == "--dry-run"
-  if !args.is_empty() && !dry_run {
-    @stdio.stderr.write(
-      "Usage: moon run --target native tools/moon/cmd/publish_crates -- [--dry-run]\n",
-    )
-    return 1
+  let mut dry_run = false
+  let selected_crates : Array[String] = []
+  let usage = "Usage: moon run --target native tools/moon/cmd/publish_crates -- [--dry-run] [--crate <crate>...]\n"
+  let mut index = 0
+  while index < args.length() {
+    match args[index] {
+      "--dry-run" => {
+        if dry_run {
+          @stdio.stderr.write(usage)
+          return 1
+        }
+        dry_run = true
+        index = index + 1
+      }
+      "--crate" => {
+        guard index + 1 < args.length() else {
+          @stdio.stderr.write(usage)
+          return 1
+        }
+        selected_crates.push(args[index + 1])
+        index = index + 2
+      }
+      _ => {
+        @stdio.stderr.write(usage)
+        return 1
+      }
+    }
+  }
+
+  let publish_targets : Array[String] = []
+  if selected_crates.is_empty() {
+    for crate_name in published_crates {
+      publish_targets.push(crate_name)
+    }
+  } else {
+    let known_crates = known_release_crates()
+    for crate_name in selected_crates {
+      if !includes_string(known_crates, crate_name) {
+        @stdio.stderr.write("Unknown release crate: \{crate_name}\n" + usage)
+        return 1
+      }
+      if includes_string(publish_targets, crate_name) {
+        @stdio.stderr.write("Duplicate release crate: \{crate_name}\n" + usage)
+        return 1
+      }
+      publish_targets.push(crate_name)
+    }
   }
 
   let cargo_toml = match @tool.read_file_to_string("Cargo.toml") {
@@ -140,21 +204,25 @@ async fn run_app() -> Int {
       "Deferred dependent crates: " + blocked_by_manual_publish_crates.join(", "),
     )
   }
+  if !selected_crates.is_empty() {
+    println("Selected crate publish plan: " + publish_targets.join(", "))
+  }
 
   if dry_run {
     let package_args = ["package", "--locked", "--no-verify"]
-    for crate_name in published_crates {
+    for crate_name in publish_targets {
       package_args.push("-p")
       package_args.push(crate_name)
     }
-    println("Packaging the complete supported crate plan for v\{version}...")
+    let plan_label = if selected_crates.is_empty() { "complete supported" } else { "selected" }
+    println("Packaging the \{plan_label} crate plan for v\{version}...")
     if @process.run("cargo", package_args) != 0 {
       @stdio.stderr.write("Crate package validation failed for v\{version}.\n")
       return 1
     }
 
     let mut frontier : String? = None
-    for crate_name in published_crates {
+    for crate_name in publish_targets {
       match query_crate_version(crate_name, version) {
         QueryFailed(message) => {
           @stdio.stderr.write("Release registry check failed: " + message + "\n")
@@ -200,7 +268,7 @@ async fn run_app() -> Int {
     return 0
   }
 
-  for crate_name in published_crates {
+  for crate_name in publish_targets {
     println("Publishing \{crate_name} v\{version}...")
     if crate_is_published(crate_name, version) {
       println("\{crate_name} v\{version} is already published, skipping publish.")


### PR DESCRIPTION
## Summary

- add `publish_crates --crate <crate>` so manual handoff crates can reuse the same idempotent publish and crates.io resolution checks as the normal release job
- add a protected `release-crates-handoff` workflow for the downstream-critical `vize_atelier_jsx` -> `vize_patina` recovery set
- lock the workflow and script behavior with focused tests, including dry-run, invalid-argument, and source-length coverage

Refs #4527.
Follow-up to #4623.

## Verification

- `MOON_HOME=/private/tmp/vize-release-moonbit.qDwVhG/moonbit MOON_BIN=/private/tmp/vize-release-moonbit.qDwVhG/moonbit-shims/moon PATH=/private/tmp/vize-release-moonbit.qDwVhG/moonbit-shims:/private/tmp/vize-release-moonbit.qDwVhG/moonbit/bin:$PATH node --test tests/tooling/moonbit-publish-crates.test.ts tests/tooling/moonbit-publish-crates-selected.test.ts tests/tooling/github-workflows-release-publish.test.ts tests/tooling/github-workflows-crates-handoff.test.ts tests/tooling/source-file-lengths.test.ts`
- `MOON_HOME=/private/tmp/vize-release-moonbit.qDwVhG/moonbit MOON_BIN=/private/tmp/vize-release-moonbit.qDwVhG/moonbit-shims/moon PATH=/private/tmp/vize-release-moonbit.qDwVhG/moonbit-shims:/private/tmp/vize-release-moonbit.qDwVhG/moonbit/bin:$PATH vp check tools/moon/cmd/publish_crates/main.mbt tests/tooling/moonbit-publish-crates.test.ts tests/tooling/moonbit-publish-crates-selected.test.ts tests/tooling/github-workflows-release-publish.test.ts tests/tooling/github-workflows-crates-handoff.test.ts .github/workflows/release-crates-handoff.yml`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered workflow for securely publishing selected JSX and Patina crates.
  * Added support for publishing specific crates with repeated `--crate` options.
  * Added validation for unknown, duplicate, or incomplete crate selections.
  * Added dry-run support for selected crates, including checks for already published versions.

* **Tests**
  * Added coverage for secure release publishing and selective crate workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->