### PR TITLE
feat(davinci): emit native event sugar

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_native_on.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_native_on.rs
@@ -1,0 +1,43 @@
+//! P2-11 `.native` event-sugar witness: the Vue 2 modifier is accepted
+//! and stripped before event-key calculation / handler wrapping, compared
+//! **byte-for-byte** against the shipped DOM lane.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    ("native_click", r#"<div @click.native="h"></div>"#),
+    ("native_stop", r#"<div @click.native.stop="h"></div>"#),
+    ("stop_native", r#"<div @click.stop.native="h"></div>"#),
+    ("native_once", r#"<div @click.native.once="h"></div>"#),
+    ("native_key", r#"<div @keyup.native.enter="h"></div>"#),
+    ("native_inline", r#"<div @click.native="count++"></div>"#),
+    ("component_native", r#"<Foo @click.native="h" />"#),
+    ("component_native_stop", r#"<Foo @click.native.stop="h" />"#),
+    (
+        "v_if_native",
+        r#"<button v-if="ok" @click.native="h"></button>"#,
+    ),
+    (
+        "v_for_native",
+        r#"<button v-for="item in items" :key="item.id" @click.native="h">{{ item.label }}</button>"#,
+    ),
+    (
+        "native_duplicate",
+        r#"<div @click.native="a" @click="b"></div>"#,
+    ),
+    (
+        "native_duplicate_stop",
+        r#"<div @click.native="a" @click.stop="b"></div>"#,
+    ),
+];
+
+#[test]
+fn s2_native_event_sugar_matches_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -34,8 +34,9 @@
 //! **dynamic `v-if` keys** (`:key="expr"`), plus **foreign namespace
 //! boundaries** (`<svg>` / `<math>` enter blocks, same-namespace descendants
 //! stay VNodes, integration points re-enter HTML), and **template refs**
-//! (static refs, dynamic `:ref`, and `ref_for` in `v-for`). `.native`
-//! and filters stay [`EmitError::Unsupported`].
+//! (static refs, dynamic `:ref`, and `ref_for` in `v-for`), and **Vue 2
+//! `.native` event sugar** (accepted and stripped like the shipped lane).
+//! Filters stay [`EmitError::Unsupported`].
 //! The old lane stays the shipped compile path; [`super::DOM_LANE_FLAG`]
 //! is named here and *read* in the atelier_dom witness.
 

--- a/crates/vize_ricalco/src/emit/on.rs
+++ b/crates/vize_ricalco/src/emit/on.rs
@@ -83,11 +83,16 @@ pub(super) fn needs_hydration(key: &str, on: &OnOp<'_>) -> bool {
     if key == "onUpdate:modelValue" || key.starts_with("onVnode") {
         return false;
     }
+    if has_native_modifier(on) {
+        return true;
+    }
     key != "onClick" || classify(on).is_ok_and(|classified| !classified.keys.is_empty())
 }
 
-pub(super) fn wraps_on(on: &OnOp<'_>) -> bool {
-    classify(on).is_ok_and(|classified| !classified.event.is_empty() || !classified.keys.is_empty())
+pub(super) fn forces_inline_on(on: &OnOp<'_>) -> bool {
+    classify(on).is_ok_and(|classified| {
+        has_native_modifier(on) || !classified.event.is_empty() || !classified.keys.is_empty()
+    })
 }
 
 pub(super) fn is_inline_handler_source(source: &str) -> bool {
@@ -183,7 +188,10 @@ fn classify<'a>(on: &'a OnOp<'a>) -> Result<Classified<'a>, EmitError> {
     let mut keys = StdVec::new();
     for modifier in on.modifiers.iter() {
         match *modifier {
-            "native" => return Err(EmitError::Unsupported),
+            // Vue 2's `.native` event sugar is stripped by the shipped
+            // lane before handler wrapping, and does not affect the event
+            // key. Keep the authored modifier accepted but inert here.
+            "native" => {}
             "capture" | "once" | "passive" => options.push(*modifier),
             "left" | "right" if keyboard => keys.push(*modifier),
             "stop" | "prevent" | "self" | "ctrl" | "shift" | "alt" | "meta" | "middle"
@@ -196,6 +204,10 @@ fn classify<'a>(on: &'a OnOp<'a>) -> Result<Classified<'a>, EmitError> {
         event,
         keys,
     })
+}
+
+fn has_native_modifier(on: &OnOp<'_>) -> bool {
+    on.modifiers.contains(&"native")
 }
 
 fn remapped_name<'a>(raw: &'a str, event: &[&str]) -> &'a str {

--- a/crates/vize_ricalco/src/emit/props_object.rs
+++ b/crates/vize_ricalco/src/emit/props_object.rs
@@ -9,7 +9,7 @@ use super::EmitCx;
 use super::EmitError;
 use super::buf::Buf;
 use super::js::{escape_js_string, push_ident_key};
-use super::on::{emit_on_pair, emit_on_value, event_key_for, is_inline_handler_source, wraps_on};
+use super::on;
 use super::props_bind::{js_value, static_bind_name};
 
 pub(super) fn emit_props_object(
@@ -99,7 +99,7 @@ pub(super) fn emit_props_object(
         match piece {
             Piece::Attr(attr) => emit_static_pair(cx, attr),
             Piece::Bind(bind) => emit_bind_pair(cx, pieces, bind, skip_normalize)?,
-            Piece::On(on) => emit_on_pair(cx, on, is_plain_element)?,
+            Piece::On(event) => on::emit_on_pair(cx, event, is_plain_element)?,
             Piece::ModelValue { name, source, .. } => super::model::emit_value(cx, name, source),
             Piece::ModelUpdate { key, source, .. } => super::model::emit_update(cx, key, source),
             Piece::ModelModifiers {
@@ -206,10 +206,10 @@ fn pieces_have_named(pieces: &[Piece<'_>], name: &str) -> bool {
 
 fn pieces_have_inline_on(pieces: &[Piece<'_>]) -> bool {
     pieces.iter().any(|piece| match piece {
-        Piece::On(on) => {
-            wraps_on(on)
-                || match on.handler {
-                    Some(ExprRef::Js(js)) => is_inline_handler_source(js.source),
+        Piece::On(event) => {
+            on::forces_inline_on(event)
+                || match event.handler {
+                    Some(ExprRef::Js(js)) => on::is_inline_handler_source(js.source),
                     _ => false,
                 }
         }
@@ -309,7 +309,7 @@ fn emit_style_value(cx: &mut EmitCx<'_>, js: &JsExpr<'_>, skip_normalize: bool) 
 
 fn piece_event_key(piece: &Piece<'_>, is_plain_element: bool) -> Option<String> {
     match piece {
-        Piece::On(on) => event_key_for(on, is_plain_element).ok(),
+        Piece::On(event) => on::event_key_for(event, is_plain_element).ok(),
         Piece::ModelUpdate { key, .. } => Some(key.clone()),
         _ => None,
     }
@@ -340,7 +340,7 @@ fn emit_merged_handlers(
         }
         first = false;
         match piece {
-            Piece::On(on) => emit_on_value(cx, on)?,
+            Piece::On(event) => on::emit_on_value(cx, event)?,
             Piece::ModelUpdate { source, .. } => super::model::emit_assignment(cx, source),
             _ => {}
         }

--- a/crates/vize_ricalco/tests/emit_on.rs
+++ b/crates/vize_ricalco/tests/emit_on.rs
@@ -161,10 +161,17 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
-fn a_click_native_is_unsupported_this_installment() {
+fn a_click_native_strips_the_modifier_but_keeps_need_hydration() {
     assert_eq!(
-        refused(r#"<div @click.native="handler"></div>"#),
-        EmitError::Unsupported
+        assembled(r#"<div @click.native="handler"></div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", {
+    onClick: handler
+  }, null, 40 /* PROPS, NEED_HYDRATION */, [\"onClick\"]))
+}"
     );
 }
 


### PR DESCRIPTION

## Summary
- accept static-name `v-on` `.native` in the Davinci DOM emitter and strip it from event keys / handler wrappers like the shipped lane
- preserve the shipped lane hydration behavior for `.native` listeners
- add a byte-for-byte atelier_dom dual-run witness for native/component/v-if/v-for/duplicate `.native` event cases

## Verification
- git diff --check
- nix develop -c cargo fmt --check
- nix develop -c cargo test -p vize_ricalco --tests
- nix develop -c cargo test -p vize_atelier_dom --test davinci_s2_native_on --test davinci_s2_dom --test davinci_s2_von --test davinci_s2_colon -- --nocapture
- nix develop -c cargo clippy -p vize_ricalco --lib --test emit_on -p vize_atelier_dom --test davinci_s2_native_on -- -D warnings
- wc -l crates/vize_ricalco/src/emit.rs crates/vize_ricalco/src/emit/on.rs crates/vize_ricalco/src/emit/props_object.rs crates/vize_ricalco/tests/emit_on.rs crates/vize_atelier_dom/tests/davinci_s2_native_on.rs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790166570&installation_model_id=422833&pr_number=4792&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4792&signature=0b0689c0b66cac25cdb7b269545063d22a83dd8a5f49da66348f2f1fe13e5296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Vue 2 `.native` event modifiers.
  * Native event handlers are emitted without the `.native` modifier while preserving hydration and inline-handler behavior.
  * Supports combinations with propagation, one-time, keyboard, conditional, loop, and component event handlers.

* **Tests**
  * Added comprehensive coverage to verify native event handling matches existing DOM output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->