### PR TITLE
test(davinci): add s2 dom binding build fixture

### DIFF
--- a/tests/_fixtures/_projects/generic-build/src/BindingPatchFlags.vue
+++ b/tests/_fixtures/_projects/generic-build/src/BindingPatchFlags.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+const rows = [
+  {
+    id: "alpha",
+    label: "Alpha",
+    value: "one",
+    field: "data-rank",
+    style: { color: "red" },
+    attrs: { draggable: "true" },
+  },
+  {
+    id: "beta",
+    label: "Beta",
+    value: "two",
+    field: "data-rank",
+    style: { color: "blue" },
+    attrs: { draggable: "false" },
+  },
+];
+
+const isReady = ref(true);
+const panelClass = ref("ready-panel");
+const panelStyle = ref({ borderColor: "tomato" });
+const panelLabel = "Rows";
+const sectionRef = ref<HTMLElement | null>(null);
+
+function activate(row: (typeof rows)[number]) {
+  return row.id;
+}
+</script>
+
+<template>
+  <section
+    ref="sectionRef"
+    class="surface"
+    :class="[panelClass, { ready: isReady }]"
+    style="background: url(a;b); color: black"
+    :style="panelStyle"
+    :aria-label="panelLabel"
+    :value.prop="rows.length"
+    v-track="isReady"
+  >
+    <article
+      v-for="row in rows"
+      :key="row.id"
+      v-bind="row.attrs"
+      :[row.field].camel.prop="row.value"
+      :style="row.style"
+      @keyup.enter="activate(row)"
+    >
+      <button .value="row.value" :aria-label.attr="row.label" @click="activate(row)">
+        {{ row.label }}
+      </button>
+    </article>
+
+    <template v-if="rows.length > 1">
+      <span>{{ rows.length }}</span>
+    </template>
+    <template v-else>
+      <span>Empty</span>
+    </template>
+  </section>
+</template>

--- a/tests/snapshots/build/__snapshots__/generic-binding-patch-flags.snap
+++ b/tests/snapshots/build/__snapshots__/generic-binding-patch-flags.snap
@@ -1,0 +1,77 @@
+import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, withKeys as _withKeys, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle, mergeProps as _mergeProps, camelize as _camelize, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue";
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode("span", null, "Empty");
+import { ref } from "vue";
+const panelLabel = "Rows";
+export default {
+  __name: "BindingPatchFlags",
+  setup(__props) {
+    const rows = [{
+      id: "alpha",
+      label: "Alpha",
+      value: "one",
+      field: "data-rank",
+      style: { color: "red" },
+      attrs: { draggable: "true" }
+    }, {
+      id: "beta",
+      label: "Beta",
+      value: "two",
+      field: "data-rank",
+      style: { color: "blue" },
+      attrs: { draggable: "false" }
+    }];
+    const isReady = ref(true);
+    const panelClass = ref("ready-panel");
+    const panelStyle = ref({ borderColor: "tomato" });
+    const sectionRef = ref(null);
+    function activate(row) {
+      return row.id;
+    }
+    return (_ctx, _cache) => {
+      const _directive_track = _resolveDirective("track");
+      return _withDirectives((_openBlock(), _createElementBlock("section", {
+        ref_key: "sectionRef",
+        ref: sectionRef,
+        class: _normalizeClass(["surface", [panelClass.value, { ready: isReady.value }]]),
+        style: _normalizeStyle([{
+          "background": "url(a;b)",
+          "color": "black"
+        }, panelStyle.value]),
+        "aria-label": panelLabel,
+        ".value": rows.length
+      }, [(_openBlock(true), _createElementBlock(
+        _Fragment,
+        null,
+        _renderList(rows, (row) => {
+          return _openBlock(), _createElementBlock("article", _mergeProps({ key: row.id }, row.attrs, {
+            [`.${_camelize(row.field || "")}`]: row.value,
+            style: row.style,
+            onKeyup: _withKeys(($event) => activate(row), ["enter"])
+          }), [_createElementVNode("button", {
+            ".value": row.value,
+            "^aria-label": row.label,
+            onClick: ($event) => activate(row)
+          }, _toDisplayString(row.label), 41, [
+            ".value",
+            "^aria-label",
+            "onClick"
+          ])], 48, ["onKeyup"]);
+        }),
+        128
+        /* KEYED_FRAGMENT */
+      )), rows.length > 1 ? (_openBlock(), _createElementBlock(
+        "span",
+        { key: 0 },
+        _toDisplayString(rows.length),
+        1
+        /* TEXT */
+      )) : (_openBlock(), _createElementBlock(
+        _Fragment,
+        { key: 1 },
+        [_hoisted_1],
+        64
+        /* STABLE_FRAGMENT */
+      ))], 46, ["aria-label", ".value"])), [[_directive_track, isReady.value]]);
+    };
+  }
+};

--- a/tests/snapshots/build/generic.ts
+++ b/tests/snapshots/build/generic.ts
@@ -40,6 +40,7 @@ describe("generic build snapshots (compiler)", () => {
         .sort();
 
       assert.deepEqual(jsFiles, [
+        "BindingPatchFlags.js",
         "DirectiveBuiltins.js",
         "FixturePanel.js",
         "NormalScriptBindings.js",
@@ -47,6 +48,7 @@ describe("generic build snapshots (compiler)", () => {
       ]);
 
       const snapshotOutputs = [
+        ["BindingPatchFlags.js", "generic-binding-patch-flags"],
         ["DirectiveBuiltins.js", "generic-directive-builtins"],
         ["FixturePanel.js", "generic-fixture-panel"],
         ["NormalScriptBindings.js", "generic-normal-script-bindings"],

--- a/tests/tooling/davinci-v-on-storage.test.ts
+++ b/tests/tooling/davinci-v-on-storage.test.ts
@@ -170,7 +170,7 @@ test("the natural committed v-on corpus fits the two-entry inline buckets", () =
     { options: 0, event: 0, keys: 0 },
   );
 
-  assert.equal(spellings.length, 180, "update the measured corpus evidence intentionally");
+  assert.equal(spellings.length, 181, "update the measured corpus evidence intentionally");
   assert.deepEqual(maxima, { options: 2, event: 2, keys: 2 });
 });
 


### PR DESCRIPTION
## Summary
- add a generic build SFC fixture that exercises S2 DOM binding and patch-flag output classes
- snapshot the generated compiler output and include it in the strict generic build output list

## Verification
- cargo build --profile ci -p vize
- UPDATE_SNAPSHOTS=1 node --test tests/snapshots/build/generic.ts
- node --test tests/snapshots/build/generic.ts
- cargo test -p vize_atelier_dom --test davinci_s2_patch_flags --test davinci_s2_bind_modifiers --test davinci_s2_dynamic_bind_keys --test davinci_s2_style_merge
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- corepack pnpm exec vp check tests/_fixtures/_projects/generic-build/src/BindingPatchFlags.vue tests/snapshots/build/generic.ts tests/snapshots/build/__snapshots__/generic-binding-patch-flags.snap
- corepack pnpm exec vp run --workspace-root check:repo
- corepack pnpm exec vp run --workspace-root check:ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790250351&installation_model_id=422833&pr_number=4864&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4864&signature=2a9da7ef20ba4211fa67fc09b326f7950700e490c5f780d3bfb322a00496a4e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive Vue fixture covering reactive state, static and dynamic attributes, property bindings, class and style updates, custom directives, event handling, keyed lists, modifiers, and conditional rendering.
  * Updated tooling coverage to recognize the complete set of supported `v-on` syntax variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->