### PR TITLE
test(tooling): add vaul vue authored lsp oracle

### DIFF
--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -770,7 +770,8 @@
           "tests/_fixtures/_git/create-vue",
           "tests/_fixtures/_git/vue-router",
           "tests/_fixtures/_git/pinia",
-          "tests/_fixtures/_git/vuefes-japan-speakers"
+          "tests/_fixtures/_git/vuefes-japan-speakers",
+          "tests/_fixtures/_git/vaul-vue"
         ]
       },
       "evidence": {

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 7,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 7,
+    "minimumProjectCount": 8,
     "trackingIssue": 3952
   },
   "projects": [
@@ -789,7 +789,85 @@
       "vueGlobs": ["packages/**/*.vue", "playground/**/*.vue"],
       "tsconfig": "packages/vaul-vue/tsconfig.json",
       "coverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "packages/vaul-vue/src/DrawerHandle.vue",
+          "symbol": "handleStartCycle",
+          "usageAnchor": "@click=\"handleStartCycle\"",
+          "declarationAnchor": "function handleStartCycle() {",
+          "hoverContains": ["function handleStartCycle(): void"],
+          "renameTo": "__vizeRenamedHandleStartCycle"
+        },
+        "componentBoundary": {
+          "importerFile": "packages/vaul-vue/src/DrawerRootNested.vue",
+          "componentFile": "packages/vaul-vue/src/DrawerRoot.vue",
+          "tagName": "DrawerRoot",
+          "tagAnchor": "<DrawerRoot\n",
+          "completionItemCount": 45,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "active-snap-point", "rank": 28 },
+            { "label": "close-threshold", "rank": 29 },
+            { "label": "should-scale-background", "rank": 30 },
+            { "label": "set-background-color-on-scale", "rank": 31 },
+            { "label": "scroll-lock-timeout", "rank": 32 },
+            { "label": "fixed", "rank": 33 },
+            { "label": "dismissible", "rank": 34 },
+            { "label": "modal", "rank": 35 },
+            { "label": "open", "rank": 36 },
+            { "label": "default-open", "rank": 37 },
+            { "label": "nested", "rank": 38 },
+            { "label": "direction", "rank": 39 },
+            { "label": "no-body-styles", "rank": 40 },
+            { "label": "handle-only", "rank": 41 },
+            { "label": "prevent-scroll-restoration", "rank": 42 },
+            { "label": "snap-points", "rank": 43 },
+            { "label": "fade-from-index", "rank": 44 }
+          ],
+          "dependencyEdit": {
+            "anchor": "defineProps<DrawerRootProps>(), {",
+            "replacement": "defineProps<DrawerRootProps & { vizeOracleProbe?: boolean }>(), {",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "packages/vaul-vue/src/__VizeOracleDrawerRoot.vue",
+          "renamedFile": "packages/vaul-vue/src/__VizeOracleRenamedDrawerRoot.vue",
+          "originalImportSpecifier": "./DrawerRoot.vue",
+          "copiedImportSpecifier": "./__VizeOracleDrawerRoot.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedDrawerRoot.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizeVaulVueFileLifecycleMarker__"
+        }
+      }
     },
     {
       "id": "vee-validate",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 7,
+      "authored-lsp": 8,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 7, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 8, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
## Summary

- add Vaul Vue to the authored real-project LSP oracle matrix for #3952
- pin template hover/definition/references/rename on `DrawerHandle.vue`
- pin `DrawerRootNested -> DrawerRoot` component completion, dependency edit, and file lifecycle behavior
- ratchet authored LSP coverage from 7 to 8 projects

## Verification

- `node --test tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts`
- `FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=18 REAL_PROJECT_LSP_TIMEOUT_MS=600000 CORSA_PATH=/private/tmp/vize-3952-authored-next.op872T/node_modules/.bin/tsgo VIZE_LSP_BIN=/private/tmp/vize-3952-authored-next.op872T/target/debug/vize node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts`
- `MOON_HOME=/tmp/vize-moonbit-release.N4SQlL/moonbit MOON_BIN=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims/moon PATH=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims:/tmp/vize-moonbit-release.N4SQlL/moonbit/bin:$PATH node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`
