### PR TITLE
feat(fresco): query nodes by test id

### DIFF
--- a/npm/fresco/src/testing/harness.test.ts
+++ b/npm/fresco/src/testing/harness.test.ts
@@ -4,7 +4,15 @@ import { defineComponent, h, nextTick, ref } from "@vue/runtime-core";
 
 import { Static, TextInput } from "../components/index.js";
 import { useWindowSize } from "../composables/index.js";
-import { getByRole, getByText, queryAllByRole, queryAllByText, renderTui } from "./index.js";
+import {
+  getByRole,
+  getByTestId,
+  getByText,
+  queryAllByRole,
+  queryAllByTestId,
+  queryAllByText,
+  renderTui,
+} from "./index.js";
 
 void test("renderTui records initial and explicit frame snapshots", async () => {
   const label = ref("ready");
@@ -101,7 +109,7 @@ void test("resize input updates the provided app dimensions", async () => {
   rendered.unmount();
 });
 
-void test("semantic queries find role, name, state, and text nodes", () => {
+void test("semantic queries find role, name, state, text, and test-id nodes", () => {
   const rendered = renderTui(() =>
     h("box", { style: { flexDirection: "column" } }, [
       h(
@@ -110,12 +118,13 @@ void test("semantic queries find role, name, state, and text nodes", () => {
           "aria-role": "button",
           "aria-label": "Save changes",
           "aria-state": { disabled: true },
+          "test-id": "save-action",
         },
         [h("text", { text: "Ignored label" })],
       ),
       h("box", { "aria-role": "button" }, [h("text", { text: "Cancel" })]),
       h("input", { "aria-role": "textbox", value: "draft" }),
-      h("text", { text: "Status: ready" }),
+      h("text", { "data-testid": "status-line", text: "Status: ready" }),
     ]),
   );
 
@@ -134,6 +143,9 @@ void test("semantic queries find role, name, state, and text nodes", () => {
   );
   assert.equal(getByText(rendered.root, "draft").type, "input");
   assert.equal(queryAllByText(rendered.root, /ready/u).length, 1);
+  assert.equal(getByTestId(rendered.root, "save-action").props["aria-label"], "Save changes");
+  assert.equal(queryAllByTestId(rendered.root, "status-line")[0]?.props.text, "Status: ready");
+  assert.throws(() => getByTestId(rendered.root, "missing"), /Unable to find Fresco node/);
   assert.throws(() => getByRole(rendered.root, "checkbox"), /Unable to find Fresco node/);
   assert.throws(() => getByRole(rendered.root, "button"), /Found 2 Fresco nodes/);
   rendered.unmount();

--- a/npm/fresco/src/testing/index.ts
+++ b/npm/fresco/src/testing/index.ts
@@ -44,8 +44,10 @@ export {
 } from "./mount.js";
 export {
   getByRole,
+  getByTestId,
   getByText,
   queryAllByRole,
+  queryAllByTestId,
   queryAllByText,
   type FrescoRoleQueryOptions,
   type FrescoTextMatcher,

--- a/npm/fresco/src/testing/queries.ts
+++ b/npm/fresco/src/testing/queries.ts
@@ -53,6 +53,10 @@ function roleOf(node: FrescoNode): AriaRole | undefined {
   return stringValue(node.props["aria-role"]) as AriaRole | undefined;
 }
 
+function testIdOf(node: FrescoNode): string | undefined {
+  return stringValue(node.props["test-id"] ?? node.props["data-testid"]);
+}
+
 function stateOf(node: FrescoNode): AriaState {
   const state = node.props["aria-state"];
   return state && typeof state === "object" ? (state as AriaState) : {};
@@ -107,4 +111,12 @@ export function queryAllByText(root: FrescoNode, text: FrescoTextMatcher): Fresc
 
 export function getByText(root: FrescoNode, text: FrescoTextMatcher): FrescoNode {
   return uniqueNode(queryAllByText(root, text), `text ${String(text)}`);
+}
+
+export function queryAllByTestId(root: FrescoNode, testId: string): FrescoNode[] {
+  return findNodes(root, (node) => testIdOf(node) === testId);
+}
+
+export function getByTestId(root: FrescoNode, testId: string): FrescoNode {
+  return uniqueNode(queryAllByTestId(root, testId), `test id ${JSON.stringify(testId)}`);
 }

--- a/npm/fresco/src/testing/types.test-d.ts
+++ b/npm/fresco/src/testing/types.test-d.ts
@@ -5,8 +5,10 @@ import { h } from "@vue/runtime-core";
 import { TextInput } from "../components/index.js";
 import {
   getByRole,
+  getByTestId,
   getByText,
   queryAllByRole,
+  queryAllByTestId,
   queryAllByText,
   renderTui,
   type FrescoFrameSnapshot,
@@ -25,8 +27,10 @@ const frames: readonly string[] = rendered.frames;
 const snapshot: FrescoFrameSnapshot = rendered.frameSnapshot();
 const snapshots: readonly FrescoFrameSnapshot[] = rendered.frameSnapshots;
 const roleNode = getByRole(rendered.root, "textbox", roleQuery);
+const testNode = getByTestId(rendered.root, "field");
 const textNode = getByText(rendered.root, textMatcher);
 const roleNodes = queryAllByRole(rendered.root, "textbox", { name: "value" });
+const testNodes = queryAllByTestId(rendered.root, "field");
 const textNodes = queryAllByText(rendered.root, /value/u);
 
 void frame;
@@ -34,8 +38,10 @@ void frames;
 void snapshot.tree.children;
 void snapshots;
 void roleNode.props;
+void testNode.id;
 void textNode.type;
 void roleNodes;
+void testNodes;
 void textNodes;
 
 export const keyFrame: Promise<FrescoFrameSnapshot> = input.key({
@@ -72,3 +78,6 @@ void getByRole(rendered.root, "dialog");
 
 // @ts-expect-error - text matchers are exact strings or regular expressions.
 void getByText(rendered.root, 123);
+
+// @ts-expect-error - test identifiers are strings.
+void getByTestId(rendered.root, /field/u);


### PR DESCRIPTION
Refs #3139

## Summary
- add queryAllByTestId and getByTestId to the Fresco testing API
- support both terminal-native test-id and compatibility data-testid props
- cover runtime and compile-only query contracts

## Validation
- nix develop --command pnpm --dir npm/fresco test -- src/testing/harness.test.ts
- nix develop --command pnpm --dir npm/fresco check
- nix develop --command pnpm --dir npm/fresco check:types
- nix develop --command vp exec oxfmt --check npm/fresco/src/testing/index.ts npm/fresco/src/testing/queries.ts npm/fresco/src/testing/harness.test.ts npm/fresco/src/testing/types.test-d.ts
- nix develop --command vp exec oxlint npm/fresco/src/testing/index.ts npm/fresco/src/testing/queries.ts npm/fresco/src/testing/harness.test.ts npm/fresco/src/testing/types.test-d.ts
- git diff --check
- wc -l touched files <= 350