### PR TITLE
perf(canon): hash appended local imports

### DIFF
--- a/crates/vize/src/commands/check/runner/default_imports.rs
+++ b/crates/vize/src/commands/check/runner/default_imports.rs
@@ -276,9 +276,10 @@ fn append_local_imports(
     validate_inputs: bool,
 ) -> Vec<PathBuf> {
     let mut appended = Vec::new();
+    let mut known: FxHashSet<PathBuf> = files.iter().cloned().collect();
     for path in discovered {
         if local_import_is_allowed(&path, explicit_input_root, validate_inputs)
-            && !files.contains(&path)
+            && known.insert(path.clone())
         {
             files.push(path.clone());
             appended.push(path);

--- a/crates/vize/src/commands/check/runner/default_imports_tests.rs
+++ b/crates/vize/src/commands/check/runner/default_imports_tests.rs
@@ -158,3 +158,29 @@ fn default_tsconfig_run_registers_hidden_ambient_declarations_for_type_resolutio
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn append_local_imports_checks_membership_once_per_discovered_path() {
+    let root = PathBuf::from("/workspace");
+    let existing = root.join("src/existing.ts");
+    let added = root.join("src/added.ts");
+    let nested = root.join("src/nested.ts");
+    let outside = root.join("outside.ts");
+    let mut files = vec![existing.clone()];
+
+    let appended = super::append_local_imports(
+        &mut files,
+        vec![
+            existing.clone(),
+            added.clone(),
+            added.clone(),
+            outside,
+            nested.clone(),
+        ],
+        Some(&root.join("src")),
+        true,
+    );
+
+    assert_eq!(appended, [added.clone(), nested.clone()]);
+    assert_eq!(files, [added, existing, nested]);
+}


### PR DESCRIPTION
Refs #4426.

## Summary
- replace the remaining linear `files.contains(PathBuf)` probe in `append_local_imports` with a seeded `FxHashSet`
- keep the existing sort/dedup output contract intact
- add a regression test for duplicate discovered imports plus explicit-root filtering

## Verification
- `nix develop --command cargo fmt --check`
- `nix develop --command cargo test -p vize commands::check::runner::default_imports::tests::append_local_imports_checks_membership_once_per_discovered_path -- --nocapture`
- `nix develop --command cargo check -p vize --locked`
- `nix develop --command cargo clippy -p vize --lib -- -D warnings`
- `git diff --check`

Note: `nix develop --command cargo clippy -p vize --all-targets -- -D warnings` currently fails on existing unrelated test lint violations (`std::string::String`, `format!`, and `useless_vec` in older tests), before this PR-specific path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790152629&installation_model_id=422833&pr_number=4768&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4768&signature=3d0677e10e42cc0bc9dd2e4e229ce0962eb8ffbd47fe546890ab044ab5ec93fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate local files from being added during import discovery.
  * Ensured files outside the workspace are excluded.
  * Preserved the expected ordering of newly discovered files.

* **Tests**
  * Added coverage for duplicate paths, nested files, existing files, and excluded paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->