### PR TITLE
feat(davinci): emit named and scoped slots from S2 (P2-11)

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
@@ -1,0 +1,97 @@
+//! P2-11 named / scoped slot witness: `<template #name>` groups,
+//! component-root `v-slot` (shipped keys that `default`), dynamic
+//! names, and simple scoped params, compared **byte-for-byte**
+//! including helper usage.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+use vize_atelier_dom::compile_template;
+use vize_carton::Allocator;
+use vize_ricalco::{emit_dom_source, DOM_LANE_FLAG};
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "named_header_text",
+        "<Foo><template #header>title</template></Foo>",
+    ),
+    (
+        "named_header_interp",
+        "<Foo><template #header>hello {{ msg }}</template></Foo>",
+    ),
+    (
+        "named_then_default",
+        "<Foo><template #header>title</template>hello</Foo>",
+    ),
+    (
+        "default_then_named",
+        "<Foo>hello<template #header>title</template></Foo>",
+    ),
+    (
+        "named_header_span",
+        "<Foo><template #header><span></span></template></Foo>",
+    ),
+    (
+        "hyphenated_slot",
+        "<Foo><template #foo-bar>x</template></Foo>",
+    ),
+    (
+        "two_named",
+        "<Foo><template #header>title</template><template #footer>end</template></Foo>",
+    ),
+    ("empty_named", "<Foo><template #header></template></Foo>"),
+    ("ws_named", "<Foo><template #header>  </template></Foo>"),
+    ("component_v_slot_header", "<Foo v-slot:header>title</Foo>"),
+    ("component_v_slot", "<Foo v-slot>title</Foo>"),
+    ("component_hash_header", "<Foo #header>title</Foo>"),
+    (
+        "dynamic_slot_name",
+        r#"<Foo><template #[name]>x</template></Foo>"#,
+    ),
+    (
+        "scoped_ident",
+        r#"<Foo><template #header="p">x</template></Foo>"#,
+    ),
+    (
+        "scoped_destructure",
+        r#"<Foo><template #header="{ foo }">x</template></Foo>"#,
+    ),
+];
+
+fn shipped(src: &str) -> String {
+    let allocator = Allocator::new();
+    let (_, errors, result) = compile_template(&allocator, src);
+    assert!(errors.is_empty(), "shipped lane errors: {errors:?}");
+    format!("{}\n{}", result.preamble, result.code)
+}
+
+#[test]
+fn s2_named_slots_match_the_shipped_dom_lane_byte_for_byte() {
+    let mut compared = 0u64;
+    let mut skipped_legacy_flag = 0u64;
+    if std::env::var(DOM_LANE_FLAG).is_ok_and(|value| value == "legacy") {
+        skipped_legacy_flag += 1;
+    } else {
+        let allocator = Allocator::new();
+        for (name, src) in BATTERY {
+            let old = shipped(src);
+            let new = emit_dom_source(&allocator, src)
+                .unwrap_or_else(|error| panic!("{name}: S2 emit refused: {error:?}"))
+                .assembled();
+            assert_eq!(
+                old.as_str(),
+                new.as_str(),
+                "{name}: S2 DOM emit diverged from the shipped lane"
+            );
+            compared += 1;
+        }
+    }
+    assert_eq!(
+        (compared, skipped_legacy_flag),
+        (BATTERY.len() as u64, 0),
+        "a cfg or {DOM_LANE_FLAG}=legacy regression disarmed the dual-run"
+    );
+}

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -14,9 +14,9 @@
 //! `mergeProps`), **static-name components** (`resolveComponent` /
 //! `createVNode` / `createBlock`), and **implicit default text slots**
 //! (`withCtx` / `_: 1|2`, including native / component children,
-//! static-vnode hoists, and hoisted static `ui.for` items). Object
-//! `v-on`, `.native`, template
-//! fragments, filters, named / scoped slots, slot outlets, and builtins stay
+//! static-vnode hoists, hoisted static `ui.for` items, and named /
+//! scoped `<template>` slots). Object `v-on`, `.native`, template
+//! fragments, filters, `createSlots`, slot outlets, and builtins stay
 //! [`EmitError::Unsupported`]. The old lane stays the shipped compile
 //! path; [`super::DOM_LANE_FLAG`] is named here and *read* in the
 //! atelier_dom witness.

--- a/crates/vize_ricalco/src/emit/component.rs
+++ b/crates/vize_ricalco/src/emit/component.rs
@@ -1,11 +1,12 @@
 //! Static-name component emission (`resolveComponent` / `createVNode` /
-//! `createBlock`) plus implicit default slots (text, native HTML,
-//! nested components). Named slots, builtins, and `<component :is>`
-//! stay unsupported this installment.
+//! `createBlock`) plus slot objects from [`SlotFacts`] (implicit
+//! default, named `<template>` groups, component-root `v-slot`).
+//! `createSlots`, builtins, and `<component :is>` stay unsupported.
 
 use alloc::vec::Vec as StdVec;
 
-use vize_disegno::op::{ComponentOp, Op, Region};
+use vize_davinci::id::NodeId;
+use vize_disegno::op::{BindingOp, ComponentOp, Op, Region};
 
 use super::buf::Buf;
 use super::flag::emit_patch_flag;
@@ -36,14 +37,18 @@ pub(super) fn emit_resolves(cx: &mut EmitCx<'_>, names: &[&str]) {
     }
 }
 
-pub(super) fn emit_root(cx: &mut EmitCx<'_>, component: &ComponentOp<'_>) -> Result<(), EmitError> {
+pub(super) fn emit_root(
+    cx: &mut EmitCx<'_>,
+    component: &ComponentOp<'_>,
+    id: Option<NodeId>,
+) -> Result<(), EmitError> {
     cx.buf.use_open_block();
     cx.buf.use_create_block();
     cx.buf.push("(");
     cx.buf.push(Buf::open_block_alias());
     cx.buf.push("(), ");
     emit_call(
-        cx, component, /* block */ true, None, /* for_item */ false,
+        cx, component, /* block */ true, None, /* for_item */ false, id,
     )?;
     cx.buf.push(")");
     Ok(())
@@ -52,10 +57,11 @@ pub(super) fn emit_root(cx: &mut EmitCx<'_>, component: &ComponentOp<'_>) -> Res
 pub(super) fn emit_nested(
     cx: &mut EmitCx<'_>,
     component: &ComponentOp<'_>,
+    id: Option<NodeId>,
 ) -> Result<(), EmitError> {
     cx.buf.use_create_vnode();
     emit_call(
-        cx, component, /* block */ false, None, /* for_item */ false,
+        cx, component, /* block */ false, None, /* for_item */ false, id,
     )
 }
 
@@ -63,6 +69,7 @@ pub(super) fn emit_if_branch(
     cx: &mut EmitCx<'_>,
     component: &ComponentOp<'_>,
     key: &str,
+    id: Option<NodeId>,
 ) -> Result<(), EmitError> {
     cx.buf.use_open_block();
     cx.buf.use_create_block();
@@ -75,6 +82,7 @@ pub(super) fn emit_if_branch(
         /* block */ true,
         Some(key),
         /* for_item */ false,
+        id,
     )?;
     cx.buf.push(")");
     Ok(())
@@ -83,6 +91,7 @@ pub(super) fn emit_if_branch(
 pub(super) fn emit_for_item(
     cx: &mut EmitCx<'_>,
     component: &ComponentOp<'_>,
+    id: Option<NodeId>,
 ) -> Result<(), EmitError> {
     cx.buf.use_open_block();
     cx.buf.use_create_block();
@@ -90,7 +99,7 @@ pub(super) fn emit_for_item(
     cx.buf.push(Buf::open_block_alias());
     cx.buf.push("(), ");
     emit_call(
-        cx, component, /* block */ true, None, /* for_item */ true,
+        cx, component, /* block */ true, None, /* for_item */ true, id,
     )?;
     cx.buf.push(")");
     Ok(())
@@ -124,8 +133,12 @@ fn emit_call(
     block: bool,
     if_key: Option<&str>,
     for_item: bool,
+    id: Option<NodeId>,
 ) -> Result<(), EmitError> {
     admit(component)?;
+    let facts = id.and_then(|id| cx.facts.slot_facts.get(id));
+    let has_slots = facts.is_some();
+    let dynamic_names = facts.is_some_and(slots::has_dynamic_names);
     let alias = if block {
         Buf::create_block_alias()
     } else {
@@ -135,15 +148,17 @@ fn emit_call(
     cx.buf.push("(");
     cx.buf
         .push(asset_ident("component", component.name).as_str());
-    let has_binds = !component.bindings.is_empty();
-    let has_slots = slots::has_implicit_default(&component.children);
+    let has_binds = component
+        .bindings
+        .iter()
+        .any(|binding| !matches!(binding, BindingOp::SlotContent(_)));
     if has_slots && !has_binds && if_key.is_none() && !component.attributes.is_empty() {
         cx.buf
             .push_hoist(compact_props_object(component.attributes.iter()));
     }
     let patch = bind_patch(&component.bindings, true);
     let mut flag = patch.flag;
-    if for_item && has_slots {
+    if (for_item && has_slots) || dynamic_names {
         flag |= 1024;
     }
     let emit_flag = flag != 0;
@@ -156,9 +171,9 @@ fn emit_call(
         // even when the component has no props, slots, or patch flag.
         cx.buf.push(", null");
     }
-    if has_slots {
+    if let Some(facts) = facts {
         cx.buf.push(", ");
-        slots::emit_default_slots(cx, &component.children)?;
+        slots::emit_slots(cx, &component.children, facts)?;
     } else if emit_flag && has_props {
         cx.buf.push(", null");
     }

--- a/crates/vize_ricalco/src/emit/props.rs
+++ b/crates/vize_ricalco/src/emit/props.rs
@@ -48,6 +48,7 @@ pub(super) fn admit_bindings(
                 }
             }
             BindingOp::On(on) => admit_on(on, &mut events)?,
+            BindingOp::SlotContent(_) => {}
             _ => return Err(EmitError::Unsupported),
         }
     }
@@ -207,6 +208,7 @@ pub(super) fn pieces<'a>(
         match binding {
             BindingOp::Bind(bind) => out.push(Piece::Bind(bind)),
             BindingOp::On(on) => out.push(Piece::On(on)),
+            BindingOp::SlotContent(_) => {}
             _ => return Err(EmitError::Unsupported),
         }
     }

--- a/crates/vize_ricalco/src/emit/slots.rs
+++ b/crates/vize_ricalco/src/emit/slots.rs
@@ -1,22 +1,33 @@
-//! Implicit default-slot objects (`withCtx` / `_: 1|2`).
+//! Slot objects (`withCtx` / `_: 1|2`) from [`SlotFacts`].
 //!
-//! Text / interpolation children, native HTML, nested components, and
-//! `ui.if` / `ui.for` inside the default slot. Static element subtrees
-//! hoist as `/*#__PURE__*/ _createElementVNode(...)`. Named / scoped
-//! slots, `<template>`, slot outlets, `v-slots`, and `createSlots` stay
-//! [`EmitError::Unsupported`].
+//! Implicit default, static / dynamic named `<template>` groups, and
+//! component-root `v-slot` (shipped codegen always keys that `default`).
+//! `createSlots` (conditional / looped templates), slot outlets, and
+//! `v-slots` stay [`EmitError::Unsupported`].
 
-use vize_disegno::op::{Namespace, Op, Region, TextOp};
+use alloc::vec::Vec as StdVec;
+
+use vize_carton::String;
+use vize_disegno::op::{BindingOp, ElementOp, Namespace, Op, Region, TextOp};
 
 use super::buf::Buf;
-use super::children::emit_slot_text_child;
+use super::children::{emit_create_text_vnode, emit_slot_text_child};
 use super::hoist::{emit_hoisted_element, is_hoistable};
+use super::js::{escape_js_string, is_valid_js_identifier};
 use super::vnode::emit_array_child;
 use super::EmitCx;
 use super::EmitError;
+use crate::pass::{SlotCarrier, SlotFacts, SlotName, SlotParams};
 
 pub(super) fn has_implicit_default(children: &Region<'_>) -> bool {
     children.ops.iter().any(|op| !is_whitespace_text(op))
+}
+
+pub(super) fn has_dynamic_names(facts: &SlotFacts) -> bool {
+    facts
+        .groups
+        .iter()
+        .any(|group| matches!(group.name, SlotName::Dynamic { .. }))
 }
 
 pub(super) fn admit_default(children: &Region<'_>) -> Result<(), EmitError> {
@@ -27,6 +38,17 @@ fn walk_admit(region: &Region<'_>) -> Result<(), EmitError> {
     for op in region.ops.iter() {
         match op {
             Op::Text(_) | Op::Interpolation(_) => {}
+            Op::Element(element) if is_slot_template(element) => {
+                if element
+                    .bindings
+                    .iter()
+                    .any(|binding| !matches!(binding, BindingOp::SlotContent(_)))
+                    || !element.attributes.is_empty()
+                {
+                    return Err(EmitError::Unsupported);
+                }
+                walk_admit(&element.children)?;
+            }
             Op::Element(element) => {
                 if element.tag == "template" || element.namespace != Namespace::Html {
                     return Err(EmitError::Unsupported);
@@ -46,40 +68,45 @@ fn walk_admit(region: &Region<'_>) -> Result<(), EmitError> {
     Ok(())
 }
 
-pub(super) fn emit_default_slots(
+pub(super) fn emit_slots(
     cx: &mut EmitCx<'_>,
     children: &Region<'_>,
+    facts: &SlotFacts,
 ) -> Result<(), EmitError> {
+    if facts.groups.iter().any(|group| group.name.text() == "_") {
+        return Err(EmitError::Unsupported);
+    }
     cx.buf.use_with_ctx();
+    cx.buf.indent();
+    cx.buf.indent();
+    let mut buckets: StdVec<StdVec<String>> = facts.groups.iter().map(|_| StdVec::new()).collect();
+    collect_pieces(cx, children, facts, &mut buckets)?;
+    cx.buf.deindent();
+    cx.buf.deindent();
     cx.buf.push("{");
     cx.buf.indent();
-    cx.buf.newline();
-    cx.buf.push("default: ");
-    cx.buf.push(Buf::with_ctx_alias());
-    cx.buf.push("(() => [");
-    cx.buf.indent();
-    let skip_ws = children
-        .ops
-        .iter()
-        .any(|op| !matches!(op, Op::Text(_) | Op::Interpolation(_)));
-    let mut first = true;
-    for op in children.ops.iter() {
-        if skip_ws && is_whitespace_text(op) {
-            let _id = cx.walk.mint();
-            continue;
-        }
-        if !first {
-            cx.buf.push(",");
-        }
+    for (i, group) in facts.groups.iter().enumerate() {
         cx.buf.newline();
-        first = false;
-        emit_slot_child(cx, op)?;
+        emit_slot_key(cx, group.carrier, &group.name)?;
+        cx.buf.push(": ");
+        cx.buf.push(Buf::with_ctx_alias());
+        cx.buf.push("(");
+        emit_slot_params(&mut cx.buf, &group.params);
+        cx.buf.push(" => [");
+        cx.buf.indent();
+        for (j, piece) in buckets[i].iter().enumerate() {
+            if j > 0 {
+                cx.buf.push(",");
+            }
+            cx.buf.newline();
+            cx.buf.push(piece.as_str());
+        }
+        cx.buf.deindent();
+        cx.buf.newline();
+        cx.buf.push("]),");
     }
-    cx.buf.deindent();
     cx.buf.newline();
-    cx.buf.push("]),");
-    cx.buf.newline();
-    if cx.in_v_for {
+    if cx.in_v_for || has_dynamic_names(facts) {
         cx.buf.push("_: 2 /* DYNAMIC */");
     } else {
         cx.buf.push("_: 1 /* STABLE */");
@@ -90,6 +117,143 @@ pub(super) fn emit_default_slots(
     Ok(())
 }
 
+fn collect_pieces(
+    cx: &mut EmitCx<'_>,
+    children: &Region<'_>,
+    facts: &SlotFacts,
+    buckets: &mut [StdVec<String>],
+) -> Result<(), EmitError> {
+    let on_component = facts
+        .groups
+        .iter()
+        .any(|group| matches!(group.carrier, SlotCarrier::Component));
+    let skip_ws = children
+        .ops
+        .iter()
+        .any(|op| !matches!(op, Op::Text(_) | Op::Interpolation(_)));
+    for op in children.ops.iter() {
+        if skip_ws && is_whitespace_text(op) {
+            let _id = cx.walk.mint();
+            continue;
+        }
+        match op {
+            Op::Element(element) if is_slot_template(element) => {
+                let id = cx.walk.mint();
+                cx.walk.skip(element.bindings.len());
+                let Some(idx) = facts.groups.iter().position(
+                    |group| matches!(group.carrier, SlotCarrier::Template(tid) if tid == id),
+                ) else {
+                    return Err(EmitError::Unsupported);
+                };
+                emit_template_pieces(cx, &element.children, &mut buckets[idx])?;
+            }
+            _ => {
+                let idx = facts.groups.iter().position(|group| {
+                    matches!(
+                        group.carrier,
+                        SlotCarrier::Implicit | SlotCarrier::Component
+                    ) && (on_component || matches!(group.carrier, SlotCarrier::Implicit))
+                });
+                let Some(idx) = idx else {
+                    return Err(EmitError::Unsupported);
+                };
+                buckets[idx].push(capture_child(cx, op)?);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn emit_template_pieces(
+    cx: &mut EmitCx<'_>,
+    children: &Region<'_>,
+    bucket: &mut StdVec<String>,
+) -> Result<(), EmitError> {
+    if children.ops.iter().all(is_whitespace_text) {
+        for op in children.ops.iter() {
+            let _id = cx.walk.mint();
+            let _ = op;
+        }
+        return Ok(());
+    }
+    if !children.ops.is_empty()
+        && children
+            .ops
+            .iter()
+            .all(|op| matches!(op, Op::Text(_) | Op::Interpolation(_)))
+    {
+        bucket.push(capture(cx, |cx| {
+            emit_create_text_vnode(cx, children.ops.as_slice())
+        })?);
+        return Ok(());
+    }
+    let skip_ws = children
+        .ops
+        .iter()
+        .any(|op| !matches!(op, Op::Text(_) | Op::Interpolation(_)));
+    for op in children.ops.iter() {
+        if skip_ws && is_whitespace_text(op) {
+            let _id = cx.walk.mint();
+            continue;
+        }
+        bucket.push(capture_child(cx, op)?);
+    }
+    Ok(())
+}
+
+fn emit_slot_key(
+    cx: &mut EmitCx<'_>,
+    carrier: SlotCarrier,
+    name: &SlotName,
+) -> Result<(), EmitError> {
+    if matches!(carrier, SlotCarrier::Component) {
+        cx.buf.push("default");
+        return Ok(());
+    }
+    match name {
+        SlotName::Static { text, .. } if is_valid_js_identifier(text.as_str()) => {
+            cx.buf.push(text.as_str());
+        }
+        SlotName::Static { text, .. } => {
+            cx.buf.push("\"");
+            cx.buf.push(escape_js_string(text.as_str()).as_str());
+            cx.buf.push("\"");
+        }
+        SlotName::Dynamic { text } => {
+            cx.buf.push("[");
+            cx.buf.push(text.as_str());
+            cx.buf.push("]");
+        }
+    }
+    Ok(())
+}
+
+fn emit_slot_params(buf: &mut Buf, params: &SlotParams) {
+    match params {
+        SlotParams::Absent => buf.push("()"),
+        SlotParams::Scoped { text, .. } => {
+            buf.push("(");
+            buf.push(text.as_str());
+            buf.push(")");
+        }
+    }
+}
+
+fn capture_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<String, EmitError> {
+    capture(cx, |cx| emit_slot_child(cx, op))
+}
+
+fn capture(
+    cx: &mut EmitCx<'_>,
+    write: impl FnOnce(&mut EmitCx<'_>) -> Result<(), EmitError>,
+) -> Result<String, EmitError> {
+    let start = cx.buf.code.len();
+    write(cx)?;
+    let piece = String::from(&cx.buf.code.as_str()[start..]);
+    cx.buf.code.truncate(start);
+    Ok(piece)
+}
+
 fn emit_slot_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> {
     match op {
         Op::Text(_) | Op::Interpolation(_) => emit_slot_text_child(cx, op),
@@ -97,6 +261,14 @@ fn emit_slot_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> {
         Op::Element(_) | Op::Component(_) | Op::If(_) | Op::For(_) => emit_array_child(cx, op),
         Op::Slot(_) => Err(EmitError::Unsupported),
     }
+}
+
+fn is_slot_template(element: &ElementOp<'_>) -> bool {
+    element.tag == "template"
+        && element
+            .bindings
+            .iter()
+            .any(|binding| matches!(binding, BindingOp::SlotContent(_)))
 }
 
 fn is_whitespace_text(op: &Op<'_>) -> bool {

--- a/crates/vize_ricalco/src/emit/vfor.rs
+++ b/crates/vize_ricalco/src/emit/vfor.rs
@@ -83,7 +83,7 @@ pub(super) fn emit_for(cx: &mut EmitCx<'_>, for_op: &ForOp<'_>) -> Result<(), Em
             Ok(())
         }
         [Op::Element(element)] => super::emit_for_item_call(cx, element, stable),
-        [Op::Component(component)] => super::component::emit_for_item(cx, component),
+        [Op::Component(component)] => super::component::emit_for_item(cx, component, _id),
         _ => Err(EmitError::Unsupported),
     };
     cx.in_v_for = prev_in_v_for;

--- a/crates/vize_ricalco/src/emit/vif.rs
+++ b/crates/vize_ricalco/src/emit/vif.rs
@@ -5,10 +5,10 @@ use vize_davinci::id::NodeId;
 use vize_disegno::expr::ExprRef;
 use vize_disegno::op::{IfBranch, IfOp, Op};
 
-use super::EmitCx;
-use super::EmitError;
 use super::buf::Buf;
 use super::js::escape_js_string;
+use super::EmitCx;
+use super::EmitError;
 use crate::pass::{BranchKeyKind, IfFacts};
 
 pub(super) fn emit_if(
@@ -114,7 +114,7 @@ fn emit_branch(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<
         [Op::Component(component)] => {
             let _id = cx.walk.mint();
             cx.walk.skip(component.bindings.len());
-            super::component::emit_if_branch(cx, component, key)
+            super::component::emit_if_branch(cx, component, key, _id)
         }
         _ => Err(EmitError::Unsupported),
     }

--- a/crates/vize_ricalco/src/emit/vnode.rs
+++ b/crates/vize_ricalco/src/emit/vnode.rs
@@ -40,7 +40,7 @@ pub(super) fn emit_root(cx: &mut EmitCx<'_>, root: &Region<'_>) -> Result<(), Em
             Op::For(for_op) => super::emit_for_op(cx, for_op)?,
             Op::Component(component) => {
                 cx.walk.skip(component.bindings.len());
-                super::component::emit_root(cx, component)?;
+                super::component::emit_root(cx, component, id)?;
             }
             _ => return Err(EmitError::Unsupported),
         }
@@ -338,7 +338,7 @@ pub(super) fn emit_array_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), E
         }
         Op::Component(component) => {
             cx.walk.skip(component.bindings.len());
-            super::component::emit_nested(cx, component)
+            super::component::emit_nested(cx, component, id)
         }
         Op::If(if_op) => super::emit_if_op(cx, if_op, id),
         Op::For(for_op) => super::emit_for_op(cx, for_op),

--- a/crates/vize_ricalco/tests/emit_named.rs
+++ b/crates/vize_ricalco/tests/emit_named.rs
@@ -1,0 +1,183 @@
+//! Named / scoped `<template>` slot emit pins (`withCtx` keys / `_`).
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use support::with_transformed;
+use vize_ricalco::{emit_dom, EmitError};
+
+fn assembled(source: &str) -> String {
+    with_transformed(source, |lowered, _folio, facts, _budget| {
+        emit_dom(lowered, facts)
+            .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
+            .assembled()
+            .to_string()
+    })
+}
+
+/// Vue's extra `newline()` after `genAssets` leaves indent on the blank line.
+fn pin(visual: &str) -> String {
+    visual.replace(")\n\n  return", ")\n  \n  return")
+}
+
+fn refused(source: &str) -> EmitError {
+    with_transformed(source, |lowered, _folio, facts, _budget| {
+        emit_dom(lowered, facts).expect_err("expected Unsupported")
+    })
+}
+
+#[test]
+fn a_named_header_slot_uses_with_ctx() {
+    assert_eq!(
+        assembled("<Foo><template #header>title</template></Foo>"),
+        pin("\
+const { resolveComponent: _resolveComponent, openBlock: _openBlock, createBlock: _createBlock, createTextVNode: _createTextVNode, withCtx: _withCtx } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, null, {
+    header: _withCtx(() => [
+      _createTextVNode(\"title\")
+    ]),
+    _: 1 /* STABLE */
+  }))
+}")
+    );
+}
+
+#[test]
+fn a_named_slot_concatenates_text_and_interpolation() {
+    assert_eq!(
+        assembled("<Foo><template #header>hello {{ msg }}</template></Foo>"),
+        pin("\
+const { resolveComponent: _resolveComponent, toDisplayString: _toDisplayString, openBlock: _openBlock, createBlock: _createBlock, createTextVNode: _createTextVNode, withCtx: _withCtx } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, null, {
+    header: _withCtx(() => [
+      _createTextVNode(\"hello \" + _toDisplayString(msg), 1 /* TEXT */)
+    ]),
+    _: 1 /* STABLE */
+  }))
+}")
+    );
+}
+
+#[test]
+fn named_and_implicit_default_share_the_object() {
+    assert_eq!(
+        assembled("<Foo>hello<template #header>title</template></Foo>"),
+        pin("\
+const { resolveComponent: _resolveComponent, openBlock: _openBlock, createBlock: _createBlock, createTextVNode: _createTextVNode, withCtx: _withCtx } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, null, {
+    header: _withCtx(() => [
+      _createTextVNode(\"title\")
+    ]),
+    default: _withCtx(() => [
+      _createTextVNode(\"hello\")
+    ]),
+    _: 1 /* STABLE */
+  }))
+}")
+    );
+}
+
+#[test]
+fn a_hyphenated_slot_name_is_quoted() {
+    assert_eq!(
+        assembled("<Foo><template #foo-bar>x</template></Foo>"),
+        pin("\
+const { resolveComponent: _resolveComponent, openBlock: _openBlock, createBlock: _createBlock, createTextVNode: _createTextVNode, withCtx: _withCtx } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, null, {
+    \"foo-bar\": _withCtx(() => [
+      _createTextVNode(\"x\")
+    ]),
+    _: 1 /* STABLE */
+  }))
+}")
+    );
+}
+
+#[test]
+fn a_dynamic_slot_name_sets_dynamic_slots() {
+    assert_eq!(
+        assembled(r#"<Foo><template #[name]>x</template></Foo>"#),
+        pin("\
+const { resolveComponent: _resolveComponent, openBlock: _openBlock, createBlock: _createBlock, createTextVNode: _createTextVNode, withCtx: _withCtx } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, null, {
+    [name]: _withCtx(() => [
+      _createTextVNode(\"x\")
+    ]),
+    _: 2 /* DYNAMIC */
+  }, 1024 /* DYNAMIC_SLOTS */))
+}")
+    );
+}
+
+#[test]
+fn a_scoped_slot_passes_the_param() {
+    assert_eq!(
+        assembled(r#"<Foo><template #header="p">x</template></Foo>"#),
+        pin("\
+const { resolveComponent: _resolveComponent, openBlock: _openBlock, createBlock: _createBlock, createTextVNode: _createTextVNode, withCtx: _withCtx } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, null, {
+    header: _withCtx((p) => [
+      _createTextVNode(\"x\")
+    ]),
+    _: 1 /* STABLE */
+  }))
+}")
+    );
+}
+
+#[test]
+fn a_component_root_v_slot_keys_default() {
+    assert_eq!(
+        assembled("<Foo v-slot:header>title</Foo>"),
+        pin("\
+const { resolveComponent: _resolveComponent, openBlock: _openBlock, createBlock: _createBlock, createTextVNode: _createTextVNode, withCtx: _withCtx } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, null, {
+    default: _withCtx(() => [
+      _createTextVNode(\"title\")
+    ]),
+    _: 1 /* STABLE */
+  }))
+}")
+    );
+}
+
+#[test]
+fn a_v_if_named_template_is_unsupported_this_installment() {
+    assert_eq!(
+        refused(r#"<Foo><template #header v-if="ok">x</template></Foo>"#),
+        EmitError::Unsupported
+    );
+}

--- a/crates/vize_ricalco/tests/emit_slots.rs
+++ b/crates/vize_ricalco/tests/emit_slots.rs
@@ -298,9 +298,9 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
-fn named_slot_templates_are_unsupported_this_installment() {
+fn create_slots_templates_are_unsupported_this_installment() {
     assert_eq!(
-        refused("<Foo><template #header>x</template></Foo>"),
+        refused(r#"<Foo><template #header v-if="ok">x</template></Foo>"#),
         EmitError::Unsupported
     );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Drive component slot objects from `SlotFacts` instead of walking children as a single implicit default.
- Static named `<template #header>` keys, hyphenated quoted names, dynamic `#[name]` (`_: 2` + `1024 /* DYNAMIC_SLOTS */`), and scoped params (`_withCtx((p) => …)` / destructure text).
- Template children that are all text/interpolation concatenate (`"hello " + _toDisplayString(msg)`), matching shipped `generate_slot_children`. Implicit default children stay separate vnodes.
- Component-root `v-slot` / `#header` matches the shipped lane: the key is always `default`.
- `createSlots` (v-if / v-for on a slot template), slot outlets, and `v-slots` stay `Unsupported`.
- Stacked on #4744 (default-slot element children).

## Change Class

- [x] Compiler and codegen

## Behavior Reference

- Vue / shipped `codegen/slots/generate.rs` (`compile_template` in `vize_atelier_dom`)
- P2-9 `SlotFacts` grouping (`vize_ricalco::pass::vslot`)
- P2-11: DOM backend on S2

## Verification Evidence

- [x] `cargo test -p vize_ricalco --test emit_named --test emit_slots --test emit_comp --test emit_for`
- [x] `cargo test -p vize_atelier_dom --test davinci_s2_dom --test davinci_s2_slots`
- [x] `cargo clippy -p vize_ricalco --all-targets -- -D warnings`
- [ ] CI Check on this PR

## Risk

- Follow-up: `createSlots`, slot outlets (`_: 3 FORWARDED`), `v-slots` spread, builtins, `<component :is>`.
- Merge after #4744; this branch is stacked on `cursor/p2-11-default-slot-elements-c525`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790142477&installation_model_id=422833&pr_number=4745&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4745&signature=69db505f92d112c31876a63dcee85f1e7fcbe0614b2be2e956128951dec21467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->