### PR TITLE
refactor(davinci): use s0 alias in vize crate

### DIFF
--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -27,7 +27,7 @@ legacy = ["vize_atelier_core/legacy", "vize_canon/legacy", "vize_maestro?/legacy
 
 [dependencies]
 # Vize crates (re-exported for unified documentation)
-vize_carton = { workspace = true }
+vize_s0 = { workspace = true }
 vize_relief = { workspace = true }
 vize_armature = { workspace = true }
 vize_atelier_core = { workspace = true }

--- a/crates/vize/src/commands/build/config.rs
+++ b/crates/vize/src/commands/build/config.rs
@@ -13,8 +13,8 @@ use std::{
 
 use super::ScriptExtension;
 use vize_atelier_sfc::SfcMacroArtifact;
-use vize_carton::String;
-use vize_carton::cstr;
+use vize_s0::String;
+use vize_s0::cstr;
 
 /// Aggregate compile statistics shared across worker threads.
 #[derive(Debug)]

--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use vize_carton::{String, cstr, profiler::global_profiler};
+use vize_s0::{String, cstr, profiler::global_profiler};
 
 use crate::profile_support;
 use vize_curator::profile::{

--- a/crates/vize/src/commands/build/runner/cache.rs
+++ b/crates/vize/src/commands/build/runner/cache.rs
@@ -8,7 +8,7 @@
 
 use std::sync::Mutex;
 
-use vize_carton::{FxHashMap, String};
+use vize_s0::{FxHashMap, String};
 
 use crate::commands::build::config::ErrorPhase;
 

--- a/crates/vize/src/commands/build/runner/cache/tests.rs
+++ b/crates/vize/src/commands/build/runner/cache/tests.rs
@@ -8,7 +8,7 @@
 //! compiler and comparing the read-back exactly.
 
 use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
-use vize_carton::hash::hash_str;
+use vize_s0::hash::hash_str;
 
 use super::{StatsCompileCache, StatsCompileCacheEntry, StatsCompileCacheKey};
 
@@ -114,7 +114,7 @@ fn cached_stats_survive_the_arena_that_produced_them() {
     assert_eq!(success_facts(&read), stats_facts(CACHED_FILE));
     // The compile that filled it returned its arena before the entry was
     // stored, which is what the per-file assertion in `compile_stats` reads.
-    assert_eq!(vize_carton::pool::checked_out(), 0);
+    assert_eq!(vize_s0::pool::checked_out(), 0);
 }
 
 /// Type-level half of the arena/cache contract: a cache entry that borrowed

--- a/crates/vize/src/commands/build/runner/collect/tests.rs
+++ b/crates/vize/src/commands/build/runner/collect/tests.rs
@@ -9,7 +9,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 #[test]
 fn collect_files_ignores_vue_extension_directories() {

--- a/crates/vize/src/commands/build/runner/compile.rs
+++ b/crates/vize/src/commands/build/runner/compile.rs
@@ -4,7 +4,7 @@
 //!
 //! The batch is file-parallel over rayon and every compile allocates from an
 //! arena, which is no longer built per file: the compiler takes it from
-//! `vize_carton::pool`, a per-worker free list, and returns it — reset, not
+//! `vize_s0::pool`, a per-worker free list, and returns it — reset, not
 //! freed — when the compile ends. Rayon worker threads outlive the batch, so
 //! one arena serves every file a worker takes, and the next file bumps into
 //! memory that is already mapped.
@@ -19,7 +19,7 @@
 //!   [`CompileError`], [`FileProfile`], the stats cache entries — so nothing
 //!   here borrows an arena, and the resident cache in `super::cache` keeps
 //!   data that outlives the arena that produced it;
-//! - `vize_carton::pool::checked_out()` is asserted to be zero once a file's
+//! - `vize_s0::pool::checked_out()` is asserted to be zero once a file's
 //!   artifacts are in hand, here and in `super::compile_stats`. That is the
 //!   runtime half of the contract: a pool guard parked anywhere it must not be
 //!   would keep an arena pinned across files.
@@ -38,10 +38,10 @@ use vize_atelier_sfc::{
     TemplateCompileOptions, compile_sfc_with_custom_elements_template_syntax_and_codegen_options,
     parse_sfc,
 };
-use vize_carton::cstr;
-use vize_carton::profile;
-use vize_carton::profiler::global_profiler;
-use vize_carton::{String, ToCompactString};
+use vize_s0::cstr;
+use vize_s0::profile;
+use vize_s0::profiler::global_profiler;
+use vize_s0::{String, ToCompactString};
 
 use crate::commands::build::ScriptExtension;
 use crate::commands::build::config::{
@@ -272,7 +272,7 @@ fn compile_file_inner(
     // so this worker must be holding no arena. A non-zero count means a pool
     // guard was parked somewhere it outlives one file.
     debug_assert_eq!(
-        vize_carton::pool::checked_out(),
+        vize_s0::pool::checked_out(),
         0,
         "a pooled arena is still checked out after compiling {}",
         path.display()

--- a/crates/vize/src/commands/build/runner/compile_stats.rs
+++ b/crates/vize/src/commands/build/runner/compile_stats.rs
@@ -13,11 +13,11 @@ use vize_atelier_sfc::{
     TemplateCompileOptions, compile_sfc_with_custom_elements_template_syntax_and_codegen_options,
     parse_sfc,
 };
-use vize_carton::cstr;
-use vize_carton::hash::hash_str;
-use vize_carton::profile;
-use vize_carton::profiler::global_profiler;
-use vize_carton::{String, ToCompactString};
+use vize_s0::cstr;
+use vize_s0::hash::hash_str;
+use vize_s0::profile;
+use vize_s0::profiler::global_profiler;
+use vize_s0::{String, ToCompactString};
 
 use crate::commands::build::ScriptExtension;
 use crate::commands::build::config::{CompileError, CompileStats, ErrorPhase, FileProfile};
@@ -228,7 +228,7 @@ pub(super) fn compile_file_stats_with_cache(
     // P1-11 file boundary: the compile is done and the cache entry stored
     // below is owned, so this worker must be holding no arena.
     debug_assert_eq!(
-        vize_carton::pool::checked_out(),
+        vize_s0::pool::checked_out(),
         0,
         "a pooled arena is still checked out after compiling {}",
         path.display()

--- a/crates/vize/src/commands/build/runner/declarations.rs
+++ b/crates/vize/src/commands/build/runner/declarations.rs
@@ -62,5 +62,5 @@ fn declaration_output_dir(args: &BuildArgs) -> PathBuf {
         return dir.to_path_buf();
     }
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    vize_carton::path::canonicalize_non_verbatim(&cwd.join(dir))
+    vize_s0::path::canonicalize_non_verbatim(&cwd.join(dir))
 }

--- a/crates/vize/src/commands/build/runner/output.rs
+++ b/crates/vize/src/commands/build/runner/output.rs
@@ -8,8 +8,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use vize_carton::profiler::global_profiler;
-use vize_carton::{String, profile};
+use vize_s0::profiler::global_profiler;
+use vize_s0::{String, profile};
 
 use super::super::{
     OutputFormat, ScriptExtension,

--- a/crates/vize/src/commands/build/runner/output/plan.rs
+++ b/crates/vize/src/commands/build/runner/output/plan.rs
@@ -1,6 +1,6 @@
 use std::path::{Component, Path, PathBuf};
 
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 use super::{OutputError, OutputFormat, ScriptExtension};
 

--- a/crates/vize/src/commands/build/runner/output/tests.rs
+++ b/crates/vize/src/commands/build/runner/output/tests.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use super::{OutputError, plan_inputs, preflight_outputs};
 use crate::commands::build::{OutputFormat, ScriptExtension};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[test]
 fn preserves_directories_for_duplicate_basenames() {

--- a/crates/vize/src/commands/build/runner/profile_facts.rs
+++ b/crates/vize/src/commands/build/runner/profile_facts.rs
@@ -3,9 +3,9 @@
 use std::{path::Path, time::Duration};
 
 use vize_atelier_core::TemplateSyntaxMode;
-use vize_carton::config::VueVersion;
-use vize_carton::profiler::global_profiler;
-use vize_carton::{String, cstr};
+use vize_s0::config::VueVersion;
+use vize_s0::profiler::global_profiler;
+use vize_s0::{String, cstr};
 
 use crate::commands::build::config::FileProfile;
 

--- a/crates/vize/src/commands/build/runner/settings.rs
+++ b/crates/vize/src/commands/build/runner/settings.rs
@@ -2,9 +2,9 @@
 
 use std::path::{Path, PathBuf};
 use vize_atelier_core::TemplateSyntaxMode;
-use vize_carton::String;
-use vize_carton::config::{ConfigFeatureFlags, VueVersion};
-use vize_carton::hash::hash_bytes;
+use vize_s0::String;
+use vize_s0::config::{ConfigFeatureFlags, VueVersion};
+use vize_s0::hash::hash_bytes;
 
 use crate::commands::build::{BuildArgs, ScriptExtension};
 use crate::commands::davinci_ice;

--- a/crates/vize/src/commands/check/dts.rs
+++ b/crates/vize/src/commands/check/dts.rs
@@ -4,7 +4,7 @@
 
 use std::{fs, path::Path};
 
-use vize_carton::{String, ToCompactString, profile, profiler::global_profiler};
+use vize_s0::{String, ToCompactString, profile, profiler::global_profiler};
 
 use super::dts_ast;
 use super::dts_import_aliases::{

--- a/crates/vize/src/commands/check/dts_ast.rs
+++ b/crates/vize/src/commands/check/dts_ast.rs
@@ -6,7 +6,7 @@ use oxc_ast::ast::{
 };
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{FxHashMap, String, ToCompactString};
+use vize_s0::{FxHashMap, String, ToCompactString};
 
 #[derive(Default)]
 struct InterfaceInfo {

--- a/crates/vize/src/commands/check/dts_import_aliases.rs
+++ b/crates/vize/src/commands/check/dts_import_aliases.rs
@@ -4,7 +4,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::{ImportDeclaration, ImportDeclarationSpecifier, ModuleExportName, Statement};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{FxHashMap, String, ToCompactString, cstr};
+use vize_s0::{FxHashMap, String, ToCompactString, cstr};
 
 use super::dts_rewrite::rewrite_relative_specifier;
 

--- a/crates/vize/src/commands/check/dts_rewrite.rs
+++ b/crates/vize/src/commands/check/dts_rewrite.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 pub(super) fn rewrite_relative_import_types(type_annotation: &str, source_dir: &Path) -> String {
     let bytes = type_annotation.as_bytes();

--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -9,8 +9,8 @@ use std::path::{Path, PathBuf};
 use vize_canon::batch::is_vue_runtime_support_specifier;
 use vize_canon::{PackageRouteBinding, PackageRouteResolver, PackageSourceOptions};
 #[cfg(test)]
-use vize_carton::cstr;
-use vize_carton::{FxHashSet, String};
+use vize_s0::cstr;
+use vize_s0::{FxHashSet, String};
 
 use super::imports_aliases::PathAliasResolver;
 use super::imports_package_routes::sort_package_route_bindings;

--- a/crates/vize/src/commands/check/imports_aliases.rs
+++ b/crates/vize/src/commands/check/imports_aliases.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 use super::imports::ImportFileOptions;
 use super::path_cache::CanonicalPathCache;

--- a/crates/vize/src/commands/check/imports_cache.rs
+++ b/crates/vize/src/commands/check/imports_cache.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use vize_canon::{
     PackageResolutionContext, PackageResolutionMode, PackageRouteLookup, PackageSourceOptions,
 };
-use vize_carton::{FxHashMap, String};
+use vize_s0::{FxHashMap, String};
 
 type ResolutionContextKey = (PathBuf, Option<OsString>, PackageResolutionMode);
 pub(super) type ResolutionContextCache =

--- a/crates/vize/src/commands/check/imports_generated_tests.rs
+++ b/crates/vize/src/commands/check/imports_generated_tests.rs
@@ -1,6 +1,6 @@
 use super::super::imports_aliases::PathAliasResolver;
 use super::*;
-use vize_carton::path::canonicalize_non_verbatim;
+use vize_s0::path::canonicalize_non_verbatim;
 
 fn write(dir: &Path, rel: &str, contents: &str) -> PathBuf {
     let path = dir.join(rel);

--- a/crates/vize/src/commands/check/imports_js_tests.rs
+++ b/crates/vize/src/commands/check/imports_js_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use vize_carton::path::canonicalize_non_verbatim;
+use vize_s0::path::canonicalize_non_verbatim;
 
 fn write(root: &Path, relative: &str, contents: &str) -> PathBuf {
     let path = root.join(relative);

--- a/crates/vize/src/commands/check/imports_package_routes.rs
+++ b/crates/vize/src/commands/check/imports_package_routes.rs
@@ -77,7 +77,7 @@ mod tests {
     ) -> PackageRouteBinding {
         PackageRouteBinding {
             importer_path: PathBuf::from("/workspace/src/app.ts"),
-            specifier: vize_carton::String::from("pkg"),
+            specifier: vize_s0::String::from("pkg"),
             occurrence_mode: mode,
             context: PackageResolutionContext::new(Some("bundler"), mode, ["import"]),
             route: None,

--- a/crates/vize/src/commands/check/imports_registration.rs
+++ b/crates/vize/src/commands/check/imports_registration.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use vize_carton::{FxHashMap, FxHashSet};
+use vize_s0::{FxHashMap, FxHashSet};
 
 use super::super::imports_aliases::PathAliasResolver;
 use super::super::path_cache::CanonicalPathCache;
@@ -28,7 +28,7 @@ pub(super) struct CachedVirtualRegistration {
 /// the scan to once per distinct route instead of once per occurrence.
 type PackageReachabilityKey = (
     PathBuf,
-    vize_carton::String,
+    vize_s0::String,
     vize_canon::PackageResolutionContext,
     u8,
 );
@@ -165,7 +165,7 @@ fn source_needs_virtual_registration(
                             occurrence.mode,
                             None,
                             None,
-                            std::iter::empty::<vize_carton::String>(),
+                            std::iter::empty::<vize_s0::String>(),
                         ),
                     };
                     let lookup = packages.lookup_with_context(
@@ -302,7 +302,7 @@ fn scan_route_reachability(
                     nested_mode,
                     None,
                     None,
-                    std::iter::empty::<vize_carton::String>(),
+                    std::iter::empty::<vize_s0::String>(),
                 ),
             };
             let (nested, consulted) = packages

--- a/crates/vize/src/commands/check/imports_resolution.rs
+++ b/crates/vize/src/commands/check/imports_resolution.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use super::super::path_cache::CanonicalPathCache;
 use super::ImportFileOptions;

--- a/crates/vize/src/commands/check/imports_specifiers.rs
+++ b/crates/vize/src/commands/check/imports_specifiers.rs
@@ -1,6 +1,6 @@
 //! Module-specifier scanning for the `vize check` transitive import walk.
 
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct ModuleSpecifierOccurrence {

--- a/crates/vize/src/commands/check/imports_tests.rs
+++ b/crates/vize/src/commands/check/imports_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use vize_carton::path::canonicalize_non_verbatim;
+use vize_s0::path::canonicalize_non_verbatim;
 
 fn write(dir: &Path, rel: &str, contents: &str) -> PathBuf {
     let path = dir.join(rel);

--- a/crates/vize/src/commands/check/nuxt.rs
+++ b/crates/vize/src/commands/check/nuxt.rs
@@ -5,7 +5,7 @@
 use std::path::Path;
 
 use vize_canon::virtual_ts::VirtualTsOptions;
-use vize_carton::{FxHashSet, String, ToCompactString, config::VueVersion};
+use vize_s0::{FxHashSet, String, ToCompactString, config::VueVersion};
 
 mod fallback;
 mod generated;

--- a/crates/vize/src/commands/check/nuxt/fallback.rs
+++ b/crates/vize/src/commands/check/nuxt/fallback.rs
@@ -13,7 +13,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::{ArrayExpressionElement, Expression};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{FxHashSet, String, ToCompactString};
+use vize_s0::{FxHashSet, String, ToCompactString};
 
 use super::parsing::{
     default_export_config_object, extract_expression, find_object_property, nuxt_config_source,

--- a/crates/vize/src/commands/check/nuxt/fallback/fallback_values.rs
+++ b/crates/vize/src/commands/check/nuxt/fallback/fallback_values.rs
@@ -1,4 +1,4 @@
-use vize_carton::String;
+use vize_s0::String;
 
 /// Hardcoded `any`-typed value stubs. Skipped whenever the project ships a
 /// generated `.nuxt` import manifest, which covers all of these names with

--- a/crates/vize/src/commands/check/nuxt/generated.rs
+++ b/crates/vize/src/commands/check/nuxt/generated.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use ignore::WalkBuilder;
 use vize_canon::virtual_ts::{TemplateGlobal, VirtualTsOptions};
-use vize_carton::{FxHashSet, String, ToCompactString, cstr};
+use vize_s0::{FxHashSet, String, ToCompactString, cstr};
 
 use super::super::dts::{
     parse_declared_global_values, parse_interface_members_with_rewritten_imports,

--- a/crates/vize/src/commands/check/nuxt/generated_ast.rs
+++ b/crates/vize/src/commands/check/nuxt/generated_ast.rs
@@ -5,7 +5,7 @@ use oxc_ast::ast::{Statement, TSImportType};
 use oxc_ast_visit::{Visit, walk::walk_ts_import_type};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{String, ToCompactString, cstr};
+use vize_s0::{String, ToCompactString, cstr};
 
 use super::super::dts::rewrite_relative_specifier;
 use super::parsing::module_export_name;

--- a/crates/vize/src/commands/check/nuxt/generated_ast_tests.rs
+++ b/crates/vize/src/commands/check/nuxt/generated_ast_tests.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use vize_canon::virtual_ts::VirtualTsOptions;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::detect_nuxt_auto_imports;
 

--- a/crates/vize/src/commands/check/nuxt/generated_dir.rs
+++ b/crates/vize/src/commands/check/nuxt/generated_dir.rs
@@ -7,7 +7,7 @@ use std::{
 
 use ignore::WalkBuilder;
 use serde_json::Value;
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use super::parsing::nuxt_config_static_string;
 use crate::commands::check::tsconfig_inputs::parse_jsonc_value;

--- a/crates/vize/src/commands/check/nuxt/generated_values.rs
+++ b/crates/vize/src/commands/check/nuxt/generated_values.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use vize_carton::{FxHashSet, String, ToCompactString};
+use vize_s0::{FxHashSet, String, ToCompactString};
 
 use super::generated_ast::collect_import_type_specifiers;
 use super::stubs::push_declared_const;

--- a/crates/vize/src/commands/check/nuxt/legacy_template_globals.rs
+++ b/crates/vize/src/commands/check/nuxt/legacy_template_globals.rs
@@ -1,5 +1,5 @@
 use vize_canon::virtual_ts::{TemplateGlobal, VirtualTsOptions};
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 pub(super) fn collect(options: &mut VirtualTsOptions) {
     for (name, type_annotation) in [

--- a/crates/vize/src/commands/check/nuxt/legacy_template_globals_tests.rs
+++ b/crates/vize/src/commands/check/nuxt/legacy_template_globals_tests.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use vize_canon::virtual_ts::VirtualTsOptions;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::{detect_legacy_nuxt_auto_imports, detect_nuxt_auto_imports};
 

--- a/crates/vize/src/commands/check/nuxt/parsing.rs
+++ b/crates/vize/src/commands/check/nuxt/parsing.rs
@@ -8,7 +8,7 @@ use oxc_ast::ast::{
 };
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use super::stubs::tracked_read_to_string;
 

--- a/crates/vize/src/commands/check/nuxt/plugins.rs
+++ b/crates/vize/src/commands/check/nuxt/plugins.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use ignore::WalkBuilder;
-use vize_carton::{FxHashSet, String, cstr};
+use vize_s0::{FxHashSet, String, cstr};
 
 use super::stubs::{push_stub, tracked_read_to_string};
 

--- a/crates/vize/src/commands/check/nuxt/plugins/extract.rs
+++ b/crates/vize/src/commands/check/nuxt/plugins/extract.rs
@@ -9,7 +9,7 @@ use oxc_ast::ast::{
 };
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::String;
+use vize_s0::String;
 
 use self::bindings::{StaticPlugin, resolve_static_plugin_from_export};
 use super::super::parsing::{

--- a/crates/vize/src/commands/check/nuxt/plugins/tests.rs
+++ b/crates/vize/src/commands/check/nuxt/plugins/tests.rs
@@ -3,7 +3,7 @@ use super::{
     render_module_augmentation_stub, render_nuxt_composition_api_augmentation_stub,
     render_nuxt_injected_properties_stub, render_nuxt_types_augmentation_stub,
 };
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 #[test]
 fn scans_src_app_plugins_for_nuxt2_injections() {

--- a/crates/vize/src/commands/check/nuxt/source_scan.rs
+++ b/crates/vize/src/commands/check/nuxt/source_scan.rs
@@ -6,7 +6,7 @@ use ignore::WalkBuilder;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{BindingPattern, Declaration, ExportDefaultDeclarationKind, Statement};
 use oxc_parser::Parser;
-use vize_carton::{FxHashMap, FxHashSet, String, ToCompactString, cstr};
+use vize_s0::{FxHashMap, FxHashSet, String, ToCompactString, cstr};
 
 use super::parsing::{is_ts_identifier, module_export_name, source_type_for_path};
 use super::stubs::{

--- a/crates/vize/src/commands/check/nuxt/stubs.rs
+++ b/crates/vize/src/commands/check/nuxt/stubs.rs
@@ -2,7 +2,7 @@
 
 use std::{fs, path::Path};
 
-use vize_carton::{FxHashSet, String, ToCompactString, cstr, profile, profiler::global_profiler};
+use vize_s0::{FxHashSet, String, ToCompactString, cstr, profile, profiler::global_profiler};
 
 pub(super) fn push_declared_const(
     stubs: &mut Vec<String>,

--- a/crates/vize/src/commands/check/nuxt/tests.rs
+++ b/crates/vize/src/commands/check/nuxt/tests.rs
@@ -5,7 +5,7 @@ use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_canon::virtual_ts::VirtualTsOptions;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::super::dts::rewrite_relative_specifier;
 use super::detect_nuxt_auto_imports;

--- a/crates/vize/src/commands/check/nuxt/tsconfig_aliases.rs
+++ b/crates/vize/src/commands/check/nuxt/tsconfig_aliases.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use serde_json::Value;
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 use crate::commands::check::tsconfig_inputs::{
     parse_jsonc_value, read_extends_entries, resolve_extended_tsconfig,
@@ -28,7 +28,7 @@ fn collect_explicit_virtual_module_aliases_inner(
     aliases: &mut FxHashSet<String>,
     seen: &mut FxHashSet<PathBuf>,
 ) {
-    let resolved = vize_carton::path::canonicalize_non_verbatim(tsconfig_path);
+    let resolved = vize_s0::path::canonicalize_non_verbatim(tsconfig_path);
     if !seen.insert(resolved.clone()) {
         return;
     }

--- a/crates/vize/src/commands/check/nuxt/virtual_modules.rs
+++ b/crates/vize/src/commands/check/nuxt/virtual_modules.rs
@@ -9,7 +9,7 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use serde_json::Value;
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-use vize_carton::{FxHashMap, FxHashSet, String, ToCompactString, append, cstr};
+use vize_s0::{FxHashMap, FxHashSet, String, ToCompactString, append, cstr};
 
 use super::NuxtPathAlias;
 use super::generated_dir::{NuxtGeneratedDir, normalize_path_lexically};

--- a/crates/vize/src/commands/check/path_cache.rs
+++ b/crates/vize/src/commands/check/path_cache.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 /// Run-scoped cache of `Path::canonicalize` results.
 ///
@@ -26,7 +26,7 @@ impl CanonicalPathCache {
         if let Some(cached) = self.cache.get(path) {
             return cached.clone();
         }
-        let canonical = vize_carton::path::canonicalize_non_verbatim(path);
+        let canonical = vize_s0::path::canonicalize_non_verbatim(path);
         self.cache.insert(path.to_path_buf(), canonical.clone());
         canonical
     }
@@ -44,10 +44,7 @@ mod tests {
 
         let mut cache = CanonicalPathCache::default();
         let canonical = cache.canonicalize(&file);
-        assert_eq!(
-            canonical,
-            vize_carton::path::canonicalize_non_verbatim(&file)
-        );
+        assert_eq!(canonical, vize_s0::path::canonicalize_non_verbatim(&file));
         // Cached lookups return the same result.
         assert_eq!(cache.canonicalize(&file), canonical);
 

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -142,7 +142,7 @@ fn prepare_and_execute(
     cache: &mut TsconfigInputCache,
     canonical_paths: &mut CanonicalPathCache,
     package_route_resolver: &mut vize_canon::PackageRouteResolver,
-) -> Result<Option<ProgramExecution>, vize_carton::String> {
+) -> Result<Option<ProgramExecution>, vize_s0::String> {
     let initial_root = candidate
         .tsconfig_path
         .as_deref()

--- a/crates/vize/src/commands/check/runner/collect.rs
+++ b/crates/vize/src/commands/check/runner/collect.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 
 use glob::{MatchOptions, Pattern};
 use ignore::WalkBuilder;
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 use super::super::patterns::{CheckFileOptions, is_supported_check_file};
 use super::ignores::CheckIgnoreSet;
@@ -270,7 +270,7 @@ fn strip_leading_current_dir(value: &str) -> String {
 }
 
 fn normalize_input_path(path: &Path) -> PathBuf {
-    vize_carton::path::canonicalize_non_verbatim(path)
+    vize_s0::path::canonicalize_non_verbatim(path)
 }
 
 pub(super) fn path_is_inside_root(root: &Path, path: &Path) -> bool {

--- a/crates/vize/src/commands/check/runner/collect_tests.rs
+++ b/crates/vize/src/commands/check/runner/collect_tests.rs
@@ -8,7 +8,7 @@ use crate::commands::check::{
 };
 use std::fs;
 use std::path::{Path, PathBuf};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[path = "collect_tests/allow_js.rs"]
 mod allow_js;

--- a/crates/vize/src/commands/check/runner/default_imports.rs
+++ b/crates/vize/src/commands/check/runner/default_imports.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use super::{
     CollectedRoots,

--- a/crates/vize/src/commands/check/runner/default_imports_tests.rs
+++ b/crates/vize/src/commands/check/runner/default_imports_tests.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use vize_carton::path::canonicalize_non_verbatim;
+use vize_s0::path::canonicalize_non_verbatim;
 
 fn unique_case_dir(name: &str) -> PathBuf {
     static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);

--- a/crates/vize/src/commands/check/runner/diagnostics.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use vize_carton::{String as CompactString, cstr, profile, profiler::global_profiler};
+use vize_s0::{String as CompactString, cstr, profile, profiler::global_profiler};
 
 use crate::commands::check::reporting::JsonOutput;
 
@@ -204,11 +204,11 @@ fn normalize_requested_virtual_ts_path(cwd: &Path, path: &Path) -> PathBuf {
     } else {
         cwd.join(path)
     };
-    vize_carton::path::canonicalize_non_verbatim(&absolute)
+    vize_s0::path::canonicalize_non_verbatim(&absolute)
 }
 
 fn paths_refer_to_same_file(candidate_path: &Path, requested_path: &Path) -> bool {
-    let candidate_path = vize_carton::path::canonicalize_non_verbatim(candidate_path);
+    let candidate_path = vize_s0::path::canonicalize_non_verbatim(candidate_path);
     candidate_path == requested_path
 }
 

--- a/crates/vize/src/commands/check/runner/diagnostics/source_context.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics/source_context.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, fs, path::PathBuf};
 
-use vize_carton::{String as CompactString, cstr};
+use vize_s0::{String as CompactString, cstr};
 
 #[derive(Default)]
 pub(super) struct SourceContextCache {

--- a/crates/vize/src/commands/check/runner/diagnostics/source_filter.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics/source_filter.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use crate::commands::check::path_cache::CanonicalPathCache;
 

--- a/crates/vize/src/commands/check/runner/execution.rs
+++ b/crates/vize/src/commands/check/runner/execution.rs
@@ -6,7 +6,7 @@ use vize_canon::{
     BatchTypeCheckResult, BatchTypeChecker, BatchTypeCheckerOptions,
     batch::TypeChecker as BatchTypeCheckerTrait,
 };
-use vize_carton::{FxHashSet, String, config::VueVersion, cstr};
+use vize_s0::{FxHashSet, String, config::VueVersion, cstr};
 
 use super::nuxt_tsconfig::{
     PreparedCheckerTsconfig, wait_for_active_config_test_barrier,
@@ -155,9 +155,9 @@ pub(super) fn execute_program(
     if let (Some(authored), Some(prepared)) =
         (input.tsconfig_path.as_ref(), checker_tsconfig.path())
     {
-        let prepared = vize_carton::path::canonicalize_non_verbatim(prepared);
+        let prepared = vize_s0::path::canonicalize_non_verbatim(prepared);
         for diagnostic in &mut result.diagnostics {
-            if vize_carton::path::canonicalize_non_verbatim(&diagnostic.file) == prepared {
+            if vize_s0::path::canonicalize_non_verbatim(&diagnostic.file) == prepared {
                 diagnostic.file = authored.clone();
             }
         }

--- a/crates/vize/src/commands/check/runner/global_components.rs
+++ b/crates/vize/src/commands/check/runner/global_components.rs
@@ -12,7 +12,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use vize_carton::{FxHashSet, String, cstr};
+use vize_s0::{FxHashSet, String, cstr};
 
 use super::resolve::resolve_from_config_dir;
 use crate::commands::check::tsconfig_inputs::{

--- a/crates/vize/src/commands/check/runner/ignores.rs
+++ b/crates/vize/src/commands/check/runner/ignores.rs
@@ -40,7 +40,7 @@ fn resolve_entry_ignore_pattern(ignore: &config::ConfigEntryIgnore, config_dir: 
     let pattern = Path::new(ignore.pattern.as_str());
     if pattern.is_absolute() {
         return if pattern.exists() {
-            vize_carton::path::canonicalize_non_verbatim(pattern)
+            vize_s0::path::canonicalize_non_verbatim(pattern)
         } else {
             pattern.to_path_buf()
         };
@@ -88,6 +88,6 @@ fn nested_node_modules_ignore(pattern: &Path) -> Option<PathBuf> {
     }
     let prefix = pattern_text.trim_end_matches(suffix).trim_end_matches('/');
     Some(PathBuf::from(
-        vize_carton::cstr!("{prefix}/**/{suffix}").as_str(),
+        vize_s0::cstr!("{prefix}/**/{suffix}").as_str(),
     ))
 }

--- a/crates/vize/src/commands/check/runner/input_scope.rs
+++ b/crates/vize/src/commands/check/runner/input_scope.rs
@@ -13,7 +13,7 @@
 
 use std::path::{Path, PathBuf};
 
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use super::super::{CheckArgs, patterns::CHECK_INPUTS_DISPLAY, reporting::JsonOutput};
 use super::{collect::path_is_inside_root, diagnostics::emit_json_output};
@@ -181,8 +181,8 @@ pub(super) fn report_no_inputs(args: &CheckArgs) {
 }
 
 fn is_strict_ancestor(ancestor: &Path, path: &Path) -> bool {
-    let ancestor = vize_carton::path::canonicalize_non_verbatim(ancestor);
-    let path = vize_carton::path::canonicalize_non_verbatim(path);
+    let ancestor = vize_s0::path::canonicalize_non_verbatim(ancestor);
+    let path = vize_s0::path::canonicalize_non_verbatim(path);
     path != ancestor && path.starts_with(&ancestor)
 }
 

--- a/crates/vize/src/commands/check/runner/input_scope/tests.rs
+++ b/crates/vize/src/commands/check/runner/input_scope/tests.rs
@@ -14,9 +14,8 @@ use super::{
 fn unique_case_dir(name: &str) -> PathBuf {
     static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    std::env::temp_dir().join(
-        vize_carton::cstr!("vize-input-scope-{name}-{}-{case_id}", std::process::id()).as_str(),
-    )
+    std::env::temp_dir()
+        .join(vize_s0::cstr!("vize-input-scope-{name}-{}-{case_id}", std::process::id()).as_str())
 }
 
 fn symlink_dir(source: &Path, target: &Path) -> std::io::Result<()> {

--- a/crates/vize/src/commands/check/runner/invocation.rs
+++ b/crates/vize/src/commands/check/runner/invocation.rs
@@ -28,7 +28,7 @@ pub(super) fn resolve_nuxt_project_root(
     } else {
         cwd.join(tsconfig)
     };
-    let tsconfig_dir = vize_carton::path::canonicalize_non_verbatim(&tsconfig_path)
+    let tsconfig_dir = vize_s0::path::canonicalize_non_verbatim(&tsconfig_path)
         .parent()
         .map(Path::to_path_buf)
         .unwrap_or_else(|| fallback.to_path_buf());

--- a/crates/vize/src/commands/check/runner/nuxt_tsconfig.rs
+++ b/crates/vize/src/commands/check/runner/nuxt_tsconfig.rs
@@ -12,7 +12,7 @@ use std::{
 
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
-use vize_carton::String;
+use vize_s0::String;
 
 mod cache;
 use cache::{
@@ -253,7 +253,7 @@ fn absolute_tsconfig_path(source_base_dir: &Path, target: &str) -> PathBuf {
     let target_path = if target_path.is_absolute() {
         target_path.to_path_buf()
     } else {
-        vize_carton::path::canonicalize_non_verbatim(source_base_dir).join(target_path)
+        vize_s0::path::canonicalize_non_verbatim(source_base_dir).join(target_path)
     };
     normalize_path_lexically(&target_path)
 }

--- a/crates/vize/src/commands/check/runner/nuxt_tsconfig/cache.rs
+++ b/crates/vize/src/commands/check/runner/nuxt_tsconfig/cache.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use sha2::{Digest, Sha256};
-use vize_carton::String;
+use vize_s0::String;
 
 mod lease;
 mod ownership;
@@ -28,10 +28,10 @@ pub(super) fn validate_config_cache_root(
     cache_root: &Path,
     project_root: &Path,
 ) -> Result<PathBuf, std::io::Error> {
-    let cache_root = vize_carton::path::canonicalize_non_verbatim(cache_root);
-    let project_root = vize_carton::path::canonicalize_non_verbatim(project_root);
+    let cache_root = vize_s0::path::canonicalize_non_verbatim(cache_root);
+    let project_root = vize_s0::path::canonicalize_non_verbatim(project_root);
     let dependency_root =
-        vize_carton::path::canonicalize_non_verbatim(&project_root.join("node_modules"));
+        vize_s0::path::canonicalize_non_verbatim(&project_root.join("node_modules"));
     let names_dependency_tree = cache_root.components().any(|component| {
         matches!(component, std::path::Component::Normal(name) if name
             .to_string_lossy()
@@ -60,7 +60,7 @@ fn canonicalize_with_missing_tail(path: &Path) -> PathBuf {
             break;
         }
     }
-    let mut resolved = vize_carton::path::canonicalize_non_verbatim(&ancestor);
+    let mut resolved = vize_s0::path::canonicalize_non_verbatim(&ancestor);
     for name in tail.into_iter().rev() {
         resolved.push(name);
     }

--- a/crates/vize/src/commands/check/runner/nuxt_tsconfig/path_options_tests.rs
+++ b/crates/vize/src/commands/check/runner/nuxt_tsconfig/path_options_tests.rs
@@ -225,7 +225,7 @@ fn target(root: &Path, relative: &str) -> String {
 }
 
 fn physical_target(root: &Path, relative: &str) -> String {
-    vize_carton::path::canonicalize_non_verbatim(root)
+    vize_s0::path::canonicalize_non_verbatim(root)
         .join(relative)
         .to_string_lossy()
         .replace('\\', "/")

--- a/crates/vize/src/commands/check/runner/output.rs
+++ b/crates/vize/src/commands/check/runner/output.rs
@@ -2,8 +2,8 @@
 
 use std::{collections::BTreeSet, path::Path, time::Duration, time::Instant};
 
-use vize_carton::profiler::global_profiler;
-use vize_carton::{String, cstr};
+use vize_s0::profiler::global_profiler;
+use vize_s0::{String, cstr};
 
 use super::{
     CheckArgs, JsonOutput, ProgramExecution,
@@ -76,7 +76,7 @@ pub(super) fn finish_executions(
 
 pub(super) fn exit_after_execution_error(
     executions: Vec<ProgramExecution>,
-    error: vize_carton::String,
+    error: vize_s0::String,
 ) -> ! {
     let style = super::text_style::TextStyle::stderr();
     eprintln!("{} {error}", style.red("Error:"));

--- a/crates/vize/src/commands/check/runner/output_declarations.rs
+++ b/crates/vize/src/commands/check/runner/output_declarations.rs
@@ -1,5 +1,5 @@
 use std::{collections::BTreeSet, time::Instant};
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use super::{
     super::resolve_declaration_emit_options, CheckArgs, DeclarationSummary, ProgramExecution,

--- a/crates/vize/src/commands/check/runner/output_json.rs
+++ b/crates/vize/src/commands/check/runner/output_json.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 use super::super::{
     CheckArgs, JsonFileResult, JsonOutput, JsonProgramResult, ProgramExecution,
@@ -20,7 +20,7 @@ pub(super) fn emit_json(
     total_warnings: usize,
     emitted: Option<&DeclarationSummary>,
     canonical_paths: &mut CanonicalPathCache,
-) -> Result<(), vize_carton::String> {
+) -> Result<(), vize_s0::String> {
     let mut files_json = executions
         .iter()
         .flat_map(|execution| {
@@ -85,7 +85,7 @@ pub(super) fn emit_json(
                     .map(|path| vize_canon::snapshot_tsconfig_compiler_options(cwd, path))
                     .transpose()
                     .map_err(|error| {
-                        vize_carton::cstr!(
+                        vize_s0::cstr!(
                             "Failed to snapshot compiler options for JSON output: {}",
                             error
                         )
@@ -93,7 +93,7 @@ pub(super) fn emit_json(
                 files,
             })
         })
-        .collect::<Result<Vec<_>, vize_carton::String>>()?;
+        .collect::<Result<Vec<_>, vize_s0::String>>()?;
 
     let reported_keys = executions
         .iter()

--- a/crates/vize/src/commands/check/runner/output_profile.rs
+++ b/crates/vize/src/commands/check/runner/output_profile.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
-use vize_carton::{String, cstr, profiler::global_profiler};
 use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report};
+use vize_s0::{String, cstr, profiler::global_profiler};
 
 use super::{DeclarationSummary, ProgramExecution};
 use crate::profile_support;

--- a/crates/vize/src/commands/check/runner/program_inputs.rs
+++ b/crates/vize/src/commands/check/runner/program_inputs.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use super::default_imports::canonical_file_set;
 use crate::commands::check::{

--- a/crates/vize/src/commands/check/runner/programs.rs
+++ b/crates/vize/src/commands/check/runner/programs.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use super::default_imports::canonical_file_set;
 use crate::commands::check::{

--- a/crates/vize/src/commands/check/runner/resolve.rs
+++ b/crates/vize/src/commands/check/runner/resolve.rs
@@ -4,7 +4,7 @@
 use std::path::{Path, PathBuf};
 
 use vize_canon::DeclarationEmitOptions;
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::commands::check::tsconfig_inputs::{
     TsconfigDeclarationOptions, load_tsconfig_declaration_options,
@@ -52,7 +52,7 @@ pub(super) fn resolve_project_root(
         } else {
             cwd.join(tsconfig)
         };
-        let tsconfig_dir = vize_carton::path::canonicalize_non_verbatim(&tsconfig_path)
+        let tsconfig_dir = vize_s0::path::canonicalize_non_verbatim(&tsconfig_path)
             .parent()
             .map(|parent| parent.to_path_buf())
             .unwrap_or_else(|| cwd.to_path_buf());
@@ -89,7 +89,7 @@ pub(super) fn resolve_tsconfig_path(
         } else {
             cwd.join(tsconfig)
         };
-        return Some(vize_carton::path::canonicalize_non_verbatim(&tsconfig_path));
+        return Some(vize_s0::path::canonicalize_non_verbatim(&tsconfig_path));
     }
 
     let candidate = project_root.join("tsconfig.json");
@@ -111,7 +111,7 @@ pub(super) fn resolve_tsconfig_path(
 }
 
 pub(super) fn explicit_input_root(project_root: &Path, cwd: &Path) -> PathBuf {
-    let cwd = vize_carton::path::canonicalize_non_verbatim(cwd);
+    let cwd = vize_s0::path::canonicalize_non_verbatim(cwd);
     if project_root.starts_with(&cwd) {
         cwd
     } else {
@@ -160,9 +160,9 @@ pub(super) fn validate_inputs_in_root(
 }
 
 fn validate_explicit_inputs_in_root(root: &Path, files: &[PathBuf]) -> Result<(), String> {
-    let root = vize_carton::path::canonicalize_non_verbatim(root);
+    let root = vize_s0::path::canonicalize_non_verbatim(root);
     for file in files {
-        let path = vize_carton::path::canonicalize_non_verbatim(file);
+        let path = vize_s0::path::canonicalize_non_verbatim(file);
         if !path.starts_with(&root) {
             return Err(format!(
                 "explicit check input `{}` is outside project root `{}`.",
@@ -236,8 +236,8 @@ fn path_has_component(path: &Path, component: &str) -> bool {
         .any(|part| part.as_os_str().to_str() == Some(component))
 }
 
-pub(super) fn display_path(base: &Path, path: &Path) -> vize_carton::String {
-    use vize_carton::cstr;
+pub(super) fn display_path(base: &Path, path: &Path) -> vize_s0::String {
+    use vize_s0::cstr;
 
     path.strip_prefix(base)
         .map(|relative| cstr!("{}", relative.display()))

--- a/crates/vize/src/commands/check/runner/socket.rs
+++ b/crates/vize/src/commands/check/runner/socket.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use vize_carton::{String, cstr, profile, profiler::global_profiler};
+use vize_s0::{String, cstr, profile, profiler::global_profiler};
 
 use super::{
     collect::collect_vue_files, display_path, output::save_virtual_ts_targets_or_exit,

--- a/crates/vize/src/commands/check/runner/text_style.rs
+++ b/crates/vize/src/commands/check/runner/text_style.rs
@@ -1,9 +1,9 @@
 use std::{fmt, io::IsTerminal};
 
-use vize_carton::{String, cstr};
 use vize_fresco::{
     ColorSupport, TerminalCapabilities, TerminalCapabilityProbe, TerminalProfileOptions,
 };
+use vize_s0::{String, cstr};
 
 #[derive(Clone, Copy)]
 pub(super) struct TextStyle {

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -8,7 +8,7 @@
 
 use std::path::{Path, PathBuf};
 
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 mod ambient;
 mod collect;

--- a/crates/vize/src/commands/check/tsconfig_inputs/ambient.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/ambient.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use super::NODE_MODULES_DIR;
 use super::collect_default_check_files_inner;

--- a/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use ignore::WalkBuilder;
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use super::glob::{normalize_input_path, normalize_walked_path};
 use super::matching::{

--- a/crates/vize/src/commands/check/tsconfig_inputs/default_exclude_tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/default_exclude_tests.rs
@@ -14,7 +14,7 @@
 
 use std::path::{Path, PathBuf};
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::TsconfigInputCache;
 
@@ -47,7 +47,7 @@ fn workspace(name: &str) -> PathBuf {
 
     // `temp_dir` is a symlink on macOS and the collector returns canonicalized
     // paths, so the case root has to be canonical for `collected`.
-    vize_carton::path::canonicalize_non_verbatim(&root)
+    vize_s0::path::canonicalize_non_verbatim(&root)
 }
 
 fn collected(root: &Path, tsconfig: &str) -> Vec<String> {

--- a/crates/vize/src/commands/check/tsconfig_inputs/glob.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/glob.rs
@@ -91,7 +91,7 @@ pub(super) fn normalize_path_separators(path: &Path) -> std::string::String {
 }
 
 pub(super) fn normalize_input_path(path: &Path) -> PathBuf {
-    vize_carton::path::canonicalize_non_verbatim(path)
+    vize_s0::path::canonicalize_non_verbatim(path)
 }
 
 pub(super) fn normalize_walked_path(root: &Path, normalized_root: &Path, path: &Path) -> PathBuf {

--- a/crates/vize/src/commands/check/tsconfig_inputs/hidden_include_tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/hidden_include_tests.rs
@@ -7,7 +7,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::TsconfigInputCache;
 

--- a/crates/vize/src/commands/check/tsconfig_inputs/loader.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/loader.rs
@@ -7,7 +7,7 @@ use std::{
 
 use serde_json::Value;
 use vize_canon::batch::{TsconfigOwnershipCache, TsconfigSourceKind};
-use vize_carton::{FxHashMap, FxHashSet, profile, profiler::global_profiler};
+use vize_s0::{FxHashMap, FxHashSet, profile, profiler::global_profiler};
 
 use super::glob::{compiler_option_dir_exclude, normalize_input_path};
 use super::jsonc::parse_jsonc_value;

--- a/crates/vize/src/commands/check/tsconfig_inputs/nuxt_manifest_tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/nuxt_manifest_tests.rs
@@ -7,7 +7,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::TsconfigInputCache;
 

--- a/crates/vize/src/commands/check/tsconfig_inputs/ownership_shared_tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/ownership_shared_tests.rs
@@ -4,7 +4,7 @@
 
 use std::path::{Path, PathBuf};
 
-use vize_carton::path::canonicalize_non_verbatim;
+use vize_s0::path::canonicalize_non_verbatim;
 
 use super::{TsconfigInputCache, resolve_tsconfig_for_files};
 

--- a/crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs
@@ -14,7 +14,7 @@
 
 use std::path::{Path, PathBuf};
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::TsconfigInputCache;
 
@@ -71,7 +71,7 @@ fn workspace(name: &str, tsconfig: &str) -> PathBuf {
 
     // `temp_dir` is a symlink on macOS, and the collector returns canonicalized
     // paths, so the case root has to be canonical for `relative_paths`.
-    vize_carton::path::canonicalize_non_verbatim(&root)
+    vize_s0::path::canonicalize_non_verbatim(&root)
 }
 
 fn collected(root: &Path) -> Vec<String> {

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
@@ -5,7 +5,7 @@
 use super::{TsconfigInputCache, load_tsconfig_declaration_options, resolve_extended_tsconfig};
 use std::fs;
 use std::path::{Path, PathBuf};
-use vize_carton::{cstr, path::canonicalize_non_verbatim};
+use vize_s0::{cstr, path::canonicalize_non_verbatim};
 mod allow_js;
 mod codegen;
 mod tsx_owner;

--- a/crates/vize/src/commands/check/tsconfig_inputs/type_references.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/type_references.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use serde_json::Value;
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use super::jsonc::parse_jsonc_value;
 

--- a/crates/vize/src/commands/check/tsconfig_inputs/type_references/tsconfig_types.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/type_references/tsconfig_types.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use serde_json::Value;
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use super::super::jsonc::parse_jsonc_value;
 use super::super::loader::{
@@ -23,7 +23,7 @@ fn load_tsconfig_type_packages(
     tsconfig_path: &Path,
     seen: &mut FxHashSet<PathBuf>,
 ) -> Option<Vec<std::string::String>> {
-    let resolved = vize_carton::path::canonicalize_non_verbatim(tsconfig_path);
+    let resolved = vize_s0::path::canonicalize_non_verbatim(tsconfig_path);
     if !seen.insert(resolved.clone()) {
         return None;
     }

--- a/crates/vize/src/commands/content_mapper.rs
+++ b/crates/vize/src/commands/content_mapper.rs
@@ -15,7 +15,7 @@ use serde_json::{Value, json};
 use vize_canon::{
     ContentMapperTransformOptions, generate_vue_content_mapper_transform_with_options,
 };
-use vize_carton::{String as CompactString, cstr};
+use vize_s0::{String as CompactString, cstr};
 
 #[path = "content_mapper/project.rs"]
 mod project;

--- a/crates/vize/src/commands/content_mapper/project.rs
+++ b/crates/vize/src/commands/content_mapper/project.rs
@@ -10,7 +10,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use vize_carton::{FxHashMap, String as CompactString, cstr};
+use vize_s0::{FxHashMap, String as CompactString, cstr};
 
 /// Mapper diagnostic code for an options value that is not an object.
 const OPTION_CODE_NOT_AN_OBJECT: i32 = 1;

--- a/crates/vize/src/commands/content_mapper/test_support.rs
+++ b/crates/vize/src/commands/content_mapper/test_support.rs
@@ -3,7 +3,7 @@
 use std::io::{BufReader, Cursor};
 
 use serde_json::{Value, json};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 pub(super) const PROJECT_HANDLE: &str = "p1";
 

--- a/crates/vize/src/commands/davinci_ice.rs
+++ b/crates/vize/src/commands/davinci_ice.rs
@@ -36,7 +36,6 @@ use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::{Path, PathBuf};
 use std::sync::Once;
 
-use vize_carton::{FxHashMap, String, cstr};
 use vize_davinci::folio::repro::{ReproFolio, failure_text};
 use vize_davinci::folio::{Folio, FolioMode};
 use vize_davinci::legacy_plan;
@@ -44,6 +43,7 @@ use vize_davinci::pass::{
     BudgetObserver, Fusability, Pair, PassDesc, PassKind, Pipeline, Preserved, TimingObserver,
     parse_pipelines, pipeline::PipelineSpec, run_pipeline,
 };
+use vize_s0::{FxHashMap, String, cstr};
 
 /// `artifact-stage` value for an embedded authored source.
 pub(crate) const ARTIFACT_STAGE_SOURCE: &str = "source";

--- a/crates/vize/src/commands/doctor.rs
+++ b/crates/vize/src/commands/doctor.rs
@@ -16,11 +16,11 @@ mod tests;
 
 use clap::{Args, ValueEnum};
 use std::{fmt, io, path::PathBuf};
-use vize_carton::String;
 use vize_doctor::{
     DoctorCategory, DoctorFilterError, DoctorReport, FindingConfidence, FindingSeverity,
     ReporterFailure, SarifSourceError, application_analysis::ApplicationAnalysisError,
 };
+use vize_s0::String;
 
 use self::{
     analysis::analyze_application,

--- a/crates/vize/src/commands/doctor/analysis.rs
+++ b/crates/vize/src/commands/doctor/analysis.rs
@@ -10,13 +10,13 @@ use vize_atelier_sfc::{
     croquis::{SfcCroquisOptions, analyze_sfc_descriptor_with_context},
     parse_sfc,
 };
-use vize_carton::{Allocator, FxHashMap, String, ToCompactString};
 use vize_croquis::{EffectGraphScript, build_effect_graph_from_sfc_scripts};
 use vize_croquis_cf::{CrossFileAnalyzer, CrossFileDiagnosticKind, CrossFileOptions, FileId};
 use vize_doctor::{
     ContentFingerprint, DoctorFinding, DoctorReport,
     application_analysis::report_from_application_graph,
 };
+use vize_s0::{Allocator, FxHashMap, String, ToCompactString};
 
 use super::{DoctorError, DoctorSource, canonical_sfc};
 

--- a/crates/vize/src/commands/doctor/canonical_sfc.rs
+++ b/crates/vize/src/commands/doctor/canonical_sfc.rs
@@ -1,12 +1,12 @@
 //! Doctor rule for the opt-in public component authoring contract.
 
 use vize_atelier_sfc::{BlockLocation, SfcDescriptor};
-use vize_carton::cstr;
 use vize_doctor::{
     AnalysisProvenance, DoctorCategory, DoctorFinding, EvidenceKind, FindingAssessment,
     FindingConfidence, FindingEvidence, FindingFix, FindingImpact, FindingSeverity, HealthPenalty,
     RuleCost, SourceLocation, SuppressionPolicy,
 };
+use vize_s0::cstr;
 
 pub(super) const RULE_CODE: &str = "VIZE_DOCTOR_SFC_EXPLICIT_SECTIONS";
 
@@ -132,7 +132,7 @@ fn bounded_offset(offset: usize) -> u32 {
 mod tests {
     use super::*;
     use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-    use vize_carton::String;
+    use vize_s0::String;
 
     #[test]
     fn accepts_semantic_attribute_order_and_companion_script() {

--- a/crates/vize/src/commands/doctor/discovery.rs
+++ b/crates/vize/src/commands/doctor/discovery.rs
@@ -6,7 +6,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 use super::DoctorError;
 

--- a/crates/vize/src/commands/doctor/tests.rs
+++ b/crates/vize/src/commands/doctor/tests.rs
@@ -1,7 +1,7 @@
 use super::{DoctorSource, analysis::analyze_application, discovery::discover_sources};
 use std::{fs, path::Path};
-use vize_carton::String;
 use vize_doctor::ContentFingerprint;
+use vize_s0::String;
 
 #[test]
 fn discovery_is_sorted_deduplicated_and_uses_standard_ignores() {

--- a/crates/vize/src/commands/doctor/tui.rs
+++ b/crates/vize/src/commands/doctor/tui.rs
@@ -15,7 +15,6 @@ use std::{
     process::Command,
 };
 
-use vize_carton::{String, ToCompactString, cstr};
 use vize_doctor::DoctorReport;
 use vize_fresco::{
     Backend, Event, FrameActivityTelemetry, FrameRenderer, TerminalCapabilities,
@@ -24,6 +23,7 @@ use vize_fresco::{
     input::read_event, install_terminal_panic_hook, install_terminal_signal_hook,
     terminal::TerminalOptions,
 };
+use vize_s0::{String, ToCompactString, cstr};
 
 use super::{DoctorFormat, DoctorSource};
 use model::{DoctorTuiModel, InteractionOutcome};

--- a/crates/vize/src/commands/doctor/tui/model.rs
+++ b/crates/vize/src/commands/doctor/tui/model.rs
@@ -4,13 +4,13 @@ mod filter;
 
 use std::path::Path;
 
-use vize_carton::{String, ToCompactString};
 use vize_doctor::{DoctorCategory, DoctorFinding, DoctorReport, FindingSeverity};
 use vize_fresco::{
     Cursor, DiagnosticWorkspaceAction, DiagnosticWorkspaceCommandOutcome,
     DiagnosticWorkspaceKeymap, DiagnosticWorkspaceState, Key, KeyEvent, KeyEventKind,
     terminal::CursorShape,
 };
+use vize_s0::{String, ToCompactString};
 
 use super::super::DoctorSource;
 use filter::{cycle, search_document};

--- a/crates/vize/src/commands/doctor/tui/model/filter.rs
+++ b/crates/vize/src/commands/doctor/tui/model/filter.rs
@@ -1,7 +1,7 @@
 //! Allocation-conscious filter labels and precomputed search documents.
 
-use vize_carton::String;
 use vize_doctor::{DoctorCategory, DoctorFinding, FindingSeverity};
+use vize_s0::String;
 
 pub(super) fn cycle(current: usize, length: usize, forward: bool) -> usize {
     if forward {

--- a/crates/vize/src/commands/doctor/tui/render.rs
+++ b/crates/vize/src/commands/doctor/tui/render.rs
@@ -4,7 +4,6 @@ mod chrome;
 mod detail;
 mod tree;
 
-use vize_carton::{String, cstr};
 use vize_doctor::FindingSeverity;
 use vize_fresco::{
     DiagnosticPresentation, DiagnosticPresentationProfile, DiagnosticTone,
@@ -12,6 +11,7 @@ use vize_fresco::{
     HeadlessSemanticNode, Rect, SemanticRole, SemanticState, TerminalCapabilities,
     terminal::{Cursor, Style},
 };
+use vize_s0::{String, cstr};
 
 use super::{DoctorSource, DoctorTuiError};
 use crate::commands::doctor::tui::model::{DoctorTuiModel, InteractionMode, severity_label};

--- a/crates/vize/src/commands/doctor/tui/render/chrome.rs
+++ b/crates/vize/src/commands/doctor/tui/render/chrome.rs
@@ -1,11 +1,11 @@
 //! Semantic title, status, shortcut, and help chrome.
 
-use vize_carton::cstr;
 use vize_fresco::{
     DiagnosticPresentation, DiagnosticTone, HeadlessSemanticNode, Rect, SemanticRole,
     SemanticState, TerminalCapabilities,
     terminal::{Color, Style},
 };
+use vize_s0::cstr;
 
 use super::{profile, tree::DoctorFrameBuilder};
 use crate::commands::doctor::tui::{

--- a/crates/vize/src/commands/doctor/tui/render/detail.rs
+++ b/crates/vize/src/commands/doctor/tui/render/detail.rs
@@ -2,7 +2,6 @@
 
 mod labels;
 
-use vize_carton::{String, cstr};
 use vize_doctor::{DoctorFinding, FixSafety};
 use vize_fresco::{
     DiagnosticPresentation, DiagnosticPresentationKind, DiagnosticTone, HeadlessSemanticNode,
@@ -10,6 +9,7 @@ use vize_fresco::{
     terminal::{Color, Style},
     text::WrapMode,
 };
+use vize_s0::{String, cstr};
 
 use super::{StyledLine, profile, severity_tone};
 use crate::commands::doctor::{

--- a/crates/vize/src/commands/doctor/tui/render/tree.rs
+++ b/crates/vize/src/commands/doctor/tui/render/tree.rs
@@ -87,7 +87,7 @@ impl DoctorFrameBuilder {
         &mut self,
         parent: u64,
         area: vize_fresco::Rect,
-        text: impl Into<vize_carton::String>,
+        text: impl Into<vize_s0::String>,
         style: Style,
         semantic: Option<HeadlessSemanticNode>,
         focused: bool,

--- a/crates/vize/src/commands/env_info.rs
+++ b/crates/vize/src/commands/env_info.rs
@@ -1,5 +1,5 @@
 use std::process::Command;
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 pub fn run() {
     println!("{}", collect().join("\n"));

--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -10,11 +10,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
-use vize_carton::{cstr, profile, profiler::global_profiler};
 use vize_glyph::{
     Allocator, FormatOptions, FormatResult, format_script_with_source_type,
     format_sfc_with_allocator,
 };
+use vize_s0::{cstr, profile, profiler::global_profiler};
 
 use super::atomic_write::atomic_write;
 use crate::{config, profile_support};

--- a/crates/vize/src/commands/fmt/data.rs
+++ b/crates/vize/src/commands/fmt/data.rs
@@ -1,8 +1,8 @@
 //! Formatting for non-SFC files: JSON, JSONC, YAML, and Markdown.
 
 use std::path::Path;
-use vize_carton::profile;
 use vize_glyph::{FormatOptions, FormatResult};
+use vize_s0::profile;
 
 mod plain;
 

--- a/crates/vize/src/commands/fmt/data/plain.rs
+++ b/crates/vize/src/commands/fmt/data/plain.rs
@@ -13,8 +13,8 @@
 //!
 //! Richer, structure-aware formatting is a follow-up that needs real parsers.
 
-use vize_carton::String;
 use vize_glyph::FormatResult;
+use vize_s0::String;
 
 /// Format a YAML document (lossless newline normalization).
 pub(super) fn format_yaml(source: &str) -> FormatResult {

--- a/crates/vize/src/commands/fmt/entries.rs
+++ b/crates/vize/src/commands/fmt/entries.rs
@@ -1,6 +1,6 @@
 use glob::glob;
 use std::path::{Path, PathBuf};
-use vize_carton::String;
+use vize_s0::String;
 
 use super::patterns::{has_explicit_patterns, is_format_extension};
 use super::{FmtArgs, files::FmtPattern};

--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -122,8 +122,8 @@ impl FmtPattern {
     }
 }
 
-fn normalize_fmt_pattern(pattern: &str) -> vize_carton::String {
-    let mut normalized: vize_carton::String = pattern.replace('\\', "/").into();
+fn normalize_fmt_pattern(pattern: &str) -> vize_s0::String {
+    let mut normalized: vize_s0::String = pattern.replace('\\', "/").into();
     while let Some(stripped) = normalized.strip_prefix("./") {
         normalized = stripped.into();
     }
@@ -150,7 +150,7 @@ fn is_format_target(path: &Path) -> bool {
 }
 
 #[inline]
-fn normalize_path(path: &Path) -> vize_carton::String {
+fn normalize_path(path: &Path) -> vize_s0::String {
     path.to_string_lossy().replace('\\', "/").into()
 }
 
@@ -192,7 +192,7 @@ mod tests {
         path::{Path, PathBuf},
         time::{SystemTime, UNIX_EPOCH},
     };
-    use vize_carton::{String, ToCompactString};
+    use vize_s0::{String, ToCompactString};
 
     #[test]
     fn absolute_glob_only_matches_requested_directory() {

--- a/crates/vize/src/commands/fmt/files_tests.rs
+++ b/crates/vize/src/commands/fmt/files_tests.rs
@@ -4,7 +4,7 @@ use std::{
     path::PathBuf,
     time::{SystemTime, UNIX_EPOCH},
 };
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 #[test]
 fn collect_files_ignores_supported_extension_directories() {

--- a/crates/vize/src/commands/fmt/ignores.rs
+++ b/crates/vize/src/commands/fmt/ignores.rs
@@ -77,6 +77,6 @@ fn nested_node_modules_ignore(pattern: &Path) -> Option<PathBuf> {
     }
     let prefix = pattern_text.trim_end_matches(suffix).trim_end_matches('/');
     Some(PathBuf::from(
-        vize_carton::cstr!("{prefix}/**/{suffix}").as_str(),
+        vize_s0::cstr!("{prefix}/**/{suffix}").as_str(),
     ))
 }

--- a/crates/vize/src/commands/inspector.rs
+++ b/crates/vize/src/commands/inspector.rs
@@ -20,8 +20,8 @@ use vize_atelier_sfc::{
     TemplateCompileOptions, compile_sfc_with_template_syntax as compile_vize_sfc,
     parse_sfc as parse_vize_sfc,
 };
-use vize_carton::{String, ToCompactString};
 use vize_curator::inspector as curator_inspector;
+use vize_s0::{String, ToCompactString};
 
 mod compare_error;
 mod no_inputs;

--- a/crates/vize/src/commands/inspector/compare_error.rs
+++ b/crates/vize/src/commands/inspector/compare_error.rs
@@ -1,6 +1,6 @@
 //! Error formatting for inspector compare's official compiler subprocess.
 
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 pub(super) fn official_compiler_error_message(stderr: &str) -> String {
     if is_missing_vue3_compiler(stderr) {

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -27,11 +27,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
-use vize_carton::{String, ToCompactString, cstr, profile, profiler::global_profiler};
 use vize_curator::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
 };
 use vize_patina::{HelpLevel, LintPreset, OutputFormat, format_results};
+use vize_s0::{String, ToCompactString, cstr, profile, profiler::global_profiler};
 
 pub fn run(args: LintArgs) {
     let start = Instant::now();
@@ -224,7 +224,7 @@ pub fn run(args: LintArgs) {
             "cli.lint.output.clone_sources",
             results
                 .iter()
-                .map(|(_, f, s, _)| (f.clone(), vize_carton::String::from(s.as_str())))
+                .map(|(_, f, s, _)| (f.clone(), vize_s0::String::from(s.as_str())))
                 .collect()
         );
 

--- a/crates/vize/src/commands/lint/args.rs
+++ b/crates/vize/src/commands/lint/args.rs
@@ -2,7 +2,7 @@
 
 use clap::Args;
 use std::path::PathBuf;
-use vize_carton::String;
+use vize_s0::String;
 
 use super::patterns::LINT_DEFAULT_PATTERNS;
 

--- a/crates/vize/src/commands/lint/collect.rs
+++ b/crates/vize/src/commands/lint/collect.rs
@@ -3,7 +3,7 @@
 use glob::{MatchOptions, Pattern};
 use ignore::WalkBuilder;
 use std::path::{Path, PathBuf};
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 use super::patterns::{is_lint_extension, is_plain_script_extension, is_standalone_html_extension};
 use crate::config;
@@ -214,7 +214,7 @@ fn resolve_entry_ignore_pattern(ignore: &config::ConfigEntryIgnore, config_dir: 
     let pattern = Path::new(ignore.pattern.as_str());
     if pattern.is_absolute() {
         return if pattern.exists() {
-            vize_carton::path::canonicalize_non_verbatim(pattern)
+            vize_s0::path::canonicalize_non_verbatim(pattern)
         } else {
             pattern.to_path_buf()
         };
@@ -251,7 +251,7 @@ fn nested_node_modules_ignore(pattern: &Path) -> Option<PathBuf> {
     }
     let prefix = pattern_text.trim_end_matches(suffix).trim_end_matches('/');
     Some(PathBuf::from(
-        vize_carton::cstr!("{prefix}/**/{suffix}").as_str(),
+        vize_s0::cstr!("{prefix}/**/{suffix}").as_str(),
     ))
 }
 

--- a/crates/vize/src/commands/lint/cross_file.rs
+++ b/crates/vize/src/commands/lint/cross_file.rs
@@ -7,7 +7,6 @@ use vize_atelier_sfc::{
     croquis::{SfcCroquisOptions, analyze_sfc_descriptor},
     parse_sfc,
 };
-use vize_carton::{Allocator, CompactString, FxHashMap, String, ToCompactString, cstr};
 use vize_croquis::Croquis;
 use vize_croquis_cf::{
     CrossFileAnalyzer, CrossFileDiagnostic, CrossFileDiagnosticKind, CrossFileOptions,
@@ -15,6 +14,7 @@ use vize_croquis_cf::{
 };
 use vize_curator::complexity::render_complexity_markdown;
 use vize_patina::{HelpLevel, LintDiagnostic, LintResult};
+use vize_s0::{Allocator, CompactString, FxHashMap, String, ToCompactString, cstr};
 
 pub(super) struct CrossFileLintOutput {
     pub(super) results: Vec<LintResult>,

--- a/crates/vize/src/commands/lint/entry_rules.rs
+++ b/crates/vize/src/commands/lint/entry_rules.rs
@@ -1,11 +1,11 @@
 //! Batch resolution of declaration-ordered `entries[].linter.rules`.
 
 use std::path::{Path, PathBuf};
-use vize_carton::{
+use vize_patina::{HelpLevel, LintPreset, Linter, Severity};
+use vize_s0::{
     FxHashMap, String,
     config::{LintRuleOptions, LintRuleSeverity, LinterConfigPlan, LinterFeatureFlags},
 };
-use vize_patina::{HelpLevel, LintPreset, Linter, Severity};
 
 use super::LintArgs;
 #[cfg(test)]

--- a/crates/vize/src/commands/lint/entry_rules_tests.rs
+++ b/crates/vize/src/commands/lint/entry_rules_tests.rs
@@ -3,8 +3,8 @@ use crate::config::{
     LintRuleSeverity as Severity, LinterConfig, LinterConfigEntry, LinterConfigPlan,
 };
 use std::{collections::BTreeMap, fs, path::PathBuf};
-use vize_carton::FxHashMap;
 use vize_patina::{LintPreset, Linter};
+use vize_s0::FxHashMap;
 
 const IMPORTED_STORE_SFC: &str = r#"<script setup lang="ts">
 import { useCounterStore } from "./store"
@@ -12,7 +12,7 @@ const { count, actions } = useCounterStore()
 </script>
 "#;
 
-fn rules(entries: &[(&str, Severity)]) -> FxHashMap<vize_carton::String, Severity> {
+fn rules(entries: &[(&str, Severity)]) -> FxHashMap<vize_s0::String, Severity> {
     entries
         .iter()
         .map(|(name, severity)| ((*name).into(), *severity))

--- a/crates/vize/src/commands/lint/fix.rs
+++ b/crates/vize/src/commands/lint/fix.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 
 use super::collect::{is_plain_script_path, is_standalone_html_path};
 use crate::commands::atomic_write::atomic_write;
-use vize_carton::{String, ToCompactString, profiler::global_profiler};
 use vize_patina::{JsxLang, LintResult, Linter, TextEdit};
+use vize_s0::{String, ToCompactString, profiler::global_profiler};
 
 pub(super) fn lint_source_with_optional_fix(
     linter: &Linter,

--- a/crates/vize/src/commands/lint/patterns.rs
+++ b/crates/vize/src/commands/lint/patterns.rs
@@ -19,11 +19,11 @@ pub(super) const LINT_DEFAULT_PATTERNS: &[&str] = &[
 pub(super) const LINT_EXTENSIONS_DISPLAY: &str =
     ".vue, .html, .htm, .js, .mjs, .cjs, .ts, .mts, .cts, .jsx, or .tsx";
 
-pub(super) fn no_lint_files_message(patterns: &[vize_carton::String]) -> vize_carton::String {
-    vize_carton::cstr!("No {LINT_EXTENSIONS_DISPLAY} files found matching patterns: {patterns:?}")
+pub(super) fn no_lint_files_message(patterns: &[vize_s0::String]) -> vize_s0::String {
+    vize_s0::cstr!("No {LINT_EXTENSIONS_DISPLAY} files found matching patterns: {patterns:?}")
 }
 
-pub(super) fn write_no_files(format: vize_patina::OutputFormat, patterns: &[vize_carton::String]) {
+pub(super) fn write_no_files(format: vize_patina::OutputFormat, patterns: &[vize_s0::String]) {
     eprintln!("{}", no_lint_files_message(patterns));
     if format == vize_patina::OutputFormat::Json {
         super::stdout::write(vize_patina::format_results(&[], &[], format).as_bytes());

--- a/crates/vize/src/commands/lint/stdout.rs
+++ b/crates/vize/src/commands/lint/stdout.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Write};
 use std::time::Duration;
-use vize_carton::cstr;
 use vize_patina::format_summary;
+use vize_s0::cstr;
 
 pub(super) fn write(bytes: &[u8]) {
     let mut stdout = io::stdout().lock();

--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -9,7 +9,7 @@ use new::NewArgs;
 use serve_plan::create_serve_plan;
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use vize_carton::{String, append, cstr};
+use vize_s0::{String, append, cstr};
 
 #[derive(Args)]
 pub struct MuseaArgs {

--- a/crates/vize/src/commands/musea/migrate.rs
+++ b/crates/vize/src/commands/musea/migrate.rs
@@ -13,8 +13,8 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use std::fs;
 use std::path::{Path, PathBuf};
-use vize_carton::String as CartonString;
-use vize_carton::append;
+use vize_s0::String as CartonString;
+use vize_s0::append;
 
 use crate::commands::fmt::collect_files;
 use csf::extract_csf;

--- a/crates/vize/src/commands/musea/migrate/csf.rs
+++ b/crates/vize/src/commands/musea/migrate/csf.rs
@@ -14,7 +14,7 @@ use oxc_ast::ast::{
     ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement, VariableDeclarationKind,
     VariableDeclarator,
 };
-use vize_carton::String;
+use vize_s0::String;
 
 use self::render::render_body;
 use self::storyfn::collect_stories;

--- a/crates/vize/src/commands/musea/migrate/emit.rs
+++ b/crates/vize/src/commands/musea/migrate/emit.rs
@@ -2,7 +2,7 @@
 
 use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, PropertyKey};
 use oxc_span::GetSpan;
-use vize_carton::{String, append};
+use vize_s0::{String, append};
 
 use self::static_args::{
     ModuleBindings, args_contain_unmigrated_bindings, args_has_static_property,

--- a/crates/vize/src/commands/musea/migrate/emit/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/emit/tests.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::String;
+use vize_s0::String;
 
 use super::super::csf::extract_csf;
 use super::emit_art;

--- a/crates/vize/src/commands/musea/migrate/jsx.rs
+++ b/crates/vize/src/commands/musea/migrate/jsx.rs
@@ -10,7 +10,7 @@ use oxc_ast::ast::{
     Expression, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXChild, JSXElement,
     JSXElementName, JSXExpression, JSXFragment, JSXMemberExpression, JSXMemberExpressionObject,
 };
-use vize_carton::{String, append};
+use vize_s0::{String, append};
 
 /// Convert a JSX expression (element or fragment) to Vue template markup.
 ///

--- a/crates/vize/src/commands/musea/migrate/jsx/tests.rs
+++ b/crates/vize/src/commands/musea/migrate/jsx/tests.rs
@@ -2,7 +2,7 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::{Expression, Statement};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::String;
+use vize_s0::String;
 
 use super::convert_render;
 

--- a/crates/vize/src/commands/musea/migrate/text.rs
+++ b/crates/vize/src/commands/musea/migrate/text.rs
@@ -1,6 +1,6 @@
 //! Escaping helpers for emitting valid `.art.vue` output.
 
-use vize_carton::String;
+use vize_s0::String;
 
 /// HTML-escape a value for placement inside a double-quoted attribute, so an
 /// expression or string containing `"` (e.g. `onClick={() => alert("hi")}`)

--- a/crates/vize/src/commands/musea/new.rs
+++ b/crates/vize/src/commands/musea/new.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 use std::fs;
 use std::path::PathBuf;
-use vize_carton::{String, ToCompactString, cstr};
+use vize_s0::{String, ToCompactString, cstr};
 
 #[derive(Args)]
 #[allow(clippy::disallowed_types)]

--- a/crates/vize/src/commands/musea/serve_plan.rs
+++ b/crates/vize/src/commands/musea/serve_plan.rs
@@ -1,7 +1,7 @@
 use super::{ServeArgs, setup};
 use setup::validate_direct_vite_musea_setup;
 use std::path::{Path, PathBuf};
-use vize_carton::{String, ToCompactString, cstr};
+use vize_s0::{String, ToCompactString, cstr};
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) struct ServePlan {

--- a/crates/vize/src/commands/musea/setup.rs
+++ b/crates/vize/src/commands/musea/setup.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 const MUSEA_VITE_PLUGIN: &str = "@vizejs/vite-plugin-musea";
 const VITE_CONFIG_FILES: &[&str] = &[

--- a/crates/vize/src/commands/profile_export.rs
+++ b/crates/vize/src/commands/profile_export.rs
@@ -7,7 +7,7 @@
 use std::path::{Path, PathBuf};
 
 use clap::Args;
-use vize_carton::profiler::{ProfileExportBudget, ProfileExportOptions, global_profiler};
+use vize_s0::profiler::{ProfileExportBudget, ProfileExportOptions, global_profiler};
 
 use crate::profile_support;
 

--- a/crates/vize/src/commands/ready.rs
+++ b/crates/vize/src/commands/ready.rs
@@ -8,7 +8,7 @@ use crate::commands::{
     check::CheckArgs,
     lint::LintArgs,
 };
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 #[cfg(feature = "glyph")]
 use crate::commands::fmt::FmtArgs;

--- a/crates/vize/src/commands/upgrade.rs
+++ b/crates/vize/src/commands/upgrade.rs
@@ -2,7 +2,7 @@
 
 use clap::{Args, ValueEnum};
 use std::process::Command;
-use vize_carton::String as CompactString;
+use vize_s0::String as CompactString;
 
 #[derive(Debug, Clone, Copy, ValueEnum, Default)]
 pub enum UpgradeSource {

--- a/crates/vize/src/config.rs
+++ b/crates/vize/src/config.rs
@@ -2,7 +2,7 @@
 
 use std::{fs, path::Path};
 
-pub use vize_carton::config::*;
+pub use vize_s0::config::*;
 
 pub const VIZE_CONFIG_SCHEMA: &str =
     include_str!("../../../npm/cli/schemas/vize.config.schema.json");

--- a/crates/vize/src/lib.rs
+++ b/crates/vize/src/lib.rs
@@ -40,7 +40,7 @@ pub mod source_write {
 pub use crate::commands::doctor::DoctorTuiBenchmark;
 
 /// Shared allocator, string, hash, and utility types.
-pub use vize_carton as carton;
+pub use vize_s0 as carton;
 
 /// Vue template AST, errors, and compiler options.
 pub use vize_relief as relief;

--- a/crates/vize/src/lint_plan.rs
+++ b/crates/vize/src/lint_plan.rs
@@ -5,7 +5,7 @@ pub(crate) mod matcher;
 use matcher::{LintPlanScope, absolute_path, normalize_path};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, path::Path};
-use vize_carton::{String, config::LintRuleSeverity};
+use vize_s0::{String, config::LintRuleSeverity};
 
 /// Serializable ordered plan accepted by the inspector surface.
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/crates/vize/src/lint_plan/matcher.rs
+++ b/crates/vize/src/lint_plan/matcher.rs
@@ -2,7 +2,7 @@
 
 use globset::{GlobBuilder, GlobMatcher};
 use std::path::{Component, Path, PathBuf};
-use vize_carton::String;
+use vize_s0::String;
 
 pub(crate) struct LintPlanScope {
     base_dir: PathBuf,

--- a/crates/vize/src/lint_plan/tests.rs
+++ b/crates/vize/src/lint_plan/tests.rs
@@ -1,6 +1,6 @@
 use super::{InspectorLintPlan, InspectorLintPlanItem, inspect_lint_plan};
 use std::{collections::BTreeMap, path::Path};
-use vize_carton::config::LintRuleSeverity as Severity;
+use vize_s0::config::LintRuleSeverity as Severity;
 
 fn item(
     name: &str,

--- a/crates/vize/src/main.rs
+++ b/crates/vize/src/main.rs
@@ -6,8 +6,8 @@ static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[cfg(feature = "profiling")]
 #[global_allocator]
-static GLOBAL_ALLOCATOR: vize_carton::profiler::ProfilingAllocator<mimalloc::MiMalloc> =
-    vize_carton::profiler::ProfilingAllocator::from_allocator(mimalloc::MiMalloc);
+static GLOBAL_ALLOCATOR: vize_s0::profiler::ProfilingAllocator<mimalloc::MiMalloc> =
+    vize_s0::profiler::ProfilingAllocator::from_allocator(mimalloc::MiMalloc);
 
 fn main() {
     vize::cli::run_from_env();

--- a/crates/vize/src/profile_support.rs
+++ b/crates/vize/src/profile_support.rs
@@ -1,12 +1,12 @@
 //! CLI profile helpers whose behavior depends on binary build features.
 
-use vize_carton::profiler::AllocationSnapshot;
+use vize_s0::profiler::AllocationSnapshot;
 
 #[inline]
 pub(crate) fn allocation_snapshot() -> Option<AllocationSnapshot> {
     #[cfg(feature = "profiling")]
     {
-        Some(vize_carton::profiler::allocation_snapshot())
+        Some(vize_s0::profiler::allocation_snapshot())
     }
 
     #[cfg(not(feature = "profiling"))]

--- a/crates/vize/tests/build_declaration_emit_cli.rs
+++ b/crates/vize/tests/build_declaration_emit_cli.rs
@@ -5,7 +5,7 @@ mod corsa_requirement;
 
 use std::{path::Path, process::Command};
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_allowjs_imports_cli.rs
+++ b/crates/vize/tests/check_allowjs_imports_cli.rs
@@ -12,7 +12,7 @@ use std::{
     process::{Command, Output},
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_ambient_export_assignment_cli.rs
+++ b/crates/vize/tests/check_ambient_export_assignment_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_boolean_tsx_regressions_cli.rs
+++ b/crates/vize/tests/check_canon_boolean_tsx_regressions_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_component_derived_props_cli.rs
+++ b/crates/vize/tests/check_canon_component_derived_props_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_component_refs_cli.rs
+++ b/crates/vize/tests/check_canon_component_refs_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_define_model_modifiers_cli.rs
+++ b/crates/vize/tests/check_canon_define_model_modifiers_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_dynamic_component_props_cli.rs
+++ b/crates/vize/tests/check_canon_dynamic_component_props_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_fallthrough_attrs_cli/support.rs
+++ b/crates/vize/tests/check_canon_fallthrough_attrs_cli/support.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_generic_inference_cli.rs
+++ b/crates/vize/tests/check_canon_generic_inference_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_generic_props_cli.rs
+++ b/crates/vize/tests/check_canon_generic_props_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_generic_sfc_mount_cli.rs
+++ b/crates/vize/tests/check_canon_generic_sfc_mount_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_graphql_cli.rs
+++ b/crates/vize/tests/check_canon_graphql_cli.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_recent_issues_cli.rs
+++ b/crates/vize/tests/check_canon_recent_issues_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_recent_type_regressions_cli.rs
+++ b/crates/vize/tests/check_canon_recent_type_regressions_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_canon_remapped_key_cli.rs
+++ b/crates/vize/tests/check_canon_remapped_key_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -9,7 +9,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::{cstr, path::canonicalize_non_verbatim};
+use vize_s0::{cstr, path::canonicalize_non_verbatim};
 
 #[test]
 fn check_json_reports_type_errors_via_project_typechecker() {

--- a/crates/vize/tests/check_declaration_emit_cli.rs
+++ b/crates/vize/tests/check_declaration_emit_cli.rs
@@ -9,7 +9,7 @@ mod workspace_package_vue_exports;
 
 use std::{path::Path, process::Command};
 
-use vize_carton::{String, ToCompactString, cstr};
+use vize_s0::{String, ToCompactString, cstr};
 
 #[path = "support/vue_stub.rs"]
 mod vue_stub;

--- a/crates/vize/tests/check_declaration_emit_cli/workspace_package_vue_exports.rs
+++ b/crates/vize/tests/check_declaration_emit_cli/workspace_package_vue_exports.rs
@@ -120,10 +120,10 @@ defineProps<WorkspaceWidgetProps>()
     assert_eq!(map["sourceRoot"], "");
     let source = map["sources"][0].as_str().unwrap();
     let mapped_source =
-        vize_carton::path::canonicalize_non_verbatim(&map_path.parent().unwrap().join(source));
+        vize_s0::path::canonicalize_non_verbatim(&map_path.parent().unwrap().join(source));
     assert_eq!(
         mapped_source,
-        vize_carton::path::canonicalize_non_verbatim(&app_root.join("src/index.ts")),
+        vize_s0::path::canonicalize_non_verbatim(&app_root.join("src/index.ts")),
         "declaration map must survive rootDir layout restoration: {map:#?}"
     );
     assert!(

--- a/crates/vize/tests/check_declaration_emit_vue_floor_cli.rs
+++ b/crates/vize/tests/check_declaration_emit_vue_floor_cli.rs
@@ -25,7 +25,7 @@ mod corsa_requirement;
 
 use std::{path::Path, process::Command};
 
-use vize_carton::{String, ToCompactString, cstr};
+use vize_s0::{String, ToCompactString, cstr};
 
 fn workspace_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_default_imports_cli.rs
+++ b/crates/vize/tests/check_default_imports_cli.rs
@@ -11,7 +11,7 @@ mod workspace_package_vue_exports;
 
 use std::{path::Path, process::Command};
 
-use vize_carton::{cstr, path::canonicalize_non_verbatim};
+use vize_s0::{cstr, path::canonicalize_non_verbatim};
 
 #[test]
 fn default_check_reports_diagnostics_from_imports_outside_tsconfig_include() {

--- a/crates/vize/tests/check_default_imports_cli/workspace_package_vue_exports.rs
+++ b/crates/vize/tests/check_default_imports_cli/workspace_package_vue_exports.rs
@@ -241,7 +241,7 @@ void props
     let _ = std::fs::remove_dir_all(case_root);
 }
 
-fn component_source(import: Option<&str>, invalid: bool) -> vize_carton::String {
+fn component_source(import: Option<&str>, invalid: bool) -> vize_s0::String {
     let import = import
         .map(|specifier| cstr!("import Nested from '{specifier}'\nvoid Nested\n"))
         .unwrap_or_default();

--- a/crates/vize/tests/check_default_run_project_root_cli.rs
+++ b/crates/vize/tests/check_default_run_project_root_cli.rs
@@ -12,7 +12,7 @@
 //! alongside the plain one because the original report arrived through a
 //! symlinked `node_modules`.
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;

--- a/crates/vize/tests/check_entry_ignores_cli.rs
+++ b/crates/vize/tests/check_entry_ignores_cli.rs
@@ -3,7 +3,7 @@ mod corsa_requirement;
 
 use std::{path::Path, process::Command};
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[test]
 fn check_config_entry_ignores_explicit_inputs() {

--- a/crates/vize/tests/check_function_props_cli.rs
+++ b/crates/vize/tests/check_function_props_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[test]
 fn check_vue_function_prop_callbacks_and_create_app_chaining() {

--- a/crates/vize/tests/check_instance_props_cli.rs
+++ b/crates/vize/tests/check_instance_props_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_legacy_vue2_class_bindings_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_class_bindings_cli.rs
@@ -5,7 +5,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;

--- a/crates/vize/tests/check_legacy_vue2_event_alias_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_event_alias_cli.rs
@@ -5,7 +5,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;

--- a/crates/vize/tests/check_legacy_vue2_event_payload_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_event_payload_cli.rs
@@ -5,7 +5,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;

--- a/crates/vize/tests/check_legacy_vue2_helpers_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_helpers_cli.rs
@@ -2,7 +2,7 @@
 
 use std::{path::Path, process::Command};
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;

--- a/crates/vize/tests/check_legacy_vue2_no_unused_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_no_unused_cli.rs
@@ -2,7 +2,7 @@
 
 use std::{path::Path, process::Command};
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;

--- a/crates/vize/tests/check_legacy_vue2_ref_unwrap_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_ref_unwrap_cli.rs
@@ -5,7 +5,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;

--- a/crates/vize/tests/check_legacy_vue2_template_scope_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_template_scope_cli.rs
@@ -5,7 +5,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;

--- a/crates/vize/tests/check_legacy_vue2_vfor_cli.rs
+++ b/crates/vize/tests/check_legacy_vue2_vfor_cli.rs
@@ -5,7 +5,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;

--- a/crates/vize/tests/check_nuxt2_classic_plugin_bindings_cli.rs
+++ b/crates/vize/tests/check_nuxt2_classic_plugin_bindings_cli.rs
@@ -5,7 +5,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
 };
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[test]
 fn check_nuxt2_use_context_sees_classic_plugin_binding_injections() {

--- a/crates/vize/tests/check_nuxt2_fallback_guidance_cli.rs
+++ b/crates/vize/tests/check_nuxt2_fallback_guidance_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[test]
 fn check_nuxt2_compiler_compat_warning_does_not_suggest_nuxi_prepare() {

--- a/crates/vize/tests/check_nuxt2_template_globals_cli.rs
+++ b/crates/vize/tests/check_nuxt2_template_globals_cli.rs
@@ -8,7 +8,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[test]
 fn check_legacy_nuxt2_template_fetch_state_and_route_globals() {

--- a/crates/vize/tests/check_nuxt_ambient_cli.rs
+++ b/crates/vize/tests/check_nuxt_ambient_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_nuxt_composition_api_cli.rs
+++ b/crates/vize/tests/check_nuxt_composition_api_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_nuxt_composition_api_plugin_augmentation_cli.rs
+++ b/crates/vize/tests/check_nuxt_composition_api_plugin_augmentation_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_ref_enum_template_cli.rs
+++ b/crates/vize/tests/check_ref_enum_template_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_reference_types_cli.rs
+++ b/crates/vize/tests/check_reference_types_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_server_cli.rs
+++ b/crates/vize/tests/check_server_cli.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use serde_json::Value;
-use vize_carton::corsa_resolver::{CorsaResolveRequest, resolve_corsa_executable};
+use vize_s0::corsa_resolver::{CorsaResolveRequest, resolve_corsa_executable};
 
 #[path = "support/vue_stub.rs"]
 mod vue_stub;

--- a/crates/vize/tests/check_sfc_string_blocks_cli.rs
+++ b/crates/vize/tests/check_sfc_string_blocks_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[test]
 fn check_ignores_sfc_blocks_inside_script_string_literals() {

--- a/crates/vize/tests/check_symlinked_node_modules_cli.rs
+++ b/crates/vize/tests/check_symlinked_node_modules_cli.rs
@@ -19,7 +19,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 const TSCONFIG: &str = r#"{
   "compilerOptions": {

--- a/crates/vize/tests/check_text_diagnostics_cli.rs
+++ b/crates/vize/tests/check_text_diagnostics_cli.rs
@@ -12,7 +12,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_text_output_cli.rs
+++ b/crates/vize/tests/check_text_output_cli.rs
@@ -12,7 +12,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> &'static Path {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_tsconfig_types_cli.rs
+++ b/crates/vize/tests/check_tsconfig_types_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_tsx_intrinsic_elements_cli.rs
+++ b/crates/vize/tests/check_tsx_intrinsic_elements_cli.rs
@@ -6,7 +6,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
+++ b/crates/vize/tests/check_tsx_sfc_attrs_cli.rs
@@ -3,7 +3,7 @@ mod corsa_requirement;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize/tests/check_vue2_vuetify_props_cli.rs
+++ b/crates/vize/tests/check_vue2_vuetify_props_cli.rs
@@ -3,7 +3,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[path = "support/corsa_requirement.rs"]
 mod corsa_requirement;

--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -5,7 +5,7 @@ use std::{path::Path, str::FromStr};
 use corsa_lsp::LspClient;
 use lsp_types::{FileChangeType, FileEvent, Uri};
 use serde_json::{Value, json};
-use vize_carton::String as CompactString;
+use vize_s0::String as CompactString;
 
 mod component_oracles;
 mod leak_assertions;

--- a/crates/vize/tests/content_mapper_tsgo_build.rs
+++ b/crates/vize/tests/content_mapper_tsgo_build.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use serde_json::json;
-use vize_carton::{String as CompactString, cstr};
+use vize_s0::{String as CompactString, cstr};
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
 const VUE_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_VUE";

--- a/crates/vize/tests/content_mapper_tsgo_cli.rs
+++ b/crates/vize/tests/content_mapper_tsgo_cli.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use serde_json::json;
-use vize_carton::{String as CompactString, cstr};
+use vize_s0::{String as CompactString, cstr};
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
 const JAVASCRIPT_TSC_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_JAVASCRIPT_TSC";

--- a/crates/vize/tests/content_mapper_tsgo_directives.rs
+++ b/crates/vize/tests/content_mapper_tsgo_directives.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use serde_json::json;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
 const VUE_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_VUE";
@@ -138,7 +138,7 @@ fn check_project(tsgo: &Path, project_root: &Path, config: &str) -> Output {
         .unwrap_or_else(|error| panic!("failed to run {}: {error}", tsgo.display()))
 }
 
-fn output_text(output: &Output) -> vize_carton::String {
+fn output_text(output: &Output) -> vize_s0::String {
     let stdout = std::str::from_utf8(&output.stdout).unwrap_or("<non-UTF-8 stdout>");
     let stderr = std::str::from_utf8(&output.stderr).unwrap_or("<non-UTF-8 stderr>");
     cstr!(

--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use corsa_lsp::{LspClient, LspSpawnConfig, VirtualDocument, jsonrpc::InboundEvent};
 use lsp_types::Uri;
 use serde_json::{Value, json};
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 #[allow(dead_code)]
 #[path = "content_mapper_tsgo_lsp_event_forms/cases.rs"]

--- a/crates/vize/tests/davinci_repro_cli.rs
+++ b/crates/vize/tests/davinci_repro_cli.rs
@@ -12,9 +12,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
-use vize_carton::String as CartonString;
 use vize_davinci::folio::repro::ReproFolio;
 use vize_davinci::folio::{Folio, FolioMode};
+use vize_s0::String as CartonString;
 
 const INJECTED_FAILURE: &str = "template.transform: injected davinci panic in pass `transform`";
 

--- a/crates/vize/tests/davinci_ts40_projection_cli.rs
+++ b/crates/vize/tests/davinci_ts40_projection_cli.rs
@@ -14,7 +14,7 @@ use std::process::Command;
 use std::time::{Duration, Instant};
 
 use sha2::{Digest, Sha256};
-use vize_carton::{String, ToCompactString, append, cstr};
+use vize_s0::{String, ToCompactString, append, cstr};
 
 const SOCKET_ORACLE_TIMEOUT: Duration = Duration::from_secs(5);
 const SOCKET_ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(10);

--- a/crates/vize/tests/lint_config_cli.rs
+++ b/crates/vize/tests/lint_config_cli.rs
@@ -25,8 +25,8 @@ fn write_project_file(root: &Path, path: &str, content: &str) {
     fs::write(file_path, content).unwrap();
 }
 
-fn output_details(output: &std::process::Output) -> vize_carton::String {
-    vize_carton::cstr!(
+fn output_details(output: &std::process::Output) -> vize_s0::String {
+    vize_s0::cstr!(
         "stdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)

--- a/crates/vize/tests/lint_pinia_dependency_cli.rs
+++ b/crates/vize/tests/lint_pinia_dependency_cli.rs
@@ -19,10 +19,10 @@ fn run_lint(root: &Path, files: &[&str]) -> std::process::Output {
         .unwrap()
 }
 
-fn output_details(output: &std::process::Output) -> vize_carton::String {
+fn output_details(output: &std::process::Output) -> vize_s0::String {
     let stdout = std::str::from_utf8(&output.stdout).unwrap_or("<non-UTF-8 stdout>");
     let stderr = std::str::from_utf8(&output.stderr).unwrap_or("<non-UTF-8 stderr>");
-    vize_carton::cstr!("stdout:\n{stdout}\nstderr:\n{stderr}")
+    vize_s0::cstr!("stdout:\n{stdout}\nstderr:\n{stderr}")
 }
 
 fn pinia_diagnostic_count(output: &std::process::Output) -> usize {

--- a/crates/vize/tests/lint_preset_scope_cli.rs
+++ b/crates/vize/tests/lint_preset_scope_cli.rs
@@ -25,8 +25,8 @@ fn write_project_file(root: &Path, path: &str, content: &str) {
     fs::write(file_path, content).unwrap();
 }
 
-fn output_details(output: &std::process::Output) -> vize_carton::String {
-    vize_carton::cstr!(
+fn output_details(output: &std::process::Output) -> vize_s0::String {
+    vize_s0::cstr!(
         "stdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)

--- a/crates/vize/tests/lsp_cli.rs
+++ b/crates/vize/tests/lsp_cli.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use serde_json::json;
-use vize_carton::{corsa_resolver::discover_corsa_in_ancestors, cstr};
+use vize_s0::{corsa_resolver::discover_corsa_in_ancestors, cstr};
 
 #[path = "support/lsp_process.rs"]
 mod lsp_process;

--- a/crates/vize/tests/support/corsa_path.rs
+++ b/crates/vize/tests/support/corsa_path.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 pub(crate) fn resolve(workspace_root: &Path) -> Option<String> {
     if let Some(path) = std::env::var_os("CORSA_PATH").filter(|path| Path::new(path).is_file()) {

--- a/crates/vize/tests/support/default_run_root.rs
+++ b/crates/vize/tests/support/default_run_root.rs
@@ -10,7 +10,7 @@ use std::{
     process::Command,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 /// Ancestor config whose program covers only the ancestor's own sources, so the
 /// nested app belongs to no project.
@@ -145,8 +145,8 @@ pub fn build_case(name: &str, layout: Layout) -> Case {
     // directory is itself reached through a link on macOS, so expectations are
     // written against the resolved spelling.
     Case {
-        workspace: vize_carton::path::canonicalize_non_verbatim(&workspace),
-        app: vize_carton::path::canonicalize_non_verbatim(&app),
+        workspace: vize_s0::path::canonicalize_non_verbatim(&workspace),
+        app: vize_s0::path::canonicalize_non_verbatim(&app),
         store,
     }
 }
@@ -207,7 +207,7 @@ pub fn unowned_error_for(workspace: &Path, app: &Path, inputs: usize) -> std::st
     )
 }
 
-pub fn stderr_lines(stderr: &str) -> Vec<vize_carton::String> {
+pub fn stderr_lines(stderr: &str) -> Vec<vize_s0::String> {
     stderr.lines().map(|line| cstr!("{line}")).collect()
 }
 

--- a/crates/vize/tests/support/jsx_check_project.rs
+++ b/crates/vize/tests/support/jsx_check_project.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 pub struct CheckOutput {
     pub success: bool,

--- a/crates/vize/tests/support/lsp_process.rs
+++ b/crates/vize/tests/support/lsp_process.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use serde_json::Value;
-use vize_carton::{String as CompactString, cstr, path::canonicalize_non_verbatim};
+use vize_s0::{String as CompactString, cstr, path::canonicalize_non_verbatim};
 
 const MESSAGE_TIMEOUT: Duration = Duration::from_secs(20);
 const PROCESS_EXIT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -276,7 +276,7 @@ mod tests {
 
         let error = read_message(&mut reader).unwrap_err();
         assert_eq!(error.kind(), ErrorKind::InvalidData);
-        assert!(vize_carton::cstr!("{error}").contains("missing Content-Length"));
+        assert!(vize_s0::cstr!("{error}").contains("missing Content-Length"));
     }
 
     #[test]

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,11 +45,11 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           908 |                    31 |               877 |             139 |     371 |             951 |      467 |           475 |           582 |
-| Linter                     |           300 |                     0 |               300 |             268 |     219 |             670 |      117 |           337 |           476 |
-| Typechecker                |           879 |                     0 |               879 |             393 |     187 |             804 |      655 |           460 |           650 |
-| Typechecker content-mapper |             8 |                     0 |                 8 |               1 |       0 |               9 |        0 |             7 |            18 |
-| Formatter                  |            38 |                    28 |                10 |               0 |      21 |              40 |       19 |            30 |            65 |
+| Compiler                   |           908 |                    60 |               848 |             139 |     371 |             951 |      467 |           475 |           582 |
+| Linter                     |           300 |                    16 |               284 |             268 |     219 |             670 |      117 |           337 |           476 |
+| Typechecker                |           879 |                   108 |               771 |             393 |     187 |             804 |      655 |           460 |           650 |
+| Typechecker content-mapper |             8 |                     3 |                 5 |               1 |       0 |               9 |        0 |             7 |            18 |
+| Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
 | LSP                        |           271 |                     0 |               271 |             113 |      44 |             323 |      105 |           166 |           387 |
 
 ## Consumer details

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -863,19 +863,19 @@ compiler	Compiler	test/dev	crates/vize_atelier_vapor/tests/davinci_expr_reparse_
 compiler	Compiler	test/dev	crates/vize_atelier_vapor/tests/davinci_teardown_without_stack_guard.rs	68	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_vapor/tests/davinci_walk_baseline.rs	25	davinci	Davinci	stage	vize_davinci	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_vapor/tests/davinci_walk_baseline.rs	25	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize/src/commands/build/config.rs	16	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize/src/commands/build/runner.rs	22	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize/src/commands/build/runner/cache.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/cache/tests.rs	11	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/collect/tests.rs	12	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize/src/commands/build/runner/compile_stats.rs	16	s0	S0/carton	stage	vize_carton	compat	6
-compiler	Compiler	source	crates/vize/src/commands/build/runner/compile.rs	41	s0	S0/carton	stage	vize_carton	compat	5
-compiler	Compiler	source	crates/vize/src/commands/build/runner/declarations.rs	65	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize/src/commands/build/runner/output.rs	11	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize/src/commands/build/runner/output/plan.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/output/tests.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize/src/commands/build/runner/profile_facts.rs	6	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize/src/commands/build/runner/settings.rs	5	s0	S0/carton	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize/src/commands/build/config.rs	16	s0	S0/carton	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize/src/commands/build/runner.rs	22	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize/src/commands/build/runner/cache.rs	11	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/cache/tests.rs	11	s0	S0/carton	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/collect/tests.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize/src/commands/build/runner/compile_stats.rs	16	s0	S0/carton	stage	vize_s0	preferred	6
+compiler	Compiler	source	crates/vize/src/commands/build/runner/compile.rs	41	s0	S0/carton	stage	vize_s0	preferred	5
+compiler	Compiler	source	crates/vize/src/commands/build/runner/declarations.rs	65	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize/src/commands/build/runner/output.rs	11	s0	S0/carton	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize/src/commands/build/runner/output/plan.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/output/tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize/src/commands/build/runner/profile_facts.rs	6	s0	S0/carton	stage	vize_s0	preferred	3
+compiler	Compiler	source	crates/vize/src/commands/build/runner/settings.rs	5	s0	S0/carton	stage	vize_s0	preferred	3
 linter	Linter	test/dev	crates/vize_patina/benches/lint_bench.rs	6	s0	S0/carton	stage	vize_carton	compat	1
 linter	Linter	test/dev	crates/vize_patina/benches/markup_ir_bench.rs	15	s0	S0/carton	stage	vize_carton	compat	3
 linter	Linter	test/dev	crates/vize_patina/benches/markup_ir_bench.rs	15	old_ast	old AST/parser	old	vize_armature	legacy	1
@@ -1474,18 +1474,18 @@ linter	Linter	test/dev	crates/vize_patina/src/visitor_scope.rs	46	s0	S0/carton	s
 linter	Linter	test/dev	crates/vize_patina/src/visitor_scope.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/visitor.rs	7	s0	S0/carton	stage	vize_carton	compat	2
 linter	Linter	source	crates/vize_patina/src/visitor.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	3
-linter	Linter	test/dev	crates/vize/src/commands/lint.rs	30	s0	S0/carton	stage	vize_carton	compat	2
-linter	Linter	source	crates/vize/src/commands/lint/args.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize/src/commands/lint/collect.rs	6	s0	S0/carton	stage	vize_carton	compat	3
-linter	Linter	source	crates/vize/src/commands/lint/cross_file.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize/src/commands/lint.rs	34	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize/src/commands/lint/args.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize/src/commands/lint/collect.rs	6	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize/src/commands/lint/cross_file.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize/src/commands/lint/cross_file.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	source	crates/vize/src/commands/lint/cross_file.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize/src/commands/lint/cross_file.rs	4	croquis	Croquis analysis	old	vize_croquis_cf	legacy	1
-linter	Linter	test/dev	crates/vize/src/commands/lint/entry_rules_tests.rs	6	s0	S0/carton	stage	vize_carton	compat	2
-linter	Linter	source	crates/vize/src/commands/lint/entry_rules.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize/src/commands/lint/fix.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize/src/commands/lint/patterns.rs	22	s0	S0/carton	stage	vize_carton	compat	4
-linter	Linter	source	crates/vize/src/commands/lint/stdout.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize/src/commands/lint/entry_rules_tests.rs	7	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize/src/commands/lint/entry_rules.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize/src/commands/lint/fix.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize/src/commands/lint/patterns.rs	22	s0	S0/carton	stage	vize_s0	preferred	4
+linter	Linter	source	crates/vize/src/commands/lint/stdout.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/benches/package_route.rs	40	s0	S0/carton	stage	vize_carton	compat	1
 typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	s0	S0/carton	stage	vize_carton	compat	1
 typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	old_ast	old AST/parser	old	vize_relief	legacy	1
@@ -2209,119 +2209,119 @@ typechecker	Typechecker	test/dev	crates/vize_canon/tests/support/auto_import_pro
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/support/tier_l_incremental_artifact.rs	6	s0	S0/carton	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/tier_l_incremental.rs	10	s0	S0/carton	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/tsconfig_option_diagnostics.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/dts_import_aliases.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/dts_import_aliases.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_import_aliases.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_import_aliases.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_import_aliases.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/dts_rewrite.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/dts.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/imports_aliases.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/imports_cache.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_generated_tests.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_js_tests.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_package_routes.rs	80	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/imports_registration.rs	3	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_registration.rs	168	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize/src/commands/check/imports_resolution.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/imports_specifiers.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_tests.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports.rs	12	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback.rs	12	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/dts_rewrite.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/dts.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/imports_aliases.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/imports_cache.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_generated_tests.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_js_tests.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_package_routes.rs	80	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/imports_registration.rs	3	s0	S0/carton	stage	vize_s0	preferred	2
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_registration.rs	168	s0	S0/carton	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize/src/commands/check/imports_resolution.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/imports_specifiers.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_tests.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports.rs	12	s0	S0/carton	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback.rs	12	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback.rs	12	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback.rs	12	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback/fallback_values.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/generated_ast_tests.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_ast.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback/fallback_values.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/generated_ast_tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_ast.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_ast.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_ast.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_ast.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_ast.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_dir.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_values.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/legacy_template_globals_tests.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/legacy_template_globals.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/parsing.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_dir.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_values.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/legacy_template_globals_tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/legacy_template_globals.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/parsing.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/parsing.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/parsing.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	9
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/parsing.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins/extract.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins/extract.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins/extract.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins/extract.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	3
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins/extract.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins/extract/bindings.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	2
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/plugins/tests.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/source_scan.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/plugins/tests.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/source_scan.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/source_scan.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/source_scan.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/source_scan.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/stubs.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/tests.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/stubs.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/tests.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/tests.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/tests.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/tsconfig_aliases.rs	9	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/virtual_modules.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/tsconfig_aliases.rs	9	s0	S0/carton	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/virtual_modules.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/virtual_modules.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/virtual_modules.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/virtual_modules.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/path_cache.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/path_cache.rs	49	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner.rs	145	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/collect_tests.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/collect.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/collect.rs	273	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/default_imports_tests.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/default_imports.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/diagnostics.rs	9	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/diagnostics/source_context.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/diagnostics/source_filter.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/execution.rs	9	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/global_components.rs	15	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/ignores.rs	43	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/input_scope.rs	16	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/input_scope/tests.rs	18	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/invocation.rs	31	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/nuxt_tsconfig.rs	15	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/nuxt_tsconfig.rs	256	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/nuxt_tsconfig/cache.rs	10	s0	S0/carton	stage	vize_carton	compat	5
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/nuxt_tsconfig/path_options_tests.rs	228	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_declarations.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_json.rs	3	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_profile.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output.rs	5	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/program_inputs.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/programs.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/resolve.rs	7	s0	S0/carton	stage	vize_carton	compat	8
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/socket.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/text_style.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/ambient.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/collect.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/default_exclude_tests.rs	17	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/glob.rs	94	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/hidden_include_tests.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/loader.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/nuxt_manifest_tests.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/ownership_shared_tests.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs	17	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/tests.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/type_references.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/type_references/tsconfig_types.rs	4	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize/src/commands/check/path_cache.rs	5	s0	S0/carton	stage	vize_s0	preferred	2
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/path_cache.rs	47	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner.rs	145	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/collect_tests.rs	11	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/collect.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/collect.rs	273	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/default_imports_tests.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/default_imports.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/diagnostics.rs	9	s0	S0/carton	stage	vize_s0	preferred	3
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/diagnostics/source_context.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/diagnostics/source_filter.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/execution.rs	9	s0	S0/carton	stage	vize_s0	preferred	3
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/global_components.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/ignores.rs	43	s0	S0/carton	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/input_scope.rs	16	s0	S0/carton	stage	vize_s0	preferred	3
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/input_scope/tests.rs	18	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/invocation.rs	31	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/nuxt_tsconfig.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/nuxt_tsconfig.rs	256	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/nuxt_tsconfig/cache.rs	10	s0	S0/carton	stage	vize_s0	preferred	5
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/nuxt_tsconfig/path_options_tests.rs	228	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_declarations.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_json.rs	3	s0	S0/carton	stage	vize_s0	preferred	4
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_profile.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output.rs	5	s0	S0/carton	stage	vize_s0	preferred	3
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/program_inputs.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/programs.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/resolve.rs	7	s0	S0/carton	stage	vize_s0	preferred	8
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/socket.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/text_style.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs.rs	11	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/ambient.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/collect.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/default_exclude_tests.rs	17	s0	S0/carton	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/glob.rs	94	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/hidden_include_tests.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/loader.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/nuxt_manifest_tests.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/ownership_shared_tests.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs	17	s0	S0/carton	stage	vize_s0	preferred	2
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/tests.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/type_references.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/type_references/tsconfig_types.rs	4	s0	S0/carton	stage	vize_s0	preferred	2
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs	1	s0	S0/carton	stage	vize_carton	compat	1
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs	12	s0	S0/carton	stage	vize_carton	compat	1
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs	4	s0	S0/carton	stage	vize_carton	compat	1
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper.rs	8	s0	S0/carton	stage	vize_carton	compat	2
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper.rs	18	s0	S0/carton	stage	vize_carton	compat	1
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper/project.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper/test_support.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper.rs	18	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper/project.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper/test_support.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
 formatter	Formatter	manifest	crates/vize_glyph/Cargo.toml	13	s0	S0/carton	stage	vize_s0	preferred	1
 formatter	Formatter	manifest	crates/vize_glyph/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 formatter	Formatter	manifest	crates/vize_glyph/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_ast	raw	1
@@ -2360,13 +2360,13 @@ formatter	Formatter	source	crates/vize_glyph/src/template/formatter/interpolatio
 formatter	Formatter	source	crates/vize_glyph/src/template/formatter/text.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
 formatter	Formatter	source	crates/vize_glyph/src/template/helpers.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
 formatter	Formatter	test/dev	crates/vize_glyph/tests/sfc_block_attributes.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize/src/commands/fmt.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-formatter	Formatter	source	crates/vize/src/commands/fmt/data.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-formatter	Formatter	source	crates/vize/src/commands/fmt/data/plain.rs	16	s0	S0/carton	stage	vize_carton	compat	1
-formatter	Formatter	source	crates/vize/src/commands/fmt/entries.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-formatter	Formatter	test/dev	crates/vize/src/commands/fmt/files_tests.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-formatter	Formatter	test/dev	crates/vize/src/commands/fmt/files.rs	125	s0	S0/carton	stage	vize_carton	compat	4
-formatter	Formatter	source	crates/vize/src/commands/fmt/ignores.rs	80	s0	S0/carton	stage	vize_carton	compat	1
+formatter	Formatter	source	crates/vize/src/commands/fmt.rs	17	s0	S0/carton	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize/src/commands/fmt/data.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize/src/commands/fmt/data/plain.rs	17	s0	S0/carton	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize/src/commands/fmt/entries.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+formatter	Formatter	test/dev	crates/vize/src/commands/fmt/files_tests.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+formatter	Formatter	test/dev	crates/vize/src/commands/fmt/files.rs	125	s0	S0/carton	stage	vize_s0	preferred	4
+formatter	Formatter	source	crates/vize/src/commands/fmt/ignores.rs	80	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	s0	S0/carton	stage	vize_carton	compat	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	old_ast	old AST/parser	old	vize_armature	legacy	1

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -53,6 +53,17 @@ function readRepoFile(...segments: string[]): string {
   return fs.readFileSync(path.join(repoRoot, ...segments), "utf8");
 }
 
+function* walkRustFiles(directory: string): Generator<string> {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkRustFiles(fullPath);
+    } else if (entry.isFile() && entry.name.endsWith(".rs")) {
+      yield fullPath;
+    }
+  }
+}
+
 const aliases = new Map<string, ReadonlyArray<readonly [string, string | null]>>([
   ["vize_davinci", [["vize_carton", "vize_s0"]]],
   ["vize_s1", [["vize_carton", "vize_s0"]]],
@@ -167,4 +178,39 @@ test("Davinci DOM lane tests import lowering through the stage alias", () => {
     const source = readRepoFile("crates", "vize_atelier_dom", "tests", file);
     assert.doesNotMatch(source, /\bvize_ricalco::/u);
   }
+});
+
+test("Vize CLI package imports S0 storage through the stage alias", () => {
+  const dependencies = workspacePackage(metadata, "vize").dependencies;
+  assert.ok(
+    dependencies.some(
+      (dependency) =>
+        dependency.kind === null &&
+        dependency.name === "vize_carton" &&
+        dependency.rename === "vize_s0",
+    ),
+    "vize must import vize_carton as vize_s0 for S0 storage",
+  );
+  assert.ok(
+    dependencies.every(
+      (dependency) => dependency.name !== "vize_carton" || dependency.rename === "vize_s0",
+    ),
+    "vize must not depend on vize_carton through its physical name",
+  );
+
+  const vizeDir = path.join(repoRoot, "crates", "vize");
+  const offenders = [];
+  let aliasImports = 0;
+  for (const fullPath of walkRustFiles(vizeDir)) {
+    const source = fs.readFileSync(fullPath, "utf8");
+    if (/\bvize_carton::/u.test(source)) {
+      offenders.push(path.relative(repoRoot, fullPath));
+    }
+    if (/\bvize_s0::|use vize_s0\b/u.test(source)) {
+      aliasImports += 1;
+    }
+  }
+
+  assert.ok(aliasImports > 0, "vize package should use the vize_s0 alias");
+  assert.deepEqual(offenders, []);
 });


### PR DESCRIPTION
## Summary
- switch the `vize` CLI package dependency from the physical `vize_carton` name to the stage alias `vize_s0`
- update `crates/vize` source and integration tests to use `vize_s0`, while preserving the public `vize::carton` re-export
- refresh the Davinci consumer migration inventory and extend stage dependency tests so `vize` cannot reintroduce physical `vize_carton` imports

## Verification
- cargo fmt --check -p vize
- cargo test -p vize commands::fmt
- cargo test -p vize
- node tools/davinci/consumer-migration-surfaces.mjs --check
- node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-glyph-stage-alias.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node tools/davinci/assertion-lint.mjs
- corepack pnpm exec vp run --workspace-root check:repo
- corepack pnpm exec vp run --workspace-root check:ci
- git diff --check origin/main...HEAD