### PR TITLE
feat(davinci): emit template refs from S2 DOM

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_refs.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_refs.rs
@@ -1,0 +1,61 @@
+//! P2-11 template-ref witness for the S2 DOM lane: static refs,
+//! dynamic `:ref`, `ref_for` inside `v-for`, and component refs are
+//! compared **byte-for-byte** against the shipped DOM lane.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    ("static_ref", r#"<div ref="el"></div>"#),
+    ("dynamic_ref", r#"<div :ref="el"></div>"#),
+    ("static_ref_interp", r#"<div ref="el">{{ msg }}</div>"#),
+    ("dynamic_ref_interp", r#"<div :ref="el">{{ msg }}</div>"#),
+    ("static_ref_dynamic_id", r#"<div ref="el" :id="id"></div>"#),
+    (
+        "dynamic_ref_dynamic_id",
+        r#"<div :ref="el" :id="id"></div>"#,
+    ),
+    ("static_ref_click", r#"<div ref="el" @click="h"></div>"#),
+    ("static_ref_for", r#"<div v-for="i in n" ref="el"></div>"#),
+    ("dynamic_ref_for", r#"<div v-for="i in n" :ref="el"></div>"#),
+    (
+        "dynamic_ref_for_with_static_prop",
+        r#"<div v-for="i in n" id="x" :ref="el"></div>"#,
+    ),
+    (
+        "dynamic_ref_for_keyed",
+        r#"<div v-for="i in n" :key="i" :ref="el"></div>"#,
+    ),
+    ("component_static_ref", r#"<Foo ref="el" />"#),
+    ("component_dynamic_ref", r#"<Foo :ref="el" />"#),
+    (
+        "component_static_ref_dynamic_id",
+        r#"<Foo ref="el" :id="id" />"#,
+    ),
+    (
+        "static_ref_object_bind",
+        r#"<div ref="el" v-bind="obj"></div>"#,
+    ),
+    (
+        "dynamic_ref_object_bind",
+        r#"<div :ref="el" v-bind="obj"></div>"#,
+    ),
+    (
+        "component_dynamic_ref_object_bind",
+        r#"<Foo :ref="el" v-bind="obj" />"#,
+    ),
+    (
+        "component_dynamic_ref_for",
+        r#"<Foo v-for="i in n" :ref="el" />"#,
+    ),
+];
+
+#[test]
+fn s2_template_refs_match_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -33,8 +33,9 @@
 //! **`createSlots` + `v-slots`** (`...expr` on the `{ _: 2 }` base), and
 //! **dynamic `v-if` keys** (`:key="expr"`), plus **foreign namespace
 //! boundaries** (`<svg>` / `<math>` enter blocks, same-namespace descendants
-//! stay VNodes, integration points re-enter HTML). `.native` and filters
-//! stay [`EmitError::Unsupported`].
+//! stay VNodes, integration points re-enter HTML), and **template refs**
+//! (static refs, dynamic `:ref`, and `ref_for` in `v-for`). `.native`
+//! and filters stay [`EmitError::Unsupported`].
 //! The old lane stays the shipped compile path; [`super::DOM_LANE_FLAG`]
 //! is named here and *read* in the atelier_dom witness.
 

--- a/crates/vize_ricalco/src/emit/component.rs
+++ b/crates/vize_ricalco/src/emit/component.rs
@@ -20,7 +20,7 @@ use super::directive;
 use super::flag::emit_patch_flag;
 use super::hoist::compact_props_object;
 use super::js::asset_ident;
-use super::props::{admit_bindings, bind_patch, emit_bind_props};
+use super::props::{admit_bindings, apply_static_ref_patch, bind_patch, emit_bind_props};
 use super::slots;
 
 pub(super) fn collect_names<'a>(root: &Region<'a>) -> StdVec<&'a str> {
@@ -243,6 +243,7 @@ fn emit_call(
     {
         flag |= 1024;
     }
+    apply_static_ref_patch(&component.attributes, &mut flag);
     if for_item {
         flag &= !512;
     }

--- a/crates/vize_ricalco/src/emit/merge.rs
+++ b/crates/vize_ricalco/src/emit/merge.rs
@@ -53,6 +53,10 @@ pub(super) fn object_patch(bindings: &[BindingOp<'_>], is_component: bool) -> Pa
                 let Ok(name) = static_bind_name(bind) else {
                     continue;
                 };
+                if name == "ref" {
+                    flag |= 512;
+                    continue;
+                }
                 if matches!(name, "class" | "style" | "key") {
                     continue;
                 }

--- a/crates/vize_ricalco/src/emit/props.rs
+++ b/crates/vize_ricalco/src/emit/props.rs
@@ -33,7 +33,7 @@ pub(super) fn admit_bindings(
             }
             BindingOp::Bind(bind) => {
                 let name = static_bind_name(bind)?;
-                if name == "ref" || !bind.modifiers.is_empty() {
+                if !bind.modifiers.is_empty() {
                     return Err(EmitError::Unsupported);
                 }
                 let vize_disegno::expr::ExprRef::Js(_) =
@@ -76,6 +76,7 @@ pub(super) fn bind_patch(bindings: &[BindingOp<'_>], is_component: bool) -> Patc
                     continue;
                 };
                 match name {
+                    "ref" => flag |= 512,
                     "class" if !is_component => flag |= 2,
                     "style" if !is_component => flag |= 4,
                     "key" => {}
@@ -144,6 +145,13 @@ pub(super) fn emit_bind_props(
         for_item && super::directive::has_custom(bindings),
         is_plain_element,
     )
+}
+
+pub(super) fn apply_static_ref_patch(attributes: &[Attribute<'_>], flag: &mut i32) {
+    let has_static_ref = attributes.iter().any(|attr| attr.name == "ref");
+    if has_static_ref && *flag & (2 | 4 | 8 | 16 | 32 | 1024) == 0 {
+        *flag |= 512;
+    }
 }
 
 fn has_attr(attributes: &[Attribute<'_>], name: &str) -> bool {

--- a/crates/vize_ricalco/src/emit/props_object.rs
+++ b/crates/vize_ricalco/src/emit/props_object.rs
@@ -46,10 +46,12 @@ pub(super) fn emit_props_object(
         return Ok(());
     }
     let extra = usize::from(if_key.is_some());
-    let multiline = visible.len() + extra > 1
-        || pieces_have_named(pieces, "class")
-        || pieces_have_named(pieces, "style")
-        || pieces_have_inline_on(pieces);
+    let multiline = (if_key.is_some() && !visible.is_empty())
+        || pieces_have_inline_on(pieces)
+        || (!cx.in_v_for
+            && (visible.len() + extra > 1
+                || pieces_have_named(pieces, "class")
+                || pieces_have_named(pieces, "style")));
     if multiline {
         cx.buf.push("{");
         cx.buf.indent();
@@ -217,6 +219,7 @@ fn pieces_have_inline_on(pieces: &[Piece<'_>]) -> bool {
 }
 
 fn emit_static_pair(cx: &mut EmitCx<'_>, attr: &Attribute<'_>) {
+    emit_ref_for(cx, attr.name);
     push_ident_key(cx, attr.name);
     cx.buf.push(": \"");
     if let Some(value) = attr.value {
@@ -233,6 +236,7 @@ fn emit_bind_pair(
 ) -> Result<(), EmitError> {
     let name = static_bind_name(bind)?;
     let js = js_value(bind)?;
+    emit_ref_for(cx, name);
     push_ident_key(cx, name);
     cx.buf.push(": ");
     match name {
@@ -241,6 +245,12 @@ fn emit_bind_pair(
         _ => cx.buf.push(js.source),
     }
     Ok(())
+}
+
+fn emit_ref_for(cx: &mut EmitCx<'_>, name: &str) {
+    if cx.in_v_for && name == "ref" {
+        cx.buf.push("ref_for: true, ");
+    }
 }
 
 fn emit_class_value(

--- a/crates/vize_ricalco/src/emit/vnode.rs
+++ b/crates/vize_ricalco/src/emit/vnode.rs
@@ -11,7 +11,7 @@ use super::directive;
 use super::flag::emit_patch_flag;
 use super::hoist::{compact_props_object, push_attr_pair, unique_attrs};
 use super::namespace;
-use super::props::{admit_bindings, bind_patch, emit_bind_props};
+use super::props::{admit_bindings, apply_static_ref_patch, bind_patch, emit_bind_props};
 
 pub(super) fn emit_unique_element(
     cx: &mut EmitCx<'_>,
@@ -157,6 +157,7 @@ fn emit_call(
     if text_flag {
         flag |= 1;
     }
+    apply_static_ref_patch(&element.attributes, &mut flag);
     if for_item {
         flag &= !512;
     }
@@ -230,7 +231,7 @@ fn emit_static_props_inline<'a>(
     attributes: impl Iterator<Item = &'a Attribute<'a>>,
 ) {
     let unique = unique_attrs(attributes);
-    let multiline = unique.len() > 1;
+    let multiline = unique.len() > 1 && !cx.in_v_for;
     if multiline {
         cx.buf.push("{");
         cx.buf.indent();
@@ -245,6 +246,9 @@ fn emit_static_props_inline<'a>(
             cx.buf.newline();
         } else if i > 0 {
             cx.buf.push(" ");
+        }
+        if cx.in_v_for && attr.name == "ref" {
+            cx.buf.push("ref_for: true, ");
         }
         let mut pair = String::default();
         push_attr_pair(&mut pair, attr);


### PR DESCRIPTION
## Summary
- Emit static refs, dynamic :ref, and ref_for from the S2 DOM path.
- Mirror the shipped lane patch-flag quirks for refs, including object-spread v-bind combinations.
- Add a dedicated S2-vs-shipped DOM dual-run battery for native/component refs and v-for refs.

## Verification
- git diff --check
- nix develop -c cargo fmt --check
- nix develop -c bash -lc vp run source:lengths -- crates/vize_ricalco/src/emit.rs crates/vize_ricalco/src/emit/component.rs crates/vize_ricalco/src/emit/merge.rs crates/vize_ricalco/src/emit/props.rs crates/vize_ricalco/src/emit/props_object.rs crates/vize_ricalco/src/emit/vnode.rs crates/vize_atelier_dom/tests/davinci_s2_refs.rs
- nix develop -c cargo test -p vize_ricalco --tests
- nix develop -c cargo test -p vize_atelier_dom --test davinci_s2_dom --test davinci_s2_refs --test davinci_s2_for -- --nocapture
- nix develop -c cargo clippy -p vize_ricalco --lib -p vize_atelier_dom --test davinci_s2_refs -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790163883&installation_model_id=422833&pr_number=4788&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4788&signature=26bdf7c86f15c1843e8c5f065f176f734f5cdf3dc475058fd8c82e9987443e6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Improved template reference handling for native elements and components.
  * Added support for static and dynamic references, including references in loops, keyed lists, and component collections.
  * Improved handling of object-bound references and references used with event handlers.
  * Ensured loop-based references correctly track multiple rendered elements.

* **Documentation**
  * Clarified template reference behavior and namespace boundaries.
  * Documented supported and unsupported template features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->