### PR TITLE
refactor(davinci): align fuzz stage aliases

### DIFF
--- a/tests/fuzz/Cargo.toml
+++ b/tests/fuzz/Cargo.toml
@@ -27,11 +27,11 @@ vize_atelier_sfc = { path = "../../crates/vize_atelier_sfc", default-features = 
   "native",
 ] }
 vize_atelier_dom = { path = "../../crates/vize_atelier_dom" }
-vize_carton = { path = "../../crates/vize_carton" }
+vize_s0 = { package = "vize_carton", path = "../../crates/vize_carton" }
 vize_davinci = { path = "../../crates/vize_davinci" }
-vize_disegno = { path = "../../crates/vize_disegno" }
-vize_ricalco = { path = "../../crates/vize_ricalco" }
-vize_sinopia = { path = "../../crates/vize_sinopia" }
+vize_s1 = { package = "vize_sinopia", path = "../../crates/vize_sinopia" }
+vize_s1_to_s2 = { package = "vize_ricalco", path = "../../crates/vize_ricalco" }
+vize_s2 = { package = "vize_disegno", path = "../../crates/vize_disegno" }
 
 [[bin]]
 name = "sfc_parse"

--- a/tests/fuzz/fuzz_targets/folio_parse.rs
+++ b/tests/fuzz/fuzz_targets/folio_parse.rs
@@ -5,8 +5,8 @@
 // Drives the hand-written Davinci folio parsers with arbitrary UTF-8
 // under the invariant that *no input must panic*: parsers return
 // `Result<_, FolioError>` for malformed pages, so a panic here is always
-// a bug. Three parsers share the input — the S2 Disegno page
-// (`vize_disegno`), the croquis page, and the repro page
+// a bug. Three parsers share the input — the S2 page
+// (`vize_s2`, package `vize_disegno`), the croquis page, and the repro page
 // (`vize_davinci`).
 //
 // When an input does parse, the mode-explicit round-trip law is asserted
@@ -19,7 +19,7 @@ use libfuzzer_sys::fuzz_target;
 use vize_davinci::folio::croquis::CroquisFolio;
 use vize_davinci::folio::repro::ReproFolio;
 use vize_davinci::folio::{Folio, FolioMode};
-use vize_disegno::folio::DisegnoFolio;
+use vize_s2::folio::DisegnoFolio;
 
 fn round_trip<F: Folio + PartialEq + core::fmt::Debug>(source: &str) {
     let Ok(parsed) = F::parse(source) else {

--- a/tests/fuzz/fuzz_targets/s1_lowering.rs
+++ b/tests/fuzz/fuzz_targets/s1_lowering.rs
@@ -3,9 +3,9 @@
 // S1 → S2 lowering fuzz target (Davinci P2-8, TS-20).
 //
 // Drives the full Davinci template front half with arbitrary UTF-8:
-// `vize_sinopia::parse` (the lossless S1 surface tree, total over
+// `vize_s1::parse` (the lossless S1 surface tree, total over
 // malformed input by the typed-hole policy) followed by
-// `vize_ricalco::lower` (the total S1→S2 lowering — S2 ops or
+// `vize_s1_to_s2::lower` (the total S1→S2 lowering — S2 ops or
 // diagnostics, never a panic and never a partial-then-abandoned state).
 //
 // The target asserts more than no-crash, so a logic break surfaces as a
@@ -17,11 +17,11 @@
 // The corpus is seeded from the `<template>` blocks of repository .vue
 // fixtures by `tools/fuzz/seed_corpus.mjs`.
 use libfuzzer_sys::fuzz_target;
-use vize_carton::Allocator;
 use vize_davinci::folio::{Folio, FolioMode};
-use vize_disegno::folio::DisegnoFolio;
-use vize_ricalco::lower;
-use vize_sinopia::parse;
+use vize_s0::Allocator;
+use vize_s1::parse;
+use vize_s1_to_s2::lower;
+use vize_s2::folio::DisegnoFolio;
 
 fuzz_target!(|data: &[u8]| {
     let Ok(source) = std::str::from_utf8(data) else {

--- a/tests/fuzz/fuzz_targets/template_compile.rs
+++ b/tests/fuzz/fuzz_targets/template_compile.rs
@@ -11,7 +11,7 @@
 // fixtures by `tools/fuzz/seed_corpus.mjs`.
 use libfuzzer_sys::fuzz_target;
 use vize_atelier_dom::compile_template;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 fuzz_target!(|data: &[u8]| {
     let Ok(source) = std::str::from_utf8(data) else {


### PR DESCRIPTION
## Summary
- rename the isolated cargo-fuzz stage dependencies to the preferred `vize_s0`, `vize_s1`, `vize_s2`, and `vize_s1_to_s2` aliases
- update fuzz target imports/comments to use the stage aliases while preserving the retained package ids and public type names

## Validation
- `cargo +nightly check --bins` from `tests/fuzz`
- `cargo +nightly fuzz check --fuzz-dir tests/fuzz s1_lowering`
- `cargo +nightly fuzz check --fuzz-dir tests/fuzz folio_parse`
- `cargo +nightly fuzz check --fuzz-dir tests/fuzz template_compile`
- `cargo +nightly fmt --check --manifest-path tests/fuzz/Cargo.toml`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790220658&installation_model_id=422833&pr_number=4841&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4841&signature=63d3ee3de0ba52d38ed7764b18a3d1ab0bbf4eed29308c2479a93b68daa14ff4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated fuzz-testing configurations and references to align with the latest package naming.
  - Preserved existing fuzz-test behavior while ensuring parsing, lowering, folio handling, and template compilation continue using the correct components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->