### PR TITLE
fix(fuzz): bound prefix operator runs

### DIFF
--- a/crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_4743.rs
+++ b/crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_4743.rs
@@ -1,0 +1,55 @@
+use vize_atelier_core::steps::expression::{
+    MAX_EXPRESSION_NESTING_DEPTH, expression_is_safe_to_parse, expression_nesting_depth,
+};
+
+#[test]
+fn rejects_long_prefix_operator_chain_without_nesting() {
+    let source = format!("{}value", "+".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1));
+
+    assert_eq!(expression_nesting_depth(&source), 0);
+    assert!(!expression_is_safe_to_parse(&source));
+}
+
+#[test]
+fn permits_ordinary_binary_plus_with_prefix_operands() {
+    assert!(expression_is_safe_to_parse("a + +b + +c"));
+}
+
+#[test]
+fn counts_prefix_operator_chains_across_trivia() {
+    let source = format!(
+        "{} value",
+        std::iter::repeat_n("+ /* trivia */", MAX_EXPRESSION_NESTING_DEPTH + 1).collect::<String>()
+    );
+
+    assert!(!expression_is_safe_to_parse(&source));
+}
+
+#[test]
+fn ignores_operator_runs_inside_literals_and_comments() {
+    let pluses = "+".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1);
+
+    assert!(expression_is_safe_to_parse(&format!("\"{pluses}\"")));
+    assert!(expression_is_safe_to_parse(&format!(
+        "value /* {pluses} */"
+    )));
+}
+
+#[test]
+fn counts_prefix_operator_chains_inside_template_interpolations() {
+    let source = format!(
+        "`literal ${{{} value}} literal`",
+        "+".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1)
+    );
+
+    assert!(!expression_is_safe_to_parse(&source));
+}
+
+#[test]
+fn ignores_prefix_operator_text_after_template_interpolations() {
+    let pluses = "+".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1);
+
+    assert!(expression_is_safe_to_parse(&format!(
+        "`${{value}} {pluses}`"
+    )));
+}

--- a/crates/vize_carton/src/expression_guard.rs
+++ b/crates/vize_carton/src/expression_guard.rs
@@ -1,12 +1,9 @@
-//! Expression nesting guard: whether text is safe to hand to OXC's
-//! recursive parser.
+//! Expression nesting guard: whether text is safe to hand to OXC's recursive parser.
 //!
-//! Lives in `vize_carton` (moved from
-//! `vize_atelier_core::transforms::transform_expression::nesting` in Davinci
-//! P1-5, original import paths preserved by a re-export shim there) so the
-//! armature retained-expression parse site shares the exact guard the
-//! transform/codegen entry points use — one guard, every entry point.
+//! Lives in `vize_carton` so armature, transform, and codegen entry points all
+//! share one guard through the existing re-export shim.
 
+mod operators;
 pub mod scan;
 
 use scan::{
@@ -341,6 +338,7 @@ pub fn expression_is_safe_to_parse(content: &str) -> bool {
     analysis.delimiters_balanced
         && analysis.max_depth <= MAX_EXPRESSION_NESTING_DEPTH
         && analysis.cumulative_speculative_type_angle_depth <= MAX_EXPRESSION_NESTING_DEPTH
+        && !operators::has_excessive_prefix_operator_run(content)
 }
 
 /// Returns true if `content` exceeds [`MAX_EXPRESSION_NESTING_DEPTH`].

--- a/crates/vize_carton/src/expression_guard/operators.rs
+++ b/crates/vize_carton/src/expression_guard/operators.rs
@@ -1,0 +1,157 @@
+//! Operator-run scan for the expression safety guard.
+//!
+//! OXC parses each prefix operator by recursing into another unary expression.
+//! A deeply repeated run such as thousands of `+` tokens therefore burns parser
+//! time without increasing bracket depth, so the nesting guard needs a separate
+//! budget for the same safety boundary.
+
+use super::{MAX_EXPRESSION_NESTING_DEPTH, scan};
+
+pub(super) fn has_excessive_prefix_operator_run(content: &str) -> bool {
+    let bytes = content.as_bytes();
+    let mut can_start_operand = true;
+    let mut delimiters = Vec::new();
+    let mut prefix_operator_run = 0usize;
+    let mut template_interpolation_depths = Vec::new();
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b' ' | b'\t' | b'\r' | b'\n' => {
+                i += 1;
+            }
+            b'"' | b'\'' => {
+                i = scan::skip_quoted(bytes, i + 1, bytes[i]);
+                can_start_operand = false;
+                prefix_operator_run = 0;
+            }
+            b'`' => {
+                let (next, has_interpolation) = scan::skip_template_text(bytes, i + 1);
+                i = next;
+                if has_interpolation {
+                    delimiters.push(b'}');
+                    template_interpolation_depths.push(delimiters.len());
+                    can_start_operand = true;
+                } else {
+                    can_start_operand = false;
+                }
+                prefix_operator_run = 0;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                i = scan::skip_line_comment(bytes, i + 2);
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                i = scan::skip_block_comment(bytes, i + 2);
+            }
+            b'/' if can_start_operand => {
+                if let Some(next) = scan::skip_regex(bytes, i + 1) {
+                    i = next;
+                    can_start_operand = false;
+                    prefix_operator_run = 0;
+                } else {
+                    can_start_operand = true;
+                    prefix_operator_run = 0;
+                    i += 1;
+                }
+            }
+            b'a'..=b'z' | b'A'..=b'Z' | b'_' | b'$' => {
+                let start = i;
+                i = scan::skip_identifier(bytes, i + 1);
+                if can_start_operand && is_prefix_keyword(&bytes[start..i]) {
+                    if increment_prefix_operator_run(&mut prefix_operator_run) {
+                        return true;
+                    }
+                    can_start_operand = true;
+                } else {
+                    can_start_operand = scan::keyword_allows_regex_after(&bytes[start..i]);
+                    prefix_operator_run = 0;
+                }
+            }
+            b'0'..=b'9' => {
+                i = scan::skip_number(bytes, i + 1);
+                can_start_operand = false;
+                prefix_operator_run = 0;
+            }
+            b'+' | b'-' if bytes.get(i + 1) == Some(&bytes[i]) => {
+                if can_start_operand {
+                    if increment_prefix_operator_run(&mut prefix_operator_run)
+                        || increment_prefix_operator_run(&mut prefix_operator_run)
+                    {
+                        return true;
+                    }
+                    can_start_operand = true;
+                } else {
+                    can_start_operand = false;
+                    prefix_operator_run = 0;
+                }
+                i += 2;
+            }
+            b'+' | b'-' | b'!' | b'~' => {
+                if can_start_operand {
+                    if increment_prefix_operator_run(&mut prefix_operator_run) {
+                        return true;
+                    }
+                } else {
+                    prefix_operator_run = 0;
+                }
+                can_start_operand = true;
+                i += 1;
+            }
+            b'(' | b'[' | b'{' | b'<' | b'@' => {
+                if matches!(bytes[i], b'(' | b'[' | b'{') {
+                    delimiters.push(match bytes[i] {
+                        b'(' => b')',
+                        b'[' => b']',
+                        _ => b'}',
+                    });
+                }
+                can_start_operand = true;
+                prefix_operator_run = 0;
+                i += 1;
+            }
+            b'}' if template_interpolation_depths.last() == Some(&delimiters.len()) => {
+                delimiters.pop();
+                template_interpolation_depths.pop();
+                let (next, has_interpolation) = scan::skip_template_text(bytes, i + 1);
+                i = next;
+                if has_interpolation {
+                    delimiters.push(b'}');
+                    template_interpolation_depths.push(delimiters.len());
+                    can_start_operand = true;
+                } else {
+                    can_start_operand = false;
+                }
+                prefix_operator_run = 0;
+            }
+            b')' | b']' | b'}' | b'.' | b'>' | b'\\' => {
+                if matches!(bytes[i], b')' | b']' | b'}') {
+                    delimiters.pop();
+                }
+                can_start_operand = false;
+                prefix_operator_run = 0;
+                i += 1;
+            }
+            b',' | b';' | b':' | b'?' | b'=' | b'*' | b'/' | b'%' | b'&' | b'|' | b'^' => {
+                can_start_operand = true;
+                prefix_operator_run = 0;
+                i += 1;
+            }
+            _ => {
+                can_start_operand = false;
+                prefix_operator_run = 0;
+                i += 1;
+            }
+        }
+    }
+
+    false
+}
+
+fn increment_prefix_operator_run(run: &mut usize) -> bool {
+    *run += 1;
+    *run > MAX_EXPRESSION_NESTING_DEPTH
+}
+
+fn is_prefix_keyword(identifier: &[u8]) -> bool {
+    matches!(identifier, b"await" | b"delete" | b"typeof" | b"void")
+}


### PR DESCRIPTION
## Summary

- add a shared expression-guard budget for excessive prefix operator runs
- keep template literal text skipped while still scanning `${...}` interpolations
- add #4743 regression coverage for long `+` chains, trivia, and literals/comments

Fixes #4743.

## Tests

- `cargo fmt --check`
- `cargo test -p vize_atelier_core --test expression_nesting_guard --test expression_nesting_guard_type_angles --test expression_nesting_guard_backslash_escapes --test expression_guard_regex --test fuzz_slow_unit_js_ts_expression_3712 --test fuzz_slow_unit_js_ts_expression_4374 --test fuzz_slow_unit_js_ts_expression_4618 --test fuzz_slow_unit_js_ts_expression_4743`
- `MOON_HOME=/tmp/vize-moonbit-release.N4SQlL/moonbit MOON_BIN=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims/moon PATH=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims:/tmp/vize-moonbit-release.N4SQlL/moonbit/bin:$PATH node --test tests/tooling/source-file-lengths.test.ts`
- `/usr/bin/time -p cargo +nightly-2026-08-02 fuzz run --fuzz-dir tests/fuzz js_ts_expression /tmp/vize-fuzz-4743-artifact.IaUwyv/slow-unit-11008c83acedf890897c436a5cc9fce1a55e2a68 -- -runs=1` (reproducer executed in 1 ms after build)
