### PR TITLE
feat(davinci): emit object-spread v-on from S2 (P2-11)

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
@@ -192,7 +192,10 @@ const BATTERY: &[(&str, &str)] = &[
         "object_bind_then_object_on",
         r#"<div v-bind="obj" v-on="handlers"></div>"#,
     ),
-    ("v_if_object_on", r#"<div v-if="ok" v-on="handlers">x</div>"#),
+    (
+        "v_if_object_on",
+        r#"<div v-if="ok" v-on="handlers">x</div>"#,
+    ),
     ("component_object_on", r#"<Foo v-on="handlers" />"#),
     (
         "component_attr_then_object_on",

--- a/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
@@ -1,7 +1,7 @@
 //! P2-11 installment 5 witness: static native HTML, interpolations,
 //! mixed text siblings, static-name binds, static-name events including
 //! event/key/option modifiers, native v-if, native v-for,
-//! object-spread v-bind, and static-name components, compared
+//! object-spread v-bind, static-name components, and object v-on, compared
 //! **byte-for-byte** including helper usage.
 //!
 //! `vize_atelier_dom` is published; the Davinci crates are not. The
@@ -174,6 +174,29 @@ const BATTERY: &[(&str, &str)] = &[
     (
         "component_attr_then_object",
         r#"<Foo id="x" v-bind="obj" />"#,
+    ),
+    ("object_on", r#"<div v-on="handlers"></div>"#),
+    (
+        "attr_then_object_on",
+        r#"<div id="x" v-on="handlers"></div>"#,
+    ),
+    (
+        "object_on_then_attr",
+        r#"<div v-on="handlers" id="x"></div>"#,
+    ),
+    (
+        "click_then_object_on",
+        r#"<div @click="h" v-on="handlers"></div>"#,
+    ),
+    (
+        "object_bind_then_object_on",
+        r#"<div v-bind="obj" v-on="handlers"></div>"#,
+    ),
+    ("v_if_object_on", r#"<div v-if="ok" v-on="handlers">x</div>"#),
+    ("component_object_on", r#"<Foo v-on="handlers" />"#),
+    (
+        "component_attr_then_object_on",
+        r#"<Foo id="x" v-on="handlers" />"#,
     ),
 ];
 

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -7,19 +7,21 @@
 //! P2-9 carve-out. This module writes the JS string **directly from
 //! S2 ops** — it does not mint relief codegen-nodes (`NodeType` 13–20).
 //!
-//! Installment 5 emits **static native HTML**, interpolations,
+//! This installment emits **static native HTML**, interpolations,
 //! mixed text siblings, static-name `ui.bind`, static-name `ui.on`
 //! (including event/key/option modifiers), native `ui.if`, **native
 //! `ui.for`**, **object-spread `v-bind`** (`normalizeProps` /
-//! `mergeProps`), and **static-name components** (`resolveComponent` /
-//! `createVNode` / `createBlock`). Object `v-on`, `.native`, template
-//! fragments, filters, slots, and builtins stay
+//! `mergeProps`), **static-name components** (`resolveComponent` /
+//! `createVNode` / `createBlock`), and **object `v-on`** (`toHandlers`).
+//! `.native`, template fragments, filters, slots, and builtins stay
 //! [`EmitError::Unsupported`]. The old lane stays the shipped compile
 //! path; [`super::DOM_LANE_FLAG`] is named here and *read* in the
 //! atelier_dom witness.
 
 #[path = "emit/buf.rs"]
 mod buf;
+#[path = "emit/helper.rs"]
+mod helper;
 #[path = "emit/children.rs"]
 mod children;
 #[path = "emit/component.rs"]

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -20,14 +20,14 @@
 
 #[path = "emit/buf.rs"]
 mod buf;
-#[path = "emit/helper.rs"]
-mod helper;
 #[path = "emit/children.rs"]
 mod children;
 #[path = "emit/component.rs"]
 mod component;
 #[path = "emit/flag.rs"]
 mod flag;
+#[path = "emit/helper.rs"]
+mod helper;
 #[path = "emit/js.rs"]
 mod js;
 #[path = "emit/merge.rs"]

--- a/crates/vize_ricalco/src/emit/buf.rs
+++ b/crates/vize_ricalco/src/emit/buf.rs
@@ -1,127 +1,8 @@
-//! Indenting JS buffer and the tiny helper set this installment uses.
+//! Indenting JS buffer. Helper names live in [`super::helper`].
 
 use vize_carton::String;
 
-/// Vue helpers this installment can mention, ranked the way
-/// `vue_helper_import_rank` orders the shipped preamble (`resolveComponent`
-/// first, then `withKeys` / `withModifiers`, `toDisplayString`, vnode
-/// creates, class/style / props normalizers, `openBlock`, block creates,
-/// `Fragment`, `createTextVNode` / `createCommentVNode`, `renderList`).
-/// Same-rank helpers keep this array order (`createElementVNode` before
-/// `createVNode`, `createBlock` before `createElementBlock`).
-#[derive(Clone, Copy)]
-enum Helper {
-    ResolveComponent,
-    WithKeys,
-    WithModifiers,
-    ToDisplayString,
-    CreateElementVNode,
-    CreateVNode,
-    NormalizeClass,
-    NormalizeStyle,
-    NormalizeProps,
-    GuardReactiveProps,
-    MergeProps,
-    OpenBlock,
-    CreateBlock,
-    CreateElementBlock,
-    Fragment,
-    CreateComment,
-    CreateText,
-    RenderList,
-}
-
-impl Helper {
-    const ALL: [Self; 18] = [
-        Self::ResolveComponent,
-        Self::WithKeys,
-        Self::WithModifiers,
-        Self::ToDisplayString,
-        Self::CreateElementVNode,
-        Self::CreateVNode,
-        Self::NormalizeClass,
-        Self::NormalizeStyle,
-        Self::NormalizeProps,
-        Self::GuardReactiveProps,
-        Self::MergeProps,
-        Self::OpenBlock,
-        Self::CreateBlock,
-        Self::CreateElementBlock,
-        Self::Fragment,
-        Self::CreateComment,
-        Self::CreateText,
-        Self::RenderList,
-    ];
-
-    const fn bit(self) -> u32 {
-        match self {
-            Self::ToDisplayString => 1,
-            Self::CreateElementVNode => 2,
-            Self::OpenBlock => 4,
-            Self::CreateElementBlock => 8,
-            Self::CreateText => 16,
-            Self::NormalizeClass => 32,
-            Self::NormalizeStyle => 64,
-            Self::WithKeys => 128,
-            Self::WithModifiers => 256,
-            Self::CreateComment => 512,
-            Self::Fragment => 1024,
-            Self::RenderList => 2048,
-            Self::NormalizeProps => 4096,
-            Self::GuardReactiveProps => 8192,
-            Self::MergeProps => 16384,
-            Self::ResolveComponent => 32768,
-            Self::CreateVNode => 65536,
-            Self::CreateBlock => 131072,
-        }
-    }
-
-    const fn name(self) -> &'static str {
-        match self {
-            Self::ResolveComponent => "resolveComponent",
-            Self::WithKeys => "withKeys",
-            Self::WithModifiers => "withModifiers",
-            Self::ToDisplayString => "toDisplayString",
-            Self::CreateElementVNode => "createElementVNode",
-            Self::CreateVNode => "createVNode",
-            Self::NormalizeClass => "normalizeClass",
-            Self::NormalizeStyle => "normalizeStyle",
-            Self::NormalizeProps => "normalizeProps",
-            Self::GuardReactiveProps => "guardReactiveProps",
-            Self::MergeProps => "mergeProps",
-            Self::OpenBlock => "openBlock",
-            Self::CreateBlock => "createBlock",
-            Self::CreateElementBlock => "createElementBlock",
-            Self::Fragment => "Fragment",
-            Self::CreateText => "createTextVNode",
-            Self::CreateComment => "createCommentVNode",
-            Self::RenderList => "renderList",
-        }
-    }
-
-    const fn alias(self) -> &'static str {
-        match self {
-            Self::ResolveComponent => "_resolveComponent",
-            Self::WithKeys => "_withKeys",
-            Self::WithModifiers => "_withModifiers",
-            Self::ToDisplayString => "_toDisplayString",
-            Self::CreateElementVNode => "_createElementVNode",
-            Self::CreateVNode => "_createVNode",
-            Self::NormalizeClass => "_normalizeClass",
-            Self::NormalizeStyle => "_normalizeStyle",
-            Self::NormalizeProps => "_normalizeProps",
-            Self::GuardReactiveProps => "_guardReactiveProps",
-            Self::MergeProps => "_mergeProps",
-            Self::OpenBlock => "_openBlock",
-            Self::CreateBlock => "_createBlock",
-            Self::CreateElementBlock => "_createElementBlock",
-            Self::Fragment => "_Fragment",
-            Self::CreateText => "_createTextVNode",
-            Self::CreateComment => "_createCommentVNode",
-            Self::RenderList => "_renderList",
-        }
-    }
-}
+use super::helper::Helper;
 
 /// Growing JS text plus the helpers the body mentioned.
 pub(super) struct Buf {
@@ -203,6 +84,9 @@ impl Buf {
     pub(super) fn use_merge_props(&mut self) {
         self.mark(Helper::MergeProps);
     }
+    pub(super) fn use_to_handlers(&mut self) {
+        self.mark(Helper::ToHandlers);
+    }
     pub(super) fn use_create_comment(&mut self) {
         self.mark(Helper::CreateComment);
     }
@@ -270,6 +154,10 @@ impl Buf {
         Helper::MergeProps.alias()
     }
 
+    pub(super) fn to_handlers_alias() -> &'static str {
+        Helper::ToHandlers.alias()
+    }
+
     pub(super) fn create_comment_alias() -> &'static str {
         Helper::CreateComment.alias()
     }
@@ -306,7 +194,7 @@ impl Buf {
     /// root static-props hoist (the shipped codegen appends hoists to
     /// the helper preamble).
     pub(super) fn preamble(&self) -> String {
-        let listed: [Helper; 18] = Helper::ALL;
+        let listed: [Helper; 19] = Helper::ALL;
         let mut n = 0;
         for helper in listed {
             if self.used & helper.bit() != 0 {

--- a/crates/vize_ricalco/src/emit/helper.rs
+++ b/crates/vize_ricalco/src/emit/helper.rs
@@ -1,0 +1,124 @@
+//! Vue helpers this installment can mention, ranked the way
+//! `vue_helper_import_rank` orders the shipped preamble. Same-rank
+//! helpers keep [`Helper::ALL`] order (`createElementVNode` before
+//! `createVNode`, `createBlock` before `createElementBlock`,
+//! `toHandlers` after `mergeProps`).
+
+#[derive(Clone, Copy)]
+pub(super) enum Helper {
+    ResolveComponent,
+    WithKeys,
+    WithModifiers,
+    ToDisplayString,
+    CreateElementVNode,
+    CreateVNode,
+    NormalizeClass,
+    NormalizeStyle,
+    NormalizeProps,
+    GuardReactiveProps,
+    MergeProps,
+    ToHandlers,
+    OpenBlock,
+    CreateBlock,
+    CreateElementBlock,
+    Fragment,
+    CreateComment,
+    CreateText,
+    RenderList,
+}
+
+impl Helper {
+    pub(super) const ALL: [Self; 19] = [
+        Self::ResolveComponent,
+        Self::WithKeys,
+        Self::WithModifiers,
+        Self::ToDisplayString,
+        Self::CreateElementVNode,
+        Self::CreateVNode,
+        Self::NormalizeClass,
+        Self::NormalizeStyle,
+        Self::NormalizeProps,
+        Self::GuardReactiveProps,
+        Self::MergeProps,
+        Self::ToHandlers,
+        Self::OpenBlock,
+        Self::CreateBlock,
+        Self::CreateElementBlock,
+        Self::Fragment,
+        Self::CreateComment,
+        Self::CreateText,
+        Self::RenderList,
+    ];
+
+    pub(super) const fn bit(self) -> u32 {
+        match self {
+            Self::ToDisplayString => 1,
+            Self::CreateElementVNode => 2,
+            Self::OpenBlock => 4,
+            Self::CreateElementBlock => 8,
+            Self::CreateText => 16,
+            Self::NormalizeClass => 32,
+            Self::NormalizeStyle => 64,
+            Self::WithKeys => 128,
+            Self::WithModifiers => 256,
+            Self::CreateComment => 512,
+            Self::Fragment => 1024,
+            Self::RenderList => 2048,
+            Self::NormalizeProps => 4096,
+            Self::GuardReactiveProps => 8192,
+            Self::MergeProps => 16384,
+            Self::ResolveComponent => 32768,
+            Self::CreateVNode => 65536,
+            Self::CreateBlock => 131072,
+            Self::ToHandlers => 262144,
+        }
+    }
+
+    pub(super) const fn name(self) -> &'static str {
+        match self {
+            Self::ResolveComponent => "resolveComponent",
+            Self::WithKeys => "withKeys",
+            Self::WithModifiers => "withModifiers",
+            Self::ToDisplayString => "toDisplayString",
+            Self::CreateElementVNode => "createElementVNode",
+            Self::CreateVNode => "createVNode",
+            Self::NormalizeClass => "normalizeClass",
+            Self::NormalizeStyle => "normalizeStyle",
+            Self::NormalizeProps => "normalizeProps",
+            Self::GuardReactiveProps => "guardReactiveProps",
+            Self::MergeProps => "mergeProps",
+            Self::ToHandlers => "toHandlers",
+            Self::OpenBlock => "openBlock",
+            Self::CreateBlock => "createBlock",
+            Self::CreateElementBlock => "createElementBlock",
+            Self::Fragment => "Fragment",
+            Self::CreateText => "createTextVNode",
+            Self::CreateComment => "createCommentVNode",
+            Self::RenderList => "renderList",
+        }
+    }
+
+    pub(super) const fn alias(self) -> &'static str {
+        match self {
+            Self::ResolveComponent => "_resolveComponent",
+            Self::WithKeys => "_withKeys",
+            Self::WithModifiers => "_withModifiers",
+            Self::ToDisplayString => "_toDisplayString",
+            Self::CreateElementVNode => "_createElementVNode",
+            Self::CreateVNode => "_createVNode",
+            Self::NormalizeClass => "_normalizeClass",
+            Self::NormalizeStyle => "_normalizeStyle",
+            Self::NormalizeProps => "_normalizeProps",
+            Self::GuardReactiveProps => "_guardReactiveProps",
+            Self::MergeProps => "_mergeProps",
+            Self::ToHandlers => "_toHandlers",
+            Self::OpenBlock => "_openBlock",
+            Self::CreateBlock => "_createBlock",
+            Self::CreateElementBlock => "_createElementBlock",
+            Self::Fragment => "_Fragment",
+            Self::CreateText => "_createTextVNode",
+            Self::CreateComment => "_createCommentVNode",
+            Self::RenderList => "_renderList",
+        }
+    }
+}

--- a/crates/vize_ricalco/src/emit/merge.rs
+++ b/crates/vize_ricalco/src/emit/merge.rs
@@ -1,22 +1,29 @@
-//! Object-spread `v-bind` (`ui.bind` with no name): `normalizeProps` /
-//! `guardReactiveProps` when the spread is alone, `mergeProps` when it
-//! sits beside other props. `v-on` object form stays unsupported.
+//! Object-spread `v-bind` (`ui.bind` with no name) and object `v-on`
+//! (`ui.on` with no name): `normalizeProps` / `guardReactiveProps` when
+//! a bind spread is alone, `toHandlers(..., true)` when an on spread is
+//! alone, `mergeProps` when a spread sits beside other props or the
+//! two spread kinds mix. The `, true` is Vue's `handlerOnly` flag — the
+//! shipped `generate_von_object_exp` always emits it.
 
 use alloc::vec::Vec as StdVec;
 
 use vize_carton::String;
-use vize_disegno::op::{Attribute, BindOp, BindingOp};
+use vize_disegno::expr::ExprRef;
+use vize_disegno::op::{Attribute, BindOp, BindingOp, OnOp};
 
 use super::EmitCx;
 use super::EmitError;
 use super::buf::Buf;
-use super::on::{event_key_for, needs_hydration};
+use super::on::event_key_for;
+use super::on::needs_hydration;
 use super::props::{Patch, Piece, emit_props_object, js_value, pieces, static_bind_name};
 
-pub(super) fn has_object_bind(bindings: &[BindingOp<'_>]) -> bool {
-    bindings
-        .iter()
-        .any(|binding| matches!(binding, BindingOp::Bind(bind) if bind.name.is_none()))
+pub(super) fn has_object_spread(bindings: &[BindingOp<'_>]) -> bool {
+    bindings.iter().any(|binding| match binding {
+        BindingOp::Bind(bind) if bind.name.is_none() => true,
+        BindingOp::On(on) if on.name.is_none() => true,
+        _ => false,
+    })
 }
 
 pub(super) fn admit_object(bind: &BindOp<'_>) -> Result<(), EmitError> {
@@ -26,12 +33,23 @@ pub(super) fn admit_object(bind: &BindOp<'_>) -> Result<(), EmitError> {
     js_value(bind).map(|_| ())
 }
 
+pub(super) fn admit_object_on(on: &OnOp<'_>) -> Result<(), EmitError> {
+    if !on.modifiers.is_empty() {
+        return Err(EmitError::Unsupported);
+    }
+    match on.handler {
+        Some(ExprRef::Js(_)) => Ok(()),
+        _ => Err(EmitError::Unsupported),
+    }
+}
+
 pub(super) fn object_patch(bindings: &[BindingOp<'_>], is_component: bool) -> Patch {
     let mut dynamic_props = StdVec::new();
     let mut flag = 16i32;
     for binding in bindings.iter() {
         match binding {
             BindingOp::Bind(bind) if bind.name.is_none() => {}
+            BindingOp::On(on) if on.name.is_none() => {}
             BindingOp::Bind(bind) => {
                 let Ok(name) = static_bind_name(bind) else {
                     continue;
@@ -71,12 +89,12 @@ pub(super) fn emit_spread_props(
     if_key: Option<&str>,
 ) -> Result<(), EmitError> {
     let args = merge_args(attributes, bindings, if_key)?;
-    let only_spread = args.iter().all(|arg| matches!(arg, Arg::Spread(_)));
-    if only_spread {
-        let Arg::Spread(bind) = args[0] else {
-            return Err(EmitError::Unsupported);
+    if let Some(lone) = lone_kind_spread(&args) {
+        return match lone {
+            Arg::BindSpread(bind) => emit_normalize_guard(cx, bind),
+            Arg::OnSpread(on) => emit_to_handlers(cx, on),
+            Arg::Object { .. } => Err(EmitError::Unsupported),
         };
-        return emit_normalize_guard(cx, bind);
     }
     cx.buf.use_merge_props();
     cx.buf.push(Buf::merge_props_alias());
@@ -86,7 +104,8 @@ pub(super) fn emit_spread_props(
             cx.buf.push(", ");
         }
         match arg {
-            Arg::Spread(bind) => cx.buf.push(js_value(bind)?.source),
+            Arg::BindSpread(bind) => cx.buf.push(js_value(bind)?.source),
+            Arg::OnSpread(on) => emit_to_handlers(cx, on)?,
             Arg::Object { if_key, pieces } => {
                 emit_props_object(cx, pieces, *if_key, true)?;
             }
@@ -96,12 +115,28 @@ pub(super) fn emit_spread_props(
     Ok(())
 }
 
+/// Every arg is the same spread kind (all binds, or all ons). Vue keeps
+/// only the first of that kind when nothing else is present.
+fn lone_kind_spread<'a>(args: &'a [Arg<'a>]) -> Option<&'a Arg<'a>> {
+    if args.is_empty() {
+        return None;
+    }
+    let all_bind = args.iter().all(|arg| matches!(arg, Arg::BindSpread(_)));
+    let all_on = args.iter().all(|arg| matches!(arg, Arg::OnSpread(_)));
+    if all_bind || all_on {
+        args.first()
+    } else {
+        None
+    }
+}
+
 enum Arg<'a> {
     Object {
         if_key: Option<&'a str>,
         pieces: StdVec<Piece<'a>>,
     },
-    Spread(&'a BindOp<'a>),
+    BindSpread(&'a BindOp<'a>),
+    OnSpread(&'a OnOp<'a>),
 }
 
 fn merge_args<'a>(
@@ -112,27 +147,19 @@ fn merge_args<'a>(
     let mut args = StdVec::new();
     let mut current = StdVec::new();
     for piece in pieces(attributes, bindings)? {
-        if let Piece::Bind(bind) = piece
-            && bind.name.is_none()
-        {
-            if !current.is_empty() {
-                args.push(Arg::Object {
-                    if_key: None,
-                    pieces: current,
-                });
-                current = StdVec::new();
+        match piece {
+            Piece::Bind(bind) if bind.name.is_none() => {
+                flush_object(&mut args, &mut current);
+                args.push(Arg::BindSpread(bind));
             }
-            args.push(Arg::Spread(bind));
-            continue;
+            Piece::On(on) if on.name.is_none() => {
+                flush_object(&mut args, &mut current);
+                args.push(Arg::OnSpread(on));
+            }
+            other => current.push(other),
         }
-        current.push(piece);
     }
-    if !current.is_empty() {
-        args.push(Arg::Object {
-            if_key: None,
-            pieces: current,
-        });
-    }
+    flush_object(&mut args, &mut current);
     if if_key.is_some() {
         match args.first_mut() {
             Some(Arg::Object { if_key: slot, .. }) => *slot = if_key,
@@ -148,6 +175,16 @@ fn merge_args<'a>(
     Ok(args)
 }
 
+fn flush_object<'a>(args: &mut StdVec<Arg<'a>>, current: &mut StdVec<Piece<'a>>) {
+    if current.is_empty() {
+        return;
+    }
+    args.push(Arg::Object {
+        if_key: None,
+        pieces: core::mem::take(current),
+    });
+}
+
 fn emit_normalize_guard(cx: &mut EmitCx<'_>, bind: &BindOp<'_>) -> Result<(), EmitError> {
     let js = js_value(bind)?;
     cx.buf.use_normalize_props();
@@ -158,5 +195,18 @@ fn emit_normalize_guard(cx: &mut EmitCx<'_>, bind: &BindOp<'_>) -> Result<(), Em
     cx.buf.push("(");
     cx.buf.push(js.source);
     cx.buf.push("))");
+    Ok(())
+}
+
+fn emit_to_handlers(cx: &mut EmitCx<'_>, on: &OnOp<'_>) -> Result<(), EmitError> {
+    let js = match on.handler {
+        Some(ExprRef::Js(js)) => js,
+        _ => return Err(EmitError::Unsupported),
+    };
+    cx.buf.use_to_handlers();
+    cx.buf.push(Buf::to_handlers_alias());
+    cx.buf.push("(");
+    cx.buf.push(js.source);
+    cx.buf.push(", true)");
     Ok(())
 }

--- a/crates/vize_ricalco/src/emit/on.rs
+++ b/crates/vize_ricalco/src/emit/on.rs
@@ -1,5 +1,6 @@
 //! Static-name `ui.on` (`@click` / `v-on:click`), including event / key /
 //! option modifiers (`withModifiers` / `withKeys`, `onClickOnce`, …).
+//! Object `v-on` lives in [`super::merge`].
 
 use alloc::vec::Vec as StdVec;
 

--- a/crates/vize_ricalco/src/emit/props.rs
+++ b/crates/vize_ricalco/src/emit/props.rs
@@ -31,6 +31,9 @@ pub(super) fn admit_bindings(
             BindingOp::Bind(bind) if bind.name.is_none() => {
                 super::merge::admit_object(bind)?;
             }
+            BindingOp::On(on) if on.name.is_none() => {
+                super::merge::admit_object_on(on)?;
+            }
             BindingOp::Bind(bind) => {
                 let name = static_bind_name(bind)?;
                 if name == "ref" || !bind.modifiers.is_empty() {
@@ -59,7 +62,7 @@ pub(super) fn admit_bindings(
 }
 
 pub(super) fn bind_patch(bindings: &[BindingOp<'_>], is_component: bool) -> Patch {
-    if super::merge::has_object_bind(bindings) {
+    if super::merge::has_object_spread(bindings) {
         return super::merge::object_patch(bindings, is_component);
     }
     let mut flag = 0i32;
@@ -110,7 +113,7 @@ pub(super) fn emit_bind_props(
     bindings: &[BindingOp<'_>],
     if_key: Option<&str>,
 ) -> Result<(), EmitError> {
-    if super::merge::has_object_bind(bindings) {
+    if super::merge::has_object_spread(bindings) {
         return super::merge::emit_spread_props(cx, attributes, bindings, if_key);
     }
     let pieces = pieces(attributes, bindings)?;

--- a/crates/vize_ricalco/tests/emit_comp.rs
+++ b/crates/vize_ricalco/tests/emit_comp.rs
@@ -162,6 +162,21 @@ fn a_dynamic_is_is_unsupported_this_installment() {
 }
 
 #[test]
+fn a_component_object_on_uses_to_handlers() {
+    assert_eq!(
+        assembled(r#"<Foo v-on="handlers" />"#),
+        pin("\
+const { resolveComponent: _resolveComponent, toHandlers: _toHandlers, openBlock: _openBlock, createBlock: _createBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, _toHandlers(handlers, true), null, 16 /* FULL_PROPS */))
+}")
+    );
+}
+
+#[test]
 fn a_component_object_bind_uses_normalize_props() {
     assert_eq!(
         assembled(r#"<Foo v-bind="obj" />"#),

--- a/crates/vize_ricalco/tests/emit_merge.rs
+++ b/crates/vize_ricalco/tests/emit_merge.rs
@@ -1,4 +1,5 @@
-//! Object-spread `v-bind` emit pins (`normalizeProps` / `mergeProps`).
+//! Object-spread `v-bind` / `v-on` emit pins (`normalizeProps` /
+//! `mergeProps` / `toHandlers`).
 
 #![allow(
     clippy::disallowed_macros,
@@ -176,10 +177,69 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
-fn a_von_object_spread_is_unsupported_this_installment() {
+fn a_static_attr_before_object_on_uses_merge_props() {
     assert_eq!(
-        refused(r#"<div v-on="handlers"></div>"#),
-        EmitError::Unsupported
+        assembled(r#"<div id="x" v-on="handlers"></div>"#),
+        "\
+const { mergeProps: _mergeProps, toHandlers: _toHandlers, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", _mergeProps({ id: \"x\" }, _toHandlers(handlers, true)), null, 16 /* FULL_PROPS */))
+}"
+    );
+}
+
+#[test]
+fn an_object_on_before_a_static_attr_keeps_author_order() {
+    assert_eq!(
+        assembled(r#"<div v-on="handlers" id="x"></div>"#),
+        "\
+const { mergeProps: _mergeProps, toHandlers: _toHandlers, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", _mergeProps(_toHandlers(handlers, true), { id: \"x\" }), null, 16 /* FULL_PROPS */))
+}"
+    );
+}
+
+#[test]
+fn a_click_beside_object_on_lists_on_click() {
+    assert_eq!(
+        assembled(r#"<div @click="h" v-on="handlers"></div>"#),
+        "\
+const { mergeProps: _mergeProps, toHandlers: _toHandlers, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", _mergeProps({ onClick: h }, _toHandlers(handlers, true)), null, 16 /* FULL_PROPS */, [\"onClick\"]))
+}"
+    );
+}
+
+#[test]
+fn an_object_bind_beside_object_on_uses_merge_props() {
+    assert_eq!(
+        assembled(r#"<div v-bind="obj" v-on="handlers"></div>"#),
+        "\
+const { mergeProps: _mergeProps, toHandlers: _toHandlers, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", _mergeProps(obj, _toHandlers(handlers, true)), null, 16 /* FULL_PROPS */))
+}"
+    );
+}
+
+#[test]
+fn a_v_if_with_object_on_merges_the_branch_key() {
+    assert_eq!(
+        assembled(r#"<div v-if="ok" v-on="handlers">x</div>"#),
+        "\
+const { mergeProps: _mergeProps, toHandlers: _toHandlers, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (ok)
+    ? (_openBlock(), _createElementBlock(\"div\", _mergeProps({ key: 0 }, _toHandlers(handlers, true)), \"x\", 16 /* FULL_PROPS */))
+    : _createCommentVNode(\"v-if\", true)
+}"
     );
 }
 

--- a/crates/vize_ricalco/tests/emit_on.rs
+++ b/crates/vize_ricalco/tests/emit_on.rs
@@ -1,4 +1,4 @@
-//! Static-name `ui.on` emit pins and the shapes this installment refuses.
+//! Static-name `ui.on` emit pins, including object `v-on` (`toHandlers`).
 
 #![allow(
     clippy::disallowed_macros,
@@ -164,10 +164,23 @@ fn a_click_native_is_unsupported_this_installment() {
 }
 
 #[test]
-fn a_von_object_spread_is_unsupported_this_installment() {
+fn an_object_on_with_modifiers_is_unsupported_this_installment() {
     assert_eq!(
-        refused(r#"<div v-on="handlers"></div>"#),
+        refused(r#"<div v-on.once="handlers"></div>"#),
         EmitError::Unsupported
+    );
+}
+
+#[test]
+fn a_lone_object_on_uses_to_handlers() {
+    assert_eq!(
+        assembled(r#"<div v-on="handlers"></div>"#),
+        "\
+const { toHandlers: _toHandlers, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", _toHandlers(handlers, true), null, 16 /* FULL_PROPS */))
+}"
     );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Emit object `v-on="handlers"` from S2 as `_toHandlers(handlers, true)` so the new DOM lane matches the shipped compiler byte-for-byte. This is the next P2-11 increment after static-name components (#4685).

Lone object `v-on` uses `toHandlers` only. Beside attrs, named events, object `v-bind`, or a `v-if` branch key it goes through `mergeProps`, keeping author order. Static-name components share the same props path. `.native` and object-on modifiers stay `Unsupported`.

Helper names moved to `emit/helper.rs` so `buf.rs` stays under the 350-line budget after adding `toHandlers` (same rank as `mergeProps`).

## Change Class

- [x] Compiler and codegen

## Behavior Reference

- Shipped `generate_von_object_exp` / `generate_props` in `crates/vize_atelier_core/src/codegen/props.rs` (always `, true` for `handlerOnly`)
- P2-11 contract in `davinci-road/plan/phase-2-tasks.md`
- Charter #23 hard byte-parity bar for DOM emit

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

Commands:

- `cargo test -p vize_ricalco --test emit_on --test emit_merge --test emit_comp --test emit_static --test emit_if --test emit_for`
- `cargo test -p vize_atelier_dom --test davinci_s2_dom` (byte-for-byte vs shipped `compile_template`, including the new object `v-on` battery)
- `node tools/davinci/croquis-consumers.mjs --check`

## Risk

Shipped compile path is unchanged. `VIZE_DAVINCI_DOM=legacy` still disarms the dual-run. Remaining Unsupported: `.native`, template fragments, filters, slots, builtins, `<component :is>`. P2-11 box stays open.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790140819&installation_model_id=422833&pr_number=4735&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4735&signature=41c2178cbda8719c5a6968dc48cd130626fbc9d5683598c73b6b3d99d33763fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for object-style event bindings on native elements and components.
  * Object event handlers now emit with dynamic event patching and preserve attribute ordering.
  * Combined object event and property bindings are supported.
  * Added coverage for conditional branches and modifier-related validation.

* **Bug Fixes**
  * Unsupported object event bindings now receive clearer validation while supported cases compile correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->