### PR TITLE
test(tooling): add vee validate authored lsp oracle

### DIFF
--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -773,6 +773,7 @@
           "tests/_fixtures/_git/pinia",
           "tests/_fixtures/_git/vuefes-japan-speakers",
           "tests/_fixtures/_git/vaul-vue",
+          "tests/_fixtures/_git/vee-validate",
           "tests/_fixtures/_git/vue-termui"
         ]
       },

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 7,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 10,
+    "minimumProjectCount": 11,
     "trackingIssue": 3952
   },
   "projects": [
@@ -942,7 +942,69 @@
       "vueGlobs": ["docs/**/*.vue", "packages/**/*.vue"],
       "tsconfig": "tsconfig.json",
       "coverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "docs/src/components/VersionSwitcher.vue",
+          "symbol": "onChange",
+          "usageAnchor": "@click=\"onChange(version)\"",
+          "declarationAnchor": "function onChange(version: (typeof versions)[0]) {",
+          "hoverContains": ["function onChange(version:"],
+          "renameTo": "__vizeRenamedOnChange"
+        },
+        "componentBoundary": {
+          "importerFile": "docs/src/components/TheHeader.vue",
+          "componentFile": "docs/src/components/SideMenuButton.vue",
+          "tagName": "SideMenuButton",
+          "tagAnchor": "      <SideMenuButton ",
+          "completionItemCount": 29,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "model-value", "rank": 28 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  modelValue: {\n    type: Boolean,\n    required: true,\n  },",
+            "replacement": "  modelValue: {\n    type: Boolean,\n    required: true,\n  },\n  vizeOracleProbe: {\n    type: Boolean,\n    required: false,\n  },",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "docs/src/components/__VizeOracleSideMenuButton.vue",
+          "renamedFile": "docs/src/components/__VizeOracleRenamedSideMenuButton.vue",
+          "originalImportSpecifier": "@/components/SideMenuButton.vue",
+          "copiedImportSpecifier": "@/components/__VizeOracleSideMenuButton.vue",
+          "renamedImportSpecifier": "@/components/__VizeOracleRenamedSideMenuButton.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizeVeeValidateFileLifecycleMarker__"
+        }
+      }
     },
     {
       "id": "create-vue",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 10,
+      "authored-lsp": 11,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 10, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 11, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
## Summary
- add VeeValidate to the authored real-project LSP oracle matrix
- pin an authored template binding hover/definition/references/rename path in `VersionSwitcher.vue`
- pin the `TheHeader.vue` -> `SideMenuButton.vue` component boundary completion surface, dependency edit refresh, and file lifecycle repair
- raise the authored LSP oracle ratchet and compatibility ledger from 10 to 11 fixtures

## Validation
- `node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts`
- `REAL_PROJECT_LSP_TIMEOUT_MS=600000 FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=19 CORSA_PATH="$PWD/node_modules/.bin/tsgo" VIZE_LSP_BIN="$PWD/target/debug/vize" FIXTURE_REPORT_DIR=tmp/vee-validate-lsp-report node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts`
- `node --test tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts`
- `node --test tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/vue-ecosystem-tsconfig-coverage.test.ts`
- `MOON_HOME=/tmp/vize-moonbit-release.N4SQlL/moonbit MOON_BIN=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims/moon PATH=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims:/tmp/vize-moonbit-release.N4SQlL/moonbit/bin:$PATH node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

Refs #3952


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added VeeValidate to authored-LSP compatibility testing.
  * Expanded coverage for template bindings, component-boundary completion and dependency editing, and file lifecycle operations.
  * Updated compatibility thresholds and reports to include 11 supported fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->