### PR TITLE
test(tooling): add motion-vue authored lsp oracle

### DIFF
--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -767,6 +767,7 @@
           "tests/_fixtures/_git/reka-ui",
           "tests/_fixtures/_git/elk",
           "tests/_fixtures/_git/misskey",
+          "tests/_fixtures/_git/motion-vue",
           "tests/_fixtures/_git/create-vue",
           "tests/_fixtures/_git/vue-router",
           "tests/_fixtures/_git/pinia",

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 7,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 7,
+    "minimumProjectCount": 8,
     "trackingIssue": 3952
   },
   "projects": [
@@ -732,7 +732,69 @@
       "vueGlobs": ["packages/**/*.vue", "playground/**/*.vue"],
       "tsconfig": "tsconfig.json",
       "coverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "playground/nuxt/pages/child.vue",
+          "symbol": "style",
+          "usageAnchor": "\"style\"\n    @click",
+          "declarationAnchor": "const style = computed(() => ({",
+          "hoverContains": ["const style: any"],
+          "renameTo": "__vizeRenamedStyle"
+        },
+        "componentBoundary": {
+          "importerFile": "playground/nuxt/pages/number-counter/index.vue",
+          "componentFile": "playground/nuxt/pages/number-counter/AdditionIcon.vue",
+          "tagName": "AdditionIcon",
+          "tagAnchor": "<AdditionIcon type=\"minus\" ",
+          "completionItemCount": 29,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "type", "rank": 28 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  type: 'plus' | 'minus'\n",
+            "replacement": "  type: 'plus' | 'minus'\n  vizeOracleProbe?: boolean\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "playground/nuxt/pages/number-counter/__VizeOracleAdditionIcon.vue",
+          "renamedFile": "playground/nuxt/pages/number-counter/__VizeOracleRenamedAdditionIcon.vue",
+          "originalImportSpecifier": "./AdditionIcon.vue",
+          "copiedImportSpecifier": "./__VizeOracleAdditionIcon.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedAdditionIcon.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizeMotionVueFileLifecycleMarker__"
+        }
+      }
     },
     {
       "id": "shadcn-vue",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 7,
+      "authored-lsp": 8,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 7, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 8, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
Summary:
- add a Motion for Vue authored LSP oracle covering template binding, component boundary completion, and file lifecycle behavior
- ratchet authored LSP fixture coverage from 7 to 8 and register the fixture in the compatibility ledger

Tests:
- nix develop --command node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts
- nix develop --command vp fmt --check tests/_fixtures/vue-ecosystem-fixtures.json tests/_fixtures/fixture-compatibility-ledger.json tests/tooling/fixture-compatibility-ledger.test.ts tools/fixtures/fixture-compatibility-ledger.mjs
- CORSA_PATH="$PWD/node_modules/.bin/tsgo" VIZE_LSP_BIN="$PWD/target/debug/vize" FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=14 REAL_PROJECT_LSP_TIMEOUT_MS=600000 nix develop --command node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts
- CORSA_PATH="$PWD/node_modules/.bin/tsgo" VIZE_LSP_BIN="$PWD/target/debug/vize" nix develop --command node --test tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts
- nix develop --command cargo build -p vize
- git diff --check

Part of #3952.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded compatibility coverage for Vue projects, including template bindings, component interactions, code completion, dependency editing, and file lifecycle operations.
  - Added an additional representative Vue fixture to authored-language-service validation.
  - Updated compatibility checks to reflect the broader test coverage and ensure future changes maintain expected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->