### PR TITLE
ci(davinci): upload compact storage bench reports

### DIFF
--- a/.github/actions/upload-davinci-compact-storage-bench-reports/action.yml
+++ b/.github/actions/upload-davinci-compact-storage-bench-reports/action.yml
@@ -1,0 +1,12 @@
+name: Upload Davinci compact-storage bench reports
+description: Uploads compact-storage bench JSON reports for Davinci wall-budget baselines.
+runs:
+  using: composite
+  steps:
+    - name: Upload reports
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: davinci-compact-storage-bench-reports
+        path: bench/results/davinci/*.json
+        if-no-files-found: error
+        retention-days: 14

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,7 +41,6 @@ jobs:
           restore-prefixes-first-match: nix-${{ runner.os }}-${{ runner.arch }}-
       - name: Check flake
         run: nix flake check
-
   fmt-rust:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 10
@@ -52,7 +51,6 @@ jobs:
           components: rustfmt
       - name: Format Rust
         run: cargo fmt --all -- --check
-
   check-js:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 15
@@ -132,7 +130,6 @@ jobs:
           else
             cargo semver-checks check-release --package ${{ matrix.crate }} "${SEMVER_ARGS[@]}"
           fi
-
   security-audit:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 20
@@ -380,6 +377,9 @@ jobs:
         run: cargo build -p vize_davinci -p vize_s1 -p vize_disegno -p vize_ricalco --lib --target wasm32-wasip2 && cargo build -p vize_davinci -p vize_s1 -p vize_disegno -p vize_ricalco --lib --target wasm32-wasip2 --no-default-features
       - name: Davinci compact-storage allocation gate
         run: cargo bench -p vize_ricalco --bench davinci_storage -- --quick && node tools/davinci/bench-compare.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket
+      - name: Upload Davinci compact-storage bench reports
+        if: ${{ always() }}
+        uses: ./.github/actions/upload-davinci-compact-storage-bench-reports
       - name: Install Pkl CLI
         run: npm install --global @pkl-community/pkl@0.27.2
       - name: Test

--- a/tests/tooling/github-workflows-davinci-bench.test.ts
+++ b/tests/tooling/github-workflows-davinci-bench.test.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import { readRepoFile } from "./support/github-workflows.ts";
+
+interface WorkflowStep {
+  name?: string;
+  if?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, unknown>;
+}
+
+interface WorkflowJob {
+  steps?: WorkflowStep[];
+}
+
+test("check workflow uploads Davinci compact-storage bench reports", () => {
+  const workflow = readRepoFile(".github", "workflows", "check.yml");
+  const action = readRepoFile(
+    ".github",
+    "actions",
+    "upload-davinci-compact-storage-bench-reports",
+    "action.yml",
+  );
+  const jobs = (parse(workflow) as { jobs?: Record<string, WorkflowJob> }).jobs ?? {};
+  const actionSteps = (parse(action) as { runs?: { steps?: WorkflowStep[] } }).runs?.steps ?? [];
+  const steps = jobs["clippy-and-test"]?.steps ?? [];
+  const gateIndex = steps.findIndex(
+    (step) => step.name === "Davinci compact-storage allocation gate",
+  );
+
+  assert.notEqual(gateIndex, -1);
+  assert.match(
+    steps[gateIndex].run ?? "",
+    /cargo bench -p vize_ricalco --bench davinci_storage -- --quick/,
+  );
+  assert.match(
+    steps[gateIndex].run ?? "",
+    /node tools\/davinci\/bench-compare\.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket/,
+  );
+  assert.deepEqual(steps[gateIndex + 1], {
+    name: "Upload Davinci compact-storage bench reports",
+    if: "${{ always() }}",
+    uses: "./.github/actions/upload-davinci-compact-storage-bench-reports",
+  });
+  assert.deepEqual(actionSteps, [
+    {
+      name: "Upload reports",
+      uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+      with: {
+        name: "davinci-compact-storage-bench-reports",
+        path: "bench/results/davinci/*.json",
+        "if-no-files-found": "error",
+        "retention-days": 14,
+      },
+    },
+  ]);
+  assert.match(
+    action,
+    /actions\/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a\s*# v7\.0\.1/,
+  );
+});


### PR DESCRIPTION
## Summary
- add a compact composite action that uploads Davinci compact-storage bench JSON reports from the existing clippy-and-test gate
- keep the workflow line-count budget stable while preserving the new artifact step
- add a workflow regression test for the gate, artifact action, pinned upload action, and fail-closed artifact settings

## Verification
- node --test tests/tooling/github-workflows-davinci-bench.test.ts tests/tooling/github-workflows-check.test.ts tests/tooling/github-workflows-check-gate.test.ts
- vp run --workspace-root check:ci
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790224049&installation_model_id=422833&pr_number=4849&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4849&signature=99cc182b05c387fc051b4dfd5279261de7bf8d46b6bc86e95fa0b189c0c15724"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->