### PR TITLE
fix(croquis): walk assignment targets for identifiers

### DIFF
--- a/crates/vize_croquis/src/drawer/helpers/identifiers/slow/walk.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/slow/walk.rs
@@ -1,8 +1,11 @@
+mod assignment_target;
+
 use oxc_ast::ast::{
     ArrayExpressionElement, BindingPattern, Expression, ObjectPropertyKind, PropertyKey,
 };
 
 use super::super::IdentifierRef;
+use assignment_target::{walk_assignment_target, walk_simple_assignment_target};
 
 pub(super) fn walk_expr(expr: &Expression<'_>, identifiers: &mut Vec<IdentifierRef>) {
     match expr {
@@ -74,22 +77,9 @@ pub(super) fn walk_expr(expr: &Expression<'_>, identifiers: &mut Vec<IdentifierR
         Expression::UnaryExpression(unary) => {
             walk_expr(&unary.argument, identifiers);
         }
-        Expression::UpdateExpression(update) => match &update.argument {
-            oxc_ast::ast::SimpleAssignmentTarget::AssignmentTargetIdentifier(id) => {
-                identifiers.push(IdentifierRef::new(id.name.as_str(), id.span.start));
-            }
-            oxc_ast::ast::SimpleAssignmentTarget::StaticMemberExpression(member) => {
-                walk_expr(&member.object, identifiers);
-            }
-            oxc_ast::ast::SimpleAssignmentTarget::ComputedMemberExpression(member) => {
-                walk_expr(&member.object, identifiers);
-                walk_expr(&member.expression, identifiers);
-            }
-            oxc_ast::ast::SimpleAssignmentTarget::PrivateFieldExpression(field) => {
-                walk_expr(&field.object, identifiers);
-            }
-            _ => {}
-        },
+        Expression::UpdateExpression(update) => {
+            walk_simple_assignment_target(&update.argument, identifiers);
+        }
         Expression::CallExpression(call) => {
             walk_expr(&call.callee, identifiers);
             for arg in call.arguments.iter() {
@@ -131,6 +121,7 @@ pub(super) fn walk_expr(expr: &Expression<'_>, identifiers: &mut Vec<IdentifierR
             }
         }
         Expression::AssignmentExpression(assign) => {
+            walk_assignment_target(&assign.left, identifiers);
             walk_expr(&assign.right, identifiers);
         }
         Expression::TemplateLiteral(template) => {

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/slow/walk/assignment_target.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/slow/walk/assignment_target.rs
@@ -1,0 +1,162 @@
+use oxc_ast::ast::{
+    AssignmentTarget, AssignmentTargetMaybeDefault, AssignmentTargetProperty,
+    SimpleAssignmentTarget,
+};
+
+use super::super::super::IdentifierRef;
+use super::walk_expr;
+
+pub(super) fn walk_assignment_target(
+    target: &AssignmentTarget<'_>,
+    identifiers: &mut Vec<IdentifierRef>,
+) {
+    match target {
+        AssignmentTarget::AssignmentTargetIdentifier(id) => {
+            identifiers.push(IdentifierRef::new(id.name.as_str(), id.span.start));
+        }
+        AssignmentTarget::StaticMemberExpression(member) => {
+            walk_expr(&member.object, identifiers);
+        }
+        AssignmentTarget::ComputedMemberExpression(member) => {
+            walk_expr(&member.object, identifiers);
+            walk_expr(&member.expression, identifiers);
+        }
+        AssignmentTarget::PrivateFieldExpression(field) => {
+            walk_expr(&field.object, identifiers);
+        }
+        AssignmentTarget::TSAsExpression(as_expr) => {
+            walk_expr(&as_expr.expression, identifiers);
+        }
+        AssignmentTarget::TSSatisfiesExpression(satisfies) => {
+            walk_expr(&satisfies.expression, identifiers);
+        }
+        AssignmentTarget::TSNonNullExpression(non_null) => {
+            walk_expr(&non_null.expression, identifiers);
+        }
+        AssignmentTarget::TSTypeAssertion(assertion) => {
+            walk_expr(&assertion.expression, identifiers);
+        }
+        AssignmentTarget::ObjectAssignmentTarget(obj) => {
+            walk_object_assignment_target(obj, identifiers);
+        }
+        AssignmentTarget::ArrayAssignmentTarget(arr) => {
+            for elem in arr.elements.iter().flatten() {
+                walk_assignment_target_maybe_default(elem, identifiers);
+            }
+            if let Some(rest) = &arr.rest {
+                walk_assignment_target(&rest.target, identifiers);
+            }
+        }
+    }
+}
+
+fn walk_assignment_target_maybe_default(
+    target: &AssignmentTargetMaybeDefault<'_>,
+    identifiers: &mut Vec<IdentifierRef>,
+) {
+    match target {
+        AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(default) => {
+            walk_assignment_target(&default.binding, identifiers);
+            walk_expr(&default.init, identifiers);
+        }
+        AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(id) => {
+            identifiers.push(IdentifierRef::new(id.name.as_str(), id.span.start));
+        }
+        AssignmentTargetMaybeDefault::StaticMemberExpression(member) => {
+            walk_expr(&member.object, identifiers);
+        }
+        AssignmentTargetMaybeDefault::ComputedMemberExpression(member) => {
+            walk_expr(&member.object, identifiers);
+            walk_expr(&member.expression, identifiers);
+        }
+        AssignmentTargetMaybeDefault::PrivateFieldExpression(field) => {
+            walk_expr(&field.object, identifiers);
+        }
+        AssignmentTargetMaybeDefault::TSAsExpression(as_expr) => {
+            walk_expr(&as_expr.expression, identifiers);
+        }
+        AssignmentTargetMaybeDefault::TSSatisfiesExpression(satisfies) => {
+            walk_expr(&satisfies.expression, identifiers);
+        }
+        AssignmentTargetMaybeDefault::TSNonNullExpression(non_null) => {
+            walk_expr(&non_null.expression, identifiers);
+        }
+        AssignmentTargetMaybeDefault::TSTypeAssertion(assertion) => {
+            walk_expr(&assertion.expression, identifiers);
+        }
+        AssignmentTargetMaybeDefault::ObjectAssignmentTarget(obj) => {
+            walk_object_assignment_target(obj, identifiers);
+        }
+        AssignmentTargetMaybeDefault::ArrayAssignmentTarget(arr) => {
+            for elem in arr.elements.iter().flatten() {
+                walk_assignment_target_maybe_default(elem, identifiers);
+            }
+            if let Some(rest) = &arr.rest {
+                walk_assignment_target(&rest.target, identifiers);
+            }
+        }
+    }
+}
+
+fn walk_object_assignment_target(
+    obj: &oxc_ast::ast::ObjectAssignmentTarget<'_>,
+    identifiers: &mut Vec<IdentifierRef>,
+) {
+    for prop in obj.properties.iter() {
+        match prop {
+            AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(prop_ident) => {
+                identifiers.push(IdentifierRef::new(
+                    prop_ident.binding.name.as_str(),
+                    prop_ident.binding.span.start,
+                ));
+                if let Some(init) = &prop_ident.init {
+                    walk_expr(init, identifiers);
+                }
+            }
+            AssignmentTargetProperty::AssignmentTargetPropertyProperty(prop_prop) => {
+                if prop_prop.computed
+                    && let Some(key_expr) = prop_prop.name.as_expression()
+                {
+                    walk_expr(key_expr, identifiers);
+                }
+                walk_assignment_target_maybe_default(&prop_prop.binding, identifiers);
+            }
+        }
+    }
+    if let Some(rest) = &obj.rest {
+        walk_assignment_target(&rest.target, identifiers);
+    }
+}
+
+pub(super) fn walk_simple_assignment_target(
+    target: &SimpleAssignmentTarget<'_>,
+    identifiers: &mut Vec<IdentifierRef>,
+) {
+    match target {
+        SimpleAssignmentTarget::AssignmentTargetIdentifier(id) => {
+            identifiers.push(IdentifierRef::new(id.name.as_str(), id.span.start));
+        }
+        SimpleAssignmentTarget::StaticMemberExpression(member) => {
+            walk_expr(&member.object, identifiers);
+        }
+        SimpleAssignmentTarget::ComputedMemberExpression(member) => {
+            walk_expr(&member.object, identifiers);
+            walk_expr(&member.expression, identifiers);
+        }
+        SimpleAssignmentTarget::PrivateFieldExpression(field) => {
+            walk_expr(&field.object, identifiers);
+        }
+        SimpleAssignmentTarget::TSAsExpression(as_expr) => {
+            walk_expr(&as_expr.expression, identifiers);
+        }
+        SimpleAssignmentTarget::TSSatisfiesExpression(satisfies) => {
+            walk_expr(&satisfies.expression, identifiers);
+        }
+        SimpleAssignmentTarget::TSNonNullExpression(non_null) => {
+            walk_expr(&non_null.expression, identifiers);
+        }
+        SimpleAssignmentTarget::TSTypeAssertion(assertion) => {
+            walk_expr(&assertion.expression, identifiers);
+        }
+    }
+}

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
@@ -135,6 +135,39 @@ fn test_extract_identifiers_ignores_regex_literals() {
 }
 
 #[test]
+fn test_extract_identifiers_slow_walks_assignment_targets() {
+    fn to_pairs(ids: Vec<IdentifierRef>) -> Vec<(CompactString, u32)> {
+        ids.into_iter()
+            .map(|identifier| (identifier.name, identifier.offset))
+            .collect()
+    }
+
+    let simple = "(step += 1) as number";
+    assert_eq!(extract_identifiers_oxc(simple), vec!["step"]);
+    assert_eq!(
+        to_pairs(extract_identifier_refs_oxc(simple)),
+        vec![("step".into(), simple.find("step").unwrap() as u32)]
+    );
+
+    let member = "({ value: row[col] = next })";
+    assert_eq!(extract_identifiers_oxc(member), vec!["row", "col", "next"]);
+    assert_eq!(
+        to_pairs(extract_identifier_refs_oxc(member)),
+        vec![
+            ("row".into(), member.find("row").unwrap() as u32),
+            ("col".into(), member.find("col").unwrap() as u32),
+            ("next".into(), member.find("next").unwrap() as u32),
+        ]
+    );
+
+    let destructured = "({ item = fallback, label: alias, ...rest } = source)";
+    assert_eq!(
+        extract_identifiers_oxc(destructured),
+        vec!["item", "fallback", "alias", "rest", "source"]
+    );
+}
+
+#[test]
 fn test_extract_identifiers_ignores_numeric_literal_tails() {
     fn to_pairs(ids: Vec<IdentifierRef>) -> Vec<(CompactString, u32)> {
         ids.into_iter()


### PR DESCRIPTION
## Summary
- walk assignment-expression left-hand targets in the slow template identifier extractor
- preserve member, computed, TS-wrapped, object, array, rest, and default assignment target identifiers
- add public helper coverage for slow-dispatch assignment target refs and offsets

## Validation
- nix develop --command cargo fmt --check
- nix develop --command cargo test -p vize_croquis drawer::helpers::identifiers::tests::test_extract_identifiers_slow_walks_assignment_targets -- --nocapture
- nix develop --command cargo test -p vize_croquis drawer::helpers::identifiers::tests -- --nocapture
- nix develop --command cargo check -p vize_croquis --locked

## Notes
- nix develop --command cargo test -p vize_croquis --features davinci-differential --test davinci_differential -- --nocapture currently fails on the existing component-reference count pin: observed component_reference_comparisons=6, expected=3. I confirmed the same failure on a clean origin/main worktree at 6a42d27e6, so it is tracked separately from this identifier-walk fix.

Refs #4365

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790149676&installation_model_id=422833&pr_number=4762&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4762&signature=cfd662c6edc7040410f619ebb9cd969a88c0f489f62c3f298636243807118710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identifier detection for assignment targets, including compound assignments and member assignments.
  * Improved handling of destructuring assignments involving objects, arrays, defaults, computed properties, and TypeScript expressions.
  * Identifier extraction now reports more accurate names and source locations across assignment patterns.

* **Tests**
  * Added coverage for assignment-target identifier extraction and source offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->