### PR TITLE
fix(matrix): accept compiler options in typecheck evidence

### DIFF
--- a/tests/tooling/fixture-tool-matrix-typechecker-programs.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typechecker-programs.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { validateTypecheckerOutput } from "../../tools/fixtures/tool-matrix-typechecker.mjs";
+
+function output(program: Record<string, unknown>) {
+  return {
+    files: [
+      {
+        file: "src/App.vue",
+        diagnostics: ["error:1:1 [TS1] synthetic error"],
+      },
+    ],
+    programs: [program],
+    errorCount: 1,
+    warningCount: 0,
+    fileCount: 1,
+  };
+}
+
+test("typechecker oracle accepts compiler options for tsconfig-backed programs", () => {
+  validateTypecheckerOutput(
+    { id: "tsconfig-program" },
+    output({
+      root: ".",
+      tsconfig: "tsconfig.json",
+      compilerOptions: {
+        module: "ESNext",
+        noUncheckedIndexedAccess: true,
+        paths: { "@/*": ["./src/*"] },
+      },
+      files: ["src/App.vue"],
+    }),
+    1,
+  );
+});
+
+test("typechecker oracle binds compiler options to tsconfig-backed programs", () => {
+  assert.throws(
+    () =>
+      validateTypecheckerOutput(
+        { id: "missing-options" },
+        output({ root: ".", tsconfig: "tsconfig.json", files: ["src/App.vue"] }),
+        1,
+      ),
+    /programs\[0\] keys must be compilerOptions, files, root, tsconfig/,
+  );
+  assert.throws(
+    () =>
+      validateTypecheckerOutput(
+        { id: "orphan-options" },
+        output({ root: ".", compilerOptions: {}, files: ["src/App.vue"] }),
+        1,
+      ),
+    /programs\[0\] keys must be files, root/,
+  );
+  assert.throws(
+    () =>
+      validateTypecheckerOutput(
+        { id: "malformed-options" },
+        output({
+          root: ".",
+          tsconfig: "tsconfig.json",
+          compilerOptions: [],
+          files: ["src/App.vue"],
+        }),
+        1,
+      ),
+    /programs\[0\]\.compilerOptions must be an object/,
+  );
+});

--- a/tools/fixtures/tool-matrix-typechecker.mjs
+++ b/tools/fixtures/tool-matrix-typechecker.mjs
@@ -4,7 +4,7 @@ import { isAbsolute } from "node:path";
 
 const outputKeys = ["errorCount", "fileCount", "files", "programs", "warningCount"];
 const fileKeys = ["diagnostics", "file"];
-const programKeys = ["files", "root", "tsconfig"];
+const programKeys = ["compilerOptions", "files", "root", "tsconfig"];
 const typecheckSourcePattern = /\.(?:vue|ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
 
 export function validateTypecheckerOutput(
@@ -70,13 +70,16 @@ export function validateTypecheckerOutput(
     const expectedKeys =
       typeof program.tsconfig === "string"
         ? programKeys
-        : programKeys.filter((key) => key !== "tsconfig");
+        : programKeys.filter((key) => key !== "compilerOptions" && key !== "tsconfig");
     requireExactKeys(program, expectedKeys, `programs[${index}]`);
     if (typeof program.root !== "string" || program.root.length === 0) {
       invalid(`programs[${index}].root must be a non-empty string`);
     }
     if ("tsconfig" in program && program.tsconfig.length === 0) {
       invalid(`programs[${index}].tsconfig must be a non-empty string`);
+    }
+    if ("compilerOptions" in program) {
+      requireRecord(program.compilerOptions, `programs[${index}].compilerOptions`);
     }
     if (!Array.isArray(program.files)) invalid(`programs[${index}].files must be an array`);
     for (const [fileIndex, file] of program.files.entries()) {


### PR DESCRIPTION
## Summary

- accept the current `vize check --format json` program schema when a tsconfig-backed program includes `compilerOptions`
- keep the matrix validator fail-closed by requiring `compilerOptions` together with `tsconfig` and rejecting non-object values
- cover accepted nested compiler options plus missing, orphaned, and malformed evidence

## Reproduction

The current-main enforce run failed 139 typechecker artifacts before divergence comparison because the validator rejected the new key:

- https://github.com/ubugeeei-prod/vize/actions/runs/32692050583
- `programs[0] keys must be files, root, tsconfig; received compilerOptions, files, root, tsconfig`

The saved `vuepress` artifact from that run passes the corrected validator unchanged.

## Validation

- `node --test tests/tooling/fixture-tool-matrix-typechecker.test.ts tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts`
- `vp run --workspace-root check:ci`
- `git diff --check`

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790140899&installation_model_id=422833&pr_number=4741&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4741&signature=365be47505f59fc68a0ea9e971bbcbe738c9770a4885182858b7c94203db9f95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation support for `compilerOptions` in typechecker programs.
  - Programs using a TypeScript configuration must provide valid object-based compiler options.
  - Programs without a TypeScript configuration now reject unsupported configuration fields.

- **Bug Fixes**
  - Improved validation errors for missing, misplaced, or incorrectly formatted compiler options.

- **Tests**
  - Added coverage for valid and invalid compiler option configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->