### PR TITLE
feat(davinci): emit custom directives via resolveDirective (P2-11)

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dirs.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dirs.rs
@@ -1,0 +1,102 @@
+//! P2-11 custom-directive witness: `resolveDirective` + `withDirectives`,
+//! compared **byte-for-byte** including helper usage, asset order, and
+//! NEED_PATCH.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+use vize_atelier_dom::compile_template;
+use vize_carton::Allocator;
+use vize_ricalco::{DOM_LANE_FLAG, emit_dom_source};
+
+const BATTERY: &[(&str, &str)] = &[
+    ("empty", r#"<div v-example></div>"#),
+    ("text", r#"<div v-example>hello</div>"#),
+    ("interp", r#"<div v-example>{{ msg }}</div>"#),
+    ("compound", r#"<div v-example>hello {{ msg }}</div>"#),
+    ("value", r#"<div v-example="val"></div>"#),
+    ("arg", r#"<div v-example:arg="val"></div>"#),
+    ("arg_only", r#"<div v-example:arg></div>"#),
+    ("mod", r#"<div v-example.foo></div>"#),
+    ("mods_value", r#"<div v-example.foo.bar="val"></div>"#),
+    ("dyn_arg", r#"<div v-example:[dyn]="val"></div>"#),
+    ("two", r#"<div v-pin v-foo></div>"#),
+    ("kebab", r#"<div v-my-dir></div>"#),
+    ("id", r#"<div id="x" v-example></div>"#),
+    ("bind_id", r#"<div :id="id" v-example></div>"#),
+    ("click", r#"<div @click="h" v-example></div>"#),
+    ("spread", r#"<div v-bind="obj" v-example></div>"#),
+    ("class_bind", r#"<div :class="c" v-example></div>"#),
+    ("nested", r#"<div><span v-example></span></div>"#),
+    ("nested_text", r#"<div><span v-example>hello</span></div>"#),
+    ("nested_dir", r#"<div v-outer><span v-inner></span></div>"#),
+    ("vif", r#"<div v-if="ok" v-example></div>"#),
+    ("vif_text", r#"<div v-if="ok" v-example>hello</div>"#),
+    ("vfor", r#"<div v-for="i in n" v-example></div>"#),
+    ("vfor_text", r#"<div v-for="i in n" v-example>hello</div>"#),
+    (
+        "vfor_interp",
+        r#"<div v-for="i in n" v-example>{{ msg }}</div>"#,
+    ),
+    (
+        "vfor_key",
+        r#"<div v-for="i in n" :key="i" v-example></div>"#,
+    ),
+    ("vfor_id", r#"<div v-for="i in n" :id="i" v-example></div>"#),
+    ("model", r#"<input v-model="x" v-example>"#),
+    ("example_then_model", r#"<input v-example v-model="x">"#),
+    ("div_model", r#"<div v-model="x" v-example></div>"#),
+    (
+        "nested_model",
+        r#"<div v-example><input v-model="x"></div>"#,
+    ),
+    ("comp", r#"<Foo v-example />"#),
+    ("comp_text", r#"<Foo v-example>hello</Foo>"#),
+    ("comp_model", r#"<Foo v-model="x" v-example />"#),
+    ("comp_nested", r#"<div><Foo v-example /></div>"#),
+    ("vif_comp", r#"<Foo v-if="ok" v-example />"#),
+    ("vfor_comp", r#"<Foo v-for="i in n" v-example />"#),
+    (
+        "vfor_comp_key",
+        r#"<Foo v-for="i in n" :key="i" v-example />"#,
+    ),
+    ("fragment", r#"<div v-example></div><p v-other></p>"#),
+];
+
+fn shipped(src: &str) -> String {
+    let allocator = Allocator::new();
+    let (_, errors, result) = compile_template(&allocator, src);
+    assert!(errors.is_empty(), "shipped lane errors: {errors:?}");
+    format!("{}\n{}", result.preamble, result.code)
+}
+
+#[test]
+fn s2_custom_dirs_match_the_shipped_dom_lane_byte_for_byte() {
+    let mut compared = 0u64;
+    let mut skipped_legacy_flag = 0u64;
+    if std::env::var(DOM_LANE_FLAG).is_ok_and(|value| value == "legacy") {
+        skipped_legacy_flag += 1;
+    } else {
+        let allocator = Allocator::new();
+        for (name, src) in BATTERY {
+            let old = shipped(src);
+            let new = emit_dom_source(&allocator, src)
+                .unwrap_or_else(|error| panic!("{name}: S2 emit refused: {error:?}"))
+                .assembled();
+            assert_eq!(
+                old.as_str(),
+                new.as_str(),
+                "{name}: S2 DOM emit diverged from the shipped lane"
+            );
+            compared += 1;
+        }
+    }
+    assert_eq!(
+        (compared, skipped_legacy_flag),
+        (BATTERY.len() as u64, 0),
+        "a cfg or {DOM_LANE_FLAG}=legacy regression disarmed the dual-run"
+    );
+}

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -22,12 +22,13 @@
 //! fragments** (empty → `null`, multi-root / compound-root
 //! `_Fragment` + `STABLE_FRAGMENT`), **`<template v-if>` /
 //! `<template v-for>` fragments** (`STABLE_FRAGMENT` / unwrap after
-//! hoist), **object `v-on`** (`toHandlers(..., true)`), and **`v-model`**
+//! hoist), **object `v-on`** (`toHandlers(..., true)`), **`v-model`**
 //! (native `withDirectives` + `vModelText`-family helpers; component
-//! `modelValue` / `onUpdate:` product props). Custom directives,
-//! `.native` and filters stay [`EmitError::Unsupported`]. The old
-//! lane stays the shipped compile path; [`super::DOM_LANE_FLAG`] is
-//! named here and *read* in the atelier_dom witness.
+//! `modelValue` / `onUpdate:` product props), and **custom directives**
+//! (`resolveDirective` + `_withDirectives`, merged with native
+//! `v-model`). `.native` and filters stay [`EmitError::Unsupported`].
+//! The old lane stays the shipped compile path; [`super::DOM_LANE_FLAG`]
+//! is named here and *read* in the atelier_dom witness.
 
 #[path = "emit/buf.rs"]
 mod buf;
@@ -39,6 +40,8 @@ mod children;
 mod component;
 #[path = "emit/create_slots.rs"]
 mod create_slots;
+#[path = "emit/directive.rs"]
+mod directive;
 #[path = "emit/flag.rs"]
 mod flag;
 #[path = "emit/fragment.rs"]
@@ -94,10 +97,12 @@ fn prefer_transform_helpers(buf: &mut Buf, region: &Region<'_>) {
     for op in region.ops.iter() {
         match op {
             Op::Element(element) => {
+                directive::prefer_helpers(buf, &element.bindings);
                 buf.prefer(Helper::CreateElementVNode);
                 prefer_transform_helpers(buf, &element.children);
             }
             Op::Component(component) => {
+                directive::prefer_helpers(buf, &component.bindings);
                 buf.prefer(Helper::ResolveComponent);
                 prefer_transform_helpers(buf, &component.children);
             }
@@ -235,8 +240,14 @@ pub fn emit_dom(lowered: &Lowered<'_>, facts: &S2Facts) -> Result<DomEmit, EmitE
     cx.buf.indent();
     cx.buf.newline();
     let names = component::collect_names(&lowered.root);
+    let dirs = directive::collect_names(&lowered.root);
     if !names.is_empty() {
         component::emit_resolves(&mut cx, &names);
+    }
+    if !dirs.is_empty() {
+        directive::emit_resolves(&mut cx, &dirs);
+    }
+    if !names.is_empty() || !dirs.is_empty() {
         cx.buf.newline();
     }
     cx.buf.push("return ");

--- a/crates/vize_ricalco/src/emit/buf.rs
+++ b/crates/vize_ricalco/src/emit/buf.rs
@@ -128,6 +128,9 @@ impl Buf {
     pub(super) fn use_resolve_component(&mut self) {
         self.mark(Helper::ResolveComponent);
     }
+    pub(super) fn use_resolve_directive(&mut self) {
+        self.mark(Helper::ResolveDirective);
+    }
     pub(super) fn use_create_vnode(&mut self) {
         self.mark(Helper::CreateVNode);
     }
@@ -214,6 +217,10 @@ impl Buf {
 
     pub(super) fn resolve_component_alias() -> &'static str {
         Helper::ResolveComponent.alias()
+    }
+
+    pub(super) fn resolve_directive_alias() -> &'static str {
+        Helper::ResolveDirective.alias()
     }
 
     pub(super) fn create_vnode_alias() -> &'static str {

--- a/crates/vize_ricalco/src/emit/component.rs
+++ b/crates/vize_ricalco/src/emit/component.rs
@@ -16,6 +16,7 @@ use super::buf::Buf;
 use super::builtin;
 use super::children::children_need_text_flag;
 use super::create_slots;
+use super::directive;
 use super::flag::emit_patch_flag;
 use super::hoist::compact_props_object;
 use super::js::asset_ident;
@@ -47,16 +48,18 @@ pub(super) fn emit_root(
     component: &ComponentOp<'_>,
     id: Option<NodeId>,
 ) -> Result<(), EmitError> {
-    cx.buf.use_open_block();
-    cx.buf.use_create_block();
-    cx.buf.push("(");
-    cx.buf.push(Buf::open_block_alias());
-    cx.buf.push("(), ");
-    emit_call(
-        cx, component, /* block */ true, None, /* for_item */ false, id,
-    )?;
-    cx.buf.push(")");
-    Ok(())
+    directive::wrap_component(cx, component, |cx| {
+        cx.buf.use_open_block();
+        cx.buf.use_create_block();
+        cx.buf.push("(");
+        cx.buf.push(Buf::open_block_alias());
+        cx.buf.push("(), ");
+        emit_call(
+            cx, component, /* block */ true, None, /* for_item */ false, id,
+        )?;
+        cx.buf.push(")");
+        Ok(())
+    })
 }
 
 pub(super) fn emit_nested(
@@ -67,10 +70,12 @@ pub(super) fn emit_nested(
     if builtin::forces_block(component) {
         return emit_root(cx, component, id);
     }
-    cx.buf.use_create_vnode();
-    emit_call(
-        cx, component, /* block */ false, None, /* for_item */ false, id,
-    )
+    directive::wrap_component(cx, component, |cx| {
+        cx.buf.use_create_vnode();
+        emit_call(
+            cx, component, /* block */ false, None, /* for_item */ false, id,
+        )
+    })
 }
 
 pub(super) fn emit_if_branch(
@@ -79,21 +84,23 @@ pub(super) fn emit_if_branch(
     key: &str,
     id: Option<NodeId>,
 ) -> Result<(), EmitError> {
-    cx.buf.use_open_block();
-    cx.buf.use_create_block();
-    cx.buf.push("(");
-    cx.buf.push(Buf::open_block_alias());
-    cx.buf.push("(), ");
-    emit_call(
-        cx,
-        component,
-        /* block */ true,
-        Some(key),
-        /* for_item */ false,
-        id,
-    )?;
-    cx.buf.push(")");
-    Ok(())
+    directive::wrap_component(cx, component, |cx| {
+        cx.buf.use_open_block();
+        cx.buf.use_create_block();
+        cx.buf.push("(");
+        cx.buf.push(Buf::open_block_alias());
+        cx.buf.push("(), ");
+        emit_call(
+            cx,
+            component,
+            /* block */ true,
+            Some(key),
+            /* for_item */ false,
+            id,
+        )?;
+        cx.buf.push(")");
+        Ok(())
+    })
 }
 
 pub(super) fn emit_for_item(
@@ -102,16 +109,18 @@ pub(super) fn emit_for_item(
     id: Option<NodeId>,
     key: Option<&str>,
 ) -> Result<(), EmitError> {
-    cx.buf.use_open_block();
-    cx.buf.use_create_block();
-    cx.buf.push("(");
-    cx.buf.push(Buf::open_block_alias());
-    cx.buf.push("(), ");
-    emit_call(
-        cx, component, /* block */ true, key, /* for_item */ true, id,
-    )?;
-    cx.buf.push(")");
-    Ok(())
+    directive::wrap_component(cx, component, |cx| {
+        cx.buf.use_open_block();
+        cx.buf.use_create_block();
+        cx.buf.push("(");
+        cx.buf.push(Buf::open_block_alias());
+        cx.buf.push("(), ");
+        emit_call(
+            cx, component, /* block */ true, key, /* for_item */ true, id,
+        )?;
+        cx.buf.push(")");
+        Ok(())
+    })
 }
 
 fn collect_from<'a>(region: &Region<'a>, names: &mut StdVec<&'a str>) {
@@ -176,6 +185,7 @@ fn emit_call(
     let has_binds = component.bindings.iter().any(|binding| {
         !matches!(binding, BindingOp::SlotContent(_))
             && !slots::is_slots_spread(binding)
+            && !directive::is_custom(binding)
             && !(skip_is && builtin::is_is_bind(binding))
     });
     let has_attrs = component
@@ -183,6 +193,7 @@ fn emit_call(
         .iter()
         .any(|attr| !skip_is || attr.name != "is");
     let unused_hoist = !has_binds
+        && !directive::has_custom(&component.bindings)
         && if_key.is_none()
         && !component.attributes.is_empty()
         && builtin::has_static_nested(&component.children);
@@ -208,6 +219,9 @@ fn emit_call(
     {
         flag |= 1024;
     }
+    if for_item {
+        flag &= !512;
+    }
     let emit_flag = flag != 0;
     if if_key.is_some() || has_binds || has_attrs {
         cx.buf.push(", ");
@@ -217,7 +231,10 @@ fn emit_call(
             &component.bindings,
             if_key,
             skip_is,
+            for_item && directive::has_custom(&component.bindings),
         )?;
+    } else if for_item && directive::has_custom(&component.bindings) {
+        cx.buf.push(", { }");
     } else if emit_flag || has_slots || has_array || for_item {
         // Vue's v-for item `createBlock` keeps an explicit null props
         // even when the component has no props, slots, or patch flag.

--- a/crates/vize_ricalco/src/emit/directive.rs
+++ b/crates/vize_ricalco/src/emit/directive.rs
@@ -1,0 +1,237 @@
+//! Custom `vue.directive` realization: `resolveDirective` assets and
+//! `_withDirectives` wrap, merging a native `v-model` entry first when
+//! the owner is `input` / `textarea` / `select`. `v-slots` stays a
+//! slots-object spread, not a runtime directive.
+
+use alloc::vec::Vec as StdVec;
+
+use vize_disegno::expr::ExprRef;
+use vize_disegno::op::{
+    BindingOp, ComponentOp, DynamicName, ElementOp, ModelOp, Op, Region, VueDirectiveOp,
+};
+
+use super::EmitCx;
+use super::EmitError;
+use super::buf::Buf;
+use super::helper::Helper;
+use super::js::asset_ident;
+use super::slots;
+
+pub(super) fn is_custom(binding: &BindingOp<'_>) -> bool {
+    matches!(binding, BindingOp::VueDirective(_)) && !slots::is_slots_spread(binding)
+}
+
+pub(super) fn has_custom(bindings: &[BindingOp<'_>]) -> bool {
+    bindings.iter().any(is_custom)
+}
+
+pub(super) fn prefer_helpers(buf: &mut Buf, bindings: &[BindingOp<'_>]) {
+    if has_custom(bindings) {
+        buf.prefer(Helper::WithDirectives);
+        buf.prefer(Helper::ResolveDirective);
+    }
+}
+
+pub(super) fn collect_names<'a>(root: &'a Region<'a>) -> StdVec<&'a str> {
+    let mut names = StdVec::new();
+    collect_from(root, &mut names);
+    names
+}
+
+pub(super) fn emit_resolves(cx: &mut EmitCx<'_>, names: &[&str]) {
+    cx.buf.use_resolve_directive();
+    for name in names {
+        cx.buf.push("const ");
+        cx.buf.push(asset_ident("directive", name).as_str());
+        cx.buf.push(" = ");
+        cx.buf.push(Buf::resolve_directive_alias());
+        cx.buf.push("(\"");
+        cx.buf.push(name);
+        cx.buf.push("\")");
+        cx.buf.newline();
+    }
+}
+
+pub(super) fn wrap_element(
+    cx: &mut EmitCx<'_>,
+    element: &ElementOp<'_>,
+    emit: impl FnOnce(&mut EmitCx<'_>) -> Result<(), EmitError>,
+) -> Result<(), EmitError> {
+    let custom = customs(&element.bindings);
+    let model = super::model::first_runtime_model(element);
+    if custom.is_empty() && model.is_none() {
+        return emit(cx);
+    }
+    wrap(cx, model.map(|model| (element, model)), &custom, emit)
+}
+
+pub(super) fn wrap_component(
+    cx: &mut EmitCx<'_>,
+    component: &ComponentOp<'_>,
+    emit: impl FnOnce(&mut EmitCx<'_>) -> Result<(), EmitError>,
+) -> Result<(), EmitError> {
+    let custom = customs(&component.bindings);
+    if custom.is_empty() {
+        return emit(cx);
+    }
+    wrap(cx, None, &custom, emit)
+}
+
+pub(super) fn admit(directive: &VueDirectiveOp<'_>) -> Result<(), EmitError> {
+    if let Some(value) = directive.value {
+        js_expr(value)?;
+    }
+    if let Some(DynamicName::Dynamic(expr)) = directive.argument {
+        js_expr(expr)?;
+    }
+    Ok(())
+}
+
+fn wrap(
+    cx: &mut EmitCx<'_>,
+    native: Option<(&ElementOp<'_>, &ModelOp<'_>)>,
+    custom: &[&VueDirectiveOp<'_>],
+    emit: impl FnOnce(&mut EmitCx<'_>) -> Result<(), EmitError>,
+) -> Result<(), EmitError> {
+    cx.buf.use_with_directives();
+    cx.buf.push(Buf::with_directives_alias());
+    cx.buf.push("(");
+    emit(cx)?;
+    cx.buf.push(", [");
+    cx.buf.newline();
+    let mut first = true;
+    if let Some((element, model)) = native {
+        super::model::emit_native_entry(cx, element, model)?;
+        first = false;
+    }
+    for directive in custom.iter() {
+        if !first {
+            cx.buf.push(",");
+            cx.buf.newline();
+        }
+        emit_entry(cx, directive)?;
+        first = false;
+    }
+    cx.buf.newline();
+    cx.buf.push("])");
+    Ok(())
+}
+
+fn emit_entry(cx: &mut EmitCx<'_>, directive: &VueDirectiveOp<'_>) -> Result<(), EmitError> {
+    cx.buf.push("  [");
+    cx.buf
+        .push(asset_ident("directive", directive.name).as_str());
+    let value = match directive.value {
+        Some(expr) => Some(js_expr(expr)?),
+        None => None,
+    };
+    if let Some(source) = value {
+        cx.buf.push(", ");
+        cx.buf.push(source);
+    }
+    if let Some(argument) = directive.argument {
+        if value.is_none() {
+            cx.buf.push(", void 0");
+        }
+        cx.buf.push(", ");
+        emit_argument(cx, argument)?;
+    }
+    if !directive.modifiers.is_empty() {
+        if value.is_none() && directive.argument.is_none() {
+            cx.buf.push(", void 0, void 0");
+        } else if directive.argument.is_none() {
+            cx.buf.push(", void 0");
+        }
+        cx.buf.push(", { ");
+        for (i, modifier) in directive.modifiers.iter().enumerate() {
+            if i > 0 {
+                cx.buf.push(", ");
+            }
+            cx.buf.push(modifier);
+            cx.buf.push(": true");
+        }
+        cx.buf.push(" }");
+    }
+    cx.buf.push("]");
+    Ok(())
+}
+
+fn emit_argument(cx: &mut EmitCx<'_>, argument: DynamicName<'_>) -> Result<(), EmitError> {
+    match argument {
+        DynamicName::Static(name) => {
+            cx.buf.push("\"");
+            cx.buf.push(name);
+            cx.buf.push("\"");
+            Ok(())
+        }
+        DynamicName::Dynamic(expr) => {
+            cx.buf.push(js_expr(expr)?);
+            Ok(())
+        }
+    }
+}
+
+fn customs<'a>(bindings: &'a [BindingOp<'a>]) -> StdVec<&'a VueDirectiveOp<'a>> {
+    bindings
+        .iter()
+        .filter_map(|binding| match binding {
+            BindingOp::VueDirective(directive) if !slots::is_slots_spread(binding) => {
+                Some(&**directive)
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+fn collect_from<'a>(region: &'a Region<'a>, names: &mut StdVec<&'a str>) {
+    for op in region.ops.iter() {
+        match op {
+            Op::Element(element) => {
+                push_from(&element.bindings, names);
+                collect_from(&element.children, names);
+            }
+            Op::Component(component) => {
+                push_from(&component.bindings, names);
+                collect_from(&component.children, names);
+            }
+            Op::Slot(slot) => {
+                push_from(&slot.bindings, names);
+                collect_from(&slot.fallback, names);
+            }
+            Op::If(if_op) => {
+                for branch in if_op.branches.iter() {
+                    collect_from(&branch.region, names);
+                }
+            }
+            Op::For(for_op) => collect_from(&for_op.region, names),
+            Op::Text(_) | Op::Interpolation(_) => {}
+        }
+    }
+}
+
+fn push_from<'a>(bindings: &'a [BindingOp<'a>], names: &mut StdVec<&'a str>) {
+    for binding in bindings.iter() {
+        let Some(name) = custom_name(binding) else {
+            continue;
+        };
+        if !names.iter().any(|seen| *seen == name) {
+            names.push(name);
+        }
+    }
+}
+
+fn custom_name<'a>(binding: &'a BindingOp<'a>) -> Option<&'a str> {
+    match binding {
+        BindingOp::VueDirective(directive) if !slots::is_slots_spread(binding) => {
+            Some(directive.name)
+        }
+        _ => None,
+    }
+}
+
+fn js_expr(expr: ExprRef<'_>) -> Result<&str, EmitError> {
+    match expr {
+        ExprRef::Js(js) => Ok(js.source),
+        _ => Err(EmitError::Unsupported),
+    }
+}

--- a/crates/vize_ricalco/src/emit/helper.rs
+++ b/crates/vize_ricalco/src/emit/helper.rs
@@ -8,6 +8,7 @@
 pub(super) enum Helper {
     ResolveComponent,
     ResolveDynamicComponent,
+    ResolveDirective,
     VModelText,
     VModelCheckbox,
     VModelRadio,
@@ -43,9 +44,10 @@ pub(super) enum Helper {
 }
 
 impl Helper {
-    pub(super) const ALL: [Self; 34] = [
+    pub(super) const ALL: [Self; 35] = [
         Self::ResolveComponent,
         Self::ResolveDynamicComponent,
+        Self::ResolveDirective,
         Self::VModelText,
         Self::VModelCheckbox,
         Self::VModelRadio,
@@ -82,7 +84,7 @@ impl Helper {
 
     pub(super) const fn rank(self) -> u8 {
         match self {
-            Self::ResolveComponent | Self::ResolveDynamicComponent => 0,
+            Self::ResolveComponent | Self::ResolveDynamicComponent | Self::ResolveDirective => 0,
             Self::VModelText | Self::VModelCheckbox | Self::VModelRadio | Self::VModelSelect => 1,
             Self::WithDirectives | Self::WithKeys | Self::WithModifiers => 2,
             Self::ToDisplayString => 3,
@@ -134,6 +136,7 @@ impl Helper {
             Self::WithDirectives => 8_589_934_592,
             Self::ResolveComponent => 32768,
             Self::ResolveDynamicComponent => 134_217_728,
+            Self::ResolveDirective => 17_179_869_184,
             Self::CreateVNode => 65536,
             Self::CreateBlock => 131072,
             Self::RenderSlot => 1_048_576,
@@ -152,6 +155,7 @@ impl Helper {
         match self {
             Self::ResolveComponent => "resolveComponent",
             Self::ResolveDynamicComponent => "resolveDynamicComponent",
+            Self::ResolveDirective => "resolveDirective",
             Self::VModelText => "vModelText",
             Self::VModelCheckbox => "vModelCheckbox",
             Self::VModelRadio => "vModelRadio",
@@ -191,6 +195,7 @@ impl Helper {
         match self {
             Self::ResolveComponent => "_resolveComponent",
             Self::ResolveDynamicComponent => "_resolveDynamicComponent",
+            Self::ResolveDirective => "_resolveDirective",
             Self::VModelText => "_vModelText",
             Self::VModelCheckbox => "_vModelCheckbox",
             Self::VModelRadio => "_vModelRadio",

--- a/crates/vize_ricalco/src/emit/merge.rs
+++ b/crates/vize_ricalco/src/emit/merge.rs
@@ -110,7 +110,7 @@ pub(super) fn emit_spread_props(
             Arg::BindSpread(bind) => cx.buf.push(js_value(bind)?.source),
             Arg::OnSpread(on) => emit_to_handlers(cx, on)?,
             Arg::Object { if_key, pieces } => {
-                emit_props_object(cx, pieces, *if_key, true)?;
+                emit_props_object(cx, pieces, *if_key, true, false)?;
             }
         }
     }

--- a/crates/vize_ricalco/src/emit/model.rs
+++ b/crates/vize_ricalco/src/emit/model.rs
@@ -11,7 +11,6 @@ use vize_disegno::op::{BindingOp, ElementOp, ModelOp};
 
 use super::EmitCx;
 use super::EmitError;
-use super::buf::Buf;
 use super::helper::Helper;
 use super::js::push_ident_key;
 use super::props::Piece;
@@ -84,19 +83,35 @@ pub(super) fn patch_keys(
     }
 }
 
-pub(super) fn wrap_native(
+pub(super) fn first_runtime_model<'a>(element: &'a ElementOp<'a>) -> Option<&'a ModelOp<'a>> {
+    if !matches!(element.tag, "input" | "textarea" | "select") {
+        return None;
+    }
+    element.bindings.iter().find_map(|binding| match binding {
+        BindingOp::Model(model) => Some(&**model),
+        _ => None,
+    })
+}
+
+pub(super) fn emit_native_entry(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
-    emit: impl FnOnce(&mut EmitCx<'_>) -> Result<(), EmitError>,
+    model: &ModelOp<'_>,
 ) -> Result<(), EmitError> {
-    let Some(model) = first_runtime_model(element) else {
-        return emit(cx);
-    };
-    cx.buf.use_with_directives();
-    cx.buf.push(Buf::with_directives_alias());
-    cx.buf.push("(");
-    emit(cx)?;
-    emit_native_closing(cx, element, model)
+    let helper = native_helper(element);
+    let source = js_source(model)?;
+    let modifiers = native_modifiers(model);
+    cx.buf.use_helper(helper);
+    if modifiers.is_empty() {
+        cx.buf.push("  [");
+        cx.buf.push(helper.alias());
+        cx.buf.push(", ");
+        cx.buf.push(source);
+        cx.buf.push("]");
+    } else {
+        emit_modified_entry(cx, helper, source, &modifiers);
+    }
+    Ok(())
 }
 
 pub(super) fn emit_value(cx: &mut EmitCx<'_>, name: &str, source: &str) {
@@ -128,31 +143,6 @@ pub(super) fn emit_assignment(cx: &mut EmitCx<'_>, source: &str) {
     cx.buf.push("$event => ((");
     cx.buf.push(source);
     cx.buf.push(") = $event)");
-}
-
-fn emit_native_closing(
-    cx: &mut EmitCx<'_>,
-    element: &ElementOp<'_>,
-    model: &ModelOp<'_>,
-) -> Result<(), EmitError> {
-    let helper = native_helper(element);
-    let source = js_source(model)?;
-    let modifiers = native_modifiers(model);
-    cx.buf.use_helper(helper);
-    cx.buf.push(", [");
-    cx.buf.newline();
-    if modifiers.is_empty() {
-        cx.buf.push("  [");
-        cx.buf.push(helper.alias());
-        cx.buf.push(", ");
-        cx.buf.push(source);
-        cx.buf.push("]");
-    } else {
-        emit_modified_entry(cx, helper, source, &modifiers);
-    }
-    cx.buf.newline();
-    cx.buf.push("])");
-    Ok(())
 }
 
 fn emit_modified_entry(cx: &mut EmitCx<'_>, helper: Helper, source: &str, modifiers: &[&str]) {
@@ -188,16 +178,6 @@ fn emit_modified_entry(cx: &mut EmitCx<'_>, helper: Helper, source: &str, modifi
     }
     cx.buf.newline();
     cx.buf.push("  ]");
-}
-
-fn first_runtime_model<'a>(element: &'a ElementOp<'a>) -> Option<&'a ModelOp<'a>> {
-    if !matches!(element.tag, "input" | "textarea" | "select") {
-        return None;
-    }
-    element.bindings.iter().find_map(|binding| match binding {
-        BindingOp::Model(model) => Some(&**model),
-        _ => None,
-    })
 }
 
 fn native_helper(element: &ElementOp<'_>) -> Helper {

--- a/crates/vize_ricalco/src/emit/props.rs
+++ b/crates/vize_ricalco/src/emit/props.rs
@@ -51,6 +51,7 @@ pub(super) fn admit_bindings(
             BindingOp::Model(model) => super::model::admit(model)?,
             BindingOp::SlotContent(_) => {}
             BindingOp::VueDirective(_) if super::slots::is_slots_spread(binding) => {}
+            BindingOp::VueDirective(directive) => super::directive::admit(directive)?,
             _ => return Err(EmitError::Unsupported),
         }
     }
@@ -103,6 +104,9 @@ pub(super) fn bind_patch(bindings: &[BindingOp<'_>], is_component: bool) -> Patc
             _ => {}
         }
     }
+    if super::directive::has_custom(bindings) && flag & (2 | 4 | 8 | 16) == 0 {
+        flag |= 512;
+    }
     Patch {
         flag,
         dynamic_props,
@@ -115,12 +119,13 @@ pub(super) fn emit_bind_props(
     bindings: &[BindingOp<'_>],
     if_key: Option<&str>,
     skip_is: bool,
+    empty_key_multiline: bool,
 ) -> Result<(), EmitError> {
     if super::merge::has_object_spread(bindings) {
         return super::merge::emit_spread_props(cx, attributes, bindings, if_key, skip_is);
     }
     let pieces = pieces(attributes, bindings, skip_is)?;
-    emit_props_object(cx, &pieces, if_key, false)
+    emit_props_object(cx, &pieces, if_key, false, empty_key_multiline)
 }
 
 pub(super) fn emit_props_object(
@@ -128,6 +133,7 @@ pub(super) fn emit_props_object(
     pieces: &[Piece<'_>],
     if_key: Option<&str>,
     skip_normalize: bool,
+    empty_key_multiline: bool,
 ) -> Result<(), EmitError> {
     let skip_class = pieces_have_named(pieces, "class");
     let skip_key = if_key.is_some();
@@ -138,9 +144,20 @@ pub(super) fn emit_props_object(
     if let Some(key) = if_key
         && visible.is_empty()
     {
-        cx.buf.push("{ key: ");
-        cx.buf.push(key);
-        cx.buf.push(" }");
+        if empty_key_multiline {
+            cx.buf.push("{");
+            cx.buf.indent();
+            cx.buf.newline();
+            cx.buf.push("key: ");
+            cx.buf.push(key);
+            cx.buf.deindent();
+            cx.buf.newline();
+            cx.buf.push("}");
+        } else {
+            cx.buf.push("{ key: ");
+            cx.buf.push(key);
+            cx.buf.push(" }");
+        }
         return Ok(());
     }
     let extra = usize::from(if_key.is_some());
@@ -237,7 +254,7 @@ pub(super) fn pieces<'a>(
             BindingOp::On(on) => out.push(Piece::On(on)),
             BindingOp::Model(model) => super::model::expand(model, &mut out)?,
             BindingOp::SlotContent(_) => {}
-            BindingOp::VueDirective(_) if super::slots::is_slots_spread(binding) => {}
+            BindingOp::VueDirective(_) => {}
             _ => return Err(EmitError::Unsupported),
         }
     }

--- a/crates/vize_ricalco/src/emit/vnode.rs
+++ b/crates/vize_ricalco/src/emit/vnode.rs
@@ -1,22 +1,22 @@
 //! Static native HTML element / children emission.
 
 use vize_carton::{String, ensure_sufficient_stack};
-use vize_disegno::op::{Attribute, ElementOp, Namespace, Op, Region};
+use vize_disegno::op::{Attribute, BindingOp, ElementOp, Namespace, Op, Region};
 
 use super::EmitCx;
 use super::EmitError;
 use super::buf::Buf;
 use super::children::{children_need_text_flag, emit_create_text_vnode, emit_text_like};
+use super::directive;
 use super::flag::emit_patch_flag;
 use super::hoist::{compact_props_object, push_attr_pair, unique_attrs};
-use super::model;
 use super::props::{admit_bindings, bind_patch, emit_bind_props};
 
 pub(super) fn emit_unique_element(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
 ) -> Result<(), EmitError> {
-    model::wrap_native(cx, element, |cx| {
+    directive::wrap_element(cx, element, |cx| {
         cx.buf.use_open_block();
         cx.buf.use_create_element_block();
         cx.buf.push("(");
@@ -24,6 +24,7 @@ pub(super) fn emit_unique_element(
         cx.buf.push("(), ");
         emit_call(
             cx, element, /* block */ true, None, /* hoist */ true,
+            /* for_item */ false,
         )?;
         cx.buf.push(")");
         Ok(())
@@ -34,19 +35,21 @@ pub(super) fn emit_fragment_element(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
 ) -> Result<(), EmitError> {
-    model::wrap_native(cx, element, |cx| {
+    directive::wrap_element(cx, element, |cx| {
         cx.buf.use_create_element_vnode();
         emit_call(
             cx, element, /* block */ false, None, /* hoist */ true,
+            /* for_item */ false,
         )
     })
 }
 
 fn emit_nested(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) -> Result<(), EmitError> {
-    model::wrap_native(cx, element, |cx| {
+    directive::wrap_element(cx, element, |cx| {
         cx.buf.use_create_element_vnode();
         emit_call(
             cx, element, /* block */ false, None, /* hoist */ false,
+            /* for_item */ false,
         )
     })
 }
@@ -56,7 +59,7 @@ pub(super) fn emit_if_branch_element(
     element: &ElementOp<'_>,
     key: &str,
 ) -> Result<(), EmitError> {
-    model::wrap_native(cx, element, |cx| {
+    directive::wrap_element(cx, element, |cx| {
         cx.buf.use_open_block();
         cx.buf.use_create_element_block();
         cx.buf.push("(");
@@ -68,6 +71,7 @@ pub(super) fn emit_if_branch_element(
             /* block */ true,
             Some(key),
             /* hoist */ false,
+            /* for_item */ false,
         )?;
         cx.buf.push(")");
         Ok(())
@@ -80,11 +84,12 @@ pub(super) fn emit_for_item_element(
     stable: bool,
     key: Option<&str>,
 ) -> Result<(), EmitError> {
-    model::wrap_native(cx, element, |cx| {
+    directive::wrap_element(cx, element, |cx| {
         if stable {
             cx.buf.use_create_element_vnode();
             return emit_call(
                 cx, element, /* block */ false, key, /* hoist */ false,
+                /* for_item */ true,
             );
         }
         cx.buf.use_open_block();
@@ -94,6 +99,7 @@ pub(super) fn emit_for_item_element(
         cx.buf.push("(), ");
         emit_call(
             cx, element, /* block */ true, key, /* hoist */ false,
+            /* for_item */ true,
         )?;
         cx.buf.push(")");
         Ok(())
@@ -106,6 +112,7 @@ fn emit_call(
     block: bool,
     if_key: Option<&str>,
     allow_hoist: bool,
+    for_item: bool,
 ) -> Result<(), EmitError> {
     admit_native(element)?;
     let alias = if block {
@@ -118,7 +125,8 @@ fn emit_call(
     cx.buf.push(element.tag);
     cx.buf.push("\"");
     let has_children = !element.children.ops.is_empty();
-    let has_binds = !element.bindings.is_empty();
+    let has_custom = directive::has_custom(&element.bindings);
+    let has_binds = has_prop_bindings(&element.bindings);
     let hoist = allow_hoist && if_key.is_none() && root_props_should_hoist(element);
     let patch = bind_patch(&element.bindings, false);
     let text_flag = children_need_text_flag(&element.children);
@@ -126,9 +134,13 @@ fn emit_call(
     if text_flag {
         flag |= 1;
     }
+    if for_item {
+        flag &= !512;
+    }
     let omit_text_only = hoist && block && flag == 1;
     let emit_flag = flag != 0 && !omit_text_only;
-    let has_props = hoist || !element.attributes.is_empty() || has_binds || if_key.is_some();
+    let empty_custom_for =
+        for_item && has_custom && !has_binds && element.attributes.is_empty() && if_key.is_none();
     if hoist {
         let alias = cx
             .buf
@@ -137,17 +149,26 @@ fn emit_call(
         cx.buf.push(alias.as_str());
     } else if if_key.is_some() || has_binds {
         cx.buf.push(", ");
-        emit_bind_props(cx, &element.attributes, &element.bindings, if_key, false)?;
+        emit_bind_props(
+            cx,
+            &element.attributes,
+            &element.bindings,
+            if_key,
+            false,
+            for_item && has_custom,
+        )?;
     } else if !element.attributes.is_empty() {
         cx.buf.push(", ");
         emit_static_props_inline(cx, element.attributes.iter());
+    } else if empty_custom_for {
+        cx.buf.push(", { }");
     } else if has_children || emit_flag {
         cx.buf.push(", null");
     }
     if has_children {
         cx.buf.push(", ");
-        emit_children(cx, &element.children)?;
-    } else if emit_flag && has_props {
+        emit_children(cx, &element.children, has_custom && allow_hoist && block)?;
+    } else if emit_flag {
         cx.buf.push(", null");
     }
     if emit_flag {
@@ -219,11 +240,25 @@ fn admit_native(element: &ElementOp<'_>) -> Result<(), EmitError> {
     admit_bindings(&element.attributes, &element.bindings)
 }
 
-fn emit_children(cx: &mut EmitCx<'_>, children: &Region<'_>) -> Result<(), EmitError> {
+fn has_prop_bindings(bindings: &[BindingOp<'_>]) -> bool {
+    bindings.iter().any(|binding| {
+        matches!(
+            binding,
+            BindingOp::Bind(_) | BindingOp::On(_) | BindingOp::Model(_)
+        )
+    })
+}
+
+fn emit_children(
+    cx: &mut EmitCx<'_>,
+    children: &Region<'_>,
+    force_array: bool,
+) -> Result<(), EmitError> {
     let ops = &children.ops;
-    if ops
-        .iter()
-        .all(|op| matches!(op, Op::Text(_) | Op::Interpolation(_)))
+    if !force_array
+        && ops
+            .iter()
+            .all(|op| matches!(op, Op::Text(_) | Op::Interpolation(_)))
     {
         return emit_text_like(cx, ops);
     }

--- a/crates/vize_ricalco/tests/emit_dirs.rs
+++ b/crates/vize_ricalco/tests/emit_dirs.rs
@@ -1,0 +1,249 @@
+//! Custom `vue.directive` emit pins (`resolveDirective` / `withDirectives`).
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use support::with_transformed;
+use vize_ricalco::emit_dom;
+
+fn assembled(source: &str) -> String {
+    with_transformed(source, |lowered, _folio, facts, _budget| {
+        emit_dom(lowered, facts)
+            .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
+            .assembled()
+            .to_string()
+    })
+}
+
+/// Vue's extra `newline()` after `genAssets` leaves indent on the blank line.
+fn pin(visual: &str) -> String {
+    visual.replace(")\n\n  return", ")\n  \n  return")
+}
+
+#[test]
+fn an_empty_unique_custom_dir_sets_need_patch() {
+    assert_eq!(
+        assembled(r#"<div v-example></div>"#),
+        pin("\
+const { resolveDirective: _resolveDirective, withDirectives: _withDirectives, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective(\"example\")
+
+  return _withDirectives((_openBlock(), _createElementBlock(\"div\", null, null, 512 /* NEED_PATCH */)), [
+    [_directive_example]
+  ])
+}")
+    );
+}
+
+#[test]
+fn unique_text_children_force_an_array() {
+    assert_eq!(
+        assembled(r#"<div v-example>hello</div>"#),
+        pin("\
+const { resolveDirective: _resolveDirective, withDirectives: _withDirectives, openBlock: _openBlock, createElementBlock: _createElementBlock, createTextVNode: _createTextVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective(\"example\")
+
+  return _withDirectives((_openBlock(), _createElementBlock(\"div\", null, [
+    _createTextVNode(\"hello\")
+  ], 512 /* NEED_PATCH */)), [
+    [_directive_example]
+  ])
+}")
+    );
+}
+
+#[test]
+fn unique_interp_combines_text_and_need_patch() {
+    assert_eq!(
+        assembled(r#"<div v-example>{{ msg }}</div>"#),
+        pin("\
+const { resolveDirective: _resolveDirective, withDirectives: _withDirectives, toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, createTextVNode: _createTextVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective(\"example\")
+
+  return _withDirectives((_openBlock(), _createElementBlock(\"div\", null, [
+    _createTextVNode(_toDisplayString(msg), 1 /* TEXT */)
+  ], 513 /* TEXT, NEED_PATCH */)), [
+    [_directive_example]
+  ])
+}")
+    );
+}
+
+#[test]
+fn a_value_arg_and_modifiers_match_the_entry_shape() {
+    assert_eq!(
+        assembled(r#"<div v-example:arg.foo="val"></div>"#),
+        pin("\
+const { resolveDirective: _resolveDirective, withDirectives: _withDirectives, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective(\"example\")
+
+  return _withDirectives((_openBlock(), _createElementBlock(\"div\", null, null, 512 /* NEED_PATCH */)), [
+    [_directive_example, val, \"arg\", { foo: true }]
+  ])
+}")
+    );
+}
+
+#[test]
+fn a_kebab_name_becomes_an_underscore_ident() {
+    assert_eq!(
+        assembled(r#"<div v-my-dir></div>"#),
+        pin("\
+const { resolveDirective: _resolveDirective, withDirectives: _withDirectives, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_my_dir = _resolveDirective(\"my-dir\")
+
+  return _withDirectives((_openBlock(), _createElementBlock(\"div\", null, null, 512 /* NEED_PATCH */)), [
+    [_directive_my_dir]
+  ])
+}")
+    );
+}
+
+#[test]
+fn a_dynamic_prop_drops_need_patch() {
+    assert_eq!(
+        assembled(r#"<div :id="id" v-example></div>"#),
+        pin("\
+const { resolveDirective: _resolveDirective, withDirectives: _withDirectives, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective(\"example\")
+
+  return _withDirectives((_openBlock(), _createElementBlock(\"div\", { id: id }, null, 8 /* PROPS */, [\"id\"])), [
+    [_directive_example]
+  ])
+}")
+    );
+}
+
+#[test]
+fn nested_text_stays_inlined() {
+    assert_eq!(
+        assembled(r#"<div><span v-example>hello</span></div>"#),
+        pin("\
+const { resolveDirective: _resolveDirective, withDirectives: _withDirectives, createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective(\"example\")
+
+  return (_openBlock(), _createElementBlock(\"div\", null, [
+    _withDirectives(_createElementVNode(\"span\", null, \"hello\", 512 /* NEED_PATCH */), [
+      [_directive_example]
+    ])
+  ]))
+}")
+    );
+}
+
+#[test]
+fn a_v_for_item_emits_empty_props_without_need_patch() {
+    assert_eq!(
+        assembled(r#"<div v-for="i in n" v-example></div>"#),
+        pin("\
+const { resolveDirective: _resolveDirective, withDirectives: _withDirectives, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, renderList: _renderList } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective(\"example\")
+
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(n, (i) => {
+    return _withDirectives((_openBlock(), _createElementBlock(\"div\", { })), [
+      [_directive_example]
+    ])
+  }), 256 /* UNKEYED_FRAGMENT */))
+}")
+    );
+}
+
+#[test]
+fn a_keyed_v_for_item_uses_a_multiline_key_object() {
+    assert_eq!(
+        assembled(r#"<div v-for="i in n" :key="i" v-example></div>"#),
+        pin("\
+const { resolveDirective: _resolveDirective, withDirectives: _withDirectives, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, renderList: _renderList } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective(\"example\")
+
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(n, (i) => {
+    return _withDirectives((_openBlock(), _createElementBlock(\"div\", {
+      key: i
+    })), [
+      [_directive_example]
+    ])
+  }), 128 /* KEYED_FRAGMENT */))
+}")
+    );
+}
+
+#[test]
+fn a_v_for_component_uses_empty_props_object() {
+    assert_eq!(
+        assembled(r#"<Foo v-for="i in n" v-example />"#),
+        pin("\
+const { resolveDirective: _resolveDirective, resolveComponent: _resolveComponent, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, renderList: _renderList } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+  const _directive_example = _resolveDirective(\"example\")
+
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(n, (i) => {
+    return _withDirectives((_openBlock(), _createBlock(_component_Foo, { })), [
+      [_directive_example]
+    ])
+  }), 256 /* UNKEYED_FRAGMENT */))
+}")
+    );
+}
+
+#[test]
+fn a_component_resolves_the_directive_before_the_tag() {
+    assert_eq!(
+        assembled(r#"<Foo v-example />"#),
+        pin("\
+const { resolveDirective: _resolveDirective, resolveComponent: _resolveComponent, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+  const _directive_example = _resolveDirective(\"example\")
+
+  return _withDirectives((_openBlock(), _createBlock(_component_Foo, null, null, 512 /* NEED_PATCH */)), [
+    [_directive_example]
+  ])
+}")
+    );
+}
+
+#[test]
+fn native_v_model_keeps_the_model_entry_first() {
+    assert_eq!(
+        assembled(r#"<input v-example v-model="x">"#),
+        pin("\
+const { resolveDirective: _resolveDirective, vModelText: _vModelText, withDirectives: _withDirectives, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective(\"example\")
+
+  return _withDirectives((_openBlock(), _createElementBlock(\"input\", {
+    \"onUpdate:modelValue\": $event => ((x) = $event)
+  }, null, 8 /* PROPS */, [\"onUpdate:modelValue\"])), [
+    [_vModelText, x],
+    [_directive_example]
+  ])
+}")
+    );
+}

--- a/crates/vize_ricalco/tests/emit_model.rs
+++ b/crates/vize_ricalco/tests/emit_model.rs
@@ -198,10 +198,22 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
-fn a_custom_directive_beside_v_model_stays_unsupported() {
+fn a_custom_directive_beside_v_model_merges_into_one_wrap() {
     assert_eq!(
-        refused(r#"<input v-model="msg" v-example>"#),
-        EmitError::Unsupported
+        assembled(r#"<input v-model="msg" v-example>"#),
+        pin("\
+const { resolveDirective: _resolveDirective, vModelText: _vModelText, withDirectives: _withDirectives, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective(\"example\")
+
+  return _withDirectives((_openBlock(), _createElementBlock(\"input\", {
+    \"onUpdate:modelValue\": $event => ((msg) = $event)
+  }, null, 8 /* PROPS */, [\"onUpdate:modelValue\"])), [
+    [_vModelText, msg],
+    [_directive_example]
+  ])
+}")
     );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S2 emit now realizes `vue.directive` the way the shipped DOM lane does.

Custom directives resolve as `_directive_<name> = _resolveDirective("name")` after components (enter / first-seen order). The vnode wraps in `_withDirectives`; a native `input` / `textarea` / `select` `v-model` entry is always first in that array. `v-slots` stays a slots-object spread, not a runtime directive.

NEED_PATCH (512) is set when no CLASS/STYLE/PROPS/FULL_PROPS flag is already present, then stripped on `v-for` items. Unique roots with custom dirs force array children (`_createTextVNode`); nested / `v-if` / `v-for` children stay inlined. Custom-only `v-for` items emit `{ }` instead of omitting props or using `null`.

`ResolveDirective` is rank 0 and preferred before `ResolveComponent` so `<Foo v-example>` keeps `resolveDirective` first in the preamble.

Stacked on #4755 (`v-model` via `withDirectives`).

## Change Class

- [x] Compiler and codegen

## Behavior Reference

Shipped `vize_atelier_core`:

- `process_element_props` custom-dir helper / `add_directive` (`crates/vize_atelier_core/src/transform/element.rs`)
- `generate_custom_directives_closing` / `generate_custom_directive_entry` (`crates/vize_atelier_core/src/codegen/element/directives.rs`)
- `generate_assets` directive loop after components (`crates/vize_atelier_core/src/codegen/root.rs`)
- `NEED_PATCH` when no normal prop flag (`crates/vize_atelier_core/src/codegen/patch_flag.rs`)
- `strip_need_patch_for_v_for_item` and `{ }` empty for-item props

S2 still stores only the `vue.directive` op. Realization stays in emit (`crates/vize_ricalco/src/emit/directive.rs`).

## Verification Evidence

- `cargo test -p vize_ricalco --test emit_dirs` — 12 pins
- `cargo test -p vize_ricalco --test emit_model` — custom-beside-v-model pin now matches
- `cargo test -p vize_atelier_dom --test davinci_s2_dirs` — 39 byte-for-byte cases vs `compile_template`
- Existing emit pins and dual-run batteries (dom / fragments / tpl / von / builtins / dynamic / slots / outlets / vslots / model) still green

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

- `v-show` (no S2 op), `@update:…` colon events, `createSlots` + `v-slots`, `.native`, filters, and static `<select>` children that Vue hoists stay unsupported or diverge until those increments.
- `VIZE_DAVINCI_DOM=legacy` is unchanged. P2-11 checkbox stays open until corpus-diff is empty with zero waivers.
- Merge after #4755.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790148441&installation_model_id=422833&pr_number=4756&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4756&signature=496805248afdf6bd5cd0bf9456c2c25282cbd61515924825ebc6332cbd6b256e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->