### PR TITLE
feat(davinci): emit renderSlot outlets and FORWARDED slots (P2-11)

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_outlets.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_outlets.rs
@@ -1,0 +1,80 @@
+//! P2-11 slot-outlet witness: `_renderSlot`, fallback, camelized props,
+//! `v-if` / `v-for` outlets, and `_: 3 /* FORWARDED */`, compared
+//! **byte-for-byte** including helper usage.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+use vize_atelier_dom::compile_template;
+use vize_carton::Allocator;
+use vize_ricalco::{emit_dom_source, DOM_LANE_FLAG};
+
+const BATTERY: &[(&str, &str)] = &[
+    ("bare", "<slot></slot>"),
+    ("self_close", "<slot/>"),
+    ("named", r#"<slot name="header"></slot>"#),
+    ("dynamic_name", r#"<slot :name="n"></slot>"#),
+    ("fallback_text", "<slot>fallback</slot>"),
+    ("fallback_interp", "<slot>hello {{ msg }}</slot>"),
+    ("fallback_span", "<slot><span></span></slot>"),
+    ("static_prop", r#"<slot foo="bar"></slot>"#),
+    ("hyphen_prop", r#"<slot foo-bar="x"></slot>"#),
+    ("bind_prop", r#"<slot :foo="bar"></slot>"#),
+    ("bind_hyphen", r#"<slot :foo-bar="x"></slot>"#),
+    ("prop_and_fallback", r#"<slot foo="bar">fb</slot>"#),
+    ("object_bind", r#"<slot v-bind="obj"></slot>"#),
+    ("in_div", "<div><slot></slot></div>"),
+    ("forwarded", "<Foo><slot></slot></Foo>"),
+    ("forwarded_nested", "<Foo><div><slot></slot></div></Foo>"),
+    ("vif", r#"<slot v-if="ok"></slot>"#),
+    ("vif_fallback", r#"<slot v-if="ok">x</slot>"#),
+    ("vif_else", r#"<slot v-if="a"></slot><slot v-else></slot>"#),
+    ("vfor", r#"<slot v-for="i in n"></slot>"#),
+    ("vfor_fallback", r#"<slot v-for="i in n">x</slot>"#),
+    (
+        "scoped_forwarded",
+        r#"<Bar v-slot="p"><Foo><slot></slot></Foo></Bar>"#,
+    ),
+    (
+        "named_mixed_props",
+        r#"<slot name="header" foo="1" :bar="b"></slot>"#,
+    ),
+];
+
+fn shipped(src: &str) -> String {
+    let allocator = Allocator::new();
+    let (_, errors, result) = compile_template(&allocator, src);
+    assert!(errors.is_empty(), "shipped lane errors: {errors:?}");
+    format!("{}\n{}", result.preamble, result.code)
+}
+
+#[test]
+fn s2_slot_outlets_match_the_shipped_dom_lane_byte_for_byte() {
+    let mut compared = 0u64;
+    let mut skipped_legacy_flag = 0u64;
+    if std::env::var(DOM_LANE_FLAG).is_ok_and(|value| value == "legacy") {
+        skipped_legacy_flag += 1;
+    } else {
+        let allocator = Allocator::new();
+        for (name, src) in BATTERY {
+            let old = shipped(src);
+            let new = emit_dom_source(&allocator, src)
+                .unwrap_or_else(|error| panic!("{name}: S2 emit refused: {error:?}"))
+                .assembled();
+            assert_eq!(
+                old.as_str(),
+                new.as_str(),
+                "{name}: S2 DOM emit diverged from the shipped lane"
+            );
+            compared += 1;
+        }
+    }
+    assert_eq!(
+        (compared, skipped_legacy_flag),
+        (BATTERY.len() as u64, 0),
+        "a cfg or {DOM_LANE_FLAG}=legacy regression disarmed the dual-run"
+    );
+}

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -15,9 +15,10 @@
 //! `createVNode` / `createBlock`), and **implicit default text slots**
 //! (`withCtx` / `_: 1|2`, including native / component children,
 //! static-vnode hoists, hoisted static `ui.for` items, named / scoped
-//! `<template>` slots, and `createSlots` for `v-if` / `v-for` slot
-//! templates). Object `v-on`, `.native`, template fragments, filters,
-//! slot outlets, and builtins stay [`EmitError::Unsupported`]. The old
+//! `<template>` slots, `createSlots` for `v-if` / `v-for` slot
+//! templates, and **slot outlets** (`renderSlot` / `_: 3 FORWARDED`)).
+//! Object `v-on`, `.native`, template fragments, filters, and builtins
+//! stay [`EmitError::Unsupported`]. The old
 //! lane stays the shipped compile path; [`super::DOM_LANE_FLAG`] is
 //! named here and *read* in the atelier_dom witness.
 
@@ -41,6 +42,8 @@ mod js;
 mod merge;
 #[path = "emit/on.rs"]
 mod on;
+#[path = "emit/outlet.rs"]
+mod outlet;
 #[path = "emit/props.rs"]
 mod props;
 #[path = "emit/slots.rs"]
@@ -56,7 +59,7 @@ use vize_carton::{Allocator, String};
 use vize_davinci::diagnostic::Severity;
 use vize_davinci::id::NodeId;
 use vize_davinci::pass::BudgetObserver;
-use vize_disegno::op::{ElementOp, ForOp, IfOp};
+use vize_disegno::op::{ElementOp, ForOp, IfOp, Op, Region};
 use vize_sinopia::parse;
 
 use crate::lower::{Lowered, lower};
@@ -64,7 +67,40 @@ use crate::pass::walk::PageWalk;
 use crate::pass::{S2Facts, run_transform};
 
 use self::buf::Buf;
+use self::helper::Helper;
 use self::vnode::emit_root;
+
+/// Transform visit order for helpers the shipped lane parks on
+/// `root.helpers` (`CreateElementVNode` on native elements,
+/// `ResolveComponent` on components, `RenderSlot` on outlets).
+fn prefer_transform_helpers(buf: &mut Buf, region: &Region<'_>) {
+    for op in region.ops.iter() {
+        match op {
+            Op::Element(element) => {
+                buf.prefer(Helper::CreateElementVNode);
+                prefer_transform_helpers(buf, &element.children);
+            }
+            Op::Component(component) => {
+                buf.prefer(Helper::ResolveComponent);
+                prefer_transform_helpers(buf, &component.children);
+            }
+            Op::Slot(slot) => {
+                buf.prefer(Helper::RenderSlot);
+                prefer_transform_helpers(buf, &slot.fallback);
+            }
+            Op::If(if_op) => {
+                for branch in if_op.branches.iter() {
+                    prefer_transform_helpers(buf, &branch.region);
+                }
+            }
+            Op::For(for_op) => {
+                buf.prefer(Helper::RenderList);
+                prefer_transform_helpers(buf, &for_op.region);
+            }
+            Op::Text(_) | Op::Interpolation(_) => {}
+        }
+    }
+}
 
 fn emit_if_op(cx: &mut EmitCx<'_>, if_op: &IfOp<'_>, id: Option<NodeId>) -> Result<(), EmitError> {
     vif::emit_if(cx, if_op, id)
@@ -100,6 +136,9 @@ struct EmitCx<'facts> {
     if_branch_key: u32,
     /// Slot objects inside `v-for` carry `_: 2 /* DYNAMIC */`.
     in_v_for: bool,
+    /// Nested components inside a scoped `withCtx` treat forwarded
+    /// outlets as `_: 2` + `DYNAMIC_SLOTS` (Vue `has_slot_params`).
+    slot_param_depth: u32,
 }
 
 /// One DOM render module, split the way the shipped codegen splits it
@@ -152,7 +191,9 @@ pub fn emit_dom(lowered: &Lowered<'_>, facts: &S2Facts) -> Result<DomEmit, EmitE
         walk: PageWalk::new(),
         if_branch_key: 0,
         in_v_for: false,
+        slot_param_depth: 0,
     };
+    prefer_transform_helpers(&mut cx.buf, &lowered.root);
     cx.buf
         .push("function render(_ctx, _cache, $props, $setup, $data, $options) {");
     cx.buf.indent();

--- a/crates/vize_ricalco/src/emit/buf.rs
+++ b/crates/vize_ricalco/src/emit/buf.rs
@@ -11,6 +11,8 @@ pub(super) struct Buf {
     pub code: String,
     indent: u32,
     used: u32,
+    /// Transform-analogue registration order (`root.helpers`).
+    preferred: StdVec<Helper>,
     /// Compact static-props / vnode RHS values, `_hoisted_1` first.
     hoists: StdVec<String>,
 }
@@ -21,6 +23,7 @@ impl Buf {
             code: String::default(),
             indent: 0,
             used: 0,
+            preferred: StdVec::new(),
             hoists: StdVec::new(),
         }
     }
@@ -48,6 +51,13 @@ impl Buf {
 
     fn mark(&mut self, helper: Helper) {
         self.used |= helper.bit();
+    }
+
+    pub(super) fn prefer(&mut self, helper: Helper) {
+        if self.preferred.iter().any(|seen| seen.bit() == helper.bit()) {
+            return;
+        }
+        self.preferred.push(helper);
     }
 
     pub(super) fn use_to_display_string(&mut self) {
@@ -100,6 +110,9 @@ impl Buf {
     }
     pub(super) fn use_create_vnode(&mut self) {
         self.mark(Helper::CreateVNode);
+    }
+    pub(super) fn use_render_slot(&mut self) {
+        self.mark(Helper::RenderSlot);
     }
     pub(super) fn use_create_block(&mut self) {
         self.mark(Helper::CreateBlock);
@@ -179,6 +192,10 @@ impl Buf {
         Helper::CreateVNode.alias()
     }
 
+    pub(super) fn render_slot_alias() -> &'static str {
+        Helper::RenderSlot.alias()
+    }
+
     pub(super) fn create_block_alias() -> &'static str {
         Helper::CreateBlock.alias()
     }
@@ -206,30 +223,39 @@ impl Buf {
         "_hoisted_1"
     }
 
+    fn ordered_helpers(&self) -> StdVec<Helper> {
+        let mut listed = StdVec::new();
+        let mut bits = 0u32;
+        let mut push = |helper: Helper| {
+            if self.used & helper.bit() == 0 || bits & helper.bit() != 0 {
+                return;
+            }
+            bits |= helper.bit();
+            listed.push(helper);
+        };
+        for helper in self.preferred.iter().copied() {
+            push(helper);
+        }
+        for helper in Helper::ALL {
+            push(helper);
+        }
+        listed.sort_by_key(|helper| helper.rank());
+        listed
+    }
+
     /// Function-mode preamble, helpers in import-rank order, then any
     /// root static-props hoist (the shipped codegen appends hoists to
     /// the helper preamble).
     pub(super) fn preamble(&self) -> String {
-        let listed: [Helper; 20] = Helper::ALL;
-        let mut n = 0;
-        for helper in listed {
-            if self.used & helper.bit() != 0 {
-                n += 1;
-            }
-        }
-        if n == 0 {
+        let listed = self.ordered_helpers();
+        if listed.is_empty() {
             return String::default();
         }
         let mut preamble = String::from("const { ");
-        let mut first = true;
-        for helper in listed {
-            if self.used & helper.bit() == 0 {
-                continue;
-            }
-            if !first {
+        for (i, helper) in listed.iter().enumerate() {
+            if i > 0 {
                 preamble.push_str(", ");
             }
-            first = false;
             preamble.push_str(helper.name());
             preamble.push_str(": ");
             preamble.push_str(helper.alias());

--- a/crates/vize_ricalco/src/emit/children.rs
+++ b/crates/vize_ricalco/src/emit/children.rs
@@ -7,10 +7,10 @@ use vize_davinci::id::NodeId;
 use vize_disegno::expr::{ExprRef, OpaqueReason};
 use vize_disegno::op::{InterpolationOp, Op, Region};
 
-use super::EmitCx;
-use super::EmitError;
 use super::buf::Buf;
 use super::js::escape_js_string;
+use super::EmitCx;
+use super::EmitError;
 use crate::lower::TextPart;
 
 pub(super) fn emit_text_like(cx: &mut EmitCx<'_>, ops: &[Op<'_>]) -> Result<(), EmitError> {
@@ -90,12 +90,26 @@ fn emit_quoted_text(cx: &mut EmitCx<'_>, content: &str) {
     cx.buf.push("\"");
 }
 
-fn emit_to_display_string(cx: &mut EmitCx<'_>, source: &str) {
+pub(super) fn emit_to_display_string(cx: &mut EmitCx<'_>, source: &str) {
     cx.buf.use_to_display_string();
     cx.buf.push(Buf::to_display_string_alias());
     cx.buf.push("(");
     cx.buf.push(source);
     cx.buf.push(")");
+}
+
+/// Static `_createTextVNode("…")` with no walk mint (compound fallback
+/// parts already minted their interpolation op).
+pub(super) fn emit_plain_text_vnode(cx: &mut EmitCx<'_>, content: &str) {
+    cx.buf.use_create_text();
+    cx.buf.push(Buf::create_text_alias());
+    if content == " " {
+        cx.buf.push("()");
+        return;
+    }
+    cx.buf.push("(\"");
+    cx.buf.push(escape_js_string(content).as_str());
+    cx.buf.push("\")");
 }
 
 /// Array-form text run: `_createTextVNode(...)`, matching

--- a/crates/vize_ricalco/src/emit/component.rs
+++ b/crates/vize_ricalco/src/emit/component.rs
@@ -12,10 +12,10 @@ use vize_disegno::op::{BindingOp, ComponentOp, Op, Region};
 use super::buf::Buf;
 use super::create_slots;
 use super::flag::emit_patch_flag;
+use super::hoist::compact_props_object;
 use super::js::asset_ident;
 use super::props::{admit_bindings, bind_patch, emit_bind_props};
 use super::slots;
-use super::vnode::compact_props_object;
 use super::EmitCx;
 use super::EmitError;
 
@@ -161,7 +161,10 @@ fn emit_call(
     }
     let patch = bind_patch(&component.bindings, true);
     let mut flag = patch.flag;
-    if (for_item && has_slots) || dynamic_names {
+    if (for_item && has_slots)
+        || dynamic_names
+        || (cx.slot_param_depth > 0 && super::outlet::has_forwarded_outlet(&component.children))
+    {
         flag |= 1024;
     }
     let emit_flag = flag != 0;

--- a/crates/vize_ricalco/src/emit/create_slots.rs
+++ b/crates/vize_ricalco/src/emit/create_slots.rs
@@ -222,7 +222,10 @@ fn emit_slot_object(
     cx.buf.push(" => [");
     let mut pieces = StdVec::new();
     cx.buf.indent();
-    emit_template_pieces(cx, &element.children, &mut pieces)?;
+    let scoped = matches!(&content.params, Some(expr) if !expr.source().is_empty());
+    super::outlet::with_slot_params(cx, scoped, |cx| {
+        emit_template_pieces(cx, &element.children, &mut pieces)
+    })?;
     for (i, piece) in pieces.iter().enumerate() {
         if i > 0 {
             cx.buf.push(",");

--- a/crates/vize_ricalco/src/emit/helper.rs
+++ b/crates/vize_ricalco/src/emit/helper.rs
@@ -1,8 +1,8 @@
 //! Vue helpers this installment can mention, ranked the way
 //! `vue_helper_import_rank` orders the shipped preamble. Same-rank
-//! helpers keep [`Helper::ALL`] order (`createElementVNode` before
-//! `createVNode`, `createBlock` before `createElementBlock`,
-//! `withCtx` after `renderList`).
+//! helpers follow transform-first registration, then emit order
+//! (`Buf::prefer` then first `use_*`), matching `root.helpers`
+//! then `used_helpers`.
 
 #[derive(Clone, Copy)]
 pub(super) enum Helper {
@@ -10,6 +10,7 @@ pub(super) enum Helper {
     WithKeys,
     WithModifiers,
     ToDisplayString,
+    RenderSlot,
     CreateElementVNode,
     CreateVNode,
     NormalizeClass,
@@ -29,11 +30,12 @@ pub(super) enum Helper {
 }
 
 impl Helper {
-    pub(super) const ALL: [Self; 20] = [
+    pub(super) const ALL: [Self; 21] = [
         Self::ResolveComponent,
         Self::WithKeys,
         Self::WithModifiers,
         Self::ToDisplayString,
+        Self::RenderSlot,
         Self::CreateElementVNode,
         Self::CreateVNode,
         Self::NormalizeClass,
@@ -51,6 +53,25 @@ impl Helper {
         Self::CreateSlots,
         Self::WithCtx,
     ];
+
+    pub(super) const fn rank(self) -> u8 {
+        match self {
+            Self::ResolveComponent => 0,
+            Self::WithKeys | Self::WithModifiers => 2,
+            Self::ToDisplayString => 3,
+            Self::RenderSlot | Self::CreateElementVNode | Self::CreateVNode => 4,
+            Self::NormalizeClass
+            | Self::NormalizeStyle
+            | Self::NormalizeProps
+            | Self::GuardReactiveProps
+            | Self::MergeProps => 5,
+            Self::OpenBlock => 6,
+            Self::CreateBlock | Self::CreateElementBlock => 7,
+            Self::Fragment => 8,
+            Self::CreateComment | Self::CreateText => 9,
+            Self::RenderList | Self::CreateSlots | Self::WithCtx => 10,
+        }
+    }
 
     pub(super) const fn bit(self) -> u32 {
         match self {
@@ -72,6 +93,7 @@ impl Helper {
             Self::ResolveComponent => 32768,
             Self::CreateVNode => 65536,
             Self::CreateBlock => 131072,
+            Self::RenderSlot => 1_048_576,
             Self::CreateSlots => 524288,
             Self::WithCtx => 262144,
         }
@@ -85,6 +107,7 @@ impl Helper {
             Self::ToDisplayString => "toDisplayString",
             Self::CreateElementVNode => "createElementVNode",
             Self::CreateVNode => "createVNode",
+            Self::RenderSlot => "renderSlot",
             Self::NormalizeClass => "normalizeClass",
             Self::NormalizeStyle => "normalizeStyle",
             Self::NormalizeProps => "normalizeProps",
@@ -110,6 +133,7 @@ impl Helper {
             Self::ToDisplayString => "_toDisplayString",
             Self::CreateElementVNode => "_createElementVNode",
             Self::CreateVNode => "_createVNode",
+            Self::RenderSlot => "_renderSlot",
             Self::NormalizeClass => "_normalizeClass",
             Self::NormalizeStyle => "_normalizeStyle",
             Self::NormalizeProps => "_normalizeProps",

--- a/crates/vize_ricalco/src/emit/hoist.rs
+++ b/crates/vize_ricalco/src/emit/hoist.rs
@@ -7,11 +7,10 @@
 use alloc::vec::Vec as StdVec;
 
 use vize_carton::String;
-use vize_disegno::op::{ElementOp, Namespace, Op, Region};
+use vize_disegno::op::{Attribute, ElementOp, Namespace, Op, Region};
 
 use super::buf::Buf;
-use super::js::escape_js_string;
-use super::vnode::compact_props_object;
+use super::js::{escape_js_string, is_valid_js_identifier};
 use super::EmitCx;
 
 pub(super) fn emit_hoisted_element(
@@ -148,4 +147,50 @@ fn meaningful<'a>(children: &'a Region<'a>) -> StdVec<&'a Op<'a>> {
 
 fn is_whitespace_text(op: &Op<'_>) -> bool {
     matches!(op, Op::Text(text) if text.content.chars().all(char::is_whitespace))
+}
+
+/// First-occurrence static attrs as a single-line object, matching
+/// hoisted `JsChildNode::Object` emission.
+pub(super) fn compact_props_object<'a>(
+    attributes: impl Iterator<Item = &'a Attribute<'a>>,
+) -> String {
+    let unique = unique_attrs(attributes);
+    let mut out = String::from("{ ");
+    for (i, attr) in unique.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        push_attr_pair(&mut out, attr);
+    }
+    out.push_str(" }");
+    out
+}
+
+pub(super) fn unique_attrs<'a>(
+    attributes: impl Iterator<Item = &'a Attribute<'a>>,
+) -> StdVec<&'a Attribute<'a>> {
+    let mut unique: StdVec<&Attribute<'_>> = StdVec::new();
+    for attr in attributes {
+        if unique.iter().any(|seen| seen.name == attr.name) {
+            continue;
+        }
+        unique.push(attr);
+    }
+    unique
+}
+
+pub(super) fn push_attr_pair(out: &mut String, attr: &Attribute<'_>) {
+    let quoted = !is_valid_js_identifier(attr.name);
+    if quoted {
+        out.push('"');
+    }
+    out.push_str(attr.name);
+    if quoted {
+        out.push('"');
+    }
+    out.push_str(": \"");
+    if let Some(value) = attr.value {
+        out.push_str(escape_js_string(value).as_str());
+    }
+    out.push('"');
 }

--- a/crates/vize_ricalco/src/emit/outlet.rs
+++ b/crates/vize_ricalco/src/emit/outlet.rs
@@ -1,0 +1,296 @@
+//! `<slot>` outlets: `_renderSlot(_ctx.$slots, name, props?, fallback?)`.
+//!
+//! Matches `vize_atelier_core::codegen/slots/outlet.rs` plus the if/for
+//! branch shapes. Static prop keys are camelized. A component that
+//! forwards an outlet uses `_: 3 /* FORWARDED */` unless it sits inside
+//! a scoped `withCtx` (then `_: 2` + `DYNAMIC_SLOTS`).
+
+use vize_carton::camelize;
+use vize_disegno::expr::{ExprRef, OpaqueReason};
+use vize_disegno::op::{BindingOp, DynamicName, InterpolationOp, Op, Region, SlotOp};
+
+use super::buf::Buf;
+use super::children::{
+    emit_create_text_vnode, emit_interpolation, emit_plain_text_vnode, emit_to_display_string,
+};
+use super::hoist::{emit_hoisted_element, is_hoistable};
+use super::js::{escape_js_string, is_valid_js_identifier};
+use super::merge;
+use super::props::{js_value, pieces, Piece};
+use super::slots::is_whitespace_text;
+use super::vnode::emit_array_child;
+use super::EmitCx;
+use super::EmitError;
+
+pub(super) fn has_forwarded_outlet(region: &Region<'_>) -> bool {
+    region.ops.iter().any(op_forwards)
+}
+
+fn op_forwards(op: &Op<'_>) -> bool {
+    match op {
+        Op::Slot(_) => true,
+        Op::Element(element) => has_forwarded_outlet(&element.children),
+        Op::Component(component) => has_forwarded_outlet(&component.children),
+        Op::If(if_op) => if_op
+            .branches
+            .iter()
+            .any(|branch| has_forwarded_outlet(&branch.region)),
+        Op::For(for_op) => has_forwarded_outlet(&for_op.region),
+        Op::Text(_) | Op::Interpolation(_) => false,
+    }
+}
+
+pub(super) fn with_slot_params<T>(
+    cx: &mut EmitCx<'_>,
+    scoped: bool,
+    write: impl FnOnce(&mut EmitCx<'_>) -> Result<T, EmitError>,
+) -> Result<T, EmitError> {
+    if scoped {
+        cx.slot_param_depth = cx.slot_param_depth.saturating_add(1);
+    }
+    let result = write(cx);
+    if scoped {
+        cx.slot_param_depth = cx.slot_param_depth.saturating_sub(1);
+    }
+    result
+}
+
+pub(super) fn emit_outlet(
+    cx: &mut EmitCx<'_>,
+    slot: &SlotOp<'_>,
+    key: Option<&str>,
+    compact_fallback: bool,
+) -> Result<(), EmitError> {
+    cx.buf.use_render_slot();
+    cx.buf.push(Buf::render_slot_alias());
+    cx.buf.push("(_ctx.$slots, ");
+    emit_name(cx, slot)?;
+    let fallback = meaningful_fallback(&slot.fallback);
+    let props = has_props(slot) || key.is_some();
+    if fallback {
+        cx.buf.push(", ");
+        if props {
+            emit_props(cx, slot, key)?;
+        } else {
+            cx.buf.push("{}");
+        }
+        cx.buf.push(", () => [");
+        emit_fallback(cx, &slot.fallback, compact_fallback)?;
+        cx.buf.push("])");
+    } else if props {
+        skip_region(cx, &slot.fallback);
+        cx.buf.push(", ");
+        emit_props(cx, slot, key)?;
+        cx.buf.push(")");
+    } else {
+        skip_region(cx, &slot.fallback);
+        cx.buf.push(")");
+    }
+    Ok(())
+}
+
+fn emit_name(cx: &mut EmitCx<'_>, slot: &SlotOp<'_>) -> Result<(), EmitError> {
+    match &slot.name {
+        DynamicName::Static(name) => {
+            cx.buf.push("\"");
+            cx.buf.push(escape_js_string(name).as_str());
+            cx.buf.push("\"");
+            Ok(())
+        }
+        DynamicName::Dynamic(ExprRef::Js(js)) => {
+            cx.buf.push(js.source);
+            Ok(())
+        }
+        DynamicName::Dynamic(_) => Err(EmitError::Unsupported),
+    }
+}
+
+fn has_props(slot: &SlotOp<'_>) -> bool {
+    !slot.attributes.is_empty()
+        || slot
+            .bindings
+            .iter()
+            .any(|binding| !matches!(binding, BindingOp::SlotContent(_)))
+}
+
+fn meaningful_fallback(region: &Region<'_>) -> bool {
+    region.ops.iter().any(|op| !is_whitespace_text(op))
+}
+
+fn emit_props(cx: &mut EmitCx<'_>, slot: &SlotOp<'_>, key: Option<&str>) -> Result<(), EmitError> {
+    if merge::has_object_bind(&slot.bindings) {
+        return merge::emit_spread_props(cx, &slot.attributes, &slot.bindings, key);
+    }
+    let list = pieces(&slot.attributes, &slot.bindings)?;
+    cx.buf.push("{");
+    let mut first = true;
+    if let Some(key) = key {
+        cx.buf.push(" key: ");
+        cx.buf.push(key);
+        first = false;
+    }
+    for piece in list.iter() {
+        if !first {
+            cx.buf.push(",");
+        }
+        cx.buf.push(" ");
+        first = false;
+        match piece {
+            Piece::Attr(attr) => {
+                push_camel_key(cx, attr.name);
+                cx.buf.push(": \"");
+                if let Some(value) = attr.value {
+                    cx.buf.push(escape_js_string(value).as_str());
+                }
+                cx.buf.push("\"");
+            }
+            Piece::Bind(bind) => {
+                let name = super::props::static_bind_name(bind)?;
+                let js = js_value(bind)?;
+                push_camel_key(cx, name);
+                cx.buf.push(": ");
+                cx.buf.push(js.source);
+            }
+            Piece::On(_) => return Err(EmitError::Unsupported),
+        }
+    }
+    if !first {
+        cx.buf.push(" ");
+    }
+    cx.buf.push("}");
+    Ok(())
+}
+
+fn push_camel_key(cx: &mut EmitCx<'_>, name: &str) {
+    let key = camelize(name);
+    if is_valid_js_identifier(key.as_str()) {
+        cx.buf.push(key.as_str());
+    } else {
+        cx.buf.push("\"");
+        cx.buf.push(escape_js_string(key.as_str()).as_str());
+        cx.buf.push("\"");
+    }
+}
+
+fn emit_fallback(cx: &mut EmitCx<'_>, region: &Region<'_>, compact: bool) -> Result<(), EmitError> {
+    if !compact {
+        cx.buf.indent();
+    }
+    let mut first = true;
+    for op in region.ops.iter() {
+        if is_whitespace_text(op) {
+            let _id = cx.walk.mint();
+            continue;
+        }
+        emit_fallback_units(cx, op, compact, &mut first)?;
+    }
+    if !compact {
+        cx.buf.deindent();
+        cx.buf.newline();
+    }
+    Ok(())
+}
+
+fn start_fallback_item(cx: &mut EmitCx<'_>, compact: bool, first: &mut bool) {
+    if !*first {
+        cx.buf.push(",");
+    }
+    *first = false;
+    if !compact {
+        cx.buf.newline();
+    }
+}
+
+fn emit_fallback_units(
+    cx: &mut EmitCx<'_>,
+    op: &Op<'_>,
+    compact: bool,
+    first: &mut bool,
+) -> Result<(), EmitError> {
+    match op {
+        Op::Text(_) => {
+            start_fallback_item(cx, compact, first);
+            emit_create_text_vnode(cx, core::slice::from_ref(op))
+        }
+        Op::Interpolation(interp) => emit_fallback_interp(cx, interp, compact, first),
+        Op::Element(element) if is_hoistable(element) => {
+            start_fallback_item(cx, compact, first);
+            emit_hoisted_element(cx, element)
+        }
+        Op::Element(_) | Op::Component(_) | Op::If(_) | Op::For(_) | Op::Slot(_) => {
+            start_fallback_item(cx, compact, first);
+            emit_array_child(cx, op)
+        }
+    }
+}
+
+/// Slot fallback walks each S1 child (`generate_node`), so a merged
+/// compound expands back into separate array entries: static parts as
+/// `_createTextVNode`, interpolations as bare `_toDisplayString`.
+fn emit_fallback_interp(
+    cx: &mut EmitCx<'_>,
+    interp: &InterpolationOp<'_>,
+    compact: bool,
+    first: &mut bool,
+) -> Result<(), EmitError> {
+    let id = cx.walk.mint();
+    match interp.expression {
+        ExprRef::Js(_) => {
+            start_fallback_item(cx, compact, first);
+            emit_interpolation(cx, interp, id)
+        }
+        ExprRef::Opaque(opaque) if opaque.reason == OpaqueReason::Compound => {
+            let id = id.ok_or(EmitError::Unsupported)?;
+            let parts = cx
+                .facts
+                .text_facts
+                .get(id)
+                .ok_or(EmitError::Unsupported)?
+                .parts
+                .clone();
+            for part in parts.iter() {
+                start_fallback_item(cx, compact, first);
+                if part.dynamic {
+                    emit_to_display_string(cx, part.text.as_str());
+                } else {
+                    emit_plain_text_vnode(cx, part.text.as_str());
+                }
+            }
+            Ok(())
+        }
+        ExprRef::Foreign(_) | ExprRef::Filter(_) | ExprRef::Opaque(_) => {
+            Err(EmitError::Unsupported)
+        }
+    }
+}
+
+fn skip_region(cx: &mut EmitCx<'_>, region: &Region<'_>) {
+    for op in region.ops.iter() {
+        skip_op(cx, op);
+    }
+}
+
+fn skip_op(cx: &mut EmitCx<'_>, op: &Op<'_>) {
+    let _id = cx.walk.mint();
+    match op {
+        Op::Element(element) => {
+            cx.walk.skip(element.bindings.len());
+            skip_region(cx, &element.children);
+        }
+        Op::Component(component) => {
+            cx.walk.skip(component.bindings.len());
+            skip_region(cx, &component.children);
+        }
+        Op::If(if_op) => {
+            for branch in if_op.branches.iter() {
+                skip_region(cx, &branch.region);
+            }
+        }
+        Op::For(for_op) => skip_region(cx, &for_op.region),
+        Op::Slot(slot) => {
+            cx.walk.skip(slot.bindings.len());
+            skip_region(cx, &slot.fallback);
+        }
+        Op::Text(_) | Op::Interpolation(_) => {}
+    }
+}

--- a/crates/vize_ricalco/src/emit/slots.rs
+++ b/crates/vize_ricalco/src/emit/slots.rs
@@ -3,7 +3,8 @@
 //! Implicit default, static / dynamic named `<template>` groups, and
 //! component-root `v-slot` (shipped codegen always keys that `default`).
 //! Conditional / looped slot templates go through [`super::create_slots`].
-//! Slot outlets and `v-slots` stay [`EmitError::Unsupported`].
+//! Outlets (`renderSlot`) live in [`super::outlet`]; `v-slots` stays
+//! [`EmitError::Unsupported`].
 
 use alloc::vec::Vec as StdVec;
 
@@ -62,7 +63,7 @@ fn walk_admit(region: &Region<'_>) -> Result<(), EmitError> {
                 }
             }
             Op::For(for_op) => walk_admit(&for_op.region)?,
-            Op::Slot(_) => return Err(EmitError::Unsupported),
+            Op::Slot(slot) => walk_admit(&slot.fallback)?,
         }
     }
     Ok(())
@@ -106,7 +107,10 @@ pub(super) fn emit_slots(
         cx.buf.push("]),");
     }
     cx.buf.newline();
-    if cx.in_v_for || has_dynamic_names(facts) {
+    let forwarded = super::outlet::has_forwarded_outlet(children);
+    if forwarded && cx.slot_param_depth == 0 && !cx.in_v_for && !has_dynamic_names(facts) {
+        cx.buf.push("_: 3 /* FORWARDED */");
+    } else if cx.in_v_for || has_dynamic_names(facts) || (forwarded && cx.slot_param_depth > 0) {
         cx.buf.push("_: 2 /* DYNAMIC */");
     } else {
         cx.buf.push("_: 1 /* STABLE */");
@@ -145,7 +149,10 @@ fn collect_pieces(
                 ) else {
                     return Err(EmitError::Unsupported);
                 };
-                emit_template_pieces(cx, &element.children, &mut buckets[idx])?;
+                let scoped = matches!(facts.groups[idx].params, SlotParams::Scoped { .. });
+                super::outlet::with_slot_params(cx, scoped, |cx| {
+                    emit_template_pieces(cx, &element.children, &mut buckets[idx])
+                })?;
             }
             _ => {
                 let idx = facts.groups.iter().position(|group| {
@@ -157,7 +164,10 @@ fn collect_pieces(
                 let Some(idx) = idx else {
                     return Err(EmitError::Unsupported);
                 };
-                buckets[idx].push(capture_child(cx, op)?);
+                let scoped = matches!(facts.groups[idx].params, SlotParams::Scoped { .. });
+                buckets[idx].push(super::outlet::with_slot_params(cx, scoped, |cx| {
+                    capture_child(cx, op)
+                })?);
             }
         }
     }
@@ -258,8 +268,9 @@ fn emit_slot_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> {
     match op {
         Op::Text(_) | Op::Interpolation(_) => emit_slot_text_child(cx, op),
         Op::Element(element) if is_hoistable(element) => emit_hoisted_element(cx, element),
-        Op::Element(_) | Op::Component(_) | Op::If(_) | Op::For(_) => emit_array_child(cx, op),
-        Op::Slot(_) => Err(EmitError::Unsupported),
+        Op::Element(_) | Op::Component(_) | Op::If(_) | Op::For(_) | Op::Slot(_) => {
+            emit_array_child(cx, op)
+        }
     }
 }
 

--- a/crates/vize_ricalco/src/emit/vfor.rs
+++ b/crates/vize_ricalco/src/emit/vfor.rs
@@ -23,6 +23,10 @@ pub(super) fn emit_for(cx: &mut EmitCx<'_>, for_op: &ForOp<'_>) -> Result<(), Em
             component.bindings.len(),
             has_item_key(&component.attributes, &component.bindings),
         ),
+        [Op::Slot(slot)] => (
+            slot.bindings.len(),
+            has_item_key(&slot.attributes, &slot.bindings),
+        ),
         _ => return Err(EmitError::Unsupported),
     };
     let stable = is_numeric(source);
@@ -84,6 +88,7 @@ pub(super) fn emit_for(cx: &mut EmitCx<'_>, for_op: &ForOp<'_>) -> Result<(), Em
         }
         [Op::Element(element)] => super::emit_for_item_call(cx, element, stable),
         [Op::Component(component)] => super::component::emit_for_item(cx, component, _id),
+        [Op::Slot(slot)] => super::outlet::emit_outlet(cx, slot, None, false),
         _ => Err(EmitError::Unsupported),
     };
     cx.in_v_for = prev_in_v_for;

--- a/crates/vize_ricalco/src/emit/vif.rs
+++ b/crates/vize_ricalco/src/emit/vif.rs
@@ -19,6 +19,7 @@ pub(super) fn emit_if(
     if if_op.branches.is_empty() {
         return Err(EmitError::Unsupported);
     }
+    cx.buf.use_open_block();
     cx.buf.use_create_comment();
     let facts = id.and_then(|id| cx.facts.if_facts.get(id));
     for (i, branch) in if_op.branches.iter().enumerate() {
@@ -115,6 +116,11 @@ fn emit_branch(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<
             let _id = cx.walk.mint();
             cx.walk.skip(component.bindings.len());
             super::component::emit_if_branch(cx, component, key, _id)
+        }
+        [Op::Slot(slot)] => {
+            let _id = cx.walk.mint();
+            cx.walk.skip(slot.bindings.len());
+            super::outlet::emit_outlet(cx, slot, Some(key), true)
         }
         _ => Err(EmitError::Unsupported),
     }

--- a/crates/vize_ricalco/src/emit/vnode.rs
+++ b/crates/vize_ricalco/src/emit/vnode.rs
@@ -1,7 +1,5 @@
 //! Static native HTML element / children emission.
 
-use alloc::vec::Vec as StdVec;
-
 use vize_carton::{ensure_sufficient_stack, String};
 use vize_disegno::op::{Attribute, ElementOp, Namespace, Op, Region, TextOp};
 
@@ -10,7 +8,7 @@ use super::children::{
     children_need_text_flag, emit_create_text_vnode, emit_interpolation, emit_text_like,
 };
 use super::flag::emit_patch_flag;
-use super::js::{escape_js_string, is_valid_js_identifier};
+use super::hoist::{compact_props_object, push_attr_pair, unique_attrs};
 use super::props::{admit_bindings, bind_patch, emit_bind_props};
 use super::EmitCx;
 use super::EmitError;
@@ -22,8 +20,6 @@ pub(super) fn emit_root(cx: &mut EmitCx<'_>, root: &Region<'_>) -> Result<(), Em
         match op {
             Op::Text(text) if is_ignorable_root_text(text) => {}
             Op::Element(element) => {
-                // Descendants mint before later root siblings (page order:
-                // owner, bindings, children, then the next root op).
                 cx.walk.skip(element.bindings.len());
                 cx.buf.use_open_block();
                 cx.buf.use_create_element_block();
@@ -42,6 +38,10 @@ pub(super) fn emit_root(cx: &mut EmitCx<'_>, root: &Region<'_>) -> Result<(), Em
                 cx.walk.skip(component.bindings.len());
                 super::component::emit_root(cx, component, id)?;
             }
+            Op::Slot(slot) => {
+                cx.walk.skip(slot.bindings.len());
+                super::outlet::emit_outlet(cx, slot, None, false)?;
+            }
             _ => return Err(EmitError::Unsupported),
         }
     }
@@ -53,7 +53,12 @@ fn admit_unique_root(root: &Region<'_>) -> Result<(), EmitError> {
     for op in root.ops.iter() {
         match op {
             Op::Text(text) if is_ignorable_root_text(text) => {}
-            Op::Element(_) | Op::Component(_) | Op::Interpolation(_) | Op::If(_) | Op::For(_)
+            Op::Element(_)
+            | Op::Component(_)
+            | Op::Interpolation(_)
+            | Op::If(_)
+            | Op::For(_)
+            | Op::Slot(_)
                 if !found =>
             {
                 found = true
@@ -200,25 +205,6 @@ fn root_props_should_hoist(element: &ElementOp<'_>) -> bool {
             .all(|attribute| attribute.name != "ref")
 }
 
-/// First-occurrence static attrs as a single-line object, matching
-/// hoisted `JsChildNode::Object` emission.
-pub(super) fn compact_props_object<'a>(
-    attributes: impl Iterator<Item = &'a Attribute<'a>>,
-) -> String {
-    let unique = unique_attrs(attributes);
-    let mut out = String::from("{ ");
-    for (i, attr) in unique.iter().enumerate() {
-        if i > 0 {
-            out.push_str(", ");
-        }
-        push_attr_pair(&mut out, attr);
-    }
-    out.push_str(" }");
-    out
-}
-
-/// First-occurrence static attrs, matching
-/// `vize_atelier_core::codegen::props::generate::try_generate_static_attrs`.
 fn emit_static_props_inline<'a>(
     cx: &mut EmitCx<'_>,
     attributes: impl Iterator<Item = &'a Attribute<'a>>,
@@ -251,35 +237,6 @@ fn emit_static_props_inline<'a>(
     } else {
         cx.buf.push(" }");
     }
-}
-
-fn unique_attrs<'a>(
-    attributes: impl Iterator<Item = &'a Attribute<'a>>,
-) -> StdVec<&'a Attribute<'a>> {
-    let mut unique: StdVec<&Attribute<'_>> = StdVec::new();
-    for attr in attributes {
-        if unique.iter().any(|seen| seen.name == attr.name) {
-            continue;
-        }
-        unique.push(attr);
-    }
-    unique
-}
-
-fn push_attr_pair(out: &mut String, attr: &Attribute<'_>) {
-    let quoted = !is_valid_js_identifier(attr.name);
-    if quoted {
-        out.push('"');
-    }
-    out.push_str(attr.name);
-    if quoted {
-        out.push('"');
-    }
-    out.push_str(": \"");
-    if let Some(value) = attr.value {
-        out.push_str(escape_js_string(value).as_str());
-    }
-    out.push('"');
 }
 
 fn admit_native(element: &ElementOp<'_>) -> Result<(), EmitError> {
@@ -342,6 +299,10 @@ pub(super) fn emit_array_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), E
         }
         Op::If(if_op) => super::emit_if_op(cx, if_op, id),
         Op::For(for_op) => super::emit_for_op(cx, for_op),
-        Op::Text(_) | Op::Interpolation(_) | Op::Slot(_) => Err(EmitError::Unsupported),
+        Op::Slot(slot) => {
+            cx.walk.skip(slot.bindings.len());
+            super::outlet::emit_outlet(cx, slot, None, false)
+        }
+        Op::Text(_) | Op::Interpolation(_) => Err(EmitError::Unsupported),
     })
 }

--- a/crates/vize_ricalco/tests/emit_outlets.rs
+++ b/crates/vize_ricalco/tests/emit_outlets.rs
@@ -1,0 +1,117 @@
+//! Slot-outlet emit pins (`renderSlot` / `_: 3 FORWARDED`).
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use support::with_transformed;
+use vize_ricalco::emit_dom;
+
+fn assembled(source: &str) -> String {
+    with_transformed(source, |lowered, _folio, facts, _budget| {
+        emit_dom(lowered, facts)
+            .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
+            .assembled()
+            .to_string()
+    })
+}
+
+fn pin(visual: &str) -> String {
+    visual.replace(")\n\n  return", ")\n  \n  return")
+}
+
+#[test]
+fn a_bare_slot_uses_render_slot() {
+    assert_eq!(
+        assembled("<slot></slot>"),
+        "\
+const { renderSlot: _renderSlot } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return _renderSlot(_ctx.$slots, \"default\")
+}"
+    );
+}
+
+#[test]
+fn a_named_slot_quotes_the_name() {
+    assert_eq!(
+        assembled(r#"<slot name="header"></slot>"#),
+        "\
+const { renderSlot: _renderSlot } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return _renderSlot(_ctx.$slots, \"header\")
+}"
+    );
+}
+
+#[test]
+fn fallback_text_passes_an_empty_props_object() {
+    assert_eq!(
+        assembled("<slot>fallback</slot>"),
+        "\
+const { renderSlot: _renderSlot, createTextVNode: _createTextVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return _renderSlot(_ctx.$slots, \"default\", {}, () => [
+    _createTextVNode(\"fallback\")
+  ])
+}"
+    );
+}
+
+#[test]
+fn a_forwarded_outlet_sets_the_forwarded_flag() {
+    assert_eq!(
+        assembled("<Foo><slot></slot></Foo>"),
+        pin("\
+const { resolveComponent: _resolveComponent, renderSlot: _renderSlot, openBlock: _openBlock, createBlock: _createBlock, withCtx: _withCtx } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, null, {
+    default: _withCtx(() => [
+      _renderSlot(_ctx.$slots, \"default\")
+    ]),
+    _: 3 /* FORWARDED */
+  }))
+}")
+    );
+}
+
+#[test]
+fn fallback_interp_expands_the_compound_into_sibling_children() {
+    assert_eq!(
+        assembled("<slot>hello {{ msg }}</slot>"),
+        "\
+const { toDisplayString: _toDisplayString, renderSlot: _renderSlot, createTextVNode: _createTextVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return _renderSlot(_ctx.$slots, \"default\", {}, () => [
+    _createTextVNode(\"hello \"),
+    _toDisplayString(msg)
+  ])
+}"
+    );
+}
+
+#[test]
+fn a_v_if_outlet_keeps_the_unused_open_block_helper() {
+    assert_eq!(
+        assembled(r#"<slot v-if="ok"></slot>"#),
+        "\
+const { renderSlot: _renderSlot, openBlock: _openBlock, createCommentVNode: _createCommentVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (ok)
+    ? _renderSlot(_ctx.$slots, \"default\", { key: 0 })
+    : _createCommentVNode(\"v-if\", true)
+}"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

P2-11 installment: S2 DOM emit now compiles `<slot>` outlets to `_renderSlot` and marks forwarded component slots `_: 3 /* FORWARDED */`, matching the shipped `compile_template` lane byte-for-byte.

- Bare / named / dynamic-name outlets (`"default"`, `"header"`, `:name`)
- Camelized static and bound props; object `v-bind` via `normalizeProps` + `guardReactiveProps`
- Fallback children: text as `_createTextVNode`, interpolations as bare `_toDisplayString`, compounds expanded back to sibling entries (Vue does not merge in slot fallback)
- `v-if` / `v-for` on the outlet (unused `openBlock` helper, compact if-branch fallback)
- Nested / recursive forwarded outlets; scoped `withCtx` uses `_: 2` + `1024 /* DYNAMIC_SLOTS */`
- Helper preamble follows transform-first registration then `vue_helper_import_rank` / `Helper::ALL`

Intentionally still unsupported here: slot `v-on` / object `v-on`, `v-slots` spread, `v-if`+`v-for` on the same slot template, builtins, `<component :is>`, template fragments, `.native`, filters.

Stacked on #4747 (`createSlots`). Merge order: #4742 → #4744 → #4745 → #4747 → this PR.

## Change Class

- [x] Compiler and codegen

## Behavior Reference

Shipped `vize_atelier_core` slot-outlet codegen (`codegen/element/{block,inline}.rs`, `codegen/v_if/branch.rs`, `codegen/v_for/slot_outlet.rs`, `codegen/slots/outlet.rs`) and `vue_helper_import_rank`.

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered

```
cargo test -p vize_ricalco --test emit_outlets --test emit_named --test emit_slots --test emit_if --test emit_create_slots --test emit_static
cargo test -p vize_atelier_dom --test davinci_s2_outlets --test davinci_s2_slots --test davinci_s2_dom
cargo clippy -p vize_ricalco -- -D warnings
```

`davinci_s2_outlets` is a 23-case byte-for-byte battery against `compile_template` (disarmed only by `VIZE_DAVINCI_DOM=legacy`).

## Risk

Follows the P2-11 slot emit stack; do not merge ahead of #4747. `v-slots` spread and eventful outlets remain later installments. No public API change (`vize_atelier_dom` stays the shipped lane).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

