### PR TITLE
test(tooling): ratchet authored lsp oracle count

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 7,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 8,
+    "minimumProjectCount": 9,
     "trackingIssue": 3952
   },
   "projects": [

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 8,
+      "authored-lsp": 9,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 8, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 9, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
## Summary

- ratchet the authored LSP oracle gate from 8 to 9 projects after the Motion Vue and Vaul Vue oracle additions
- keep the compatibility report and fail-closed ledger count aligned with the actual 9-project oracle membership

## Verification

- `node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts`
- `MOON_HOME=/tmp/vize-moonbit-release.N4SQlL/moonbit MOON_BIN=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims/moon PATH=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims:/tmp/vize-moonbit-release.N4SQlL/moonbit/bin:$PATH node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790170193&installation_model_id=422833&pr_number=4798&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4798&signature=1deec23ee482b604cb723d1f48079ef74134a4b639f3f063a52ae91fa7a93a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated compatibility checks to recognize the expanded set of authored LSP oracle fixtures.
  - Increased the required fixture threshold from 8 to 9 to keep validation aligned with the current Vue ecosystem coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->