### PR TITLE
test(croquis): refresh davinci component pins

### DIFF
--- a/crates/vize_croquis/tests/davinci_differential.rs
+++ b/crates/vize_croquis/tests/davinci_differential.rs
@@ -128,14 +128,15 @@ fn differential_lane_agrees_and_reports() {
     // -- committed battery, pinned counts ---------------------------------
     // 8 comment-free retained slow-dispatch expressions (the comment-carrying
     // interpolation is planted as fallback-class coverage and must not be
-    // compared), 3 `<component :is>` references, 2 v-for shapes.
+    // compared), 3 `<component :is>` references checked in both drawer passes,
+    // 2 v-for shapes.
     analyze_source(BATTERY_SOURCE, SfcCroquisOptions::full());
     let after_battery = differential::stats();
     assert_eq!(
         after_battery,
         differential::DifferentialStats {
             identifier_comparisons: 8,
-            component_reference_comparisons: 3,
+            component_reference_comparisons: 6,
             v_for_shapes: 2,
         },
         "battery comparison counts moved: dispatch, retention, or drawer routing changed — re-derive the pin deliberately"
@@ -151,7 +152,7 @@ fn differential_lane_agrees_and_reports() {
         after_ladder,
         differential::DifferentialStats {
             identifier_comparisons: 24,
-            component_reference_comparisons: 5,
+            component_reference_comparisons: 10,
             v_for_shapes: 4,
         },
         "ladder comparison counts moved: dispatch, retention, or fixture content changed — re-derive the pin deliberately"


### PR DESCRIPTION
## Summary
- update davinci differential component-reference exact counts to match current drawer routing
- document that the three `<component :is>` battery references are checked in both drawer passes
- restore the feature-gated differential lane as a runnable #4365 guard

## Validation
- nix develop --command cargo fmt --check
- nix develop --command cargo test -p vize_croquis --features davinci-differential --test davinci_differential -- --nocapture

Refs #4365

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790149839&installation_model_id=422833&pr_number=4763&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4763&signature=2b17c3f77ee398fc70869c0751c6ca64993eddc9074b1d507e59d9a2f81c43c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->