### PR TITLE
test(tooling): add vue-draggable-plus authored lsp oracle

### DIFF
--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -774,6 +774,7 @@
           "tests/_fixtures/_git/vuefes-japan-speakers",
           "tests/_fixtures/_git/vaul-vue",
           "tests/_fixtures/_git/vee-validate",
+          "tests/_fixtures/_git/vue-draggable-plus",
           "tests/_fixtures/_git/vue-termui"
         ]
       },

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 7,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 11,
+    "minimumProjectCount": 12,
     "trackingIssue": 3952
   },
   "projects": [
@@ -2770,7 +2770,69 @@
         "syntax-highlighter",
         "lsp"
       ],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "src/__docs__/nested/NestedComponent.vue",
+          "symbol": "list",
+          "usageAnchor": "v-model=\"list\"",
+          "declarationAnchor": "const list = computed",
+          "hoverContains": ["const list: IList[]"],
+          "renameTo": "__vizeRenamedList"
+        },
+        "componentBoundary": {
+          "importerFile": "src/__docs__/nested/demo.vue",
+          "componentFile": "src/__docs__/nested/NestedComponent.vue",
+          "tagName": "nested-draggable",
+          "tagAnchor": "<nested-draggable ",
+          "completionItemCount": 29,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "model-value", "rank": 28 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  modelValue: IList[]\n",
+            "replacement": "  modelValue: IList[]\n  vizeOracleProbe?: boolean\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "src/__docs__/nested/__VizeOracleNestedComponent.vue",
+          "renamedFile": "src/__docs__/nested/__VizeOracleRenamedNestedComponent.vue",
+          "originalImportSpecifier": "./NestedComponent.vue",
+          "copiedImportSpecifier": "./__VizeOracleNestedComponent.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedNestedComponent.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizeVueDraggablePlusFileLifecycleMarker__"
+        }
+      }
     },
     {
       "id": "tdesign",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 11,
+      "authored-lsp": 12,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 11, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 12, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
## Summary
- add a vue-draggable-plus authored LSP oracle covering template binding, component boundary completion, dependency edits, and file lifecycle events
- raise the authored LSP oracle ratchet from 10 to 11 and update the compatibility ledger

## Tests
- nix develop --command node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts
- nix develop --command vp fmt --check tests/_fixtures/vue-ecosystem-fixtures.json tests/_fixtures/fixture-compatibility-ledger.json tests/tooling/fixture-compatibility-ledger.test.ts tools/fixtures/fixture-compatibility-ledger.mjs
- CORSA_PATH="/Users/ubugeeei/Source/github.com/ubugeeei-prod/vize--p0p1/node_modules/.bin/tsgo" VIZE_LSP_BIN="/Users/ubugeeei/Source/github.com/ubugeeei-prod/vize--p0p1/target/debug/vize" FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=95 REAL_PROJECT_LSP_TIMEOUT_MS=600000 nix develop --command node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts
- CORSA_PATH="/Users/ubugeeei/Source/github.com/ubugeeei-prod/vize--p0p1/node_modules/.bin/tsgo" VIZE_LSP_BIN="/Users/ubugeeei/Source/github.com/ubugeeei-prod/vize--p0p1/target/debug/vize" nix develop --command node --test tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts
- git diff --check

Refs #3952.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added `vue-draggable-plus` to the authored-LSP compatibility fixture set.
  * Expanded coverage for template bindings, component-boundary completions, dependency editing, and file lifecycle operations.
  * Increased the minimum validated fixture count from 10 to 11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->