### PR TITLE
docs(davinci): record P2-11 bind modifier installment

### DIFF
--- a/davinci-road/plan/phase-2-records/p2-11.md
+++ b/davinci-road/plan/phase-2-records/p2-11.md
@@ -14,7 +14,7 @@ atelier_dom **test space** (dev-dep carve-out). The old DOM lane is
 still the shipped compile path. The exit gate is unchanged.
 
 The `emit.rs` module docs keep a running capability list. **This
-record's numbers are the eighteen `origin/main` PRs**, not that comment.
+record's numbers are the nineteen `origin/main` PRs**, not that comment.
 
 ## Installment table
 
@@ -38,6 +38,7 @@ record's numbers are the eighteen `origin/main` PRs**, not that comment.
 | 16  | 2026-08-24 | [#4788](https://github.com/ubugeeei-prod/vize/pull/4788) | `6f89ad59`  | emit template refs                           |
 | 17  | 2026-08-24 | [#4792](https://github.com/ubugeeei-prod/vize/pull/4792) | `44ab9f8`   | emit `.native` event sugar                   |
 | 18  | 2026-08-24 | [#4796](https://github.com/ubugeeei-prod/vize/pull/4796) | `95d1848e`  | emit static+dynamic `style` merge            |
+| 19  | 2026-08-24 | [#4803](https://github.com/ubugeeei-prod/vize/pull/4803) | `5a13ccfb6` | emit static-name `v-bind` modifiers          |
 
 `landed` is the UTC committer date on `origin/main` (the merge-to-main
 clock). Per-installment records live in [p2-11/](./p2-11/):
@@ -60,11 +61,15 @@ clock). Per-installment records live in [p2-11/](./p2-11/):
 - [Installment 16 — template refs](./p2-11/installment-16.md)
 - [Installment 17 — `.native` event sugar](./p2-11/installment-17.md)
 - [Installment 18 — static+dynamic `style` merge](./p2-11/installment-18.md)
+- [Installment 19 — static-name `v-bind` modifiers](./p2-11/installment-19.md)
 
-## Named `Unsupported` remainder (after #4796)
+## Named `Unsupported` remainder (after #4803)
 
-Quoted from `crates/vize_ricalco/src/emit.rs` after installment 18:
-Filters stay [`EmitError::Unsupported`]. `emit.rs` now
+Quoted from `crates/vize_ricalco/src/emit.rs` after installment 19:
+Static-name `v-bind` modifiers (`.camel`, `.prop`, `.attr`, plus the
+dot shorthand) are realized into the shipped DOM prop-key shape. Filters
+and dynamic-argument bind modifiers stay [`EmitError::Unsupported`].
+`emit.rs` now
 also names foreign namespace boundaries and template refs as emitted:
 `<svg>` / `<math>` enter block-local namespaces, same-namespace
 descendants stay inline VNodes, integration points re-enter HTML, and
@@ -78,7 +83,8 @@ Also still refused by local guards in emit modules — so the next
 increment is not implicit:
 
 - **filters** — `ExprRef::Filter` in `emit/children.rs`
-- **bind modifiers** (`props.rs`)
+- **dynamic-argument bind names / modifiers** — `emit/props_bind.rs`
+  only admits `DynamicName::Static`
 - **bracketed outlet names and malformed slot regions** —
   `emit/slots.rs`, `emit/outlet.rs`, `emit/create_slots.rs`
 - **P2-10 style carrier** — still skip; it is not a DOM `<style>`

--- a/davinci-road/plan/phase-2-records/p2-11/installment-19.md
+++ b/davinci-road/plan/phase-2-records/p2-11/installment-19.md
@@ -1,0 +1,35 @@
+# P2-11 Installment 19 — static-name `v-bind` modifiers (2026-08-24)
+
+> Part of the [P2-11 series record](../p2-11.md), split per installment.
+
+[#4803](https://github.com/ubugeeei-prod/vize/pull/4803) moved
+static-name `v-bind` modifiers out of the S2 DOM emit lane's local
+`Unsupported` bucket. Davinci now realizes `.camel`, `.prop`, `.attr`,
+and the dot shorthand into the same DOM prop-key spellings as the
+shipped lane:
+
+- `.camel` camelizes the static key before emission.
+- `.prop` prefixes the emitted key with `.` and preserves the shipped
+  `NEED_HYDRATION` patch-flag bit.
+- `.attr` prefixes the emitted key with `^`.
+- `.foo="bar"` follows the lowering's parser-mirrored dot shorthand and
+  emits exactly like `:foo.prop="bar"`.
+
+The implementation keeps raw S2 names separate from realized DOM keys:
+`emit/props_bind.rs` now owns the static bind-key transform and callers
+choose ordinary props casing or the `<slot>` outlet camelizing rule. The
+same helper feeds ordinary props, `mergeProps` dynamic-prop tracking, and
+slot outlet props, so the modifier rules do not drift across the three
+emit sites.
+
+The durable witnesses are:
+
+- `crates/vize_ricalco/tests/emit_bind_modifiers.rs` — direct S2 emit
+  snapshots for `.camel`, `.prop`, `.attr`, and the dot shorthand.
+- `crates/vize_atelier_dom/tests/davinci_s2_bind_modifiers.rs` — eleven
+  S2-vs-shipped DOM lane byte-for-byte comparisons covering native
+  elements, components, `mergeProps`, `v-if`, `v-for`, and slot outlets.
+
+This installment does not tick P2-11. Filters, dynamic-argument
+`v-bind` names/modifiers, and local slot/outlet guard-only shapes remain
+in the named unsupported list.


### PR DESCRIPTION
## Summary
- record #4803 as P2-11 installment 19 after it landed on origin/main
- add the per-installment note for static-name `v-bind` modifiers
- update the named Unsupported remainder now that `.camel`, `.prop`, `.attr`, and dot shorthand are realized

## Validation
- `nix develop -c vp fmt davinci-road/plan/phase-2-records/p2-11.md davinci-road/plan/phase-2-records/p2-11/installment-19.md`
- `nix develop -c vp fmt --check davinci-road/plan/phase-2-records/p2-11.md davinci-road/plan/phase-2-records/p2-11/installment-19.md`
- `git diff --check`
