### PR TITLE
test(davinci): pin DOM patch flag parity

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
@@ -1,0 +1,176 @@
+//! P2-11 patch-flag witness: the S2 DOM lane must compute the
+//! same per-node patch flags as the shipped lane, including dynamic
+//! prop arrays plus slot and fragment stability markers.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use vize_carton::Allocator;
+use vize_ricalco::emit_dom_source;
+
+struct Case {
+    name: &'static str,
+    src: &'static str,
+    sites: &'static [&'static str],
+}
+
+const CASES: &[Case] = &[
+    Case {
+        name: "text_child",
+        src: "<div>{{ msg }}</div>",
+        sites: &["1 /* TEXT */"],
+    },
+    Case {
+        name: "class",
+        src: r#"<div :class="cls"></div>"#,
+        sites: &["2 /* CLASS */"],
+    },
+    Case {
+        name: "style",
+        src: r#"<div :style="style"></div>"#,
+        sites: &["4 /* STYLE */"],
+    },
+    Case {
+        name: "prop",
+        src: r#"<div :id="id"></div>"#,
+        sites: &["8 /* PROPS */, [\"id\"]"],
+    },
+    Case {
+        name: "full_props",
+        src: r#"<div :[key]="value"></div>"#,
+        sites: &["16 /* FULL_PROPS */"],
+    },
+    Case {
+        name: "full_props_need_hydration",
+        src: r#"<div :[key].prop="value"></div>"#,
+        sites: &["48 /* FULL_PROPS, NEED_HYDRATION */"],
+    },
+    Case {
+        name: "click_event_props",
+        src: r#"<div @click="handler"></div>"#,
+        sites: &["8 /* PROPS */, [\"onClick\"]"],
+    },
+    Case {
+        name: "hydrating_key_event",
+        src: r#"<div @keyup.enter="handler"></div>"#,
+        sites: &["40 /* PROPS, NEED_HYDRATION */, [\"onKeyup\"]"],
+    },
+    Case {
+        name: "need_patch",
+        src: r#"<div ref="el"></div>"#,
+        sites: &["512 /* NEED_PATCH */"],
+    },
+    Case {
+        name: "dynamic_slots",
+        src: r#"<Foo><template #header v-if="ok">x</template></Foo>"#,
+        sites: &["2 /* DYNAMIC */", "1024 /* DYNAMIC_SLOTS */"],
+    },
+    Case {
+        name: "text_and_class",
+        src: r#"<div :class="cls">{{ msg }}</div>"#,
+        sites: &["3 /* TEXT, CLASS */"],
+    },
+    Case {
+        name: "stable_fragment",
+        src: "<div></div><span></span>",
+        sites: &["64 /* STABLE_FRAGMENT */"],
+    },
+    Case {
+        name: "keyed_fragment",
+        src: r#"<div v-for="item in list" :key="item.id">{{ item.label }}</div>"#,
+        sites: &["1 /* TEXT */", "128 /* KEYED_FRAGMENT */"],
+    },
+    Case {
+        name: "unkeyed_fragment",
+        src: r#"<div v-for="item in list">{{ item.label }}</div>"#,
+        sites: &["1 /* TEXT */", "256 /* UNKEYED_FRAGMENT */"],
+    },
+];
+
+#[test]
+fn s2_patch_flags_match_the_shipped_dom_lane_per_node() {
+    let battery: Vec<_> = CASES.iter().map(|case| (case.name, case.src)).collect();
+    support::assert_s2_matches_shipped(&battery);
+
+    let mut mismatches = Vec::new();
+    for case in CASES {
+        let expected: Vec<_> = case.sites.iter().map(|site| site.to_string()).collect();
+        let old = support::shipped(case.src);
+        let allocator = Allocator::new();
+        let new = emit_dom_source(&allocator, case.src)
+            .unwrap_or_else(|error| panic!("{}: S2 emit refused: {error:?}", case.name))
+            .assembled();
+        let old_sites = patch_sites(&old);
+        let new_sites = patch_sites(&new);
+
+        if old_sites != expected || new_sites != expected {
+            mismatches.push(format!(
+                "{}: expected={expected:?} old={old_sites:?} new={new_sites:?}",
+                case.name
+            ));
+        }
+    }
+    assert!(
+        mismatches.is_empty(),
+        "patch flag mismatches:\n{}",
+        mismatches.join("\n")
+    );
+}
+
+fn patch_sites(source: &str) -> Vec<String> {
+    let bytes = source.as_bytes();
+    let mut sites = Vec::new();
+    let mut cursor = 0usize;
+    while let Some(comment_rel) = source[cursor..].find(" /* ") {
+        let comment_start = cursor + comment_rel;
+        let Some(comment_end_rel) = source[comment_start..].find(" */") else {
+            break;
+        };
+        let comment_end = comment_start + comment_end_rel + " */".len();
+        let Some(number_start) = flag_number_start(bytes, comment_start) else {
+            cursor = comment_end;
+            continue;
+        };
+        let mut site_end = comment_end;
+        if let Some(array_end) = dynamic_props_array_end(source, comment_end) {
+            site_end = array_end;
+        }
+        sites.push(source[number_start..site_end].trim().to_string());
+        cursor = site_end;
+    }
+    sites
+}
+
+fn flag_number_start(bytes: &[u8], comment_start: usize) -> Option<usize> {
+    let mut index = comment_start;
+    while index > 0 && bytes[index - 1].is_ascii_whitespace() {
+        index -= 1;
+    }
+    if index == 0 || !bytes[index - 1].is_ascii_digit() {
+        return None;
+    }
+    while index > 0 && bytes[index - 1].is_ascii_digit() {
+        index -= 1;
+    }
+    if index > 0 && bytes[index - 1] == b'-' {
+        index -= 1;
+    }
+    Some(index)
+}
+
+fn dynamic_props_array_end(source: &str, comment_end: usize) -> Option<usize> {
+    let tail = &source[comment_end..];
+    let trimmed = tail.trim_start();
+    if !trimmed.starts_with(", [") {
+        return None;
+    }
+    let offset = tail.len() - trimmed.len();
+    let array_start = comment_end + offset + ", ".len();
+    let array_tail = &source[array_start..];
+    Some(array_start + array_tail.find(']')? + 1)
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -42,7 +42,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           906 |             139 |     371 |             951 |      465 |           474 |           581 |
+| Compiler                   |           908 |             139 |     371 |             951 |      467 |           475 |           582 |
 | Linter                     |           300 |             268 |     219 |             670 |      117 |           337 |           476 |
 | Typechecker                |           879 |             393 |     187 |             804 |      655 |           460 |           650 |
 | Typechecker content-mapper |             8 |               1 |       0 |               9 |        0 |             7 |            18 |
@@ -58,10 +58,10 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          21 |               4 |       17 |
-| S0/carton        |         837 |             490 |      347 |
+| S0/carton        |         838 |             490 |      348 |
 | S1/sinopia       |           5 |               1 |        4 |
 | S2/disegno       |          15 |               1 |       14 |
-| S1->S2/ricalco   |          28 |               2 |       26 |
+| S1->S2/ricalco   |          29 |               2 |       27 |
 | old AST/parser   |          74 |              54 |       20 |
 | Croquis analysis |          65 |              56 |        9 |
 | raw OXC          |         371 |             343 |       28 |
@@ -88,7 +88,7 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | `crates/vize_atelier_sfc/src/compile_script/props/tests.rs:4` | test/dev | S0/carton 15                                                                 |    15 |
 | `crates/vize_atelier_core/tests/s2_support/compare.rs:10`     | test/dev | Davinci 2<br>S0/carton 4<br>S1/sinopia 1<br>S2/disegno 1<br>S1->S2/ricalco 3 |    11 |
 
-Additional test/dev rows are in the TSV: 191 omitted.
+Additional test/dev rows are in the TSV: 192 omitted.
 
 ### Linter
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -242,6 +242,8 @@ compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/branch_keys.rs	3	s0	S0/
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/conditional_v_model_quirks.rs	5	s0	S0/carton	stage	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_expr_reparse_floor.rs	20	s0	S0/carton	stage	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_dom.rs	22	s1_to_s2	S1->S2/ricalco	stage	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s0	S0/carton	stage	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s1_to_s2	S1->S2/ricalco	stage	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_slots.rs	14	s1_to_s2	S1->S2/ricalco	stage	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_teardown_without_stack_guard.rs	25	s0	S0/carton	stage	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_walk_baseline.rs	25	davinci	Davinci	stage	1

--- a/tests/tooling/davinci-v-on-storage.test.ts
+++ b/tests/tooling/davinci-v-on-storage.test.ts
@@ -170,7 +170,7 @@ test("the natural committed v-on corpus fits the two-entry inline buckets", () =
     { options: 0, event: 0, keys: 0 },
   );
 
-  assert.equal(spellings.length, 179, "update the measured corpus evidence intentionally");
+  assert.equal(spellings.length, 180, "update the measured corpus evidence intentionally");
   assert.deepEqual(maxima, { options: 2, event: 2, keys: 2 });
 });
 


### PR DESCRIPTION
## Summary
- add a P2-11 DOM/S2 patch-flag parity witness
- pin per-node flags for TEXT, CLASS, STYLE, PROPS, FULL_PROPS, NEED_HYDRATION, NEED_PATCH, DYNAMIC_SLOTS, and fragment stability
- keep the shipped compile_template lane unchanged; this is test-only and has no rollout path change

## Verification
- cargo fmt --all -- --check
- cargo test -p vize_atelier_dom --test davinci_s2_patch_flags -- --nocapture
- cargo test -p vize_atelier_dom
- cargo clippy -p vize_atelier_dom --test davinci_s2_patch_flags -- -D warnings -D clippy::wildcard_imports
- node tools/davinci/assertion-lint.mjs
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check origin/main...HEAD
- vp run --workspace-root check:ci
- cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- cargo clippy -p vize_maestro --tests -- -D warnings
- bash tools/github/check-maestro-feature-contract.sh
- cargo build -p vize_davinci -p vize_s1 -p vize_disegno -p vize_ricalco --lib --target wasm32-wasip2
- cargo build -p vize_davinci -p vize_s1 -p vize_disegno -p vize_ricalco --lib --target wasm32-wasip2 --no-default-features
- cargo bench -p vize_ricalco --bench davinci_storage -- --quick
- node tools/davinci/bench-compare.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket
- cargo test --workspace && cargo test -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli && cargo test -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 && cargo test -p vize_vitrine --no-default-features --features wasm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4848"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790223421&installation_model_id=422833&pr_number=4848&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4848&signature=a9d93a4a0900695511575c08feb4761f38dbe00238389745b490b5fa1a15e3e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->