### PR TITLE
feat(marquette): name native capability definitions

### DIFF
--- a/crates/vize_marquette/src/adapter/mod.rs
+++ b/crates/vize_marquette/src/adapter/mod.rs
@@ -14,7 +14,7 @@ pub use model::{
 };
 pub use native_profile::{
     NATIVE_ENGINE_CAPABILITY_IDS, NATIVE_ENGINE_CAPABILITY_VERSION,
-    native_engine_capability_profile,
+    native_engine_capability_definitions, native_engine_capability_profile,
 };
 pub use negotiate::negotiate_adapter_capabilities;
 pub use validate::validate_adapter_capability_manifest;

--- a/crates/vize_marquette/src/adapter/native_profile.rs
+++ b/crates/vize_marquette/src/adapter/native_profile.rs
@@ -1,22 +1,76 @@
 use super::AdapterCapabilitySupport;
+use crate::CapabilityDefinition;
 
 /// Current contract version shared by the native-engine capability profile.
 pub const NATIVE_ENGINE_CAPABILITY_VERSION: u32 = 1;
 
-/// Closed set of capability identifiers required from a native rendering engine.
+/// Closed set of native-engine capabilities and application-side summaries.
+///
+/// The order is part of the language-neutral profile and follows the execution
+/// boundary from rendering through lifecycle management.
+const NATIVE_ENGINE_CAPABILITIES: [(&str, &str); 8] = [
+    (
+        "native.rendering",
+        "Render native view trees produced from compiled SFC output.",
+    ),
+    (
+        "native.events",
+        "Dispatch typed native input and lifecycle events into the application.",
+    ),
+    (
+        "native.layout",
+        "Measure and position native nodes with deterministic layout results.",
+    ),
+    (
+        "native.text",
+        "Shape, measure, and render text with locale and accessibility metadata.",
+    ),
+    (
+        "native.images",
+        "Resolve, decode, cache, and draw application image assets.",
+    ),
+    (
+        "native.animation",
+        "Drive declarative native animations with deterministic completion signals.",
+    ),
+    (
+        "native.accessibility",
+        "Expose native semantics, focus, and assistive technology metadata.",
+    ),
+    (
+        "native.lifecycle",
+        "Report application, screen, and host runtime lifecycle transitions.",
+    ),
+];
+
+/// Stable capability identifiers required from a native rendering engine.
 ///
 /// The order is part of the language-neutral profile and follows the execution
 /// boundary from rendering through lifecycle management.
 pub const NATIVE_ENGINE_CAPABILITY_IDS: [&str; 8] = [
-    "native.rendering",
-    "native.events",
-    "native.layout",
-    "native.text",
-    "native.images",
-    "native.animation",
-    "native.accessibility",
-    "native.lifecycle",
+    NATIVE_ENGINE_CAPABILITIES[0].0,
+    NATIVE_ENGINE_CAPABILITIES[1].0,
+    NATIVE_ENGINE_CAPABILITIES[2].0,
+    NATIVE_ENGINE_CAPABILITIES[3].0,
+    NATIVE_ENGINE_CAPABILITIES[4].0,
+    NATIVE_ENGINE_CAPABILITIES[5].0,
+    NATIVE_ENGINE_CAPABILITIES[6].0,
+    NATIVE_ENGINE_CAPABILITIES[7].0,
 ];
+
+/// Creates the canonical application-side native-engine capability definitions.
+///
+/// The returned definitions are the requirements matched against
+/// [`native_engine_capability_profile`].
+pub fn native_engine_capability_definitions() -> Vec<CapabilityDefinition> {
+    NATIVE_ENGINE_CAPABILITIES
+        .map(|(id, description)| CapabilityDefinition {
+            id: id.into(),
+            description: description.into(),
+            version: NATIVE_ENGINE_CAPABILITY_VERSION,
+        })
+        .to_vec()
+}
 
 /// Creates the canonical version-one native-engine capability profile.
 ///

--- a/crates/vize_marquette/src/lib.rs
+++ b/crates/vize_marquette/src/lib.rs
@@ -57,7 +57,8 @@ pub use adapter::{
     AdapterCapabilityDiagnostic, AdapterCapabilityDiagnosticCode, AdapterCapabilityManifest,
     AdapterCapabilityMismatch, AdapterCapabilityMismatchCode, AdapterCapabilityNegotiation,
     AdapterCapabilitySupport, NATIVE_ENGINE_CAPABILITY_IDS, NATIVE_ENGINE_CAPABILITY_VERSION,
-    compare_adapter_capabilities, native_engine_capability_profile, negotiate_adapter_capabilities,
+    compare_adapter_capabilities, native_engine_capability_definitions,
+    native_engine_capability_profile, negotiate_adapter_capabilities,
     validate_adapter_capability_manifest,
 };
 pub use canonical::{CanonicalContractError, canonical_json, contract_fingerprint};

--- a/crates/vize_marquette/tests/adapter_conformance.rs
+++ b/crates/vize_marquette/tests/adapter_conformance.rs
@@ -5,8 +5,8 @@ use serde_json::Value;
 use vize_carton::{String, ToCompactString};
 use vize_marquette::{
     ADAPTER_CAPABILITY_MANIFEST_JSON_SCHEMA, AdapterCapabilityManifest, ApplicationContract,
-    CapabilityDefinition, NATIVE_ENGINE_CAPABILITY_IDS, NATIVE_ENGINE_CAPABILITY_VERSION,
-    compare_adapter_capabilities, contract_fingerprint, native_engine_capability_profile,
+    NATIVE_ENGINE_CAPABILITY_IDS, NATIVE_ENGINE_CAPABILITY_VERSION, compare_adapter_capabilities,
+    contract_fingerprint, native_engine_capability_definitions, native_engine_capability_profile,
     negotiate_adapter_capabilities, validate_adapter_capability_manifest,
 };
 
@@ -63,12 +63,22 @@ fn native_engine_profile_matches_the_shared_contract_and_negotiates_fail_closed(
             && support.max_version == NATIVE_ENGINE_CAPABILITY_VERSION
     }));
 
+    let definitions = native_engine_capability_definitions();
+    let definition_ids = definitions
+        .iter()
+        .map(|definition| definition.id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(definition_ids, NATIVE_ENGINE_CAPABILITY_IDS.to_vec());
+    assert!(definitions.iter().all(|definition| {
+        definition.version == NATIVE_ENGINE_CAPABILITY_VERSION
+            && !definition.description.trim().is_empty()
+    }));
+
     let mut contract = ApplicationContract::new("native-profile");
-    for id in NATIVE_ENGINE_CAPABILITY_IDS {
-        contract.capabilities.insert(
-            id.into(),
-            CapabilityDefinition::new(id, "Native engine contract"),
-        );
+    for definition in definitions {
+        contract
+            .capabilities
+            .insert(definition.id.clone(), definition);
     }
     let compatible =
         negotiate_adapter_capabilities(&contract, NATIVE_ENGINE_CAPABILITY_IDS, &actual);


### PR DESCRIPTION
## Summary
- add canonical application-side native engine capability definitions
- export the definitions beside the native capability profile
- require adapter conformance tests to negotiate from the shared definitions

Refs #3132

## Tests
- nix develop --command cargo fmt --all --check
- nix develop --command cargo test -p vize_marquette --test adapter_conformance --all-features
- nix develop --command cargo clippy -p vize_marquette --all-targets --all-features -- -D warnings
- nix develop --command cargo test -p vize_marquette --all-features
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790156533&installation_model_id=422833&pr_number=4778&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4778&signature=20bec6adde73e130f696c4e4e87b95fac51042ebab1516e6f70a93121c583594"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->