### PR TITLE
fix(release): skip rollback on handoff dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -556,7 +556,7 @@ jobs:
     permissions: { actions: write, contents: read, issues: read }
     uses: ./.github/workflows/release-preflight.yml
   rollback-unpublished-tag:
-    if: ${{ always() && needs.release-preflight.result != 'success' }}
+    if: ${{ github.event_name == 'push' && always() && needs.release-preflight.result != 'success' }}
     needs: release-preflight
     permissions: { contents: write }
     uses: ./.github/workflows/release-tag-rollback.yml

--- a/tests/tooling/github-workflows-crates-handoff.test.ts
+++ b/tests/tooling/github-workflows-crates-handoff.test.ts
@@ -47,6 +47,10 @@ test("crates.io handoff workflow recovers the JSX and Patina release set", () =>
   ]) {
     assert.equal(workflow.jobs?.[jobName]?.if, "github.event_name == 'push'", jobName);
   }
+  assert.match(
+    workflow.jobs?.["rollback-unpublished-tag"]?.if ?? "",
+    /github\.event_name == 'push'/,
+  );
 
   const job = workflow.jobs?.["release-crates-handoff"];
   assert.ok(job);

--- a/tests/tooling/release-tag-rollback.test.ts
+++ b/tests/tooling/release-tag-rollback.test.ts
@@ -198,7 +198,10 @@ test("release calls a credential-minimal hosted rollback workflow after prefligh
   };
   const caller = release.jobs["rollback-unpublished-tag"];
   assert.equal(caller.needs, "release-preflight");
-  assert.equal(caller.if, "${{ always() && needs.release-preflight.result != 'success' }}");
+  assert.equal(
+    caller.if,
+    "${{ github.event_name == 'push' && always() && needs.release-preflight.result != 'success' }}",
+  );
   assert.deepEqual(caller.permissions, { contents: "write" });
   assert.equal(caller.uses, "./.github/workflows/release-tag-rollback.yml");
   assert.deepEqual(caller.with, {


### PR DESCRIPTION
## Summary

- keep `rollback-unpublished-tag` restricted to real tag push releases
- prevent `release.yml` handoff dispatch runs from invoking the rollback workflow when `release-preflight` is skipped
- cover the dispatch-only guard in the crates handoff and rollback workflow tests

Follow-up to #4730.
Refs #4527.

## Notes

The `release.yml` handoff dispatch now gets past crates.io Trusted Publishing token retrieval. The current remaining publish blocker is crate-specific Trusted Publishing authorization:

`403 Forbidden: The provided access token is not valid for crate vize_atelier_jsx`

## Verification

- `MOON_HOME=/private/tmp/vize-release-moonbit.qDwVhG/moonbit MOON_BIN=/private/tmp/vize-release-moonbit.qDwVhG/moonbit-shims/moon PATH=/private/tmp/vize-release-moonbit.qDwVhG/moonbit-shims:/private/tmp/vize-release-moonbit.qDwVhG/moonbit/bin:$PATH vp check --fix .github/workflows/release.yml tests/tooling/github-workflows-crates-handoff.test.ts tests/tooling/release-tag-rollback.test.ts`
- `MOON_HOME=/private/tmp/vize-release-moonbit.qDwVhG/moonbit MOON_BIN=/private/tmp/vize-release-moonbit.qDwVhG/moonbit-shims/moon PATH=/private/tmp/vize-release-moonbit.qDwVhG/moonbit-shims:/private/tmp/vize-release-moonbit.qDwVhG/moonbit/bin:$PATH node --test tests/tooling/github-workflows-crates-handoff.test.ts tests/tooling/release-tag-rollback.test.ts tests/tooling/github-workflows-release-publish.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790134748&installation_model_id=422833&pr_number=4731&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4731&signature=6ccdf18834bf5a0280646eccd665164231ffe1d174365a5f2d48ffb057666b84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release rollback behavior so it runs only for push-triggered releases.
  * Prevented rollback actions from running during manually triggered releases, even when preflight checks fail.

* **Tests**
  * Added and updated coverage to verify rollback behavior across supported release triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->