### PR TITLE
feat(davinci): emit template v-if/v-for fragments (P2-11)

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_tpl.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_tpl.rs
@@ -1,0 +1,125 @@
+//! P2-11 `<template v-if>` / `<template v-for>` fragment witness,
+//! compared **byte-for-byte** including helper usage and hoists.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+use vize_atelier_dom::compile_template;
+use vize_carton::Allocator;
+use vize_ricalco::{DOM_LANE_FLAG, emit_dom_source};
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "vif_two_span",
+        r#"<template v-if="ok"><span></span><span></span></template>"#,
+    ),
+    (
+        "vif_one_span",
+        r#"<template v-if="ok"><span></span></template>"#,
+    ),
+    ("vif_interp", r#"<template v-if="ok">{{ msg }}</template>"#),
+    ("vif_text", r#"<template v-if="ok">hello</template>"#),
+    (
+        "vif_compound",
+        r#"<template v-if="ok">hello {{ msg }}</template>"#,
+    ),
+    (
+        "vif_key",
+        r#"<template v-if="ok" key="k"><span></span><p></p></template>"#,
+    ),
+    (
+        "vif_else",
+        r#"<template v-if="ok"><span>a</span><span>b</span></template><div v-else>no</div>"#,
+    ),
+    (
+        "vif_nested",
+        r#"<div><template v-if="ok"><span></span><p></p></template></div>"#,
+    ),
+    (
+        "vif_comp",
+        r#"<template v-if="ok"><Foo /><Bar /></template>"#,
+    ),
+    (
+        "vif_text_span",
+        r#"<template v-if="ok">hello<span></span></template>"#,
+    ),
+    (
+        "vif_unwrap_dyn",
+        r#"<template v-if="ok"><span>{{ msg }}</span></template>"#,
+    ),
+    (
+        "vif_unwrap_comp",
+        r#"<template v-if="ok"><Foo /></template>"#,
+    ),
+    ("empty_tpl_vif", r#"<template v-if="ok"></template>"#),
+    (
+        "vif_for",
+        r#"<template v-if="ok"><div v-for="i in n">{{ i }}</div></template>"#,
+    ),
+    (
+        "vfor_two",
+        r#"<template v-for="item in list"><span></span><span></span></template>"#,
+    ),
+    (
+        "vfor_keyed",
+        r#"<template v-for="item in list" :key="item"><span></span><span></span></template>"#,
+    ),
+    (
+        "vfor_one",
+        r#"<template v-for="item in list"><span></span></template>"#,
+    ),
+    (
+        "vfor_one_keyed",
+        r#"<template v-for="item in list" :key="item"><span>{{ item }}</span></template>"#,
+    ),
+    (
+        "vfor_numeric",
+        r#"<template v-for="n in 3"><span></span><span></span></template>"#,
+    ),
+    (
+        "vfor_interp",
+        r#"<template v-for="item in list">{{ item }}</template>"#,
+    ),
+    (
+        "vfor_unwrap_dyn",
+        r#"<template v-for="item in list"><span>{{ item }}</span></template>"#,
+    ),
+];
+
+fn shipped(src: &str) -> String {
+    let allocator = Allocator::new();
+    let (_, errors, result) = compile_template(&allocator, src);
+    assert!(errors.is_empty(), "shipped lane errors: {errors:?}");
+    format!("{}\n{}", result.preamble, result.code)
+}
+
+#[test]
+fn s2_template_wrapper_fragments_match_the_shipped_dom_lane_byte_for_byte() {
+    let mut compared = 0u64;
+    let mut skipped_legacy_flag = 0u64;
+    if std::env::var(DOM_LANE_FLAG).is_ok_and(|value| value == "legacy") {
+        skipped_legacy_flag += 1;
+    } else {
+        let allocator = Allocator::new();
+        for (name, src) in BATTERY {
+            let old = shipped(src);
+            let new = emit_dom_source(&allocator, src)
+                .unwrap_or_else(|error| panic!("{name}: S2 emit refused: {error:?}"))
+                .assembled();
+            assert_eq!(
+                old.as_str(),
+                new.as_str(),
+                "{name}: S2 DOM emit diverged from the shipped lane"
+            );
+            compared += 1;
+        }
+    }
+    assert_eq!(
+        (compared, skipped_legacy_flag),
+        (BATTERY.len() as u64, 0),
+        "a cfg or {DOM_LANE_FLAG}=legacy regression disarmed the dual-run"
+    );
+}

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -20,8 +20,9 @@
 //! Vue builtins (`Teleport` / `KeepAlive` / `Transition` / `Suspense`),
 //! `<component :is>` (`resolveDynamicComponent`), and **template
 //! fragments** (empty → `null`, multi-root / compound-root
-//! `_Fragment` + `STABLE_FRAGMENT`), and **object `v-on`**
-//! (`toHandlers(..., true)`).
+//! `_Fragment` + `STABLE_FRAGMENT`), **`<template v-if>` /
+//! `<template v-for>` fragments** (`STABLE_FRAGMENT` / unwrap after
+//! hoist), and **object `v-on`** (`toHandlers(..., true)`).
 //! `.native` and filters stay [`EmitError::Unsupported`]. The old
 //! lane stays the shipped compile path; [`super::DOM_LANE_FLAG`] is
 //! named here and *read* in the atelier_dom witness.
@@ -56,6 +57,8 @@ mod outlet;
 mod props;
 #[path = "emit/slots.rs"]
 mod slots;
+#[path = "emit/tpl.rs"]
+mod tpl;
 #[path = "emit/vfor.rs"]
 mod vfor;
 #[path = "emit/vif.rs"]
@@ -67,16 +70,17 @@ use vize_carton::{Allocator, String};
 use vize_davinci::diagnostic::Severity;
 use vize_davinci::id::NodeId;
 use vize_davinci::pass::BudgetObserver;
+use vize_davinci::side_table::SideTable;
 use vize_disegno::op::{ElementOp, ForOp, IfOp, Op, Region};
 use vize_sinopia::parse;
 
-use crate::lower::{Lowered, lower};
+use crate::lower::{ForWrapper, Lowered, WrapperKeys, lower};
 use crate::pass::walk::PageWalk;
 use crate::pass::{S2Facts, run_transform};
 
 use self::buf::Buf;
-use self::helper::Helper;
 use self::fragment::emit_root;
+use self::helper::Helper;
 
 /// Transform visit order for helpers the shipped lane parks on
 /// `root.helpers` (`CreateElementVNode` on native elements,
@@ -131,16 +135,22 @@ fn emit_if_branch_call(
     vnode::emit_if_branch_element(cx, element, key)
 }
 
-fn emit_for_op(cx: &mut EmitCx<'_>, for_op: &ForOp<'_>) -> Result<(), EmitError> {
-    vfor::emit_for(cx, for_op)
+fn emit_for_op(
+    cx: &mut EmitCx<'_>,
+    for_op: &ForOp<'_>,
+    id: Option<NodeId>,
+    fragment_key: Option<&str>,
+) -> Result<(), EmitError> {
+    vfor::emit_for(cx, for_op, id, fragment_key)
 }
 
 fn emit_for_item_call(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
     stable: bool,
+    key: Option<&str>,
 ) -> Result<(), EmitError> {
-    vnode::emit_for_item_element(cx, element, stable)
+    vnode::emit_for_item_element(cx, element, stable, key)
 }
 
 /// Per-emit numbering + helper buffer. Page-order ids re-derive the
@@ -148,6 +158,8 @@ fn emit_for_item_call(
 struct EmitCx<'facts> {
     buf: Buf,
     facts: &'facts S2Facts,
+    wrappers: &'facts SideTable<WrapperKeys>,
+    for_wrappers: &'facts SideTable<ForWrapper>,
     walk: PageWalk,
     /// Sibling `v-if` chains share one counter; nested chains reset.
     if_branch_key: u32,
@@ -205,6 +217,8 @@ pub fn emit_dom(lowered: &Lowered<'_>, facts: &S2Facts) -> Result<DomEmit, EmitE
     let mut cx = EmitCx {
         buf: Buf::new(),
         facts,
+        wrappers: &lowered.wrappers,
+        for_wrappers: &lowered.for_wrappers,
         walk: PageWalk::new(),
         if_branch_key: 0,
         in_v_for: false,

--- a/crates/vize_ricalco/src/emit/fragment.rs
+++ b/crates/vize_ricalco/src/emit/fragment.rs
@@ -7,6 +7,8 @@
 use vize_disegno::expr::{ExprRef, OpaqueReason};
 use vize_disegno::op::{InterpolationOp, Op, Region};
 
+use super::EmitCx;
+use super::EmitError;
 use super::buf::Buf;
 use super::children::{
     emit_create_text_vnode, emit_interpolation, emit_plain_text_vnode, emit_to_display_string,
@@ -14,8 +16,6 @@ use super::children::{
 use super::helper::Helper;
 use super::slots::is_whitespace_text;
 use super::vnode;
-use super::EmitCx;
-use super::EmitError;
 
 pub(super) fn root_needs_fragment(root: &Region<'_>) -> bool {
     let mut count = 0u32;
@@ -86,7 +86,7 @@ fn emit_unique(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> {
         }
         Op::For(for_op) => {
             let _id = cx.walk.mint();
-            super::emit_for_op(cx, for_op)
+            super::emit_for_op(cx, for_op, _id, None)
         }
         Op::Slot(slot) => {
             let _id = cx.walk.mint();
@@ -157,7 +157,7 @@ fn emit_units(cx: &mut EmitCx<'_>, op: &Op<'_>, first: &mut bool) -> Result<(), 
         Op::For(for_op) => {
             start_item(cx, first);
             let _id = cx.walk.mint();
-            super::emit_for_op(cx, for_op)
+            super::emit_for_op(cx, for_op, _id, None)
         }
         Op::Slot(slot) => {
             start_item(cx, first);

--- a/crates/vize_ricalco/src/emit/tpl.rs
+++ b/crates/vize_ricalco/src/emit/tpl.rs
@@ -1,0 +1,251 @@
+//! Unwrapped `<template v-if>` / `<template v-for>` fragments.
+//!
+//! The lowering unwraps the wrapper, so emit reads
+//! [`WrapperKeys::from_template`] / [`ForWrapper`] to recover the
+//! shipped hoist-then-codegen split: a still-dynamic single element
+//! unwraps to a block; a hoistable / text / multi child stays a
+//! `STABLE_FRAGMENT`.
+
+use vize_carton::String;
+use vize_disegno::expr::{ExprRef, OpaqueReason};
+use vize_disegno::op::{IfBranch, Op};
+
+use super::EmitCx;
+use super::EmitError;
+use super::buf::Buf;
+use super::children::{emit_create_text_vnode, emit_plain_text_vnode, emit_to_display_string};
+use super::hoist::{emit_hoisted_element, is_hoistable};
+use super::js::escape_js_string;
+use super::vnode;
+use crate::lower::WrapperKey;
+
+#[derive(Clone, Copy)]
+enum ChildMode {
+    /// `generate_children_force_array`: interpolations are
+    /// `_createTextVNode(_toDisplayString(…), 1)`.
+    ForceArray,
+    /// `generate_node` per child: interpolations stay bare
+    /// `_toDisplayString`.
+    GenerateNode,
+}
+
+pub(super) fn wrapper_key_js(key: &WrapperKey) -> Result<String, EmitError> {
+    match key {
+        WrapperKey::Static { value: None, .. } => Ok(String::from("\"\"")),
+        WrapperKey::Static {
+            value: Some(value), ..
+        } => {
+            let mut out = String::from("\"");
+            out.push_str(escape_js_string(value.as_str()).as_str());
+            out.push('"');
+            Ok(out)
+        }
+        WrapperKey::Dynamic { source, .. } if source.is_empty() => Err(EmitError::Unsupported),
+        WrapperKey::Dynamic { source, .. } => Ok(source.clone()),
+    }
+}
+
+pub(super) fn emit_if_template_branch(
+    cx: &mut EmitCx<'_>,
+    branch: &IfBranch<'_>,
+    key: &str,
+) -> Result<(), EmitError> {
+    if should_unwrap_if(&branch.region.ops) {
+        return unwrap_if(cx, branch, key);
+    }
+    emit_inner_fragment(cx, &branch.region.ops, Some(key), ChildMode::ForceArray)
+}
+
+fn should_unwrap_if(ops: &[Op<'_>]) -> bool {
+    match ops {
+        [Op::Element(element)] => !is_hoistable(element),
+        [Op::Component(_)] | [Op::Slot(_)] | [Op::For(_)] => true,
+        _ => false,
+    }
+}
+
+fn unwrap_if(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<(), EmitError> {
+    match branch.region.ops.as_slice() {
+        [Op::Element(element)] => {
+            let _id = cx.walk.mint();
+            cx.walk.skip(element.bindings.len());
+            super::emit_if_branch_call(cx, element, key)
+        }
+        [Op::Component(component)] => {
+            let id = cx.walk.mint();
+            cx.walk.skip(component.bindings.len());
+            super::component::emit_if_branch(cx, component, key, id)
+        }
+        [Op::Slot(slot)] => {
+            let _id = cx.walk.mint();
+            cx.walk.skip(slot.bindings.len());
+            super::outlet::emit_outlet(cx, slot, Some(key), true)
+        }
+        [Op::For(for_op)] => {
+            let id = cx.walk.mint();
+            super::emit_for_op(cx, for_op, id, Some(key))
+        }
+        _ => Err(EmitError::Unsupported),
+    }
+}
+
+pub(super) fn should_unwrap_for(ops: &[Op<'_>]) -> bool {
+    matches!(ops, [Op::Element(element)] if !is_hoistable(element))
+}
+
+pub(super) fn emit_for_template_item(
+    cx: &mut EmitCx<'_>,
+    ops: &[Op<'_>],
+    stable: bool,
+    key: Option<&str>,
+) -> Result<(), EmitError> {
+    if should_unwrap_for(ops) {
+        let Op::Element(element) = &ops[0] else {
+            return Err(EmitError::Unsupported);
+        };
+        let _id = cx.walk.mint();
+        cx.walk.skip(element.bindings.len());
+        return super::emit_for_item_call(cx, element, stable, key);
+    }
+    emit_inner_fragment(cx, ops, key, ChildMode::GenerateNode)
+}
+
+fn emit_inner_fragment(
+    cx: &mut EmitCx<'_>,
+    ops: &[Op<'_>],
+    key: Option<&str>,
+    mode: ChildMode,
+) -> Result<(), EmitError> {
+    cx.buf.use_open_block();
+    cx.buf.use_create_element_block();
+    cx.buf.use_fragment();
+    cx.buf.push("(");
+    cx.buf.push(Buf::open_block_alias());
+    cx.buf.push("(), ");
+    cx.buf.push(Buf::create_element_block_alias());
+    cx.buf.push("(");
+    cx.buf.push(Buf::fragment_alias());
+    if let Some(key) = key {
+        cx.buf.push(", { key: ");
+        cx.buf.push(key);
+        cx.buf.push(" }, ");
+    } else {
+        cx.buf.push(", null, ");
+    }
+    emit_fragment_children(cx, ops, mode)?;
+    cx.buf.push(", 64 /* STABLE_FRAGMENT */))");
+    Ok(())
+}
+
+fn emit_fragment_children(
+    cx: &mut EmitCx<'_>,
+    ops: &[Op<'_>],
+    mode: ChildMode,
+) -> Result<(), EmitError> {
+    if ops.is_empty() {
+        cx.buf.push("null");
+        return Ok(());
+    }
+    cx.buf.push("[");
+    cx.buf.indent();
+    match mode {
+        ChildMode::ForceArray => emit_force_array(cx, ops)?,
+        ChildMode::GenerateNode => emit_generate_node(cx, ops)?,
+    }
+    cx.buf.deindent();
+    cx.buf.newline();
+    cx.buf.push("]");
+    Ok(())
+}
+
+fn emit_force_array(cx: &mut EmitCx<'_>, ops: &[Op<'_>]) -> Result<(), EmitError> {
+    let mut i = 0;
+    let mut first = true;
+    while i < ops.len() {
+        if matches!(ops[i], Op::Text(_) | Op::Interpolation(_)) {
+            let start = i;
+            while i < ops.len() && matches!(ops[i], Op::Text(_) | Op::Interpolation(_)) {
+                i += 1;
+            }
+            start_item(cx, &mut first);
+            emit_create_text_vnode(cx, &ops[start..i])?;
+            continue;
+        }
+        start_item(cx, &mut first);
+        emit_node_child(cx, &ops[i])?;
+        i += 1;
+    }
+    Ok(())
+}
+
+fn emit_generate_node(cx: &mut EmitCx<'_>, ops: &[Op<'_>]) -> Result<(), EmitError> {
+    let mut first = true;
+    for op in ops {
+        match op {
+            Op::Text(_) => {
+                start_item(cx, &mut first);
+                emit_create_text_vnode(cx, core::slice::from_ref(op))?;
+            }
+            Op::Interpolation(interp) => {
+                emit_gen_interp(cx, interp, &mut first)?;
+            }
+            _ => {
+                start_item(cx, &mut first);
+                emit_node_child(cx, op)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn emit_gen_interp(
+    cx: &mut EmitCx<'_>,
+    interp: &vize_disegno::op::InterpolationOp<'_>,
+    first: &mut bool,
+) -> Result<(), EmitError> {
+    let id = cx.walk.mint();
+    match interp.expression {
+        ExprRef::Js(js) => {
+            start_item(cx, first);
+            emit_to_display_string(cx, js.source);
+            Ok(())
+        }
+        ExprRef::Opaque(opaque) if opaque.reason == OpaqueReason::Compound => {
+            let id = id.ok_or(EmitError::Unsupported)?;
+            let parts = cx
+                .facts
+                .text_facts
+                .get(id)
+                .ok_or(EmitError::Unsupported)?
+                .parts
+                .clone();
+            for part in parts.iter() {
+                start_item(cx, first);
+                if part.dynamic {
+                    emit_to_display_string(cx, part.text.as_str());
+                } else {
+                    emit_plain_text_vnode(cx, part.text.as_str());
+                }
+            }
+            Ok(())
+        }
+        ExprRef::Foreign(_) | ExprRef::Filter(_) | ExprRef::Opaque(_) => {
+            Err(EmitError::Unsupported)
+        }
+    }
+}
+
+fn emit_node_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> {
+    match op {
+        Op::Element(element) if is_hoistable(element) => emit_hoisted_element(cx, element),
+        _ => vnode::emit_array_child(cx, op),
+    }
+}
+
+fn start_item(cx: &mut EmitCx<'_>, first: &mut bool) {
+    if !*first {
+        cx.buf.push(",");
+    }
+    *first = false;
+    cx.buf.newline();
+}

--- a/crates/vize_ricalco/src/emit/vfor.rs
+++ b/crates/vize_ricalco/src/emit/vfor.rs
@@ -1,33 +1,49 @@
 //! Native HTML `ui.for` (`v-for`) emission.
 
 use vize_carton::ToCompactString;
+use vize_davinci::id::NodeId;
 use vize_disegno::expr::ExprRef;
 use vize_disegno::op::{Attribute, BindingOp, DynamicName, ForOp, Op};
 
-use super::buf::Buf;
-use super::js::is_valid_js_identifier;
 use super::EmitCx;
 use super::EmitError;
+use super::buf::Buf;
+use super::js::is_valid_js_identifier;
 
-pub(super) fn emit_for(cx: &mut EmitCx<'_>, for_op: &ForOp<'_>) -> Result<(), EmitError> {
+pub(super) fn emit_for(
+    cx: &mut EmitCx<'_>,
+    for_op: &ForOp<'_>,
+    id: Option<NodeId>,
+    fragment_key: Option<&str>,
+) -> Result<(), EmitError> {
     let source = js_source(&for_op.binding.source)?;
     let value = value_alias(&for_op.binding.value)?;
     let key_alias = optional_ident(&for_op.binding.key)?;
     let index_alias = optional_ident(&for_op.binding.index)?;
-    let (bind_len, keyed) = match for_op.region.ops.as_slice() {
-        [Op::Element(element)] => (
-            element.bindings.len(),
-            has_item_key(&element.attributes, &element.bindings),
-        ),
-        [Op::Component(component)] => (
-            component.bindings.len(),
-            has_item_key(&component.attributes, &component.bindings),
-        ),
-        [Op::Slot(slot)] => (
-            slot.bindings.len(),
-            has_item_key(&slot.attributes, &slot.bindings),
-        ),
-        _ => return Err(EmitError::Unsupported),
+    let wrapper = id.and_then(|id| cx.for_wrappers.get(id));
+    let wrapper_key = match wrapper.and_then(|wrapper| wrapper.key.as_ref()) {
+        Some(key) => Some(super::tpl::wrapper_key_js(key)?),
+        None => None,
+    };
+    let from_template = wrapper.is_some();
+    let (bind_len, keyed) = if from_template {
+        (0, wrapper_key.is_some())
+    } else {
+        match for_op.region.ops.as_slice() {
+            [Op::Element(element)] => (
+                element.bindings.len(),
+                has_item_key(&element.attributes, &element.bindings),
+            ),
+            [Op::Component(component)] => (
+                component.bindings.len(),
+                has_item_key(&component.attributes, &component.bindings),
+            ),
+            [Op::Slot(slot)] => (
+                slot.bindings.len(),
+                has_item_key(&slot.attributes, &slot.bindings),
+            ),
+            _ => return Err(EmitError::Unsupported),
+        }
     };
     let stable = is_numeric(source);
     let flag = if stable {
@@ -58,7 +74,13 @@ pub(super) fn emit_for(cx: &mut EmitCx<'_>, for_op: &ForOp<'_>) -> Result<(), Em
     cx.buf.push(Buf::create_element_block_alias());
     cx.buf.push("(");
     cx.buf.push(Buf::fragment_alias());
-    cx.buf.push(", null, ");
+    if let Some(key) = fragment_key {
+        cx.buf.push(", { key: ");
+        cx.buf.push(key);
+        cx.buf.push(" }, ");
+    } else {
+        cx.buf.push(", null, ");
+    }
     cx.buf.push(Buf::render_list_alias());
     cx.buf.push("(");
     cx.buf.push(source);
@@ -76,20 +98,12 @@ pub(super) fn emit_for(cx: &mut EmitCx<'_>, for_op: &ForOp<'_>) -> Result<(), Em
     cx.buf.indent();
     cx.buf.newline();
     cx.buf.push("return ");
-    let _id = cx.walk.mint();
-    cx.walk.skip(bind_len);
     let prev_in_v_for = cx.in_v_for;
     cx.in_v_for = true;
-    let item = match for_op.region.ops.as_slice() {
-        [Op::Element(element)] if super::hoist::is_hoistable(element) => {
-            let alias = super::hoist::hoist_static_element(cx, element);
-            cx.buf.push(alias.as_str());
-            Ok(())
-        }
-        [Op::Element(element)] => super::emit_for_item_call(cx, element, stable),
-        [Op::Component(component)] => super::component::emit_for_item(cx, component, _id),
-        [Op::Slot(slot)] => super::outlet::emit_outlet(cx, slot, None, false),
-        _ => Err(EmitError::Unsupported),
+    let item = if from_template {
+        super::tpl::emit_for_template_item(cx, &for_op.region.ops, stable, wrapper_key.as_deref())
+    } else {
+        emit_plain_item(cx, for_op, bind_len, stable)
     };
     cx.in_v_for = prev_in_v_for;
     item?;
@@ -101,6 +115,27 @@ pub(super) fn emit_for(cx: &mut EmitCx<'_>, for_op: &ForOp<'_>) -> Result<(), Em
     cx.buf.push(flag_name);
     cx.buf.push(" */))");
     Ok(())
+}
+
+fn emit_plain_item(
+    cx: &mut EmitCx<'_>,
+    for_op: &ForOp<'_>,
+    bind_len: usize,
+    stable: bool,
+) -> Result<(), EmitError> {
+    let id = cx.walk.mint();
+    cx.walk.skip(bind_len);
+    match for_op.region.ops.as_slice() {
+        [Op::Element(element)] if super::hoist::is_hoistable(element) => {
+            let alias = super::hoist::hoist_static_element(cx, element);
+            cx.buf.push(alias.as_str());
+            Ok(())
+        }
+        [Op::Element(element)] => super::emit_for_item_call(cx, element, stable, None),
+        [Op::Component(component)] => super::component::emit_for_item(cx, component, id),
+        [Op::Slot(slot)] => super::outlet::emit_outlet(cx, slot, None, false),
+        _ => Err(EmitError::Unsupported),
+    }
 }
 
 pub(super) fn js_source<'a>(expr: &'a ExprRef<'a>) -> Result<&'a str, EmitError> {

--- a/crates/vize_ricalco/src/emit/vif.rs
+++ b/crates/vize_ricalco/src/emit/vif.rs
@@ -5,10 +5,10 @@ use vize_davinci::id::NodeId;
 use vize_disegno::expr::ExprRef;
 use vize_disegno::op::{IfBranch, IfOp, Op};
 
-use super::buf::Buf;
-use super::js::escape_js_string;
 use super::EmitCx;
 use super::EmitError;
+use super::buf::Buf;
+use super::js::escape_js_string;
 use crate::pass::{BranchKeyKind, IfFacts};
 
 pub(super) fn emit_if(
@@ -48,7 +48,15 @@ pub(super) fn emit_if(
         let key = branch_key_js(facts, i, allocated)?;
         let saved = cx.if_branch_key;
         cx.if_branch_key = 0;
-        emit_branch(cx, branch, key.as_str())?;
+        let from_template = id
+            .and_then(|id| cx.wrappers.get(id))
+            .and_then(|keys| keys.from_template.get(i).copied())
+            .unwrap_or(false);
+        if from_template {
+            super::tpl::emit_if_template_branch(cx, branch, key.as_str())?;
+        } else {
+            emit_branch(cx, branch, key.as_str())?;
+        }
         cx.if_branch_key = saved;
         if branch.condition.is_some() && i > 0 {
             cx.buf.deindent();

--- a/crates/vize_ricalco/src/emit/vnode.rs
+++ b/crates/vize_ricalco/src/emit/vnode.rs
@@ -1,15 +1,15 @@
 //! Static native HTML element / children emission.
 
-use vize_carton::{ensure_sufficient_stack, String};
+use vize_carton::{String, ensure_sufficient_stack};
 use vize_disegno::op::{Attribute, ElementOp, Namespace, Op, Region};
 
+use super::EmitCx;
+use super::EmitError;
 use super::buf::Buf;
 use super::children::{children_need_text_flag, emit_create_text_vnode, emit_text_like};
 use super::flag::emit_patch_flag;
 use super::hoist::{compact_props_object, push_attr_pair, unique_attrs};
 use super::props::{admit_bindings, bind_patch, emit_bind_props};
-use super::EmitCx;
-use super::EmitError;
 
 pub(super) fn emit_unique_element(
     cx: &mut EmitCx<'_>,
@@ -69,11 +69,12 @@ pub(super) fn emit_for_item_element(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
     stable: bool,
+    key: Option<&str>,
 ) -> Result<(), EmitError> {
     if stable {
         cx.buf.use_create_element_vnode();
         return emit_call(
-            cx, element, /* block */ false, None, /* hoist */ false,
+            cx, element, /* block */ false, key, /* hoist */ false,
         );
     }
     cx.buf.use_open_block();
@@ -82,7 +83,7 @@ pub(super) fn emit_for_item_element(
     cx.buf.push(Buf::open_block_alias());
     cx.buf.push("(), ");
     emit_call(
-        cx, element, /* block */ true, None, /* hoist */ false,
+        cx, element, /* block */ true, key, /* hoist */ false,
     )?;
     cx.buf.push(")");
     Ok(())
@@ -259,7 +260,7 @@ pub(super) fn emit_array_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), E
             super::component::emit_nested(cx, component, id)
         }
         Op::If(if_op) => super::emit_if_op(cx, if_op, id),
-        Op::For(for_op) => super::emit_for_op(cx, for_op),
+        Op::For(for_op) => super::emit_for_op(cx, for_op, id, None),
         Op::Slot(slot) => {
             cx.walk.skip(slot.bindings.len());
             super::outlet::emit_outlet(cx, slot, None, false)

--- a/crates/vize_ricalco/src/lower.rs
+++ b/crates/vize_ricalco/src/lower.rs
@@ -56,7 +56,7 @@ pub(crate) use expr::simple_identifier;
 // The wrapper-key channel (P2-9 series 5): captured `<template v-if>`
 // keys, folded into branch-key facts by the v-if pass.
 pub use css::lower_style_block;
-pub use structural::{WrapperKey, WrapperKeys};
+pub use structural::{ForWrapper, WrapperKey, WrapperKeys};
 // The one-rebuild rule (the same discipline): the text pass re-derives a
 // compound's source with exactly the spelling the lowering minted.
 pub use text::{TextPart, TextParts, rebuild_source};
@@ -90,8 +90,12 @@ pub struct Lowered<'a> {
     pub texts: SideTable<TextParts>,
     /// Captured `<template v-if>` wrapper keys, keyed by the `ui.if`
     /// op's page-order id (P2-9 series 5, [`WrapperKeys`]); folded into
-    /// branch-key facts by `pass::vif`.
+    /// branch-key facts by `pass::vif`. `from_template` is the P2-11
+    /// emit signal for template-fragment vs branch-root blocks.
     pub wrappers: SideTable<WrapperKeys>,
+    /// Captured `<template v-for>` unwrap facts, keyed by the `ui.for`
+    /// op's page-order id. Presence means the carrier was a template.
+    pub for_wrappers: SideTable<ForWrapper>,
     /// Vue dialect sugar the lowering (and the legalizing pass) consult.
     /// [`LegacyCaps::VUE3`] unless the caller used [`lower_with_caps`].
     pub caps: LegacyCaps,
@@ -143,6 +147,7 @@ pub fn lower_with_caps<'a>(
         scopes: cx.scopes,
         texts: cx.texts,
         wrappers: cx.wrappers,
+        for_wrappers: cx.for_wrappers,
         caps,
     }
 }
@@ -157,6 +162,7 @@ impl fmt::Debug for Lowered<'_> {
             .field("scopes", &self.scopes)
             .field("texts", &self.texts)
             .field("wrappers", &self.wrappers)
+            .field("for_wrappers", &self.for_wrappers)
             .field("caps", &self.caps)
             .finish_non_exhaustive()
     }

--- a/crates/vize_ricalco/src/lower/cx.rs
+++ b/crates/vize_ricalco/src/lower/cx.rs
@@ -41,6 +41,7 @@ pub(crate) struct Cx<'a> {
     pub scopes: SideTable<ScopeFacts>,
     pub texts: SideTable<super::text::TextParts>,
     pub wrappers: SideTable<super::structural::WrapperKeys>,
+    pub for_wrappers: SideTable<super::structural::ForWrapper>,
     pub caps: super::caps::LegacyCaps,
 }
 
@@ -62,6 +63,7 @@ impl<'a> Cx<'a> {
             scopes: SideTable::new(),
             texts: SideTable::new(),
             wrappers: SideTable::new(),
+            for_wrappers: SideTable::new(),
             caps,
         }
     }
@@ -98,6 +100,17 @@ impl<'a> Cx<'a> {
     ) {
         if let Some(id) = node {
             self.wrappers.insert(id, keys);
+        }
+    }
+
+    /// Attach a `<template v-for>` unwrap fact to its `ui.for` op.
+    pub(crate) fn attach_for_wrapper(
+        &mut self,
+        node: Option<NodeId>,
+        wrapper: super::structural::ForWrapper,
+    ) {
+        if let Some(id) = node {
+            self.for_wrappers.insert(id, wrapper);
         }
     }
 

--- a/crates/vize_ricalco/src/lower/forop.rs
+++ b/crates/vize_ricalco/src/lower/forop.rs
@@ -4,17 +4,17 @@
 
 use alloc::vec::Vec as StdVec;
 
-use vize_carton::{cstr, Box, String, Vec};
+use vize_carton::{Box, String, Vec, cstr};
 use vize_sinopia::Element;
 
 use vize_disegno::expr::{ExprRef, OpaqueReason};
 use vize_disegno::op::{ForBinding, ForOp, Namespace, Op, Region};
 use vize_disegno::scope::{ScopeBinding, ScopeFacts, ScopeOrigin};
 
-use super::cx::{attr_slice, attr_span, element_span, Cx};
-use super::element::{attr_value_text, element_core, Analyzed};
+use super::cx::{Cx, attr_slice, attr_span, element_span};
+use super::element::{Analyzed, attr_value_text, element_core};
 use super::expr::{desc, expr_at, opaque_at, simple_identifier, trimmed};
-use super::structural::{lower_children, record_template_drops};
+use super::structural::{ForWrapper, capture_wrapper_key, lower_children, record_template_drops};
 use super::vfor::{split_aliases, split_for};
 
 /// Build the `ui.for` for an element's `v-for` — or, when the directive
@@ -126,7 +126,13 @@ pub(crate) fn lower_for<'a>(
     let region = Region {
         ops: if element.tag() == "template" && !analyzed.has_slot_spelling() {
             cx.report_missing_close(element);
-            record_template_drops(cx, element, analyzed, None);
+            let captured = capture_wrapper_key(cx, element, analyzed);
+            let (skip, key) = match captured {
+                Some((index, key)) => (Some(index), Some(key)),
+                None => (None, None),
+            };
+            record_template_drops(cx, element, analyzed, skip);
+            cx.attach_for_wrapper(node, ForWrapper { key });
             lower_children(cx, &element.children, ns)
         } else {
             let op = element_core(cx, element, analyzed, ns);

--- a/crates/vize_ricalco/src/lower/structural.rs
+++ b/crates/vize_ricalco/src/lower/structural.rs
@@ -15,13 +15,13 @@
 
 use alloc::vec::Vec as StdVec;
 
-use vize_carton::{cstr, Box, Span, String, Vec};
+use vize_carton::{Box, Span, String, Vec, cstr};
 use vize_sinopia::{Element, SurfaceChild};
 
 use vize_disegno::op::{IfBranch, IfOp, Namespace, Op, Region};
 
-use super::cx::{attr_slice, attr_span, element_span, Cx};
-use super::element::{analyze, attr_value_text, element_core, Analyzed, BranchKind};
+use super::cx::{Cx, attr_slice, attr_span, element_span};
+use super::element::{Analyzed, BranchKind, analyze, attr_value_text, element_core};
 use super::expr::expr_at;
 use super::forop::lower_for;
 use super::leaf::lower_leaf;
@@ -30,9 +30,8 @@ use super::text;
 #[path = "structural/wrapper.rs"]
 mod wrapper;
 
-use wrapper::capture_wrapper_key;
-pub(crate) use wrapper::record_template_drops;
-pub use wrapper::{WrapperKey, WrapperKeys};
+pub(crate) use wrapper::{capture_wrapper_key, record_template_drops};
+pub use wrapper::{ForWrapper, WrapperKey, WrapperKeys};
 
 /// One scanned branch of a chain: its element, analysis, branch-attr
 /// index, and the gap children it consumes.
@@ -158,6 +157,7 @@ fn lower_if_group<'a>(
 
     let mut lowered: Vec<'a, IfBranch<'a>> = Vec::new_in(&cx.allocator);
     let mut wrapper_keys: StdVec<Option<WrapperKey>> = StdVec::new();
+    let mut from_template: StdVec<bool> = StdVec::new();
     for (element, analyzed, attr_idx, gaps) in branches {
         for gap in gaps {
             if let SurfaceChild::Text(token) | SurfaceChild::Comment(token) = &children[gap] {
@@ -196,7 +196,7 @@ fn lower_if_group<'a>(
                 Some(expr_at(cx, slice))
             }
         };
-        let (ops, wrapper_key) = branch_body(cx, element, &analyzed, ns);
+        let (ops, wrapper_key, is_template) = branch_body(cx, element, &analyzed, ns);
         if let Some(key) = &wrapper_key {
             let (key_span, spelling) = match key {
                 WrapperKey::Static { span, .. } | WrapperKey::Dynamic { span, .. } => (
@@ -215,17 +215,19 @@ fn lower_if_group<'a>(
             );
         }
         wrapper_keys.push(wrapper_key);
+        from_template.push(is_template);
         lowered.push(IfBranch {
             condition,
             region: Region { ops },
             span: element_span(cx, element),
         });
     }
-    if wrapper_keys.iter().any(Option::is_some) {
+    if wrapper_keys.iter().any(Option::is_some) || from_template.iter().any(|flag| *flag) {
         cx.attach_wrappers(
             node,
             WrapperKeys {
                 branches: wrapper_keys,
+                from_template,
             },
         );
     }
@@ -240,21 +242,22 @@ fn lower_if_group<'a>(
 }
 
 /// The ops a branch's element contributes (plus its captured wrapper
-/// key): its `v-for` wrap when it has one, its children directly when it
-/// is an unwrapped `<template>`, the element op otherwise.
+/// key and whether the carrier was an unwrapped `<template>`): its
+/// `v-for` wrap when it has one, its children directly when it is an
+/// unwrapped `<template>`, the element op otherwise.
 fn branch_body<'a>(
     cx: &mut Cx<'a>,
     element: &Element<'a>,
     analyzed: &Analyzed<'a>,
     ns: Namespace,
-) -> (Vec<'a, Op<'a>>, Option<WrapperKey>) {
+) -> (Vec<'a, Op<'a>>, Option<WrapperKey>, bool) {
     if analyzed.vfor.is_some() {
         // Vue 3 precedence: the key belongs to `v-for`, so no wrapper
         // capture — exactly the legacy `has_v_for` guard.
         let op = lower_for(cx, element, analyzed, ns);
         let mut ops: Vec<'a, Op<'a>> = Vec::new_in(&cx.allocator);
         ops.push(op);
-        return (ops, None);
+        return (ops, None, false);
     }
     if element.tag() == "template" {
         if analyzed.has_slot_spelling() {
@@ -263,7 +266,7 @@ fn branch_body<'a>(
             let op = element_core(cx, element, analyzed, ns);
             let mut ops: Vec<'a, Op<'a>> = Vec::new_in(&cx.allocator);
             ops.push(op);
-            return (ops, None);
+            return (ops, None, false);
         }
         cx.report_missing_close(element);
         let captured = capture_wrapper_key(cx, element, analyzed);
@@ -272,12 +275,12 @@ fn branch_body<'a>(
             None => (None, None),
         };
         record_template_drops(cx, element, analyzed, skip);
-        return (lower_children(cx, &element.children, ns), key);
+        return (lower_children(cx, &element.children, ns), key, true);
     }
     let op = element_core(cx, element, analyzed, ns);
     let mut ops: Vec<'a, Op<'a>> = Vec::new_in(&cx.allocator);
     ops.push(op);
-    (ops, None)
+    (ops, None, false)
 }
 
 /// Lower an element, wrapping it in its `ui.for` when it carries one.

--- a/crates/vize_ricalco/src/lower/structural/wrapper.rs
+++ b/crates/vize_ricalco/src/lower/structural/wrapper.rs
@@ -47,6 +47,21 @@ pub struct WrapperKeys {
     /// `branches[i]` is branch `i`'s wrapper key, when its carrier was
     /// an unwrapped `<template>` with one.
     pub branches: StdVec<Option<WrapperKey>>,
+    /// `from_template[i]` is true when branch `i`'s carrier was an
+    /// unwrapped `<template>` (slot-bearing templates stay wrapped and
+    /// stay false). P2-11 emit needs this: after hoist, a static child
+    /// of `<template v-if>` is a fragment, while the same element as a
+    /// `v-if` branch root is a block.
+    pub from_template: StdVec<bool>,
+}
+
+/// A `<template v-for>` the lowering unwraps: presence of this fact on
+/// a `ui.for` is the emit signal, and `key` is the wrapper `:key` /
+/// `key` the legacy lane keeps on the template vnode.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ForWrapper {
+    /// The wrapper's captured key, when it authored one.
+    pub key: Option<WrapperKey>,
 }
 
 /// Facts cross compile boundaries with their artifact (P1-11).
@@ -54,13 +69,15 @@ const _: () = {
     const fn assert_owned<T: 'static>() {}
     assert_owned::<WrapperKey>();
     assert_owned::<WrapperKeys>();
+    assert_owned::<ForWrapper>();
 };
 
 /// 64-bit footprints, guarded like every fact-size assert.
 #[cfg(target_pointer_width = "64")]
 const _: () = {
     assert!(core::mem::size_of::<WrapperKey>() == 40);
-    assert!(core::mem::size_of::<WrapperKeys>() == 24);
+    assert!(core::mem::size_of::<WrapperKeys>() == 48);
+    assert!(core::mem::size_of::<ForWrapper>() == 40);
 };
 
 /// The first key-ish attribute of a `<template v-if>` wrapper: a static
@@ -69,7 +86,7 @@ const _: () = {
 /// `:[key]` is **not** captured (the legacy lane's arg-content match
 /// admits it — a recorded quirk the differential lane counts rather
 /// than imitates).
-pub(super) fn capture_wrapper_key<'a>(
+pub(crate) fn capture_wrapper_key<'a>(
     cx: &mut Cx<'a>,
     element: &Element<'a>,
     analyzed: &Analyzed<'a>,

--- a/crates/vize_ricalco/src/pass.rs
+++ b/crates/vize_ricalco/src/pass.rs
@@ -205,6 +205,7 @@ pub fn run_transform<'a, O: PassObserver>(lowered: &mut Lowered<'a>, observer: &
             verify.check_table(event, &folio, &lowered.scopes);
             verify.check_table(event, &folio, &lowered.texts);
             verify.check_table(event, &folio, &lowered.wrappers);
+            verify.check_table(event, &folio, &lowered.for_wrappers);
             verify.check_table(event, &folio, &facts.if_facts);
             verify.check_table(event, &folio, &facts.for_facts);
             verify.check_table(event, &folio, &facts.slot_facts);

--- a/crates/vize_ricalco/src/pass/legacy/ids.rs
+++ b/crates/vize_ricalco/src/pass/legacy/ids.rs
@@ -63,6 +63,7 @@ pub(super) fn rekey(lowered: &mut Lowered<'_>, sync_ids: &[NodeId]) {
     rekey_table(&mut lowered.scopes, sync_ids);
     rekey_table(&mut lowered.texts, sync_ids);
     rekey_table(&mut lowered.wrappers, sync_ids);
+    rekey_table(&mut lowered.for_wrappers, sync_ids);
     for record in &mut lowered.provenance {
         if let Some(id) = record.node {
             record.node = Some(shift(id, sync_ids));

--- a/crates/vize_ricalco/tests/emit_for.rs
+++ b/crates/vize_ricalco/tests/emit_for.rs
@@ -1,4 +1,4 @@
-//! Native `ui.for` emit pins and the shapes this installment refuses.
+//! Native `ui.for` emit pins, including `<template v-for>` fragments.
 
 #![allow(
     clippy::disallowed_macros,
@@ -9,7 +9,7 @@
 mod support;
 
 use support::with_transformed;
-use vize_ricalco::{emit_dom, EmitError};
+use vize_ricalco::{EmitError, emit_dom};
 
 fn assembled(source: &str) -> String {
     with_transformed(source, |lowered, _folio, facts, _budget| {
@@ -99,9 +99,22 @@ fn a_destructured_v_for_is_unsupported_this_installment() {
 }
 
 #[test]
-fn a_template_v_for_is_unsupported_this_installment() {
+fn a_template_v_for_matches_the_shipped_snapshot() {
     assert_eq!(
-        refused(r#"<template v-for="item in list"><span></span><span></span></template>"#),
-        EmitError::Unsupported
+        assembled(r#"<template v-for="item in list"><span></span><span></span></template>"#),
+        "\
+const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, renderList: _renderList } = Vue
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode(\"span\")
+const _hoisted_2 = /*#__PURE__*/ _createElementVNode(\"span\")
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(list, (item) => {
+    return (_openBlock(), _createElementBlock(_Fragment, null, [
+      _hoisted_1,
+      _hoisted_2
+    ], 64 /* STABLE_FRAGMENT */))
+  }), 256 /* UNKEYED_FRAGMENT */))
+}"
     );
 }

--- a/crates/vize_ricalco/tests/emit_if.rs
+++ b/crates/vize_ricalco/tests/emit_if.rs
@@ -1,4 +1,4 @@
-//! Native `ui.if` emit pins and the shapes this installment refuses.
+//! Native `ui.if` emit pins, including `<template v-if>` fragments.
 
 #![allow(
     clippy::disallowed_macros,
@@ -9,7 +9,7 @@
 mod support;
 
 use support::with_transformed;
-use vize_ricalco::{EmitError, emit_dom};
+use vize_ricalco::emit_dom;
 
 fn assembled(source: &str) -> String {
     with_transformed(source, |lowered, _folio, facts, _budget| {
@@ -17,12 +17,6 @@ fn assembled(source: &str) -> String {
             .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
             .assembled()
             .to_string()
-    })
-}
-
-fn refused(source: &str) -> EmitError {
-    with_transformed(source, |lowered, _, facts, _| {
-        emit_dom(lowered, facts).expect_err("expected Unsupported")
     })
 }
 
@@ -92,9 +86,22 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
-fn a_template_fragment_v_if_is_unsupported_this_installment() {
+fn a_template_fragment_v_if_matches_the_shipped_snapshot() {
     assert_eq!(
-        refused(r#"<template v-if="ok"><span></span><span></span></template>"#),
-        EmitError::Unsupported
+        assembled(r#"<template v-if="ok"><span></span><span></span></template>"#),
+        "\
+const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode } = Vue
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode(\"span\")
+const _hoisted_2 = /*#__PURE__*/ _createElementVNode(\"span\")
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (ok)
+    ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [
+      _hoisted_1,
+      _hoisted_2
+    ], 64 /* STABLE_FRAGMENT */))
+    : _createCommentVNode(\"v-if\", true)
+}"
     );
 }

--- a/crates/vize_ricalco/tests/emit_tpl.rs
+++ b/crates/vize_ricalco/tests/emit_tpl.rs
@@ -1,0 +1,140 @@
+//! `<template v-if>` / `<template v-for>` fragment pins.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use support::with_transformed;
+use vize_ricalco::emit_dom;
+
+fn assembled(source: &str) -> String {
+    with_transformed(source, |lowered, _folio, facts, _budget| {
+        emit_dom(lowered, facts)
+            .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
+            .assembled()
+            .to_string()
+    })
+}
+
+#[test]
+fn a_single_static_template_v_if_stays_a_fragment() {
+    assert_eq!(
+        assembled(r#"<template v-if="ok"><span></span></template>"#),
+        "\
+const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode } = Vue
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode(\"span\")
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (ok)
+    ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [
+      _hoisted_1
+    ], 64 /* STABLE_FRAGMENT */))
+    : _createCommentVNode(\"v-if\", true)
+}"
+    );
+}
+
+#[test]
+fn a_template_v_if_interpolation_uses_create_text() {
+    assert_eq!(
+        assembled(r#"<template v-if="ok">{{ msg }}</template>"#),
+        "\
+const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode, createTextVNode: _createTextVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (ok)
+    ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [
+      _createTextVNode(_toDisplayString(msg), 1 /* TEXT */)
+    ], 64 /* STABLE_FRAGMENT */))
+    : _createCommentVNode(\"v-if\", true)
+}"
+    );
+}
+
+#[test]
+fn an_empty_template_v_if_emits_null_children() {
+    assert_eq!(
+        assembled(r#"<template v-if="ok"></template>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (ok)
+    ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, null, 64 /* STABLE_FRAGMENT */))
+    : _createCommentVNode(\"v-if\", true)
+}"
+    );
+}
+
+#[test]
+fn a_dynamic_template_v_if_child_unwraps() {
+    assert_eq!(
+        assembled(r#"<template v-if="ok"><span>{{ msg }}</span></template>"#),
+        "\
+const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (ok)
+    ? (_openBlock(), _createElementBlock(\"span\", { key: 0 }, _toDisplayString(msg), 1 /* TEXT */))
+    : _createCommentVNode(\"v-if\", true)
+}"
+    );
+}
+
+#[test]
+fn a_keyed_template_v_for_puts_the_key_on_the_inner_fragment() {
+    assert_eq!(
+        assembled(r#"<template v-for="item in list" :key="item"><span></span><span></span></template>"#),
+        "\
+const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, renderList: _renderList } = Vue
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode(\"span\")
+const _hoisted_2 = /*#__PURE__*/ _createElementVNode(\"span\")
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(list, (item) => {
+    return (_openBlock(), _createElementBlock(_Fragment, { key: item }, [
+      _hoisted_1,
+      _hoisted_2
+    ], 64 /* STABLE_FRAGMENT */))
+  }), 128 /* KEYED_FRAGMENT */))
+}"
+    );
+}
+
+#[test]
+fn a_keyed_dynamic_template_v_for_unwraps() {
+    assert_eq!(
+        assembled(r#"<template v-for="item in list" :key="item"><span>{{ item }}</span></template>"#),
+        "\
+const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, renderList: _renderList } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(list, (item) => {
+    return (_openBlock(), _createElementBlock(\"span\", { key: item }, _toDisplayString(item), 1 /* TEXT */))
+  }), 128 /* KEYED_FRAGMENT */))
+}"
+    );
+}
+
+#[test]
+fn a_template_v_if_wrapping_v_for_puts_the_key_on_the_list() {
+    assert_eq!(
+        assembled(r#"<template v-if="ok"><div v-for="i in n">{{ i }}</div></template>"#),
+        "\
+const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode, renderList: _renderList } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (ok)
+    ? (_openBlock(true), _createElementBlock(_Fragment, { key: 0 }, _renderList(n, (i) => {
+      return (_openBlock(), _createElementBlock(\"div\", null, _toDisplayString(i), 1 /* TEXT */))
+    }), 256 /* UNKEYED_FRAGMENT */))
+    : _createCommentVNode(\"v-if\", true)
+}"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S2 emit now matches the shipped DOM lane for unwrapped `<template v-if>` / `<template v-for>` wrappers.

The P2-9 lowering still unwraps those templates (folio and wrapper-key channel stay intact). This PR adds the missing emit signal:

- `WrapperKeys.from_template` — always attached when any `v-if` branch was a non-slot `<template>`
- `ForWrapper` — attached on `<template v-for>`, carrying the wrapper `:key` / `key`

Emit then recovers the shipped hoist-then-codegen split:

- still-dynamic single element / component / slot / nested `v-for` → unwrap to a block (v-if key or for-item key applied)
- hoistable, text, interpolation, empty, or multi-child → `_createElementBlock(_Fragment, …, 64 /* STABLE_FRAGMENT */)`
- v-if fragment children use `generate_children_force_array` (`_createTextVNode(_toDisplayString(…), 1)`)
- v-for fragment children use `generate_node` (bare `_toDisplayString`)

Stacked on #4753 (object `v-on` / `_toHandlers`).

## Change Class

- [x] Compiler and codegen

## Behavior Reference

Shipped `vize_atelier_core` codegen:

- `generate_if_branch` / `generate_if_branch_template_fragment` (`crates/vize_atelier_core/src/codegen/v_if/branch.rs`)
- `unwrap_template_single_element` / `generate_for_item` (`crates/vize_atelier_core/src/codegen/v_for/generate.rs`)

After hoist, a static template child is `Hoisted` so the wrapper stays a fragment; a dynamic element stays an `Element` and unwraps. S2 has no `Hoisted` node, so `is_hoistable` plus the new origin facts stand in.

## Verification Evidence

- `cargo test -p vize_ricalco --test emit_if --test emit_for --test emit_tpl`
- `cargo test -p vize_atelier_dom --test davinci_s2_tpl` — 21 byte-for-byte cases vs `compile_template`
- Existing dual-run batteries (dom / fragments / slots / von / builtins / dynamic / outlets / vslots) still green
- Lowering folio pins (`lowering_shapes`, `vif_pass_keys`) unchanged: templates still unwrap

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

- `createSlots` + `v-slots`, `.native`, filters, destructured `v-for`, dynamic `v-if` keys, and comments-inside-templates stay unsupported.
- `VIZE_DAVINCI_DOM=legacy` is unchanged. P2-11 checkbox stays open until corpus-diff is empty with zero waivers.
- Merge after #4753.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790146889&installation_model_id=422833&pr_number=4754&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4754&signature=b97f771bfcfb006167b69d6caed967c2828b55dd2a19c5a31b393e67fdd0f037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->