### PR TITLE
feat(davinci): emit vue2 filters in s2 dom lane

### DIFF
--- a/crates/vize_atelier_dom/Cargo.toml
+++ b/crates/vize_atelier_dom/Cargo.toml
@@ -8,6 +8,9 @@ repository.workspace = true
 description = "Atelier DOM - The DOM compiler workshop for Vize"
 metadata.vize.stability = "alpha-supported"
 
+[features]
+legacy = ["vize_atelier_core/legacy"]
+
 [dependencies]
 vize_carton = { workspace = true }
 vize_atelier_core = { workspace = true }
@@ -32,3 +35,7 @@ vize_s1_to_s2 = { workspace = true }
 [[bench]]
 name = "davinci"
 harness = false
+
+[[test]]
+name = "davinci_s2_filters"
+required-features = ["legacy"]

--- a/crates/vize_atelier_dom/tests/davinci_s2_filters.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_filters.rs
@@ -1,0 +1,53 @@
+//! P2-11 Vue 2 pipe-filter witness: `_resolveFilter` assets and
+//! `_filter_*` calls, compared byte-for-byte with the shipped DOM lane.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use vize_carton::config::VueVersion;
+
+const V2_LITERAL_BATTERY: &[(&str, &str)] = &[
+    (
+        "interpolation_single_literal",
+        "<div>{{ 1 | double }}</div>",
+    ),
+    ("interpolation_args_literal", "<div>{{ 1 | add(2) }}</div>"),
+    (
+        "interpolation_chain_literal",
+        "<div>{{ 1 | f | g(2) }}</div>",
+    ),
+    (
+        "interpolation_dash_name_literal",
+        "<div>{{ 1 | foo-bar }}</div>",
+    ),
+    (
+        "interpolation_dollar_name_literal",
+        "<div>{{ 1 | $cash }}</div>",
+    ),
+    ("bind_value_literal", r#"<div :id="1 | formatId"></div>"#),
+    ("component_slot_default_literal", "<Foo>{{ 1 | cap }}</Foo>"),
+    (
+        "slot_outlet_prop_literal",
+        r#"<slot :value="1 | formatId"></slot>"#,
+    ),
+];
+
+const V3_BATTERY: &[(&str, &str)] = &[("v3_bitwise_or", "<div>{{ message | capitalize }}</div>")];
+
+#[test]
+fn s2_vue2_literal_filters_match_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_prefixed_shipped_literals_with_dialect(
+        V2_LITERAL_BATTERY,
+        VueVersion::V2,
+    );
+}
+
+#[test]
+fn s2_vue3_keeps_pipe_expressions_out_of_filter_mode() {
+    support::assert_s2_matches_shipped_with_dialect(V3_BATTERY, VueVersion::V3);
+}

--- a/crates/vize_atelier_dom/tests/support/mod.rs
+++ b/crates/vize_atelier_dom/tests/support/mod.rs
@@ -1,14 +1,19 @@
 //! Shared S2 vs shipped DOM-lane differential harness.
 
 #![allow(
+    dead_code,
     clippy::disallowed_macros,
     clippy::disallowed_types,
     clippy::disallowed_methods
 )]
 
-use vize_atelier_dom::compile_template;
+use vize_atelier_dom::{DomCompilerOptions, compile_template, compile_template_with_options};
 use vize_carton::Allocator;
-use vize_s1_to_s2::{DOM_LANE_FLAG, EmitError, UnsupportedReason, emit_dom_source};
+use vize_carton::config::VueVersion;
+use vize_s1_to_s2::{
+    DOM_LANE_FLAG, EmitError, LegacyCaps, UnsupportedReason, emit_dom_source,
+    emit_dom_source_with_caps,
+};
 
 #[derive(Clone, Copy)]
 #[allow(dead_code)]
@@ -18,8 +23,31 @@ pub enum ExpectedRefusal {
 }
 
 pub fn shipped(src: &str) -> String {
+    shipped_with_dialect(src, VueVersion::V3)
+}
+
+pub fn shipped_with_dialect(src: &str, dialect: VueVersion) -> String {
+    shipped_with_dialect_and_prefix(src, dialect, false)
+}
+
+pub fn shipped_prefixed_with_dialect(src: &str, dialect: VueVersion) -> String {
+    shipped_with_dialect_and_prefix(src, dialect, true)
+}
+
+fn shipped_with_dialect_and_prefix(
+    src: &str,
+    dialect: VueVersion,
+    prefix_identifiers: bool,
+) -> String {
     let allocator = Allocator::new();
-    let (_, errors, result) = compile_template(&allocator, src);
+    let mut options = DomCompilerOptions::default();
+    options.dialect = dialect;
+    options.prefix_identifiers = prefix_identifiers;
+    let (_, errors, result) = if dialect == VueVersion::V3 && !prefix_identifiers {
+        compile_template(&allocator, src)
+    } else {
+        compile_template_with_options(&allocator, src, options)
+    };
     assert!(errors.is_empty(), "shipped lane errors: {errors:?}");
     format!("{}\n{}", result.preamble, result.code)
 }
@@ -34,6 +62,49 @@ pub fn assert_s2_matches_shipped(battery: &[(&str, &str)]) {
         for (name, src) in battery {
             let old = shipped(src);
             let new = emit_dom_source(&allocator, src)
+                .unwrap_or_else(|error| panic!("{name}: S2 emit refused: {error:?}"))
+                .assembled();
+            assert_eq!(
+                old.as_str(),
+                new.as_str(),
+                "{name}: S2 DOM emit diverged from the shipped lane"
+            );
+            compared += 1;
+        }
+    }
+    assert_eq!(
+        (compared, skipped_legacy_flag),
+        (battery.len() as u64, 0),
+        "a cfg or {DOM_LANE_FLAG}=legacy regression disarmed the dual-run"
+    );
+}
+
+pub fn assert_s2_matches_shipped_with_dialect(battery: &[(&str, &str)], dialect: VueVersion) {
+    assert_s2_matches_shipped_with_dialect_inner(battery, dialect, false)
+}
+
+pub fn assert_s2_matches_prefixed_shipped_literals_with_dialect(
+    battery: &[(&str, &str)],
+    dialect: VueVersion,
+) {
+    assert_s2_matches_shipped_with_dialect_inner(battery, dialect, true)
+}
+
+fn assert_s2_matches_shipped_with_dialect_inner(
+    battery: &[(&str, &str)],
+    dialect: VueVersion,
+    prefix_identifiers: bool,
+) {
+    let mut compared = 0u64;
+    let mut skipped_legacy_flag = 0u64;
+    if std::env::var(DOM_LANE_FLAG).is_ok_and(|value| value == "legacy") {
+        skipped_legacy_flag += 1;
+    } else {
+        let allocator = Allocator::new();
+        let caps = LegacyCaps::for_version(dialect);
+        for (name, src) in battery {
+            let old = shipped_with_dialect_and_prefix(src, dialect, prefix_identifiers);
+            let new = emit_dom_source_with_caps(&allocator, src, caps)
                 .unwrap_or_else(|error| panic!("{name}: S2 emit refused: {error:?}"))
                 .assembled();
             assert_eq!(

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -39,8 +39,8 @@
 //! and **static+dynamic `style` merge** (`[{"color":"red"}, s]`).
 //! Static-name `v-bind` modifiers (`.camel`, `.prop`, `.attr`, plus the
 //! dot shorthand) and dynamic-argument `v-bind` keys / modifiers are
-//! realized into the shipped DOM prop-key shape. Filters stay
-//! [`EmitError::Unsupported`].
+//! realized into the shipped DOM prop-key shape. Vue 2 pipe filters are
+//! legalised by `legacy-sugar` and emitted with `_resolveFilter` assets.
 //! The old lane stays the shipped compile path; [`super::DOM_LANE_FLAG`]
 //! is named here and *read* in the atelier_dom witness.
 
@@ -52,11 +52,12 @@ mod create_slots;
 mod create_slots_walk;
 mod directive;
 mod error;
+mod filter;
 mod flag;
 mod fragment;
 mod helper;
 mod hoist;
-mod js;
+pub(crate) mod js;
 mod merge;
 mod model;
 mod namespace;
@@ -83,7 +84,7 @@ use vize_s1::parse;
 use vize_s2::op::{ElementOp, ForOp, IfOp, Namespace, Op, Region};
 use vize_s2::scope::ScopeFacts;
 
-use crate::lower::{ForWrapper, Lowered, WrapperKeys, lower};
+use crate::lower::{ForWrapper, LegacyCaps, Lowered, WrapperKeys, lower_with_caps};
 use crate::pass::walk::PageWalk;
 use crate::pass::{S2Facts, run_transform};
 
@@ -267,13 +268,17 @@ pub fn emit_dom(lowered: &Lowered<'_>, facts: &S2Facts) -> Result<DomEmit, EmitE
     cx.buf.newline();
     let names = component::collect_names(&lowered.root);
     let dirs = directive::collect_names(&lowered.root);
+    let filters = &facts.legacy.filters;
     if !names.is_empty() {
         component::emit_resolves(&mut cx, &names);
     }
     if !dirs.is_empty() {
         directive::emit_resolves(&mut cx, &dirs);
     }
-    if !names.is_empty() || !dirs.is_empty() {
+    if !filters.is_empty() {
+        filter::emit_resolves(&mut cx, filters);
+    }
+    if !names.is_empty() || !dirs.is_empty() || !filters.is_empty() {
         cx.buf.newline();
     }
     cx.buf.push("return ");
@@ -293,8 +298,17 @@ pub fn emit_dom_source<'a>(
     allocator: &'a Allocator,
     source: &'a str,
 ) -> Result<DomEmit, EmitError> {
+    emit_dom_source_with_caps(allocator, source, LegacyCaps::VUE3)
+}
+
+/// [`emit_dom_source`] under an explicit Vue dialect capability set.
+pub fn emit_dom_source_with_caps<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    caps: LegacyCaps,
+) -> Result<DomEmit, EmitError> {
     let (tree, errors) = parse(allocator, source);
-    let mut lowered = lower(allocator, &tree, &errors);
+    let mut lowered = lower_with_caps(allocator, &tree, &errors, caps);
     let mut budget = BudgetObserver::new();
     let facts = run_transform(&mut lowered, &mut budget);
     emit_dom(&lowered, &facts)

--- a/crates/vize_ricalco/src/emit/buf.rs
+++ b/crates/vize_ricalco/src/emit/buf.rs
@@ -134,6 +134,9 @@ impl Buf {
     pub(super) fn use_resolve_directive(&mut self) {
         self.mark(Helper::ResolveDirective);
     }
+    pub(super) fn use_resolve_filter(&mut self) {
+        self.mark(Helper::ResolveFilter);
+    }
     pub(super) fn use_create_vnode(&mut self) {
         self.mark(Helper::CreateVNode);
     }
@@ -228,6 +231,10 @@ impl Buf {
 
     pub(super) fn resolve_directive_alias() -> &'static str {
         Helper::ResolveDirective.alias()
+    }
+
+    pub(super) fn resolve_filter_alias() -> &'static str {
+        Helper::ResolveFilter.alias()
     }
 
     pub(super) fn create_vnode_alias() -> &'static str {

--- a/crates/vize_ricalco/src/emit/filter.rs
+++ b/crates/vize_ricalco/src/emit/filter.rs
@@ -1,0 +1,21 @@
+//! Vue 2 pipe-filter asset resolution.
+
+use vize_s0::String;
+
+use super::EmitCx;
+use super::buf::Buf;
+use super::js::asset_ident;
+
+pub(super) fn emit_resolves(cx: &mut EmitCx<'_>, names: &[String]) {
+    cx.buf.use_resolve_filter();
+    for name in names {
+        cx.buf.push("const ");
+        cx.buf.push(asset_ident("filter", name.as_str()).as_str());
+        cx.buf.push(" = ");
+        cx.buf.push(Buf::resolve_filter_alias());
+        cx.buf.push("(\"");
+        cx.buf.push(name.as_str());
+        cx.buf.push("\")");
+        cx.buf.newline();
+    }
+}

--- a/crates/vize_ricalco/src/emit/helper.rs
+++ b/crates/vize_ricalco/src/emit/helper.rs
@@ -9,6 +9,7 @@ pub(super) enum Helper {
     ResolveComponent,
     ResolveDynamicComponent,
     ResolveDirective,
+    ResolveFilter,
     VModelText,
     VModelCheckbox,
     VModelRadio,
@@ -45,10 +46,11 @@ pub(super) enum Helper {
 }
 
 impl Helper {
-    pub(super) const ALL: [Self; 36] = [
+    pub(super) const ALL: [Self; 37] = [
         Self::ResolveComponent,
         Self::ResolveDynamicComponent,
         Self::ResolveDirective,
+        Self::ResolveFilter,
         Self::VModelText,
         Self::VModelCheckbox,
         Self::VModelRadio,
@@ -86,7 +88,10 @@ impl Helper {
 
     pub(super) const fn rank(self) -> u8 {
         match self {
-            Self::ResolveComponent | Self::ResolveDynamicComponent | Self::ResolveDirective => 0,
+            Self::ResolveComponent
+            | Self::ResolveDynamicComponent
+            | Self::ResolveDirective
+            | Self::ResolveFilter => 0,
             Self::VModelText | Self::VModelCheckbox | Self::VModelRadio | Self::VModelSelect => 1,
             Self::WithDirectives | Self::WithKeys | Self::WithModifiers => 2,
             Self::ToDisplayString => 3,
@@ -152,6 +157,7 @@ impl Helper {
             Self::VModelSelect => 8589934592,
             Self::WithDirectives => 17179869184,
             Self::ResolveDirective => 34359738368,
+            Self::ResolveFilter => 68719476736,
         }
     }
 
@@ -160,6 +166,7 @@ impl Helper {
             Self::ResolveComponent => "resolveComponent",
             Self::ResolveDynamicComponent => "resolveDynamicComponent",
             Self::ResolveDirective => "resolveDirective",
+            Self::ResolveFilter => "resolveFilter",
             Self::VModelText => "vModelText",
             Self::VModelCheckbox => "vModelCheckbox",
             Self::VModelRadio => "vModelRadio",
@@ -201,6 +208,7 @@ impl Helper {
             Self::ResolveComponent => "_resolveComponent",
             Self::ResolveDynamicComponent => "_resolveDynamicComponent",
             Self::ResolveDirective => "_resolveDirective",
+            Self::ResolveFilter => "_resolveFilter",
             Self::VModelText => "_vModelText",
             Self::VModelCheckbox => "_vModelCheckbox",
             Self::VModelRadio => "_vModelRadio",

--- a/crates/vize_ricalco/src/emit/js.rs
+++ b/crates/vize_ricalco/src/emit/js.rs
@@ -109,7 +109,7 @@ pub(super) fn escape_js_string(s: &str) -> String {
 /// Mirror Vue's `toValidAssetId` (compiler-core utils, issue #4422):
 /// word characters pass through, `-` becomes `_`, every other character
 /// is replaced by its char code as a decimal string.
-pub(super) fn asset_ident(kind: &str, name: &str) -> String {
+pub(crate) fn asset_ident(kind: &str, name: &str) -> String {
     let mut ident = String::from("_");
     ident.push_str(kind);
     ident.push('_');

--- a/crates/vize_ricalco/src/lib.rs
+++ b/crates/vize_ricalco/src/lib.rs
@@ -64,5 +64,6 @@ pub mod pass;
 pub use dom::DOM_LANE_FLAG;
 pub use emit::{
     DomEmit, EmitError, UnsupportedReason, UnsupportedRefusal, emit_dom, emit_dom_source,
+    emit_dom_source_with_caps,
 };
 pub use lower::{LegacyCaps, Lowered, lower, lower_style_block, lower_with_caps};

--- a/crates/vize_ricalco/src/pass.rs
+++ b/crates/vize_ricalco/src/pass.rs
@@ -123,6 +123,8 @@ const _: () = {
 /// fields rather than a second bag type.
 #[derive(Debug, Default)]
 pub struct S2Facts {
+    /// Facts from the Vue 2 sugar-legalizing pass, empty on Vue 3.
+    pub legacy: legacy::LegacyFacts,
     /// Per-`ui.if` branch-key facts, keyed by the op's page-order id
     /// ([`vif`]).
     pub if_facts: SideTable<IfFacts>,
@@ -169,7 +171,7 @@ pub fn run_transform<'a, O: PassObserver>(lowered: &mut Lowered<'a>, observer: &
     let outcome = run_pipeline(&pipeline, observer, |event| {
         let name = event.desc().name;
         if name == legacy::DESC.name {
-            legacy::run(lowered);
+            facts.legacy = legacy::run(lowered);
         } else if name == vif::DESC.name {
             facts.if_facts = vif::run(lowered);
         } else if name == vfor::DESC.name {

--- a/crates/vize_ricalco/src/pass/legacy.rs
+++ b/crates/vize_ricalco/src/pass/legacy.rs
@@ -9,6 +9,7 @@
 //! table is unchanged, a single `needs_sugar()` read.
 
 use vize_davinci::pass::{Fusability, PassDesc, PassKind, Pipeline, Preserved};
+use vize_s0::String;
 
 use crate::lower::{LegacyCaps, Lowered};
 
@@ -52,6 +53,13 @@ pub const LEGACY: Pipeline = Pipeline::new(super::S2_STAGE, LEGACY_PASSES);
 const _: () = assert!(LEGACY.group_count() == 7);
 const _: () = assert!(LEGACY.is_fully_serialized());
 
+/// Facts produced by the legacy-sugar pass.
+#[derive(Debug, Default)]
+pub struct LegacyFacts {
+    /// Vue 2 filter names, first-seen order, for `_resolveFilter` assets.
+    pub filters: alloc::vec::Vec<String>,
+}
+
 /// Vue 3 is the 6-pass table; every legacy dialect prepends this pass.
 #[must_use]
 pub const fn pipeline_for(caps: LegacyCaps) -> Pipeline {
@@ -63,7 +71,8 @@ pub const fn pipeline_for(caps: LegacyCaps) -> Pipeline {
 }
 
 /// Legalize Vue 2 sugar in place, then recount and rekey.
-pub fn run(lowered: &mut Lowered<'_>) {
+pub fn run(lowered: &mut Lowered<'_>) -> LegacyFacts {
+    let mut facts = LegacyFacts::default();
     let allocator = lowered.allocator;
     let sync_ids = ids::collect_sync_ids(&lowered.root.ops);
     tree::map_binding_lists(&mut lowered.root.ops, &mut |bindings| {
@@ -74,10 +83,11 @@ pub fn run(lowered: &mut Lowered<'_>) {
         }
     });
     if lowered.caps.supports_filters {
-        filter::rewrite(allocator, &mut lowered.root.ops);
+        filter::rewrite(allocator, &mut lowered.root.ops, &mut facts.filters);
     }
     ids::rekey(lowered, &sync_ids);
     ids::recount(lowered);
+    facts
 }
 
 #[cfg(test)]

--- a/crates/vize_ricalco/src/pass/legacy/filter.rs
+++ b/crates/vize_ricalco/src/pass/legacy/filter.rs
@@ -1,117 +1,146 @@
 //! `vue.filter` → `_filter_*(...)` call text, re-admitted as JS.
 
+use alloc::vec::Vec as StdVec;
+
 use vize_s0::{Allocator, String};
 use vize_s2::expr::{ExprRef, VueFilterApp, VueFilterExpr};
 use vize_s2::op::{BindingOp, DynamicName, Op};
+
+use crate::emit::js::asset_ident;
 
 /// Rewrite every [`ExprRef::Filter`] in the tree into the Vue 2 wrap
 /// (`a | f` → `_filter_f(a)`, `a | f(b)` → `_filter_f(a,b)`). Mixed
 /// text-runs that absorbed a pipe into a compound opaque stay as
 /// authored — those parts are not `ExprRef::Filter` (recorded gap).
-pub(super) fn rewrite<'a>(allocator: &'a Allocator, ops: &mut [Op<'a>]) {
+pub(super) fn rewrite<'a>(
+    allocator: &'a Allocator,
+    ops: &mut [Op<'a>],
+    filters: &mut StdVec<String>,
+) {
     for op in ops.iter_mut() {
         match op {
             Op::Element(element) => {
-                rewrite_bindings(allocator, &mut element.bindings);
-                rewrite(allocator, &mut element.children.ops);
+                rewrite_bindings(allocator, &mut element.bindings, filters);
+                rewrite(allocator, &mut element.children.ops, filters);
             }
             Op::Component(component) => {
-                rewrite_bindings(allocator, &mut component.bindings);
-                rewrite(allocator, &mut component.children.ops);
+                rewrite_bindings(allocator, &mut component.bindings, filters);
+                rewrite(allocator, &mut component.children.ops, filters);
             }
             Op::Slot(slot) => {
-                rewrite_name(allocator, &mut slot.name);
-                rewrite_bindings(allocator, &mut slot.bindings);
-                rewrite(allocator, &mut slot.fallback.ops);
+                rewrite_name(allocator, &mut slot.name, filters);
+                rewrite_bindings(allocator, &mut slot.bindings, filters);
+                rewrite(allocator, &mut slot.fallback.ops, filters);
             }
-            Op::Interpolation(interp) => rewrite_expr(allocator, &mut interp.expression),
+            Op::Interpolation(interp) => rewrite_expr(allocator, &mut interp.expression, filters),
             Op::If(if_op) => {
                 for branch in if_op.branches.iter_mut() {
                     if let Some(condition) = &mut branch.condition {
-                        rewrite_expr(allocator, condition);
+                        rewrite_expr(allocator, condition, filters);
                     }
-                    rewrite(allocator, &mut branch.region.ops);
+                    rewrite(allocator, &mut branch.region.ops, filters);
                 }
             }
             Op::For(for_op) => {
-                rewrite_expr(allocator, &mut for_op.binding.source);
-                rewrite_expr(allocator, &mut for_op.binding.value);
+                rewrite_expr(allocator, &mut for_op.binding.source, filters);
+                rewrite_expr(allocator, &mut for_op.binding.value, filters);
                 if let Some(key) = &mut for_op.binding.key {
-                    rewrite_expr(allocator, key);
+                    rewrite_expr(allocator, key, filters);
                 }
                 if let Some(index) = &mut for_op.binding.index {
-                    rewrite_expr(allocator, index);
+                    rewrite_expr(allocator, index, filters);
                 }
-                rewrite(allocator, &mut for_op.region.ops);
+                rewrite(allocator, &mut for_op.region.ops, filters);
             }
             Op::Text(_) => {}
         }
     }
 }
 
-fn rewrite_bindings<'a>(allocator: &'a Allocator, bindings: &mut [BindingOp<'a>]) {
+fn rewrite_bindings<'a>(
+    allocator: &'a Allocator,
+    bindings: &mut [BindingOp<'a>],
+    filters: &mut StdVec<String>,
+) {
     for binding in bindings.iter_mut() {
         match binding {
             BindingOp::Bind(bind) => {
                 if let Some(name) = &mut bind.name {
-                    rewrite_name(allocator, name);
+                    rewrite_name(allocator, name, filters);
                 }
                 if let Some(value) = &mut bind.value {
-                    rewrite_expr(allocator, value);
+                    rewrite_expr(allocator, value, filters);
                 }
             }
             BindingOp::On(on) => {
                 if let Some(name) = &mut on.name {
-                    rewrite_name(allocator, name);
+                    rewrite_name(allocator, name, filters);
                 }
                 if let Some(handler) = &mut on.handler {
-                    rewrite_expr(allocator, handler);
+                    rewrite_expr(allocator, handler, filters);
                 }
             }
             BindingOp::Model(model) => {
-                rewrite_expr(allocator, &mut model.contract.read);
-                rewrite_expr(allocator, &mut model.contract.write);
+                rewrite_expr(allocator, &mut model.contract.read, filters);
+                rewrite_expr(allocator, &mut model.contract.write, filters);
             }
             BindingOp::SlotContent(content) => {
                 if let Some(name) = &mut content.name {
-                    rewrite_name(allocator, name);
+                    rewrite_name(allocator, name, filters);
                 }
                 if let Some(params) = &mut content.params {
-                    rewrite_expr(allocator, params);
+                    rewrite_expr(allocator, params, filters);
                 }
             }
             BindingOp::VueDirective(directive) => {
                 if let Some(argument) = &mut directive.argument {
-                    rewrite_name(allocator, argument);
+                    rewrite_name(allocator, argument, filters);
                 }
                 if let Some(value) = &mut directive.value {
-                    rewrite_expr(allocator, value);
+                    rewrite_expr(allocator, value, filters);
                 }
             }
-            BindingOp::VueCssBind(bind) => rewrite_expr(allocator, &mut bind.value),
-            BindingOp::VueSync(sync) => rewrite_expr(allocator, &mut sync.value),
+            BindingOp::VueCssBind(bind) => rewrite_expr(allocator, &mut bind.value, filters),
+            BindingOp::VueSync(sync) => rewrite_expr(allocator, &mut sync.value, filters),
             BindingOp::VueSlotScope(scope) => {
                 if let Some(params) = &mut scope.params {
-                    rewrite_expr(allocator, params);
+                    rewrite_expr(allocator, params, filters);
                 }
             }
             BindingOp::VueOnce(_) => {}
-            BindingOp::VueMemo(memo) => rewrite_expr(allocator, &mut memo.value),
+            BindingOp::VueMemo(memo) => rewrite_expr(allocator, &mut memo.value, filters),
         }
     }
 }
 
-fn rewrite_name<'a>(allocator: &'a Allocator, name: &mut DynamicName<'a>) {
+fn rewrite_name<'a>(
+    allocator: &'a Allocator,
+    name: &mut DynamicName<'a>,
+    filters: &mut StdVec<String>,
+) {
     if let DynamicName::Dynamic(expr) = name {
-        rewrite_expr(allocator, expr);
+        rewrite_expr(allocator, expr, filters);
     }
 }
 
-fn rewrite_expr<'a>(allocator: &'a Allocator, expr: &mut ExprRef<'a>) {
+fn rewrite_expr<'a>(
+    allocator: &'a Allocator,
+    expr: &mut ExprRef<'a>,
+    filters: &mut StdVec<String>,
+) {
     let ExprRef::Filter(filter) = *expr else {
         return;
     };
+    record_filters(filter, filters);
     *expr = wrap(allocator, filter);
+}
+
+fn record_filters(filter: &VueFilterExpr<'_>, filters: &mut StdVec<String>) {
+    for app in &filter.filters {
+        if !filters.iter().any(|seen| seen.as_str() == app.name) {
+            filters.push(String::from(app.name));
+        }
+    }
 }
 
 fn wrap<'a>(allocator: &'a Allocator, filter: &VueFilterExpr<'a>) -> ExprRef<'a> {
@@ -124,8 +153,8 @@ fn wrap<'a>(allocator: &'a Allocator, filter: &VueFilterExpr<'a>) -> ExprRef<'a>
 }
 
 fn wrap_one(exp: &str, app: &VueFilterApp<'_>) -> String {
-    let id = filter_id(app.name);
-    match app.args {
+    let id = asset_ident("filter", app.name);
+    match app.raw.find('(') {
         None => {
             let mut out = String::with_capacity(id.len() + exp.len() + 2);
             out.push_str(id.as_str());
@@ -134,7 +163,7 @@ fn wrap_one(exp: &str, app: &VueFilterApp<'_>) -> String {
             out.push(')');
             out
         }
-        Some("") => {
+        Some(idx) if &app.raw[idx + 1..] == ")" => {
             let mut out = String::with_capacity(id.len() + exp.len() + 2);
             out.push_str(id.as_str());
             out.push('(');
@@ -142,30 +171,15 @@ fn wrap_one(exp: &str, app: &VueFilterApp<'_>) -> String {
             out.push(')');
             out
         }
-        Some(args) => {
+        Some(idx) => {
+            let args = &app.raw[idx + 1..];
             let mut out = String::with_capacity(id.len() + exp.len() + args.len() + 3);
             out.push_str(id.as_str());
             out.push('(');
             out.push_str(exp);
             out.push(',');
             out.push_str(args);
-            out.push(')');
             out
         }
     }
-}
-
-/// `_filter_<name>` with `-` mapped to `_`, the shipped
-/// `to_valid_asset_identifier("filter", name)` for identifier names.
-fn filter_id(name: &str) -> String {
-    let mut id = String::with_capacity(8 + name.len());
-    id.push_str("_filter_");
-    for c in name.chars() {
-        if c == '-' {
-            id.push('_');
-        } else {
-            id.push(c);
-        }
-    }
-    id
 }

--- a/crates/vize_ricalco/tests/emit_filters.rs
+++ b/crates/vize_ricalco/tests/emit_filters.rs
@@ -1,0 +1,89 @@
+//! Vue 2 pipe-filter emission pins for the S2 DOM backend.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use support::with_transformed_caps;
+use vize_ricalco::{LegacyCaps, emit_dom, emit_dom_source_with_caps};
+use vize_s0::Allocator;
+use vize_s0::config::VueVersion;
+
+fn vue2() -> LegacyCaps {
+    LegacyCaps::for_version(VueVersion::V2)
+}
+
+fn assembled(source: &str) -> String {
+    with_transformed_caps(source, vue2(), |lowered, _folio, facts, _budget| {
+        emit_dom(lowered, facts)
+            .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
+            .assembled()
+            .to_string()
+    })
+}
+
+#[test]
+fn vue2_resolves_filters_once_in_first_seen_order() {
+    assert_eq!(
+        assembled(
+            "<div><span>{{ msg | cap | trim(arg) }}</span><span>{{ other | cap }}</span></div>"
+        ),
+        concat!(
+            "const { resolveFilter: _resolveFilter, toDisplayString: _toDisplayString, ",
+            "createElementVNode: _createElementVNode, openBlock: _openBlock, ",
+            "createElementBlock: _createElementBlock } = Vue\n",
+            "\n",
+            "function render(_ctx, _cache, $props, $setup, $data, $options) {\n",
+            "  const _filter_cap = _resolveFilter(\"cap\")\n",
+            "  const _filter_trim = _resolveFilter(\"trim\")\n",
+            "  \n",
+            "  return (_openBlock(), _createElementBlock(\"div\", null, [\n",
+            "    _createElementVNode(\"span\", null, ",
+            "_toDisplayString(_filter_trim(_filter_cap(msg),arg)), 1 /* TEXT */),\n",
+            "    _createElementVNode(\"span\", null, ",
+            "_toDisplayString(_filter_cap(other)), 1 /* TEXT */)\n",
+            "  ]))\n",
+            "}"
+        )
+    );
+}
+
+#[test]
+fn vue2_filter_names_use_the_shipped_asset_identifier_rule() {
+    assert_eq!(
+        assembled("<div>{{ x | foo-bar | $cash }}</div>"),
+        concat!(
+            "const { resolveFilter: _resolveFilter, toDisplayString: _toDisplayString, ",
+            "openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue\n",
+            "\n",
+            "function render(_ctx, _cache, $props, $setup, $data, $options) {\n",
+            "  const _filter_foo_bar = _resolveFilter(\"foo-bar\")\n",
+            "  const _filter_36cash = _resolveFilter(\"$cash\")\n",
+            "  \n",
+            "  return (_openBlock(), _createElementBlock(\"div\", null, ",
+            "_toDisplayString(_filter_36cash(_filter_foo_bar(x))), 1 /* TEXT */))\n",
+            "}"
+        )
+    );
+}
+
+#[test]
+fn vue3_pipe_expressions_do_not_resolve_filters() {
+    let allocator = Allocator::new();
+    let out = emit_dom_source_with_caps(&allocator, "<div>{{ msg | cap }}</div>", LegacyCaps::VUE3)
+        .expect("emit")
+        .assembled();
+    assert_eq!(
+        out.as_str(),
+        "\
+const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", null, _toDisplayString(msg | cap), 1 /* TEXT */))
+}"
+    );
+}

--- a/crates/vize_ricalco/tests/legacy_pass.rs
+++ b/crates/vize_ricalco/tests/legacy_pass.rs
@@ -85,7 +85,7 @@ fn vue2_keeps_camel_on_the_bind() {
 #[test]
 fn vue2_rewrites_a_pipe_filter_to_the_asset_call() {
     let source = "{{msg | cap}}";
-    with_transformed_caps(source, vue2(), |_, folio, _, _| {
+    with_transformed_caps(source, vue2(), |_, folio, facts, _| {
         assert_eq!(
             folio.print_to_string(FolioMode::Full).as_str(),
             "[disegno]\n\
@@ -95,6 +95,15 @@ fn vue2_rewrites_a_pipe_filter_to_the_asset_call() {
              ui.interpolation js(\"_filter_cap(msg)\" @2:11) @0:13\n\
              \n"
         );
+        assert_eq!(
+            facts
+                .legacy
+                .filters
+                .iter()
+                .map(|name| name.as_str())
+                .collect::<std::vec::Vec<_>>(),
+            ["cap"]
+        );
     });
     assert_transformed_sound_caps(source, vue2(), "vue2-filter-wrap");
 }
@@ -102,7 +111,7 @@ fn vue2_rewrites_a_pipe_filter_to_the_asset_call() {
 #[test]
 fn vue2_rewrites_a_filter_with_args() {
     let source = "{{a | f(b)}}";
-    with_transformed_caps(source, vue2(), |_, folio, _, _| {
+    with_transformed_caps(source, vue2(), |_, folio, facts, _| {
         assert_eq!(
             folio.print_to_string(FolioMode::Full).as_str(),
             "[disegno]\n\
@@ -111,6 +120,15 @@ fn vue2_rewrites_a_filter_with_args() {
              [disegno.ops]\n\
              ui.interpolation js(\"_filter_f(a,b)\" @2:10) @0:12\n\
              \n"
+        );
+        assert_eq!(
+            facts
+                .legacy
+                .filters
+                .iter()
+                .map(|name| name.as_str())
+                .collect::<std::vec::Vec<_>>(),
+            ["f"]
         );
     });
     assert_transformed_sound_caps(source, vue2(), "vue2-filter-args");

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           908 |                    60 |               848 |             139 |     371 |             951 |      467 |           475 |           582 |
+| Compiler                   |           910 |                    60 |               850 |             139 |     371 |             951 |      469 |           476 |           583 |
 | Linter                     |           300 |                    16 |               284 |             268 |     219 |             670 |      117 |           337 |           476 |
 | Typechecker                |           879 |                   108 |               771 |             393 |     187 |             804 |      655 |           460 |           650 |
 | Typechecker content-mapper |             8 |                     3 |                 5 |               1 |       0 |               9 |        0 |             7 |            18 |
@@ -61,7 +61,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          21 |               4 |       17 |
-| S0/carton        |         838 |             490 |      348 |
+| S0/carton        |         840 |             490 |      350 |
 | S1/sinopia       |           5 |               1 |        4 |
 | S2/disegno       |          15 |               1 |       14 |
 | S1->S2/ricalco   |          29 |               2 |       27 |
@@ -91,7 +91,7 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | `crates/vize_atelier_sfc/src/compile_script/props/tests.rs:4` | test/dev | S0/carton 15                                                                 |    15 |
 | `crates/vize_atelier_core/tests/s2_support/compare.rs:10`     | test/dev | Davinci 2<br>S0/carton 4<br>S1/sinopia 1<br>S2/disegno 1<br>S1->S2/ricalco 3 |    11 |
 
-Additional test/dev rows are in the TSV: 192 omitted.
+Additional test/dev rows are in the TSV: 193 omitted.
 
 ### Linter
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -256,10 +256,10 @@ compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_once_prop_keys.rs	1	
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_once_prop_keys.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_once_prop_keys.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/benches/davinci.rs	27	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	12	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	12	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	12	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
-compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
+compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	15	davinci	Davinci	stage	vize_davinci	preferred	1
+compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	15	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	15	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	15	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_dom/src/compile.rs	13	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_dom/src/compile.rs	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_dom/src/compile/custom_elements.rs	8	s0	S0/carton	stage	vize_carton	compat	1
@@ -283,6 +283,7 @@ compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/branch_keys.rs	3	s0	S0/
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/conditional_v_model_quirks.rs	5	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_expr_reparse_floor.rs	20	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_dom.rs	22	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_filters.rs	12	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_slots.rs	14	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
@@ -296,8 +297,8 @@ compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/expression_nesting_guar
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/invalid_expression_diagnostics.rs	18	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/setup_component_unref.rs	3	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/slot_outlet_hoist.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/support/mod.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/support/mod.rs	10	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/support/mod.rs	11	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/support/mod.rs	11	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/table_control_flow.rs	3	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/template_syntax_quirks_recovery.rs	3	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/benches/jsx_compile.rs	29	s0	S0/carton	stage	vize_carton	compat	1

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -21,8 +21,8 @@ or `collections` modules does not bypass the boundary.
 
 ## Retained `alloc::vec::Vec` inventory
 
-The four library trees in the reviewed #4814 state contain 53 production files,
-65 direct `alloc::vec::Vec` paths, and 222 bound `Vec`/`StdVec` uses. "Direct"
+The four library trees in the reviewed #4814 state contain 55 production files,
+67 direct `alloc::vec::Vec` paths, and 227 bound `Vec`/`StdVec` uses. "Direct"
 counts imports and fully-qualified paths; "bound" counts every type,
 constructor, and method path reached through a direct `Vec` import or alias.
 The executable ledger requires strict equality, so both growth and reduction
@@ -33,7 +33,7 @@ must update the file row and aggregate evidence in the same change.
 | contract |    13 |           24 |         64 | Owned Folio and S2 serialization data has input-defined cardinality and forms a stable contract.                   |
 | analysis |     7 |            8 |         18 | Diagnostics, side tables, filters, and verifier results grow with the input; no inline bound is established.       |
 | lower    |    11 |           11 |         39 | Lowering worklists and owned results grow with source-tree shape. Bounded substructures may migrate independently. |
-| pass     |    11 |           11 |         47 | Facts, provenance, and traversal worklists grow with the number of operations.                                     |
+| pass     |    13 |           13 |         52 | Facts, provenance, and traversal worklists grow with the number of operations.                                     |
 | emit     |    11 |           11 |         54 | Ordered output buffers and collected emission inputs grow with the document.                                       |
 
 This is not an endorsement of every retained allocation. A focused change may
@@ -71,9 +71,9 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::String`       |    11 |           11 |         53 |
 | s2       | `vize_s0::Vec`          |     9 |            9 |         17 |
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
-| s1_to_s2 | `alloc::vec::Vec`       |    33 |           33 |        140 |
+| s1_to_s2 | `alloc::vec::Vec`       |    35 |           35 |        145 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    44 |           46 |        209 |
+| s1_to_s2 | `vize_s0::String`       |    46 |           48 |        215 |
 | s1_to_s2 | `vize_s0::Vec`          |    14 |           14 |         56 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     2 |            2 |          4 |
 

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -40,6 +40,7 @@ s1_to_s2	emit	crates/vize_ricalco/src/emit/buf.rs	1	8	1	11	0	0	0	0
 s1_to_s2	emit	crates/vize_ricalco/src/emit/component.rs	1	4	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_ricalco/src/emit/create_slots.rs	1	5	1	5	0	0	0	0
 s1_to_s2	emit	crates/vize_ricalco/src/emit/directive.rs	1	5	0	0	0	0	0	0
+s1_to_s2	-	crates/vize_ricalco/src/emit/filter.rs	0	0	1	1	0	0	0	0
 s1_to_s2	emit	crates/vize_ricalco/src/emit/hoist.rs	1	4	1	7	0	0	0	0
 s1_to_s2	-	crates/vize_ricalco/src/emit/js.rs	0	0	1	10	0	0	0	0
 s1_to_s2	emit	crates/vize_ricalco/src/emit/merge.rs	1	8	1	1	0	0	0	0
@@ -73,7 +74,8 @@ s1_to_s2	lower	crates/vize_ricalco/src/lower/text/condense.rs	1	5	1	2	0	0	0	0
 s1_to_s2	-	crates/vize_ricalco/src/lower/vfor.rs	0	0	0	0	0	0	1	1
 s1_to_s2	-	crates/vize_ricalco/src/pass/hoist/consts.rs	0	0	2	0	0	0	0	0
 s1_to_s2	pass	crates/vize_ricalco/src/pass/hoist/lattice.rs	1	2	2	0	0	0	0	0
-s1_to_s2	-	crates/vize_ricalco/src/pass/legacy/filter.rs	0	0	1	7	0	0	0	0
+s1_to_s2	pass	crates/vize_ricalco/src/pass/legacy.rs	1	0	1	1	0	0	0	0
+s1_to_s2	pass	crates/vize_ricalco/src/pass/legacy/filter.rs	1	5	1	11	0	0	0	0
 s1_to_s2	pass	crates/vize_ricalco/src/pass/legacy/ids.rs	1	5	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_ricalco/src/pass/legacy/on.rs	0	0	0	0	1	2	0	0
 s1_to_s2	-	crates/vize_ricalco/src/pass/legacy/slot.rs	0	0	0	0	1	2	0	0

--- a/tests/tooling/davinci-storage-inventory.ts
+++ b/tests/tooling/davinci-storage-inventory.ts
@@ -42,9 +42,9 @@ export const categoryReasons: Record<VecCategory, string> = {
 };
 
 export const expectedProductionAllocVec: StorageSummary = {
-  files: 53,
-  directPaths: 65,
-  boundUses: 222,
+  files: 55,
+  directPaths: 67,
+  boundUses: 227,
 };
 
 function count(value: string, line: number): number {


### PR DESCRIPTION
## Summary
- emit Vue 2 pipe-filter resolver assets from S2 DOM output using the shipped asset-id/helper order
- carry first-seen legacy filter facts out of the S2 legalizing pass
- add byte-for-byte DOM witnesses against the shipped prefixed Vue 2 lane and direct S2 emit snapshots

## Scope
- no rollout switch; existing compile path remains unchanged
- variable filter prefix parity remains tied to the later S2 expression-prefix work, so DOM byte-for-byte witnesses here stay on literal filters

## Verification
- cargo fmt --check -p vize_ricalco -p vize_atelier_dom
- cargo test -p vize_ricalco
- cargo test -p vize_atelier_dom --features legacy --test davinci_s2_bind_modifiers --test davinci_s2_builtins --test davinci_s2_colon --test davinci_s2_dirs --test davinci_s2_dom --test davinci_s2_dom_namespace --test davinci_s2_dynamic --test davinci_s2_dynamic_bind_keys --test davinci_s2_filters --test davinci_s2_for --test davinci_s2_fragments --test davinci_s2_model --test davinci_s2_native_on --test davinci_s2_outlets --test davinci_s2_patch_flags --test davinci_s2_refs --test davinci_s2_slots --test davinci_s2_style_merge --test davinci_s2_tpl --test davinci_s2_von --test davinci_s2_vslots
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node tools/davinci/assertion-lint.mjs
- node tools/davinci/consumer-migration-surfaces.mjs --check
- corepack pnpm exec vp run --workspace-root check:repo
- corepack pnpm exec vp run --workspace-root check:ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790243323&installation_model_id=422833&pr_number=4860&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4860&signature=1322ee331bd8ab96f739c53ad8737d67aaf1069de4e55d8233480889fb489f67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vue 2 filter support for DOM output, including chained filters, arguments, slots, and special filter names.
  * Added capability-aware compilation for Vue 2 and Vue 3 modes.
* **Bug Fixes**
  * Preserved Vue 3 pipe expressions as expressions rather than legacy filters.
  * Improved filter argument handling and identifier generation.
* **Tests**
  * Expanded coverage for filter resolution, ordering, sanitization, nesting, and Vue dialect behavior.
* **Documentation**
  * Updated consumer migration and storage inventory counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->