### PR TITLE
feat(davinci): emit foreign namespace elements

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dom_namespace.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dom_namespace.rs
@@ -1,0 +1,34 @@
+//! P2-11 foreign namespace witness for the S2 DOM lane.
+//!
+//! SVG / MathML render output must stay byte-for-byte aligned with the shipped
+//! lane because Vue's runtime infers namespaces from contiguous vnode trees.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    ("svg_static_tree", "<svg><path/></svg>"),
+    (
+        "svg_foreign_object_boundary",
+        r#"<svg><foreignObject><div>hi</div></foreignObject><rect x="1" y="1"/></svg>"#,
+    ),
+    (
+        "nested_svg_dynamic_prop_boundary",
+        r#"<div><svg xmlns="http://www.w3.org/2000/svg" :width="w" /></div>"#,
+    ),
+    (
+        "svg_same_namespace_dynamic_descendants",
+        r#"<div><svg><defs><pattern :x="x"><line :x1="w"/></pattern></defs></svg></div>"#,
+    ),
+    ("mathml_static_tree", "<math><mi>x</mi></math>"),
+];
+
+#[test]
+fn s2_foreign_namespaces_match_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -7,7 +7,8 @@
 //! P2-9 carve-out. This module writes the JS string **directly from
 //! S2 ops** — it does not mint relief codegen-nodes (`NodeType` 13–20).
 //!
-//! This installment emits **static native HTML**, interpolations,
+//! This installment emits **static native HTML / SVG / MathML**,
+//! interpolations,
 //! mixed text siblings, static-name `ui.bind`, static-name `ui.on`
 //! (including event/key/option modifiers), native `ui.if`, **native
 //! `ui.for`**, **object-spread `v-bind`** (`normalizeProps` /
@@ -30,8 +31,10 @@
 //! `@vue:mounted`) including merged duplicate handlers, and
 //! **destructured `v-for` aliases** (`({ id })`, `[a, b]`, defaults),
 //! **`createSlots` + `v-slots`** (`...expr` on the `{ _: 2 }` base), and
-//! **dynamic `v-if` keys** (`:key="expr"`). `.native` and filters stay
-//! [`EmitError::Unsupported`].
+//! **dynamic `v-if` keys** (`:key="expr"`), plus **foreign namespace
+//! boundaries** (`<svg>` / `<math>` enter blocks, same-namespace descendants
+//! stay VNodes, integration points re-enter HTML). `.native` and filters
+//! stay [`EmitError::Unsupported`].
 //! The old lane stays the shipped compile path; [`super::DOM_LANE_FLAG`]
 //! is named here and *read* in the atelier_dom witness.
 
@@ -63,6 +66,8 @@ mod js;
 mod merge;
 #[path = "emit/model.rs"]
 mod model;
+#[path = "emit/namespace.rs"]
+mod namespace;
 #[path = "emit/on.rs"]
 mod on;
 #[path = "emit/outlet.rs"]
@@ -89,7 +94,7 @@ use vize_davinci::diagnostic::Severity;
 use vize_davinci::id::NodeId;
 use vize_davinci::pass::BudgetObserver;
 use vize_davinci::side_table::SideTable;
-use vize_disegno::op::{ElementOp, ForOp, IfOp, Op, Region};
+use vize_disegno::op::{ElementOp, ForOp, IfOp, Namespace, Op, Region};
 use vize_sinopia::parse;
 
 use crate::lower::{ForWrapper, Lowered, WrapperKeys, lower};
@@ -188,6 +193,10 @@ struct EmitCx<'facts> {
     /// Nested components inside a scoped `withCtx` treat forwarded
     /// outlets as `_: 2` + `DYNAMIC_SLOTS` (Vue `has_slot_params`).
     slot_param_depth: u32,
+    /// Current native parent namespace. DOM runtime namespace inference
+    /// depends on SVG/MathML boundaries staying block-local while same-namespace
+    /// descendants remain inline VNodes.
+    parent_ns: Namespace,
 }
 
 /// One DOM render module, split the way the shipped codegen splits it
@@ -243,6 +252,7 @@ pub fn emit_dom(lowered: &Lowered<'_>, facts: &S2Facts) -> Result<DomEmit, EmitE
         if_branch_key: 0,
         in_v_for: false,
         slot_param_depth: 0,
+        parent_ns: Namespace::Html,
     };
     prefer_transform_helpers(&mut cx.buf, &lowered.root);
     fragment::prefer_root_fragment(&mut cx.buf, &lowered.root);

--- a/crates/vize_ricalco/src/emit/namespace.rs
+++ b/crates/vize_ricalco/src/emit/namespace.rs
@@ -1,0 +1,60 @@
+//! DOM namespace threading for SVG / MathML render emission.
+//!
+//! Vue's runtime infers SVG / MathML creation from the contiguous vnode tree:
+//! a boundary element must open its own block, while descendants that remain
+//! in the same namespace stay plain VNodes.
+
+use vize_carton::ensure_sufficient_stack;
+use vize_disegno::op::{ElementOp, Namespace, Op, Region};
+
+use super::{EmitCx, EmitError};
+
+pub(super) fn child_namespace(element: &ElementOp<'_>) -> Namespace {
+    match element.namespace {
+        Namespace::Svg if matches!(element.tag, "foreignObject" | "desc" | "title") => {
+            Namespace::Html
+        }
+        Namespace::MathMl
+            if matches!(
+                element.tag,
+                "annotation-xml" | "mi" | "mo" | "mn" | "ms" | "mtext"
+            ) =>
+        {
+            Namespace::Html
+        }
+        namespace => namespace,
+    }
+}
+
+pub(super) fn crosses_boundary(cx: &EmitCx<'_>, element: &ElementOp<'_>) -> bool {
+    element.namespace != cx.parent_ns
+        || children_cross_boundary(element.namespace, &element.children)
+}
+
+fn children_cross_boundary(ns: Namespace, children: &Region<'_>) -> bool {
+    children.ops.iter().any(|child| child_crosses(ns, child))
+}
+
+fn child_crosses(ns: Namespace, child: &Op<'_>) -> bool {
+    match child {
+        Op::Element(element) => element.namespace != ns,
+        Op::If(if_op) => if_op
+            .branches
+            .iter()
+            .any(|branch| ensure_sufficient_stack(|| children_cross_boundary(ns, &branch.region))),
+        Op::For(for_op) => ensure_sufficient_stack(|| children_cross_boundary(ns, &for_op.region)),
+        Op::Component(_) | Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => false,
+    }
+}
+
+pub(super) fn with_child<T>(
+    cx: &mut EmitCx<'_>,
+    element: &ElementOp<'_>,
+    f: impl FnOnce(&mut EmitCx<'_>) -> Result<T, EmitError>,
+) -> Result<T, EmitError> {
+    let saved = cx.parent_ns;
+    cx.parent_ns = child_namespace(element);
+    let result = f(cx);
+    cx.parent_ns = saved;
+    result
+}

--- a/crates/vize_ricalco/src/emit/vnode.rs
+++ b/crates/vize_ricalco/src/emit/vnode.rs
@@ -1,7 +1,7 @@
 //! Static native HTML element / children emission.
 
 use vize_carton::{String, ensure_sufficient_stack};
-use vize_disegno::op::{Attribute, BindingOp, ElementOp, Namespace, Op, Region};
+use vize_disegno::op::{Attribute, BindingOp, ElementOp, Op, Region};
 
 use super::EmitCx;
 use super::EmitError;
@@ -10,6 +10,7 @@ use super::children::{children_need_text_flag, emit_create_text_vnode, emit_text
 use super::directive;
 use super::flag::emit_patch_flag;
 use super::hoist::{compact_props_object, push_attr_pair, unique_attrs};
+use super::namespace;
 use super::props::{admit_bindings, bind_patch, emit_bind_props};
 
 pub(super) fn emit_unique_element(
@@ -35,6 +36,9 @@ pub(super) fn emit_fragment_element(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
 ) -> Result<(), EmitError> {
+    if namespace::crosses_boundary(cx, element) {
+        return emit_nested_block(cx, element);
+    }
     directive::wrap_element(cx, element, |cx| {
         cx.buf.use_create_element_vnode();
         emit_call(
@@ -45,12 +49,31 @@ pub(super) fn emit_fragment_element(
 }
 
 fn emit_nested(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) -> Result<(), EmitError> {
+    if namespace::crosses_boundary(cx, element) {
+        return emit_nested_block(cx, element);
+    }
     directive::wrap_element(cx, element, |cx| {
         cx.buf.use_create_element_vnode();
         emit_call(
             cx, element, /* block */ false, None, /* hoist */ false,
             /* for_item */ false,
         )
+    })
+}
+
+fn emit_nested_block(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) -> Result<(), EmitError> {
+    directive::wrap_element(cx, element, |cx| {
+        cx.buf.use_open_block();
+        cx.buf.use_create_element_block();
+        cx.buf.push("(");
+        cx.buf.push(Buf::open_block_alias());
+        cx.buf.push("(), ");
+        emit_call(
+            cx, element, /* block */ true, None, /* hoist */ false,
+            /* for_item */ false,
+        )?;
+        cx.buf.push(")");
+        Ok(())
     })
 }
 
@@ -168,7 +191,9 @@ fn emit_call(
     }
     if has_children {
         cx.buf.push(", ");
-        emit_children(cx, &element.children, has_custom && allow_hoist && block)?;
+        namespace::with_child(cx, element, |cx| {
+            emit_children(cx, &element.children, has_custom && allow_hoist && block)
+        })?;
     } else if emit_flag {
         cx.buf.push(", null");
     }
@@ -235,9 +260,6 @@ fn emit_static_props_inline<'a>(
 }
 
 fn admit_native(element: &ElementOp<'_>) -> Result<(), EmitError> {
-    if element.namespace != Namespace::Html {
-        return Err(EmitError::Unsupported);
-    }
     admit_bindings(&element.attributes, &element.bindings)
 }
 


### PR DESCRIPTION
## Summary
- Thread SVG and MathML parent namespaces through the Davinci DOM emitter.
- Keep namespace boundary elements as blocks while same-namespace descendants stay VNodes.
- Add a dedicated S2-vs-shipped DOM dual-run battery for SVG, foreignObject, nested SVG, and MathML cases.

## Verification
- git diff --check
- nix develop -c cargo fmt --check
- nix develop -c bash -lc vp run source:lengths -- crates/vize_ricalco/src/emit.rs crates/vize_ricalco/src/emit/vnode.rs crates/vize_ricalco/src/emit/namespace.rs crates/vize_atelier_dom/tests/davinci_s2_dom.rs crates/vize_atelier_dom/tests/davinci_s2_dom_namespace.rs
- nix develop -c cargo test -p vize_ricalco --tests
- nix develop -c cargo test -p vize_atelier_dom --test davinci_s2_dom
- nix develop -c cargo test -p vize_atelier_dom --test davinci_s2_dom_namespace
- nix develop -c cargo clippy -p vize_ricalco --lib -p vize_atelier_dom --test davinci_s2_dom -p vize_atelier_dom --test davinci_s2_dom_namespace -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering static SVG and MathML content.
  * Improved handling of SVG `foreignObject` boundaries and nested dynamic content.
  * Preserved correct namespaces across fragments, conditionals, loops, and nested elements.

* **Bug Fixes**
  * Fixed namespace handling for mixed HTML, SVG, and MathML content during DOM emission.

* **Tests**
  * Added coverage for SVG, MathML, namespace transitions, and dynamic descendants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->