### PR TITLE
feat(davinci): emit dynamic v-if branch keys (P2-11)

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
@@ -97,6 +97,21 @@ const BATTERY: &[(&str, &str)] = &[
     ("nested_v_if", r#"<div><p v-if="ok">x</p></div>"#),
     ("v_if_class", r#"<div v-if="ok" class="x"></div>"#),
     ("v_if_static_key", r#"<div v-if="ok" key="k"></div>"#),
+    ("v_if_dyn_key", r#"<div v-if="ok" :key="k"></div>"#),
+    (
+        "v_if_dyn_key_expr",
+        r#"<div v-if="ok" :key="item.id">x</div>"#,
+    ),
+    ("v_if_dyn_key_same", r#"<div v-if="ok" :key></div>"#),
+    ("component_v_if_dyn_key", r#"<Foo v-if="ok" :key="k" />"#),
+    (
+        "v_if_dyn_key_chain",
+        r#"<div v-if="a" :key="ka">a</div><div v-else-if="b" :key="kb">b</div><div v-else :key="kc">c</div>"#,
+    ),
+    (
+        "tpl_v_if_dyn_key",
+        r#"<template v-if="ok" :key="k"><span>x</span></template>"#,
+    ),
     (
         "sibling_v_if",
         r#"<div><p v-if="a">1</p><span v-if="b">2</span></div>"#,

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -29,8 +29,9 @@
 //! `v-model`), **colon / vnode-hook events** (`@update:…`,
 //! `@vue:mounted`) including merged duplicate handlers, and
 //! **destructured `v-for` aliases** (`({ id })`, `[a, b]`, defaults),
-//! and **`createSlots` + `v-slots`** (`...expr` on the `{ _: 2 }` base).
-//! `.native` and filters stay [`EmitError::Unsupported`].
+//! **`createSlots` + `v-slots`** (`...expr` on the `{ _: 2 }` base), and
+//! **dynamic `v-if` keys** (`:key="expr"`). `.native` and filters stay
+//! [`EmitError::Unsupported`].
 //! The old lane stays the shipped compile path; [`super::DOM_LANE_FLAG`]
 //! is named here and *read* in the atelier_dom witness.
 

--- a/crates/vize_ricalco/src/emit/vif.rs
+++ b/crates/vize_ricalco/src/emit/vif.rs
@@ -109,7 +109,10 @@ fn branch_key_js(
             out.push('"');
             Ok(out)
         }
-        Some(BranchKeyKind::Dynamic { .. }) => Err(EmitError::Unsupported),
+        Some(BranchKeyKind::Dynamic { source, .. }) if source.is_empty() => {
+            Ok(allocated.to_compact_string())
+        }
+        Some(BranchKeyKind::Dynamic { source, .. }) => Ok(source.clone()),
     }
 }
 

--- a/crates/vize_ricalco/tests/emit_if.rs
+++ b/crates/vize_ricalco/tests/emit_if.rs
@@ -20,6 +20,11 @@ fn assembled(source: &str) -> String {
     })
 }
 
+/// Vue's extra `newline()` after `genAssets` leaves indent on the blank line.
+fn pin(visual: &str) -> String {
+    visual.replace(")\n\n  return", ")\n  \n  return")
+}
+
 #[test]
 fn a_root_v_if_matches_the_shipped_snapshot() {
     assert_eq!(
@@ -83,12 +88,6 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
     : _createCommentVNode(\"v-if\", true)
 }"
     );
-}
-
-#[test]
-/// Vue's extra `newline()` after `genAssets` leaves indent on the blank line.
-fn pin(visual: &str) -> String {
-    visual.replace(")\n\n  return", ")\n  \n  return")
 }
 
 #[test]

--- a/crates/vize_ricalco/tests/emit_if.rs
+++ b/crates/vize_ricalco/tests/emit_if.rs
@@ -86,6 +86,59 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+/// Vue's extra `newline()` after `genAssets` leaves indent on the blank line.
+fn pin(visual: &str) -> String {
+    visual.replace(")\n\n  return", ")\n  \n  return")
+}
+
+#[test]
+fn a_dynamic_branch_key_emits_the_expression() {
+    assert_eq!(
+        assembled(r#"<div v-if="ok" :key="k"></div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (ok)
+    ? (_openBlock(), _createElementBlock(\"div\", { key: k }))
+    : _createCommentVNode(\"v-if\", true)
+}"
+    );
+}
+
+#[test]
+fn a_valueless_dynamic_key_expands_to_the_name() {
+    assert_eq!(
+        assembled(r#"<div v-if="ok" :key></div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (ok)
+    ? (_openBlock(), _createElementBlock(\"div\", { key: key }))
+    : _createCommentVNode(\"v-if\", true)
+}"
+    );
+}
+
+#[test]
+fn a_dynamic_key_on_a_component_stays_on_the_props() {
+    assert_eq!(
+        assembled(r#"<Foo v-if="ok" :key="k" />"#),
+        pin("\
+const { resolveComponent: _resolveComponent, openBlock: _openBlock, createBlock: _createBlock, createCommentVNode: _createCommentVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (ok)
+    ? (_openBlock(), _createBlock(_component_Foo, { key: k }))
+    : _createCommentVNode(\"v-if\", true)
+}")
+    );
+}
+
+#[test]
 fn a_template_fragment_v_if_matches_the_shipped_snapshot() {
     assert_eq!(
         assembled(r#"<template v-if="ok"><span></span><span></span></template>"#),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

S2 emit now writes dynamic `v-if` branch keys the way the shipped DOM lane does.

`<div v-if="ok" :key="k">` becomes `{ key: k }` instead of the allocated integer. A valueless `:key` expands to the name (`{ key: key }`). Template-wrapper `:key` already used `wrapper_key_js`; this installment only admits `BranchKeyKind::Dynamic` on ordinary branches. An empty dynamic source still falls back to the allocated integer.

Stacked on #4760 (`createSlots` + `v-slots`).

## Change Class

- [x] Compiler and codegen

## Behavior Reference

Shipped v-if key extraction / `generate` of `{ key: <exp> }` (`crates/vize_atelier_core/src/codegen/v_if/`). S2 already records `BranchKeyKind::Dynamic { source }` in `IfFacts`; emit now uses that source.

## Verification Evidence

- `cargo test -p vize_ricalco --test emit_if` — 8 pins green
- `cargo test -p vize_atelier_dom --test davinci_s2_dom` — green (includes 6 new dynamic-key cases)
- `davinci_s2_tpl` still green

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

- `v-show` (no S2 op), filters, `.native`, `vue.once` / `vue.memo` emit, and static `<select>` children that Vue hoists stay unsupported or diverge until those increments.
- `VIZE_DAVINCI_DOM=legacy` is unchanged. P2-11 checkbox stays open until corpus-diff is empty with zero waivers.
- Merge after #4760.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7bea060-5f8a-463e-9cd1-a2743bb6c525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790149348&installation_model_id=422833&pr_number=4761&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4761&signature=9b128339cd04c0ed65dc487d893641dfcf7619411f6dc59103790cfa7b37445f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->