### PR TITLE
perf(canon): dedupe package route bindings by key

### DIFF
--- a/crates/vize/src/commands/check.rs
+++ b/crates/vize/src/commands/check.rs
@@ -11,6 +11,7 @@ mod dts_import_aliases;
 mod dts_rewrite;
 mod imports;
 mod imports_aliases;
+mod imports_package_routes;
 mod nuxt;
 mod path_cache;
 mod patterns;

--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -13,6 +13,7 @@ use vize_carton::cstr;
 use vize_carton::{FxHashSet, String};
 
 use super::imports_aliases::PathAliasResolver;
+use super::imports_package_routes::sort_package_route_bindings;
 use super::path_cache::CanonicalPathCache;
 
 #[path = "imports_cache.rs"]
@@ -312,14 +313,7 @@ pub(super) fn collect_transitive_local_imports_with_resolver(
         }
     }
 
-    package_routes.sort_by(|left, right| {
-        (&left.importer_path, &left.specifier, left.occurrence_mode).cmp(&(
-            &right.importer_path,
-            &right.specifier,
-            right.occurrence_mode,
-        ))
-    });
-    package_routes.dedup_by(|left, right| left == right);
+    sort_package_route_bindings(&mut package_routes);
     TransitiveLocalImports {
         registrations,
         authored,

--- a/crates/vize/src/commands/check/imports_package_routes.rs
+++ b/crates/vize/src/commands/check/imports_package_routes.rs
@@ -1,0 +1,115 @@
+use std::cmp::Ordering;
+
+use vize_canon::{PackageResolutionContext, PackageRouteBinding};
+
+pub(super) fn sort_package_route_bindings(bindings: &mut Vec<PackageRouteBinding>) {
+    bindings.sort_by(compare_binding_keys);
+
+    let mut deduped = Vec::with_capacity(bindings.len());
+    let mut merged = false;
+    for mut binding in bindings.drain(..) {
+        if let Some(previous) = deduped.last_mut()
+            && same_binding_key(previous, &binding)
+        {
+            previous
+                .invalidation_paths
+                .append(&mut binding.invalidation_paths);
+            merged = true;
+            if binding.route.is_some() {
+                previous.route = binding.route;
+            }
+            continue;
+        }
+        deduped.push(binding);
+    }
+    if merged {
+        for binding in &mut deduped {
+            binding.invalidation_paths.sort();
+            binding.invalidation_paths.dedup();
+        }
+    }
+    *bindings = deduped;
+}
+
+fn compare_binding_keys(left: &PackageRouteBinding, right: &PackageRouteBinding) -> Ordering {
+    (&left.importer_path, &left.specifier, left.occurrence_mode)
+        .cmp(&(
+            &right.importer_path,
+            &right.specifier,
+            right.occurrence_mode,
+        ))
+        .then_with(|| compare_contexts(&left.context, &right.context))
+}
+
+fn compare_contexts(left: &PackageResolutionContext, right: &PackageResolutionContext) -> Ordering {
+    (
+        &left.module_resolution,
+        left.mode,
+        &left.active_conditions,
+        &left.scope_manifest_path,
+    )
+        .cmp(&(
+            &right.module_resolution,
+            right.mode,
+            &right.active_conditions,
+            &right.scope_manifest_path,
+        ))
+}
+
+fn same_binding_key(left: &PackageRouteBinding, right: &PackageRouteBinding) -> bool {
+    left.importer_path == right.importer_path
+        && left.specifier == right.specifier
+        && left.occurrence_mode == right.occurrence_mode
+        && left.context == right.context
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use vize_canon::{PackageResolutionContext, PackageResolutionMode};
+
+    use super::*;
+
+    fn binding(
+        mode: PackageResolutionMode,
+        invalidation_paths: impl IntoIterator<Item = &'static str>,
+    ) -> PackageRouteBinding {
+        PackageRouteBinding {
+            importer_path: PathBuf::from("/workspace/src/app.ts"),
+            specifier: vize_carton::String::from("pkg"),
+            occurrence_mode: mode,
+            context: PackageResolutionContext::new(Some("bundler"), mode, ["import"]),
+            route: None,
+            invalidation_paths: invalidation_paths.into_iter().map(PathBuf::from).collect(),
+        }
+    }
+
+    #[test]
+    fn package_route_bindings_merge_by_importer_specifier_mode_and_context() {
+        let mut bindings = vec![
+            binding(
+                PackageResolutionMode::Import,
+                ["/workspace/pkg/package.json"],
+            ),
+            binding(PackageResolutionMode::Import, ["/workspace/pkg/index.d.ts"]),
+            binding(
+                PackageResolutionMode::Require,
+                ["/workspace/pkg-cjs/package.json"],
+            ),
+        ];
+
+        sort_package_route_bindings(&mut bindings);
+
+        assert_eq!(bindings.len(), 2);
+        assert_eq!(bindings[0].occurrence_mode, PackageResolutionMode::Import);
+        assert_eq!(
+            bindings[0].invalidation_paths,
+            vec![
+                PathBuf::from("/workspace/pkg/index.d.ts"),
+                PathBuf::from("/workspace/pkg/package.json"),
+            ]
+        );
+        assert_eq!(bindings[1].occurrence_mode, PackageResolutionMode::Require);
+    }
+}

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -12,6 +12,7 @@ use std::{
 use super::{
     CheckArgs,
     imports::ImportFileOptions,
+    imports_package_routes::sort_package_route_bindings,
     path_cache::CanonicalPathCache,
     patterns::CheckFileOptions,
     reporting::{JsonFileResult, JsonOutput, JsonProgramResult},
@@ -258,14 +259,7 @@ fn prepare_and_execute(
         return Ok(None);
     }
 
-    package_routes.sort_by(|left, right| {
-        (&left.importer_path, &left.specifier, left.occurrence_mode).cmp(&(
-            &right.importer_path,
-            &right.specifier,
-            right.occurrence_mode,
-        ))
-    });
-    package_routes.dedup_by(|left, right| left == right);
+    sort_package_route_bindings(&mut package_routes);
     let mut execution = execute_program(
         ProgramExecutionInput {
             files: &candidate.files,

--- a/crates/vize/src/commands/check/runner/default_imports.rs
+++ b/crates/vize/src/commands/check/runner/default_imports.rs
@@ -12,6 +12,7 @@ use crate::commands::check::{
         ImportFileOptions, TransitiveLocalImports, collect_transitive_local_imports_with_resolver,
     },
     imports_aliases::PathAliasResolver,
+    imports_package_routes::sort_package_route_bindings,
     path_cache::CanonicalPathCache,
     tsconfig_inputs::{
         TsconfigInputCache, collect_ambient_declaration_files, collect_default_check_files,
@@ -118,14 +119,7 @@ pub(super) fn collect_default_run_files(
         resolver,
     );
     package_routes.extend(hidden_discovered.package_routes);
-    package_routes.sort_by(|left, right| {
-        (&left.importer_path, &left.specifier, left.occurrence_mode).cmp(&(
-            &right.importer_path,
-            &right.specifier,
-            right.occurrence_mode,
-        ))
-    });
-    package_routes.dedup_by(|left, right| left == right);
+    sort_package_route_bindings(&mut package_routes);
 
     CollectedRoots {
         files,


### PR DESCRIPTION
## Summary
- replace deep `PackageRouteBinding` equality deduplication with key-based package route binding normalization
- merge duplicate invalidation paths without comparing full package route graphs
- reuse the normalized binding order across default, explicit, and per-program check collection paths

Closes #4426

## Tests
- `nix develop --command cargo fmt --all --check`
- `git diff --check`
- `nix develop --command cargo test -p vize package_route`
- `nix develop --command cargo test -p vize --test check_importer_scoped_package_cli`
- `nix develop --command cargo check -p vize`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package route handling by consistently ordering and deduplicating route bindings.
  * Merged duplicate route entries while preserving relevant invalidation paths and resolved routes.
  * Improved consistency across import checking and default import processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->