### PR TITLE
test(ui): require documented slots

### DIFF
--- a/npm/ui/core/src/ActionButton.vue
+++ b/npm/ui/core/src/ActionButton.vue
@@ -49,6 +49,7 @@ const {
 }>();
 
 defineSlots<{
+  /** Renders the button contents with current availability state. */
   default(props: {
     readonly disabled: boolean;
     readonly loading: boolean;

--- a/npm/ui/core/src/DeterministicIdProvider.vue
+++ b/npm/ui/core/src/DeterministicIdProvider.vue
@@ -24,6 +24,7 @@ const { prefix = undefined, seed = undefined } = defineProps<{
 }>();
 
 defineSlots<{
+  /** Renders descendants with the resolved deterministic identifier namespace. */
   default(props: { readonly namespace: string; readonly prefix: string }): unknown;
 }>();
 

--- a/npm/ui/tooling/authoring-contract.md
+++ b/npm/ui/tooling/authoring-contract.md
@@ -23,6 +23,8 @@ the SFC quality gate.
   an `@default` tag for editor hover and generated docs.
 - `event-doc`: every public event has documentation comments explaining when it
   fires and what payload it carries.
+- `slot-doc`: every public slot has documentation comments explaining its
+  purpose and typed slot props.
 - `source-regex-behavior`: source-text assertions are not behavior evidence
   unless a nearby `source-contract:` pragma explains why mounted output cannot
   observe the invariant.
@@ -35,6 +37,7 @@ the SFC quality gate.
   `source-regex-behavior`.
 - `api-default-documentation` is enforced by `prop-default-doc`.
 - `api-event-documentation` is enforced by `event-doc`.
+- `api-slot-documentation` is enforced by `slot-doc`.
 
 Future source installation manifests, gallery metadata, and CI policy should
 consume the exported contract rather than duplicating these identifiers.

--- a/npm/ui/tooling/authoring-contract.ts
+++ b/npm/ui/tooling/authoring-contract.ts
@@ -81,6 +81,14 @@ export const VIZE_UI_SFC_AUTHORING_RULES = [
     remediation: "Add documentation comments to each public event in the `defineEmits<T>` type.",
   },
   {
+    id: "slot-doc",
+    title: "Documented component slots",
+    requirement:
+      "Every public slot documents its purpose and typed slot props for editor hover and generated docs.",
+    evidence: ["defineSlots<T> slot JSDoc"],
+    remediation: "Add documentation comments to each public slot in the `defineSlots<T>` type.",
+  },
+  {
     id: "source-regex-behavior",
     title: "No source-regex behavior proof",
     requirement:
@@ -135,6 +143,14 @@ export const VIZE_UI_SFC_QUALITY_GATES = [
       "Public events expose their dispatch timing and payload intent through documentation comments and editor hover.",
     evidence: ["defineEmits<T> event JSDoc"],
     enforcedByRules: ["event-doc"],
+  },
+  {
+    id: "api-slot-documentation",
+    title: "API slot documentation",
+    requirement:
+      "Public slots expose their purpose and typed props through documentation comments and editor hover.",
+    evidence: ["defineSlots<T> slot JSDoc"],
+    enforcedByRules: ["slot-doc"],
   },
 ] as const satisfies readonly SfcQualityGateContract<SfcAuthoringRuleId>[];
 

--- a/npm/ui/tooling/authoring-gate-slots.test.ts
+++ b/npm/ui/tooling/authoring-gate-slots.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { auditComponentAuthoring, formatAuthoringViolations } from "./authoring-gate.ts";
+
+const COMPLIANT_SFC = `<script setup lang="ts">
+defineProps<{
+  /**
+   * Whether the widget starts open.
+   *
+   * @default false
+   */
+  readonly open?: boolean;
+}>();
+</script>
+
+<template>
+  <div data-vize-ui="widget"><slot name="default" /></div>
+</template>
+
+<style scoped>
+/* Headless by design. */
+</style>
+`;
+
+async function withSlotFixture(sfc: string, run: (directory: string) => Promise<void>) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "authoring-gate-slots-"));
+  try {
+    await mkdir(path.join(directory, "src"), { recursive: true });
+    await writeFile(path.join(directory, "src", "TheWidget.vue"), sfc);
+    await writeFile(path.join(directory, "src", "widget.behavior.md"), "TheWidget.vue");
+    await writeFile(
+      path.join(directory, "src", "widget.test.ts"),
+      'import TheWidget from "./TheWidget.vue";\nexport default TheWidget;\n',
+    );
+    await run(path.join(directory, "src"));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+function withSlots(lines: readonly string[]): string {
+  return COMPLIANT_SFC.replace(
+    "</script>",
+    ["", "const slots = defineSlots<{", ...lines, "}>();", "void slots;", "</script>"].join("\n"),
+  );
+}
+
+void test("requires public slots to be documented for editor hover", async () => {
+  await withSlotFixture(
+    withSlots(["  default: (props: { readonly open: boolean }) => unknown;"]),
+    async (directory) => {
+      const violations = await auditComponentAuthoring(directory);
+      assert.deepEqual(
+        violations.map((violation) => violation.rule),
+        ["slot-doc"],
+      );
+      assert.match(formatAuthoringViolations(violations), /Slot default is missing documentation/);
+    },
+  );
+});
+
+void test("accepts documented slot functions and nested slot props", async () => {
+  await withSlotFixture(
+    withSlots([
+      "  /** Renders the widget body with its current controlled state. */",
+      "  default: (props: { readonly state: { readonly open: boolean } }) => unknown;",
+      "  /** Renders an optional named footer after widget content. */",
+      "  footer?: (props: { readonly close: () => void }) => unknown;",
+    ]),
+    async (directory) => {
+      assert.deepEqual(await auditComponentAuthoring(directory), []);
+    },
+  );
+});
+
+void test("rejects slot interface indirection before slot docs are inferred", async () => {
+  const sfc = COMPLIANT_SFC.replace(
+    "</script>",
+    [
+      "interface Slots {",
+      "  /** Renders the widget body. */",
+      "  default: () => unknown;",
+      "}",
+      "const slots = defineSlots<Slots>();",
+      "void slots;",
+      "</script>",
+    ].join("\n"),
+  );
+  await withSlotFixture(sfc, async (directory) => {
+    const violations = await auditComponentAuthoring(directory);
+    assert.deepEqual(
+      violations.map((violation) => violation.rule),
+      ["explicit-sfc"],
+    );
+    assert.match(formatAuthoringViolations(violations), /defineSlots types/);
+  });
+});

--- a/npm/ui/tooling/authoring-gate-slots.test.ts
+++ b/npm/ui/tooling/authoring-gate-slots.test.ts
@@ -99,3 +99,26 @@ void test("rejects slot interface indirection before slot docs are inferred", as
     assert.match(formatAuthoringViolations(violations), /defineSlots types/);
   });
 });
+
+void test("rejects slot type alias indirection before slot docs are inferred", async () => {
+  const sfc = COMPLIANT_SFC.replace(
+    "</script>",
+    [
+      "type SlotShape = {",
+      "  /** Renders the widget body. */",
+      "  default: () => unknown;",
+      "};",
+      "const slots = defineSlots<SlotShape>();",
+      "void slots;",
+      "</script>",
+    ].join("\n"),
+  );
+  await withSlotFixture(sfc, async (directory) => {
+    const violations = await auditComponentAuthoring(directory);
+    assert.deepEqual(
+      violations.map((violation) => violation.rule),
+      ["explicit-sfc"],
+    );
+    assert.match(formatAuthoringViolations(violations), /defineSlots types/);
+  });
+});

--- a/npm/ui/tooling/authoring-gate.test.ts
+++ b/npm/ui/tooling/authoring-gate.test.ts
@@ -107,7 +107,7 @@ void test("emits only rule ids published by the machine-readable contract", asyn
     {
       "TheWidget.vue":
         "<script setup>defineProps<{ readonly label?: string }>(); " +
-        "defineEmits<{ change: [value: boolean] }>(); const value = 1;</script>\n",
+        "defineEmits<{ change: [value: boolean] }>(); defineSlots<{ default: () => unknown }>(); const value = 1;</script>\n",
       "widget.test.ts": [
         'import { readFile } from "node:fs/promises";',
         'const source = await readFile(new URL("./TheWidget.vue", import.meta.url), "utf8");',

--- a/npm/ui/tooling/authoring-gate.ts
+++ b/npm/ui/tooling/authoring-gate.ts
@@ -4,7 +4,11 @@ import path from "node:path";
 import { parse } from "@vue/compiler-sfc";
 
 import { VIZE_UI_SFC_AUTHORING_RULES, type SfcAuthoringRuleId } from "./authoring-contract.ts";
-import { splitTopLevelTypeMembers, typeLiteralCallBodies } from "./type-member-parser.ts";
+import {
+  nonLiteralTypeArgumentCalls,
+  splitTopLevelTypeMembers,
+  typeLiteralCallBodies,
+} from "./type-member-parser.ts";
 
 /** Rule identifiers enforced by the component authoring gate. */
 export type AuthoringRule = SfcAuthoringRuleId;
@@ -156,7 +160,10 @@ function explicitSfcProblems(source: string, filename: string): string[] {
     .filter((script): script is string => script !== undefined)
     .join("\n");
   if (/\bh\s*\(/.test(scripts)) problems.push("Render-function escape hatch h() is not allowed");
-  if (/defineOptions|withDefaults|interface (?:Props|Emits|Slots)/.test(scripts)) {
+  if (
+    /defineOptions|withDefaults|interface (?:Props|Emits|Slots)/.test(scripts) ||
+    nonLiteralTypeArgumentCalls(scripts, DEFINE_SLOTS).length > 0
+  ) {
     problems.push(
       "Use literal defineProps/defineEmits/defineSlots types without helper indirection",
     );

--- a/npm/ui/tooling/authoring-gate.ts
+++ b/npm/ui/tooling/authoring-gate.ts
@@ -26,10 +26,13 @@ const SFC_SOURCE_READ = /readFile\([^)]*\.vue/;
 const SOURCE_CONTRACT_PRAGMA = "source-contract:";
 const DEFINE_PROPS_TYPE = /defineProps\s*<\s*\{([\s\S]*?)\}\s*>\s*\(/g;
 const DEFINE_EMITS = "defineEmits";
+const DEFINE_SLOTS = "defineSlots";
 const PROP_DECLARATION =
   /(?:(\/\*\*[\s\S]*?\*\/)\s*)?readonly\s+(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$]*))\??\s*:/g;
 const EVENT_MEMBER_DECLARATION =
   /^(?:(\/\*\*[\s\S]*?\*\/)\s*)?(?:readonly\s+)?(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$]*))\??\s*:\s*(?:readonly\s*)?\[/;
+const SLOT_MEMBER_DECLARATION =
+  /^(?:(\/\*\*[\s\S]*?\*\/)\s*)?(?:readonly\s+)?(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$]*))\??\s*(?::|\()/;
 const AUTHORING_RULE_IDS = new Set<AuthoringRule>(
   VIZE_UI_SFC_AUTHORING_RULES.map((rule) => rule.id),
 );
@@ -46,6 +49,8 @@ const AUTHORING_RULE_IDS = new Set<AuthoringRule>(
  * behavior cannot observe the contract.
  * Public props must also document their default value with an `@default` tag
  * in the prop JSDoc, so hover and generated docs preserve first-render behavior.
+ * Public events and slots must carry documentation comments in their literal
+ * `defineEmits` and `defineSlots` type members.
  *
  * @param sourceDirectory Directory containing SFC sources, tests, and behavior tables.
  * @returns Violations in stable path order; an empty array means full compliance.
@@ -79,6 +84,7 @@ export async function auditComponentAuthoring(
       report(sfc, "prop-default-doc", message);
     }
     for (const message of eventDocProblems(source, sfc)) report(sfc, "event-doc", message);
+    for (const message of slotDocProblems(source, sfc)) report(sfc, "slot-doc", message);
 
     if (!behaviorSources.some((table) => table.includes(basename))) {
       report(
@@ -150,8 +156,10 @@ function explicitSfcProblems(source: string, filename: string): string[] {
     .filter((script): script is string => script !== undefined)
     .join("\n");
   if (/\bh\s*\(/.test(scripts)) problems.push("Render-function escape hatch h() is not allowed");
-  if (/defineOptions|withDefaults|interface (?:Props|Emits)/.test(scripts)) {
-    problems.push("Use literal defineProps/defineEmits types without helper indirection");
+  if (/defineOptions|withDefaults|interface (?:Props|Emits|Slots)/.test(scripts)) {
+    problems.push(
+      "Use literal defineProps/defineEmits/defineSlots types without helper indirection",
+    );
   }
   return problems;
 }
@@ -191,6 +199,22 @@ function eventDocProblems(source: string, filename: string): string[] {
   return problems;
 }
 
+function slotDocProblems(source: string, filename: string): string[] {
+  const { descriptor, errors } = parse(source, { filename });
+  if (errors.length > 0 || descriptor.scriptSetup === null) return [];
+
+  const problems: string[] = [];
+  for (const body of typeLiteralCallBodies(descriptor.scriptSetup.content, DEFINE_SLOTS)) {
+    for (const slot of topLevelSlotMembers(body)) {
+      if (slot.jsdoc.trim().length > 0) continue;
+      problems.push(
+        `Slot ${slot.name} is missing documentation; document purpose and typed slot props`,
+      );
+    }
+  }
+  return problems;
+}
+
 function topLevelEventMembers(body: string): { readonly name: string; readonly jsdoc: string }[] {
   return splitTopLevelTypeMembers(body).flatMap((member) => {
     const event = EVENT_MEMBER_DECLARATION.exec(member.trim());
@@ -199,6 +223,19 @@ function topLevelEventMembers(body: string): { readonly name: string; readonly j
       {
         jsdoc: event[1] ?? "",
         name: event[2] ?? event[3] ?? event[4] ?? "<unknown>",
+      },
+    ];
+  });
+}
+
+function topLevelSlotMembers(body: string): { readonly name: string; readonly jsdoc: string }[] {
+  return splitTopLevelTypeMembers(body).flatMap((member) => {
+    const slot = SLOT_MEMBER_DECLARATION.exec(member.trim());
+    if (slot === null) return [];
+    return [
+      {
+        jsdoc: slot[1] ?? "",
+        name: slot[2] ?? slot[3] ?? slot[4] ?? "<unknown>",
       },
     ];
   });

--- a/npm/ui/tooling/package.json
+++ b/npm/ui/tooling/package.json
@@ -11,9 +11,9 @@
     "./lint-sfc": "./lint-sfc.ts"
   },
   "scripts": {
-    "check": "vp check authoring-contract.ts authoring-gate.ts authoring-gate-events.test.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts type-member-parser.ts",
-    "fmt": "vp fmt --write authoring-contract.ts authoring-contract.md authoring-gate.ts authoring-gate-events.test.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts type-member-parser.ts",
-    "test": "vp exec node --test authoring-gate-events.test.ts authoring-gate.test.ts lint-sfc.test.ts"
+    "check": "vp check authoring-contract.ts authoring-gate.ts authoring-gate-events.test.ts authoring-gate-slots.test.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts type-member-parser.ts",
+    "fmt": "vp fmt --write authoring-contract.ts authoring-contract.md authoring-gate.ts authoring-gate-events.test.ts authoring-gate-slots.test.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts type-member-parser.ts",
+    "test": "vp exec node --test authoring-gate-events.test.ts authoring-gate-slots.test.ts authoring-gate.test.ts lint-sfc.test.ts"
   },
   "dependencies": {
     "@vue/compiler-sfc": "catalog:vue-stable"

--- a/npm/ui/tooling/type-member-parser.ts
+++ b/npm/ui/tooling/type-member-parser.ts
@@ -29,6 +29,40 @@ export function typeLiteralCallBodies(source: string, callee: string): string[] 
   return bodies;
 }
 
+/** Find generic calls whose type argument is not an inline object literal. */
+export function nonLiteralTypeArgumentCalls(source: string, callee: string): string[] {
+  const typeArguments: string[] = [];
+  let cursor = 0;
+
+  while (cursor < source.length) {
+    const found = source.indexOf(callee, cursor);
+    if (found === -1) break;
+
+    cursor = found + callee.length;
+    if (isIdentifierPart(source[found - 1]) || isIdentifierPart(source[cursor])) continue;
+
+    const genericStart = skipTrivia(source, cursor);
+    if (source[genericStart] !== "<") continue;
+
+    const typeStart = skipTrivia(source, genericStart + 1);
+    if (source[typeStart] === "{") {
+      cursor = typeStart + 1;
+      continue;
+    }
+
+    const typeEnd = findMatchingTypeArgument(source, genericStart);
+    if (typeEnd === undefined) continue;
+
+    const afterType = skipTrivia(source, typeEnd + 1);
+    if (source[afterType] === "(") {
+      typeArguments.push(source.slice(typeStart, typeEnd).trim());
+    }
+    cursor = Math.max(cursor, afterType + 1);
+  }
+
+  return typeArguments;
+}
+
 /** Split only top-level members; nested tuple/object payload fields stay inside one member. */
 export function splitTopLevelTypeMembers(body: string): string[] {
   const members: string[] = [];
@@ -133,6 +167,59 @@ function findMatchingObject(source: string, openIndex: number): number | undefin
     }
     if (char === "{") depth += 1;
     if (char === "}" && --depth === 0) return index;
+  }
+
+  return undefined;
+}
+
+function findMatchingTypeArgument(source: string, openIndex: number): number | undefined {
+  let depth = 0;
+  let quote: '"' | "'" | "`" | undefined;
+  let inBlockComment = false;
+  let inLineComment = false;
+
+  for (let index = openIndex; index < source.length; index += 1) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (inLineComment) {
+      if (char === "\n") inLineComment = false;
+      continue;
+    }
+    if (inBlockComment) {
+      if (char === "*" && next === "/") {
+        inBlockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote !== undefined) {
+      if (char === "\\") index += 1;
+      else if (char === quote) quote = undefined;
+      continue;
+    }
+    if (char === "/" && next === "/") {
+      inLineComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === "/" && next === "*") {
+      inBlockComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === '"' || char === "'" || char === "`") {
+      quote = char;
+      continue;
+    }
+    if (char === "<") {
+      depth += 1;
+      continue;
+    }
+    if (char === ">" && source[index - 1] !== "=") {
+      depth -= 1;
+      if (depth === 0) return index;
+    }
   }
 
   return undefined;


### PR DESCRIPTION
## Summary
- publish a slot documentation rule in the UI SFC authoring contract
- require literal defineSlots members to carry documentation comments
- add focused slot authoring gate tests without growing the existing over-limit test file

Refs #3134

## Tests
- nix develop --command pnpm --dir npm/ui/tooling test
- nix develop --command pnpm --dir npm/ui/tooling check
- git diff --check

## Notes
- nix develop --command node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts is not locally actionable because this machine's MoonBit registry resolution cannot find moonbitlang/async or moonbitlang/x. Touched files are 259 lines or smaller except the pre-existing 291-line authoring-gate.test.ts, whose line count did not grow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation requiring documentation for public component slots, including their purpose and typed properties.
  * Added a dedicated quality check for slot documentation.

* **Bug Fixes**
  * Improved authoring feedback by identifying undocumented slots and unsupported indirect slot declarations.

* **Documentation**
  * Added documentation for default slots in button and identifier provider components.

* **Tests**
  * Added coverage for documented, undocumented, nested-property, and invalid slot scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->