### PR TITLE
feat(fresco): add semantic testing queries

### DIFF
--- a/npm/fresco/src/testing/harness.test.ts
+++ b/npm/fresco/src/testing/harness.test.ts
@@ -4,7 +4,7 @@ import { defineComponent, h, nextTick, ref } from "@vue/runtime-core";
 
 import { Static, TextInput } from "../components/index.js";
 import { useWindowSize } from "../composables/index.js";
-import { renderTui } from "./index.js";
+import { getByRole, getByText, queryAllByRole, queryAllByText, renderTui } from "./index.js";
 
 void test("renderTui records initial and explicit frame snapshots", async () => {
   const label = ref("ready");
@@ -98,5 +98,43 @@ void test("resize input updates the provided app dimensions", async () => {
   assert.equal(rendered.lastFrame(), "20x8");
   await rendered.input.resize(120, 40);
   assert.equal(rendered.lastFrame(), "120x40");
+  rendered.unmount();
+});
+
+void test("semantic queries find role, name, state, and text nodes", () => {
+  const rendered = renderTui(() =>
+    h("box", { style: { flexDirection: "column" } }, [
+      h(
+        "box",
+        {
+          "aria-role": "button",
+          "aria-label": "Save changes",
+          "aria-state": { disabled: true },
+        },
+        [h("text", { text: "Ignored label" })],
+      ),
+      h("box", { "aria-role": "button" }, [h("text", { text: "Cancel" })]),
+      h("input", { "aria-role": "textbox", value: "draft" }),
+      h("text", { text: "Status: ready" }),
+    ]),
+  );
+
+  assert.equal(queryAllByRole(rendered.root, "button").length, 2);
+  assert.equal(
+    getByRole(rendered.root, "button", { name: "Save changes" }).props["aria-role"],
+    "button",
+  );
+  assert.equal(
+    getByRole(rendered.root, "button", { state: { disabled: true } }).props["aria-label"],
+    "Save changes",
+  );
+  assert.equal(
+    getByRole(rendered.root, "button", { name: "Cancel" }).children[0]?.props.text,
+    "Cancel",
+  );
+  assert.equal(getByText(rendered.root, "draft").type, "input");
+  assert.equal(queryAllByText(rendered.root, /ready/u).length, 1);
+  assert.throws(() => getByRole(rendered.root, "checkbox"), /Unable to find Fresco node/);
+  assert.throws(() => getByRole(rendered.root, "button"), /Found 2 Fresco nodes/);
   rendered.unmount();
 });

--- a/npm/fresco/src/testing/index.ts
+++ b/npm/fresco/src/testing/index.ts
@@ -42,6 +42,14 @@ export {
   type MountedFresco,
   type MountFrescoOptions,
 } from "./mount.js";
+export {
+  getByRole,
+  getByText,
+  queryAllByRole,
+  queryAllByText,
+  type FrescoRoleQueryOptions,
+  type FrescoTextMatcher,
+} from "./queries.js";
 
 export type RenderTuiOptions = MountFrescoOptions;
 export type RenderTuiRoot = Component | (() => VNodeChild);

--- a/npm/fresco/src/testing/queries.ts
+++ b/npm/fresco/src/testing/queries.ts
@@ -1,0 +1,110 @@
+import type { AriaRole, AriaState } from "../accessibility.js";
+import type { FrescoNode } from "../renderer.js";
+import { findNodes } from "./mount.js";
+
+export type FrescoTextMatcher = string | RegExp;
+
+export interface FrescoRoleQueryOptions {
+  readonly name?: FrescoTextMatcher;
+  readonly state?: AriaState;
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value === "string" || typeof value === "number") return String(value);
+  return undefined;
+}
+
+function ownText(node: FrescoNode): string | undefined {
+  if (node.text !== undefined) return node.text;
+  const propText = node.props.text ?? node.props.content;
+  if (typeof propText === "string" || typeof propText === "number") return String(propText);
+
+  if (node.type === "input") {
+    const value = node.props.value;
+    const placeholder = node.props.placeholder;
+    if (typeof value === "string" || typeof value === "number") return String(value);
+    if (typeof placeholder === "string" || typeof placeholder === "number")
+      return String(placeholder);
+  }
+
+  return undefined;
+}
+
+function accessibleName(node: FrescoNode): string {
+  const ariaLabel = stringValue(node.props["aria-label"]);
+  if (ariaLabel !== undefined) return ariaLabel;
+
+  const text = ownText(node);
+  if (text !== undefined) return text;
+
+  return node.children
+    .map((child) => accessibleName(child))
+    .filter(Boolean)
+    .join(" ");
+}
+
+function matchesText(text: string, matcher: FrescoTextMatcher): boolean {
+  if (typeof matcher === "string") return text === matcher;
+  matcher.lastIndex = 0;
+  return matcher.test(text);
+}
+
+function roleOf(node: FrescoNode): AriaRole | undefined {
+  return stringValue(node.props["aria-role"]) as AriaRole | undefined;
+}
+
+function stateOf(node: FrescoNode): AriaState {
+  const state = node.props["aria-state"];
+  return state && typeof state === "object" ? (state as AriaState) : {};
+}
+
+function matchesState(node: FrescoNode, expected: AriaState | undefined): boolean {
+  if (expected === undefined) return true;
+  const actual = stateOf(node);
+  return Object.entries(expected).every(([key, value]) => actual[key as keyof AriaState] === value);
+}
+
+function describeRole(role: AriaRole, options: FrescoRoleQueryOptions): string {
+  const parts = [`role ${JSON.stringify(role)}`];
+  if (options.name !== undefined) parts.push(`name ${String(options.name)}`);
+  if (options.state !== undefined) parts.push(`state ${JSON.stringify(options.state)}`);
+  return parts.join(", ");
+}
+
+function uniqueNode(nodes: readonly FrescoNode[], description: string): FrescoNode {
+  if (nodes.length === 0) throw new Error(`Unable to find Fresco node with ${description}`);
+  if (nodes.length > 1) throw new Error(`Found ${nodes.length} Fresco nodes with ${description}`);
+  return nodes[0]!;
+}
+
+export function queryAllByRole(
+  root: FrescoNode,
+  role: AriaRole,
+  options: FrescoRoleQueryOptions = {},
+): FrescoNode[] {
+  return findNodes(root, (node) => {
+    if (roleOf(node) !== role) return false;
+    if (options.name !== undefined && !matchesText(accessibleName(node), options.name))
+      return false;
+    return matchesState(node, options.state);
+  });
+}
+
+export function getByRole(
+  root: FrescoNode,
+  role: AriaRole,
+  options: FrescoRoleQueryOptions = {},
+): FrescoNode {
+  return uniqueNode(queryAllByRole(root, role, options), describeRole(role, options));
+}
+
+export function queryAllByText(root: FrescoNode, text: FrescoTextMatcher): FrescoNode[] {
+  return findNodes(root, (node) => {
+    const value = ownText(node);
+    return value !== undefined && matchesText(value, text);
+  });
+}
+
+export function getByText(root: FrescoNode, text: FrescoTextMatcher): FrescoNode {
+  return uniqueNode(queryAllByText(root, text), `text ${String(text)}`);
+}

--- a/npm/fresco/src/testing/types.test-d.ts
+++ b/npm/fresco/src/testing/types.test-d.ts
@@ -4,23 +4,39 @@ import { h } from "@vue/runtime-core";
 
 import { TextInput } from "../components/index.js";
 import {
+  getByRole,
+  getByText,
+  queryAllByRole,
+  queryAllByText,
   renderTui,
   type FrescoFrameSnapshot,
   type FrescoInputDriver,
+  type FrescoRoleQueryOptions,
+  type FrescoTextMatcher,
   type RenderTuiResult,
 } from "./index.js";
 
 const rendered: RenderTuiResult = renderTui(() => h(TextInput, { modelValue: "value" }));
+const roleQuery: FrescoRoleQueryOptions = { name: /value/u, state: { disabled: false } };
+const textMatcher: FrescoTextMatcher = "value";
 const input: FrescoInputDriver = rendered.input;
 const frame: string = rendered.lastFrame();
 const frames: readonly string[] = rendered.frames;
 const snapshot: FrescoFrameSnapshot = rendered.frameSnapshot();
 const snapshots: readonly FrescoFrameSnapshot[] = rendered.frameSnapshots;
+const roleNode = getByRole(rendered.root, "textbox", roleQuery);
+const textNode = getByText(rendered.root, textMatcher);
+const roleNodes = queryAllByRole(rendered.root, "textbox", { name: "value" });
+const textNodes = queryAllByText(rendered.root, /value/u);
 
 void frame;
 void frames;
 void snapshot.tree.children;
 void snapshots;
+void roleNode.props;
+void textNode.type;
+void roleNodes;
+void textNodes;
 
 export const keyFrame: Promise<FrescoFrameSnapshot> = input.key({
   key: "enter",
@@ -50,3 +66,9 @@ void input.mouse({ button: "left" });
 
 // @ts-expect-error - frame outputs are strings.
 const _invalidOutput: number = snapshot.output;
+
+// @ts-expect-error - role names are closed to the Fresco accessibility contract.
+void getByRole(rendered.root, "dialog");
+
+// @ts-expect-error - text matchers are exact strings or regular expressions.
+void getByText(rendered.root, 123);


### PR DESCRIPTION
Refs #3139.

## Summary
- add `getByRole`, `queryAllByRole`, `getByText`, and `queryAllByText` to `@vizejs/fresco/testing`
- derive role names from `aria-label`, node text/value/placeholder, and descendant text
- cover role/name/state/text runtime queries plus compile-time query API assertions

## Validation
- nix develop --command pnpm --dir npm/fresco test -- src/testing/harness.test.ts
- nix develop --command pnpm --dir npm/fresco check
- nix develop --command pnpm --dir npm/fresco check:types
- nix develop --command vp exec oxlint npm/fresco/src/testing/index.ts npm/fresco/src/testing/queries.ts npm/fresco/src/testing/harness.test.ts npm/fresco/src/testing/types.test-d.ts
- nix develop --command vp exec oxfmt --check npm/fresco/src/testing/index.ts npm/fresco/src/testing/queries.ts npm/fresco/src/testing/harness.test.ts npm/fresco/src/testing/types.test-d.ts
- git diff --check origin/main..HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790153972&installation_model_id=422833&pr_number=4771&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4771&signature=ccf4712efee38416a29420e46bcf7f9870dd39a1e422a0cccc792b5a021a39aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->