### PR TITLE
feat(davinci): emit destructured v-for aliases (P2-11)

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_for.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_for.rs
@@ -1,0 +1,84 @@
+//! P2-11 destructured `v-for` aliases, compared **byte-for-byte**
+//! including helper usage and fragment flags.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+use vize_atelier_dom::compile_template;
+use vize_carton::Allocator;
+use vize_ricalco::{DOM_LANE_FLAG, emit_dom_source};
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "obj",
+        r#"<div v-for="{ id } in list" :key="id">{{ id }}</div>"#,
+    ),
+    (
+        "obj_idx",
+        r#"<div v-for="({ id, name }, i) in list" :key="id">{{ name }}</div>"#,
+    ),
+    ("arr", r#"<div v-for="[a, b] in list">{{ a }}</div>"#),
+    (
+        "nested",
+        r#"<div v-for="{ user: { name } } in list">{{ name }}</div>"#,
+    ),
+    (
+        "rest",
+        r#"<div v-for="{ id, ...rest } in list" :key="id">{{ id }}</div>"#,
+    ),
+    (
+        "default",
+        r#"<div v-for="{ id = 1 } in list" :key="id">{{ id }}</div>"#,
+    ),
+    (
+        "rename",
+        r#"<div v-for="{ id: rowId } in list" :key="rowId">{{ rowId }}</div>"#,
+    ),
+    (
+        "hole",
+        r#"<div v-for="(item, , i) in list" :key="i">{{ item }}</div>"#,
+    ),
+    (
+        "tpl",
+        r#"<template v-for="{ id } in list" :key="id"><span>{{ id }}</span></template>"#,
+    ),
+    ("comp", r#"<Foo v-for="{ id } in list" :key="id" />"#),
+];
+
+fn shipped(src: &str) -> String {
+    let allocator = Allocator::new();
+    let (_, errors, result) = compile_template(&allocator, src);
+    assert!(errors.is_empty(), "shipped lane errors: {errors:?}");
+    format!("{}\n{}", result.preamble, result.code)
+}
+
+#[test]
+fn s2_destructured_v_for_matches_the_shipped_dom_lane_byte_for_byte() {
+    let mut compared = 0u64;
+    let mut skipped_legacy_flag = 0u64;
+    if std::env::var(DOM_LANE_FLAG).is_ok_and(|value| value == "legacy") {
+        skipped_legacy_flag += 1;
+    } else {
+        let allocator = Allocator::new();
+        for (name, src) in BATTERY {
+            let old = shipped(src);
+            let new = emit_dom_source(&allocator, src)
+                .unwrap_or_else(|error| panic!("{name}: S2 emit refused: {error:?}"))
+                .assembled();
+            assert_eq!(
+                old.as_str(),
+                new.as_str(),
+                "{name}: S2 DOM emit diverged from the shipped lane"
+            );
+            compared += 1;
+        }
+    }
+    assert_eq!(
+        (compared, skipped_legacy_flag),
+        (BATTERY.len() as u64, 0),
+        "a cfg or {DOM_LANE_FLAG}=legacy regression disarmed the dual-run"
+    );
+}

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -26,9 +26,10 @@
 //! (native `withDirectives` + `vModelText`-family helpers; component
 //! `modelValue` / `onUpdate:` product props), and **custom directives**
 //! (`resolveDirective` + `_withDirectives`, merged with native
-//! `v-model`), and **colon / vnode-hook events** (`@update:…`,
-//! `@vue:mounted`) including merged duplicate handlers. `.native` and
-//! filters stay [`EmitError::Unsupported`].
+//! `v-model`), **colon / vnode-hook events** (`@update:…`,
+//! `@vue:mounted`) including merged duplicate handlers, and
+//! **destructured `v-for` aliases** (`({ id })`, `[a, b]`, defaults).
+//! `.native` and filters stay [`EmitError::Unsupported`].
 //! The old lane stays the shipped compile path; [`super::DOM_LANE_FLAG`]
 //! is named here and *read* in the atelier_dom witness.
 

--- a/crates/vize_ricalco/src/emit/vfor.rs
+++ b/crates/vize_ricalco/src/emit/vfor.rs
@@ -8,7 +8,7 @@ use vize_disegno::op::{Attribute, BindingOp, DynamicName, ForOp, Op};
 use super::EmitCx;
 use super::EmitError;
 use super::buf::Buf;
-use super::js::{escape_js_string, is_valid_js_identifier};
+use super::js::escape_js_string;
 
 pub(super) fn emit_for(
     cx: &mut EmitCx<'_>,
@@ -154,7 +154,11 @@ pub(super) fn js_source<'a>(expr: &'a ExprRef<'a>) -> Result<&'a str, EmitError>
 pub(super) fn value_alias<'a>(expr: &'a ExprRef<'a>) -> Result<&'a str, EmitError> {
     match expr {
         ExprRef::Js(js) if js.source.is_empty() => Ok("_item"),
-        ExprRef::Js(js) if is_valid_js_identifier(js.source) => Ok(js.source),
+        ExprRef::Js(js) => Ok(js.source),
+        // `{ id = 1 }` is a pattern, not a JS expression; law 5 says
+        // emit the authored source verbatim into the callback param.
+        ExprRef::Opaque(opaque) if opaque.source.is_empty() => Ok("_item"),
+        ExprRef::Opaque(opaque) => Ok(opaque.source),
         _ => Err(EmitError::Unsupported),
     }
 }

--- a/crates/vize_ricalco/tests/emit_for.rs
+++ b/crates/vize_ricalco/tests/emit_for.rs
@@ -9,7 +9,7 @@
 mod support;
 
 use support::with_transformed;
-use vize_ricalco::{EmitError, emit_dom};
+use vize_ricalco::emit_dom;
 
 fn assembled(source: &str) -> String {
     with_transformed(source, |lowered, _folio, facts, _budget| {
@@ -20,10 +20,9 @@ fn assembled(source: &str) -> String {
     })
 }
 
-fn refused(source: &str) -> EmitError {
-    with_transformed(source, |lowered, _, facts, _| {
-        emit_dom(lowered, facts).expect_err("expected Unsupported")
-    })
+/// Vue's extra `newline()` after `genAssets` leaves indent on the blank line.
+fn pin(visual: &str) -> String {
+    visual.replace(")\n\n  return", ")\n  \n  return")
 }
 
 #[test]
@@ -91,10 +90,79 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
-fn a_destructured_v_for_is_unsupported_this_installment() {
+fn an_object_destructured_v_for_emits_the_pattern() {
     assert_eq!(
-        refused(r#"<div v-for="{ id } in list" :key="id"></div>"#),
-        EmitError::Unsupported
+        assembled(r#"<div v-for="{ id } in list" :key="id">{{ id }}</div>"#),
+        "\
+const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, renderList: _renderList } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(list, ({ id }) => {
+    return (_openBlock(), _createElementBlock(\"div\", { key: id }, _toDisplayString(id), 1 /* TEXT */))
+  }), 128 /* KEYED_FRAGMENT */))
+}"
+    );
+}
+
+#[test]
+fn an_array_destructured_v_for_emits_the_pattern() {
+    assert_eq!(
+        assembled(r#"<div v-for="[a, b] in list">{{ a }}</div>"#),
+        "\
+const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, renderList: _renderList } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(list, ([a, b]) => {
+    return (_openBlock(), _createElementBlock(\"div\", null, _toDisplayString(a), 1 /* TEXT */))
+  }), 256 /* UNKEYED_FRAGMENT */))
+}"
+    );
+}
+
+#[test]
+fn a_defaulted_destructure_emits_the_authored_pattern() {
+    assert_eq!(
+        assembled(r#"<div v-for="{ id = 1 } in list" :key="id">{{ id }}</div>"#),
+        "\
+const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, renderList: _renderList } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(list, ({ id = 1 }) => {
+    return (_openBlock(), _createElementBlock(\"div\", { key: id }, _toDisplayString(id), 1 /* TEXT */))
+  }), 128 /* KEYED_FRAGMENT */))
+}"
+    );
+}
+
+#[test]
+fn a_middle_hole_drops_the_empty_key_alias() {
+    assert_eq!(
+        assembled(r#"<div v-for="(item, , i) in list" :key="i">{{ item }}</div>"#),
+        "\
+const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, renderList: _renderList } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(list, (item, i) => {
+    return (_openBlock(), _createElementBlock(\"div\", { key: i }, _toDisplayString(item), 1 /* TEXT */))
+  }), 128 /* KEYED_FRAGMENT */))
+}"
+    );
+}
+
+#[test]
+fn a_destructured_v_for_component_uses_the_pattern() {
+    assert_eq!(
+        assembled(r#"<Foo v-for="{ id } in list" :key="id" />"#),
+        pin("\
+const { resolveComponent: _resolveComponent, openBlock: _openBlock, createBlock: _createBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, renderList: _renderList } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(list, ({ id }) => {
+    return (_openBlock(), _createBlock(_component_Foo, { key: id }))
+  }), 128 /* KEYED_FRAGMENT */))
+}")
     );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S2 emit now writes destructured `v-for` aliases into the `_renderList` callback the way the shipped DOM lane does.

Object / array / rest / rename patterns that parse as JS ride `ExprRef::Js` source. Defaulted patterns (`{ id = 1 }`) are not JS expressions, so they ride `ExprRef::Opaque` and are emitted verbatim (pessimal law 5). An empty alias still becomes `_item`; an empty middle hole (`(item, , i)`) still drops the missing key, matching Vue (`(item, i)`).

Stacked on #4757 (colon events / handler merge).

## Change Class

- [x] Compiler and codegen

## Behavior Reference

Shipped `vize_atelier_core`:

- `generate_for` callback params (`crates/vize_atelier_core/src/codegen/v_for.rs`) — `generate_expression` of each alias, `_item` when value is absent
- `split_top_level_aliases` / `parse_for_expression` for the authored pattern text

S2 already stores the pattern slices on `ForBinding`. This installment only relaxes `value_alias` so non-identifier sources emit.

## Verification Evidence

- `cargo test -p vize_ricalco --test emit_for` — 10 pins green
- `cargo test -p vize_atelier_dom --test davinci_s2_for` — 10 byte-for-byte cases vs `compile_template`
- `davinci_s2_colon` / `davinci_s2_dom` still green

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

- `v-show` (no S2 op), filters, `createSlots` + `v-slots`, `.native`, `vue.once` / `vue.memo` emit, dynamic v-if keys, and static `<select>` children that Vue hoists stay unsupported or diverge until those increments.
- `VIZE_DAVINCI_DOM=legacy` is unchanged. P2-11 checkbox stays open until corpus-diff is empty with zero waivers.
- Merge after #4757.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790149192&installation_model_id=422833&pr_number=4759&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4759&signature=4be35ad767e36ac75be3d0b14d4597283902a50f497dae2a16158aead278bc83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->