### PR TITLE
test(init): cover js checkjs fresh project smoke

### DIFF
--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -66,6 +66,13 @@ test("the fresh-project matrix covers every documented package manager", () => {
   }
 });
 
+test("the fresh-project matrix covers every declared project shape", () => {
+  const matrixShapes = new Set(FRESH_INIT_MATRIX.map((cell) => cell.shape));
+  for (const shape of Object.keys(PROJECT_SHAPES)) {
+    assert.ok(matrixShapes.has(shape), `fresh-project matrix does not cover ${shape}`);
+  }
+});
+
 test("fresh-project package managers use exact Corepack runners where needed", () => {
   for (const [managerId, corepackSpec] of Object.entries(COREPACK_MANAGER_SPECS)) {
     const manager = PACKAGE_MANAGERS[managerId];

--- a/tools/npm/smoke-release-init-js-shapes.mjs
+++ b/tools/npm/smoke-release-init-js-shapes.mjs
@@ -1,0 +1,202 @@
+const MAIN_LABEL_CLEAN = '"root"';
+const MAIN_LABEL_BROKEN = "42";
+
+function mainJsSource(broken) {
+  return [
+    'import { createApp } from "vue";',
+    'import App from "./App.vue";',
+    "",
+    "/** @type {string} */",
+    `const mountLabel = ${broken ? MAIN_LABEL_BROKEN : MAIN_LABEL_CLEAN};`,
+    "void mountLabel;",
+    "",
+    'createApp(App).mount("#app");',
+    "",
+  ].join("\n");
+}
+
+function appJsSource() {
+  return [
+    "<template>",
+    '  <HelloWorld :msg="message" />',
+    "</template>",
+    "",
+    "<script setup>",
+    'import HelloWorld from "./components/HelloWorld.vue";',
+    "",
+    'const message = "vize";',
+    "</script>",
+    "",
+  ].join("\n");
+}
+
+function helloWorldJsSource() {
+  return [
+    "<template>",
+    '  <p class="greeting">{{ props.msg.toUpperCase() }}</p>',
+    "</template>",
+    "",
+    "<script setup>",
+    "const props = defineProps({",
+    "  msg: { type: String, required: true },",
+    "});",
+    "</script>",
+    "",
+  ].join("\n");
+}
+
+function viteVueJsCheckJsFiles(peers) {
+  return {
+    "package.json": `${JSON.stringify(
+      {
+        name: "vize-fresh-init-vite-vue-js-checkjs",
+        version: "0.0.0",
+        private: true,
+        type: "module",
+        scripts: { dev: "vite", build: "vite build" },
+        dependencies: { vue: peers.vue },
+        devDependencies: { vite: peers.vite },
+      },
+      null,
+      2,
+    )}\n`,
+    "index.html": '<div id="app"></div><script type="module" src="/src/main.js"></script>\n',
+    "vite.config.js": [
+      'import { defineConfig } from "vite";',
+      "",
+      "export default defineConfig({",
+      "  plugins: [],",
+      "});",
+      "",
+    ].join("\n"),
+    "src/main.js": mainJsSource(false),
+    "src/App.vue": appJsSource(),
+    "src/components/HelloWorld.vue": helloWorldJsSource(),
+  };
+}
+
+function viteJsDetection(manager) {
+  return [
+    "  framework:       Vite (vite.config.js)",
+    `  package manager: ${manager.detectedPackageManager}`,
+    "  language:        JavaScript (no tsconfig.json)",
+    "  lint command:    oxlint",
+    "  vize config:     none",
+    "  oxlint config:   none",
+  ];
+}
+
+function configuredViteJsDetection(manager) {
+  return [
+    "  framework:       Vite (vite.config.js)",
+    `  package manager: ${manager.detectedPackageManager}`,
+    "  language:        TypeScript (tsconfig.json)",
+    "  lint command:    oxlint",
+    "  vize config:     vize.config.ts",
+    "  oxlint config:   none",
+  ];
+}
+
+const EXPECTED_CHECKJS_TSCONFIG = `${JSON.stringify(
+  {
+    compilerOptions: {
+      strict: true,
+      target: "ES2022",
+      module: "ESNext",
+      moduleResolution: "Bundler",
+      jsx: "preserve",
+      allowJs: true,
+      checkJs: true,
+      noEmit: true,
+      skipLibCheck: true,
+    },
+    include: ["src/**/*"],
+  },
+  null,
+  2,
+)}\n`;
+
+const EXPECTED_VIZE_CONFIG = [
+  'import { defineConfig } from "vize";',
+  "",
+  "export default defineConfig({",
+  "  compiler: {",
+  '    templateSyntax: "standard",',
+  "  },",
+  "  formatter: {",
+  "    singleAttributePerLine: false,",
+  "    sortBlocks: true,",
+  "  },",
+  "  typeChecker: {",
+  "    enabled: true,",
+  "    strict: true,",
+  "    jsxTypecheck: true,",
+  "  },",
+  "  vite: {",
+  '    scanPatterns: ["src/**/*.vue"],',
+  "  },",
+  "});",
+  "",
+].join("\n");
+
+const EXPECTED_EXTENSIONS = `${JSON.stringify({ recommendations: ["ubugeeei.vize"] }, null, 2)}\n`;
+
+export const VITE_VUE_JS_CHECKJS_SHAPE = {
+  id: "vite-vue-js-checkjs",
+  requires: ["vize", "@vizejs/vite-plugin"],
+  files: viteVueJsCheckJsFiles,
+  initFlags: ["--yes", "--no-lint", "--vite", "--fmt", "--typecheck", "--editor"],
+  detection: viteJsDetection,
+  features: [
+    "  lint      skipped    not selected",
+    "  bundler   configured adds vize() to vite.config.js",
+    "  fmt       configured writes vize.config.ts",
+    "  typecheck configured writes tsconfig.json and vize.config.ts",
+    "  editor    configured writes .vscode/extensions.json recommending ubugeeei.vize",
+  ],
+  reconfiguredDetection: configuredViteJsDetection,
+  reconfiguredFeatures: [
+    "  lint      skipped    not selected",
+    "  bundler   unchanged  vite.config.js already uses @vizejs/vite-plugin",
+    "  fmt       unchanged  vize.config.ts already exists and was left unchanged",
+    "  typecheck unchanged  vize.config.ts already exists and was left unchanged",
+    "  editor    unchanged  .vscode/extensions.json already recommends ubugeeei.vize",
+  ],
+  createdFiles: ["tsconfig.json", "vize.config.ts", ".vscode/extensions.json"],
+  updatedFiles: ["vite.config.js", "package.json"],
+  addedScripts: ["vize:fmt", "vize:fmt:fix", "vize:check"],
+  plannedDependencies: ["@vizejs/vite-plugin", "vize"],
+  expectedDevDependencies: ["@vizejs/vite-plugin", "vite", "vize"],
+  expectedScripts: {
+    dev: "vite",
+    build: "vite build",
+    "vize:fmt": "vize fmt --check src",
+    "vize:fmt:fix": "vize fmt --write src",
+    "vize:check": "vize check",
+  },
+  expectedFiles: {
+    "tsconfig.json": EXPECTED_CHECKJS_TSCONFIG,
+    "vize.config.ts": EXPECTED_VIZE_CONFIG,
+    ".vscode/extensions.json": EXPECTED_EXTENSIONS,
+    "vite.config.js": [
+      'import { defineConfig } from "vite";',
+      'import vize from "@vizejs/vite-plugin";',
+      "",
+      "export default defineConfig({",
+      "  plugins: [vize()],",
+      "});",
+      "",
+    ].join("\n"),
+  },
+  check: {
+    broken: {
+      "src/main.js": mainJsSource(true),
+    },
+    brokenDiagnostics: [
+      {
+        file: "src/main.js",
+        diagnostics: ["error:5:7 [TS2322] Type 'number' is not assignable to type 'string'."],
+      },
+    ],
+  },
+};

--- a/tools/npm/smoke-release-init-shapes.mjs
+++ b/tools/npm/smoke-release-init-shapes.mjs
@@ -1,3 +1,5 @@
+import { VITE_VUE_JS_CHECKJS_SHAPE } from "./smoke-release-init-js-shapes.mjs";
+
 /**
  * Matrix data for the fresh-project release smoke (#3956).
  *
@@ -13,6 +15,7 @@
 /** Cells this slice runs. Further cells are added here, not in the driver. */
 export const FRESH_INIT_MATRIX = [
   { packageManager: "npm", shape: "vite-vue-ts" },
+  { packageManager: "npm", shape: "vite-vue-js-checkjs" },
   { packageManager: "pnpm", shape: "vite-vue-ts" },
   { packageManager: "yarn", shape: "vite-vue-ts" },
   { packageManager: "bun", shape: "vite-vue-ts" },
@@ -206,6 +209,7 @@ const CHECK_TRIPLE = {
  * the narrower `release-npm-native` smoke stays green.
  */
 export const PROJECT_SHAPES = {
+  "vite-vue-js-checkjs": VITE_VUE_JS_CHECKJS_SHAPE,
   "vite-vue-ts": {
     id: "vite-vue-ts",
     // A `create vue` TypeScript app flattened to a single tsconfig: no project


### PR DESCRIPTION
Refs #3956.

## Summary
- add a create-vue-style JavaScript/checkJs fresh-project shape to the release init smoke matrix
- assert that every declared fresh-project shape is present in the runtime matrix
- keep the new shape under the source-length budget by splitting it from the existing TS shape data

## Validation
- nix develop --command node --experimental-strip-types --test tests/tooling/release-smoke-init-fresh.test.ts tests/tooling/release-smoke-init-toolchain.test.ts tests/tooling/release-smoke-init-machine-output.test.ts
- nix develop --command vp exec oxfmt --check tools/npm/smoke-release-init-js-shapes.mjs tools/npm/smoke-release-init-shapes.mjs tests/tooling/release-smoke-init-fresh.test.ts
- nix develop --command vp exec oxlint tools/npm/smoke-release-init-js-shapes.mjs tools/npm/smoke-release-init-shapes.mjs tests/tooling/release-smoke-init-fresh.test.ts
- git diff --check origin/main..HEAD
- wc -l tools/npm/smoke-release-init-shapes.mjs tools/npm/smoke-release-init-js-shapes.mjs tests/tooling/release-smoke-init-fresh.test.ts

Note: the local source-file-length test still cannot resolve MoonBit registry deps (moonbitlang/async, moonbitlang/x), so I validated the touched file line counts directly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790153336&installation_model_id=422833&pr_number=4769&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4769&signature=d26bf43a2cf8735ff937ad3d8a02313728a69f2212a86911971773fc2d807e97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->