### PR TITLE
feat(davinci): emit v-slots spreads on createSlots bases (P2-11)

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_vslots.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_vslots.rs
@@ -1,6 +1,6 @@
 //! P2-11 `v-slots` witness: the forwarded object as the children
-//! argument, and `...expr` after authored slots, compared
-//! **byte-for-byte** including helper usage and the missing `_` flag.
+//! argument, `...expr` after authored slots, and the spread on a
+//! `createSlots` base, compared **byte-for-byte**.
 
 #![allow(
     clippy::disallowed_macros,
@@ -25,6 +25,18 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<Comp v-slots="slots"><template #header>x</template></Comp>"#,
     ),
     ("with_static_prop", r#"<Comp id="x" v-slots="slots" />"#),
+    (
+        "create_if",
+        r#"<Foo v-slots="slots"><template #header v-if="ok">x</template></Foo>"#,
+    ),
+    (
+        "create_default_if",
+        r#"<Foo v-slots="slots">hello<template #header v-if="ok">x</template></Foo>"#,
+    ),
+    (
+        "create_for",
+        r#"<Foo v-slots="slots"><template v-for="i in n" #header>x</template></Foo>"#,
+    ),
 ];
 
 fn shipped(src: &str) -> String {

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -28,7 +28,8 @@
 //! (`resolveDirective` + `_withDirectives`, merged with native
 //! `v-model`), **colon / vnode-hook events** (`@update:…`,
 //! `@vue:mounted`) including merged duplicate handlers, and
-//! **destructured `v-for` aliases** (`({ id })`, `[a, b]`, defaults).
+//! **destructured `v-for` aliases** (`({ id })`, `[a, b]`, defaults),
+//! and **`createSlots` + `v-slots`** (`...expr` on the `{ _: 2 }` base).
 //! `.native` and filters stay [`EmitError::Unsupported`].
 //! The old lane stays the shipped compile path; [`super::DOM_LANE_FLAG`]
 //! is named here and *read* in the atelier_dom witness.

--- a/crates/vize_ricalco/src/emit/component.rs
+++ b/crates/vize_ricalco/src/emit/component.rs
@@ -160,7 +160,7 @@ fn emit_call(
     let create = create_slots::needs_create_slots(&component.children);
     let spread = slots::slots_spread(&component.bindings)?;
     let array = builtin::array_children(component.name);
-    if (create && spread.is_some()) || (array && (create || spread.is_some())) {
+    if array && (create || spread.is_some()) {
         return Err(EmitError::Unsupported);
     }
     let has_array = array && slots::has_implicit_default(&component.children);
@@ -272,7 +272,7 @@ fn emit_call(
         }
     } else if create {
         cx.buf.push(", ");
-        create_slots::emit_create_slots(cx, &component.children)?;
+        create_slots::emit_create_slots(cx, &component.children, spread)?;
     } else if let Some(facts) = facts {
         cx.buf.push(", ");
         slots::emit_slots(cx, &component.children, facts, spread)?;

--- a/crates/vize_ricalco/src/emit/create_slots.rs
+++ b/crates/vize_ricalco/src/emit/create_slots.rs
@@ -1,5 +1,6 @@
 //! `createSlots` for `v-if` / `v-for` slot templates (`{ _: 2 }` base
 //! plus `{ name, fn }` entries — ternaries, `_renderList`, static named).
+//! A `v-slots` spread lands in the base object (`...expr`) before `_: 2`.
 
 use alloc::vec::Vec as StdVec;
 
@@ -26,6 +27,7 @@ pub(super) fn needs_create_slots(children: &Region<'_>) -> bool {
 pub(super) fn emit_create_slots(
     cx: &mut EmitCx<'_>,
     children: &Region<'_>,
+    spread: Option<&str>,
 ) -> Result<(), EmitError> {
     cx.buf.use_create_slots();
     cx.buf.use_with_ctx();
@@ -34,7 +36,7 @@ pub(super) fn emit_create_slots(
     cx.buf.deindent();
     cx.buf.push(Buf::create_slots_alias());
     cx.buf.push("(");
-    emit_base(cx, &defaults);
+    emit_base(cx, &defaults, spread);
     cx.buf.push(", [");
     cx.buf.indent();
     for (i, entry) in entries.iter().enumerate() {
@@ -85,28 +87,36 @@ fn collect(
     Ok((defaults, entries))
 }
 
-fn emit_base(cx: &mut EmitCx<'_>, defaults: &[String]) {
-    if defaults.is_empty() {
+fn emit_base(cx: &mut EmitCx<'_>, defaults: &[String], spread: Option<&str>) {
+    if defaults.is_empty() && spread.is_none() {
         cx.buf.push("{ _: 2 /* DYNAMIC */ }");
         return;
     }
     cx.buf.push("{");
     cx.buf.indent();
-    cx.buf.newline();
-    cx.buf.push("default: ");
-    cx.buf.push(Buf::with_ctx_alias());
-    cx.buf.push("(() => [");
-    cx.buf.indent();
-    for (i, piece) in defaults.iter().enumerate() {
-        if i > 0 {
-            cx.buf.push(",");
-        }
+    if !defaults.is_empty() {
         cx.buf.newline();
-        cx.buf.push(piece.as_str());
+        cx.buf.push("default: ");
+        cx.buf.push(Buf::with_ctx_alias());
+        cx.buf.push("(() => [");
+        cx.buf.indent();
+        for (i, piece) in defaults.iter().enumerate() {
+            if i > 0 {
+                cx.buf.push(",");
+            }
+            cx.buf.newline();
+            cx.buf.push(piece.as_str());
+        }
+        cx.buf.deindent();
+        cx.buf.newline();
+        cx.buf.push("]),");
     }
-    cx.buf.deindent();
-    cx.buf.newline();
-    cx.buf.push("]),");
+    if let Some(spread) = spread {
+        cx.buf.newline();
+        cx.buf.push("...");
+        cx.buf.push(spread);
+        cx.buf.push(",");
+    }
     cx.buf.newline();
     cx.buf.push("_: 2 /* DYNAMIC */");
     cx.buf.deindent();

--- a/crates/vize_ricalco/tests/emit_create_slots.rs
+++ b/crates/vize_ricalco/tests/emit_create_slots.rs
@@ -138,6 +138,65 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+fn a_v_slots_spread_lands_on_the_create_slots_base() {
+    assert_eq!(
+        assembled(r#"<Foo v-slots="slots"><template #header v-if="ok">x</template></Foo>"#),
+        pin("\
+const { resolveComponent: _resolveComponent, openBlock: _openBlock, createBlock: _createBlock, createTextVNode: _createTextVNode, createSlots: _createSlots, withCtx: _withCtx } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, null, _createSlots({
+    ...slots,
+    _: 2 /* DYNAMIC */
+  }, [
+    (ok)
+      ? {
+        name: \"header\",
+        fn: _withCtx(() => [
+          _createTextVNode(\"x\")
+        ]),
+        key: \"0\"
+      }
+    : undefined
+  ]), 1024 /* DYNAMIC_SLOTS */))
+}")
+    );
+}
+
+#[test]
+fn a_v_slots_spread_follows_the_implicit_default() {
+    assert_eq!(
+        assembled(r#"<Foo v-slots="slots">hello<template #header v-if="ok">x</template></Foo>"#),
+        pin("\
+const { resolveComponent: _resolveComponent, openBlock: _openBlock, createBlock: _createBlock, createTextVNode: _createTextVNode, createSlots: _createSlots, withCtx: _withCtx } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, null, _createSlots({
+    default: _withCtx(() => [
+      _createTextVNode(\"hello\")
+    ]),
+    ...slots,
+    _: 2 /* DYNAMIC */
+  }, [
+    (ok)
+      ? {
+        name: \"header\",
+        fn: _withCtx(() => [
+          _createTextVNode(\"x\")
+        ]),
+        key: \"0\"
+      }
+    : undefined
+  ]), 1024 /* DYNAMIC_SLOTS */))
+}")
+    );
+}
+
+#[test]
 fn a_v_else_branch_omits_the_trailing_undefined() {
     assert_eq!(
         assembled(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S2 emit now merges a `v-slots` spread into a `createSlots` base the way the shipped DOM lane does.

`<Foo v-slots="slots"><template #header v-if="ok">…</template></Foo>` keeps the `createSlots` shape: the forwarded object is `...slots` on the base, then `_: 2`, then the conditional / looped entries. An implicit default stays first. Teleport / KeepAlive array children mixed with `createSlots` or `v-slots` stay Unsupported.

Stacked on #4759 (destructured v-for).

## Change Class

- [x] Compiler and codegen

## Behavior Reference

Shipped `generate_create_slots_base` (`crates/vize_atelier_core/src/codegen/slots/create_slots.rs`): a `v-slots` spread on `v-if` / `v-for` slot templates goes into the base object; `_: 2` stays because the dynamic entries need it.

## Verification Evidence

- `cargo test -p vize_ricalco --test emit_create_slots` — 7 pins green
- `cargo test -p vize_ricalco --test emit_vslots` — 3 pins green
- `cargo test -p vize_atelier_dom --test davinci_s2_vslots` — 9 byte-for-byte cases vs `compile_template`
- `davinci_s2_for` still green

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

- `v-show` (no S2 op), filters, `.native`, `vue.once` / `vue.memo` emit, dynamic v-if keys, and static `<select>` children that Vue hoists stay unsupported or diverge until those increments.
- `VIZE_DAVINCI_DOM=legacy` is unchanged. P2-11 checkbox stays open until corpus-diff is empty with zero waivers.
- Merge after #4759.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790149276&installation_model_id=422833&pr_number=4760&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4760&signature=742f54a08192e2093dc25c6c85bd1b642c4ddf209a5cfa46b45da569aaaa01c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->