### PR TITLE
feat(doctor): name capability telemetry

### DIFF
--- a/crates/vize_doctor/src/capability_execution/telemetry.rs
+++ b/crates/vize_doctor/src/capability_execution/telemetry.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use vize_carton::String;
 
 use super::CapabilityExecutionOutcome;
 use crate::{CapabilityCacheKey, ContentFingerprint};
@@ -17,6 +18,7 @@ pub enum CapabilityExecutionCacheStatus {
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct CapabilityExecutionTelemetry {
+    capability: String,
     cache_key: CapabilityCacheKey,
     cache_status: CapabilityExecutionCacheStatus,
     finding_count: usize,
@@ -27,6 +29,7 @@ impl CapabilityExecutionTelemetry {
     pub(super) fn from_outcome(outcome: &CapabilityExecutionOutcome) -> Self {
         let snapshot = outcome.snapshot();
         Self {
+            capability: snapshot.identity().capability().into(),
             cache_key: snapshot.cache_key(),
             cache_status: match outcome {
                 CapabilityExecutionOutcome::CacheHit { .. } => CapabilityExecutionCacheStatus::Hit,
@@ -37,6 +40,11 @@ impl CapabilityExecutionTelemetry {
             finding_count: snapshot.findings().len(),
             output_fingerprint: snapshot.output_fingerprint(),
         }
+    }
+
+    /// Returns the stable analysis capability identifier.
+    pub fn capability(&self) -> &str {
+        &self.capability
     }
 
     /// Returns the cache key used by this capability execution.

--- a/crates/vize_doctor/src/capability_execution/tests.rs
+++ b/crates/vize_doctor/src/capability_execution/tests.rs
@@ -117,6 +117,7 @@ fn execution_outcome_reports_stable_cache_telemetry() {
         miss_telemetry.cache_status(),
         CapabilityExecutionCacheStatus::Miss
     );
+    assert_eq!(miss_telemetry.capability(), "template-semantics");
     assert_eq!(miss_telemetry.cache_key(), identity.cache_key());
     assert_eq!(miss_telemetry.finding_count(), 1);
     assert_eq!(
@@ -132,6 +133,10 @@ fn execution_outcome_reports_stable_cache_telemetry() {
     assert_eq!(
         serde_json::to_value(hit.telemetry()).unwrap()["findingCount"],
         1
+    );
+    assert_eq!(
+        serde_json::to_value(hit.telemetry()).unwrap()["capability"],
+        "template-semantics"
     );
 }
 


### PR DESCRIPTION
## Summary
- add the stable capability identifier to capability execution telemetry
- cover the new telemetry field in typed and JSON assertions

Refs #3138

## Validation
- nix develop --command cargo fmt --all --check
- nix develop --command cargo test -p vize_doctor capability_execution --all-features
- nix develop --command cargo clippy -p vize_doctor --all-targets --all-features -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4776"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790155535&installation_model_id=422833&pr_number=4776&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4776&signature=a38538dd40091ccc282a7742466ae2573592b70abbe8f63ecae2ba40866e7e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->