### PR TITLE
feat(davinci): emit static bind modifiers

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_bind_modifiers.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_bind_modifiers.rs
@@ -1,0 +1,39 @@
+//! P2-11 `v-bind` modifier witness: static-name `.camel`, `.prop`,
+//! `.attr`, and the dot shorthand compare byte-for-byte against the
+//! shipped DOM lane.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    ("native_camel", r#"<div :foo-bar.camel="value"></div>"#),
+    ("native_prop", r#"<div :value.prop="value"></div>"#),
+    ("native_attr", r#"<div :value.attr="value"></div>"#),
+    ("dot_shorthand", r#"<div .value="value"></div>"#),
+    ("component_camel", r#"<Foo :foo-bar.camel="value" />"#),
+    ("component_prop", r#"<Foo :value.prop="value" />"#),
+    (
+        "merge_props_camel",
+        r#"<div v-bind="bag" :foo-bar.camel="value"></div>"#,
+    ),
+    (
+        "merge_props_prop",
+        r#"<div v-bind="bag" :value.prop="value"></div>"#,
+    ),
+    ("v_if_attr", r#"<div v-if="ok" :value.attr="value"></div>"#),
+    (
+        "v_for_camel",
+        r#"<div v-for="item in items" :key="item.id" :foo-bar.camel="item.value"></div>"#,
+    ),
+    ("slot_outlet_prop", r#"<slot :foo-bar.prop="value" />"#),
+];
+
+#[test]
+fn s2_bind_modifiers_match_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -37,7 +37,9 @@
 //! (static refs, dynamic `:ref`, and `ref_for` in `v-for`), and **Vue 2
 //! `.native` event sugar** (accepted and stripped like the shipped lane),
 //! and **static+dynamic `style` merge** (`[{"color":"red"}, s]`).
-//! Filters stay [`EmitError::Unsupported`].
+//! Static-name `v-bind` modifiers (`.camel`, `.prop`, `.attr`, plus the
+//! dot shorthand) are realized into the shipped DOM prop-key shape. Filters
+//! and dynamic-argument bind modifiers stay [`EmitError::Unsupported`].
 //! The old lane stays the shipped compile path; [`super::DOM_LANE_FLAG`]
 //! is named here and *read* in the atelier_dom witness.
 

--- a/crates/vize_ricalco/src/emit/merge.rs
+++ b/crates/vize_ricalco/src/emit/merge.rs
@@ -15,7 +15,10 @@ use super::EmitCx;
 use super::EmitError;
 use super::buf::Buf;
 use super::on::{event_key_for, needs_hydration};
-use super::props::{Patch, Piece, emit_props_object, js_value, pieces, static_bind_name};
+use super::props::{
+    Patch, Piece, StaticBindKeyCasing, emit_props_object, has_prop_modifier, js_value, pieces,
+    static_bind_key, static_bind_name,
+};
 
 pub(super) fn has_object_spread(bindings: &[BindingOp<'_>]) -> bool {
     bindings.iter().any(|binding| match binding {
@@ -50,19 +53,25 @@ pub(super) fn object_patch(bindings: &[BindingOp<'_>], is_component: bool) -> Pa
             BindingOp::Bind(bind) if bind.name.is_none() => {}
             BindingOp::On(on) if on.name.is_none() => {}
             BindingOp::Bind(bind) => {
-                let Ok(name) = static_bind_name(bind) else {
+                let Ok(raw_name) = static_bind_name(bind) else {
                     continue;
                 };
-                if name == "ref" {
+                if raw_name == "ref" {
                     flag |= 512;
                     continue;
                 }
-                if matches!(name, "class" | "style" | "key") {
+                if matches!(raw_name, "class" | "style" | "key") {
                     continue;
                 }
-                let owned = String::from(name);
+                let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
+                    continue;
+                };
+                let owned = String::from(key.as_str());
                 if !dynamic_props.contains(&owned) {
                     dynamic_props.push(owned);
+                }
+                if has_prop_modifier(bind) {
+                    flag |= 32;
                 }
             }
             BindingOp::On(on) => {

--- a/crates/vize_ricalco/src/emit/outlet.rs
+++ b/crates/vize_ricalco/src/emit/outlet.rs
@@ -153,9 +153,12 @@ fn emit_props(cx: &mut EmitCx<'_>, slot: &SlotOp<'_>, key: Option<&str>) -> Resu
                 cx.buf.push("\"");
             }
             Piece::Bind(bind) => {
-                let name = super::props::static_bind_name(bind)?;
+                let key = super::props::static_bind_key(
+                    bind,
+                    super::props::StaticBindKeyCasing::Camelize,
+                )?;
                 let js = js_value(bind)?;
-                push_camel_key(cx, name);
+                push_key(cx, key.as_str());
                 cx.buf.push(": ");
                 cx.buf.push(js.source);
             }
@@ -174,11 +177,15 @@ fn emit_props(cx: &mut EmitCx<'_>, slot: &SlotOp<'_>, key: Option<&str>) -> Resu
 
 fn push_camel_key(cx: &mut EmitCx<'_>, name: &str) {
     let key = camelize(name);
-    if is_valid_js_identifier(key.as_str()) {
-        cx.buf.push(key.as_str());
+    push_key(cx, key.as_str());
+}
+
+fn push_key(cx: &mut EmitCx<'_>, key: &str) {
+    if is_valid_js_identifier(key) {
+        cx.buf.push(key);
     } else {
         cx.buf.push("\"");
-        cx.buf.push(escape_js_string(key.as_str()).as_str());
+        cx.buf.push(escape_js_string(key).as_str());
         cx.buf.push("\"");
     }
 }

--- a/crates/vize_ricalco/src/emit/props.rs
+++ b/crates/vize_ricalco/src/emit/props.rs
@@ -9,7 +9,9 @@ use super::EmitCx;
 use super::EmitError;
 use super::on::{admit_on, event_key_for, needs_hydration};
 
-pub(super) use super::props_bind::{js_value, static_bind_name};
+pub(super) use super::props_bind::{
+    StaticBindKeyCasing, has_prop_modifier, js_value, static_bind_key, static_bind_name,
+};
 pub(super) use super::props_object::{Piece, emit_props_object, pieces};
 
 pub(super) struct Patch {
@@ -33,9 +35,6 @@ pub(super) fn admit_bindings(
             }
             BindingOp::Bind(bind) => {
                 let name = static_bind_name(bind)?;
-                if !bind.modifiers.is_empty() {
-                    return Err(EmitError::Unsupported);
-                }
                 let vize_disegno::expr::ExprRef::Js(_) =
                     bind.value.ok_or(EmitError::Unsupported)?
                 else {
@@ -72,19 +71,25 @@ pub(super) fn bind_patch(bindings: &[BindingOp<'_>], is_component: bool) -> Patc
     for binding in bindings.iter() {
         match binding {
             BindingOp::Bind(bind) => {
-                let Ok(name) = static_bind_name(bind) else {
+                let Ok(raw_name) = static_bind_name(bind) else {
                     continue;
                 };
-                match name {
+                match raw_name {
                     "ref" => flag |= 512,
                     "class" if !is_component => flag |= 2,
                     "style" if !is_component => flag |= 4,
                     "key" => {}
                     _ => {
                         flag |= 8;
-                        let owned = String::from(name);
+                        let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
+                            continue;
+                        };
+                        let owned = String::from(key.as_str());
                         if !dynamic_props.contains(&owned) {
                             dynamic_props.push(owned);
+                        }
+                        if has_prop_modifier(bind) {
+                            flag |= 32;
                         }
                     }
                 }

--- a/crates/vize_ricalco/src/emit/props_bind.rs
+++ b/crates/vize_ricalco/src/emit/props_bind.rs
@@ -1,9 +1,33 @@
 //! Static-name `ui.bind` accessors shared by props admission and object emit.
 
+use vize_carton::{String, camelize};
 use vize_disegno::expr::{ExprRef, JsExpr};
 use vize_disegno::op::{BindOp, DynamicName};
 
 use super::EmitError;
+
+/// Whether static bind keys should use their ordinary casing or the
+/// `<slot>` outlet casing rule.
+#[derive(Clone, Copy)]
+pub(super) enum StaticBindKeyCasing {
+    Preserve,
+    Camelize,
+}
+
+/// The DOM prop key after static `v-bind` modifiers have been realized.
+pub(super) enum StaticBindKey<'a> {
+    Borrowed(&'a str),
+    Owned(String),
+}
+
+impl StaticBindKey<'_> {
+    pub(super) fn as_str(&self) -> &str {
+        match self {
+            Self::Borrowed(text) => text,
+            Self::Owned(text) => text.as_str(),
+        }
+    }
+}
 
 pub(super) fn static_bind_name<'a>(bind: &'a BindOp<'a>) -> Result<&'a str, EmitError> {
     match bind.name {
@@ -12,9 +36,65 @@ pub(super) fn static_bind_name<'a>(bind: &'a BindOp<'a>) -> Result<&'a str, Emit
     }
 }
 
+pub(super) fn static_bind_key<'a>(
+    bind: &'a BindOp<'a>,
+    casing: StaticBindKeyCasing,
+) -> Result<StaticBindKey<'a>, EmitError> {
+    let raw = static_bind_name(bind)?;
+    let mods = StaticBindModifiers::of(bind);
+    let mut key = if mods.camel || matches!(casing, StaticBindKeyCasing::Camelize) {
+        StaticBindKey::Owned(camelize(raw))
+    } else {
+        StaticBindKey::Borrowed(raw)
+    };
+    if mods.prop {
+        key = prefixed('.', key);
+    } else if mods.attr {
+        key = prefixed('^', key);
+    }
+    Ok(key)
+}
+
+pub(super) fn has_prop_modifier(bind: &BindOp<'_>) -> bool {
+    StaticBindModifiers::of(bind).prop
+}
+
 pub(super) fn js_value<'a>(bind: &'a BindOp<'a>) -> Result<&'a JsExpr<'a>, EmitError> {
     match bind.value {
         Some(ExprRef::Js(js)) => Ok(js),
         _ => Err(EmitError::Unsupported),
     }
+}
+
+struct StaticBindModifiers {
+    camel: bool,
+    prop: bool,
+    attr: bool,
+}
+
+impl StaticBindModifiers {
+    fn of(bind: &BindOp<'_>) -> Self {
+        let mut out = Self {
+            camel: false,
+            prop: false,
+            attr: false,
+        };
+        for modifier in bind.modifiers.iter() {
+            match *modifier {
+                "camel" => out.camel = true,
+                "prop" => out.prop = true,
+                "attr" => out.attr = true,
+                _ => {}
+            }
+        }
+        out
+    }
+}
+
+fn prefixed(prefix: char, key: StaticBindKey<'_>) -> StaticBindKey<'_> {
+    let key = key.as_str();
+    let mut text = String::with_capacity(prefix.len_utf8() + key.len());
+    text.push(prefix);
+    text.push_str(key);
+    StaticBindKey::Owned(text)
 }

--- a/crates/vize_ricalco/src/emit/props_object.rs
+++ b/crates/vize_ricalco/src/emit/props_object.rs
@@ -10,7 +10,7 @@ use super::EmitError;
 use super::buf::Buf;
 use super::js::{escape_js_string, push_ident_key};
 use super::on;
-use super::props_bind::{js_value, static_bind_name};
+use super::props_bind::{StaticBindKeyCasing, js_value, static_bind_key, static_bind_name};
 
 pub(super) fn emit_props_object(
     cx: &mut EmitCx<'_>,
@@ -238,12 +238,13 @@ fn emit_bind_pair(
     bind: &BindOp<'_>,
     skip_normalize: bool,
 ) -> Result<(), EmitError> {
-    let name = static_bind_name(bind)?;
+    let raw_name = static_bind_name(bind)?;
+    let key = static_bind_key(bind, StaticBindKeyCasing::Preserve)?;
     let js = js_value(bind)?;
-    emit_ref_for(cx, name);
-    push_ident_key(cx, name);
+    emit_ref_for(cx, key.as_str());
+    push_ident_key(cx, key.as_str());
     cx.buf.push(": ");
-    match name {
+    match raw_name {
         "class" => emit_class_value(cx, pieces, bind, js, skip_normalize),
         "style" => {
             super::style::emit_style_value(cx, static_style_piece(pieces), bind, js, skip_normalize)

--- a/crates/vize_ricalco/tests/emit_bind_modifiers.rs
+++ b/crates/vize_ricalco/tests/emit_bind_modifiers.rs
@@ -1,0 +1,68 @@
+//! P2-11: static-name `v-bind` modifiers in the S2 DOM emitter.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use support::with_transformed;
+use vize_ricalco::emit_dom;
+
+fn assembled(source: &str) -> String {
+    with_transformed(source, |lowered, _folio, facts, _budget| {
+        emit_dom(lowered, facts)
+            .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
+            .assembled()
+            .to_string()
+    })
+}
+
+#[test]
+fn a_static_camel_bind_uses_the_camelized_prop_key() {
+    assert_eq!(
+        assembled(r#"<div :foo-bar.camel="value"></div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", { fooBar: value }, null, 8 /* PROPS */, [\"fooBar\"]))
+}"
+    );
+}
+
+#[test]
+fn a_static_prop_bind_prefixes_the_prop_key_and_sets_hydration() {
+    assert_eq!(
+        assembled(r#"<div :value.prop="value"></div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", { \".value\": value }, null, 40 /* PROPS, NEED_HYDRATION */, [\".value\"]))
+}"
+    );
+}
+
+#[test]
+fn a_static_attr_bind_prefixes_the_attr_key() {
+    assert_eq!(
+        assembled(r#"<div :value.attr="value"></div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", { \"^value\": value }, null, 8 /* PROPS */, [\"^value\"]))
+}"
+    );
+}
+
+#[test]
+fn the_dot_shorthand_is_the_same_static_prop_modifier() {
+    assert_eq!(
+        assembled(r#"<div .value="value"></div>"#),
+        assembled(r#"<div :value.prop="value"></div>"#)
+    );
+}


### PR DESCRIPTION
## Summary
- realize static-name `v-bind` `.camel`, `.prop`, `.attr`, and dot-shorthand modifiers in the S2 DOM emitter
- share the transformed static bind key across props, mergeProps patching, and slot outlet props
- add direct S2 emitter tests plus a byte-for-byte shipped DOM lane battery

## Tests
- `nix develop -c cargo fmt`
- `nix develop -c cargo test -p vize_ricalco`
- `nix develop -c cargo test -p vize_atelier_dom --test davinci_s2_bind_modifiers`
- `nix develop -c cargo clippy -p vize_ricalco --test emit_bind_modifiers -- -D warnings`
- `nix develop -c cargo clippy -p vize_atelier_dom --test davinci_s2_bind_modifiers -- -D warnings`
- `nix develop -c moon run --target native tools/moon/cmd/source_file_lengths -- --check --base-ref origin/main --max-lines 350 --limit 20`
- `git diff --check`

## Notes
- P2-11 series records only list PRs after they land on `origin/main`; I will follow up with the installment record after this PR merges so the PR number and merge SHA are factual.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for static-name `v-bind` modifiers: `.camel`, `.prop`, `.attr`, and dot shorthand.
  - Preserved binding key casing and applied appropriate property or attribute prefixes.
  - Added support across elements, components, merged props, conditional and loop content, and slot outlets.

- **Bug Fixes**
  - Corrected generated binding keys and patch flags when modifiers are used.

- **Tests**
  - Added coverage validating generated output for modifier and shorthand bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->