### PR TITLE
perf(davinci): gate compact storage wall baselines

### DIFF
--- a/bench/results/davinci/baseline/ricalco_emit_von_two_per_bucket.json
+++ b/bench/results/davinci/baseline/ricalco_emit_von_two_per_bucket.json
@@ -1,0 +1,13 @@
+{
+  "bench_id": "ricalco_emit_von_two_per_bucket",
+  "fixture": "synthetic:v-on-two-option-event-key-modifiers",
+  "platform": "linux",
+  "wall_ns": {
+    "p50": 1478,
+    "p95": 17313
+  },
+  "allocs": 18,
+  "alloc_bytes_peak": 648,
+  "rss_peak_bytes": 130359296,
+  "harness_version": "0.387.0"
+}

--- a/bench/results/davinci/baseline/ricalco_lower_vfor_three_aliases.json
+++ b/bench/results/davinci/baseline/ricalco_lower_vfor_three_aliases.json
@@ -1,0 +1,13 @@
+{
+  "bench_id": "ricalco_lower_vfor_three_aliases",
+  "fixture": "synthetic:v-for-three-aliases",
+  "platform": "linux",
+  "wall_ns": {
+    "p50": 784,
+    "p95": 43582
+  },
+  "allocs": 10,
+  "alloc_bytes_peak": 1254,
+  "rss_peak_bytes": 111464448,
+  "harness_version": "0.387.0"
+}

--- a/davinci-road/plan/budgets.toml
+++ b/davinci-road/plan/budgets.toml
@@ -181,8 +181,8 @@ davinci_pipeline_no_observer = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0
 
 # Compact-storage probes. Setup is excluded with stage windows so these exact
 # allocation counts localize the v-for split and v-on emit paths.
-ricalco_lower_vfor_three_aliases = { wall_p50_ns = 0, allocs = 10, rss_peak_bytes = 0, wall_tolerance = 0.05 }
-ricalco_emit_von_two_per_bucket = { wall_p50_ns = 0, allocs = 18, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+ricalco_lower_vfor_three_aliases = { wall_p50_ns = 784, allocs = 10, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+ricalco_emit_von_two_per_bucket = { wall_p50_ns = 1478, allocs = 18, rss_peak_bytes = 0, wall_tolerance = 0.05 }
 
 [allocation_peak]
 # Exact peak live bytes over each stage window. The counting allocator makes

--- a/tests/tooling/davinci-budgets.test.ts
+++ b/tests/tooling/davinci-budgets.test.ts
@@ -217,6 +217,43 @@ test("compact-storage peaks are exact per-platform allocation budgets", () => {
   }
 });
 
+test("compact-storage wall budgets match the committed linux baseline reports", () => {
+  const expected = {
+    ricalco_lower_vfor_three_aliases: {
+      fixture: "synthetic:v-for-three-aliases",
+      wallP50Ns: 784,
+      allocs: 10,
+      allocBytesPeak: 1254,
+    },
+    ricalco_emit_von_two_per_bucket: {
+      fixture: "synthetic:v-on-two-option-event-key-modifiers",
+      wallP50Ns: 1478,
+      allocs: 18,
+      allocBytesPeak: 648,
+    },
+  };
+  for (const [id, row] of Object.entries(expected)) {
+    const reportPath = path.join(repoRoot, "bench", "results", "davinci", "baseline", `${id}.json`);
+    const report = JSON.parse(fs.readFileSync(reportPath, "utf8")) as {
+      bench_id: string;
+      fixture: string;
+      platform: string;
+      wall_ns: { p50: number };
+      allocs: number;
+      alloc_bytes_peak: number;
+    };
+    assert.equal(report.bench_id, id);
+    assert.equal(report.fixture, row.fixture);
+    assert.equal(report.platform, "linux");
+    assert.equal(report.wall_ns.p50, row.wallP50Ns);
+    assert.equal(budgets.bench[id]?.wall_p50_ns, row.wallP50Ns);
+    assert.equal(report.allocs, row.allocs);
+    assert.equal(budgets.bench[id]?.allocs, row.allocs);
+    assert.equal(report.alloc_bytes_peak, row.allocBytesPeak);
+    assert.equal(budgets.allocation_peak[id]?.linux, row.allocBytesPeak);
+  }
+});
+
 test("toml-lite parses inline tables and rejects malformed ones", () => {
   assert.deepEqual(parseTomlLite("[bench]\na = { x = 1, y = 0.5 }\n"), {
     bench: { a: { x: 1, y: 0.5 } },


### PR DESCRIPTION
## Summary
- commit the Blacksmith compact-storage bench reports uploaded by the PR CI run
- record wall_p50_ns for ricalco_lower_vfor_three_aliases and ricalco_emit_von_two_per_bucket
- assert the compact-storage linux baseline reports stay aligned with budgets.toml and allocation peaks

This records previously unrecorded wall baselines from the reference runner; it is not a budget loosen.

## Evidence
- Source artifact: Check run 32810397388, clippy-and-test job 97688511484 on blacksmith-32vcpu-ubuntu-2404
- ricalco_lower_vfor_three_aliases: p50 784ns, p95 43582ns, allocs 10, alloc_bytes_peak 1254
- ricalco_emit_von_two_per_bucket: p50 1478ns, p95 17313ns, allocs 18, alloc_bytes_peak 648

## Local verification
- vp install --frozen-lockfile --prefer-offline
- vp run --workspace-root check:ci
- node --test tests/tooling/davinci-budgets.test.ts tests/tooling/davinci-bench-compare.test.ts tests/tooling/source-file-lengths.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node tools/davinci/bench-compare.mjs --results bench/results/davinci/baseline --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation that benchmark baseline reports match configured performance budgets.
  * Verified timing, allocation, memory, platform, fixture, and benchmark identifiers for compact-storage scenarios.

* **Chores**
  * Added Linux benchmark baseline results for two compact-storage scenarios.
  * Updated recorded wall-time budgets to reflect the new performance baselines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->