### PR TITLE
docs(fresco): record performance size policy

### DIFF
--- a/docs/fresco/compatibility.md
+++ b/docs/fresco/compatibility.md
@@ -190,3 +190,5 @@ constraints:
   matching row (and the audit commit above) in the same PR.
 - Rows may only move to Implemented together with the behavior/type tests required by the issue's
   non-functional acceptance criteria.
+- Performance-sensitive #3113 changes follow the
+  [Fresco performance and size policy](./performance-policy.md).

--- a/docs/fresco/performance-policy.md
+++ b/docs/fresco/performance-policy.md
@@ -1,0 +1,73 @@
+# Fresco Performance And Size Policy
+
+This policy records the M0 performance and package-size contract for
+[#3113](https://github.com/ubugeeei-prod/vize/issues/3113). It covers
+`vize_fresco`, `@vizejs/fresco-native`, and `@vizejs/fresco`.
+
+## Measurement Surfaces
+
+Rust renderer and terminal behavior are measured by the crate Criterion benches:
+
+```sh
+cargo bench -p vize_fresco --bench render
+cargo bench -p vize_fresco --bench capabilities
+```
+
+The `render` bench is the regression surface for buffer writes, Unicode text
+width, wrapping, layout, diffing, virtual lists, diagnostic workspace state,
+headless snapshots, and terminal output telemetry. The `capabilities` bench is
+the regression surface for terminal capability resolution and style fallback.
+
+The JavaScript package size surface is the published package, not the source
+tree:
+
+```sh
+vp run --filter './npm/fresco' build
+npm pack --json --pack-destination "$TMPDIR" npm/fresco
+```
+
+`@vizejs/fresco` publishes only `dist`, so size evidence must report the packed
+tarball bytes and the unpacked `dist` bytes. Changes to `exports`,
+dependencies, build output, optional feature entry points, or bundled examples
+must include that before/after evidence in the pull request body.
+
+Native binding size is tracked separately from the Vue package. Changes to
+`@vizejs/fresco-native`, N-API declarations, or the `napi` feature must report
+the produced platform binary names and sizes from the relevant release or local
+native build artifact.
+
+## CI Gates
+
+Pull requests that touch Fresco runtime, renderer, package, or native binding
+surfaces rely on these shared checks:
+
+- `cargo-semver-checks (vize_fresco)` for public Rust API compatibility.
+- `clippy-and-test` for Rust correctness and crate tests.
+- `criterion-ab` for impacted Criterion benchmark comparisons.
+- `build-js-packages` for Fresco native declaration checks, native package
+  build readiness, and JS package build output.
+- `test-js-packages` for `@vizejs/fresco` behavior and type-contract tests.
+- `check-js` for TypeScript and package-level static checks.
+
+Renderer benchmark regressions are blocking when the benchmark gate reports a
+deterministic regression. When a benchmark is intentionally slower, the PR must
+name the affected bench, explain the user-visible tradeoff, and include the
+before/after output accepted by review.
+
+Package size is record-only until a checked-in size baseline lands. Until then,
+size-increasing changes are allowed only with explicit packed and unpacked
+before/after numbers plus the reason the new bytes belong in the core package
+rather than an optional provider.
+
+## Review Checklist
+
+For each Fresco performance-sensitive pull request:
+
+- Cite the exact measurement command or CI check that covers the changed path.
+- Record package-size evidence when public package contents or dependencies
+  change.
+- Keep optional rich display integrations out of the core package unless the PR
+  also updates this policy with a new size budget.
+- Do not mark a #3113 performance or size item complete from local numbers
+  alone; the PR must reach green CI with the relevant benchmark and package
+  checks visible.

--- a/tests/tooling/fresco-performance-policy.test.ts
+++ b/tests/tooling/fresco-performance-policy.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function readText(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function assertMentions(text: string, fragments: readonly string[]) {
+  for (const fragment of fragments) {
+    assert.ok(text.includes(fragment), `expected policy to mention ${fragment}`);
+  }
+}
+
+test("Fresco performance policy cites the live measurement surfaces", () => {
+  const policy = readText("docs/fresco/performance-policy.md");
+  const frescoPackage = JSON.parse(readText("npm/fresco/package.json")) as {
+    files?: string[];
+    scripts?: Record<string, string>;
+  };
+
+  assertMentions(policy, [
+    "#3113",
+    "cargo bench -p vize_fresco --bench render",
+    "cargo bench -p vize_fresco --bench capabilities",
+    "vp run --filter './npm/fresco' build",
+    "npm pack --json",
+    "criterion-ab",
+    "build-js-packages",
+    "test-js-packages",
+  ]);
+  assert.equal(frescoPackage.scripts?.build, "vp pack");
+  assert.deepEqual(frescoPackage.files, ["dist"]);
+  assert.ok(fs.existsSync(path.join(repoRoot, "crates/vize_fresco/benches/render.rs")));
+  assert.ok(fs.existsSync(path.join(repoRoot, "crates/vize_fresco/benches/capabilities.rs")));
+});
+
+test("Fresco compatibility matrix links the performance policy", () => {
+  const matrix = readText("docs/fresco/compatibility.md");
+  assert.ok(matrix.includes("performance-policy.md"));
+});


### PR DESCRIPTION
Refs #3113.

## Summary
- add the Fresco M0 performance and package-size policy under `docs/fresco/`
- link the policy from the compatibility matrix
- add a tooling regression test that pins the policy to live bench/package surfaces

## Verification
- `nix develop --command node --experimental-strip-types --test tests/tooling/fresco-performance-policy.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790152358&installation_model_id=422833&pr_number=4767&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4767&signature=f0144d080009bd950a24a29e81d8867cbbaf04b960264b6127b69a9dcb774db8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->