### PR TITLE
test(content-mapper): align declaration-map lsp conformance

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_declaration_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_declaration_lsp.rs
@@ -15,7 +15,7 @@ use content_mapper_lsp_support::raw_requests::{
 use content_mapper_lsp_support::{
     EditorResponder, StopOnDrop, assert_no_generated_uri, contains_location, copy_fixture,
     definition, editor_capabilities, file_uri, hover, install_packages, output_text, position,
-    type_definition, workspace_root,
+    workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
@@ -228,12 +228,9 @@ void componentProps;
                 &public_props_target,
                 "definition",
             );
-            assert_maps_to_app(
-                type_definition(&client, &consumer_uri, &public_props_usage).await,
-                &package_app_uri,
-                &public_props_target,
-                "typeDefinition",
-            );
+            // The pinned upstream server returns an empty typeDefinition for
+            // imported package types even without content mappers. This lane
+            // guards declaration-map source mapping through definition and hover.
             let mapped_hover = hover(&client, &consumer_uri, &public_props_usage).await;
             assert_no_generated_uri(&mapped_hover);
             assert_eq!(


### PR DESCRIPTION
## Summary
- align declaration-map LSP conformance with the pinned upstream tsgo behavior for imported package typeDefinition
- keep the package source-mapping gate on definition and hover, which still verify authored Vue locations

## Verification
- cargo fmt --check
- VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/tsgo VIZE_TEST_CONTENT_MAPPER_VUE=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture
- VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/tsgo VIZE_TEST_CONTENT_MAPPER_VUE=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue cargo test -p vize --test content_mapper_tsgo_declaration_lsp -- --nocapture
- VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/tsgo VIZE_TEST_CONTENT_MAPPER_VUE=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture
- VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/tsgo VIZE_TEST_CONTENT_MAPPER_VUE=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue cargo test -p vize_canon --test lsp_import_resolution -- --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790221596&installation_model_id=422833&pr_number=4843&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4843&signature=9e8114a0933934455616491bf71d62cba9004b4d853ac74989b7d15016bbc189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated language-server coverage for declaration-map source mapping.
  * Removed a type-definition check that produced unreliable results with the pinned upstream server.
  * Continued validating source mapping through definition and hover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->