### PR TITLE
fix(content-mapper): drop protocol version negotiation

### DIFF
--- a/crates/vize/src/commands/content_mapper.rs
+++ b/crates/vize/src/commands/content_mapper.rs
@@ -21,7 +21,6 @@ use vize_carton::{String as CompactString, cstr};
 mod project;
 use project::{CloseProjectParams, OpenProjectParams, ProjectRegistry, resolve_open_project};
 
-const PROTOCOL_VERSION: u8 = 1;
 const MAX_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
 
 #[derive(Args, Default)]
@@ -51,7 +50,6 @@ struct Request {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct InitializeParams {
-    protocol_version: Option<u8>,
     #[allow(dead_code)]
     locale: Option<CompactString>,
     position_encodings: Vec<CompactString>,
@@ -89,17 +87,6 @@ fn serve<R: BufRead, W: Write>(reader: &mut R, writer: &mut W) -> io::Result<()>
                         continue;
                     }
                 };
-                if params
-                    .protocol_version
-                    .is_some_and(|version| version != PROTOCOL_VERSION)
-                {
-                    let message = cstr!(
-                        "Unsupported protocol version {} (expected {PROTOCOL_VERSION})",
-                        params.protocol_version.unwrap_or_default()
-                    );
-                    write_error(writer, id, -32602, &message)?;
-                    continue;
-                }
                 if !params
                     .position_encodings
                     .iter()

--- a/crates/vize/src/commands/content_mapper/test_support.rs
+++ b/crates/vize/src/commands/content_mapper/test_support.rs
@@ -13,7 +13,6 @@ pub(super) fn initialize_request() -> Value {
         "id": 1,
         "method": "initialize",
         "params": {
-            "protocolVersion": 1,
             "positionEncodings": ["utf-8"]
         }
     })

--- a/crates/vize/src/commands/content_mapper/tests.rs
+++ b/crates/vize/src/commands/content_mapper/tests.rs
@@ -5,14 +5,14 @@ use super::test_support::{
 };
 
 #[test]
-fn accepts_legacy_initialize_version_without_echoing_it() {
+fn ignores_legacy_initialize_version_without_echoing_it() {
     let input = frames(&[
         json!({
             "jsonrpc": "2.0",
             "id": 1,
             "method": "initialize",
             "params": {
-                "protocolVersion": 1,
+                "protocolVersion": 999,
                 "positionEncodings": ["utf-16", "utf-8"],
                 "locale": "en-US"
             }


### PR DESCRIPTION
## Summary

- Remove Content Mapper protocol-version negotiation from the Vize mapper server.
- Keep legacy `protocolVersion` initialize params ignored rather than rejected, matching TypeScript's post-#63936 capability-based handshake.
- Update the test helper so Vize's own Content Mapper tests use the current initialize shape.

## Validation

- `cargo test -p vize content_mapper --lib -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `MOON_HOME=/tmp/vize-moonbit-release.N4SQlL/moonbit MOON_BIN=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims/moon PATH=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims:/tmp/vize-moonbit-release.N4SQlL/moonbit/bin:$PATH node --test tests/tooling/source-file-lengths.test.ts`

Refs #4052.
Related upstream: microsoft/TypeScript#63936.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790177485&installation_model_id=422833&pr_number=4807&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4807&signature=6132ab180217a2c4be7db57b90950ee4b3b4e1519a84f315332a9836b061731f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization compatibility with clients using legacy or unrecognized protocol versions.
  * Continued requiring UTF-8 position encoding for reliable content transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->