### PR TITLE
test(content-mapper): prove declaration map navigation

### DIFF
--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -9,15 +9,21 @@ use vize_carton::String as CompactString;
 
 mod leak_assertions;
 mod navigation;
+mod package_install;
+mod process_output;
 pub mod raw_requests;
 mod responder;
+mod stop;
 pub use leak_assertions::{assert_no_generated_uri, assert_no_generated_uri_or_zero_range};
 #[allow(unused_imports)]
 pub use navigation::{
     contains_location_range, contains_range, contains_text_edit, document_highlights, references,
     rename,
 };
+pub use package_install::install_packages;
+pub use process_output::output_text;
 pub use responder::EditorResponder;
+pub use stop::StopOnDrop;
 
 struct RawDocumentDiagnostic;
 struct RawHover;
@@ -252,40 +258,6 @@ pub fn copy_fixture(source: &Path, destination: &Path) {
             std::fs::copy(source_path, destination_path).unwrap();
         }
     }
-}
-
-pub fn install_packages(project_root: &Path) {
-    let mapper_root = project_root.join("node_modules/vize");
-    std::fs::create_dir_all(&mapper_root).unwrap();
-    std::fs::write(
-        mapper_root.join("package.json"),
-        serde_json::to_vec_pretty(&json!({
-            "name": "vize",
-            "private": true,
-            "typescript": { "contentMapper": {
-                "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
-                "compilerOptions": ["noUnusedLocals"],
-            } },
-        }))
-        .unwrap(),
-    )
-    .unwrap();
-
-    let store = workspace_root().join("node_modules/.pnpm");
-    let mut candidates = std::fs::read_dir(&store)
-        .unwrap()
-        .filter_map(Result::ok)
-        .filter(|entry| entry.file_name().to_string_lossy().starts_with("vue@3."))
-        .map(|entry| entry.path().join("node_modules/vue"))
-        .filter(|path| path.join("package.json").is_file())
-        .collect::<Vec<_>>();
-    candidates.sort();
-    let source = candidates.pop().expect("workspace Vue package");
-    let target = project_root.join("node_modules/vue");
-    #[cfg(unix)]
-    std::os::unix::fs::symlink(source, target).unwrap();
-    #[cfg(windows)]
-    std::os::windows::fs::symlink_dir(source, target).unwrap();
 }
 
 pub fn file_uri(path: &Path) -> CompactString {

--- a/crates/vize/tests/content_mapper_lsp_support/package_install.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/package_install.rs
@@ -1,0 +1,54 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::json;
+
+use super::workspace_root;
+
+pub fn install_packages(project_root: &Path) {
+    install_mapper_package(project_root);
+    link_vue_package(project_root);
+}
+
+fn install_mapper_package(project_root: &Path) {
+    let mapper_root = project_root.join("node_modules/vize");
+    std::fs::create_dir_all(&mapper_root).unwrap();
+    std::fs::write(
+        mapper_root.join("package.json"),
+        serde_json::to_vec_pretty(&json!({
+            "name": "vize",
+            "private": true,
+            "typescript": { "contentMapper": {
+                "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
+                "compilerOptions": ["noUnusedLocals"],
+            } },
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+}
+
+fn link_vue_package(project_root: &Path) {
+    let source = configured_vue_package().unwrap_or_else(workspace_vue_package);
+    let target = project_root.join("node_modules/vue");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(source, target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(source, target).unwrap();
+}
+
+fn configured_vue_package() -> Option<PathBuf> {
+    std::env::var_os("VIZE_TEST_CONTENT_MAPPER_VUE").map(PathBuf::from)
+}
+
+fn workspace_vue_package() -> PathBuf {
+    let store = workspace_root().join("node_modules/.pnpm");
+    let mut candidates = std::fs::read_dir(&store)
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|entry| entry.file_name().to_string_lossy().starts_with("vue@3."))
+        .map(|entry| entry.path().join("node_modules/vue"))
+        .filter(|path| path.join("package.json").is_file())
+        .collect::<Vec<_>>();
+    candidates.sort();
+    candidates.pop().expect("workspace Vue package")
+}

--- a/crates/vize/tests/content_mapper_lsp_support/process_output.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/process_output.rs
@@ -1,0 +1,10 @@
+use std::process::Output;
+
+pub fn output_text(output: &Output) -> String {
+    let stdout = std::str::from_utf8(&output.stdout).unwrap_or("<non-UTF-8 stdout>");
+    let stderr = std::str::from_utf8(&output.stderr).unwrap_or("<non-UTF-8 stderr>");
+    format!(
+        "status: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status, stdout, stderr
+    )
+}

--- a/crates/vize/tests/content_mapper_lsp_support/stop.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/stop.rs
@@ -1,0 +1,9 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+
+pub struct StopOnDrop<'a>(pub &'a AtomicBool);
+
+impl Drop for StopOnDrop<'_> {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}

--- a/crates/vize/tests/content_mapper_tsgo_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -12,19 +13,12 @@ use content_mapper_lsp_support::raw_requests::{
     RawInitialize, RawInitialized, RawSetContentMapperContributions,
 };
 use content_mapper_lsp_support::{
-    EditorResponder, copy_fixture, editor_capabilities, file_uri, install_packages,
+    EditorResponder, StopOnDrop, assert_no_generated_uri, contains_location, copy_fixture,
+    definition, editor_capabilities, file_uri, install_packages, output_text, position,
     pull_diagnostics, workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
-
-struct StopOnDrop<'a>(&'a AtomicBool);
-
-impl Drop for StopOnDrop<'_> {
-    fn drop(&mut self) {
-        self.0.store(true, Ordering::Relaxed);
-    }
-}
 
 #[test]
 fn standard_tsgo_lsp_accepts_authored_vue_content_mapper_contribution() {
@@ -132,6 +126,213 @@ fn standard_tsgo_lsp_accepts_authored_vue_content_mapper_contribution() {
 
             let clean = pull_diagnostics(&client, &child_uri).await;
             assert_eq!(clean["items"], json!([]), "{clean:#}");
+            stop.store(true, Ordering::Relaxed);
+            client.graceful_close().await.unwrap();
+            responder.join().unwrap();
+        });
+    });
+}
+
+#[test]
+fn standard_tsgo_lsp_uses_vue_declaration_maps_from_packed_consumer() {
+    let Some(tsgo) = std::env::var_os(TSGO_ENV).map(PathBuf::from) else {
+        eprintln!("skipping exact Content Mapper declaration-map consumer: {TSGO_ENV} is not set");
+        return;
+    };
+    let cases_root = workspace_root().join("target/vize-tests/tests");
+    std::fs::create_dir_all(&cases_root).unwrap();
+    let library = tempfile::Builder::new()
+        .prefix("content-mapper-declaration-library-")
+        .tempdir_in(&cases_root)
+        .unwrap();
+    install_packages(library.path());
+    std::fs::create_dir_all(library.path().join("src")).unwrap();
+    let app_source = r#"<script setup lang="ts">
+export interface PublicProps {
+  label: string;
+}
+
+defineProps<PublicProps>();
+</script>
+
+<template>
+  <p>{{ label }}</p>
+</template>
+"#;
+    let index_source = r#"export { default as App } from "./App.vue";
+export type { PublicProps } from "./App.vue";
+"#;
+    std::fs::write(library.path().join("src/App.vue"), app_source).unwrap();
+    std::fs::write(library.path().join("src/index.ts"), index_source).unwrap();
+    std::fs::write(
+        library.path().join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "contentMappers": [{ "package": "vize", "extensions": [".vue"] }],
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    let emit = Command::new(&tsgo)
+        .current_dir(library.path())
+        .args([
+            "--runExternalCode",
+            "-p",
+            "tsconfig.json",
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+    assert!(emit.status.success(), "{}", output_text(&emit));
+
+    let consumer = tempfile::Builder::new()
+        .prefix("content-mapper-declaration-consumer-")
+        .tempdir_in(cases_root)
+        .unwrap();
+    install_packages(consumer.path());
+    std::fs::create_dir_all(consumer.path().join("src")).unwrap();
+    let consumer_source = r#"import { App } from "@scope/emitted-vue";
+import type { PublicProps } from "@scope/emitted-vue";
+
+const props: PublicProps = { label: "ok" };
+type ComponentProps = InstanceType<typeof App>["$props"];
+const componentProps: ComponentProps = props;
+void componentProps;
+"#;
+    std::fs::write(consumer.path().join("src/index.ts"), consumer_source).unwrap();
+    std::fs::write(
+        consumer.path().join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    let package_root = consumer.path().join("node_modules/@scope/emitted-vue");
+    std::fs::create_dir_all(&package_root).unwrap();
+    std::fs::write(
+        package_root.join("package.json"),
+        r#"{
+  "name": "@scope/emitted-vue",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./index.js"
+    }
+  }
+}"#,
+    )
+    .unwrap();
+    copy_fixture(&library.path().join("dist"), &package_root.join("dist"));
+    copy_fixture(&library.path().join("src"), &package_root.join("src"));
+
+    let consumer_path = consumer.path().join("src/index.ts");
+    let consumer_uri = file_uri(&consumer_path);
+    let package_app_path = package_root.join("src/App.vue");
+    let package_app_uri = file_uri(&package_app_path);
+    let root_uri = file_uri(consumer.path());
+    let public_props_position = position(
+        consumer_source,
+        consumer_source
+            .find("PublicProps")
+            .expect("consumer imports PublicProps"),
+    );
+    let public_props_target = position(
+        app_source,
+        app_source
+            .find("PublicProps")
+            .expect("authored Vue source exports PublicProps"),
+    );
+
+    let stop = AtomicBool::new(false);
+    let editor = EditorResponder::default();
+    std::thread::scope(|scope| {
+        let _stop_on_drop = StopOnDrop(&stop);
+        corsa::runtime::block_on(async {
+            let client = LspClient::spawn(
+                LspSpawnConfig::new(&tsgo)
+                    .with_cwd(consumer.path())
+                    .with_request_timeout(Some(Duration::from_secs(30))),
+            )
+            .await
+            .unwrap();
+            let responder_client = client.clone();
+            let events = responder_client.subscribe();
+            let stop_ref = &stop;
+            let editor_ref = &editor;
+            let responder = scope.spawn(move || {
+                while !stop_ref.load(Ordering::Relaxed) {
+                    if let Ok(InboundEvent::Request { id, method, params }) =
+                        events.recv_timeout(Duration::from_millis(50))
+                    {
+                        let result = editor_ref.respond_to(method.as_str(), &params);
+                        let _ = responder_client.respond(id, result);
+                    }
+                }
+            });
+            let initialize = client
+                .request::<RawInitialize>(json!({
+                    "processId": std::process::id(),
+                    "rootUri": root_uri,
+                    "workspaceFolders": [{ "uri": root_uri, "name": "content-mapper-consumer" }],
+                    "capabilities": editor_capabilities(),
+                    "initializationOptions": { "runExternalCode": true }
+                }))
+                .await
+                .unwrap();
+            assert!(initialize["capabilities"].is_object(), "{initialize:#}");
+            client.notify::<RawInitialized>(json!({})).unwrap();
+            client
+                .request::<RawSetContentMapperContributions>(json!({
+                    "contributions": [{
+                        "contributorId": "vize",
+                        "extensions": [".vue"],
+                        "inferredProjectContribution": {
+                            "options": {},
+                            "manifest": {
+                                "name": "vize",
+                                "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
+                                "compilerOptions": ["noUnusedLocals"]
+                            }
+                        }
+                    }],
+                    "openDocuments": [{ "uri": consumer_uri }, { "uri": package_app_uri }]
+                }))
+                .await
+                .unwrap();
+
+            let overlay = client.overlay();
+            let uri = Uri::from_str(&consumer_uri).unwrap();
+            overlay
+                .open(VirtualDocument::new(uri, "typescript", consumer_source))
+                .unwrap();
+            let mapped_definition =
+                definition(&client, &consumer_uri, &public_props_position).await;
+            assert!(
+                contains_location(&mapped_definition, &package_app_uri, &public_props_target),
+                "definition should use declaration maps to land on authored App.vue:\n{mapped_definition:#}"
+            );
+            assert_no_generated_uri(&mapped_definition);
+
             stop.store(true, Ordering::Relaxed);
             client.graceful_close().await.unwrap();
             responder.join().unwrap();


### PR DESCRIPTION
## Summary
- add an exact tsgo LSP packed-consumer oracle for Vue declaration maps
- emit a package with `.d.ts.map`, install it into a separate consumer, and assert definition jumps back to authored `App.vue`
- let the LSP test helper use `VIZE_TEST_CONTENT_MAPPER_VUE` for isolated worktrees

## Validation
- VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/vize-tsgo-63936-s1zxyd/tsgo VIZE_TEST_CONTENT_MAPPER_VUE=/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue GOCACHE=/private/tmp/vize-go-cache-test cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture
- VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/vize-tsgo-63936-s1zxyd/tsgo VIZE_TEST_CONTENT_MAPPER_VUE=/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue GOCACHE=/private/tmp/vize-go-cache-test cargo test -p vize --test content_mapper_tsgo_build -- --nocapture
- cargo fmt --all --check
- git diff --check
- MOON_HOME=/tmp/vize-moonbit-release.N4SQlL/moonbit MOON_BIN=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims/moon PATH=/tmp/vize-moonbit-release.N4SQlL/moonbit-shims:/tmp/vize-moonbit-release.N4SQlL/moonbit/bin:$PATH node --test tests/tooling/source-file-lengths.test.ts

Refs #4052

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790181726&installation_model_id=422833&pr_number=4812&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4812&signature=1430f53ee53939c0fc856d07c1d52452759877f78585196119a200811fbcdf9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for TypeScript declaration-map resolution in Vue libraries.
  * Improved test setup for package installation, process output reporting, and cleanup handling.
  * Verified that consumers resolve definitions to authored Vue source files rather than generated URIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->