### PR TITLE
feat(davinci): emit static style merges

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_style_merge.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_style_merge.rs
@@ -1,0 +1,51 @@
+//! P2-11 static+dynamic `style` merge witness: static style attributes
+//! beside `:style` compile to the same array/object shape as the shipped
+//! DOM lane, including CSS semicolons inside function calls.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "static_then_dynamic",
+        r#"<div style="color: red" :style="s"></div>"#,
+    ),
+    (
+        "dynamic_then_static",
+        r#"<div :style="s" style="color: red"></div>"#,
+    ),
+    (
+        "object_literal",
+        r#"<div style="color: red" :style="{ fontSize: x }"></div>"#,
+    ),
+    (
+        "css_function_semicolon",
+        r#"<div style="background: url(a;b); color: red" :style="s"></div>"#,
+    ),
+    (
+        "v_if_style_merge",
+        r#"<div v-if="ok" style="color: red" :style="s"></div>"#,
+    ),
+    (
+        "v_for_style_merge",
+        r#"<div v-for="item in items" :key="item.id" style="color: red" :style="item.style">{{ item.label }}</div>"#,
+    ),
+    (
+        "spread_after_merge",
+        r#"<input style="color: red" :style="dynamicStyle" v-bind="attrs" />"#,
+    ),
+    (
+        "spread_before_merge",
+        r#"<input v-bind="attrs" style="color: red" :style="dynamicStyle" />"#,
+    ),
+];
+
+#[test]
+fn s2_static_dynamic_style_merges_match_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -35,7 +35,8 @@
 //! boundaries** (`<svg>` / `<math>` enter blocks, same-namespace descendants
 //! stay VNodes, integration points re-enter HTML), and **template refs**
 //! (static refs, dynamic `:ref`, and `ref_for` in `v-for`), and **Vue 2
-//! `.native` event sugar** (accepted and stripped like the shipped lane).
+//! `.native` event sugar** (accepted and stripped like the shipped lane),
+//! and **static+dynamic `style` merge** (`[{"color":"red"}, s]`).
 //! Filters stay [`EmitError::Unsupported`].
 //! The old lane stays the shipped compile path; [`super::DOM_LANE_FLAG`]
 //! is named here and *read* in the atelier_dom witness.
@@ -82,6 +83,8 @@ mod props_bind;
 mod props_object;
 #[path = "emit/slots.rs"]
 mod slots;
+#[path = "emit/style.rs"]
+mod style;
 #[path = "emit/tpl.rs"]
 mod tpl;
 #[path = "emit/vfor.rs"]

--- a/crates/vize_ricalco/src/emit/props.rs
+++ b/crates/vize_ricalco/src/emit/props.rs
@@ -57,7 +57,7 @@ pub(super) fn admit_bindings(
             _ => return Err(EmitError::Unsupported),
         }
     }
-    if style && has_attr(attributes, "style") {
+    if style && has_attr(attributes, "style") && static_attr_value(attributes, "style").is_none() {
         return Err(EmitError::Unsupported);
     }
     Ok(())
@@ -156,4 +156,11 @@ pub(super) fn apply_static_ref_patch(attributes: &[Attribute<'_>], flag: &mut i3
 
 fn has_attr(attributes: &[Attribute<'_>], name: &str) -> bool {
     attributes.iter().any(|attr| attr.name == name)
+}
+
+fn static_attr_value<'a>(attributes: &'a [Attribute<'a>], name: &str) -> Option<&'a str> {
+    attributes
+        .iter()
+        .find(|attr| attr.name == name)
+        .and_then(|attr| attr.value)
 }

--- a/crates/vize_ricalco/src/emit/props_object.rs
+++ b/crates/vize_ricalco/src/emit/props_object.rs
@@ -21,10 +21,11 @@ pub(super) fn emit_props_object(
     is_plain_element: bool,
 ) -> Result<(), EmitError> {
     let skip_class = pieces_have_named(pieces, "class");
+    let skip_style = pieces_have_named(pieces, "style");
     let skip_key = if_key.is_some();
     let visible: StdVec<&Piece<'_>> = pieces
         .iter()
-        .filter(|piece| !skip_emitted_key(piece, if_key, skip_class, skip_key))
+        .filter(|piece| !skip_emitted_key(piece, if_key, skip_class, skip_style, skip_key))
         .collect();
     if let Some(key) = if_key
         && visible.is_empty()
@@ -178,11 +179,14 @@ fn skip_emitted_key(
     piece: &Piece<'_>,
     if_key: Option<&str>,
     skip_class: bool,
+    skip_style: bool,
     skip_key: bool,
 ) -> bool {
     match piece {
         Piece::Attr(attr) => {
-            (skip_class && attr.name == "class") || (skip_key && attr.name == "key")
+            (skip_class && attr.name == "class")
+                || (skip_style && attr.name == "style" && attr.value.is_some())
+                || (skip_key && attr.name == "key")
         }
         Piece::Bind(bind)
             if skip_key
@@ -241,7 +245,9 @@ fn emit_bind_pair(
     cx.buf.push(": ");
     match name {
         "class" => emit_class_value(cx, pieces, bind, js, skip_normalize),
-        "style" => emit_style_value(cx, js, skip_normalize),
+        "style" => {
+            super::style::emit_style_value(cx, static_style_piece(pieces), bind, js, skip_normalize)
+        }
         _ => cx.buf.push(js.source),
     }
     Ok(())
@@ -293,18 +299,11 @@ fn emit_class_value(
     }
 }
 
-fn emit_style_value(cx: &mut EmitCx<'_>, js: &JsExpr<'_>, skip_normalize: bool) {
-    let object_literal = js.source.trim_start().starts_with('{');
-    let wrap = !skip_normalize && !object_literal;
-    if wrap {
-        cx.buf.use_normalize_style();
-        cx.buf.push(Buf::normalize_style_alias());
-        cx.buf.push("(");
-    }
-    cx.buf.push(js.source);
-    if wrap {
-        cx.buf.push(")");
-    }
+fn static_style_piece<'a>(pieces: &'a [Piece<'a>]) -> Option<(&'a Attribute<'a>, &'a str)> {
+    pieces.iter().find_map(|piece| match piece {
+        Piece::Attr(attr) if attr.name == "style" => attr.value.map(|value| (*attr, value)),
+        _ => None,
+    })
 }
 
 fn piece_event_key(piece: &Piece<'_>, is_plain_element: bool) -> Option<String> {

--- a/crates/vize_ricalco/src/emit/style.rs
+++ b/crates/vize_ricalco/src/emit/style.rs
@@ -1,0 +1,84 @@
+//! Static style-attribute serialization used by dynamic `:style` merges.
+
+use oxc_ast::ast::Expression;
+use vize_disegno::expr::JsExpr;
+use vize_disegno::op::{Attribute, BindOp};
+
+use super::EmitCx;
+use super::buf::Buf;
+use super::js::escape_js_string;
+
+pub(super) fn emit_style_value(
+    cx: &mut EmitCx<'_>,
+    static_style: Option<(&Attribute<'_>, &str)>,
+    bind: &BindOp<'_>,
+    js: &JsExpr<'_>,
+    skip_normalize: bool,
+) {
+    let bare_object_literal =
+        static_style.is_none() && matches!(js.ast, Expression::ObjectExpression(_));
+    let wrap = !skip_normalize && !bare_object_literal;
+    if wrap {
+        cx.buf.use_normalize_style();
+        cx.buf.push(Buf::normalize_style_alias());
+        cx.buf.push("(");
+    }
+    if let Some((attr, value)) = static_style {
+        let before = attr.span.start <= bind.span.start;
+        cx.buf.push("[");
+        if before {
+            emit_static_style_object(cx, value);
+            cx.buf.push(", ");
+            cx.buf.push(js.source);
+        } else {
+            cx.buf.push(js.source);
+            cx.buf.push(", ");
+            emit_static_style_object(cx, value);
+        }
+        cx.buf.push("]");
+    } else {
+        cx.buf.push(js.source);
+    }
+    if wrap {
+        cx.buf.push(")");
+    }
+}
+
+fn emit_static_style_object(cx: &mut EmitCx<'_>, value: &str) {
+    cx.buf.push("{");
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    let mut emitted = 0usize;
+    for (i, ch) in value.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' if depth > 0 => depth -= 1,
+            ';' if depth == 0 => {
+                emit_declaration(cx, &value[start..i], &mut emitted);
+                start = i + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    emit_declaration(cx, &value[start..], &mut emitted);
+    cx.buf.push("}");
+}
+
+fn emit_declaration(cx: &mut EmitCx<'_>, declaration: &str, emitted: &mut usize) {
+    let declaration = declaration.trim();
+    if declaration.is_empty() {
+        return;
+    }
+    let Some((key, value)) = declaration.split_once(':') else {
+        return;
+    };
+    if *emitted > 0 {
+        cx.buf.push(",");
+    }
+    *emitted += 1;
+    cx.buf.push("\"");
+    cx.buf.push(escape_js_string(key.trim()).as_str());
+    cx.buf.push("\":\"");
+    cx.buf.push(escape_js_string(value.trim()).as_str());
+    cx.buf.push("\"");
+}


### PR DESCRIPTION
## Summary
- emit static + dynamic style as shipped-lane style arrays, including CSS declarations with semicolons inside functions
- keep valued static style attrs admissible beside static-name :style while preserving valueless attr refusals
- add a P2-11 S2 dual-run witness for style merge, v-if/v-for, and mergeProps spread cases

Note: the s0/s1/s2 crate/implementation naming cleanup is intentionally left for a separate small PR.

## Verification
- nix develop -c cargo test -p vize_atelier_dom --test davinci_s2_style_merge --test davinci_s2_dom -- --nocapture
- nix develop -c cargo test -p vize_ricalco --tests
- nix develop -c cargo clippy -p vize_ricalco --lib -p vize_atelier_dom --test davinci_s2_style_merge -- -D warnings
- nix develop -c cargo fmt --check
- git diff --check

Head: 29ae718fc3dea0bfc71530fed13e635d8dbd5d3f