### PR TITLE
refactor(davinci): use S1-to-S2 alias in DOM tests

### DIFF
--- a/crates/vize_atelier_dom/Cargo.toml
+++ b/crates/vize_atelier_dom/Cargo.toml
@@ -27,7 +27,7 @@ insta = { workspace = true }
 # the release gate (tests/tooling/moonbit-publish-crates.test.ts) encodes
 # for published crates exercising unpublished ones.
 vize_davinci = { workspace = true }
-vize_ricalco = { workspace = true }
+vize_s1_to_s2 = { workspace = true }
 
 [[bench]]
 name = "davinci"

--- a/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dom.rs
@@ -19,7 +19,7 @@
 
 mod support;
 
-use vize_ricalco::DOM_LANE_FLAG;
+use vize_s1_to_s2::DOM_LANE_FLAG;
 
 const BATTERY: &[(&str, &str)] = &[
     ("empty_div", "<div></div>"),

--- a/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
@@ -11,7 +11,7 @@
 mod support;
 
 use vize_carton::Allocator;
-use vize_ricalco::emit_dom_source;
+use vize_s1_to_s2::emit_dom_source;
 
 struct Case {
     name: &'static str,

--- a/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
@@ -11,7 +11,7 @@
 
 mod support;
 
-use vize_ricalco::UnsupportedReason as Reason;
+use vize_s1_to_s2::UnsupportedReason as Reason;
 
 const BATTERY: &[(&str, &str)] = &[
     (

--- a/crates/vize_atelier_dom/tests/support/mod.rs
+++ b/crates/vize_atelier_dom/tests/support/mod.rs
@@ -8,7 +8,7 @@
 
 use vize_atelier_dom::compile_template;
 use vize_carton::Allocator;
-use vize_ricalco::{DOM_LANE_FLAG, EmitError, UnsupportedReason, emit_dom_source};
+use vize_s1_to_s2::{DOM_LANE_FLAG, EmitError, UnsupportedReason, emit_dom_source};
 
 #[derive(Clone, Copy)]
 #[allow(dead_code)]

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -148,6 +148,15 @@ test("Davinci fuzz harness imports stage packages through aliases", () => {
 test("Davinci DOM lane tests import lowering through the stage alias", () => {
   const lowering = dependency(metadata, "vize_atelier_dom", "vize_ricalco", "dev");
   assert.equal(lowering.rename, "vize_s1_to_s2");
+  const dependencies = workspacePackage(metadata, "vize_atelier_dom").dependencies;
+  assert.ok(
+    dependencies.every(
+      (dependency) =>
+        dependency.name !== "vize_ricalco" ||
+        (dependency.kind === "dev" && dependency.rename === "vize_s1_to_s2"),
+    ),
+    "vize_atelier_dom must not depend on vize_ricalco through its physical name",
+  );
 
   for (const file of ["davinci_s2_dom.rs", "davinci_s2_slots.rs", path.join("support", "mod.rs")]) {
     const source = readRepoFile("crates", "vize_atelier_dom", "tests", file);

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -158,7 +158,12 @@ test("Davinci DOM lane tests import lowering through the stage alias", () => {
     "vize_atelier_dom must not depend on vize_ricalco through its physical name",
   );
 
-  for (const file of ["davinci_s2_dom.rs", "davinci_s2_slots.rs", path.join("support", "mod.rs")]) {
+  for (const file of [
+    "davinci_s2_dom.rs",
+    "davinci_s2_patch_flags.rs",
+    "davinci_s2_slots.rs",
+    path.join("support", "mod.rs"),
+  ]) {
     const source = readRepoFile("crates", "vize_atelier_dom", "tests", file);
     assert.doesNotMatch(source, /\bvize_ricalco::/u);
   }

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -36,6 +36,19 @@ function workspacePackage(metadata: Metadata, name: string): Package {
   return found;
 }
 
+function dependency(
+  metadata: Metadata,
+  packageName: string,
+  dependencyName: string,
+  kind: Dependency["kind"],
+): Dependency {
+  const found = workspacePackage(metadata, packageName).dependencies.find(
+    (dependency) => dependency.kind === kind && dependency.name === dependencyName,
+  );
+  assert.ok(found, `${packageName} must declare ${kind ?? "normal"} dependency ${dependencyName}`);
+  return found;
+}
+
 function readRepoFile(...segments: string[]): string {
   return fs.readFileSync(path.join(repoRoot, ...segments), "utf8");
 }
@@ -129,5 +142,15 @@ test("Davinci fuzz harness imports stage packages through aliases", () => {
   for (const target of ["folio_parse.rs", "s1_lowering.rs", "template_compile.rs"]) {
     const source = readRepoFile("tests", "fuzz", "fuzz_targets", target);
     assert.doesNotMatch(source, /\bvize_(?:carton|disegno|ricalco)::/u);
+  }
+});
+
+test("Davinci DOM lane tests import lowering through the stage alias", () => {
+  const lowering = dependency(metadata, "vize_atelier_dom", "vize_ricalco", "dev");
+  assert.equal(lowering.rename, "vize_s1_to_s2");
+
+  for (const file of ["davinci_s2_dom.rs", "davinci_s2_slots.rs", path.join("support", "mod.rs")]) {
+    const source = readRepoFile("crates", "vize_atelier_dom", "tests", file);
+    assert.doesNotMatch(source, /\bvize_ricalco::/u);
   }
 });


### PR DESCRIPTION
## Summary
- rename the `vize_atelier_dom` Davinci DOM-lane dev dependency to the `vize_s1_to_s2` stage alias
- update the DOM S2 comparison tests to import lowering symbols through the alias
- add a tooling guard so these tests do not drift back to direct `vize_ricalco::` imports

## Tests
- `vp run --workspace-root check:ci`
- `node --test tests/tooling/davinci-stage-dependencies.test.ts`
- `cargo test -p vize_atelier_dom --test davinci_s2_dom --test davinci_s2_slots`
- `cargo fmt --all -- --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation ensuring the DOM tooling uses the updated dependency configuration.
  * Added checks preventing outdated direct imports in DOM lane tests.
  * Confirmed existing DOM test behavior remains unchanged while validating the updated setup.
* **Chores**
  * Updated internal development and test references to use the replacement package consistently.
  * Improved consistency across DOM tooling development configuration and test support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->