### PR TITLE
test(davinci): fail closed on partial differential corpus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3554,6 +3554,7 @@ dependencies = [
  "compact_str",
  "criterion",
  "davinci_harness",
+ "davinci_test_support",
  "insta",
  "memoffset",
  "oxc_allocator",
@@ -3627,6 +3628,7 @@ version = "0.387.0"
 dependencies = [
  "criterion",
  "davinci_harness",
+ "davinci_test_support",
  "insta",
  "lightningcss",
  "memchr",

--- a/crates/vize_atelier_core/Cargo.toml
+++ b/crates/vize_atelier_core/Cargo.toml
@@ -51,6 +51,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 davinci_harness = { workspace = true }
+davinci_test_support.workspace = true
 insta = { workspace = true }
 
 # The Davinci S2 lane, test-space only (P2-9): dev-dependencies with no

--- a/crates/vize_atelier_core/tests/davinci_s2_transform_corpus.rs
+++ b/crates/vize_atelier_core/tests/davinci_s2_transform_corpus.rs
@@ -20,6 +20,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use davinci_harness::fixtures::template_block;
+use davinci_test_support::corpus::{CorpusScope, corpus_root_from_env};
 use s2_support::{
     BATTERY, Counters, HoistCounters, SlotCounters, SurfaceCounters, TextCounters, compare,
 };
@@ -138,31 +139,28 @@ fn the_s2_transform_lane_holds_over_the_corpus() {
     );
 
     // -- optional corpus sweep --------------------------------------
-    let Some(corpus_root) = std::env::var_os("VIZE_DAVINCI_DIFFERENTIAL_CORPUS") else {
+    let Some(corpus_root) =
+        corpus_root_from_env(env!("CARGO_MANIFEST_DIR")).unwrap_or_else(|error| panic!("{error}"))
+    else {
         eprintln!("VIZE_DAVINCI_DIFFERENTIAL_CORPUS unset: committed battery only");
         return;
     };
-    let corpus_root = PathBuf::from(corpus_root);
-    // Cargo runs test binaries from the package directory; let
-    // workspace-root-relative paths (`tests/_fixtures/_git`) work too.
-    let corpus_root = if corpus_root.is_relative() && !corpus_root.is_dir() {
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../..")
-            .join(&corpus_root)
-    } else {
-        corpus_root
-    };
     assert!(
-        corpus_root.is_dir(),
+        corpus_root.path().is_dir(),
         "VIZE_DAVINCI_DIFFERENTIAL_CORPUS must name a directory: {}",
-        corpus_root.display()
+        corpus_root.path().display()
+    );
+    eprintln!(
+        "davinci s2 transform corpus scope: {} closure_evidence={}",
+        corpus_root.scope().label(),
+        matches!(corpus_root.scope(), CorpusScope::ClosureEvidence)
     );
     let mut files = Vec::new();
-    collect_vue_files(&corpus_root, &mut files);
+    collect_vue_files(corpus_root.path(), &mut files);
     assert!(
         !files.is_empty(),
         "corpus sweep found no .vue files under {}",
-        corpus_root.display()
+        corpus_root.path().display()
     );
     let mut corpus = Counters::default();
     let mut unreadable = 0u64;

--- a/crates/vize_atelier_sfc/Cargo.toml
+++ b/crates/vize_atelier_sfc/Cargo.toml
@@ -56,6 +56,7 @@ toml = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 davinci_harness = { workspace = true }
+davinci_test_support.workspace = true
 criterion = { workspace = true }
 
 [[bench]]

--- a/crates/vize_atelier_sfc/tests/davinci_differential.rs
+++ b/crates/vize_atelier_sfc/tests/davinci_differential.rs
@@ -32,6 +32,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use davinci_test_support::corpus::{CorpusScope, corpus_root_from_env};
 use vize_atelier_core::retained::differential;
 use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
 
@@ -220,28 +221,25 @@ fn differential_lane_body() {
     );
 
     // -- optional corpus sweep --------------------------------------------
-    if let Some(corpus_root) = std::env::var_os("VIZE_DAVINCI_DIFFERENTIAL_CORPUS") {
-        let corpus_root = PathBuf::from(corpus_root);
-        // Cargo runs test binaries from the package directory; let
-        // workspace-root-relative paths (`tests/_fixtures/_git`) work too.
-        let corpus_root = if corpus_root.is_relative() && !corpus_root.is_dir() {
-            Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("../..")
-                .join(&corpus_root)
-        } else {
-            corpus_root
-        };
+    let corpus_root =
+        corpus_root_from_env(env!("CARGO_MANIFEST_DIR")).unwrap_or_else(|error| panic!("{error}"));
+    if let Some(corpus_root) = corpus_root {
         assert!(
-            corpus_root.is_dir(),
+            corpus_root.path().is_dir(),
             "VIZE_DAVINCI_DIFFERENTIAL_CORPUS must name a directory: {}",
-            corpus_root.display()
+            corpus_root.path().display()
+        );
+        eprintln!(
+            "davinci-differential corpus scope: {} closure_evidence={}",
+            corpus_root.scope().label(),
+            matches!(corpus_root.scope(), CorpusScope::ClosureEvidence)
         );
         let mut files = Vec::new();
-        collect_vue_files(&corpus_root, &mut files);
+        collect_vue_files(corpus_root.path(), &mut files);
         assert!(
             !files.is_empty(),
             "corpus sweep found no .vue files under {}",
-            corpus_root.display()
+            corpus_root.path().display()
         );
         let mut compiled = 0u64;
         for file in &files {

--- a/crates/vize_ricalco/tests/davinci_lowering_corpus.rs
+++ b/crates/vize_ricalco/tests/davinci_lowering_corpus.rs
@@ -25,6 +25,7 @@ mod support;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use davinci_test_support::corpus::{CorpusScope, corpus_root_from_env};
 use davinci_test_support::surface_fixture as battery;
 use support::{assert_sound, with_lowered};
 
@@ -77,31 +78,28 @@ fn lowering_corpus_is_total() {
     );
 
     // -- optional corpus sweep -----------------------------------------
-    let Some(corpus_root) = std::env::var_os("VIZE_DAVINCI_DIFFERENTIAL_CORPUS") else {
+    let Some(corpus_root) =
+        corpus_root_from_env(env!("CARGO_MANIFEST_DIR")).unwrap_or_else(|error| panic!("{error}"))
+    else {
         eprintln!("VIZE_DAVINCI_DIFFERENTIAL_CORPUS unset: committed battery only");
         return;
     };
-    let corpus_root = PathBuf::from(corpus_root);
-    // Cargo runs test binaries from the package directory; let
-    // workspace-root-relative paths (`tests/_fixtures/_git`) work too.
-    let corpus_root = if corpus_root.is_relative() && !corpus_root.is_dir() {
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../..")
-            .join(&corpus_root)
-    } else {
-        corpus_root
-    };
     assert!(
-        corpus_root.is_dir(),
+        corpus_root.path().is_dir(),
         "VIZE_DAVINCI_DIFFERENTIAL_CORPUS must name a directory: {}",
-        corpus_root.display()
+        corpus_root.path().display()
+    );
+    eprintln!(
+        "davinci lowering corpus scope: {} closure_evidence={}",
+        corpus_root.scope().label(),
+        matches!(corpus_root.scope(), CorpusScope::ClosureEvidence)
     );
     let mut files = Vec::new();
-    collect_vue_files(&corpus_root, &mut files);
+    collect_vue_files(corpus_root.path(), &mut files);
     assert!(
         !files.is_empty(),
         "corpus sweep found no .vue files under {}",
-        corpus_root.display()
+        corpus_root.path().display()
     );
     let mut checked = 0u64;
     let mut with_diagnostics = 0u64;

--- a/tests/davinci_test_support/src/corpus.rs
+++ b/tests/davinci_test_support/src/corpus.rs
@@ -1,0 +1,204 @@
+//! Corpus-root preflight for Davinci real-project differential lanes.
+//!
+//! The canonical closure corpus is the current checkout's own
+//! `tests/_fixtures/_git` gitlink tree. Arbitrary roots can still be swept as
+//! smoke shards, but they are labeled as non-closure evidence and do not claim
+//! the phase gate.
+
+use std::env;
+use std::fmt;
+use std::path::{Component, Path, PathBuf};
+
+use vize_s0::String;
+
+mod preflight;
+
+use preflight::assert_canonical_hydrated;
+
+pub const DIFFERENTIAL_CORPUS_ENV: &str = "VIZE_DAVINCI_DIFFERENTIAL_CORPUS";
+pub const CANONICAL_CORPUS_ROOT: &str = "tests/_fixtures/_git";
+
+const HYDRATE_COMMAND: &str =
+    "git submodule update --init --checkout --force -- tests/_fixtures/_git";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CorpusScope {
+    ClosureEvidence,
+    SmokeShard,
+}
+
+impl CorpusScope {
+    #[must_use]
+    pub const fn closure_evidence(self) -> bool {
+        matches!(self, Self::ClosureEvidence)
+    }
+
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::ClosureEvidence => "canonical-closure",
+            Self::SmokeShard => "external-smoke",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorpusRoot {
+    path: PathBuf,
+    scope: CorpusScope,
+}
+
+impl CorpusRoot {
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    #[must_use]
+    pub const fn scope(&self) -> CorpusScope {
+        self.scope
+    }
+
+    #[must_use]
+    pub const fn closure_evidence(&self) -> bool {
+        self.scope.closure_evidence()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CorpusPreflightError {
+    Git { command: String, detail: String },
+    Hydration(Box<HydrationReport>),
+}
+
+impl fmt::Display for CorpusPreflightError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Git { command, detail } => write!(f, "`{command}` failed: {detail}"),
+            Self::Hydration(report) => report.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for CorpusPreflightError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HydrationReport {
+    root: String,
+    indexed: usize,
+    clean: usize,
+    missing: Vec<String>,
+    drifted: Vec<String>,
+    conflicted: Vec<String>,
+    invalid: Vec<String>,
+    inventory_mismatch: Vec<String>,
+}
+
+impl HydrationReport {
+    #[must_use]
+    pub fn is_clean(&self) -> bool {
+        self.indexed > 0
+            && self.clean == self.indexed
+            && self.missing.is_empty()
+            && self.drifted.is_empty()
+            && self.conflicted.is_empty()
+            && self.invalid.is_empty()
+            && self.inventory_mismatch.is_empty()
+    }
+}
+
+impl fmt::Display for HydrationReport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Davinci canonical corpus preflight failed:")?;
+        writeln!(f, "  root: {}", self.root)?;
+        writeln!(f, "  closure_evidence: true")?;
+        writeln!(f, "  indexed gitlinks: {}", self.indexed)?;
+        writeln!(f, "  clean submodules: {}", self.clean)?;
+        write_group(f, "missing submodules", &self.missing)?;
+        write_group(f, "drifted submodules", &self.drifted)?;
+        write_group(f, "conflicted submodules", &self.conflicted)?;
+        write_group(f, "invalid submodules", &self.invalid)?;
+        write_group(f, "inventory mismatches", &self.inventory_mismatch)?;
+        writeln!(f, "  hydrate with:")?;
+        writeln!(f, "    {HYDRATE_COMMAND}")?;
+        write!(
+            f,
+            "  partial fixture trees are refused before collecting .vue files"
+        )
+    }
+}
+
+fn write_group(f: &mut fmt::Formatter<'_>, label: &str, rows: &[String]) -> fmt::Result {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    writeln!(f, "  {label}: {}", rows.len())?;
+    for row in rows.iter().take(5) {
+        writeln!(f, "    {row}")?;
+    }
+    if rows.len() > 5 {
+        writeln!(f, "    ... and {} more", rows.len() - 5)?;
+    }
+    Ok(())
+}
+
+pub fn corpus_root_from_env(
+    package_manifest_dir: impl AsRef<Path>,
+) -> Result<Option<CorpusRoot>, CorpusPreflightError> {
+    let Some(value) = env::var_os(DIFFERENTIAL_CORPUS_ENV) else {
+        return Ok(None);
+    };
+    prepare_corpus_root(value, package_manifest_dir).map(Some)
+}
+
+pub fn prepare_corpus_root(
+    raw_root: impl Into<PathBuf>,
+    package_manifest_dir: impl AsRef<Path>,
+) -> Result<CorpusRoot, CorpusPreflightError> {
+    let workspace = workspace_root(package_manifest_dir.as_ref());
+    let root = resolve_root(raw_root.into(), &workspace);
+    let canonical = normalize_path(&workspace.join(CANONICAL_CORPUS_ROOT));
+    let scope = if normalize_path(&root) == canonical {
+        assert_canonical_hydrated(&workspace)?;
+        CorpusScope::ClosureEvidence
+    } else {
+        CorpusScope::SmokeShard
+    };
+    Ok(CorpusRoot { path: root, scope })
+}
+
+fn workspace_root(package_manifest_dir: &Path) -> PathBuf {
+    package_manifest_dir
+        .ancestors()
+        .nth(2)
+        .unwrap_or(package_manifest_dir)
+        .to_path_buf()
+}
+
+fn resolve_root(raw_root: PathBuf, workspace: &Path) -> PathBuf {
+    let path = if raw_root.is_absolute() {
+        raw_root
+    } else {
+        workspace.join(raw_root)
+    };
+    normalize_path(&path)
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                out.push(component.as_os_str());
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/tests/davinci_test_support/src/corpus.rs
+++ b/tests/davinci_test_support/src/corpus.rs
@@ -7,6 +7,7 @@
 
 use std::env;
 use std::fmt;
+use std::fs;
 use std::path::{Component, Path, PathBuf};
 
 use vize_s0::String;
@@ -157,8 +158,8 @@ pub fn prepare_corpus_root(
 ) -> Result<CorpusRoot, CorpusPreflightError> {
     let workspace = workspace_root(package_manifest_dir.as_ref());
     let root = resolve_root(raw_root.into(), &workspace);
-    let canonical = normalize_path(&workspace.join(CANONICAL_CORPUS_ROOT));
-    let scope = if normalize_path(&root) == canonical {
+    let canonical = real_path(&workspace.join(CANONICAL_CORPUS_ROOT));
+    let scope = if real_path(&root) == canonical {
         assert_canonical_hydrated(&workspace)?;
         CorpusScope::ClosureEvidence
     } else {
@@ -170,7 +171,8 @@ pub fn prepare_corpus_root(
 fn workspace_root(package_manifest_dir: &Path) -> PathBuf {
     package_manifest_dir
         .ancestors()
-        .nth(2)
+        .find(|candidate| candidate.join("pnpm-workspace.yaml").is_file())
+        .or_else(|| package_manifest_dir.ancestors().nth(2))
         .unwrap_or(package_manifest_dir)
         .to_path_buf()
 }
@@ -198,6 +200,11 @@ fn normalize_path(path: &Path) -> PathBuf {
         }
     }
     out
+}
+
+fn real_path(path: &Path) -> PathBuf {
+    let normalized = normalize_path(path);
+    fs::canonicalize(&normalized).unwrap_or(normalized)
 }
 
 #[cfg(test)]

--- a/tests/davinci_test_support/src/corpus/preflight.rs
+++ b/tests/davinci_test_support/src/corpus/preflight.rs
@@ -279,7 +279,7 @@ fn git(workspace: &Path, args: &[&str]) -> Result<String, CorpusPreflightError> 
 
 fn output_text(bytes: &[u8]) -> String {
     match core::str::from_utf8(bytes) {
-        Ok(text) => text.trim().to_compact_string(),
+        Ok(text) => text.trim_end().to_compact_string(),
         Err(_) => "<non-utf8 output>".into(),
     }
 }
@@ -295,7 +295,16 @@ fn git_command(args: &[&str]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_status_line;
+    use super::{output_text, parse_status_line};
+
+    #[test]
+    fn output_text_preserves_clean_status_marker() {
+        let output =
+            output_text(b" 0123456789012345678901234567890123456789 tests/_fixtures/_git/clean\n");
+
+        assert!(output.starts_with(' '));
+        assert!(!output.ends_with('\n'));
+    }
 
     #[test]
     fn status_parser_handles_paths_with_spaces() {

--- a/tests/davinci_test_support/src/corpus/preflight.rs
+++ b/tests/davinci_test_support/src/corpus/preflight.rs
@@ -1,0 +1,258 @@
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use vize_s0::{String, ToCompactString, cstr};
+
+use super::{CANONICAL_CORPUS_ROOT, CorpusPreflightError, HydrationReport};
+
+pub(super) fn assert_canonical_hydrated(workspace: &Path) -> Result<(), CorpusPreflightError> {
+    let gitlinks = read_indexed_gitlinks(workspace)?;
+    let statuses = read_submodule_statuses(workspace, gitlinks.keys())?;
+    let report = build_report(workspace, &gitlinks, &statuses);
+    if report.is_clean() {
+        Ok(())
+    } else {
+        Err(CorpusPreflightError::Hydration(Box::new(report)))
+    }
+}
+
+fn read_indexed_gitlinks(
+    workspace: &Path,
+) -> Result<BTreeMap<String, String>, CorpusPreflightError> {
+    let output = git(
+        workspace,
+        &["ls-files", "--stage", "--", CANONICAL_CORPUS_ROOT],
+    )?;
+    let mut gitlinks = BTreeMap::new();
+    for line in output.lines() {
+        let Some((meta, path)) = line.split_once('\t') else {
+            continue;
+        };
+        let mut fields = meta.split_whitespace();
+        let (Some(mode), Some(sha), Some(stage)) = (fields.next(), fields.next(), fields.next())
+        else {
+            continue;
+        };
+        if mode == "160000" {
+            gitlinks.insert(path.into(), cstr!("{sha}:{stage}"));
+        }
+    }
+    Ok(gitlinks)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SubmoduleStatus {
+    marker: char,
+    path: String,
+}
+
+fn read_submodule_statuses<'a>(
+    workspace: &Path,
+    indexed_paths: impl Iterator<Item = &'a String>,
+) -> Result<BTreeMap<String, SubmoduleStatus>, CorpusPreflightError> {
+    let paths: Vec<&str> = indexed_paths.map(String::as_str).collect();
+    let output = git(
+        workspace,
+        &["submodule", "status", "--", CANONICAL_CORPUS_ROOT],
+    )?;
+    let mut statuses = BTreeMap::new();
+    for line in output.lines() {
+        if let Some(status) = parse_status_line(line, &paths) {
+            statuses.insert(status.path.clone(), status);
+        }
+    }
+    Ok(statuses)
+}
+
+fn parse_status_line(line: &str, indexed_paths: &[&str]) -> Option<SubmoduleStatus> {
+    let marker = line.chars().next()?;
+    let rest = line.get(marker.len_utf8()..)?.trim_start();
+    let (_sha, tail) = rest.split_once(' ')?;
+    let mut candidates: Vec<&str> = indexed_paths.to_vec();
+    candidates.sort_by_key(|path| core::cmp::Reverse(path.len()));
+    let path = candidates.into_iter().find(|path| {
+        tail == *path
+            || tail
+                .strip_prefix(*path)
+                .is_some_and(|tail| tail.starts_with(' '))
+    })?;
+    Some(SubmoduleStatus {
+        marker,
+        path: path.into(),
+    })
+}
+
+fn build_report(
+    workspace: &Path,
+    gitlinks: &BTreeMap<String, String>,
+    statuses: &BTreeMap<String, SubmoduleStatus>,
+) -> HydrationReport {
+    let mut report = HydrationReport {
+        root: CANONICAL_CORPUS_ROOT.into(),
+        indexed: gitlinks.len(),
+        clean: 0,
+        missing: Vec::new(),
+        drifted: Vec::new(),
+        conflicted: Vec::new(),
+        invalid: Vec::new(),
+        inventory_mismatch: Vec::new(),
+    };
+    if gitlinks.is_empty() {
+        report
+            .inventory_mismatch
+            .push(cstr!("no indexed gitlinks under {CANONICAL_CORPUS_ROOT}"));
+    }
+    for (path, expected_stage) in gitlinks {
+        classify_gitlink(
+            workspace,
+            &mut report,
+            path,
+            expected_stage,
+            statuses.get(path),
+        );
+    }
+    for path in statuses.keys() {
+        if !gitlinks.contains_key(path) {
+            report
+                .inventory_mismatch
+                .push(cstr!("{path}: submodule status has no indexed gitlink"));
+        }
+    }
+    report
+}
+
+fn classify_gitlink(
+    workspace: &Path,
+    report: &mut HydrationReport,
+    path: &str,
+    expected_stage: &str,
+    status: Option<&SubmoduleStatus>,
+) {
+    let Some((expected, stage)) = expected_stage.split_once(':') else {
+        report.invalid.push(cstr!("{path}: malformed index entry"));
+        return;
+    };
+    if stage != "0" {
+        report
+            .conflicted
+            .push(cstr!("{path}: unmerged gitlink stage {stage}"));
+        return;
+    }
+    match status.map(|status| status.marker) {
+        // A real unhydrated submodule reports `-` and then fails the checkout
+        // probe below. Synthetic test repos can carry a standalone checkout at
+        // the path; in that case the indexed SHA remains the source of truth.
+        Some('-' | ' ') => {}
+        Some('+') => {
+            report
+                .drifted
+                .push(cstr!("{path}: checked out at a different sha"));
+            return;
+        }
+        Some('U') => {
+            report.conflicted.push(cstr!("{path}: has merge conflicts"));
+            return;
+        }
+        Some(marker) => {
+            report
+                .invalid
+                .push(cstr!("{path}: invalid submodule status marker {marker:?}"));
+            return;
+        }
+        None => {
+            report
+                .inventory_mismatch
+                .push(cstr!("{path}: absent from git submodule status"));
+            return;
+        }
+    }
+    let checkout = workspace.join(path);
+    if !is_non_empty_directory(&checkout) {
+        report.missing.push(cstr!("{path}: not hydrated or empty"));
+        return;
+    }
+    match read_head(&checkout) {
+        Ok(actual) if actual == expected => report.clean += 1,
+        Ok(_) => report
+            .drifted
+            .push(cstr!("{path}: HEAD does not match the indexed sha")),
+        Err(detail) => report.invalid.push(cstr!("{path}: {detail}")),
+    }
+}
+
+fn is_non_empty_directory(directory: &Path) -> bool {
+    fs::read_dir(directory)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false)
+}
+
+fn read_head(directory: &Path) -> Result<String, String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(directory)
+        .arg("rev-parse")
+        .arg("HEAD")
+        .output()
+        .map_err(|error| cstr!("{error}"))?;
+    if output.status.success() {
+        Ok(output_text(&output.stdout))
+    } else {
+        let detail = output_text(&output.stderr);
+        Err(if detail.is_empty() {
+            "not a git checkout".into()
+        } else {
+            detail
+        })
+    }
+}
+
+fn git(workspace: &Path, args: &[&str]) -> Result<String, CorpusPreflightError> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(workspace)
+        .output()
+        .map_err(|error| CorpusPreflightError::Git {
+            command: git_command(args),
+            detail: cstr!("{error}"),
+        })?;
+    if output.status.success() {
+        Ok(output_text(&output.stdout))
+    } else {
+        let stderr = output_text(&output.stderr);
+        let stdout = output_text(&output.stdout);
+        Err(CorpusPreflightError::Git {
+            command: git_command(args),
+            detail: if stderr.is_empty() { stdout } else { stderr },
+        })
+    }
+}
+
+fn output_text(bytes: &[u8]) -> String {
+    match core::str::from_utf8(bytes) {
+        Ok(text) => text.trim().to_compact_string(),
+        Err(_) => "<non-utf8 output>".into(),
+    }
+}
+
+fn git_command(args: &[&str]) -> String {
+    let mut command = String::from("git");
+    for arg in args {
+        command.push(' ');
+        command.push_str(arg);
+    }
+    command
+}
+
+#[test]
+fn status_parser_handles_paths_with_spaces() {
+    let paths = ["tests/_fixtures/_git/path with spaces"];
+    let status = parse_status_line(
+        " 0123456789012345678901234567890123456789 tests/_fixtures/_git/path with spaces",
+        &paths,
+    )
+    .expect("status line");
+    assert_eq!(status.marker, ' ');
+    assert_eq!(status.path, "tests/_fixtures/_git/path with spaces");
+}

--- a/tests/davinci_test_support/src/corpus/preflight.rs
+++ b/tests/davinci_test_support/src/corpus/preflight.rs
@@ -23,7 +23,14 @@ fn read_indexed_gitlinks(
 ) -> Result<BTreeMap<String, String>, CorpusPreflightError> {
     let output = git(
         workspace,
-        &["ls-files", "--stage", "--", CANONICAL_CORPUS_ROOT],
+        &[
+            "-c",
+            "core.quotePath=false",
+            "ls-files",
+            "--stage",
+            "--",
+            CANONICAL_CORPUS_ROOT,
+        ],
     )?;
     let mut gitlinks = BTreeMap::new();
     for line in output.lines() {
@@ -52,18 +59,53 @@ fn read_submodule_statuses<'a>(
     workspace: &Path,
     indexed_paths: impl Iterator<Item = &'a String>,
 ) -> Result<BTreeMap<String, SubmoduleStatus>, CorpusPreflightError> {
-    let paths: Vec<&str> = indexed_paths.map(String::as_str).collect();
+    let indexed: Vec<String> = indexed_paths.cloned().collect();
+    let gitmodules = read_gitmodules_paths(workspace)?;
+    let mut paths = indexed.clone();
+    paths.extend(gitmodules.iter().cloned());
+    paths.sort();
+    paths.dedup();
+    let path_refs: Vec<&str> = paths.iter().map(String::as_str).collect();
     let output = git(
         workspace,
         &["submodule", "status", "--", CANONICAL_CORPUS_ROOT],
     )?;
     let mut statuses = BTreeMap::new();
     for line in output.lines() {
-        if let Some(status) = parse_status_line(line, &paths) {
+        if let Some(status) = parse_status_line(line, &path_refs) {
             statuses.insert(status.path.clone(), status);
         }
     }
+    for path in gitmodules {
+        if !indexed.contains(&path) && !statuses.contains_key(&path) {
+            statuses.insert(path.clone(), SubmoduleStatus { marker: ' ', path });
+        }
+    }
     Ok(statuses)
+}
+
+fn read_gitmodules_paths(workspace: &Path) -> Result<Vec<String>, CorpusPreflightError> {
+    if !workspace.join(".gitmodules").is_file() {
+        return Ok(Vec::new());
+    }
+    let output = git(
+        workspace,
+        &["config", "--file", ".gitmodules", "--get-regexp", "path"],
+    )?;
+    let mut paths = Vec::new();
+    for line in output.lines() {
+        let Some((_key, path)) = line.split_once(' ') else {
+            continue;
+        };
+        if path == CANONICAL_CORPUS_ROOT
+            || path
+                .strip_prefix(CANONICAL_CORPUS_ROOT)
+                .is_some_and(|tail| tail.starts_with('/'))
+        {
+            paths.push(path.into());
+        }
+    }
+    Ok(paths)
 }
 
 fn parse_status_line(line: &str, indexed_paths: &[&str]) -> Option<SubmoduleStatus> {
@@ -77,11 +119,17 @@ fn parse_status_line(line: &str, indexed_paths: &[&str]) -> Option<SubmoduleStat
             || tail
                 .strip_prefix(*path)
                 .is_some_and(|tail| tail.starts_with(' '))
-    })?;
+    });
+    let path = path.or_else(|| status_path_fallback(tail))?;
     Some(SubmoduleStatus {
         marker,
         path: path.into(),
     })
+}
+
+fn status_path_fallback(tail: &str) -> Option<&str> {
+    let path = tail.split_once(" (").map_or(tail, |(path, _)| path);
+    (!path.is_empty()).then_some(path)
 }
 
 fn build_report(
@@ -245,14 +293,30 @@ fn git_command(args: &[&str]) -> String {
     command
 }
 
-#[test]
-fn status_parser_handles_paths_with_spaces() {
-    let paths = ["tests/_fixtures/_git/path with spaces"];
-    let status = parse_status_line(
-        " 0123456789012345678901234567890123456789 tests/_fixtures/_git/path with spaces",
-        &paths,
-    )
-    .expect("status line");
-    assert_eq!(status.marker, ' ');
-    assert_eq!(status.path, "tests/_fixtures/_git/path with spaces");
+#[cfg(test)]
+mod tests {
+    use super::parse_status_line;
+
+    #[test]
+    fn status_parser_handles_paths_with_spaces() {
+        let paths = ["tests/_fixtures/_git/path with spaces"];
+        let status = parse_status_line(
+            " 0123456789012345678901234567890123456789 tests/_fixtures/_git/path with spaces",
+            &paths,
+        )
+        .expect("status line");
+        assert_eq!(status.marker, ' ');
+        assert_eq!(status.path, "tests/_fixtures/_git/path with spaces");
+    }
+
+    #[test]
+    fn status_parser_keeps_unmatched_surplus_paths() {
+        let status = parse_status_line(
+            " 0123456789012345678901234567890123456789 tests/_fixtures/_git/surplus (heads/main)",
+            &[],
+        )
+        .expect("status line");
+        assert_eq!(status.marker, ' ');
+        assert_eq!(status.path, "tests/_fixtures/_git/surplus");
+    }
 }

--- a/tests/davinci_test_support/src/corpus/tests.rs
+++ b/tests/davinci_test_support/src/corpus/tests.rs
@@ -81,6 +81,10 @@ fn pin_gitlink(root: &Path, rel_path: &str, revision: &str) {
     );
 }
 
+fn unpin_gitlink(root: &Path, rel_path: &str) {
+    git(root, &["update-index", "--force-remove", rel_path]);
+}
+
 fn output_text(bytes: &[u8]) -> String {
     match core::str::from_utf8(bytes) {
         Ok(text) => text.trim().into(),
@@ -134,16 +138,9 @@ fn canonical_partial_hydration_fails_before_the_sweep() {
 #[test]
 fn canonical_preflight_reports_drift_empty_spaces_and_inventory_mismatches() {
     let repo = TempRepo::new("mixed");
-    let expected = commit_fixture(
-        &repo.root,
-        "tests/_fixtures/_git/path with spaces",
-        "spaces",
-    );
-    pin_gitlink(
-        &repo.root,
-        "tests/_fixtures/_git/path with spaces",
-        &expected,
-    );
+    let spaced = "tests/_fixtures/_git/path with spaces caf\u{e9}";
+    let expected = commit_fixture(&repo.root, spaced, "spaces");
+    pin_gitlink(&repo.root, spaced, &expected);
 
     let actual = commit_fixture(&repo.root, "tests/_fixtures/_git/drifted", "actual");
     let other = commit_fixture(&repo.root, "other", "expected");
@@ -152,6 +149,11 @@ fn canonical_preflight_reports_drift_empty_spaces_and_inventory_mismatches() {
 
     fs::create_dir_all(repo.root.join("tests/_fixtures/_git/empty")).expect("empty fixture");
     pin_gitlink(&repo.root, "tests/_fixtures/_git/empty", &expected);
+
+    let surplus = "tests/_fixtures/_git/surplus";
+    let surplus_revision = commit_fixture(&repo.root, surplus, "surplus");
+    pin_gitlink(&repo.root, surplus, &surplus_revision);
+    unpin_gitlink(&repo.root, surplus);
 
     let mut error = match prepare_corpus_root("tests/_fixtures/_git", repo.package_dir())
         .expect_err("mixed canonical root must fail")
@@ -165,4 +167,10 @@ fn canonical_preflight_reports_drift_empty_spaces_and_inventory_mismatches() {
     assert_eq!(error.clean, 1);
     assert!(error.drifted.iter().any(|row| row.contains("drifted")));
     assert!(error.missing.iter().any(|row| row.contains("empty")));
+    assert!(
+        error
+            .inventory_mismatch
+            .iter()
+            .any(|row| row.contains("surplus"))
+    );
 }

--- a/tests/davinci_test_support/src/corpus/tests.rs
+++ b/tests/davinci_test_support/src/corpus/tests.rs
@@ -1,0 +1,168 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use vize_s0::{String, cstr};
+
+use super::{CorpusPreflightError, CorpusScope, prepare_corpus_root};
+
+struct TempRepo {
+    root: PathBuf,
+}
+
+impl TempRepo {
+    fn new(label: &str) -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock must move forward")
+            .as_nanos();
+        let root = std::env::temp_dir()
+            .join(cstr!("vize-davinci-corpus-{label}-{}-{nonce}", std::process::id()).as_str());
+        fs::create_dir_all(&root).expect("temp repo dir");
+        git(&root, &["init", "-q"]);
+        git(&root, &["config", "user.name", "Fixture"]);
+        git(&root, &["config", "user.email", "fixture@example.com"]);
+        fs::create_dir_all(root.join("crates/pkg")).expect("package dir");
+        Self { root }
+    }
+
+    fn package_dir(&self) -> PathBuf {
+        self.root.join("crates/pkg")
+    }
+}
+
+impl Drop for TempRepo {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn git(cwd: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .expect("git must run");
+    assert!(
+        output.status.success(),
+        "git {} failed:\n{}",
+        args.join(" "),
+        output_text(&output.stderr)
+    );
+    output_text(&output.stdout)
+}
+
+fn commit_fixture(root: &Path, rel_path: &str, marker: &str) -> String {
+    let path = root.join(rel_path);
+    fs::create_dir_all(&path).expect("fixture dir");
+    git(&path, &["init", "-q"]);
+    git(&path, &["config", "user.name", "Fixture"]);
+    git(&path, &["config", "user.email", "fixture@example.com"]);
+    let readme = cstr!("{marker}\n");
+    fs::write(path.join("README.md"), readme.as_bytes()).expect("fixture readme");
+    git(&path, &["add", "README.md"]);
+    git(&path, &["commit", "-qm", marker]);
+    git(&path, &["rev-parse", "HEAD"])
+}
+
+fn pin_gitlink(root: &Path, rel_path: &str, revision: &str) {
+    let gitmodules = root.join(".gitmodules");
+    let mut content = fs::read_to_string(&gitmodules).unwrap_or_default();
+    content.push_str(cstr!(
+        "[submodule \"{rel_path}\"]\n\tpath = {rel_path}\n\turl = https://example.com/{rel_path}.git\n"
+    ).as_str());
+    fs::write(&gitmodules, content).expect("gitmodules");
+    git(root, &["add", ".gitmodules"]);
+    let cacheinfo = cstr!("160000,{revision},{rel_path}");
+    git(
+        root,
+        &["update-index", "--add", "--cacheinfo", cacheinfo.as_str()],
+    );
+}
+
+fn output_text(bytes: &[u8]) -> String {
+    match core::str::from_utf8(bytes) {
+        Ok(text) => text.trim().into(),
+        Err(_) => "<non-utf8 output>".into(),
+    }
+}
+
+#[test]
+fn external_roots_are_smoke_shards_not_closure_evidence() {
+    let repo = TempRepo::new("external");
+    let external = repo.root.join("external/tests/_fixtures/_git");
+    fs::create_dir_all(&external).expect("external corpus root");
+
+    let root = prepare_corpus_root(&external, repo.package_dir()).expect("external root");
+
+    assert_eq!(root.scope(), CorpusScope::SmokeShard);
+    assert!(!root.closure_evidence());
+    assert_eq!(root.path(), external);
+}
+
+#[test]
+fn canonical_partial_hydration_fails_before_the_sweep() {
+    let repo = TempRepo::new("partial");
+    let revision = commit_fixture(&repo.root, "tests/_fixtures/_git/clean-0", "clean-0");
+    pin_gitlink(&repo.root, "tests/_fixtures/_git/clean-0", &revision);
+    for index in 0..5 {
+        if index == 0 {
+            continue;
+        }
+        let rel = cstr!("tests/_fixtures/_git/clean-{index}");
+        let marker = cstr!("clean-{index}");
+        let revision = commit_fixture(&repo.root, rel.as_str(), marker.as_str());
+        pin_gitlink(&repo.root, rel.as_str(), &revision);
+    }
+    for index in 0..141 {
+        let rel = cstr!("tests/_fixtures/_git/missing-{index:03}");
+        pin_gitlink(&repo.root, rel.as_str(), &revision);
+    }
+
+    let error = prepare_corpus_root("tests/_fixtures/_git", repo.package_dir())
+        .expect_err("partial canonical root must fail");
+    let message = cstr!("{error}");
+
+    assert!(message.contains("indexed gitlinks: 146"));
+    assert!(message.contains("clean submodules: 5"));
+    assert!(message.contains("missing submodules: 141"));
+    assert!(message.contains("hydrate with:"));
+    assert!(message.contains("partial fixture trees are refused before collecting .vue files"));
+}
+
+#[test]
+fn canonical_preflight_reports_drift_empty_spaces_and_inventory_mismatches() {
+    let repo = TempRepo::new("mixed");
+    let expected = commit_fixture(
+        &repo.root,
+        "tests/_fixtures/_git/path with spaces",
+        "spaces",
+    );
+    pin_gitlink(
+        &repo.root,
+        "tests/_fixtures/_git/path with spaces",
+        &expected,
+    );
+
+    let actual = commit_fixture(&repo.root, "tests/_fixtures/_git/drifted", "actual");
+    let other = commit_fixture(&repo.root, "other", "expected");
+    pin_gitlink(&repo.root, "tests/_fixtures/_git/drifted", &other);
+    assert_ne!(actual, other);
+
+    fs::create_dir_all(repo.root.join("tests/_fixtures/_git/empty")).expect("empty fixture");
+    pin_gitlink(&repo.root, "tests/_fixtures/_git/empty", &expected);
+
+    let mut error = match prepare_corpus_root("tests/_fixtures/_git", repo.package_dir())
+        .expect_err("mixed canonical root must fail")
+    {
+        CorpusPreflightError::Hydration(report) => report,
+        error => panic!("expected hydration error, got {error}"),
+    };
+    error.drifted.sort();
+    error.missing.sort();
+
+    assert_eq!(error.clean, 1);
+    assert!(error.drifted.iter().any(|row| row.contains("drifted")));
+    assert!(error.missing.iter().any(|row| row.contains("empty")));
+}

--- a/tests/davinci_test_support/src/lib.rs
+++ b/tests/davinci_test_support/src/lib.rs
@@ -3,5 +3,6 @@
 //! Keeping cross-crate fixtures and validators in a regular dependency avoids
 //! relative `#[path]` includes while preserving one source of truth.
 
+pub mod corpus;
 pub mod schema;
 pub mod surface_fixture;


### PR DESCRIPTION
## Summary

- add shared Davinci corpus-root preflight for Rust differential lanes
- require the current checkout's canonical `tests/_fixtures/_git` root to have all indexed gitlinks hydrated before collecting `.vue` files
- label arbitrary external roots as smoke shards with `closure_evidence=false`

Closes #4831

## Verification

- `cargo test -p davinci_test_support`
- `cargo test -p vize_ricalco --features davinci-differential --test davinci_lowering_corpus -- --nocapture`
- `cargo test -p vize_atelier_core --features davinci-differential --test davinci_s2_transform_corpus -- --nocapture`
- `cargo test -p vize_atelier_sfc --features davinci-differential --test davinci_differential -- --nocapture`
- `cargo clippy -p davinci_test_support --tests -- -D warnings`
- `cargo clippy -p vize_ricalco --features davinci-differential --test davinci_lowering_corpus -- -D warnings`
- `cargo clippy -p vize_atelier_core --features davinci-differential --test davinci_s2_transform_corpus -- -D warnings`
- `cargo clippy -p vize_atelier_sfc --features davinci-differential --test davinci_differential -- -D warnings`
- `git diff --check`
- expected failure: `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git cargo test -p vize_ricalco --features davinci-differential --test davinci_lowering_corpus -- --nocapture` fails before `.vue` collection with 146 indexed gitlinks, 6 clean, 139 missing, 1 drifted

## Notes

- `moon run --target native tools/moon/cmd/source_file_lengths -- --max-lines 350` currently fails before this diff is checked with MoonBit lexscan errors in `moonbitlang/x/path/win32/path.mbt`; touched source files are 204, 258, 168, 185, 297 and 125 lines.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790265851&installation_model_id=422833&pr_number=4870&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4870&signature=81edf9c92fcc8693d5fa17a9d8fb0097d2ced0a7ab594af8941046cad786a04c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Davinci corpus test setup and validation.
  * Added automatic detection of canonical fixture hydration, missing data, repository drift, and inventory mismatches.
  * Added clearer diagnostics and guidance when corpus preparation fails.
  * Classified test corpora as closure evidence or external smoke shards.
  * Added coverage for paths containing spaces and partial corpus states.
  * Standardized corpus-root resolution across Davinci test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->