### PR TITLE
test(tooling): add pinia authored lsp oracle

### DIFF
--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -768,6 +768,7 @@
           "tests/_fixtures/_git/elk",
           "tests/_fixtures/_git/misskey",
           "tests/_fixtures/_git/create-vue",
+          "tests/_fixtures/_git/pinia",
           "tests/_fixtures/_git/vuefes-japan-speakers"
         ]
       },

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 7,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 5,
+    "minimumProjectCount": 6,
     "trackingIssue": 3952
   },
   "projects": [
@@ -903,7 +903,71 @@
       "vueGlobs": ["packages/**/*.vue"],
       "tsconfig": "tsconfig.json",
       "coverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "packages/playground/src/App.vue",
+          "symbol": "sourceCodeLink",
+          "usageAnchor": ":href=\"sourceCodeLink\"",
+          "declarationAnchor": "const sourceCodeLink = computed(() => {",
+          "hoverContains": ["const sourceCodeLink: string"],
+          "renameTo": "__vizeRenamedSourceCodeLink"
+        },
+        "componentBoundary": {
+          "importerFile": "packages/online-playground/src/Header.vue",
+          "componentFile": "packages/online-playground/src/VersionSelect.vue",
+          "tagName": "VersionSelect",
+          "tagAnchor": "<VersionSelect v-model=\"store.state.typescriptVersion\" ",
+          "completionItemCount": 31,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "pkg", "rank": 28 },
+            { "label": "label", "rank": 29 },
+            { "label": "model-value", "rank": 30 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  label?: string\n",
+            "replacement": "  label?: string\n  vizeOracleProbe?: string\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "packages/online-playground/src/__VizeOracleVersionSelect.vue",
+          "renamedFile": "packages/online-playground/src/__VizeOracleRenamedVersionSelect.vue",
+          "originalImportSpecifier": "./VersionSelect.vue",
+          "copiedImportSpecifier": "./__VizeOracleVersionSelect.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedVersionSelect.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizePiniaFileLifecycleMarker__"
+        }
+      }
     },
     {
       "id": "vue-tui",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 5,
+      "authored-lsp": 6,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tests/tooling/real-project-lsp-authored-oracle.test.ts
+++ b/tests/tooling/real-project-lsp-authored-oracle.test.ts
@@ -52,11 +52,16 @@ test("real-project LSP exercises authored binding and component boundary feature
     assertOrderedEvents(session.events, [
       ["textDocument/didOpen:1:Binding.vue", "textDocument/publishDiagnostics:1:Binding.vue"],
       ["textDocument/didOpen:1:FeatureChild.vue", "textDocument/didChange:2:FeatureChild.vue"],
+      [
+        "textDocument/publishDiagnostics:1:FeatureParent.vue",
+        "textDocument/didChange:2:FeatureParent.vue",
+      ],
+      ["textDocument/didChange:2:FeatureParent.vue", "workspace/didCreateFiles"],
       ["workspace/didCreateFiles", "workspace/symbol"],
       ["workspace/willRenameFiles", "workspace/didRenameFiles"],
-      ["workspace/didDeleteFiles", "textDocument/publishDiagnostics:3:FeatureParent.vue"],
-      ["workspace/didDeleteFiles", "textDocument/didChange:4:FeatureParent.vue"],
-      ["textDocument/didChange:4:FeatureParent.vue", "textDocument/didClose:FeatureParent.vue"],
+      ["workspace/didDeleteFiles", "textDocument/publishDiagnostics:4:FeatureParent.vue"],
+      ["workspace/didDeleteFiles", "textDocument/didChange:5:FeatureParent.vue"],
+      ["textDocument/didChange:5:FeatureParent.vue", "textDocument/didClose:FeatureParent.vue"],
       ["textDocument/didClose:FeatureParent.vue", "textDocument/didClose:FeatureChild.vue"],
       ["textDocument/didClose:FeatureChild.vue", "textDocument/didClose:Binding.vue"],
     ]);

--- a/tests/tooling/support/real-project-lsp-authored-oracle.ts
+++ b/tests/tooling/support/real-project-lsp-authored-oracle.ts
@@ -166,7 +166,7 @@ export async function exerciseAuthoredLspOracle(
       timeoutMs(),
     );
     open(session, importerDocument.uri, importerDocument.source, 1, openUris);
-    const importerDiagnostics = await waitForDiagnostics(
+    const initialImporterDiagnostics = await waitForDiagnostics(
       session,
       importerDocument.uri,
       1,
@@ -234,6 +234,18 @@ export async function exerciseAuthoredLspOracle(
       false,
       "dependency repair must remove the probe completion",
     );
+    // Type diagnostics can arrive after the importer opened with an initial
+    // lint-only publish. Recompute the unchanged importer immediately before
+    // the create/rename/delete lifecycle so the final repair is compared
+    // against the server's settled baseline for that exact source.
+    const lifecycleImporterVersion = (initialImporterDiagnostics.version ?? 1) + 1;
+    change(session, importerDocument.uri, importerDocument.source, lifecycleImporterVersion);
+    const lifecycleImporterDiagnostics = await waitForDiagnostics(
+      session,
+      importerDocument.uri,
+      lifecycleImporterVersion,
+      timeoutMs(),
+    );
     const fileLifecycle = await exerciseAuthoredFileLifecycle(
       session,
       workspaceDir,
@@ -241,7 +253,7 @@ export async function exerciseAuthoredLspOracle(
       importerDocument,
       childDocument,
       tagRange,
-      importerDiagnostics,
+      lifecycleImporterDiagnostics,
       timeoutMs,
     );
     const evidence = (request: { durationMs: number }, response: unknown, count: number) =>

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 5, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 6, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
## Summary

- Add pinia as the sixth authored real-project LSP oracle for #3952.
- Cover template hover/definition/references/rename, component-boundary definition/completion, unsaved dependency edits, and create/rename/delete file lifecycle repair.
- Refresh the importer diagnostic baseline immediately before lifecycle mutations so async type diagnostics are compared against the settled source.
- Ratchet the authored-lsp fixture ledger from 5 to 6.

Refs #3952

## Validation

- `node --test tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts`
- `FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=22 REAL_PROJECT_LSP_TIMEOUT_MS=600000 CORSA_PATH=/private/tmp/vize-3952-authored-next.op872T/node_modules/.bin/tsgo VIZE_LSP_BIN=/private/tmp/vize-3952-authored-next.op872T/target/debug/vize node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts`
- `MOON_HOME=/tmp/vize-moonbit-release.N4SQlL/moonbit MOON_BIN=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims/moon PATH=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims:/tmp/vize-moonbit-release.N4SQlL/moonbit/bin:$PATH node --test tests/tooling/source-file-lengths.test.ts`
