### PR TITLE
feat(doctor): expose capability cache telemetry

### DIFF
--- a/crates/vize_doctor/README.md
+++ b/crates/vize_doctor/README.md
@@ -195,8 +195,14 @@ let outcome = execute_cached_capability(&mut cache, identity.clone(), |_| {
 
 assert!(outcome.is_cache_miss());
 assert_eq!(cache.len(), 1);
+assert_eq!(outcome.telemetry().finding_count(), 1);
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
+
+`CapabilityExecutionOutcome::telemetry()` and
+`CapabilityInvalidation::telemetry()` expose deterministic cache status,
+snapshot identity, output identity, finding count, and invalidation-boundary
+counts for reporters, CI, and editor integrations.
 
 ## Reporter integrations
 

--- a/crates/vize_doctor/src/cache_identity.rs
+++ b/crates/vize_doctor/src/cache_identity.rs
@@ -15,7 +15,7 @@ use vize_carton::String;
 use crate::{ContentFingerprint, contract::is_stable_id};
 
 pub use error::CapabilityCacheIdentityError;
-pub use invalidation::CapabilityInvalidation;
+pub use invalidation::{CapabilityInvalidation, CapabilityInvalidationTelemetry};
 pub use key::{CapabilityCacheKey, CapabilityCacheKeyParseError};
 
 /// Current wire and hashing contract for [`CapabilityCacheIdentity`].

--- a/crates/vize_doctor/src/cache_identity/invalidation.rs
+++ b/crates/vize_doctor/src/cache_identity/invalidation.rs
@@ -5,6 +5,10 @@ use vize_carton::String;
 
 use super::CapabilityCacheIdentity;
 
+mod telemetry;
+
+pub use telemetry::CapabilityInvalidationTelemetry;
+
 /// Exact reasons a previous capability result cannot be reused.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/crates/vize_doctor/src/cache_identity/invalidation/telemetry.rs
+++ b/crates/vize_doctor/src/cache_identity/invalidation/telemetry.rs
@@ -1,0 +1,73 @@
+use serde::Serialize;
+
+use super::CapabilityInvalidation;
+
+/// Machine-readable summary of why a previous capability result was or was not reusable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CapabilityInvalidationTelemetry {
+    reusable: bool,
+    capability_changed: bool,
+    implementation_changed: bool,
+    configuration_changed: bool,
+    added_input_count: usize,
+    removed_input_count: usize,
+    changed_input_count: usize,
+}
+
+impl CapabilityInvalidationTelemetry {
+    pub(super) fn from_invalidation(invalidation: &CapabilityInvalidation) -> Self {
+        Self {
+            reusable: invalidation.is_reusable(),
+            capability_changed: invalidation.capability_changed(),
+            implementation_changed: invalidation.implementation_changed(),
+            configuration_changed: invalidation.configuration_changed(),
+            added_input_count: invalidation.added_inputs().len(),
+            removed_input_count: invalidation.removed_inputs().len(),
+            changed_input_count: invalidation.changed_inputs().len(),
+        }
+    }
+
+    /// Returns whether all cache identity boundaries are unchanged.
+    pub const fn is_reusable(&self) -> bool {
+        self.reusable
+    }
+
+    /// Returns whether the stable capability identifier changed.
+    pub const fn capability_changed(&self) -> bool {
+        self.capability_changed
+    }
+
+    /// Returns whether analyzer implementation behavior changed.
+    pub const fn implementation_changed(&self) -> bool {
+        self.implementation_changed
+    }
+
+    /// Returns whether behavior-affecting configuration changed.
+    pub const fn configuration_changed(&self) -> bool {
+        self.configuration_changed
+    }
+
+    /// Returns the number of newly declared invalidation inputs.
+    pub const fn added_input_count(&self) -> usize {
+        self.added_input_count
+    }
+
+    /// Returns the number of no-longer-declared invalidation inputs.
+    pub const fn removed_input_count(&self) -> usize {
+        self.removed_input_count
+    }
+
+    /// Returns the number of content-changed invalidation inputs.
+    pub const fn changed_input_count(&self) -> usize {
+        self.changed_input_count
+    }
+}
+
+impl CapabilityInvalidation {
+    /// Returns deterministic telemetry for this cache invalidation decision.
+    #[must_use]
+    pub fn telemetry(&self) -> CapabilityInvalidationTelemetry {
+        CapabilityInvalidationTelemetry::from_invalidation(self)
+    }
+}

--- a/crates/vize_doctor/src/cache_identity/tests.rs
+++ b/crates/vize_doctor/src/cache_identity/tests.rs
@@ -135,9 +135,25 @@ fn invalidation_classifies_every_boundary_in_stable_order() {
     assert_eq!(invalidation.added_inputs(), ["c"]);
     assert_eq!(invalidation.removed_inputs(), ["a"]);
     assert_eq!(invalidation.changed_inputs(), ["d"]);
+    assert_eq!(invalidation.telemetry().added_input_count(), 1);
+    assert_eq!(invalidation.telemetry().removed_input_count(), 1);
+    assert_eq!(invalidation.telemetry().changed_input_count(), 1);
+    assert_eq!(
+        serde_json::to_value(invalidation.telemetry()).unwrap(),
+        json!({
+            "reusable": false,
+            "capabilityChanged": true,
+            "implementationChanged": true,
+            "configurationChanged": true,
+            "addedInputCount": 1,
+            "removedInputCount": 1,
+            "changedInputCount": 1
+        })
+    );
 
     let reusable = current.invalidation_from(&current);
     assert!(reusable.is_reusable());
+    assert!(reusable.telemetry().is_reusable());
     assert_eq!(
         serde_json::to_value(reusable).unwrap(),
         json!({

--- a/crates/vize_doctor/src/capability_execution.rs
+++ b/crates/vize_doctor/src/capability_execution.rs
@@ -1,5 +1,6 @@
 //! Cache-backed execution for independently reusable analysis capabilities.
 
+mod telemetry;
 #[cfg(test)]
 mod tests;
 
@@ -13,6 +14,8 @@ use crate::{
     CapabilityCacheIdentity, CapabilityCacheKey, CapabilitySnapshot, CapabilitySnapshotError,
     ContentFingerprint, DoctorFinding,
 };
+
+pub use telemetry::{CapabilityExecutionCacheStatus, CapabilityExecutionTelemetry};
 
 /// Cache storage for validated capability snapshots.
 ///

--- a/crates/vize_doctor/src/capability_execution/telemetry.rs
+++ b/crates/vize_doctor/src/capability_execution/telemetry.rs
@@ -1,0 +1,69 @@
+use serde::Serialize;
+
+use super::CapabilityExecutionOutcome;
+use crate::{CapabilityCacheKey, ContentFingerprint};
+
+/// Cache status recorded for one capability execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CapabilityExecutionCacheStatus {
+    /// The cache supplied a trusted snapshot and analysis did not run.
+    Hit,
+    /// Analysis ran and the resulting snapshot was accepted by storage.
+    Miss,
+}
+
+/// Machine-readable cache telemetry for one capability execution outcome.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CapabilityExecutionTelemetry {
+    cache_key: CapabilityCacheKey,
+    cache_status: CapabilityExecutionCacheStatus,
+    finding_count: usize,
+    output_fingerprint: ContentFingerprint,
+}
+
+impl CapabilityExecutionTelemetry {
+    pub(super) fn from_outcome(outcome: &CapabilityExecutionOutcome) -> Self {
+        let snapshot = outcome.snapshot();
+        Self {
+            cache_key: snapshot.cache_key(),
+            cache_status: match outcome {
+                CapabilityExecutionOutcome::CacheHit { .. } => CapabilityExecutionCacheStatus::Hit,
+                CapabilityExecutionOutcome::CacheMiss { .. } => {
+                    CapabilityExecutionCacheStatus::Miss
+                }
+            },
+            finding_count: snapshot.findings().len(),
+            output_fingerprint: snapshot.output_fingerprint(),
+        }
+    }
+
+    /// Returns the cache key used by this capability execution.
+    pub const fn cache_key(&self) -> CapabilityCacheKey {
+        self.cache_key
+    }
+
+    /// Returns whether the execution reused cache output or stored a miss.
+    pub const fn cache_status(&self) -> CapabilityExecutionCacheStatus {
+        self.cache_status
+    }
+
+    /// Returns how many findings were present in the trusted snapshot.
+    pub const fn finding_count(&self) -> usize {
+        self.finding_count
+    }
+
+    /// Returns the stable fingerprint of the trusted snapshot output.
+    pub const fn output_fingerprint(&self) -> ContentFingerprint {
+        self.output_fingerprint
+    }
+}
+
+impl CapabilityExecutionOutcome {
+    /// Returns deterministic cache telemetry for this execution outcome.
+    #[must_use]
+    pub fn telemetry(&self) -> CapabilityExecutionTelemetry {
+        CapabilityExecutionTelemetry::from_outcome(self)
+    }
+}

--- a/crates/vize_doctor/src/capability_execution/tests.rs
+++ b/crates/vize_doctor/src/capability_execution/tests.rs
@@ -7,8 +7,8 @@ use std::{
 };
 
 use super::{
-    CapabilityExecutionError, CapabilitySnapshotCache, MemoryCapabilitySnapshotCache,
-    MemoryCapabilitySnapshotCacheError, execute_cached_capability,
+    CapabilityExecutionCacheStatus, CapabilityExecutionError, CapabilitySnapshotCache,
+    MemoryCapabilitySnapshotCache, MemoryCapabilitySnapshotCacheError, execute_cached_capability,
 };
 use crate::{
     AnalysisProvenance, CapabilityCacheIdentity, CapabilityCacheKey, CapabilitySnapshot,
@@ -101,6 +101,38 @@ fn miss_runs_analysis_once_and_returns_after_store() {
     let cached = execute_cached_capability(&mut cache, identity, unreachable_analysis).unwrap();
     assert!(cached.is_cache_hit());
     assert_eq!(calls.get(), 1);
+}
+
+#[test]
+fn execution_outcome_reports_stable_cache_telemetry() {
+    let identity = identity("template-semantics", "source-a");
+    let mut cache = MemoryCapabilitySnapshotCache::new();
+
+    let miss = execute_cached_capability(&mut cache, identity.clone(), |_| {
+        Ok::<_, Infallible>([finding("template-semantics", "VIZE_A", "source-a")])
+    })
+    .unwrap();
+    let miss_telemetry = miss.telemetry();
+    assert_eq!(
+        miss_telemetry.cache_status(),
+        CapabilityExecutionCacheStatus::Miss
+    );
+    assert_eq!(miss_telemetry.cache_key(), identity.cache_key());
+    assert_eq!(miss_telemetry.finding_count(), 1);
+    assert_eq!(
+        miss_telemetry.output_fingerprint(),
+        miss.snapshot().output_fingerprint()
+    );
+
+    let hit = execute_cached_capability(&mut cache, identity, unreachable_analysis).unwrap();
+    assert_eq!(
+        hit.telemetry().cache_status(),
+        CapabilityExecutionCacheStatus::Hit
+    );
+    assert_eq!(
+        serde_json::to_value(hit.telemetry()).unwrap()["findingCount"],
+        1
+    );
 }
 
 #[test]

--- a/crates/vize_doctor/src/lib.rs
+++ b/crates/vize_doctor/src/lib.rs
@@ -77,11 +77,12 @@ pub use ai_context::{
 pub use cache_identity::{
     CAPABILITY_CACHE_KEY_PREFIX, CapabilityCacheIdentity, CapabilityCacheIdentityError,
     CapabilityCacheInput, CapabilityCacheKey, CapabilityCacheKeyParseError, CapabilityInvalidation,
-    DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION,
+    CapabilityInvalidationTelemetry, DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION,
 };
 pub use capability_execution::{
-    CapabilityExecutionError, CapabilityExecutionOutcome, CapabilitySnapshotCache,
-    MemoryCapabilitySnapshotCache, MemoryCapabilitySnapshotCacheError, execute_cached_capability,
+    CapabilityExecutionCacheStatus, CapabilityExecutionError, CapabilityExecutionOutcome,
+    CapabilityExecutionTelemetry, CapabilitySnapshotCache, MemoryCapabilitySnapshotCache,
+    MemoryCapabilitySnapshotCacheError, execute_cached_capability,
 };
 pub use capability_snapshot::{
     CapabilitySnapshot, CapabilitySnapshotError, DOCTOR_CAPABILITY_SNAPSHOT_FORMAT_VERSION,


### PR DESCRIPTION
Refs #3138.

## Summary
- add `CapabilityExecutionOutcome::telemetry()` with cache hit/miss status, cache key, finding count, and output fingerprint
- add `CapabilityInvalidation::telemetry()` with reusable status and invalidation-boundary counts
- document the telemetry surface in the Doctor README

## Verification
- `nix develop --command cargo fmt --check`
- `nix develop --command cargo test -p vize_doctor -- --nocapture`
- `nix develop --command cargo check -p vize_doctor --locked`
- `nix develop --command cargo clippy -p vize_doctor --all-targets -- -D warnings`
- `nix develop --command cargo test -p vize_doctor --all-features -- --nocapture`
- `nix develop --command cargo clippy -p vize_doctor --all-targets --all-features -- -D warnings`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790152192&installation_model_id=422833&pr_number=4766&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4766&signature=b8206d4c6cbeeae1ff098910369bc2e693d0e4f8311ff20e8ab5168c8182aa09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->