### PR TITLE
feat(fresco): query nodes by description

### DIFF
--- a/npm/fresco/src/testing/harness.test.ts
+++ b/npm/fresco/src/testing/harness.test.ts
@@ -5,9 +5,11 @@ import { defineComponent, h, nextTick, ref } from "@vue/runtime-core";
 import { Static, TextInput } from "../components/index.js";
 import { useWindowSize } from "../composables/index.js";
 import {
+  getByDescription,
   getByRole,
   getByTestId,
   getByText,
+  queryAllByDescription,
   queryAllByRole,
   queryAllByTestId,
   queryAllByText,
@@ -109,7 +111,7 @@ void test("resize input updates the provided app dimensions", async () => {
   rendered.unmount();
 });
 
-void test("semantic queries find role, name, state, text, and test-id nodes", () => {
+void test("semantic queries find role, name, description, state, text, and test-id nodes", () => {
   const rendered = renderTui(() =>
     h("box", { style: { flexDirection: "column" } }, [
       h(
@@ -117,6 +119,7 @@ void test("semantic queries find role, name, state, text, and test-id nodes", ()
         {
           "aria-role": "button",
           "aria-label": "Save changes",
+          "aria-description": "Writes the current draft",
           "aria-state": { disabled: true },
           "test-id": "save-action",
         },
@@ -124,7 +127,11 @@ void test("semantic queries find role, name, state, text, and test-id nodes", ()
       ),
       h("box", { "aria-role": "button" }, [h("text", { text: "Cancel" })]),
       h("input", { "aria-role": "textbox", value: "draft" }),
-      h("text", { "data-testid": "status-line", text: "Status: ready" }),
+      h("text", {
+        "aria-description": "Current status summary",
+        "data-testid": "status-line",
+        text: "Status: ready",
+      }),
     ]),
   );
 
@@ -138,13 +145,23 @@ void test("semantic queries find role, name, state, text, and test-id nodes", ()
     "Save changes",
   );
   assert.equal(
+    getByRole(rendered.root, "button", { description: /current draft/u }).props["aria-label"],
+    "Save changes",
+  );
+  assert.equal(
     getByRole(rendered.root, "button", { name: "Cancel" }).children[0]?.props.text,
     "Cancel",
   );
   assert.equal(getByText(rendered.root, "draft").type, "input");
   assert.equal(queryAllByText(rendered.root, /ready/u).length, 1);
+  assert.equal(
+    getByDescription(rendered.root, "Current status summary").props.text,
+    "Status: ready",
+  );
+  assert.equal(queryAllByDescription(rendered.root, /draft/u).length, 1);
   assert.equal(getByTestId(rendered.root, "save-action").props["aria-label"], "Save changes");
   assert.equal(queryAllByTestId(rendered.root, "status-line")[0]?.props.text, "Status: ready");
+  assert.throws(() => getByDescription(rendered.root, "missing"), /Unable to find Fresco node/);
   assert.throws(() => getByTestId(rendered.root, "missing"), /Unable to find Fresco node/);
   assert.throws(() => getByRole(rendered.root, "checkbox"), /Unable to find Fresco node/);
   assert.throws(() => getByRole(rendered.root, "button"), /Found 2 Fresco nodes/);

--- a/npm/fresco/src/testing/index.ts
+++ b/npm/fresco/src/testing/index.ts
@@ -43,9 +43,11 @@ export {
   type MountFrescoOptions,
 } from "./mount.js";
 export {
+  getByDescription,
   getByRole,
   getByTestId,
   getByText,
+  queryAllByDescription,
   queryAllByRole,
   queryAllByTestId,
   queryAllByText,

--- a/npm/fresco/src/testing/queries.ts
+++ b/npm/fresco/src/testing/queries.ts
@@ -6,6 +6,7 @@ export type FrescoTextMatcher = string | RegExp;
 
 export interface FrescoRoleQueryOptions {
   readonly name?: FrescoTextMatcher;
+  readonly description?: FrescoTextMatcher;
   readonly state?: AriaState;
 }
 
@@ -43,6 +44,12 @@ function accessibleName(node: FrescoNode): string {
     .join(" ");
 }
 
+function accessibleDescription(node: FrescoNode): string | undefined {
+  return stringValue(
+    node.props["aria-description"] ?? node.props.ariaDescription ?? node.props.description,
+  );
+}
+
 function matchesText(text: string, matcher: FrescoTextMatcher): boolean {
   if (typeof matcher === "string") return text === matcher;
   matcher.lastIndex = 0;
@@ -71,6 +78,7 @@ function matchesState(node: FrescoNode, expected: AriaState | undefined): boolea
 function describeRole(role: AriaRole, options: FrescoRoleQueryOptions): string {
   const parts = [`role ${JSON.stringify(role)}`];
   if (options.name !== undefined) parts.push(`name ${String(options.name)}`);
+  if (options.description !== undefined) parts.push(`description ${String(options.description)}`);
   if (options.state !== undefined) parts.push(`state ${JSON.stringify(options.state)}`);
   return parts.join(", ");
 }
@@ -89,6 +97,11 @@ export function queryAllByRole(
   return findNodes(root, (node) => {
     if (roleOf(node) !== role) return false;
     if (options.name !== undefined && !matchesText(accessibleName(node), options.name))
+      return false;
+    if (
+      options.description !== undefined &&
+      !matchesText(accessibleDescription(node) ?? "", options.description)
+    )
       return false;
     return matchesState(node, options.state);
   });
@@ -111,6 +124,20 @@ export function queryAllByText(root: FrescoNode, text: FrescoTextMatcher): Fresc
 
 export function getByText(root: FrescoNode, text: FrescoTextMatcher): FrescoNode {
   return uniqueNode(queryAllByText(root, text), `text ${String(text)}`);
+}
+
+export function queryAllByDescription(
+  root: FrescoNode,
+  description: FrescoTextMatcher,
+): FrescoNode[] {
+  return findNodes(root, (node) => {
+    const value = accessibleDescription(node);
+    return value !== undefined && matchesText(value, description);
+  });
+}
+
+export function getByDescription(root: FrescoNode, description: FrescoTextMatcher): FrescoNode {
+  return uniqueNode(queryAllByDescription(root, description), `description ${String(description)}`);
 }
 
 export function queryAllByTestId(root: FrescoNode, testId: string): FrescoNode[] {

--- a/npm/fresco/src/testing/types.test-d.ts
+++ b/npm/fresco/src/testing/types.test-d.ts
@@ -4,9 +4,11 @@ import { h } from "@vue/runtime-core";
 
 import { TextInput } from "../components/index.js";
 import {
+  getByDescription,
   getByRole,
   getByTestId,
   getByText,
+  queryAllByDescription,
   queryAllByRole,
   queryAllByTestId,
   queryAllByText,
@@ -19,7 +21,11 @@ import {
 } from "./index.js";
 
 const rendered: RenderTuiResult = renderTui(() => h(TextInput, { modelValue: "value" }));
-const roleQuery: FrescoRoleQueryOptions = { name: /value/u, state: { disabled: false } };
+const roleQuery: FrescoRoleQueryOptions = {
+  description: /field help/u,
+  name: /value/u,
+  state: { disabled: false },
+};
 const textMatcher: FrescoTextMatcher = "value";
 const input: FrescoInputDriver = rendered.input;
 const frame: string = rendered.lastFrame();
@@ -27,9 +33,11 @@ const frames: readonly string[] = rendered.frames;
 const snapshot: FrescoFrameSnapshot = rendered.frameSnapshot();
 const snapshots: readonly FrescoFrameSnapshot[] = rendered.frameSnapshots;
 const roleNode = getByRole(rendered.root, "textbox", roleQuery);
+const descriptionNode = getByDescription(rendered.root, /field help/u);
 const testNode = getByTestId(rendered.root, "field");
 const textNode = getByText(rendered.root, textMatcher);
 const roleNodes = queryAllByRole(rendered.root, "textbox", { name: "value" });
+const descriptionNodes = queryAllByDescription(rendered.root, "field help");
 const testNodes = queryAllByTestId(rendered.root, "field");
 const textNodes = queryAllByText(rendered.root, /value/u);
 
@@ -38,9 +46,11 @@ void frames;
 void snapshot.tree.children;
 void snapshots;
 void roleNode.props;
+void descriptionNode.props;
 void testNode.id;
 void textNode.type;
 void roleNodes;
+void descriptionNodes;
 void testNodes;
 void textNodes;
 
@@ -78,6 +88,9 @@ void getByRole(rendered.root, "dialog");
 
 // @ts-expect-error - text matchers are exact strings or regular expressions.
 void getByText(rendered.root, 123);
+
+// @ts-expect-error - descriptions are exact strings or regular expressions.
+void getByDescription(rendered.root, 123);
 
 // @ts-expect-error - test identifiers are strings.
 void getByTestId(rendered.root, /field/u);


### PR DESCRIPTION
## Summary
- add Fresco semantic description queries to the testing harness
- allow role queries to match accessible descriptions
- cover behavior and exported type assertions

Refs #3139

## Validation
- nix develop --command pnpm --dir npm/fresco test -- src/testing/harness.test.ts
- nix develop --command pnpm --dir npm/fresco check
- nix develop --command pnpm --dir npm/fresco check:types
- nix develop --command vp exec oxfmt --check npm/fresco/src/testing/harness.test.ts npm/fresco/src/testing/queries.ts npm/fresco/src/testing/index.ts npm/fresco/src/testing/types.test-d.ts
- nix develop --command vp exec oxlint npm/fresco/src/testing/queries.ts npm/fresco/src/testing/index.ts npm/fresco/src/testing/harness.test.ts npm/fresco/src/testing/types.test-d.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790155856&installation_model_id=422833&pr_number=4777&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4777&signature=68178bab1b06900687cbc2f0df5e30f2bc51b692e45b2db60d7776aeab0a8e3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->