### PR TITLE
test(tooling): add vue-router authored lsp oracle

### DIFF
--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -768,6 +768,7 @@
           "tests/_fixtures/_git/elk",
           "tests/_fixtures/_git/misskey",
           "tests/_fixtures/_git/create-vue",
+          "tests/_fixtures/_git/vue-router",
           "tests/_fixtures/_git/pinia",
           "tests/_fixtures/_git/vuefes-japan-speakers"
         ]

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 7,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 6,
+    "minimumProjectCount": 7,
     "trackingIssue": 3952
   },
   "projects": [
@@ -890,7 +890,68 @@
       "vueGlobs": ["packages/**/*.vue"],
       "tsconfig": "packages/router/tsconfig.json",
       "coverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "packages/playground/src/App.vue",
+          "symbol": "flushWaiter",
+          "usageAnchor": "@before-enter=\"flushWaiter\"",
+          "declarationAnchor": "function flushWaiter() {",
+          "hoverContains": ["function flushWaiter(): void"],
+          "renameTo": "__vizeRenamedFlushWaiter"
+        },
+        "componentBoundary": {
+          "importerFile": "packages/router/src/tests/data-loaders/ComponentWithNestedLoader.vue",
+          "componentFile": "packages/router/src/tests/data-loaders/ComponentWithLoader.vue",
+          "tagName": "ComponentWithLoader",
+          "tagAnchor": "<ComponentWithLoader ",
+          "completionItemCount": 28,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 }
+          ],
+          "dependencyEdit": {
+            "anchor": "<script lang=\"ts\" setup>\n",
+            "replacement": "<script lang=\"ts\" setup>\ndefineProps<{ vizeOracleProbe?: boolean }>()\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "packages/router/src/tests/data-loaders/__VizeOracleComponentWithLoader.vue",
+          "renamedFile": "packages/router/src/tests/data-loaders/__VizeOracleRenamedComponentWithLoader.vue",
+          "originalImportSpecifier": "./ComponentWithLoader.vue",
+          "copiedImportSpecifier": "./__VizeOracleComponentWithLoader.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedComponentWithLoader.vue",
+          "markerInsertionAnchor": "<script lang=\"ts\" setup>\n",
+          "markerSymbol": "__vizeVueRouterFileLifecycleMarker__"
+        }
+      }
     },
     {
       "id": "pinia",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 6,
+      "authored-lsp": 7,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 6, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 7, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
## Summary
- add a Vue Router authored LSP oracle covering a real template binding, component boundary, dependency completion refresh, and file lifecycle
- ratchet authored LSP coverage from 6 to 7 fixtures and sync the compatibility ledger

Refs #3952.

## Tests
- nix develop --command node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts
- CORSA_PATH="/Users/ubugeeei/Source/github.com/ubugeeei-prod/vize--p0p1/node_modules/.bin/tsgo" VIZE_LSP_BIN="/Users/ubugeeei/Source/github.com/ubugeeei-prod/vize--p0p1/target/debug/vize" FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=21 REAL_PROJECT_LSP_TIMEOUT_MS=600000 nix develop --command node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts
- nix develop --command node --test tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts
- nix develop --command vp fmt --check tests/_fixtures/vue-ecosystem-fixtures.json tests/_fixtures/fixture-compatibility-ledger.json tests/tooling/fixture-compatibility-ledger.test.ts tools/fixtures/fixture-compatibility-ledger.mjs
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790166749&installation_model_id=422833&pr_number=4793&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4793&signature=180faba18519c9d3994d395327885651c0a272058409d19f4885fd4227187da9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->