### PR TITLE
feat(doctor): expose invalidation input telemetry

### DIFF
--- a/crates/vize_doctor/src/cache_identity/invalidation/telemetry.rs
+++ b/crates/vize_doctor/src/cache_identity/invalidation/telemetry.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use vize_carton::String;
 
 use super::CapabilityInvalidation;
 
@@ -13,6 +14,9 @@ pub struct CapabilityInvalidationTelemetry {
     added_input_count: usize,
     removed_input_count: usize,
     changed_input_count: usize,
+    added_inputs: Vec<String>,
+    removed_inputs: Vec<String>,
+    changed_inputs: Vec<String>,
 }
 
 impl CapabilityInvalidationTelemetry {
@@ -25,6 +29,9 @@ impl CapabilityInvalidationTelemetry {
             added_input_count: invalidation.added_inputs().len(),
             removed_input_count: invalidation.removed_inputs().len(),
             changed_input_count: invalidation.changed_inputs().len(),
+            added_inputs: invalidation.added_inputs().to_vec(),
+            removed_inputs: invalidation.removed_inputs().to_vec(),
+            changed_inputs: invalidation.changed_inputs().to_vec(),
         }
     }
 
@@ -61,6 +68,21 @@ impl CapabilityInvalidationTelemetry {
     /// Returns the number of content-changed invalidation inputs.
     pub const fn changed_input_count(&self) -> usize {
         self.changed_input_count
+    }
+
+    /// Returns newly declared inputs in stable order.
+    pub fn added_inputs(&self) -> &[String] {
+        &self.added_inputs
+    }
+
+    /// Returns no-longer-declared inputs in stable order.
+    pub fn removed_inputs(&self) -> &[String] {
+        &self.removed_inputs
+    }
+
+    /// Returns content-changed inputs in stable order.
+    pub fn changed_inputs(&self) -> &[String] {
+        &self.changed_inputs
     }
 }
 

--- a/crates/vize_doctor/src/cache_identity/tests.rs
+++ b/crates/vize_doctor/src/cache_identity/tests.rs
@@ -135,11 +135,15 @@ fn invalidation_classifies_every_boundary_in_stable_order() {
     assert_eq!(invalidation.added_inputs(), ["c"]);
     assert_eq!(invalidation.removed_inputs(), ["a"]);
     assert_eq!(invalidation.changed_inputs(), ["d"]);
-    assert_eq!(invalidation.telemetry().added_input_count(), 1);
-    assert_eq!(invalidation.telemetry().removed_input_count(), 1);
-    assert_eq!(invalidation.telemetry().changed_input_count(), 1);
+    let telemetry = invalidation.telemetry();
+    assert_eq!(telemetry.added_input_count(), 1);
+    assert_eq!(telemetry.removed_input_count(), 1);
+    assert_eq!(telemetry.changed_input_count(), 1);
+    assert_eq!(telemetry.added_inputs(), ["c"]);
+    assert_eq!(telemetry.removed_inputs(), ["a"]);
+    assert_eq!(telemetry.changed_inputs(), ["d"]);
     assert_eq!(
-        serde_json::to_value(invalidation.telemetry()).unwrap(),
+        serde_json::to_value(telemetry).unwrap(),
         json!({
             "reusable": false,
             "capabilityChanged": true,
@@ -147,13 +151,31 @@ fn invalidation_classifies_every_boundary_in_stable_order() {
             "configurationChanged": true,
             "addedInputCount": 1,
             "removedInputCount": 1,
-            "changedInputCount": 1
+            "changedInputCount": 1,
+            "addedInputs": ["c"],
+            "removedInputs": ["a"],
+            "changedInputs": ["d"]
         })
     );
 
     let reusable = current.invalidation_from(&current);
     assert!(reusable.is_reusable());
     assert!(reusable.telemetry().is_reusable());
+    assert_eq!(
+        serde_json::to_value(reusable.telemetry()).unwrap(),
+        json!({
+            "reusable": true,
+            "capabilityChanged": false,
+            "implementationChanged": false,
+            "configurationChanged": false,
+            "addedInputCount": 0,
+            "removedInputCount": 0,
+            "changedInputCount": 0,
+            "addedInputs": [],
+            "removedInputs": [],
+            "changedInputs": []
+        })
+    );
     assert_eq!(
         serde_json::to_value(reusable).unwrap(),
         json!({


### PR DESCRIPTION
## Summary
- serialize exact added, removed, and changed invalidation input ids in capability telemetry
- keep existing invalidation input counts for summary consumers
- cover reusable and non-reusable telemetry JSON shapes

Refs #3138

## Tests
- nix develop --command cargo test -p vize_doctor cache_identity --all-features
- nix develop --command cargo test -p vize_doctor --all-features
- nix develop --command cargo clippy -p vize_doctor --all-targets --all-features -- -D warnings
- nix develop --command cargo fmt --all --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790156746&installation_model_id=422833&pr_number=4779&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4779&signature=c307ac0be137a197929fcd19ce7f6d188b5a63797429ae7003f533405eedc726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->