### PR TITLE
test(ui): require documented prop defaults

### DIFF
--- a/npm/ui/tooling/authoring-contract.md
+++ b/npm/ui/tooling/authoring-contract.md
@@ -16,6 +16,8 @@ the SFC quality gate.
   source and describing state, input, and outcome.
 - `interaction-test`: every SFC has a mounted interaction test importing the
   component source.
+- `prop-default-doc`: every public prop has documentation comments that include
+  an `@default` tag for editor hover and generated docs.
 - `source-regex-behavior`: source-text assertions are not behavior evidence
   unless a nearby `source-contract:` pragma explains why mounted output cannot
   observe the invariant.
@@ -26,6 +28,7 @@ the SFC quality gate.
 - `behavior-contract` is enforced by `behavior-table`.
 - `mounted-interaction` is enforced by `interaction-test` and
   `source-regex-behavior`.
+- `api-default-documentation` is enforced by `prop-default-doc`.
 
 Future source installation manifests, gallery metadata, and CI policy should
 consume the exported contract rather than duplicating these identifiers.

--- a/npm/ui/tooling/authoring-contract.ts
+++ b/npm/ui/tooling/authoring-contract.ts
@@ -65,6 +65,14 @@ export const VIZE_UI_SFC_AUTHORING_RULES = [
     remediation: "Add a `*.test.ts` file that imports the SFC and exercises observable behavior.",
   },
   {
+    id: "prop-default-doc",
+    title: "Documented prop defaults",
+    requirement:
+      "Every public prop documents its default value in the prop JSDoc so hover and generated docs explain first-render behavior.",
+    evidence: ["defineProps<T> prop JSDoc with `@default`"],
+    remediation: "Add an `@default` tag to each public prop's documentation comment.",
+  },
+  {
     id: "source-regex-behavior",
     title: "No source-regex behavior proof",
     requirement:
@@ -103,6 +111,14 @@ export const VIZE_UI_SFC_QUALITY_GATES = [
       "Behavior gates are proven through mounted DOM/runtime assertions rather than string inspection.",
     evidence: ["*.test.ts", "`source-contract:` escape hatch for source-only invariants"],
     enforcedByRules: ["interaction-test", "source-regex-behavior"],
+  },
+  {
+    id: "api-default-documentation",
+    title: "API default documentation",
+    requirement:
+      "Public props expose their first-render defaults through documentation comments and editor hover.",
+    evidence: ["defineProps<T> JSDoc `@default` tags"],
+    enforcedByRules: ["prop-default-doc"],
   },
 ] as const satisfies readonly SfcQualityGateContract<SfcAuthoringRuleId>[];
 

--- a/npm/ui/tooling/authoring-gate.test.ts
+++ b/npm/ui/tooling/authoring-gate.test.ts
@@ -105,7 +105,8 @@ void test("requires a behavior table and an interaction test per SFC", async () 
 void test("emits only rule ids published by the machine-readable contract", async () => {
   await withFixture(
     {
-      "TheWidget.vue": "<script setup>const value = 1;</script>\n",
+      "TheWidget.vue":
+        "<script setup>defineProps<{ readonly label?: string }>(); const value = 1;</script>\n",
       "widget.test.ts": [
         'import { readFile } from "node:fs/promises";',
         'const source = await readFile(new URL("./TheWidget.vue", import.meta.url), "utf8");',
@@ -170,10 +171,36 @@ void test("allows annotated source assertions that behavior cannot observe", asy
   );
 });
 
+void test("requires public prop defaults to be documented for editor hover", async () => {
+  const sfc = COMPLIANT_SFC.replace("   * @default false\n", "");
+  await withFixture(
+    {
+      "TheWidget.vue": sfc,
+      "widget.behavior.md": "TheWidget.vue",
+      "widget.test.ts": 'import TheWidget from "./TheWidget.vue";\nexport default TheWidget;\n',
+    },
+    async (directory) => {
+      const violations = await auditComponentAuthoring(directory);
+      assert.deepEqual(
+        violations.map((violation) => violation.rule),
+        ["prop-default-doc"],
+      );
+      assert.match(formatAuthoringViolations(violations), /Prop open is missing @default/);
+    },
+  );
+});
+
 void test("rejects SFCs that bypass the explicit authoring contract", async () => {
   const sfc = [
     '<script setup lang="ts">',
-    "const props = withDefaults(defineProps<{ open?: boolean }>(), { open: false });",
+    "const props = withDefaults(defineProps<{",
+    "  /**",
+    "   * Whether the widget starts open.",
+    "   *",
+    "   * @default false",
+    "   */",
+    "  readonly open?: boolean;",
+    "}>(), { open: false });",
     "</script>",
     "",
     "<template>",

--- a/npm/ui/tooling/authoring-gate.ts
+++ b/npm/ui/tooling/authoring-gate.ts
@@ -23,6 +23,9 @@ export interface AuthoringViolation {
 const SOURCE_REGEX_ASSERTION = /\.(?:match|doesNotMatch)\(\s*source\b/;
 const SFC_SOURCE_READ = /readFile\([^)]*\.vue/;
 const SOURCE_CONTRACT_PRAGMA = "source-contract:";
+const DEFINE_PROPS_TYPE = /defineProps\s*<\s*\{([\s\S]*?)\}\s*>\s*\(/g;
+const PROP_DECLARATION =
+  /(?:(\/\*\*[\s\S]*?\*\/)\s*)?readonly\s+(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$]*))\??\s*:/g;
 const AUTHORING_RULE_IDS = new Set<AuthoringRule>(
   VIZE_UI_SFC_AUTHORING_RULES.map((rule) => rule.id),
 );
@@ -37,6 +40,8 @@ const AUTHORING_RULE_IDS = new Set<AuthoringRule>(
  * reads inside tests are violations unless the same or one of the two
  * preceding lines carries a `source-contract:` pragma naming why mounted-DOM
  * behavior cannot observe the contract.
+ * Public props must also document their default value with an `@default` tag
+ * in the prop JSDoc, so hover and generated docs preserve first-render behavior.
  *
  * @param sourceDirectory Directory containing SFC sources, tests, and behavior tables.
  * @returns Violations in stable path order; an empty array means full compliance.
@@ -66,6 +71,9 @@ export async function auditComponentAuthoring(
     const source = await read(sfc);
 
     for (const message of explicitSfcProblems(source, sfc)) report(sfc, "explicit-sfc", message);
+    for (const message of propDefaultDocProblems(source, sfc)) {
+      report(sfc, "prop-default-doc", message);
+    }
 
     if (!behaviorSources.some((table) => table.includes(basename))) {
       report(
@@ -139,6 +147,25 @@ function explicitSfcProblems(source: string, filename: string): string[] {
   if (/\bh\s*\(/.test(scripts)) problems.push("Render-function escape hatch h() is not allowed");
   if (/defineOptions|withDefaults|interface (?:Props|Emits)/.test(scripts)) {
     problems.push("Use literal defineProps/defineEmits types without helper indirection");
+  }
+  return problems;
+}
+
+function propDefaultDocProblems(source: string, filename: string): string[] {
+  const { descriptor, errors } = parse(source, { filename });
+  if (errors.length > 0 || descriptor.scriptSetup === null) return [];
+
+  const problems: string[] = [];
+  for (const propsType of descriptor.scriptSetup.content.matchAll(DEFINE_PROPS_TYPE)) {
+    const body = propsType[1] ?? "";
+    for (const prop of body.matchAll(PROP_DECLARATION)) {
+      const jsdoc = prop[1] ?? "";
+      if (/@default\b/u.test(jsdoc)) continue;
+      const propName = prop[2] ?? prop[3] ?? prop[4] ?? "<unknown>";
+      problems.push(
+        `Prop ${propName} is missing @default documentation; document the public default value`,
+      );
+    }
   }
   return problems;
 }


### PR DESCRIPTION
Refs #3134.

## Summary
- publish a `prop-default-doc` authoring rule and `api-default-documentation` quality gate for public SFC props
- make `auditComponentAuthoring` reject literal `defineProps<T>` props whose JSDoc lacks `@default`
- document the new rule in the UI authoring contract

## Validation
- nix develop --command node --experimental-strip-types --test npm/ui/tooling/authoring-gate.test.ts
- nix develop --command pnpm --dir npm/ui/tooling test
- nix develop --command pnpm --dir npm/ui/tooling check
- nix develop --command vp test run src/authoring-gate.test.ts (from npm/ui/core)
- nix develop --command vp exec oxfmt --check npm/ui/tooling/authoring-contract.ts npm/ui/tooling/authoring-gate.ts npm/ui/tooling/authoring-gate.test.ts npm/ui/tooling/authoring-contract.md npm/ui/core/src/authoring-gate.test.ts
- nix develop --command vp exec oxlint npm/ui/tooling/authoring-contract.ts npm/ui/tooling/authoring-gate.ts npm/ui/tooling/authoring-gate.test.ts npm/ui/core/src/authoring-gate.test.ts
- git diff --check

Note: `pnpm --dir npm/ui/core lint:sfc` is blocked in this checkout by a local native binding package version mismatch (`expected 0.381.0 but got 0.373.0`); the focused core authoring-gate test passes under the package runner.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790153614&installation_model_id=422833&pr_number=4770&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4770&signature=b4fd49ef8a4f7903c6a025d8a13ca582016056ad43bd7cddff23a5a331493663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->