### PR TITLE
test(content-mapper): stabilize exact LSP oracle

### DIFF
--- a/crates/vize/tests/content_mapper_lsp_support/component_oracles.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/component_oracles.rs
@@ -1,0 +1,120 @@
+use std::time::Duration;
+
+use corsa_lsp::{LspClient, LspOverlay};
+use lsp_types::Uri;
+use serde_json::Value;
+
+use super::{
+    assert_completion, assert_no_generated_uri, assert_no_generated_uri_or_zero_range,
+    contains_location, definition, hover, position,
+};
+
+pub async fn assert_component_completions(
+    client: &LspClient,
+    overlay: &LspOverlay,
+    uri: &Uri,
+    source: &str,
+) {
+    let partial = source
+        .replace(":count", ":cou")
+        .replace("@save=", "@sa=")
+        .replace("@save-item", "@save-");
+    let prop_position = position(&partial, partial.find(":cou").unwrap() + ":cou".len());
+    let event_position = position(&partial, partial.find("@sa").unwrap() + "@sa".len());
+    let kebab_event_position = position(&partial, partial.find("@save-").unwrap() + "@save-".len());
+    overlay.replace(uri, partial.as_str()).unwrap();
+    let uri_text = uri.as_str();
+    assert_completion(
+        client,
+        uri_text,
+        &prop_position,
+        "count",
+        &["(property) count: number"],
+    )
+    .await;
+    assert_completion(client, uri_text, &event_position, "save", &["number"]).await;
+    assert_completion(
+        client,
+        uri_text,
+        &kebab_event_position,
+        "save-item",
+        &["string"],
+    )
+    .await;
+    overlay.replace(uri, source).unwrap();
+}
+
+pub async fn assert_component_navigation(
+    client: &LspClient,
+    uri: &str,
+    position: &Value,
+    component_name: &str,
+    target_uri: &str,
+) {
+    let component_hover = hover(client, uri, position).await;
+    let hover_text = serde_json::to_string(&component_hover).unwrap();
+    let component_hover_matches =
+        hover_text.contains(component_name) && !hover_text.contains("__vize_component__");
+    assert!(component_hover_matches, "{component_hover:#}");
+    let component_definition = definition(client, uri, position).await;
+    assert_no_generated_uri(&component_definition);
+    let definition_text = serde_json::to_string(&component_definition).unwrap();
+    let definition_targets_authored_file = definition_text.contains(target_uri);
+    let definition_hides_virtual_file = !definition_text.contains(".vue.ts");
+    assert!(definition_targets_authored_file, "{component_definition:#}");
+    assert!(definition_hides_virtual_file, "{component_definition:#}");
+}
+
+pub async fn assert_prop_navigation(
+    client: &LspClient,
+    uri: &str,
+    position: &Value,
+    prop_name: &str,
+    prop_type: &str,
+    target_uri: &str,
+    target_start: &Value,
+) {
+    let mut prop_hover = hover(client, uri, position).await;
+    let mut hover_text = serde_json::to_string(&prop_hover).unwrap();
+    let mut prop_definition = definition(client, uri, position).await;
+    for _ in 0..60 {
+        let hover_ready = hover_text.contains(prop_name) && hover_text.contains(prop_type);
+        let definition_ready = contains_location(&prop_definition, target_uri, target_start);
+        if hover_ready && definition_ready {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+        if !hover_ready {
+            prop_hover = hover(client, uri, position).await;
+            hover_text = serde_json::to_string(&prop_hover).unwrap();
+        }
+        if !definition_ready {
+            prop_definition = definition(client, uri, position).await;
+        }
+    }
+    let hover_ready = hover_text.contains(prop_name) && hover_text.contains(prop_type);
+    assert!(
+        hover_ready,
+        "{prop_name} hover should include {prop_type}:\nhover:\n{prop_hover:#}\ndefinition:\n{prop_definition:#}"
+    );
+    assert_no_generated_uri_or_zero_range(&prop_definition);
+    assert!(
+        contains_location(&prop_definition, target_uri, target_start),
+        "{prop_name} definition should map to authored declaration:\n{prop_definition:#}"
+    );
+}
+
+pub async fn assert_component_members(
+    client: &LspClient,
+    parent: (&str, &str),
+    child: (&str, &str),
+) {
+    for (usage, declaration, name, ty) in [
+        (":count", "count: number", "count", "number"),
+        ("@save", "save: [value", "save", "number"),
+    ] {
+        let usage = position(parent.1, parent.1.find(usage).unwrap() + 1);
+        let declaration = position(child.1, child.1.find(declaration).unwrap());
+        assert_prop_navigation(client, parent.0, &usage, name, ty, child.0, &declaration).await;
+    }
+}

--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -2,11 +2,12 @@
 
 use std::{path::Path, str::FromStr};
 
-use corsa_lsp::{LspClient, LspOverlay};
+use corsa_lsp::LspClient;
 use lsp_types::{FileChangeType, FileEvent, Uri};
 use serde_json::{Value, json};
 use vize_carton::String as CompactString;
 
+mod component_oracles;
 mod leak_assertions;
 mod navigation;
 mod package_install;
@@ -14,6 +15,11 @@ mod process_output;
 pub mod raw_requests;
 mod responder;
 mod stop;
+#[allow(unused_imports)]
+pub use component_oracles::{
+    assert_component_completions, assert_component_members, assert_component_navigation,
+    assert_prop_navigation,
+};
 pub use leak_assertions::{assert_no_generated_uri, assert_no_generated_uri_or_zero_range};
 #[allow(unused_imports)]
 pub use navigation::{
@@ -24,6 +30,7 @@ pub use package_install::install_packages;
 #[allow(unused_imports)]
 pub use process_output::output_text;
 pub use responder::EditorResponder;
+#[allow(unused_imports)]
 pub use stop::StopOnDrop;
 
 struct RawDocumentDiagnostic;
@@ -129,104 +136,6 @@ pub async fn assert_completion(
         "{resolved:#}"
     );
     assert!(!resolved_text.contains(".vue.ts"), "{resolved:#}");
-}
-
-pub async fn assert_component_completions(
-    client: &LspClient,
-    overlay: &LspOverlay,
-    uri: &Uri,
-    source: &str,
-) {
-    let partial = source
-        .replace(":count", ":cou")
-        .replace("@save=", "@sa=")
-        .replace("@save-item", "@save-");
-    let prop_position = position(&partial, partial.find(":cou").unwrap() + ":cou".len());
-    let event_position = position(&partial, partial.find("@sa").unwrap() + "@sa".len());
-    let kebab_event_position = position(&partial, partial.find("@save-").unwrap() + "@save-".len());
-    overlay.replace(uri, partial.as_str()).unwrap();
-    let uri_text = uri.as_str();
-    assert_completion(
-        client,
-        uri_text,
-        &prop_position,
-        "count",
-        &["(property) count: number"],
-    )
-    .await;
-    assert_completion(client, uri_text, &event_position, "save", &["number"]).await;
-    assert_completion(
-        client,
-        uri_text,
-        &kebab_event_position,
-        "save-item",
-        &["string"],
-    )
-    .await;
-    overlay.replace(uri, source).unwrap();
-}
-
-pub async fn assert_component_navigation(
-    client: &LspClient,
-    uri: &str,
-    position: &Value,
-    component_name: &str,
-    target_uri: &str,
-) {
-    let component_hover = hover(client, uri, position).await;
-    let hover_text = serde_json::to_string(&component_hover).unwrap();
-    assert!(
-        hover_text.contains(component_name) && !hover_text.contains("__vize_component__"),
-        "{component_hover:#}"
-    );
-    let component_definition = definition(client, uri, position).await;
-    assert_no_generated_uri(&component_definition);
-    let definition_text = serde_json::to_string(&component_definition).unwrap();
-    assert!(
-        definition_text.contains(target_uri),
-        "{component_definition:#}"
-    );
-    assert!(
-        !definition_text.contains(".vue.ts"),
-        "{component_definition:#}"
-    );
-}
-
-pub async fn assert_prop_navigation(
-    client: &LspClient,
-    uri: &str,
-    position: &Value,
-    prop_name: &str,
-    prop_type: &str,
-    target_uri: &str,
-    target_start: &Value,
-) {
-    let prop_hover = hover(client, uri, position).await;
-    let hover_text = serde_json::to_string(&prop_hover).unwrap();
-    assert!(
-        hover_text.contains(prop_name) && hover_text.contains(prop_type),
-        "{prop_hover:#}"
-    );
-    let prop_definition = definition(client, uri, position).await;
-    assert_no_generated_uri_or_zero_range(&prop_definition);
-    assert!(
-        contains_location(&prop_definition, target_uri, target_start),
-        "{prop_definition:#}"
-    );
-}
-pub async fn assert_component_members(
-    client: &LspClient,
-    parent: (&str, &str),
-    child: (&str, &str),
-) {
-    for (usage, declaration, name, ty) in [
-        (":count", "count: number", "count", "number"),
-        ("@save", "save: [value", "save", "number"),
-    ] {
-        let usage = position(parent.1, parent.1.find(usage).unwrap() + 1);
-        let declaration = position(child.1, child.1.find(declaration).unwrap());
-        assert_prop_navigation(client, parent.0, &usage, name, ty, child.0, &declaration).await;
-    }
 }
 
 pub async fn pull_diagnostics(client: &LspClient, uri: &str) -> Value {

--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -163,7 +163,9 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
                             }
                         }
                     }],
-                    "openDocuments": cases.iter().map(|case| json!({ "uri": case.0 })).collect::<Vec<_>>()
+                    "openDocuments": std::iter::once(json!({ "uri": &app_uri }))
+                        .chain(cases.iter().map(|case| json!({ "uri": case.0 })))
+                        .collect::<Vec<_>>()
                 }))
                 .await
                 .unwrap();
@@ -181,9 +183,23 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
                 .unwrap();
             let mut opened = FxHashSet::default();
             let zero = json!({ "line": 0, "character": 0 });
+            for (uri, source, ..) in &cases {
+                if opened.insert(uri.as_str()) {
+                    overlay
+                        .open(VirtualDocument::new(
+                            Uri::from_str(uri).unwrap(),
+                            "vue",
+                            source.as_str(),
+                        ))
+                        .unwrap();
+                }
+            }
+            let app_clean = pull_diagnostics(&client, &app_uri).await;
+            assert_eq!(app_clean["items"], json!([]), "{app_clean:#}");
+
             for (
                 uri,
-                source,
+                _source,
                 usage,
                 usage_end,
                 declaration,
@@ -195,15 +211,8 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
                 rename_supported,
             ) in &cases
             {
-                if opened.insert(uri.as_str()) {
-                    overlay
-                        .open(VirtualDocument::new(
-                            Uri::from_str(uri).unwrap(),
-                            "vue",
-                            source.as_str(),
-                        ))
-                        .unwrap();
-                }
+                let clean = pull_diagnostics(&client, uri).await;
+                assert_eq!(clean["items"], json!([]), "{clean:#}");
                 assert_prop_navigation(&client, &app_uri, usage, name, ty, uri, declaration).await;
                 let references = references(&client, &app_uri, usage).await;
                 assert_no_generated_uri_or_zero_range(&references);
@@ -237,8 +246,6 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
                 } else {
                     assert!(rename.is_null(), "{rename:#}");
                 }
-                let clean = pull_diagnostics(&client, uri).await;
-                assert_eq!(clean["items"], json!([]), "{clean:#}");
             }
 
             let broken_handler =


### PR DESCRIPTION
## Summary
- include App.vue in the exact tsgo event-form content-mapper open document set
- open all event child documents and pull clean diagnostics before event navigation assertions
- poll event hover/definition assertions together so the pinned upstream LSP cannot race initial content-mapper indexing
- move shared component LSP oracles into a small support module to stay under the source length gate
- improve event-form assertion messages for future failures

## Verification
- vp install --frozen-lockfile --prefer-offline
- cargo fmt --all -- --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node tools/davinci/assertion-lint.mjs
- TSGO_PATH=/tmp/tsgo-d6c4afddb2c55f4a9dea7b59293a99a8fdea1799 VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/tsgo-d6c4afddb2c55f4a9dea7b59293a99a8fdea1799 cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture (3x)
- TSGO_PATH=/tmp/tsgo-d6c4afddb2c55f4a9dea7b59293a99a8fdea1799 VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/tsgo-d6c4afddb2c55f4a9dea7b59293a99a8fdea1799 cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture
- TSGO_PATH=/tmp/tsgo-d6c4afddb2c55f4a9dea7b59293a99a8fdea1799 VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/tsgo-d6c4afddb2c55f4a9dea7b59293a99a8fdea1799 cargo test -p vize --test content_mapper_tsgo_declaration_lsp -- --nocapture
- TSGO_PATH=/tmp/tsgo-d6c4afddb2c55f4a9dea7b59293a99a8fdea1799 VIZE_TEST_CONTENT_MAPPER_TSGO=/tmp/tsgo-d6c4afddb2c55f4a9dea7b59293a99a8fdea1799 cargo test -p vize_canon --test lsp_import_resolution -- --nocapture
- git diff --check

Note: local full `vp run --workspace-root test:scripts` hit ENOSPC in generated glyph corpus output; CI test-scripts is the source of truth for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved language server test coverage for component completions, navigation, hover, definitions, props, and events.
  * Added validation that navigation resolves to authored source files instead of generated files.
  * Improved diagnostic testing reliability by opening related documents before validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->