### PR TITLE
test(davinci): pin corpus hydration preflight

### DIFF
--- a/tests/tooling/davinci-corpus-hydration.test.ts
+++ b/tests/tooling/davinci-corpus-hydration.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  assertHydratedGitlinkFixtures,
+  fixtureHydrationFailures,
+} from "../../tools/davinci/lib/corpus-hydration.mjs";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, LANG: "C", LC_ALL: "C" },
+  }).trim();
+}
+
+function createRepository(directory: string, marker: string): string {
+  fs.mkdirSync(directory, { recursive: true });
+  git(directory, ["init", "-q"]);
+  git(directory, ["config", "user.name", "Fixture"]);
+  git(directory, ["config", "user.email", "fixture@example.com"]);
+  fs.writeFileSync(path.join(directory, "README.md"), `${marker}\n`);
+  git(directory, ["add", "README.md"]);
+  git(directory, ["commit", "-qm", `fixture ${marker}`]);
+  return git(directory, ["rev-parse", "HEAD"]);
+}
+
+function pinGitlink(root: string, relPath: string, revision: string): void {
+  git(root, ["update-index", "--add", "--cacheinfo", `160000,${revision},${relPath}`]);
+}
+
+test("corpus hydration preflight catches missing, empty, and wrong fixture gitlinks", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-corpus-hydration-"));
+  try {
+    git(root, ["init", "-q"]);
+    const okRevision = createRepository(path.join(root, "fixtures", "ok"), "ok");
+    const wrongActualRevision = createRepository(path.join(root, "fixtures", "wrong"), "wrong");
+    const wrongExpectedRevision = createRepository(path.join(root, "expected-wrong"), "expected");
+    fs.mkdirSync(path.join(root, "fixtures", "empty"), { recursive: true });
+
+    pinGitlink(root, "fixtures/ok", okRevision);
+    pinGitlink(root, "fixtures/missing", okRevision);
+    pinGitlink(root, "fixtures/empty", okRevision);
+    pinGitlink(root, "fixtures/wrong", wrongExpectedRevision);
+
+    assert.notEqual(wrongActualRevision, wrongExpectedRevision);
+    assert.deepEqual(fixtureHydrationFailures(root, ["fixtures/ok"]), []);
+
+    const failures = fixtureHydrationFailures(root, [
+      "fixtures/ok",
+      "fixtures/missing",
+      "fixtures/empty",
+      "fixtures/wrong",
+      "fixtures/not-gitlink",
+      "../escape",
+      "/absolute",
+    ]).map((line) => line.replaceAll(/[0-9a-f]{40}/g, "<sha>"));
+
+    assert.deepEqual(failures, [
+      "../escape: not a safe relative fixture path",
+      "/absolute: not a safe relative fixture path",
+      "fixtures/empty: not hydrated (expected <sha>)",
+      "fixtures/missing: not hydrated (expected <sha>)",
+      "fixtures/not-gitlink: not a pinned gitlink",
+      "fixtures/wrong: checked out <sha>, expected <sha>",
+    ]);
+
+    assert.throws(
+      () => assertHydratedGitlinkFixtures(["fixtures/missing"], root),
+      (error) => {
+        assert(error instanceof Error);
+        assert.match(error.message, /corpus fixture hydration preflight failed:/);
+        assert.match(error.message, /git submodule update --init --depth 1 -- fixtures\/missing/);
+        return true;
+      },
+    );
+    assert.throws(
+      () =>
+        assertHydratedGitlinkFixtures(
+          ["fixtures/missing", "../escape", "/absolute", "fixtures/not-gitlink"],
+          root,
+        ),
+      (error) => {
+        assert(error instanceof Error);
+        assert.match(error.message, /git submodule update --init --depth 1 -- fixtures\/missing/);
+        assert.doesNotMatch(error.message, /git submodule update[^\n]*\.\.\/escape/);
+        assert.doesNotMatch(error.message, /git submodule update[^\n]*\/absolute/);
+        assert.doesNotMatch(error.message, /git submodule update[^\n]*fixtures\/not-gitlink/);
+        return true;
+      },
+    );
+    assert.throws(
+      () => assertHydratedGitlinkFixtures(["fixtures/not-gitlink"], root),
+      (error) => {
+        assert(error instanceof Error);
+        assert.doesNotMatch(error.message, /\nRun:\n/);
+        return true;
+      },
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tools/davinci/lib/corpus-baseline-run.mjs
+++ b/tools/davinci/lib/corpus-baseline-run.mjs
@@ -9,12 +9,13 @@
 // Node builtins only. Reduction output is deterministic: stable sorts, no
 // timestamps, no machine identity, no absolute paths.
 
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import path from "node:path";
 
 import { HASHED_FIELDS } from "./corpus-baseline-contract.mjs";
+import { assertHydratedGitlinkFixtures } from "./corpus-hydration.mjs";
 import { byKey } from "./ordering.mjs";
 import { repoRoot } from "./paths.mjs";
 
@@ -29,6 +30,7 @@ const PAYLOAD_FAILURE_FIELDS = ["spawnError", "parseError", "validationError"];
  */
 export async function runMatrix({ shards, vizeBin, tools, scratchDir, timeoutMs, log }) {
   mkdirSync(scratchDir, { recursive: true });
+  assertHydratedGitlinkFixtures(listMatrixFixturePaths(shards));
   const runs = [];
   for (let index = 0; index < shards; index += 1) {
     const outputDir = path.join(scratchDir, `shard-${index}`);
@@ -60,6 +62,30 @@ export async function runMatrix({ shards, vizeBin, tools, scratchDir, timeoutMs,
     throw new Error(`matrix run failed:\n  ${failures.join("\n  ")}`);
   }
   return runs.map((run) => run.outputDir);
+}
+
+function listMatrixFixturePaths(shards) {
+  const fixturePaths = [];
+  for (let index = 0; index < shards; index += 1) {
+    const result = spawnSync(
+      process.execPath,
+      [
+        MATRIX_SCRIPT,
+        "--list-fixture-paths",
+        "--shard-index",
+        String(index),
+        "--shard-count",
+        String(shards),
+      ],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+    if (result.status !== 0) {
+      const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`;
+      throw new Error(`fixture path selection failed for shard ${index}: ${detail}`);
+    }
+    fixturePaths.push(...result.stdout.split("\n").filter(Boolean));
+  }
+  return fixturePaths;
 }
 
 function spawnShard(args, index, log) {

--- a/tools/davinci/lib/corpus-hydration.mjs
+++ b/tools/davinci/lib/corpus-hydration.mjs
@@ -1,0 +1,131 @@
+// Hydration preflight for Davinci real-project corpus runs.
+//
+// The corpus runners operate on pinned gitlinks under tests/_fixtures/_git.
+// A checkout that has the gitlink but not the submodule working tree must fail
+// before the tool matrix starts, otherwise an empty directory can look like a
+// successful zero-file corpus run.
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+import { repoRoot } from "./paths.mjs";
+
+export function assertHydratedGitlinkFixtures(fixturePaths, root = repoRoot) {
+  const uniquePaths = uniqueFixturePaths(fixturePaths);
+  const failures = fixtureHydrationFailures(root, uniquePaths);
+  if (failures.length === 0) return;
+  const recoveryPaths = gitlinkFixturePaths(root, uniquePaths);
+
+  throw new Error(
+    [
+      "corpus fixture hydration preflight failed:",
+      ...failures.map((failure) => `  ${failure}`),
+      ...recoveryCommandLines(recoveryPaths),
+    ].join("\n"),
+  );
+}
+
+export function fixtureHydrationFailures(root, fixturePaths) {
+  const uniquePaths = uniqueFixturePaths(fixturePaths);
+  const safePaths = uniquePaths.filter(isRelativeFixturePath);
+  const gitlinks = readGitlinks(root, safePaths);
+  const failures = [];
+  for (const relPath of uniquePaths) {
+    if (!isRelativeFixturePath(relPath)) {
+      failures.push(`${relPath}: not a safe relative fixture path`);
+      continue;
+    }
+
+    const expected = gitlinks.get(relPath);
+    if (expected == null) {
+      failures.push(`${relPath}: not a pinned gitlink`);
+      continue;
+    }
+
+    const fixtureDir = path.join(root, relPath);
+    if (!isNonEmptyDirectory(fixtureDir)) {
+      failures.push(`${relPath}: not hydrated (expected ${expected})`);
+      continue;
+    }
+
+    const actual = readHead(fixtureDir);
+    if (actual == null) {
+      failures.push(`${relPath}: hydrated path is not a git checkout (expected ${expected})`);
+    } else if (actual !== expected) {
+      failures.push(`${relPath}: checked out ${actual}, expected ${expected}`);
+    }
+  }
+  return failures;
+}
+
+function uniqueFixturePaths(fixturePaths) {
+  return [...new Set(fixturePaths)].sort((left, right) => left.localeCompare(right));
+}
+
+function isRelativeFixturePath(relPath) {
+  if (path.posix.isAbsolute(relPath)) return false;
+  const normalized = path.posix.normalize(relPath);
+  return normalized === relPath && normalized !== "." && !normalized.startsWith("..");
+}
+
+function isNonEmptyDirectory(directory) {
+  try {
+    return existsSync(directory) && readdirSync(directory).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+function readGitlinks(root, fixturePaths) {
+  if (fixturePaths.length === 0) return new Map();
+  const result = git(root, ["ls-files", "--stage", "--", ...fixturePaths]);
+  return new Map(
+    result
+      .split("\n")
+      .map((line) => /^160000\s+([0-9a-f]{40})\s+\d+\t(.+)$/.exec(line))
+      .filter((match) => match != null)
+      .map((match) => [match[2], match[1]]),
+  );
+}
+
+function gitlinkFixturePaths(root, fixturePaths) {
+  const safePaths = fixturePaths.filter(isRelativeFixturePath);
+  const gitlinks = readGitlinks(root, safePaths);
+  return fixturePaths.filter((relPath) => gitlinks.has(relPath));
+}
+
+function recoveryCommandLines(recoveryPaths) {
+  if (recoveryPaths.length === 0) return [];
+  return [
+    "Run:",
+    `  git submodule update --init --depth 1 -- ${recoveryPaths.map(shellQuote).join(" ")}`,
+  ];
+}
+
+function readHead(directory) {
+  const result = spawnSync("git", ["-C", directory, "rev-parse", "HEAD"], {
+    encoding: "utf8",
+    env: { ...process.env, LANG: "C", LC_ALL: "C" },
+  });
+  if (result.status !== 0) return null;
+  return result.stdout.trim();
+}
+
+function git(cwd, args) {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, LANG: "C", LC_ALL: "C" },
+  });
+  if (result.status !== 0) {
+    const detail = result.stderr.trim() || result.stdout.trim() || `exit ${result.status}`;
+    throw new Error(`git ${args.join(" ")} failed: ${detail}`);
+  }
+  return result.stdout.trim();
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}


### PR DESCRIPTION
## Summary
- add a Davinci corpus fixture hydration preflight for gitlink-backed real-project fixtures
- fail corpus baseline/diff matrix runs before shard execution when selected fixtures are missing, empty, not git checkouts, or checked out at the wrong revision
- add regression coverage for hydrated, missing, empty, unsafe, non-gitlink, and wrong-revision fixture paths

## Verification
- node --test tests/tooling/davinci-corpus-hydration.test.ts
- node -e "await import('./tools/davinci/lib/corpus-baseline-run.mjs')"
- corepack pnpm exec oxfmt --check tools/davinci/lib/corpus-hydration.mjs tools/davinci/lib/corpus-baseline-run.mjs tests/tooling/davinci-corpus-hydration.test.ts
- corepack pnpm exec oxlint tools/davinci/lib/corpus-hydration.mjs tools/davinci/lib/corpus-baseline-run.mjs tests/tooling/davinci-corpus-hydration.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node tools/davinci/assertion-lint.mjs
- corepack pnpm exec vp run --workspace-root check:repo
- corepack pnpm exec vp run --workspace-root check:ci
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790237822&installation_model_id=422833&pr_number=4858&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4858&signature=40acff8a2757d72c70af3066e578254ddcebe89558d6824e7461e73f4a917d10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added preflight validation for corpus fixtures before matrix runs begin.
  * Detects unsafe paths, missing or empty fixtures, invalid Git links, and revision mismatches.
  * Reports all detected fixture issues together with an actionable recovery command.
  * Prevents matrix processes from starting when required fixtures are not correctly hydrated.

* **Tests**
  * Added coverage for valid fixtures and expected failure scenarios, including actionable error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->