### PR TITLE
test(lsp): record authored feature latency

### DIFF
--- a/tests/tooling/real-project-lsp-authored-oracle.test.ts
+++ b/tests/tooling/real-project-lsp-authored-oracle.test.ts
@@ -28,6 +28,17 @@ test("real-project LSP exercises authored binding and component boundary feature
     assert.equal(result.hover.count, 1);
     assert.equal(result.references.count, 2);
     assert.equal(result.rename.count, 2);
+    for (const evidence of [
+      result.completion,
+      result.componentDefinition,
+      result.definition,
+      result.hover,
+      result.references,
+      result.rename,
+    ]) {
+      assert.ok(Number.isFinite(evidence.durationMs));
+      assert.ok(evidence.durationMs >= 0);
+    }
     assert.deepEqual(result.dependencyCompletion, {
       baselineContainsProbe: false,
       changedContainsProbe: true,

--- a/tests/tooling/real-project-lsp.test.ts
+++ b/tests/tooling/real-project-lsp.test.ts
@@ -43,6 +43,7 @@ test("LSP report summarizes authored feature coverage from project evidence", ()
   );
 
   assert.equal(report.summary.projectCount, 3);
+  assert.equal(report.version, 3);
   assert.equal(report.summary.authoredFeatureProjectCount, 1);
   assert.deepEqual(report.summary.missingAuthoredFeatureProjectIds, [
     "missing-oracle",
@@ -239,7 +240,8 @@ function projectEvidence(
 }
 
 function authoredEvidence(): AuthoredLspEvidence {
-  const response = { count: 1, sha256: "0".repeat(64) };
+  const diagnostic = { count: 0, sha256: "0".repeat(64) };
+  const response = { count: 1, durationMs: 0, sha256: "0".repeat(64) };
   return {
     completion: response,
     componentDefinition: response,
@@ -256,9 +258,9 @@ function authoredEvidence(): AuthoredLspEvidence {
       createdWorkspaceSymbols: response,
       deletedDefinition: { ...response, count: 0 },
       deletedDocumentSymbols: { ...response, count: 0 },
-      deletedImporterDiagnostics: { ...response, count: 0 },
+      deletedImporterDiagnostics: diagnostic,
       deletedWorkspaceSymbols: { ...response, count: 0 },
-      repairedDiagnostics: { ...response, count: 0 },
+      repairedDiagnostics: diagnostic,
       renameEdit: response,
       renamedDefinition: response,
       renamedFile: "Renamed.vue",

--- a/tests/tooling/support/real-project-lsp-authored-oracle.ts
+++ b/tests/tooling/support/real-project-lsp-authored-oracle.ts
@@ -16,6 +16,7 @@ import {
   sortLocations,
   sortTextEdits,
   textDocumentPosition,
+  timedRequest,
   uniqueAnchorOffset,
   type CompletionResponse,
   type Hover,
@@ -76,11 +77,13 @@ export async function exerciseAuthoredLspOracle(
       1,
       timeoutMs(),
     );
-    const hover = (await session.request(
+    const hoverRequest = await timedRequest<Hover>(
+      session,
       "textDocument/hover",
       textDocumentPosition(bindingDocument.uri, usageRange.start),
       timeoutMs(),
-    )) as Hover;
+    );
+    const hover = hoverRequest.response;
     assert.ok(hover, `hover must resolve the authored ${binding.symbol} binding`);
     assert.deepEqual(
       hover.range,
@@ -92,26 +95,30 @@ export async function exerciseAuthoredLspOracle(
       assert.ok(hoverText.includes(expected), `hover for ${binding.symbol} is missing ${expected}`);
     }
 
+    const definitionRequest = await timedRequest<unknown>(
+      session,
+      "textDocument/definition",
+      textDocumentPosition(bindingDocument.uri, usageRange.start),
+      timeoutMs(),
+    );
     const definition = locations(
-      await session.request(
-        "textDocument/definition",
-        textDocumentPosition(bindingDocument.uri, usageRange.start),
-        timeoutMs(),
-      ),
+      definitionRequest.response,
       `definition must resolve the authored ${binding.symbol} binding`,
     );
-    assert.deepEqual(definition, [{ range: declarationRange, uri: bindingDocument.uri }]);
+    const referencesRequest = await timedRequest<unknown>(
+      session,
+      "textDocument/references",
+      {
+        ...textDocumentPosition(bindingDocument.uri, usageRange.start),
+        context: { includeDeclaration: true },
+      },
+      timeoutMs(),
+    );
     const references = locations(
-      await session.request(
-        "textDocument/references",
-        {
-          ...textDocumentPosition(bindingDocument.uri, usageRange.start),
-          context: { includeDeclaration: true },
-        },
-        timeoutMs(),
-      ),
+      referencesRequest.response,
       `references must resolve the authored ${binding.symbol} binding`,
     );
+    assert.deepEqual(definition, [{ range: declarationRange, uri: bindingDocument.uri }]);
     assert.deepEqual(
       sortLocations(references),
       sortLocations([
@@ -127,14 +134,16 @@ export async function exerciseAuthoredLspOracle(
       timeoutMs(),
     );
     assert.deepEqual(prepareRename, usageRange, "prepareRename must select the template token");
-    const rename = (await session.request(
+    const renameRequest = await timedRequest<WorkspaceEdit | null>(
+      session,
       "textDocument/rename",
       {
         ...textDocumentPosition(bindingDocument.uri, usageRange.start),
         newName: binding.renameTo,
       },
       timeoutMs(),
-    )) as WorkspaceEdit | null;
+    );
+    const rename = renameRequest.response;
     const renameEdits = rename?.changes?.[bindingDocument.uri];
     assert.ok(renameEdits, `rename must edit the authored ${binding.symbol} binding`);
     assert.deepEqual(
@@ -161,25 +170,27 @@ export async function exerciseAuthoredLspOracle(
       1,
       timeoutMs(),
     );
+    const componentDefinitionRequest = await timedRequest<unknown>(
+      session,
+      "textDocument/definition",
+      textDocumentPosition(importerDocument.uri, tagRange.start),
+      timeoutMs(),
+    );
     const componentDefinition = locations(
-      await session.request(
-        "textDocument/definition",
-        textDocumentPosition(importerDocument.uri, tagRange.start),
-        timeoutMs(),
-      ),
+      componentDefinitionRequest.response,
       `definition must cross the authored ${boundary.tagName} component boundary`,
     );
     assert.equal(componentDefinition.length, 1);
     assert.equal(componentDefinition[0]?.uri, childDocument.uri);
     assertRangeInDocument(componentDefinition[0]!.range, childDocument.source, boundary.tagName);
 
-    const baselineLabels = completionLabels(
-      (await session.request(
-        "textDocument/completion",
-        textDocumentPosition(importerDocument.uri, completionPosition),
-        timeoutMs(),
-      )) as CompletionResponse,
+    const completionRequest = await timedRequest<CompletionResponse>(
+      session,
+      "textDocument/completion",
+      textDocumentPosition(importerDocument.uri, completionPosition),
+      timeoutMs(),
     );
+    const baselineLabels = completionLabels(completionRequest.response);
     assert.equal(
       baselineLabels.length,
       boundary.completionItemCount,
@@ -231,22 +242,24 @@ export async function exerciseAuthoredLspOracle(
       importerDiagnostics,
       timeoutMs,
     );
+    const evidence = (request: { durationMs: number }, response: unknown, count: number) =>
+      responseEvidence(response, count, workspaceDir, request.durationMs);
 
     return {
-      completion: responseEvidence(baselineLabels, baselineLabels.length, workspaceDir),
-      componentDefinition: responseEvidence(componentDefinition, 1, workspaceDir),
+      completion: evidence(completionRequest, baselineLabels, baselineLabels.length),
+      componentDefinition: evidence(componentDefinitionRequest, componentDefinition, 1),
       componentFile: boundary.componentFile,
-      definition: responseEvidence(definition, definition.length, workspaceDir),
+      definition: evidence(definitionRequest, definition, definition.length),
       dependencyCompletion: {
         baselineContainsProbe,
         changedContainsProbe,
         repairedContainsProbe,
       },
       fileLifecycle,
-      hover: responseEvidence(hover, 1, workspaceDir),
+      hover: evidence(hoverRequest, hover, 1),
       importerFile: boundary.importerFile,
-      references: responseEvidence(sortLocations(references), references.length, workspaceDir),
-      rename: responseEvidence(sortTextEdits(renameEdits), renameEdits.length, workspaceDir),
+      references: evidence(referencesRequest, sortLocations(references), references.length),
+      rename: evidence(renameRequest, sortTextEdits(renameEdits), renameEdits.length),
       templateBindingDiagnostics: diagnosticEvidence(bindingDiagnostics.diagnostics),
       templateBindingFile: binding.file,
     };

--- a/tests/tooling/support/real-project-lsp-authored-utils.ts
+++ b/tests/tooling/support/real-project-lsp-authored-utils.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { performance } from "node:perf_hooks";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { offsetToPosition } from "./lsp/assertions.ts";
@@ -160,14 +161,27 @@ export function responseEvidence(
   response: unknown,
   count: number,
   workspaceDir: string,
+  durationMs = 0,
 ): LspResponseEvidence {
   const normalized = normalizeResponse(response, workspaceDir);
   return {
     count,
+    durationMs,
     sha256: createHash("sha256")
       .update(`${JSON.stringify(normalized)}\n`)
       .digest("hex"),
   };
+}
+
+export async function timedRequest<T>(
+  session: OracleSession,
+  method: string,
+  params: unknown,
+  timeoutMs: number,
+): Promise<{ durationMs: number; response: T }> {
+  const started = performance.now();
+  const response = (await session.request(method, params, timeoutMs)) as T;
+  return { durationMs: elapsedMs(started), response };
 }
 
 export function normalizeDiagnostics(diagnostics: LspDiagnostic[]): string[] {
@@ -225,6 +239,10 @@ function normalizeResponse(value: unknown, workspaceDir: string): unknown {
 
 function compareKeys(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function elapsedMs(started: number): number {
+  return Number(Math.max(0, performance.now() - started).toFixed(3));
 }
 
 function locationKey(location: Location): string {

--- a/tests/tooling/support/real-project-lsp-report.ts
+++ b/tests/tooling/support/real-project-lsp-report.ts
@@ -57,6 +57,7 @@ export type DiagnosticEvidence = {
 
 export type LspResponseEvidence = {
   count: number;
+  durationMs: number;
   sha256: string;
 };
 
@@ -139,7 +140,7 @@ export function createLspReport(
 ) {
   return {
     schema: "vize.realProjectLspLifecycle",
-    version: 2,
+    version: 3,
     commitSha: resolveCommitSha(environment),
     shard: { count: selection.shardCount, index: selection.shardIndex },
     summary: {


### PR DESCRIPTION
Refs #3952

## Summary
- add durationMs to real-project LSP response evidence and bump the report schema
- measure authored hover, definition, references, rename, component definition, and completion requests
- assert latency evidence is finite and non-negative in the authored oracle unit test

## Validation
- nix develop --command node --experimental-strip-types --test tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp.test.ts
- nix develop --command vp exec oxfmt --check tests/tooling/support/real-project-lsp-report.ts tests/tooling/support/real-project-lsp-authored-utils.ts tests/tooling/support/real-project-lsp-authored-oracle.ts tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp.test.ts
- nix develop --command vp exec oxlint tests/tooling/support/real-project-lsp-report.ts tests/tooling/support/real-project-lsp-authored-utils.ts tests/tooling/support/real-project-lsp-authored-oracle.ts tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp.test.ts
- git diff --check
- wc -l touched files <= 350