### PR TITLE
feat(davinci): emit `<component :is>` via resolveDynamicComponent (P2-11)

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dynamic.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dynamic.rs
@@ -1,0 +1,74 @@
+//! P2-11 `<component :is>` witness: `resolveDynamicComponent`, skipped
+//! `is` props / patch flags, nested `createBlock`, compared
+//! **byte-for-byte** including helper usage.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+use vize_atelier_dom::compile_template;
+use vize_carton::Allocator;
+use vize_ricalco::{DOM_LANE_FLAG, emit_dom_source};
+
+const BATTERY: &[(&str, &str)] = &[
+    ("dynamic_bind", r#"<component :is="x" />"#),
+    ("dynamic_empty", r#"<component :is="x"></component>"#),
+    ("static_is", r#"<component is="Foo" />"#),
+    ("pascal_bind", r#"<Component :is="x" />"#),
+    ("pascal_static", r#"<Component is="Foo" />"#),
+    ("bare_component", "<component />"),
+    ("with_id", r#"<component :is="x" id="a" />"#),
+    ("with_bind", r#"<component :is="x" :foo="bar" />"#),
+    ("text_slot", r#"<component :is="x">hello</component>"#),
+    (
+        "span_slot",
+        r#"<component :is="x"><span></span></component>"#,
+    ),
+    ("nested", r#"<div><component :is="x" /></div>"#),
+    ("vif", r#"<component v-if="ok" :is="x" />"#),
+    ("vfor", r#"<component v-for="i in n" :is="x" />"#),
+    ("object_bind", r#"<component :is="x" v-bind="obj" />"#),
+    ("in_slot", r#"<Foo><component :is="x" /></Foo>"#),
+    (
+        "static_is_slot",
+        r#"<component is="Foo" id="a">hello</component>"#,
+    ),
+    ("quoted", r#"<component :is="'Foo'" />"#),
+];
+
+fn shipped(src: &str) -> String {
+    let allocator = Allocator::new();
+    let (_, errors, result) = compile_template(&allocator, src);
+    assert!(errors.is_empty(), "shipped lane errors: {errors:?}");
+    format!("{}\n{}", result.preamble, result.code)
+}
+
+#[test]
+fn s2_dynamic_is_matches_the_shipped_dom_lane_byte_for_byte() {
+    let mut compared = 0u64;
+    let mut skipped_legacy_flag = 0u64;
+    if std::env::var(DOM_LANE_FLAG).is_ok_and(|value| value == "legacy") {
+        skipped_legacy_flag += 1;
+    } else {
+        let allocator = Allocator::new();
+        for (name, src) in BATTERY {
+            let old = shipped(src);
+            let new = emit_dom_source(&allocator, src)
+                .unwrap_or_else(|error| panic!("{name}: S2 emit refused: {error:?}"))
+                .assembled();
+            assert_eq!(
+                old.as_str(),
+                new.as_str(),
+                "{name}: S2 DOM emit diverged from the shipped lane"
+            );
+            compared += 1;
+        }
+    }
+    assert_eq!(
+        (compared, skipped_legacy_flag),
+        (BATTERY.len() as u64, 0),
+        "a cfg or {DOM_LANE_FLAG}=legacy regression disarmed the dual-run"
+    );
+}

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -17,9 +17,10 @@
 //! static-vnode hoists, hoisted static `ui.for` items, named / scoped
 //! `<template>` slots, `createSlots` for `v-if` / `v-for` slot
 //! templates, **slot outlets** (`renderSlot` / `_: 3 FORWARDED`), and
-//! Vue builtins (`Teleport` / `KeepAlive` / `Transition` / `Suspense`)).
-//! Object `v-on`, `.native`, template fragments, filters, and
-//! `<component :is>` stay [`EmitError::Unsupported`]. The old
+//! Vue builtins (`Teleport` / `KeepAlive` / `Transition` / `Suspense`),
+//! and `<component :is>` (`resolveDynamicComponent`)).
+//! Object `v-on`, `.native`, template fragments, and filters
+//! stay [`EmitError::Unsupported`]. The old
 //! lane stays the shipped compile path; [`super::DOM_LANE_FLAG`] is
 //! named here and *read* in the atelier_dom witness.
 

--- a/crates/vize_ricalco/src/emit/builtin.rs
+++ b/crates/vize_ricalco/src/emit/builtin.rs
@@ -5,12 +5,13 @@
 //! child). KeepAlive always carries `DYNAMIC_SLOTS`. Teleport / KeepAlive
 //! / Suspense stay `createBlock` even when nested.
 
-use vize_disegno::op::{Namespace, Op, Region};
+use vize_disegno::op::{BindingOp, ComponentOp, DynamicName, Namespace, Op, Region};
 
 use super::EmitCx;
 use super::EmitError;
 use super::helper::Helper;
 use super::outlet;
+use super::props::js_value;
 use super::slots;
 
 pub(super) fn helper(name: &str) -> Option<Helper> {
@@ -25,11 +26,52 @@ pub(super) fn helper(name: &str) -> Option<Helper> {
     }
 }
 
-pub(super) fn forces_block(name: &str) -> bool {
+pub(super) fn forces_block(component: &ComponentOp<'_>) -> bool {
     matches!(
-        name,
+        component.name,
         "Teleport" | "teleport" | "Suspense" | "suspense" | "KeepAlive" | "keep-alive"
+    ) || is_dynamic_component(component)
+}
+
+pub(super) fn is_dynamic_component(component: &ComponentOp<'_>) -> bool {
+    matches!(component.name, "component" | "Component") && has_is(component)
+}
+
+fn has_is(component: &ComponentOp<'_>) -> bool {
+    component.attributes.iter().any(|attr| attr.name == "is")
+        || component.bindings.iter().any(is_is_bind)
+}
+
+pub(super) fn is_is_bind(binding: &BindingOp<'_>) -> bool {
+    matches!(
+        binding,
+        BindingOp::Bind(bind) if matches!(bind.name, Some(DynamicName::Static("is")))
     )
+}
+
+pub(super) fn emit_dynamic_tag(
+    cx: &mut EmitCx<'_>,
+    component: &ComponentOp<'_>,
+) -> Result<bool, EmitError> {
+    if !is_dynamic_component(component) {
+        return Ok(false);
+    }
+    cx.buf.use_helper(Helper::ResolveDynamicComponent);
+    cx.buf.push(Helper::ResolveDynamicComponent.alias());
+    cx.buf.push("(");
+    if let Some(BindingOp::Bind(bind)) = component.bindings.iter().find(|b| is_is_bind(b)) {
+        cx.buf.push(js_value(bind)?.source);
+    } else if let Some(attr) = component.attributes.iter().find(|attr| attr.name == "is") {
+        cx.buf.push("\"");
+        if let Some(value) = attr.value {
+            cx.buf.push(value);
+        }
+        cx.buf.push("\"");
+    } else {
+        return Err(EmitError::Unsupported);
+    }
+    cx.buf.push(")");
+    Ok(true)
 }
 
 pub(super) fn array_children(name: &str) -> bool {

--- a/crates/vize_ricalco/src/emit/component.rs
+++ b/crates/vize_ricalco/src/emit/component.rs
@@ -2,9 +2,8 @@
 //! `createBlock`) plus slot objects from [`SlotFacts`] (implicit
 //! default, named `<template>` groups, component-root `v-slot`) and
 //! `createSlots` for `v-if` / `v-for` slot templates, the `v-slots`
-//! spread, and Vue builtins (`Teleport` / `KeepAlive` / `Transition` /
-//! `Suspense` / `TransitionGroup` / `BaseTransition`). `<component :is>`
-//! stays unsupported.
+//! spread, Vue builtins, and `<component :is>`
+//! (`resolveDynamicComponent`).
 
 use alloc::vec::Vec as StdVec;
 
@@ -65,7 +64,7 @@ pub(super) fn emit_nested(
     component: &ComponentOp<'_>,
     id: Option<NodeId>,
 ) -> Result<(), EmitError> {
-    if builtin::forces_block(component.name) {
+    if builtin::forces_block(component) {
         return emit_root(cx, component, id);
     }
     cx.buf.use_create_vnode();
@@ -120,7 +119,9 @@ fn collect_from<'a>(region: &Region<'a>, names: &mut StdVec<&'a str>) {
             Op::Element(element) => collect_from(&element.children, names),
             Op::Component(component) => {
                 collect_from(&component.children, names);
-                if !is_builtin(component.name) && !names.iter().any(|seen| *seen == component.name)
+                if !is_builtin(component.name)
+                    && !builtin::is_dynamic_component(component)
+                    && !names.iter().any(|seen| *seen == component.name)
                 {
                     names.push(component.name);
                 }
@@ -162,16 +163,24 @@ fn emit_call(
     };
     cx.buf.push(alias);
     cx.buf.push("(");
-    if let Some(helper) = builtin::helper(component.name) {
+    if builtin::emit_dynamic_tag(cx, component)? {
+    } else if let Some(helper) = builtin::helper(component.name) {
         cx.buf.use_helper(helper);
         cx.buf.push(helper.alias());
     } else {
         cx.buf
             .push(asset_ident("component", component.name).as_str());
     }
+    let skip_is = builtin::is_dynamic_component(component);
     let has_binds = component.bindings.iter().any(|binding| {
-        !matches!(binding, BindingOp::SlotContent(_)) && !slots::is_slots_spread(binding)
+        !matches!(binding, BindingOp::SlotContent(_))
+            && !slots::is_slots_spread(binding)
+            && !(skip_is && builtin::is_is_bind(binding))
     });
+    let has_attrs = component
+        .attributes
+        .iter()
+        .any(|attr| !skip_is || attr.name != "is");
     let unused_hoist = !has_binds
         && if_key.is_none()
         && !component.attributes.is_empty()
@@ -180,7 +189,13 @@ fn emit_call(
         cx.buf
             .push_hoist(compact_props_object(component.attributes.iter()));
     }
-    let patch = bind_patch(&component.bindings, true);
+    let mut patch = bind_patch(&component.bindings, true);
+    if skip_is {
+        patch.dynamic_props.retain(|name| name.as_str() != "is");
+        if patch.dynamic_props.is_empty() {
+            patch.flag &= !8;
+        }
+    }
     let mut flag = patch.flag;
     if array && children_need_text_flag(&component.children) {
         flag |= 1;
@@ -193,9 +208,15 @@ fn emit_call(
         flag |= 1024;
     }
     let emit_flag = flag != 0;
-    if if_key.is_some() || has_binds || !component.attributes.is_empty() {
+    if if_key.is_some() || has_binds || has_attrs {
         cx.buf.push(", ");
-        emit_bind_props(cx, &component.attributes, &component.bindings, if_key)?;
+        emit_bind_props(
+            cx,
+            &component.attributes,
+            &component.bindings,
+            if_key,
+            skip_is,
+        )?;
     } else if emit_flag || has_slots || has_array || for_item {
         // Vue's v-for item `createBlock` keeps an explicit null props
         // even when the component has no props, slots, or patch flag.
@@ -240,9 +261,6 @@ fn emit_call(
 }
 
 fn admit(component: &ComponentOp<'_>) -> Result<(), EmitError> {
-    if component.name == "component" {
-        return Err(EmitError::Unsupported);
-    }
     if create_slots::needs_create_slots(&component.children)
         || slots::has_implicit_default(&component.children)
     {

--- a/crates/vize_ricalco/src/emit/helper.rs
+++ b/crates/vize_ricalco/src/emit/helper.rs
@@ -7,6 +7,7 @@
 #[derive(Clone, Copy)]
 pub(super) enum Helper {
     ResolveComponent,
+    ResolveDynamicComponent,
     WithKeys,
     WithModifiers,
     ToDisplayString,
@@ -36,8 +37,9 @@ pub(super) enum Helper {
 }
 
 impl Helper {
-    pub(super) const ALL: [Self; 27] = [
+    pub(super) const ALL: [Self; 28] = [
         Self::ResolveComponent,
+        Self::ResolveDynamicComponent,
         Self::WithKeys,
         Self::WithModifiers,
         Self::ToDisplayString,
@@ -68,7 +70,7 @@ impl Helper {
 
     pub(super) const fn rank(self) -> u8 {
         match self {
-            Self::ResolveComponent => 0,
+            Self::ResolveComponent | Self::ResolveDynamicComponent => 0,
             Self::WithKeys | Self::WithModifiers => 2,
             Self::ToDisplayString => 3,
             Self::RenderSlot | Self::CreateElementVNode | Self::CreateVNode => 4,
@@ -111,6 +113,7 @@ impl Helper {
             Self::GuardReactiveProps => 8192,
             Self::MergeProps => 16384,
             Self::ResolveComponent => 32768,
+            Self::ResolveDynamicComponent => 134_217_728,
             Self::CreateVNode => 65536,
             Self::CreateBlock => 131072,
             Self::RenderSlot => 1_048_576,
@@ -128,6 +131,7 @@ impl Helper {
     pub(super) const fn name(self) -> &'static str {
         match self {
             Self::ResolveComponent => "resolveComponent",
+            Self::ResolveDynamicComponent => "resolveDynamicComponent",
             Self::WithKeys => "withKeys",
             Self::WithModifiers => "withModifiers",
             Self::ToDisplayString => "toDisplayString",
@@ -160,6 +164,7 @@ impl Helper {
     pub(super) const fn alias(self) -> &'static str {
         match self {
             Self::ResolveComponent => "_resolveComponent",
+            Self::ResolveDynamicComponent => "_resolveDynamicComponent",
             Self::WithKeys => "_withKeys",
             Self::WithModifiers => "_withModifiers",
             Self::ToDisplayString => "_toDisplayString",

--- a/crates/vize_ricalco/src/emit/js.rs
+++ b/crates/vize_ricalco/src/emit/js.rs
@@ -124,3 +124,13 @@ pub(super) fn asset_ident(kind: &str, name: &str) -> String {
     }
     ident
 }
+
+pub(super) fn push_ident_key(cx: &mut super::EmitCx<'_>, name: &str) {
+    if !is_valid_js_identifier(name) {
+        cx.buf.push("\"");
+        cx.buf.push(name);
+        cx.buf.push("\"");
+    } else {
+        cx.buf.push(name);
+    }
+}

--- a/crates/vize_ricalco/src/emit/merge.rs
+++ b/crates/vize_ricalco/src/emit/merge.rs
@@ -69,8 +69,9 @@ pub(super) fn emit_spread_props(
     attributes: &[Attribute<'_>],
     bindings: &[BindingOp<'_>],
     if_key: Option<&str>,
+    skip_is: bool,
 ) -> Result<(), EmitError> {
-    let args = merge_args(attributes, bindings, if_key)?;
+    let args = merge_args(attributes, bindings, if_key, skip_is)?;
     let only_spread = args.iter().all(|arg| matches!(arg, Arg::Spread(_)));
     if only_spread {
         let Arg::Spread(bind) = args[0] else {
@@ -108,10 +109,11 @@ fn merge_args<'a>(
     attributes: &'a [Attribute<'a>],
     bindings: &'a [BindingOp<'a>],
     if_key: Option<&'a str>,
+    skip_is: bool,
 ) -> Result<StdVec<Arg<'a>>, EmitError> {
     let mut args = StdVec::new();
     let mut current = StdVec::new();
-    for piece in pieces(attributes, bindings)? {
+    for piece in pieces(attributes, bindings, skip_is)? {
         if let Piece::Bind(bind) = piece
             && bind.name.is_none()
         {

--- a/crates/vize_ricalco/src/emit/outlet.rs
+++ b/crates/vize_ricalco/src/emit/outlet.rs
@@ -119,9 +119,9 @@ fn meaningful_fallback(region: &Region<'_>) -> bool {
 
 fn emit_props(cx: &mut EmitCx<'_>, slot: &SlotOp<'_>, key: Option<&str>) -> Result<(), EmitError> {
     if merge::has_object_bind(&slot.bindings) {
-        return merge::emit_spread_props(cx, &slot.attributes, &slot.bindings, key);
+        return merge::emit_spread_props(cx, &slot.attributes, &slot.bindings, key, false);
     }
-    let list = pieces(&slot.attributes, &slot.bindings)?;
+    let list = pieces(&slot.attributes, &slot.bindings, false)?;
     cx.buf.push("{");
     let mut first = true;
     if let Some(key) = key {

--- a/crates/vize_ricalco/src/emit/props.rs
+++ b/crates/vize_ricalco/src/emit/props.rs
@@ -9,7 +9,7 @@ use vize_disegno::op::{Attribute, BindOp, BindingOp, DynamicName, OnOp};
 use super::EmitCx;
 use super::EmitError;
 use super::buf::Buf;
-use super::js::{escape_js_string, is_valid_js_identifier};
+use super::js::{escape_js_string, push_ident_key};
 use super::on::{
     admit_on, emit_on_pair, event_key_for, is_inline_handler_source, needs_hydration, wraps_on,
 };
@@ -110,11 +110,12 @@ pub(super) fn emit_bind_props(
     attributes: &[Attribute<'_>],
     bindings: &[BindingOp<'_>],
     if_key: Option<&str>,
+    skip_is: bool,
 ) -> Result<(), EmitError> {
     if super::merge::has_object_bind(bindings) {
-        return super::merge::emit_spread_props(cx, attributes, bindings, if_key);
+        return super::merge::emit_spread_props(cx, attributes, bindings, if_key, skip_is);
     }
-    let pieces = pieces(attributes, bindings)?;
+    let pieces = pieces(attributes, bindings, skip_is)?;
     emit_props_object(cx, &pieces, if_key, false)
 }
 
@@ -199,13 +200,19 @@ pub(super) enum Piece<'a> {
 pub(super) fn pieces<'a>(
     attributes: &'a [Attribute<'a>],
     bindings: &'a [BindingOp<'a>],
+    skip_is: bool,
 ) -> Result<StdVec<Piece<'a>>, EmitError> {
     let mut out = StdVec::new();
     for attr in attributes.iter() {
+        if skip_is && attr.name == "is" {
+            continue;
+        }
         out.push(Piece::Attr(attr));
     }
     for binding in bindings.iter() {
         match binding {
+            BindingOp::Bind(bind)
+                if skip_is && matches!(bind.name, Some(DynamicName::Static("is"))) => {}
             BindingOp::Bind(bind) => out.push(Piece::Bind(bind)),
             BindingOp::On(on) => out.push(Piece::On(on)),
             BindingOp::SlotContent(_) => {}
@@ -252,7 +259,7 @@ fn pieces_have_inline_on(pieces: &[Piece<'_>]) -> bool {
 }
 
 fn emit_static_pair(cx: &mut EmitCx<'_>, attr: &Attribute<'_>) {
-    push_key(cx, attr.name);
+    push_ident_key(cx, attr.name);
     cx.buf.push(": \"");
     if let Some(value) = attr.value {
         cx.buf.push(escape_js_string(value).as_str());
@@ -268,7 +275,7 @@ fn emit_bind_pair(
 ) -> Result<(), EmitError> {
     let name = static_bind_name(bind)?;
     let js = js_value(bind)?;
-    push_key(cx, name);
+    push_ident_key(cx, name);
     cx.buf.push(": ");
     match name {
         "class" => emit_class_value(cx, pieces, bind, js, skip_normalize),
@@ -336,15 +343,5 @@ pub(super) fn js_value<'a>(bind: &'a BindOp<'a>) -> Result<&'a JsExpr<'a>, EmitE
     match bind.value {
         Some(ExprRef::Js(js)) => Ok(js),
         _ => Err(EmitError::Unsupported),
-    }
-}
-
-fn push_key(cx: &mut EmitCx<'_>, name: &str) {
-    if !is_valid_js_identifier(name) {
-        cx.buf.push("\"");
-        cx.buf.push(name);
-        cx.buf.push("\"");
-    } else {
-        cx.buf.push(name);
     }
 }

--- a/crates/vize_ricalco/src/emit/vnode.rs
+++ b/crates/vize_ricalco/src/emit/vnode.rs
@@ -164,7 +164,7 @@ fn emit_call(
         cx.buf.push(Buf::hoisted_props_alias());
     } else if if_key.is_some() || has_binds {
         cx.buf.push(", ");
-        emit_bind_props(cx, &element.attributes, &element.bindings, if_key)?;
+        emit_bind_props(cx, &element.attributes, &element.bindings, if_key, false)?;
     } else if !element.attributes.is_empty() {
         cx.buf.push(", ");
         emit_static_props_inline(cx, element.attributes.iter());

--- a/crates/vize_ricalco/tests/emit_comp.rs
+++ b/crates/vize_ricalco/tests/emit_comp.rs
@@ -10,7 +10,7 @@
 mod support;
 
 use support::with_transformed;
-use vize_ricalco::{EmitError, emit_dom};
+use vize_ricalco::emit_dom;
 
 fn assembled(source: &str) -> String {
     with_transformed(source, |lowered, _folio, facts, _budget| {
@@ -24,12 +24,6 @@ fn assembled(source: &str) -> String {
 /// Vue's extra `newline()` after `genAssets` leaves indent on the blank line.
 fn pin(visual: &str) -> String {
     visual.replace(")\n\n  return", ")\n  \n  return")
-}
-
-fn refused(source: &str) -> EmitError {
-    with_transformed(source, |lowered, _, facts, _| {
-        emit_dom(lowered, facts).expect_err("expected Unsupported")
-    })
 }
 
 #[test]
@@ -177,8 +171,16 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
-fn a_dynamic_is_is_unsupported_this_installment() {
-    assert_eq!(refused(r#"<component :is="x" />"#), EmitError::Unsupported);
+fn a_dynamic_is_uses_resolve_dynamic_component() {
+    assert_eq!(
+        assembled(r#"<component :is="x" />"#),
+        pin("\
+const { resolveDynamicComponent: _resolveDynamicComponent, openBlock: _openBlock, createBlock: _createBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent(x)))
+}")
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

P2-11 increment on top of #4750: S2 DOM emit produces `<component :is>` / `<Component is>` through `_resolveDynamicComponent`.

- `:is="expr"` → `_resolveDynamicComponent(expr)`; `is="Foo"` → `_resolveDynamicComponent("Foo")`.
- The `is` prop is omitted from the props object and from PROPS patch-flag names (object `v-bind` still uses `FULL_PROPS`).
- Nested dynamic components stay `(_openBlock(), _createBlock(...))`.
- Bare `<component />` (no `is`) matches the shipped `_component_component` asset id (no `resolveComponent` preamble).
- Unused static-props hoists still include `is` in the unused object when other static attrs + static nested children exist.

## Change Class

- [x] Compiler and codegen

## Behavior Reference

Shipped `vize_atelier_core` codegen (`is_dynamic_component`, `skip_is_prop`, `calculate_element_patch_info_skip_is`, `ResolveDynamicComponent` rank 0).

## Verification Evidence

- `cargo test -p vize_ricalco --test emit_comp --test emit_builtins --test emit_slots --test emit_merge --test emit_outlets`
- `cargo test -p vize_atelier_dom --test davinci_s2_dynamic --test davinci_s2_builtins --test davinci_s2_dom --test davinci_s2_vslots --test davinci_s2_outlets`
- `cargo clippy -p vize_ricalco --tests -- -D warnings`

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

Stack PR: merge after #4750 (`cursor/p2-11-builtins-c525`). Still unsupported: object `v-on`, `.native`, template fragments, filters, `createSlots` + `v-slots`. P2-11 corpus-diff / waiver-zero is not claimed here.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790145236&installation_model_id=422833&pr_number=4751&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4751&signature=ba4fd59c5eea73b5b160cbe1dd25218e8e6ed4e33e4813b2f726d5a1afb6a648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->