### PR TITLE
fix(davinci): fail closed on invalid bench report dirs

### DIFF
--- a/tests/tooling/davinci-bench-compare.test.ts
+++ b/tests/tooling/davinci-bench-compare.test.ts
@@ -132,6 +132,18 @@ test("bench-compare still gates allocs when no baseline report exists", () => {
   );
 });
 
+test("bench-compare fails closed when the baseline reports path is not a directory", () => {
+  const overrides = { baseline: `${fixtureRel}/budgets.toml` };
+  const result = runCompare(compareArgs("within-tolerance", overrides));
+  assert.equal(result.status, 2, result.stderr);
+  assert.equal(result.stdout, header("within-tolerance", overrides));
+  assert.match(
+    result.stderr,
+    /^bench-compare: baseline reports directory tests\/_fixtures\/davinci-bench-compare\/budgets\.toml cannot be read: /u,
+  );
+  assert.match(result.stderr, /ENOTDIR|not a directory/u);
+});
+
 test("bench-compare reports the wall side but gates allocs when the wall baseline is unrecorded", () => {
   const overrides = { budgets: `${fixtureRel}/budgets-unrecorded.toml` };
   const result = runCompare(compareArgs("within-tolerance", overrides));

--- a/tools/davinci/lib/bench-reports.mjs
+++ b/tools/davinci/lib/bench-reports.mjs
@@ -5,7 +5,8 @@
 // The loader re-validates the fields the gate reads instead of trusting the
 // exporter: a truncated or hand-edited report must fail the gate loudly
 // rather than compare as a suspiciously fast run. A missing directory is an
-// empty set, which is how "no baseline recorded yet" reaches the gate.
+// empty set, which is how "no baseline recorded yet" reaches the gate; other
+// directory read failures are configuration errors.
 
 import fs from "node:fs";
 import path from "node:path";
@@ -18,13 +19,19 @@ function integerOrNull(value) {
   return value === null || (Number.isSafeInteger(value) && value >= 0);
 }
 
+function errorCode(error) {
+  return error != null && typeof error === "object" && "code" in error ? error.code : undefined;
+}
+
 export function loadReports(dir, label) {
   const reports = new Map();
   let entries;
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
-  } catch {
-    return reports; // a missing directory is an empty report set
+  } catch (error) {
+    if (errorCode(error) === "ENOENT") return reports;
+    const reason = error instanceof Error ? error.message : String(error);
+    fail(`${label} reports directory ${dir} cannot be read: ${reason}`);
   }
   for (const entry of entries) {
     if (!entry.isFile() || !entry.name.endsWith(".json")) continue;


### PR DESCRIPTION
## Summary
- treat only missing Davinci bench report directories as an empty report set
- fail with a config error for invalid or unreadable report directories
- add a regression that prevents an invalid baseline path from becoming report-only

## Tests
- node --test tests/tooling/davinci-bench-compare.test.ts
- node --test tests/tooling/davinci-bench-compare.test.ts tests/tooling/davinci-bench-platform.test.ts tests/tooling/davinci-budgets.test.ts tests/tooling/github-workflows-davinci-bench.test.ts tests/tooling/davinci-portability-lane.test.ts
- corepack pnpm exec oxlint tests/tooling/davinci-bench-compare.test.ts tools/davinci/lib/bench-reports.mjs
- corepack pnpm exec oxfmt --check tests/tooling/davinci-bench-compare.test.ts tools/davinci/lib/bench-reports.mjs
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node tools/davinci/assertion-lint.mjs
- corepack pnpm exec vp run --workspace-root check:repo
- corepack pnpm exec vp run --workspace-root check:ci
- git diff --check

Note: the first local check:ci attempt hit a transient tsgolint/tsgo SIGSEGV in npm/fresco; the immediate rerun passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790229811&installation_model_id=422833&pr_number=4856&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4856&signature=c56d856e6ffdb95e1b8c897db57889aa819548f4db8b326ce0b86504873743a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Benchmark comparison now reports configuration errors when the baseline path is invalid or inaccessible.
  * Missing baseline directories continue to be handled gracefully as empty report sets.
  * Error messages now identify the underlying reason for directory read failures.

* **Tests**
  * Added regression coverage confirming invalid baseline files fail with an appropriate status and diagnostic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->