### PR TITLE
fix(release): accept typecheck divergence v6 evidence

### DIFF
--- a/tests/tooling/_helpers/release-preflight-matrix-evidence-fixture.ts
+++ b/tests/tooling/_helpers/release-preflight-matrix-evidence-fixture.ts
@@ -79,7 +79,7 @@ export function shardEntries(
   entries[`${projectId}-typecheck-dependencies.json`] = dependencyText;
   entries[`${projectId}-typecheck-divergence.json`] = json({
     schema: "vize.fixtureTypecheckDivergenceRun",
-    version: 5,
+    version: 6,
     project: projectId,
     revision: "b".repeat(40),
     evidence: { commitSha: releaseSha },

--- a/tools/github/release-preflight-typecheck-evidence.mjs
+++ b/tools/github/release-preflight-typecheck-evidence.mjs
@@ -114,7 +114,7 @@ function assertReleaseTypecheckDivergenceArtifact({
 }) {
   if (
     divergence.schema !== "vize.fixtureTypecheckDivergenceRun" ||
-    divergence.version !== 5 ||
+    divergence.version !== 6 ||
     divergence.evidence?.commitSha !== run.head_sha
   ) {
     throw new Error(


### PR DESCRIPTION
## Summary
- update release preflight typecheck evidence validation to accept the current fixtureTypecheckDivergenceRun v6 artifact schema
- update the release preflight matrix evidence test fixture to match the divergence report writer

## Tests
- nix develop --command node --test tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/release-preflight-matrix-evidence-rejections.test.ts tests/tooling/typecheck-divergence-report.test.ts
- nix develop --command vp fmt --check tools/github/release-preflight-typecheck-evidence.mjs tests/tooling/_helpers/release-preflight-matrix-evidence-fixture.ts
- git diff --check

Refs #4461.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790177628&installation_model_id=422833&pr_number=4808&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4808&signature=6bc6d1d4bbe1e058b1a93acd9a13db9855c122c43b8c072f59de88bc21ed8ee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->