### PR TITLE
test(davinci): extend s2 DOM patch flag witness

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
@@ -51,6 +51,11 @@ const CASES: &[Case] = &[
         sites: &["48 /* FULL_PROPS, NEED_HYDRATION */"],
     },
     Case {
+        name: "prop_modifier_need_hydration",
+        src: r#"<div :value.prop="value"></div>"#,
+        sites: &["40 /* PROPS, NEED_HYDRATION */, [\".value\"]"],
+    },
+    Case {
         name: "click_event_props",
         src: r#"<div @click="handler"></div>"#,
         sites: &["8 /* PROPS */, [\"onClick\"]"],
@@ -61,13 +66,38 @@ const CASES: &[Case] = &[
         sites: &["40 /* PROPS, NEED_HYDRATION */, [\"onKeyup\"]"],
     },
     Case {
+        name: "hydrating_key_event_plain",
+        src: r#"<div @keyup="handler"></div>"#,
+        sites: &["40 /* PROPS, NEED_HYDRATION */, [\"onKeyup\"]"],
+    },
+    Case {
         name: "need_patch",
         src: r#"<div ref="el"></div>"#,
         sites: &["512 /* NEED_PATCH */"],
     },
     Case {
+        name: "directive_need_patch",
+        src: r#"<div v-example></div>"#,
+        sites: &["512 /* NEED_PATCH */"],
+    },
+    Case {
+        name: "directive_text_need_patch",
+        src: r#"<div v-example>{{ msg }}</div>"#,
+        sites: &["1 /* TEXT */", "513 /* TEXT, NEED_PATCH */"],
+    },
+    Case {
         name: "dynamic_slots",
         src: r#"<Foo><template #header v-if="ok">x</template></Foo>"#,
+        sites: &["2 /* DYNAMIC */", "1024 /* DYNAMIC_SLOTS */"],
+    },
+    Case {
+        name: "dynamic_slots_builtin",
+        src: "<KeepAlive><Foo /></KeepAlive>",
+        sites: &["1024 /* DYNAMIC_SLOTS */"],
+    },
+    Case {
+        name: "dynamic_slot_name",
+        src: r#"<Foo><template #[name]>x</template></Foo>"#,
         sites: &["2 /* DYNAMIC */", "1024 /* DYNAMIC_SLOTS */"],
     },
     Case {


### PR DESCRIPTION
## Summary
- extend the P2-11 S2 DOM patch-flag witness that is already on main
- add edge coverage for static .prop hydration, plain keyup hydration, custom directive NEED_PATCH, directive text + NEED_PATCH composition, KeepAlive dynamic slots, and dynamic slot names
- keep rollout/default routing unchanged; this remains observational compatibility coverage only

## Validation
- cargo fmt --all -- --check
- cargo test -p vize_atelier_dom --test davinci_s2_patch_flags -- --nocapture
- cargo clippy -p vize_atelier_dom --test davinci_s2_patch_flags -- -D warnings -D clippy::wildcard_imports
- cargo test -p vize_atelier_dom --tests
- cargo test -p vize_ricalco --tests
- node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-module-layout.test.ts tests/tooling/davinci-storage-policy.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node tools/davinci/assertion-lint.mjs
- node tools/davinci/consumer-migration-surfaces.mjs --check
- git diff --check

Note: broad cargo clippy -p vize_atelier_dom --tests currently fails on an unchanged main-derived lint in crates/vize_atelier_dom/tests/davinci_teardown_without_stack_guard.rs:73 (drop_non_drop). The touched test target clippy passes.