### PR TITLE
fix(davinci): stabilize compact storage wall gate

### DIFF
--- a/bench/results/davinci/baseline/ricalco_emit_von_two_per_bucket.json
+++ b/bench/results/davinci/baseline/ricalco_emit_von_two_per_bucket.json
@@ -3,11 +3,11 @@
   "fixture": "synthetic:v-on-two-option-event-key-modifiers",
   "platform": "linux",
   "wall_ns": {
-    "p50": 1478,
-    "p95": 17313
+    "p50": 1566,
+    "p95": 18815
   },
   "allocs": 18,
   "alloc_bytes_peak": 648,
-  "rss_peak_bytes": 130359296,
+  "rss_peak_bytes": 128843776,
   "harness_version": "0.387.0"
 }

--- a/bench/results/davinci/baseline/ricalco_lower_vfor_three_aliases.json
+++ b/bench/results/davinci/baseline/ricalco_lower_vfor_three_aliases.json
@@ -3,11 +3,11 @@
   "fixture": "synthetic:v-for-three-aliases",
   "platform": "linux",
   "wall_ns": {
-    "p50": 784,
-    "p95": 43582
+    "p50": 764,
+    "p95": 48030
   },
   "allocs": 10,
   "alloc_bytes_peak": 1254,
-  "rss_peak_bytes": 111464448,
+  "rss_peak_bytes": 99250176,
   "harness_version": "0.387.0"
 }

--- a/davinci-road/plan/budgets.toml
+++ b/davinci-road/plan/budgets.toml
@@ -180,9 +180,10 @@ davinci_pipeline_unobserved = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0,
 davinci_pipeline_no_observer = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
 
 # Compact-storage probes. Setup is excluded with stage windows so these exact
-# allocation counts localize the v-for split and v-on emit paths.
-ricalco_lower_vfor_three_aliases = { wall_p50_ns = 784, allocs = 10, rss_peak_bytes = 0, wall_tolerance = 0.05 }
-ricalco_emit_von_two_per_bucket = { wall_p50_ns = 1478, allocs = 18, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+# allocation counts localize the v-for split and v-on emit paths; the wall
+# side uses the stage-window tolerance because the timed window is sub-2us.
+ricalco_lower_vfor_three_aliases = { wall_p50_ns = 764, allocs = 10, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+ricalco_emit_von_two_per_bucket = { wall_p50_ns = 1566, allocs = 18, rss_peak_bytes = 0, wall_tolerance = 0.10 }
 
 [allocation_peak]
 # Exact peak live bytes over each stage window. The counting allocator makes

--- a/tests/tooling/davinci-budgets.test.ts
+++ b/tests/tooling/davinci-budgets.test.ts
@@ -31,6 +31,11 @@ const budgets = parseTomlLite(budgetsText) as {
   allocation_peak: Record<string, Record<string, number>>;
 };
 
+const COMPACT_STORAGE_STAGE_WINDOWS = new Set([
+  "ricalco_lower_vfor_three_aliases",
+  "ricalco_emit_von_two_per_bucket",
+]);
+
 // --- bench-id enumeration from the bench sources -------------------------
 //
 // Bench ids are constructed either as a direct string literal passed to
@@ -159,7 +164,8 @@ test("every budget entry carries exactly the documented fields within the tolera
     const stageWindow =
       id.includes("_transform_") ||
       id.startsWith("atelier_vapor_lower_") ||
-      id.startsWith("atelier_ssr_codegen_");
+      id.startsWith("atelier_ssr_codegen_") ||
+      COMPACT_STORAGE_STAGE_WINDOWS.has(id);
     const ceiling = stageWindow ? 0.1 : 0.05;
     assert.ok(
       tolerance <= ceiling,
@@ -221,13 +227,15 @@ test("compact-storage wall budgets match the committed linux baseline reports", 
   const expected = {
     ricalco_lower_vfor_three_aliases: {
       fixture: "synthetic:v-for-three-aliases",
-      wallP50Ns: 784,
+      wallP50Ns: 764,
+      wallTolerance: 0.1,
       allocs: 10,
       allocBytesPeak: 1254,
     },
     ricalco_emit_von_two_per_bucket: {
       fixture: "synthetic:v-on-two-option-event-key-modifiers",
-      wallP50Ns: 1478,
+      wallP50Ns: 1566,
+      wallTolerance: 0.1,
       allocs: 18,
       allocBytesPeak: 648,
     },
@@ -247,6 +255,7 @@ test("compact-storage wall budgets match the committed linux baseline reports", 
     assert.equal(report.platform, "linux");
     assert.equal(report.wall_ns.p50, row.wallP50Ns);
     assert.equal(budgets.bench[id]?.wall_p50_ns, row.wallP50Ns);
+    assert.equal(budgets.bench[id]?.wall_tolerance, row.wallTolerance);
     assert.equal(report.allocs, row.allocs);
     assert.equal(budgets.bench[id]?.allocs, row.allocs);
     assert.equal(report.alloc_bytes_peak, row.allocBytesPeak);


### PR DESCRIPTION
## Summary
- refresh compact-storage wall baselines from the second #4854 reference-runner artifact
- classify the setup-free sub-2us compact-storage probes as stage-window benches with 0.10 wall tolerance
- keep allocation and allocation-peak gates exact and unchanged

budget-loosen: davinci-road/plan/budgets.toml compact-storage stage-window policy

## Verification
- node tools/davinci/bench-compare.mjs --results /private/tmp/vize-davinci-artifacts-4854/first --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket
- node tools/davinci/bench-compare.mjs --results /private/tmp/vize-davinci-artifacts-4854/second --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket
- node --test tests/tooling/davinci-budgets.test.ts tests/tooling/davinci-bench-compare.test.ts tests/tooling/davinci-bench-platform.test.ts
- corepack pnpm exec oxfmt --check davinci-road/plan/budgets.toml tests/tooling/davinci-budgets.test.ts bench/results/davinci/baseline/ricalco_lower_vfor_three_aliases.json bench/results/davinci/baseline/ricalco_emit_von_two_per_bucket.json
- corepack pnpm exec oxlint tests/tooling/davinci-budgets.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node tools/davinci/assertion-lint.mjs
- corepack pnpm exec vp run --workspace-root check:repo
- corepack pnpm exec vp run --workspace-root check:ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790235495&installation_model_id=422833&pr_number=4857&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4857&signature=d79642379d5856530e46ea4807cd402c53c1494819669221c8c41275ccca1d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Updated compact-storage benchmark baselines to reflect current latency and peak memory measurements.
  * Recorded improved p50 latency and reduced peak memory usage for one benchmark, alongside revised measurements for another.

* **Tests**
  * Updated performance checks to accept the revised wall-time tolerance and baseline values.
  * Added coverage for both compact-storage benchmark scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->