### PR TITLE
test(davinci): add vue2 filter build fixture

### DIFF
--- a/.github/actions/check-vue-parity/action.yml
+++ b/.github/actions/check-vue-parity/action.yml
@@ -175,6 +175,12 @@ runs:
         VIZE_RUNTIME_NODE_MODULES: node_modules
       run: cargo test --locked --profile ci -p vize_canon --test tier_l_incremental -- --ignored --nocapture
 
+    - name: Check Vue 2 build snapshots
+      shell: bash
+      env:
+        VIZE_TEST_BIN: target/ci/vize
+      run: node --test --test-concurrency=1 tests/snapshots/build/vue2-filters.ts
+
     - name: Check glyph formatter corpus properties
       shell: bash
       env:

--- a/tests/_fixtures/_projects/vue2-filter-build/src/LegacyFilters.vue
+++ b/tests/_fixtures/_projects/vue2-filter-build/src/LegacyFilters.vue
@@ -1,0 +1,23 @@
+<script>
+export default {
+  name: "LegacyFilters",
+  data() {
+    return {
+      amount: 12,
+      order: {
+        id: "a-1",
+        status: "paid",
+      },
+    };
+  },
+};
+</script>
+
+<template>
+  <section class="legacy-filters">
+    <p>{{ order.id | normalizeId }}</p>
+    <p>{{ amount | currency("$") | suffix(" USD") }}</p>
+    <StatusBadge :type="order.status | statusFilter" />
+    <slot :value="amount | currency"></slot>
+  </section>
+</template>

--- a/tests/_fixtures/_projects/vue2-filter-build/vize.config.json
+++ b/tests/_fixtures/_projects/vue2-filter-build/vize.config.json
@@ -1,0 +1,7 @@
+{
+  "compiler": {
+    "compatibility": {
+      "vueVersion": "2"
+    }
+  }
+}

--- a/tests/snapshots/build/__snapshots__/vue2-filters-legacy-filters.snap
+++ b/tests/snapshots/build/__snapshots__/vue2-filters-legacy-filters.snap
@@ -1,0 +1,32 @@
+
+const _sfc_main = {
+  name: "LegacyFilters",
+  data() {
+    return {
+      amount: 12,
+      order: {
+        id: "a-1",
+        status: "paid",
+      },
+    };
+  },
+}
+
+import { resolveFilter as _resolveFilter, resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, renderSlot as _renderSlot, createVNode as _createVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_StatusBadge = _resolveComponent("StatusBadge")
+  const _filter_normalizeId = _resolveFilter("normalizeId")
+  const _filter_currency = _resolveFilter("currency")
+  const _filter_suffix = _resolveFilter("suffix")
+  const _filter_statusFilter = _resolveFilter("statusFilter")
+  
+  return (_openBlock(), _createElementBlock("section", { class: "legacy-filters" }, [
+    _createElementVNode("p", null, _toDisplayString(_filter_normalizeId($data.order.id)), 1 /* TEXT */),
+    _createElementVNode("p", null, _toDisplayString(_filter_suffix(_filter_currency($data.amount,"$")," USD")), 1 /* TEXT */),
+    _createVNode(_component_StatusBadge, { type: _filter_statusFilter($data.order.status) }, null, 8 /* PROPS */, ["type"]),
+    _renderSlot(_ctx.$slots, "default", { value: _filter_currency($data.amount) })
+  ]))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/build/vue2-filters.ts
+++ b/tests/snapshots/build/vue2-filters.ts
@@ -1,0 +1,104 @@
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { VIZE_BIN } from "../../_helpers/apps.ts";
+import { assertParsesAsModule } from "../../_helpers/assertions.ts";
+import { assertSnapshot } from "../../_helpers/snapshot.ts";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const FIXTURE_DIR = path.resolve(__dirname, "../../_fixtures/_projects/vue2-filter-build");
+const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
+const VIZE_BUILD_BIN = resolveVizeBuildBin();
+
+function resolveVizeBuildBin(): string {
+  const candidate = process.env.VIZE_TEST_BIN;
+  if (candidate == null || candidate.length === 0) return VIZE_BIN;
+  if (path.isAbsolute(candidate) || (!candidate.includes("/") && !candidate.includes("\\"))) {
+    return candidate;
+  }
+  return path.resolve(REPO_ROOT, candidate);
+}
+
+function requireVizeBuildBin(): void {
+  if (path.isAbsolute(VIZE_BUILD_BIN) || VIZE_BUILD_BIN.includes("/")) {
+    assert.ok(
+      fs.existsSync(VIZE_BUILD_BIN),
+      `vize CLI is required at ${VIZE_BUILD_BIN}. Build it with \`cargo build --profile ci -p vize --features legacy\`.`,
+    );
+    return;
+  }
+  execFileSync(VIZE_BUILD_BIN, ["--version"], { cwd: REPO_ROOT });
+}
+
+describe("Vue 2 filter build snapshots (compiler)", () => {
+  before(() => {
+    requireVizeBuildBin();
+  });
+
+  it("snapshots generated filter output exactly", () => {
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-vue2-filter-build-"));
+
+    try {
+      const stdout = execFileSync(
+        VIZE_BUILD_BIN,
+        [
+          "build",
+          "src/**/*.vue",
+          "--config",
+          "vize.config.json",
+          "-o",
+          outDir,
+          "--continue-on-error",
+        ],
+        {
+          cwd: FIXTURE_DIR,
+          timeout: 120_000,
+          maxBuffer: 100 * 1024 * 1024,
+        },
+      ).toString();
+      console.log(stdout);
+
+      const jsFiles = fs
+        .readdirSync(outDir, { recursive: true })
+        .map((entry) => String(entry))
+        .filter((entry) => entry.endsWith(".js"))
+        .sort();
+
+      assert.deepEqual(jsFiles, ["LegacyFilters.js"]);
+
+      const content = fs.readFileSync(path.join(outDir, "LegacyFilters.js"), "utf-8");
+      assertParsesAsModule(content, "LegacyFilters.js");
+
+      for (const expected of [
+        "resolveFilter as _resolveFilter",
+        'const _filter_normalizeId = _resolveFilter("normalizeId")',
+        'const _filter_currency = _resolveFilter("currency")',
+        'const _filter_suffix = _resolveFilter("suffix")',
+        'const _filter_statusFilter = _resolveFilter("statusFilter")',
+        "_toDisplayString(_filter_normalizeId($data.order.id))",
+        '_filter_suffix(_filter_currency($data.amount,"$")," USD")',
+        "type: _filter_statusFilter($data.order.status)",
+        "value: _filter_currency($data.amount)",
+      ]) {
+        assert.equal(content.includes(expected), true, `${expected}\n${content}`);
+      }
+
+      for (const forbidden of [
+        "$data.order.id | _ctx.normalizeId",
+        '$data.amount | _ctx.currency("$") | _ctx.suffix(" USD")',
+        "$data.order.status | _ctx.statusFilter",
+      ]) {
+        assert.equal(content.includes(forbidden), false, `${forbidden}\n${content}`);
+      }
+
+      assertSnapshot(SNAPSHOT_DIR, "vue2-filters-legacy-filters", content);
+    } finally {
+      fs.rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/tooling/github-workflows-vue-parity.test.ts
+++ b/tests/tooling/github-workflows-vue-parity.test.ts
@@ -190,6 +190,13 @@ test("Vue parity structurally gates compiler fixtures and incremental LSP behavi
     "cargo test --locked --profile ci -p vize_canon --test tier_l_incremental -- --ignored --nocapture",
   );
 
+  const vue2Build = steps.find((step) => step.name === "Check Vue 2 build snapshots");
+  assert.deepEqual(vue2Build?.env, { VIZE_TEST_BIN: "target/ci/vize" });
+  assert.equal(
+    vue2Build?.run,
+    "node --test --test-concurrency=1 tests/snapshots/build/vue2-filters.ts",
+  );
+
   const glyphProperties = steps.find(
     (step) => step.name === "Check glyph formatter corpus properties",
   );


### PR DESCRIPTION
## Summary
- add a small Vue 2 filter build fixture with a pinned generated JS snapshot
- wire the snapshot into the vue-parity action, where CI builds the legacy-capable CLI
- add a workflow contract assertion so the legacy build snapshot stays gated

## Verification
- cargo build --profile ci -p vize
- cargo build --profile ci -p vize --features legacy
- VIZE_TEST_BIN=target/ci/vize node --test tests/snapshots/build/vue2-filters.ts
- node --test tests/tooling/github-workflows-vue-parity.test.ts
- cargo test -p vize_atelier_dom --features legacy --test davinci_s2_filters
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- corepack pnpm exec vp check .github/actions/check-vue-parity/action.yml tests/tooling/github-workflows-vue-parity.test.ts tests/snapshots/build/vue2-filters.ts tests/_fixtures/_projects/vue2-filter-build/src/LegacyFilters.vue tests/_fixtures/_projects/vue2-filter-build/vize.config.json
- node --test tests/tooling/e2e-tasks.test.ts
- corepack pnpm exec vp run --workspace-root check:repo
- corepack pnpm exec vp run --workspace-root check:ci

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790252616&installation_model_id=422833&pr_number=4865&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4865&signature=d4b40d01ca7a823da7f8e076637473f69ebd1be691b815ac55fc3ed9f0c46aed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded Vue 2 compatibility coverage for builds using legacy filters, including formatting, ordering, status, and slot values.
  - Added automated snapshot validation to detect unexpected changes in Vue 2 build output.
  - Improved consistency and reliability of cross-version build verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->