### PR TITLE
refactor(davinci): use s1 alias in curator

### DIFF
--- a/crates/vize_curator/Cargo.toml
+++ b/crates/vize_curator/Cargo.toml
@@ -25,7 +25,7 @@ vize_croquis_cf = { workspace = true }
 # pages are proven through; both `no_std + alloc`, so the wasm consumer
 # (`vize_vitrine --features wasm`) is untouched.
 vize_davinci = { workspace = true }
-vize_sinopia = { workspace = true }
+vize_s1 = { workspace = true }
 
 [dev-dependencies]
 davinci_test_support.workspace = true

--- a/crates/vize_curator/src/inspector/spolvero.rs
+++ b/crates/vize_curator/src/inspector/spolvero.rs
@@ -10,13 +10,13 @@
 //! # What the feed carries today
 //!
 //! - **S1**: one page per `.vue` file with a template block, produced by
-//!   parsing the template into `vize_sinopia`'s lossless surface tree and
+//!   parsing the template into `vize_s1`'s lossless surface tree and
 //!   rendering it back (`stage: "s1"`, `pass: "parse"` - a parse product,
 //!   not a pass product). By the S1 byte-fidelity law (TS-19) the text
 //!   equals the authored template bytes, malformed input included - which
 //!   is exactly what the ladder's S1 rung shows, proven through the tree
 //!   rather than copied from the source.
-//! - **S2**: nothing yet. `vize_disegno` has no producer until the S1→S2
+//! - **S2**: nothing yet. `vize_s2` has no producer until the S1→S2
 //!   lowering (P2-8) lands; the feed shape is stage-agnostic, so S2 pages
 //!   join by pushing more [`SpolveroPage`]s here, with no schema change.
 //!
@@ -31,13 +31,13 @@ use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 
 use super::payload::InspectorSourceFile;
 
-/// The S1 page for one template: sinopia parse + byte-faithful render.
+/// The S1 page for one template: S1 parse + byte-faithful render.
 #[must_use]
 pub fn s1_page(path: &str, template: &str) -> SpolveroPage {
     let allocator = Allocator::default();
-    let (tree, _errors) = vize_sinopia::parse(&allocator, template);
+    let (tree, _errors) = vize_s1::parse(&allocator, template);
     let mut text = String::default();
-    vize_sinopia::render::render(&tree, &mut |slice| text.push_str(slice));
+    vize_s1::render::render(&tree, &mut |slice| text.push_str(slice));
     SpolveroPage {
         path: Some(String::from(path)),
         stage: cstr!("s1"),

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -49,10 +49,31 @@ const aliases = new Map<string, ReadonlyArray<readonly [string, string]>>([
   ],
 ]);
 
+const consumerAliases = new Map<string, ReadonlyArray<readonly [string, string]>>([
+  ["vize_curator", [["vize_sinopia", "vize_s1"]]],
+]);
+
 const metadata = readMetadata();
 
 test("Davinci crates import retained packages through stage aliases", () => {
   for (const [packageName, expectedAliases] of aliases) {
+    const dependencies = workspacePackage(metadata, packageName).dependencies;
+    for (const [dependencyName, rename] of expectedAliases) {
+      assert.ok(
+        dependencies.some(
+          (dependency) =>
+            dependency.kind === null &&
+            dependency.name === dependencyName &&
+            dependency.rename === rename,
+        ),
+        `${packageName} must import ${dependencyName} as ${rename}`,
+      );
+    }
+  }
+});
+
+test("Davinci consumers import stage packages through stage aliases", () => {
+  for (const [packageName, expectedAliases] of consumerAliases) {
     const dependencies = workspacePackage(metadata, packageName).dependencies;
     for (const [dependencyName, rename] of expectedAliases) {
       assert.ok(


### PR DESCRIPTION
## Summary
- import the S1 surface-tree package in vize_curator through the preferred `vize_s1` dependency alias
- align Spolvero S1/S2 implementation docs with physical stage names while preserving the Folio output contract
- add a Cargo-metadata ratchet for Davinci consumer stage aliases

## Validation
- `cargo check -p vize_curator --locked`
- `cargo test -p vize_curator --locked`
- `node --test tests/tooling/davinci-stage-dependencies.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790221783&installation_model_id=422833&pr_number=4845&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4845&signature=50330114b76e8652fc4bc6bc27670dabb7f1a1caf3cd13c0c88f87d101d4640b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->