### PR TITLE
test(davinci): use stage aliases in fuzz harness

### DIFF
--- a/tests/fuzz/Cargo.toml
+++ b/tests/fuzz/Cargo.toml
@@ -27,11 +27,11 @@ vize_atelier_sfc = { path = "../../crates/vize_atelier_sfc", default-features = 
   "native",
 ] }
 vize_atelier_dom = { path = "../../crates/vize_atelier_dom" }
-vize_carton = { path = "../../crates/vize_carton" }
 vize_davinci = { path = "../../crates/vize_davinci" }
-vize_disegno = { path = "../../crates/vize_disegno" }
-vize_ricalco = { path = "../../crates/vize_ricalco" }
+vize_s0 = { package = "vize_carton", path = "../../crates/vize_carton" }
 vize_s1 = { path = "../../crates/vize_s1" }
+vize_s1_to_s2 = { package = "vize_ricalco", path = "../../crates/vize_ricalco" }
+vize_s2 = { package = "vize_disegno", path = "../../crates/vize_disegno" }
 
 [[bin]]
 name = "sfc_parse"

--- a/tests/fuzz/fuzz_targets/folio_parse.rs
+++ b/tests/fuzz/fuzz_targets/folio_parse.rs
@@ -6,7 +6,7 @@
 // under the invariant that *no input must panic*: parsers return
 // `Result<_, FolioError>` for malformed pages, so a panic here is always
 // a bug. Three parsers share the input — the S2 Disegno page
-// (`vize_disegno`), the croquis page, and the repro page
+// (`vize_s2`, package `vize_disegno`), the croquis page, and the repro page
 // (`vize_davinci`).
 //
 // When an input does parse, the mode-explicit round-trip law is asserted
@@ -19,7 +19,7 @@ use libfuzzer_sys::fuzz_target;
 use vize_davinci::folio::croquis::CroquisFolio;
 use vize_davinci::folio::repro::ReproFolio;
 use vize_davinci::folio::{Folio, FolioMode};
-use vize_disegno::folio::DisegnoFolio;
+use vize_s2::folio::DisegnoFolio;
 
 fn round_trip<F: Folio + PartialEq + core::fmt::Debug>(source: &str) {
     let Ok(parsed) = F::parse(source) else {

--- a/tests/fuzz/fuzz_targets/s1_lowering.rs
+++ b/tests/fuzz/fuzz_targets/s1_lowering.rs
@@ -5,7 +5,7 @@
 // Drives the full Davinci template front half with arbitrary UTF-8:
 // `vize_s1::parse` (the lossless S1 surface tree, total over
 // malformed input by the typed-hole policy) followed by
-// `vize_ricalco::lower` (the total S1→S2 lowering — S2 ops or
+// `vize_s1_to_s2::lower` (the total S1→S2 lowering — S2 ops or
 // diagnostics, never a panic and never a partial-then-abandoned state).
 //
 // The target asserts more than no-crash, so a logic break surfaces as a
@@ -17,11 +17,11 @@
 // The corpus is seeded from the `<template>` blocks of repository .vue
 // fixtures by `tools/fuzz/seed_corpus.mjs`.
 use libfuzzer_sys::fuzz_target;
-use vize_carton::Allocator;
 use vize_davinci::folio::{Folio, FolioMode};
-use vize_disegno::folio::DisegnoFolio;
-use vize_ricalco::lower;
+use vize_s0::Allocator;
 use vize_s1::parse;
+use vize_s1_to_s2::lower;
+use vize_s2::folio::DisegnoFolio;
 
 fuzz_target!(|data: &[u8]| {
     let Ok(source) = std::str::from_utf8(data) else {

--- a/tests/fuzz/fuzz_targets/template_compile.rs
+++ b/tests/fuzz/fuzz_targets/template_compile.rs
@@ -11,7 +11,7 @@
 // fixtures by `tools/fuzz/seed_corpus.mjs`.
 use libfuzzer_sys::fuzz_target;
 use vize_atelier_dom::compile_template;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 fuzz_target!(|data: &[u8]| {
     let Ok(source) = std::str::from_utf8(data) else {

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -33,6 +34,10 @@ function workspacePackage(metadata: Metadata, name: string): Package {
   const found = metadata.packages.find((pkg) => pkg.name === name);
   assert.ok(found, `workspace package ${name} must exist`);
   return found;
+}
+
+function readRepoFile(...segments: string[]): string {
+  return fs.readFileSync(path.join(repoRoot, ...segments), "utf8");
 }
 
 const aliases = new Map<string, ReadonlyArray<readonly [string, string | null]>>([
@@ -102,5 +107,27 @@ test("Davinci stage dependencies are one-way and acyclic", () => {
           `(tier ${dependencyTier})`,
       );
     }
+  }
+});
+
+test("Davinci fuzz harness imports stage packages through aliases", () => {
+  const manifest = readRepoFile("tests", "fuzz", "Cargo.toml");
+  assert.match(
+    manifest,
+    /^vize_s0 = \{ package = "vize_carton", path = "\.\.\/\.\.\/crates\/vize_carton" \}$/m,
+  );
+  assert.match(
+    manifest,
+    /^vize_s1_to_s2 = \{ package = "vize_ricalco", path = "\.\.\/\.\.\/crates\/vize_ricalco" \}$/m,
+  );
+  assert.match(
+    manifest,
+    /^vize_s2 = \{ package = "vize_disegno", path = "\.\.\/\.\.\/crates\/vize_disegno" \}$/m,
+  );
+  assert.doesNotMatch(manifest, /^vize_(?:carton|disegno|ricalco) = /m);
+
+  for (const target of ["folio_parse.rs", "s1_lowering.rs", "template_compile.rs"]) {
+    const source = readRepoFile("tests", "fuzz", "fuzz_targets", target);
+    assert.doesNotMatch(source, /\bvize_(?:carton|disegno|ricalco)::/u);
   }
 });


### PR DESCRIPTION
## Summary
- rename the isolated cargo-fuzz dependencies to `vize_s0`, `vize_s2`, and `vize_s1_to_s2` while retaining their package ids
- update fuzz target imports/comments to use the stage aliases
- pin the fuzz harness alias spellings in `davinci-stage-dependencies.test.ts`

## Validation
- `node --test tests/tooling/davinci-stage-dependencies.test.ts`
- `cargo +nightly check --manifest-path tests/fuzz/Cargo.toml --bins`
- `cargo fmt --all -- --check`
- `cargo +nightly fmt --manifest-path tests/fuzz/Cargo.toml --all -- --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

Note: `tests/fuzz` is an isolated cargo-fuzz workspace without a committed `Cargo.lock`, so `--locked` is intentionally not used for that manifest check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790223138&installation_model_id=422833&pr_number=4847&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4847&signature=925e6149188da4b85e16a7620de82df3833c72153c8d57846ae7ef3221646b07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->