### PR TITLE
chore(rust): raise workspace MSRV to 1.98

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -104,7 +104,7 @@ jobs:
         run: node tools/github/semver-change-marker.mjs "$RUNNER_TEMP/semver-change-marker.txt"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          toolchain: 1.95.0
+          toolchain: 1.98.0
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
           wild-version: "0.9.0"
@@ -119,7 +119,7 @@ jobs:
       - name: Check public API SemVer compatibility
         env:
           BASELINE_REV: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || (github.event_name == 'push' && github.event.before || '') }}
-          RUSTUP_TOOLCHAIN: 1.95.0
+          RUSTUP_TOOLCHAIN: 1.98.0
         run: |
           case "$BASELINE_REV" in 0000000000000000000000000000000000000000) BASELINE_REV="";; esac
           SEMVER_CHANGE_MARKER="$(cat "$RUNNER_TEMP/semver-change-marker.txt")"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ members = [
 [workspace.package]
 version = "0.387.0"
 edition = "2024"
-rust-version = "1.95.0"
+rust-version = "1.98.0"
 license = "MIT"
 repository = "https://github.com/ubugeeei-prod/vize"
 

--- a/docs/content/contributing.md
+++ b/docs/content/contributing.md
@@ -12,7 +12,7 @@ are here to report findings rather than open a PR, start with the
 ## Setup
 
 Use the Node.js version from `.node-version` and the Rust version from `rust-toolchain.toml`. The
-workspace declares a minimum supported Rust version (MSRV) of `1.95.0` in `Cargo.toml`
+workspace declares a minimum supported Rust version (MSRV) of `1.98.0` in `Cargo.toml`
 (`[workspace.package].rust-version`); contributions must compile under that version.
 
 The default Nix shell contains the reproducible local toolchain. Blacksmith Testbox support is

--- a/docs/content/fr/contributing.md
+++ b/docs/content/fr/contributing.md
@@ -14,7 +14,7 @@ ici pour rapporter des résultats plutôt que pour ouvrir une PR, commencez par 
 ## Mise en place
 
 Utilisez la version Node.js de `.node-version` et la version Rust de `rust-toolchain.toml`. L’espace de travail
-déclare une version minimale Rust prise en charge (MSRV) de `1.95.0` dans `Cargo.toml`
+déclare une version minimale Rust prise en charge (MSRV) de `1.98.0` dans `Cargo.toml`
 (`[workspace.package].rust-version`; les contributions doivent être compilées sous cette version.
 
 Le shell Nix par défaut contient la chaîne d’outils locale reproductible. Le support de Blacksmith Testbox est

--- a/docs/content/ja/contributing.md
+++ b/docs/content/ja/contributing.md
@@ -14,7 +14,7 @@ PR を開くのではなく、調査結果を報告するためにここにい�
 ## 設定
 
 Node.js バージョンは `.node-version` から、Rust バージョンは `rust-toolchain.toml` から使用します。の
-ワークスペースは、`Cargo.toml` で `1.95.0` のサポートされる最小 Rust バージョン (MSRV) を宣言します
+ワークスペースは、`Cargo.toml` で `1.98.0` のサポートされる最小 Rust バージョン (MSRV) を宣言します
 (`[workspace.package].rust-version`);コントリビューションはそのバージョンでコンパイルする必要があります。
 
 デフォルトの Nix シェルには、再現可能なローカル ツールチェーンが含まれています。 Blacksmith テストボックスのサポートは

--- a/docs/content/pt-BR/contributing.md
+++ b/docs/content/pt-BR/contributing.md
@@ -14,7 +14,7 @@ está aqui para relatar descobertas em vez de abrir um PR, comece pelo guia
 ## Configuração
 
 Use a versão Node.js da `.node-version` e a versão da Ferrugem da `rust-toolchain.toml`. O
-workspace declara uma versão mínima suportada de Rust (MSRV) de `1.95.0` em `Cargo.toml`
+workspace declara uma versão mínima suportada de Rust (MSRV) de `1.98.0` em `Cargo.toml`
 (`[workspace.package].rust-version`); as contribuições devem ser compiladas sob essa versão.
 
 O shell padrão do Nix contém a cadeia de ferramentas local reproduzível. O suporte ao Blacksmith Testbox

--- a/docs/content/zh-CN/contributing.md
+++ b/docs/content/zh-CN/contributing.md
@@ -14,7 +14,7 @@ title: 贡献
 ## 布置
 
 用`.node-version`的Node.js版本和`rust-toolchain.toml`的Rust版本。该
-workspace 在 `Cargo.toml` 中声明了最低支持的 Rust 版本（MSRV）的 `1.95.0`
+workspace 在 `Cargo.toml` 中声明了最低支持的 Rust 版本（MSRV）的 `1.98.0`
 （`[workspace.package].rust-version`）;贡献必须按该版本编译。
 
 默认的 Nix shell 包含可重复的本地工具链。Blacksmith测试盒支持是


### PR DESCRIPTION
## Summary
- raise the workspace `rust-version` MSRV from 1.95.0 to 1.98.0
- align the semver-check CI job with Rust 1.98.0
- update current contributing docs across locales

## Validation
- rustup check (`stable-aarch64-apple-darwin` reports 1.98.0 up to date)
- rustc -Vv (`rustc 1.98.0 (88d9e12ae 2026-08-18)`)
- cargo fmt --all --check
- git diff --check
- cargo check --workspace --locked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Raised the minimum supported Rust version to 1.98.0.

- **Documentation**
  - Updated contribution guides in English, French, Japanese, Portuguese, and Simplified Chinese to reflect the new minimum Rust version.

- **Tests**
  - Updated compatibility checks to validate against Rust 1.98.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->