### PR TITLE
refactor(glyph): use S0 alias for allocation

### DIFF
--- a/crates/vize_glyph/Cargo.toml
+++ b/crates/vize_glyph/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 # Internal crates
-vize_carton.workspace = true
+vize_s0.workspace = true
 vize_atelier_sfc.workspace = true
 
 # OXC dependencies

--- a/crates/vize_glyph/README.md
+++ b/crates/vize_glyph/README.md
@@ -24,7 +24,7 @@
 
 - `vize` exposes Glyph through `vize fmt`
 - `vize_maestro` can use Glyph for LSP formatting
-- `vize_atelier_sfc` and `vize_carton` provide parsing and allocation support behind the formatter
+- `vize_atelier_sfc` and `vize_s0` provide parsing and allocation support behind the formatter
 
 ## License
 

--- a/crates/vize_glyph/src/error.rs
+++ b/crates/vize_glyph/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types for vize_glyph formatter.
 
 use thiserror::Error;
-use vize_carton::String;
+use vize_s0::String;
 
 /// Errors that can occur during formatting
 #[derive(Debug, Error)]

--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -14,7 +14,7 @@ use crate::script;
 use crate::style;
 use std::borrow::Cow;
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-use vize_carton::{Allocator, FxHashMap, String, ToCompactString};
+use vize_s0::{Allocator, FxHashMap, String, ToCompactString};
 
 /// Result of formatting a Vue SFC
 #[derive(Debug, Clone)]

--- a/crates/vize_glyph/src/formatter/block_indent.rs
+++ b/crates/vize_glyph/src/formatter/block_indent.rs
@@ -44,11 +44,11 @@ pub(super) fn write_indented_block(
 mod tests {
     use super::write_indented_block;
 
-    fn indent(content: &str) -> vize_carton::String {
+    fn indent(content: &str) -> vize_s0::String {
         indent_with(content, b"\n")
     }
 
-    fn indent_with(content: &str, newline: &[u8]) -> vize_carton::String {
+    fn indent_with(content: &str, newline: &[u8]) -> vize_s0::String {
         let mut output = Vec::new();
         write_indented_block(&mut output, content, b"  ", newline);
         core::str::from_utf8(&output).unwrap().into()

--- a/crates/vize_glyph/src/json.rs
+++ b/crates/vize_glyph/src/json.rs
@@ -19,7 +19,7 @@
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
-use vize_carton::String;
+use vize_s0::String;
 
 mod ast;
 mod number;

--- a/crates/vize_glyph/src/json/ast.rs
+++ b/crates/vize_glyph/src/json/ast.rs
@@ -1,7 +1,7 @@
 //! The JSON / JSONC value tree and the comment-placement helper shared by the
 //! parser and printer.
 
-use vize_carton::String;
+use vize_s0::String;
 
 pub(super) enum Node {
     /// `{}` (compact when empty) or a multi-line mapping.

--- a/crates/vize_glyph/src/json/number.rs
+++ b/crates/vize_glyph/src/json/number.rs
@@ -2,7 +2,7 @@ use super::json_error;
 use crate::error::FormatError;
 use std::iter::Peekable;
 use std::str::Chars;
-use vize_carton::String;
+use vize_s0::String;
 
 /// Scan a JSON number and copy it verbatim.
 ///

--- a/crates/vize_glyph/src/json/parser.rs
+++ b/crates/vize_glyph/src/json/parser.rs
@@ -3,7 +3,7 @@
 use super::ast::{Comment, Element, Member, Node, split_trailing};
 use super::{json_error, number, trim_end};
 use crate::error::FormatError;
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 pub(super) struct Parser<'a> {
     iter: std::iter::Peekable<std::str::Chars<'a>>,

--- a/crates/vize_glyph/src/json/printer.rs
+++ b/crates/vize_glyph/src/json/printer.rs
@@ -1,7 +1,7 @@
 //! Pretty-printer for the [`super::ast`] value tree.
 
 use super::ast::{Comment, Node};
-use vize_carton::String;
+use vize_s0::String;
 
 pub(super) struct Printer<'a> {
     pub(super) indent: &'a str,

--- a/crates/vize_glyph/src/lib.rs
+++ b/crates/vize_glyph/src/lib.rs
@@ -13,7 +13,7 @@
 //! ## Performance
 //!
 //! This crate is designed for maximum performance:
-//! - Arena allocation via `vize_carton::Allocator` for minimal heap allocations
+//! - Arena allocation via `vize_s0::Allocator` for minimal heap allocations
 //! - Zero-copy parsing where possible
 //! - SIMD-accelerated string operations via `memchr`
 //! - Efficient buffer management with pre-allocated capacity
@@ -50,8 +50,8 @@ pub use error::*;
 pub use formatter::*;
 pub use json::{format_json_source as format_json, format_jsonc_source as format_jsonc};
 pub use options::*;
-pub use vize_carton::Allocator;
-use vize_carton::String;
+pub use vize_s0::Allocator;
+use vize_s0::String;
 
 /// Format a Vue SFC source string
 ///

--- a/crates/vize_glyph/src/options.rs
+++ b/crates/vize_glyph/src/options.rs
@@ -3,7 +3,7 @@
 //! These options are designed to be compatible with Prettier and oxfmt.
 
 use serde::{Deserialize, Serialize};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 /// Formatting options for Vue SFC
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/vize_glyph/src/script.rs
+++ b/crates/vize_glyph/src/script.rs
@@ -10,7 +10,7 @@ use crate::options::FormatOptions;
 use oxc_allocator::Allocator as OxcAllocator;
 use oxc_formatter::{format_program, parse_for_format};
 use oxc_span::SourceType;
-use vize_carton::{Allocator, String, ToCompactString};
+use vize_s0::{Allocator, String, ToCompactString};
 
 pub(crate) use block_identity::format_sfc_script_content_stable;
 
@@ -208,7 +208,7 @@ mod tests {
         format_script_content_with_source_type,
     };
     use oxc_span::SourceType;
-    use vize_carton::String;
+    use vize_s0::String;
 
     #[test]
     fn test_format_simple_script() {

--- a/crates/vize_glyph/src/script/block_identity.rs
+++ b/crates/vize_glyph/src/script/block_identity.rs
@@ -5,7 +5,7 @@ use oxc_allocator::Allocator as OxcAllocator;
 use oxc_ast::ast::Statement;
 use oxc_formatter::parse_for_format;
 use oxc_span::SourceType;
-use vize_carton::{Allocator, String, ToCompactString};
+use vize_s0::{Allocator, String, ToCompactString};
 
 /// Formats an SFC script without letting cleanup erase its block identity.
 ///

--- a/crates/vize_glyph/src/style.rs
+++ b/crates/vize_glyph/src/style.rs
@@ -8,7 +8,7 @@ mod stabilization;
 use crate::error::FormatError;
 use crate::options::FormatOptions;
 use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 /// Format CSS content using lightningcss.
 ///

--- a/crates/vize_glyph/src/style/stabilization.rs
+++ b/crates/vize_glyph/src/style/stabilization.rs
@@ -6,7 +6,7 @@
 
 use crate::error::FormatError;
 use memchr::memmem;
-use vize_carton::String;
+use vize_s0::String;
 
 /// Upper bound for a pathological non-converging lightningcss value.
 const MAX_PASSES: usize = 4;
@@ -223,7 +223,7 @@ mod tests {
     use super::format_to_fixed_point;
     use crate::{options::FormatOptions, style::format_style_content};
     use std::cell::Cell;
-    use vize_carton::ToCompactString;
+    use vize_s0::ToCompactString;
 
     #[test]
     fn ordinary_css_is_parsed_and_printed_once() {

--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -25,7 +25,7 @@ pub(crate) const WHITESPACE_SIGNIFICANT_NATIVE_ELEMENTS: [&str; 3] = ["pre", "te
 mod attribute_priority_tests;
 
 use crate::{error::FormatError, options::FormatOptions};
-use vize_carton::String;
+use vize_s0::String;
 
 use formatter::TemplateFormatter;
 use helpers::is_whitespace;
@@ -54,7 +54,7 @@ mod tests {
     use directives::{custom_attribute_priority, format_v_for_expression, matches_attr_pattern};
     use formatter::format_interpolations;
     use helpers::{is_tag_name_char, is_void_element_str};
-    use vize_carton::ToCompactString;
+    use vize_s0::ToCompactString;
 
     #[test]
     fn test_format_simple_template() {

--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -2,7 +2,7 @@ use crate::{
     attribute::write_attr_value,
     options::{AttributeSortOrder, FormatOptions},
 };
-use vize_carton::String;
+use vize_s0::String;
 
 use super::helpers::template_literal_state_after_line_from;
 

--- a/crates/vize_glyph/src/template/directives.rs
+++ b/crates/vize_glyph/src/template/directives.rs
@@ -4,7 +4,7 @@
 //! `v-slot:` -> `#`) and JS expression formatting in directive values.
 
 use crate::{options::FormatOptions, script};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use super::attributes::attribute_priority;
 use super::helpers::template_literal_state_after_line_from;

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -6,7 +6,7 @@
 
 use crate::{error::FormatError, options::FormatOptions, script};
 use memchr::memchr3;
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use super::{
     attributes::{

--- a/crates/vize_glyph/src/template/formatter/interpolation.rs
+++ b/crates/vize_glyph/src/template/formatter/interpolation.rs
@@ -6,7 +6,7 @@
 //! idempotent. (#3247)
 
 use super::TemplateFormatter;
-use vize_carton::String;
+use vize_s0::String;
 
 impl TemplateFormatter<'_> {
     /// Render the lines of a formatted interpolation expression at `depth + 1`,

--- a/crates/vize_glyph/src/template/formatter/text.rs
+++ b/crates/vize_glyph/src/template/formatter/text.rs
@@ -7,7 +7,7 @@ use super::{
     TemplateFormatter, format_interpolation_expression, format_interpolations,
     suppression::{LineJoiner, TextRun},
 };
-use vize_carton::String;
+use vize_s0::String;
 
 impl TemplateFormatter<'_> {
     /// Flush accumulated text content with interpolation formatting.

--- a/crates/vize_glyph/src/template/helpers.rs
+++ b/crates/vize_glyph/src/template/helpers.rs
@@ -3,7 +3,7 @@
 //! Provides byte-level helpers for tag parsing, whitespace detection,
 //! and HTML void element recognition.
 
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 /// Find a byte subsequence in a slice.
 pub(crate) fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {

--- a/crates/vize_glyph/tests/sfc_block_attributes.rs
+++ b/crates/vize_glyph/tests/sfc_block_attributes.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-use vize_carton::{FxHashMap, String};
 use vize_glyph::{FormatOptions, format_sfc};
+use vize_s0::{FxHashMap, String};
 
 type BlockAttrs<'a> = FxHashMap<Cow<'a, str>, Cow<'a, str>>;
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1991,7 +1991,7 @@ formatter	Formatter	source	crates/vize_glyph/src/template/formatter.rs	9	s0	S0/c
 formatter	Formatter	source	crates/vize_glyph/src/template/formatter/interpolation.rs	9	s0	S0/carton	stage	1
 formatter	Formatter	source	crates/vize_glyph/src/template/formatter/text.rs	10	s0	S0/carton	stage	1
 formatter	Formatter	source	crates/vize_glyph/src/template/helpers.rs	6	s0	S0/carton	stage	1
-formatter	Formatter	test/dev	crates/vize_glyph/tests/sfc_block_attributes.rs	4	s0	S0/carton	stage	1
+formatter	Formatter	test/dev	crates/vize_glyph/tests/sfc_block_attributes.rs	5	s0	S0/carton	stage	1
 formatter	Formatter	source	crates/vize/src/commands/fmt.rs	13	s0	S0/carton	stage	1
 formatter	Formatter	source	crates/vize/src/commands/fmt/data.rs	4	s0	S0/carton	stage	1
 formatter	Formatter	source	crates/vize/src/commands/fmt/data/plain.rs	16	s0	S0/carton	stage	1

--- a/tests/tooling/davinci-glyph-stage-alias.test.ts
+++ b/tests/tooling/davinci-glyph-stage-alias.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const glyphRoot = path.join(repoRoot, "crates", "vize_glyph");
+const scannedExtensions = new Set([".md", ".rs", ".toml"]);
+
+function* walkFiles(dir: string): Generator<string> {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkFiles(fullPath);
+    } else if (entry.isFile() && scannedExtensions.has(path.extname(entry.name))) {
+      yield fullPath;
+    }
+  }
+}
+
+test("Glyph depends on the stage-named S0 alias", () => {
+  const cargoToml = fs.readFileSync(path.join(glyphRoot, "Cargo.toml"), "utf8");
+
+  assert.match(cargoToml, /^vize_s0\.workspace = true$/m);
+  assert.doesNotMatch(cargoToml, /^vize_carton\.workspace = true$/m);
+});
+
+test("Glyph does not name the Carton crate directly", () => {
+  const offenders = [];
+
+  for (const file of walkFiles(glyphRoot)) {
+    const source = fs.readFileSync(file, "utf8");
+    if (source.includes("vize_carton")) {
+      offenders.push(path.relative(repoRoot, file));
+    }
+  }
+
+  assert.deepEqual(offenders, []);
+});


### PR DESCRIPTION
## Summary
- switch vize_glyph from the Carton dependency name to the stage-named vize_s0 alias
- update Glyph docs/imports and the generated consumer migration surface TSV line anchor
- add a tooling regression so Glyph cannot reintroduce direct vize_carton references

## Rollout
- no command routing, formatter backend, package export, protocol, or user-visible behavior changes

## Tests
- vp check --fix
- vp run --workspace-root check:ci
- cargo fmt --check
- cargo test -p vize_glyph
- node tools/davinci/consumer-migration-surfaces.mjs --check
- node --test tests/tooling/davinci-glyph-stage-alias.test.ts
- node --test tests/tooling/davinci-matrices.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790224107&installation_model_id=422833&pr_number=4850&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4850&signature=d069455e48563dcf8cbb3bee5cf678353422bc43443dfa0f6180497a0fb554a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->