### PR TITLE
test(glyph): compare stable Pug compiler warnings

### DIFF
--- a/tests/tooling/glyph-pug-oracle.test.ts
+++ b/tests/tooling/glyph-pug-oracle.test.ts
@@ -15,7 +15,8 @@ import {
   comparePugTemplateEquivalence,
   isPugSfc,
 } from "./support/pug-template-equivalence.ts";
-import { sha256 } from "./support/pug/oracle-runtime.ts";
+import { diagnosticSignatures, sha256 } from "./support/pug/oracle-runtime.ts";
+import type { CapturedDiagnostic } from "./support/pug/oracle-runtime.ts";
 
 const pugMutationBaseline = `<template lang="pug">
 main
@@ -31,6 +32,18 @@ main
 </template>
 `;
 
+function nestingWarning(element: "pre" | "ul"): CapturedDiagnostic {
+  return {
+    severity: "warning",
+    value: {
+      name: "SyntaxError",
+      message:
+        `<${element}> cannot be child of <p>, according to HTML specifications. ` +
+        "This can cause hydration errors or potentially disrupt future functionality.",
+    },
+  };
+}
+
 const waveUiStableWarningRegressions = [
   {
     path: "src/documentation/views/customization.vue",
@@ -43,7 +56,7 @@ main
     | , the selector changes.
 </template>
 `,
-    warning: "<pre> cannot be child of <p>",
+    warning: nestingWarning("pre"),
   },
   {
     path: "src/documentation/views/ui-components/button/examples.vue",
@@ -55,7 +68,7 @@ div
       li Status colors have white text.
 </template>
 `,
-    warning: "<ul> cannot be child of <p>",
+    warning: nestingWarning("ul"),
   },
 ] as const;
 
@@ -187,25 +200,43 @@ test("Pug oracle accepts the two Wave UI files with stable compiler warnings", (
       });
       assert.equal(result.baselineUsable, true, regression.path);
       assert.deepEqual(result.differences, [], regression.path);
-      assert.match(
-        result.evidence.pristine.diagnosticsSha256 ?? "",
-        /^[0-9a-f]{64}$/u,
-        regression.path,
+      const expectedWarningHash = sha256(
+        JSON.stringify(diagnosticSignatures([regression.warning])),
       );
       assert.equal(
         result.evidence.pristine.diagnosticsSha256,
-        result.evidence.formatted.diagnosticsSha256,
-        regression.path,
+        expectedWarningHash,
+        `${regression.path} must emit exactly its pinned warning`,
       );
-      assert.notEqual(
-        result.evidence.pristine.diagnosticsSha256,
-        sha256(JSON.stringify([])),
-        regression.warning,
+      assert.equal(
+        result.evidence.formatted.diagnosticsSha256,
+        expectedWarningHash,
+        `${regression.path} must preserve exactly its pinned warning`,
       );
     }
   } finally {
     fs.rmSync(basedir, { recursive: true, force: true });
   }
+});
+
+test("Pug warning signatures ignore order but preserve duplicate multiplicity", () => {
+  const [preWarning, ulWarning] = waveUiStableWarningRegressions.map(
+    (regression) => regression.warning,
+  );
+  const ordered = diagnosticSignatures([preWarning, ulWarning]);
+  const reordered = diagnosticSignatures([ulWarning, preWarning]);
+  assert.deepEqual(reordered, ordered);
+
+  const withDuplicate = diagnosticSignatures([preWarning, ulWarning, preWarning]);
+  assert.notDeepEqual(withDuplicate, ordered, "adding a duplicate warning must change output");
+  assert.notEqual(JSON.stringify(withDuplicate), JSON.stringify(ordered));
+  const afterDuplicateRemoval = diagnosticSignatures([ulWarning, preWarning]);
+  assert.notDeepEqual(
+    withDuplicate,
+    afterDuplicateRemoval,
+    "removing a duplicate warning must change output",
+  );
+  assert.equal(withDuplicate.length, ordered.length + 1);
 });
 
 test("Pug oracle rejects warning additions, removals, and content changes", () => {

--- a/tests/tooling/glyph-pug-oracle.test.ts
+++ b/tests/tooling/glyph-pug-oracle.test.ts
@@ -15,6 +15,7 @@ import {
   comparePugTemplateEquivalence,
   isPugSfc,
 } from "./support/pug-template-equivalence.ts";
+import { sha256 } from "./support/pug/oracle-runtime.ts";
 
 const pugMutationBaseline = `<template lang="pug">
 main
@@ -29,6 +30,34 @@ main
     a  b
 </template>
 `;
+
+const waveUiStableWarningRegressions = [
+  {
+    path: "src/documentation/views/customization.vue",
+    source: `<template lang="pug">
+main
+  p
+    | For instance if you set the scope to:
+    pre.ssh-pre(data-type="css")
+      strong.pink $css-scope
+    | , the selector changes.
+</template>
+`,
+    warning: "<pre> cannot be child of <p>",
+  },
+  {
+    path: "src/documentation/views/ui-components/button/examples.vue",
+    source: `<template lang="pug">
+div
+  p
+    strong.mr1 Note:
+    ul
+      li Status colors have white text.
+</template>
+`,
+    warning: "<ul> cannot be child of <p>",
+  },
+] as const;
 
 function temporaryPugContext() {
   const basedir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-pug-oracle-"));
@@ -142,6 +171,70 @@ test("Pug oracle pins provenance and accepts only an opaque outer-indent rebase"
       displayFilename: "different-logical-name/App.vue",
     });
     assert.notEqual(result.evidence.contextSha256, otherContext.evidence.contextSha256);
+  } finally {
+    fs.rmSync(basedir, { recursive: true, force: true });
+  }
+});
+
+test("Pug oracle accepts the two Wave UI files with stable compiler warnings", () => {
+  const { basedir, context } = temporaryPugContext();
+  try {
+    for (const regression of waveUiStableWarningRegressions) {
+      const result = comparePugTemplateEquivalence(regression.source, regression.source, {
+        ...context,
+        filename: path.join(basedir, regression.path),
+        displayFilename: `wave-ui/${regression.path}`,
+      });
+      assert.equal(result.baselineUsable, true, regression.path);
+      assert.deepEqual(result.differences, [], regression.path);
+      assert.match(
+        result.evidence.pristine.diagnosticsSha256 ?? "",
+        /^[0-9a-f]{64}$/u,
+        regression.path,
+      );
+      assert.equal(
+        result.evidence.pristine.diagnosticsSha256,
+        result.evidence.formatted.diagnosticsSha256,
+        regression.path,
+      );
+      assert.notEqual(
+        result.evidence.pristine.diagnosticsSha256,
+        sha256(JSON.stringify([])),
+        regression.warning,
+      );
+    }
+  } finally {
+    fs.rmSync(basedir, { recursive: true, force: true });
+  }
+});
+
+test("Pug oracle rejects warning additions, removals, and content changes", () => {
+  const { basedir, context } = temporaryPugContext();
+  const clean = '<template lang="pug">\nmain\n  p text\n</template>\n';
+  const preWarning = waveUiStableWarningRegressions[0].source;
+  const ulWarning = waveUiStableWarningRegressions[1].source;
+  try {
+    for (const [label, before, after] of [
+      ["addition", clean, preWarning],
+      ["removal", preWarning, clean],
+      ["content change", preWarning, ulWarning],
+    ] as const) {
+      const result = comparePugTemplateEquivalence(before, after, context);
+      assert.equal(result.baselineUsable, true, label);
+      assert.match(result.differences.join("\n"), /Vue compiler warnings changed:/u, label);
+    }
+  } finally {
+    fs.rmSync(basedir, { recursive: true, force: true });
+  }
+});
+
+test("Pug oracle keeps fatal Vue compiler diagnostics unusable", () => {
+  const { basedir, context } = temporaryPugContext();
+  const source = '<template lang="pug">\nmain(v-for="")\n</template>\n';
+  try {
+    const result = comparePugTemplateEquivalence(source, source, context);
+    assert.equal(result.baselineUsable, false);
+    assert.match(result.differences.join("\n"), /pristine Vue baseline failed:/u);
   } finally {
     fs.rmSync(basedir, { recursive: true, force: true });
   }

--- a/tests/tooling/support/pug-template-equivalence.ts
+++ b/tests/tooling/support/pug-template-equivalence.ts
@@ -115,27 +115,32 @@ export function comparePugTemplateEquivalence(
   const differences = compareSfcBlockStructure(original, formatted, context.filename);
   const pristine = compileSide(original, context);
   const after = compileSide(formatted, context);
-  const baselineUsable = pristine.compiled != null && pristine.diagnostics.length === 0;
+  const pristineErrors = diagnosticsOfSeverity(pristine.diagnostics, "error");
+  const afterErrors = diagnosticsOfSeverity(after.diagnostics, "error");
+  const baselineUsable =
+    pristine.compiled != null && pristine.error == null && pristineErrors.length === 0;
 
   if (pristine.error != null) differences.push(`pristine Pug baseline failed: ${pristine.error}`);
-  if (pristine.diagnostics.length > 0) {
-    differences.push(`pristine Vue baseline failed: ${diagnosticSummary(pristine.diagnostics)}`);
+  if (pristineErrors.length > 0) {
+    differences.push(`pristine Vue baseline failed: ${diagnosticSummary(pristineErrors)}`);
   }
   if (after.error != null) differences.push(`formatted Pug baseline failed: ${after.error}`);
-  if (after.diagnostics.length > 0) {
-    differences.push(`formatted Vue baseline failed: ${diagnosticSummary(after.diagnostics)}`);
+  if (afterErrors.length > 0) {
+    differences.push(`formatted Vue baseline failed: ${diagnosticSummary(afterErrors)}`);
   }
 
   if (pristine.compiled != null && after.compiled != null) {
     if (pristine.evidence.relativePugSha256 !== after.evidence.relativePugSha256) {
       differences.push("relative authored Pug bytes changed");
     }
-    const beforeDiagnostics = diagnosticSignatures(pristine.diagnostics);
-    const afterDiagnostics = diagnosticSignatures(after.diagnostics);
-    if (JSON.stringify(beforeDiagnostics) !== JSON.stringify(afterDiagnostics)) {
+    const beforeWarnings = diagnosticSignatures(
+      diagnosticsOfSeverity(pristine.diagnostics, "warning"),
+    );
+    const afterWarnings = diagnosticSignatures(diagnosticsOfSeverity(after.diagnostics, "warning"));
+    if (JSON.stringify(beforeWarnings) !== JSON.stringify(afterWarnings)) {
       differences.push(
-        `Vue compiler diagnostics changed: ${JSON.stringify(beforeDiagnostics)} -> ` +
-          JSON.stringify(afterDiagnostics),
+        `Vue compiler warnings changed: ${JSON.stringify(beforeWarnings)} -> ` +
+          JSON.stringify(afterWarnings),
       );
     }
     const dependencyBefore = JSON.stringify(pristine.evidence.dependencies);
@@ -177,6 +182,13 @@ export function comparePugTemplateEquivalence(
             JSON.stringify(after.evidence.templateOffsets),
     },
   };
+}
+
+function diagnosticsOfSeverity(
+  diagnostics: CapturedDiagnostic[],
+  severity: CapturedDiagnostic["severity"],
+): CapturedDiagnostic[] {
+  return diagnostics.filter((diagnostic) => diagnostic.severity === severity);
 }
 
 function compileSide(


### PR DESCRIPTION
## Summary

- treat stable Pug compiler warnings as part of the formatter corpus oracle while keeping warning-only output usable
- compare deterministic warning signatures before and after formatting, including exact Wave UI warning fixtures
- prove order-insensitive comparison while preserving duplicate diagnostic cardinality

## Validation

- focused oracle and waiver tests pass locally
- the full sharded Glyph corpus and repository checks run in GitHub Actions

Fixes #4819