### PR TITLE
test(tooling): record prepare rename evidence

### DIFF
--- a/tests/tooling/real-project-lsp.test.ts
+++ b/tests/tooling/real-project-lsp.test.ts
@@ -270,6 +270,7 @@ function authoredEvidence(): AuthoredLspEvidence {
     },
     hover: response,
     importerFile: "FeatureParent.vue",
+    prepareRename: response,
     references: response,
     rename: response,
     templateBindingFile: "Binding.vue",

--- a/tests/tooling/support/real-project-lsp-authored-oracle.ts
+++ b/tests/tooling/support/real-project-lsp-authored-oracle.ts
@@ -128,11 +128,13 @@ export async function exerciseAuthoredLspOracle(
       "references must cover exactly the authored template use and declaration",
     );
 
-    const prepareRename = await session.request(
+    const prepareRenameRequest = await timedRequest<LspRange | null>(
+      session,
       "textDocument/prepareRename",
       textDocumentPosition(bindingDocument.uri, usageRange.start),
       timeoutMs(),
     );
+    const prepareRename = prepareRenameRequest.response;
     assert.deepEqual(prepareRename, usageRange, "prepareRename must select the template token");
     const renameRequest = await timedRequest<WorkspaceEdit | null>(
       session,
@@ -258,6 +260,7 @@ export async function exerciseAuthoredLspOracle(
       fileLifecycle,
       hover: evidence(hoverRequest, hover, 1),
       importerFile: boundary.importerFile,
+      prepareRename: evidence(prepareRenameRequest, prepareRename, 1),
       references: evidence(referencesRequest, sortLocations(references), references.length),
       rename: evidence(renameRequest, sortTextEdits(renameEdits), renameEdits.length),
       templateBindingDiagnostics: diagnosticEvidence(bindingDiagnostics.diagnostics),

--- a/tests/tooling/support/real-project-lsp-report.ts
+++ b/tests/tooling/support/real-project-lsp-report.ts
@@ -91,6 +91,7 @@ export type AuthoredLspEvidence = {
   fileLifecycle: AuthoredFileLifecycleEvidence;
   hover: LspResponseEvidence;
   importerFile: string;
+  prepareRename: LspResponseEvidence;
   references: LspResponseEvidence;
   rename: LspResponseEvidence;
   templateBindingFile: string;


### PR DESCRIPTION
## Summary
- time the authored template prepareRename request in the real-project LSP oracle
- include prepareRename hash/count/latency evidence in authored LSP reports
- update the report fixture helper to preserve the new evidence field

Refs #3952

## Tests
- nix develop --command node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts
- nix develop --command vp exec oxfmt --check tests/tooling/support/real-project-lsp-authored-oracle.ts tests/tooling/support/real-project-lsp-report.ts tests/tooling/real-project-lsp.test.ts
- nix develop --command vp exec oxlint tests/tooling/support/real-project-lsp-authored-oracle.ts tests/tooling/support/real-project-lsp-report.ts tests/tooling/real-project-lsp.test.ts
- git diff --check