### PR TITLE
test(davinci): cover s2 dom witnesses in alias guard

### DIFF
--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -64,6 +64,20 @@ function* walkRustFiles(directory: string): Generator<string> {
   }
 }
 
+function s2DomWitnessFiles(): string[] {
+  const testDir = path.join(repoRoot, "crates", "vize_atelier_dom", "tests");
+  const witnesses = fs
+    .readdirSync(testDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && /^davinci_s2_.*\.rs$/u.test(entry.name))
+    .map((entry) => entry.name)
+    .sort();
+  assert.ok(
+    witnesses.length >= 20,
+    `expected broad S2 DOM witness coverage, found only ${witnesses.length} files`,
+  );
+  return [...witnesses, path.join("support", "mod.rs")];
+}
+
 const aliases = new Map<string, ReadonlyArray<readonly [string, string | null]>>([
   ["vize_davinci", [["vize_carton", "vize_s0"]]],
   ["vize_s1", [["vize_carton", "vize_s0"]]],
@@ -166,14 +180,9 @@ test("Davinci DOM lane tests import lowering through the stage alias", () => {
     "vize_atelier_dom must not depend on vize_ricalco through its physical name",
   );
 
-  for (const file of [
-    "davinci_s2_dom.rs",
-    "davinci_s2_patch_flags.rs",
-    "davinci_s2_slots.rs",
-    path.join("support", "mod.rs"),
-  ]) {
+  for (const file of s2DomWitnessFiles()) {
     const source = readRepoFile("crates", "vize_atelier_dom", "tests", file);
-    assert.doesNotMatch(source, /\bvize_ricalco::/u);
+    assert.doesNotMatch(source, /\bvize_ricalco::/u, `${file} must use vize_s1_to_s2`);
   }
 });
 


### PR DESCRIPTION

## Summary

- replace the hard-coded S2 DOM alias-guard file list with a scan over every `davinci_s2_*.rs` witness test
- keep the support module in the same guard and pin that broad witness coverage remains present

## Verification

- `node --test tests/tooling/davinci-stage-dependencies.test.ts`
- `corepack pnpm exec vp check tests/tooling/davinci-stage-dependencies.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `corepack pnpm exec vp run --workspace-root check:repo`
- `corepack pnpm exec vp run --workspace-root check:ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790249144&installation_model_id=422833&pr_number=4863&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4863&signature=9c959404ed31828ad2dcf83624ad4a19833327d5e03ad9bf657c09293802792a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded DOM dependency validation to cover all available witness files.
  * Added checks to ensure the expected number of witness files is present.
  * Continued verifying that each witness file uses the required dependency reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->