### PR TITLE
test(init): name fresh vscode absence

### DIFF
--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -33,6 +33,22 @@ test("the fresh-project matrix is data, so new cells need no driver change", () 
     for (const key of SHAPE_KEYS) {
       assert.ok(key in shape, `${cell.shape} is missing ${key}`);
     }
+    const authored = Object.keys(
+      shape.files({ typescript: "0", vite: "0", "vite-plus": "0", vue: "0" }),
+    );
+    for (const name of shape.initialAbsentFiles) {
+      assert.equal(
+        authored.some((file) => file === name || file.startsWith(`${name}/`)),
+        false,
+        `${cell.shape} authors ${name} before init`,
+      );
+    }
+    if (shape.createdFiles.includes(".vscode/extensions.json")) {
+      assert.ok(
+        shape.initialAbsentFiles.includes(".vscode"),
+        `${cell.shape} creates VS Code recommendations without naming the absent .vscode start`,
+      );
+    }
     // The plan the smoke asserts must be the plan it installs, and the install
     // must leave the project declaring nothing beyond it.
     for (const name of shape.plannedDependencies) {

--- a/tests/tooling/support/release-smoke-init-contract.ts
+++ b/tests/tooling/support/release-smoke-init-contract.ts
@@ -7,6 +7,7 @@ export const SHAPE_KEYS = [
   "expectedScripts",
   "features",
   "initFlags",
+  "initialAbsentFiles",
   "plannedDependencies",
   "reconfiguredDetection",
   "reconfiguredFeatures",

--- a/tools/npm/smoke-release-init-fresh.mjs
+++ b/tools/npm/smoke-release-init-fresh.mjs
@@ -87,7 +87,7 @@ function runFreshProjectCell(context, cell) {
   fs.mkdirSync(projectRootPath, { recursive: true });
   const projectRoot = fs.realpathSync.native(projectRootPath);
   writeFiles(projectRoot, authored);
-  assertFreshProject(projectRoot, context);
+  assertFreshProject(projectRoot, context, shape.initialAbsentFiles);
   runManager(manager, manager.bootstrapArgs, { cwd: projectRoot });
   assert.ok(fs.existsSync(path.join(projectRoot, manager.lockfile)), `no ${manager.lockfile}`);
 

--- a/tools/npm/smoke-release-init-js-shapes.mjs
+++ b/tools/npm/smoke-release-init-js-shapes.mjs
@@ -146,6 +146,7 @@ export const VITE_VUE_JS_CHECKJS_SHAPE = {
   requires: ["vize", "@vizejs/vite-plugin"],
   files: viteVueJsCheckJsFiles,
   initFlags: ["--yes", "--no-lint", "--vite", "--fmt", "--typecheck", "--editor"],
+  initialAbsentFiles: [".vscode"],
   detection: viteJsDetection,
   features: [
     "  lint      skipped    not selected",

--- a/tools/npm/smoke-release-init-project.mjs
+++ b/tools/npm/smoke-release-init-project.mjs
@@ -120,7 +120,7 @@ function resolveShapeField(shape, name, ...args) {
  * `vize` from outside the project, which is exactly the workspace link the
  * issue's first acceptance criterion rules out.
  */
-export function assertFreshProject(projectRoot, context) {
+export function assertFreshProject(projectRoot, context, initialAbsentFiles = []) {
   assert.ok(
     isOutside(context.installDir, projectRoot),
     `${projectRoot} is inside the install tree`,
@@ -140,7 +140,9 @@ export function assertFreshProject(projectRoot, context) {
     }
     if (directory === context.tempDir) break;
   }
-  assert.equal(fs.existsSync(path.join(projectRoot, ".vscode")), false);
+  for (const name of initialAbsentFiles) {
+    assert.equal(fs.existsSync(path.join(projectRoot, name)), false, `${name} exists before init`);
+  }
   assert.equal(fs.existsSync(path.join(projectRoot, "node_modules")), false);
 }
 

--- a/tools/npm/smoke-release-init-shapes.mjs
+++ b/tools/npm/smoke-release-init-shapes.mjs
@@ -219,6 +219,7 @@ export const PROJECT_SHAPES = {
     // `--no-lint` because the lint plan pulls `oxlint` and `oxlint-plugin-vize`,
     // and `oxlint-plugin-vize` is not packed by every caller of this smoke.
     initFlags: ["--yes", "--no-lint", "--vite", "--fmt", "--typecheck", "--editor"],
+    initialAbsentFiles: [".vscode"],
     detection: (manager) => viteDetection(manager),
     features: [
       "  lint      skipped    not selected",
@@ -274,6 +275,7 @@ export const PROJECT_SHAPES = {
     requires: ["vize", "@vizejs/vite-plugin"],
     files: vitePlusVueTsFiles,
     initFlags: ["--yes", "--no-lint", "--vite", "--fmt", "--typecheck", "--editor"],
+    initialAbsentFiles: [".vscode"],
     detection: (manager) => viteDetection(manager, "Vite+"),
     features: [
       "  lint      skipped    not selected",


### PR DESCRIPTION
Refs #3956

## Summary
- add an initialAbsentFiles contract to fresh-project init shapes
- require VS Code recommendation shapes to prove they start without .vscode
- drive the fresh-project boundary assertion from shape data

## Validation
- nix develop --command node --experimental-strip-types --test tests/tooling/release-smoke-init-fresh.test.ts
- nix develop --command vp exec oxfmt --check tools/npm/smoke-release-init-project.mjs tools/npm/smoke-release-init-fresh.mjs tools/npm/smoke-release-init-shapes.mjs tools/npm/smoke-release-init-js-shapes.mjs tests/tooling/release-smoke-init-fresh.test.ts tests/tooling/support/release-smoke-init-contract.ts
- nix develop --command vp exec oxlint tools/npm/smoke-release-init-project.mjs tools/npm/smoke-release-init-fresh.mjs tools/npm/smoke-release-init-shapes.mjs tools/npm/smoke-release-init-js-shapes.mjs tests/tooling/release-smoke-init-fresh.test.ts tests/tooling/support/release-smoke-init-contract.ts
- git diff --check
- wc -l touched files <= 350

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790154274&installation_model_id=422833&pr_number=4772&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4772&signature=2b6e0feaa95501d29428384df359ae2fb343e50d20f1a99dfa0d310a5c3f98ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->