### PR TITLE
fix(croquis): walk statement handler identifiers

### DIFF
--- a/crates/vize_croquis/src/drawer/helpers/identifiers.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers.rs
@@ -51,6 +51,7 @@ impl IdentifierRef {
 /// - Type assertions: `as Type`
 /// - Arrow functions: `() =>`
 /// - Regex literals and division: `/`
+/// - Statement bodies: `;`
 #[inline]
 fn needs_ast_extraction(expr: &str) -> bool {
     !expr.is_ascii()
@@ -58,6 +59,7 @@ fn needs_ast_extraction(expr: &str) -> bool {
         || expr.contains(" as ")
         || expr.contains("=>")
         || expr.contains('/')
+        || expr.contains(';')
 }
 
 /// Hybrid identifier extraction - fast path for simple expressions, OXC for complex ones.

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/slow.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/slow.rs
@@ -1,8 +1,9 @@
 mod walk;
 
 use oxc_allocator::Allocator;
+use oxc_ast::ast::Expression;
 use oxc_parser::Parser;
-use oxc_span::SourceType;
+use oxc_span::{GetSpan, SourceType};
 use vize_carton::{CompactString, profile};
 
 use super::IdentifierRef;
@@ -51,8 +52,16 @@ pub(super) fn extract_identifier_refs_oxc_slow(expr: &str) -> Vec<IdentifierRef>
     );
     let parsed_expr = match ret {
         Ok(expr) => expr,
-        Err(_) => return Vec::new(),
+        Err(_) => {
+            return extract_identifier_refs_oxc_program(expr, source_type).unwrap_or_default();
+        }
     };
+
+    if !expression_consumes_source(expr, &parsed_expr)
+        && let Some(identifiers) = extract_identifier_refs_oxc_program(expr, source_type)
+    {
+        return identifiers;
+    }
 
     let mut identifiers = Vec::with_capacity(4);
     profile!(
@@ -60,4 +69,31 @@ pub(super) fn extract_identifier_refs_oxc_slow(expr: &str) -> Vec<IdentifierRef>
         walk::walk_expr(&parsed_expr, &mut identifiers)
     );
     identifiers
+}
+
+fn expression_consumes_source(expr: &str, parsed_expr: &Expression<'_>) -> bool {
+    let end = parsed_expr.span().end as usize;
+    expr.get(end..)
+        .is_none_or(|tail| tail.chars().all(char::is_whitespace))
+}
+
+fn extract_identifier_refs_oxc_program(
+    expr: &str,
+    source_type: SourceType,
+) -> Option<Vec<IdentifierRef>> {
+    let allocator = Allocator::default();
+    let ret = profile!(
+        "croquis.helpers.identifiers.oxc_parse_program",
+        Parser::new(&allocator, expr, source_type).parse()
+    );
+    if ret.panicked || !ret.diagnostics.is_empty() {
+        return None;
+    }
+
+    let mut identifiers = Vec::with_capacity(4);
+    profile!(
+        "croquis.helpers.identifiers.walk_program",
+        walk::walk_program(&ret.program, &mut identifiers)
+    );
+    Some(identifiers)
 }

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/slow/walk.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/slow/walk.rs
@@ -1,4 +1,5 @@
 mod assignment_target;
+mod statement;
 
 use oxc_ast::ast::{
     ArrayExpressionElement, BindingPattern, Expression, ObjectPropertyKind, PropertyKey,
@@ -6,6 +7,8 @@ use oxc_ast::ast::{
 
 use super::super::IdentifierRef;
 use assignment_target::{walk_assignment_target, walk_simple_assignment_target};
+
+pub(super) use statement::walk_program;
 
 pub(super) fn walk_expr(expr: &Expression<'_>, identifiers: &mut Vec<IdentifierRef>) {
     match expr {

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/slow/walk/statement.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/slow/walk/statement.rs
@@ -1,0 +1,119 @@
+use super::super::super::IdentifierRef;
+use super::walk_expr;
+
+pub(in crate::drawer::helpers::identifiers::slow) fn walk_program(
+    program: &oxc_ast::ast::Program<'_>,
+    identifiers: &mut Vec<IdentifierRef>,
+) {
+    for statement in program.body.iter() {
+        walk_statement(statement, identifiers);
+    }
+}
+
+fn walk_statement(statement: &oxc_ast::ast::Statement<'_>, identifiers: &mut Vec<IdentifierRef>) {
+    match statement {
+        oxc_ast::ast::Statement::BlockStatement(block) => {
+            for statement in block.body.iter() {
+                walk_statement(statement, identifiers);
+            }
+        }
+        oxc_ast::ast::Statement::ExpressionStatement(expr_stmt) => {
+            walk_expr(&expr_stmt.expression, identifiers);
+        }
+        oxc_ast::ast::Statement::IfStatement(if_stmt) => {
+            walk_expr(&if_stmt.test, identifiers);
+            walk_statement(&if_stmt.consequent, identifiers);
+            if let Some(alternate) = &if_stmt.alternate {
+                walk_statement(alternate, identifiers);
+            }
+        }
+        oxc_ast::ast::Statement::VariableDeclaration(var_decl) => {
+            walk_variable_declaration(var_decl, identifiers);
+        }
+        oxc_ast::ast::Statement::WhileStatement(while_stmt) => {
+            walk_expr(&while_stmt.test, identifiers);
+            walk_statement(&while_stmt.body, identifiers);
+        }
+        oxc_ast::ast::Statement::DoWhileStatement(do_while) => {
+            walk_statement(&do_while.body, identifiers);
+            walk_expr(&do_while.test, identifiers);
+        }
+        oxc_ast::ast::Statement::ForStatement(for_stmt) => {
+            if let Some(init) = &for_stmt.init {
+                if let oxc_ast::ast::ForStatementInit::VariableDeclaration(var_decl) = init {
+                    walk_variable_declaration(var_decl, identifiers);
+                } else if let Some(expr) = init.as_expression() {
+                    walk_expr(expr, identifiers);
+                }
+            }
+            if let Some(test) = &for_stmt.test {
+                walk_expr(test, identifiers);
+            }
+            if let Some(update) = &for_stmt.update {
+                walk_expr(update, identifiers);
+            }
+            walk_statement(&for_stmt.body, identifiers);
+        }
+        oxc_ast::ast::Statement::ForInStatement(for_in) => {
+            walk_expr(&for_in.right, identifiers);
+            walk_statement(&for_in.body, identifiers);
+        }
+        oxc_ast::ast::Statement::ForOfStatement(for_of) => {
+            walk_expr(&for_of.right, identifiers);
+            walk_statement(&for_of.body, identifiers);
+        }
+        oxc_ast::ast::Statement::ReturnStatement(return_stmt) => {
+            if let Some(argument) = &return_stmt.argument {
+                walk_expr(argument, identifiers);
+            }
+        }
+        oxc_ast::ast::Statement::SwitchStatement(switch_stmt) => {
+            walk_expr(&switch_stmt.discriminant, identifiers);
+            for case in switch_stmt.cases.iter() {
+                if let Some(test) = &case.test {
+                    walk_expr(test, identifiers);
+                }
+                for statement in case.consequent.iter() {
+                    walk_statement(statement, identifiers);
+                }
+            }
+        }
+        oxc_ast::ast::Statement::ThrowStatement(throw_stmt) => {
+            walk_expr(&throw_stmt.argument, identifiers);
+        }
+        oxc_ast::ast::Statement::TryStatement(try_stmt) => {
+            for statement in try_stmt.block.body.iter() {
+                walk_statement(statement, identifiers);
+            }
+            if let Some(handler) = &try_stmt.handler {
+                for statement in handler.body.body.iter() {
+                    walk_statement(statement, identifiers);
+                }
+            }
+            if let Some(finalizer) = &try_stmt.finalizer {
+                for statement in finalizer.body.iter() {
+                    walk_statement(statement, identifiers);
+                }
+            }
+        }
+        oxc_ast::ast::Statement::WithStatement(with_stmt) => {
+            walk_expr(&with_stmt.object, identifiers);
+            walk_statement(&with_stmt.body, identifiers);
+        }
+        oxc_ast::ast::Statement::LabeledStatement(labeled) => {
+            walk_statement(&labeled.body, identifiers);
+        }
+        _ => {}
+    }
+}
+
+fn walk_variable_declaration(
+    var_decl: &oxc_ast::ast::VariableDeclaration<'_>,
+    identifiers: &mut Vec<IdentifierRef>,
+) {
+    for declarator in var_decl.declarations.iter() {
+        if let Some(init) = &declarator.init {
+            walk_expr(init, identifiers);
+        }
+    }
+}

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
@@ -184,6 +184,59 @@ fn test_extract_identifiers_ignores_numeric_literal_tails() {
 }
 
 #[test]
+fn test_extract_identifiers_slow_walks_statement_bodies() {
+    fn to_pairs(ids: Vec<IdentifierRef>) -> Vec<(CompactString, u32)> {
+        ids.into_iter()
+            .map(|identifier| (identifier.name, identifier.offset))
+            .collect()
+    }
+
+    let calls = "close();modifyInventory()";
+    assert_eq!(
+        extract_identifiers_oxc(calls),
+        vec!["close", "modifyInventory"]
+    );
+    assert_eq!(
+        to_pairs(extract_identifier_refs_oxc(calls)),
+        vec![
+            ("close".into(), calls.find("close").unwrap() as u32),
+            (
+                "modifyInventory".into(),
+                calls.find("modifyInventory").unwrap() as u32
+            ),
+        ]
+    );
+
+    let emit_then_close = "$emit('selected', $event); close()";
+    assert_eq!(
+        extract_identifiers_oxc(emit_then_close),
+        vec!["$emit", "$event", "close"]
+    );
+    assert_eq!(
+        to_pairs(extract_identifier_refs_oxc(emit_then_close)),
+        vec![
+            (
+                "$emit".into(),
+                emit_then_close.find("$emit").unwrap() as u32
+            ),
+            (
+                "$event".into(),
+                emit_then_close.find("$event").unwrap() as u32
+            ),
+            (
+                "close".into(),
+                emit_then_close.find("close").unwrap() as u32
+            ),
+        ]
+    );
+
+    assert_eq!(
+        extract_identifiers_oxc("if (active) toggle(); close()"),
+        vec!["active", "toggle", "close"]
+    );
+}
+
+#[test]
 fn test_extract_identifier_refs_preserve_root_offsets() {
     fn to_pairs(ids: Vec<IdentifierRef>) -> Vec<(CompactString, u32)> {
         ids.into_iter()


### PR DESCRIPTION
## Summary
- route semicolon-bearing template expressions through the OXC slow path
- fall back to Program parsing when expression parsing leaves a statement tail or fails
- walk statement bodies for multi-statement and statement-shaped handlers without growing walk.rs past the source-length gate

## Validation
- nix develop --command cargo fmt --check
- nix develop --command cargo test -p vize_croquis drawer::helpers::identifiers::tests -- --nocapture
- nix develop --command cargo check -p vize_croquis --locked
- nix develop --command cargo test -p vize_croquis --features davinci-differential --test davinci_differential -- --nocapture
- wc -l crates/vize_croquis/src/drawer/helpers/identifiers/slow/walk.rs crates/vize_croquis/src/drawer/helpers/identifiers/slow/walk/statement.rs

Refs #4365