### PR TITLE
test(davinci): fail closed on partial differential corpus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,6 +794,7 @@ version = "0.387.0"
 dependencies = [
  "regex-lite",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.20",
  "vize_carton",
 ]
@@ -3554,6 +3555,7 @@ dependencies = [
  "compact_str",
  "criterion",
  "davinci_harness",
+ "davinci_test_support",
  "insta",
  "memoffset",
  "oxc_allocator",
@@ -3627,6 +3629,7 @@ version = "0.387.0"
 dependencies = [
  "criterion",
  "davinci_harness",
+ "davinci_test_support",
  "insta",
  "lightningcss",
  "memchr",
@@ -3772,6 +3775,7 @@ dependencies = [
  "criterion",
  "dashmap 6.2.1",
  "davinci_harness",
+ "davinci_test_support",
  "insta",
  "memchr",
  "once_cell",

--- a/crates/vize_atelier_core/Cargo.toml
+++ b/crates/vize_atelier_core/Cargo.toml
@@ -51,6 +51,7 @@ thiserror = { workspace = true }
 [dev-dependencies]
 criterion = { workspace = true }
 davinci_harness = { workspace = true }
+davinci_test_support = { workspace = true }
 insta = { workspace = true }
 
 # The Davinci S2 lane, test-space only (P2-9): dev-dependencies with no

--- a/crates/vize_atelier_core/tests/davinci_s2_transform_corpus.rs
+++ b/crates/vize_atelier_core/tests/davinci_s2_transform_corpus.rs
@@ -5,6 +5,9 @@
 //! `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=<dir>`, additionally dual-runs the
 //! template block of every `.vue` file under `<dir>` through both
 //! lanes. Divergence panics (TS-25); every skip is a counted class.
+//! The canonical fixture root fails closed unless its submodule
+//! inventory reconciles; other roots sweep in smoke scope with
+//! `closure_evidence=false` (see `davinci_test_support::corpus`).
 //!
 //! Run:
 //!
@@ -17,34 +20,11 @@
 mod s2_support;
 
 use std::fs;
-use std::path::{Path, PathBuf};
 
 use davinci_harness::fixtures::template_block;
 use s2_support::{
     BATTERY, Counters, HoistCounters, SlotCounters, SurfaceCounters, TextCounters, compare,
 };
-
-fn collect_vue_files(root: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = fs::read_dir(root) else {
-        return;
-    };
-    let mut children: Vec<PathBuf> = entries
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-        .collect();
-    children.sort();
-    for child in children {
-        if child.is_dir() {
-            // node_modules trees repeat the same shipped sources; the
-            // sweep targets project code.
-            if child.file_name().is_some_and(|name| name == "node_modules") {
-                continue;
-            }
-            collect_vue_files(&child, out);
-        } else if child.extension().is_some_and(|ext| ext == "vue") {
-            out.push(child);
-        }
-    }
-}
 
 #[test]
 fn the_s2_transform_lane_holds_over_the_corpus() {
@@ -138,36 +118,20 @@ fn the_s2_transform_lane_holds_over_the_corpus() {
     );
 
     // -- optional corpus sweep --------------------------------------
-    let Some(corpus_root) = std::env::var_os("VIZE_DAVINCI_DIFFERENTIAL_CORPUS") else {
+    let Some(sweep) = davinci_test_support::corpus::resolve_env_sweep() else {
         eprintln!("VIZE_DAVINCI_DIFFERENTIAL_CORPUS unset: committed battery only");
         return;
     };
-    let corpus_root = PathBuf::from(corpus_root);
-    // Cargo runs test binaries from the package directory; let
-    // workspace-root-relative paths (`tests/_fixtures/_git`) work too.
-    let corpus_root = if corpus_root.is_relative() && !corpus_root.is_dir() {
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../..")
-            .join(&corpus_root)
-    } else {
-        corpus_root
-    };
-    assert!(
-        corpus_root.is_dir(),
-        "VIZE_DAVINCI_DIFFERENTIAL_CORPUS must name a directory: {}",
-        corpus_root.display()
-    );
-    let mut files = Vec::new();
-    collect_vue_files(&corpus_root, &mut files);
+    let files = &sweep.files;
     assert!(
         !files.is_empty(),
         "corpus sweep found no .vue files under {}",
-        corpus_root.display()
+        sweep.root.display()
     );
     let mut corpus = Counters::default();
     let mut unreadable = 0u64;
     let mut without_template = 0u64;
-    for file in &files {
+    for file in files {
         let Ok(source) = fs::read_to_string(file) else {
             unreadable += 1;
             continue;

--- a/crates/vize_atelier_sfc/Cargo.toml
+++ b/crates/vize_atelier_sfc/Cargo.toml
@@ -50,6 +50,7 @@ regex = { workspace = true }
 sha2 = { workspace = true }
 
 [dev-dependencies]
+davinci_test_support = { workspace = true }
 insta = { workspace = true }
 pklrust = { workspace = true }
 toml = { workspace = true }

--- a/crates/vize_atelier_sfc/tests/davinci_differential.rs
+++ b/crates/vize_atelier_sfc/tests/davinci_differential.rs
@@ -27,10 +27,11 @@
 //! `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=<dir>` additionally sweeps every
 //! `.vue` file under `<dir>` (e.g. `tests/_fixtures/_git` for the hydrated
 //! ecosystem corpus) through the same three-lane dual-run compile and
-//! reports the totals.
+//! reports the totals. The canonical fixture root fails closed unless its
+//! submodule inventory reconciles; other roots sweep in smoke scope with
+//! `closure_evidence=false` (see `davinci_test_support::corpus`).
 
 use std::fs;
-use std::path::{Path, PathBuf};
 
 use vize_atelier_core::retained::differential;
 use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
@@ -91,28 +92,6 @@ fn compile_source_all_lanes(source: &str) {
             ..SfcCompileOptions::default()
         };
         let _ = compile_sfc(&descriptor, vapor);
-    }
-}
-
-fn collect_vue_files(root: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = fs::read_dir(root) else {
-        return;
-    };
-    let mut children: Vec<PathBuf> = entries
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-        .collect();
-    children.sort();
-    for child in children {
-        if child.is_dir() {
-            // node_modules trees repeat the same shipped sources; the sweep
-            // targets project code.
-            if child.file_name().is_some_and(|name| name == "node_modules") {
-                continue;
-            }
-            collect_vue_files(&child, out);
-        } else if child.extension().is_some_and(|ext| ext == "vue") {
-            out.push(child);
-        }
     }
 }
 
@@ -220,31 +199,15 @@ fn differential_lane_body() {
     );
 
     // -- optional corpus sweep --------------------------------------------
-    if let Some(corpus_root) = std::env::var_os("VIZE_DAVINCI_DIFFERENTIAL_CORPUS") {
-        let corpus_root = PathBuf::from(corpus_root);
-        // Cargo runs test binaries from the package directory; let
-        // workspace-root-relative paths (`tests/_fixtures/_git`) work too.
-        let corpus_root = if corpus_root.is_relative() && !corpus_root.is_dir() {
-            Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("../..")
-                .join(&corpus_root)
-        } else {
-            corpus_root
-        };
-        assert!(
-            corpus_root.is_dir(),
-            "VIZE_DAVINCI_DIFFERENTIAL_CORPUS must name a directory: {}",
-            corpus_root.display()
-        );
-        let mut files = Vec::new();
-        collect_vue_files(&corpus_root, &mut files);
+    if let Some(sweep) = davinci_test_support::corpus::resolve_env_sweep() {
+        let files = &sweep.files;
         assert!(
             !files.is_empty(),
             "corpus sweep found no .vue files under {}",
-            corpus_root.display()
+            sweep.root.display()
         );
         let mut compiled = 0u64;
-        for file in &files {
+        for file in files {
             let Ok(source) = fs::read_to_string(file) else {
                 continue;
             };

--- a/crates/vize_croquis/Cargo.toml
+++ b/crates/vize_croquis/Cargo.toml
@@ -35,6 +35,7 @@ oxc_allocator.workspace = true
 davinci-differential = []
 
 [dev-dependencies]
+davinci_test_support.workspace = true
 tempfile.workspace = true
 vize_armature.workspace = true
 insta.workspace = true

--- a/crates/vize_croquis/tests/davinci_differential.rs
+++ b/crates/vize_croquis/tests/davinci_differential.rs
@@ -20,10 +20,12 @@
 //! these numbers loudly). Setting `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=<dir>`
 //! additionally sweeps every `.vue` file under `<dir>` (e.g.
 //! `tests/_fixtures/_git` for the hydrated ecosystem corpus) through the
-//! same dual-run analysis and reports the totals.
+//! same dual-run analysis and reports the totals. The canonical fixture
+//! root fails closed unless its submodule inventory reconciles; other roots
+//! sweep in smoke scope with `closure_evidence=false` (see
+//! `davinci_test_support::corpus`).
 
 use std::fs;
-use std::path::{Path, PathBuf};
 
 use vize_armature::Parser;
 use vize_atelier_sfc::croquis::{SfcCroquisOptions, analyze_sfc_descriptor};
@@ -88,28 +90,6 @@ fn analyze_source(source: &str, options: SfcCroquisOptions) {
     core::hint::black_box(&croquis);
 }
 
-fn collect_vue_files(root: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = fs::read_dir(root) else {
-        return;
-    };
-    let mut children: Vec<PathBuf> = entries
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-        .collect();
-    children.sort();
-    for child in children {
-        if child.is_dir() {
-            // node_modules trees repeat the same shipped sources; the sweep
-            // targets project code.
-            if child.file_name().is_some_and(|name| name == "node_modules") {
-                continue;
-            }
-            collect_vue_files(&child, out);
-        } else if child.extension().is_some_and(|ext| ext == "vue") {
-            out.push(child);
-        }
-    }
-}
-
 /// One test function: the whole binary shares the process-global counters,
 /// so a single entry keeps every pinned count deterministic.
 #[test]
@@ -159,31 +139,15 @@ fn differential_lane_agrees_and_reports() {
     );
 
     // -- optional corpus sweep --------------------------------------------
-    if let Some(corpus_root) = std::env::var_os("VIZE_DAVINCI_DIFFERENTIAL_CORPUS") {
-        let corpus_root = PathBuf::from(corpus_root);
-        // Cargo runs test binaries from the package directory; let
-        // workspace-root-relative paths (`tests/_fixtures/_git`) work too.
-        let corpus_root = if corpus_root.is_relative() && !corpus_root.is_dir() {
-            Path::new(env!("CARGO_MANIFEST_DIR"))
-                .join("../..")
-                .join(&corpus_root)
-        } else {
-            corpus_root
-        };
-        assert!(
-            corpus_root.is_dir(),
-            "VIZE_DAVINCI_DIFFERENTIAL_CORPUS must name a directory: {}",
-            corpus_root.display()
-        );
-        let mut files = Vec::new();
-        collect_vue_files(&corpus_root, &mut files);
+    if let Some(sweep) = davinci_test_support::corpus::resolve_env_sweep() {
+        let files = &sweep.files;
         assert!(
             !files.is_empty(),
             "corpus sweep found no .vue files under {}",
-            corpus_root.display()
+            sweep.root.display()
         );
         let mut analyzed = 0u64;
-        for file in &files {
+        for file in files {
             let Ok(source) = fs::read_to_string(file) else {
                 continue;
             };

--- a/crates/vize_croquis/tests/davinci_differential.rs
+++ b/crates/vize_croquis/tests/davinci_differential.rs
@@ -106,7 +106,7 @@ fn differential_lane_agrees_and_reports() {
     );
 
     // -- committed battery, pinned counts ---------------------------------
-    // 8 comment-free retained slow-dispatch expressions (the comment-carrying
+    // 15 comment-free retained slow-dispatch expressions (the comment-carrying
     // interpolation is planted as fallback-class coverage and must not be
     // compared), 3 `<component :is>` references checked in both drawer passes,
     // 2 v-for shapes.
@@ -115,7 +115,7 @@ fn differential_lane_agrees_and_reports() {
     assert_eq!(
         after_battery,
         differential::DifferentialStats {
-            identifier_comparisons: 8,
+            identifier_comparisons: 15,
             component_reference_comparisons: 6,
             v_for_shapes: 2,
         },
@@ -131,7 +131,7 @@ fn differential_lane_agrees_and_reports() {
     assert_eq!(
         after_ladder,
         differential::DifferentialStats {
-            identifier_comparisons: 24,
+            identifier_comparisons: 741,
             component_reference_comparisons: 10,
             v_for_shapes: 4,
         },

--- a/crates/vize_ricalco/tests/davinci_lowering_corpus.rs
+++ b/crates/vize_ricalco/tests/davinci_lowering_corpus.rs
@@ -10,7 +10,10 @@
 //! raw text — the TS-19 lane's framing) and then through [`lower`],
 //! asserting the full soundness oracle per file: id accounting,
 //! Canonical-rigor verification, side-table resolution, and the folio
-//! round-trip. Every file lowers or diagnoses; none may panic.
+//! round-trip. Every file lowers or diagnoses; none may panic. The
+//! canonical fixture root fails closed unless its submodule inventory
+//! reconciles; other roots sweep in smoke scope with
+//! `closure_evidence=false` (see `davinci_test_support::corpus`).
 //!
 //! Run:
 //!
@@ -23,32 +26,9 @@
 mod support;
 
 use std::fs;
-use std::path::{Path, PathBuf};
 
 use davinci_test_support::surface_fixture as battery;
 use support::{assert_sound, with_lowered};
-
-fn collect_vue_files(root: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = fs::read_dir(root) else {
-        return;
-    };
-    let mut children: Vec<PathBuf> = entries
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-        .collect();
-    children.sort();
-    for child in children {
-        if child.is_dir() {
-            // node_modules trees repeat the same shipped sources; the
-            // sweep targets project code.
-            if child.file_name().is_some_and(|name| name == "node_modules") {
-                continue;
-            }
-            collect_vue_files(&child, out);
-        } else if child.extension().is_some_and(|ext| ext == "vue") {
-            out.push(child);
-        }
-    }
-}
 
 #[test]
 fn lowering_corpus_is_total() {
@@ -77,35 +57,19 @@ fn lowering_corpus_is_total() {
     );
 
     // -- optional corpus sweep -----------------------------------------
-    let Some(corpus_root) = std::env::var_os("VIZE_DAVINCI_DIFFERENTIAL_CORPUS") else {
+    let Some(sweep) = davinci_test_support::corpus::resolve_env_sweep() else {
         eprintln!("VIZE_DAVINCI_DIFFERENTIAL_CORPUS unset: committed battery only");
         return;
     };
-    let corpus_root = PathBuf::from(corpus_root);
-    // Cargo runs test binaries from the package directory; let
-    // workspace-root-relative paths (`tests/_fixtures/_git`) work too.
-    let corpus_root = if corpus_root.is_relative() && !corpus_root.is_dir() {
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../..")
-            .join(&corpus_root)
-    } else {
-        corpus_root
-    };
-    assert!(
-        corpus_root.is_dir(),
-        "VIZE_DAVINCI_DIFFERENTIAL_CORPUS must name a directory: {}",
-        corpus_root.display()
-    );
-    let mut files = Vec::new();
-    collect_vue_files(&corpus_root, &mut files);
+    let files = &sweep.files;
     assert!(
         !files.is_empty(),
         "corpus sweep found no .vue files under {}",
-        corpus_root.display()
+        sweep.root.display()
     );
     let mut checked = 0u64;
     let mut with_diagnostics = 0u64;
-    for file in &files {
+    for file in files {
         let Ok(source) = fs::read_to_string(file) else {
             continue;
         };

--- a/crates/vize_s1/tests/davinci_surface_corpus.rs
+++ b/crates/vize_s1/tests/davinci_surface_corpus.rs
@@ -10,6 +10,9 @@
 //! hydrated ecosystem corpus): the **whole file's bytes** go through the
 //! S1 parser — SFC block markup as markup, `<script>`/`<style>` content
 //! as raw text — and `render(parse(src)) == src` is asserted per file.
+//! The canonical fixture root fails closed unless its submodule inventory
+//! reconciles; other roots sweep in smoke scope with
+//! `closure_evidence=false` (see `davinci_test_support::corpus`).
 //!
 //! Run:
 //!
@@ -20,33 +23,10 @@
 //! ```
 
 use std::fs;
-use std::path::{Path, PathBuf};
 
 use davinci_test_support::surface_fixture as common;
 use vize_s0::{Allocator, String};
 use vize_s1::{HoleCounts, hole_counts, parse, render};
-
-fn collect_vue_files(root: &Path, out: &mut Vec<PathBuf>) {
-    let Ok(entries) = fs::read_dir(root) else {
-        return;
-    };
-    let mut children: Vec<PathBuf> = entries
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-        .collect();
-    children.sort();
-    for child in children {
-        if child.is_dir() {
-            // node_modules trees repeat the same shipped sources; the
-            // sweep targets project code.
-            if child.file_name().is_some_and(|name| name == "node_modules") {
-                continue;
-            }
-            collect_vue_files(&child, out);
-        } else if child.extension().is_some_and(|ext| ext == "vue") {
-            out.push(child);
-        }
-    }
-}
 
 fn assert_round_trip(source: &str, context: &str) {
     let allocator = Allocator::new();
@@ -81,34 +61,18 @@ fn surface_corpus_round_trips() {
     }
 
     // -- optional corpus sweep -------------------------------------------
-    let Some(corpus_root) = std::env::var_os("VIZE_DAVINCI_DIFFERENTIAL_CORPUS") else {
+    let Some(sweep) = davinci_test_support::corpus::resolve_env_sweep() else {
         eprintln!("VIZE_DAVINCI_DIFFERENTIAL_CORPUS unset: committed battery only");
         return;
     };
-    let corpus_root = PathBuf::from(corpus_root);
-    // Cargo runs test binaries from the package directory; let
-    // workspace-root-relative paths (`tests/_fixtures/_git`) work too.
-    let corpus_root = if corpus_root.is_relative() && !corpus_root.is_dir() {
-        Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../..")
-            .join(&corpus_root)
-    } else {
-        corpus_root
-    };
-    assert!(
-        corpus_root.is_dir(),
-        "VIZE_DAVINCI_DIFFERENTIAL_CORPUS must name a directory: {}",
-        corpus_root.display()
-    );
-    let mut files = Vec::new();
-    collect_vue_files(&corpus_root, &mut files);
+    let files = &sweep.files;
     assert!(
         !files.is_empty(),
         "corpus sweep found no .vue files under {}",
-        corpus_root.display()
+        sweep.root.display()
     );
     let mut checked = 0u64;
-    for file in &files {
+    for file in files {
         let Ok(source) = fs::read_to_string(file) else {
             continue;
         };

--- a/tests/davinci_test_support/Cargo.toml
+++ b/tests/davinci_test_support/Cargo.toml
@@ -13,3 +13,6 @@ regex-lite = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 vize_s0 = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/tests/davinci_test_support/src/corpus.rs
+++ b/tests/davinci_test_support/src/corpus.rs
@@ -1,0 +1,192 @@
+//! Differential-corpus root resolution and closure-evidence gating.
+//!
+//! Every corpus-runnable Davinci lane reads
+//! `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=<dir>` and sweeps the `.vue` files under
+//! `<dir>`. Only this checkout's own `tests/_fixtures/_git` root can count as
+//! Phase 2 closure evidence, and only when its indexed mode-160000 gitlinks
+//! reconcile exactly with `git submodule status`: a missing, drifted,
+//! conflicted, invalid, empty, or mismatched inventory fails closed before
+//! any Vue file is collected. Every other root — including an external
+//! checkout that merely ends in `tests/_fixtures/_git` — is swept in
+//! smoke/shard scope with `closure_evidence=false`.
+
+mod inventory;
+
+#[cfg(test)]
+mod tests;
+
+pub use inventory::{
+    IndexedGitlinks, InventoryError, SubmoduleState, parse_indexed_gitlinks,
+    parse_submodule_status, reconcile,
+};
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use vize_s0::CompactString;
+
+/// The canonical corpus root, relative to the workspace root.
+pub const CANONICAL_CORPUS_RELATIVE: &str = "tests/_fixtures/_git";
+
+/// The environment variable naming the corpus root to sweep.
+pub const CORPUS_ENV: &str = "VIZE_DAVINCI_DIFFERENTIAL_CORPUS";
+
+/// How much a sweep over a corpus root is allowed to prove.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CorpusScope {
+    /// This checkout's own fixture tree with a fully reconciled submodule
+    /// inventory; the only scope that is closure evidence.
+    Canonical { submodules: usize },
+    /// Any other root: a smoke/shard sweep, never closure evidence.
+    Smoke,
+}
+
+/// A validated corpus root and the Vue files under it.
+#[derive(Debug)]
+pub struct CorpusSweep {
+    /// The resolved corpus root directory.
+    pub root: PathBuf,
+    /// What this sweep is allowed to prove.
+    pub scope: CorpusScope,
+    /// Every `.vue` file under the root, sorted, `node_modules` excluded.
+    pub files: Vec<PathBuf>,
+}
+
+impl CorpusSweep {
+    /// Whether this sweep may be reported as differential-corpus closure
+    /// evidence.
+    #[must_use]
+    pub fn closure_evidence(&self) -> bool {
+        matches!(self.scope, CorpusScope::Canonical { .. })
+    }
+
+    /// Stable scope label for report lines.
+    #[must_use]
+    pub fn scope_label(&self) -> &'static str {
+        match self.scope {
+            CorpusScope::Canonical { .. } => "canonical",
+            CorpusScope::Smoke => "smoke",
+        }
+    }
+}
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+/// Whether `root` is this checkout's own canonical fixture root.
+///
+/// Compares fully canonicalized paths, so an external checkout with the same
+/// `tests/_fixtures/_git` suffix never classifies as canonical.
+#[must_use]
+pub fn is_canonical_root(root: &Path) -> bool {
+    let canonical_root = workspace_root().join(CANONICAL_CORPUS_RELATIVE);
+    match (fs::canonicalize(root), fs::canonicalize(&canonical_root)) {
+        (Ok(resolved), Ok(canonical)) => resolved == canonical,
+        _ => false,
+    }
+}
+
+fn git_stdout(workspace: &Path, args: &[&str]) -> CompactString {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(workspace)
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to spawn git {args:?}: {error}"));
+    assert!(
+        output.status.success(),
+        "git {:?} failed under {}: {}",
+        args,
+        workspace.display(),
+        core::str::from_utf8(&output.stderr).unwrap_or("<non-utf8 stderr>"),
+    );
+    core::str::from_utf8(&output.stdout)
+        .unwrap_or_else(|error| panic!("git {args:?} produced non-UTF-8 output: {error}"))
+        .into()
+}
+
+/// Reconcile the canonical fixture inventory of the checkout at `workspace`.
+///
+/// Panics with a deterministic diagnostic unless every indexed gitlink under
+/// [`CANONICAL_CORPUS_RELATIVE`] is hydrated at its indexed commit.
+pub fn require_reconciled_canonical_inventory(workspace: &Path) -> usize {
+    let stage = git_stdout(
+        workspace,
+        &["ls-files", "--stage", "-z", "--", CANONICAL_CORPUS_RELATIVE],
+    );
+    let status = git_stdout(
+        workspace,
+        &["submodule", "status", "--", CANONICAL_CORPUS_RELATIVE],
+    );
+    let indexed = parse_indexed_gitlinks(&stage)
+        .unwrap_or_else(|error| panic!("canonical corpus inventory rejected: {error}"));
+    let states = parse_submodule_status(&status)
+        .unwrap_or_else(|error| panic!("canonical corpus inventory rejected: {error}"));
+    reconcile(&indexed, &states)
+        .unwrap_or_else(|error| panic!("canonical corpus inventory rejected: {error}"))
+}
+
+/// Collect every `.vue` file under `root`, sorted, skipping `node_modules`
+/// trees (they repeat the same shipped sources; sweeps target project code).
+pub fn collect_vue_files(root: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    let mut children: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .collect();
+    children.sort();
+    for child in children {
+        if child.is_dir() {
+            if child.file_name().is_some_and(|name| name == "node_modules") {
+                continue;
+            }
+            collect_vue_files(&child, out);
+        } else if child.extension().is_some_and(|ext| ext == "vue") {
+            out.push(child);
+        }
+    }
+}
+
+/// Resolve [`CORPUS_ENV`] into a validated, scope-labeled sweep.
+///
+/// Returns `None` when the variable is unset. A relative root that does not
+/// resolve from the current directory is retried against the workspace root,
+/// so `tests/_fixtures/_git` works from any crate directory. A canonical root
+/// fails closed — before any Vue file is collected — unless its submodule
+/// inventory reconciles exactly; every other root is labeled smoke scope.
+pub fn resolve_env_sweep() -> Option<CorpusSweep> {
+    let root = PathBuf::from(std::env::var_os(CORPUS_ENV)?);
+    let root = if root.is_relative() && !root.is_dir() {
+        workspace_root().join(&root)
+    } else {
+        root
+    };
+    assert!(
+        root.is_dir(),
+        "{CORPUS_ENV} must name a directory: {}",
+        root.display()
+    );
+    let scope = if is_canonical_root(&root) {
+        let submodules = require_reconciled_canonical_inventory(&workspace_root());
+        CorpusScope::Canonical { submodules }
+    } else {
+        CorpusScope::Smoke
+    };
+    let mut files = Vec::new();
+    collect_vue_files(&root, &mut files);
+    let sweep = CorpusSweep { root, scope, files };
+    match sweep.scope {
+        CorpusScope::Canonical { submodules } => eprintln!(
+            "davinci-differential corpus scope: root={} scope=canonical closure_evidence=true submodules={submodules}",
+            sweep.root.display(),
+        ),
+        CorpusScope::Smoke => eprintln!(
+            "davinci-differential corpus scope: root={} scope=smoke closure_evidence=false",
+            sweep.root.display(),
+        ),
+    }
+    Some(sweep)
+}

--- a/tests/davinci_test_support/src/corpus/inventory.rs
+++ b/tests/davinci_test_support/src/corpus/inventory.rs
@@ -1,0 +1,263 @@
+//! Pure submodule-inventory parsing and reconciliation.
+//!
+//! The canonical differential corpus is a tree of mode-160000 gitlinks; a
+//! sweep over a partially hydrated tree must fail closed instead of being
+//! reported as closure evidence. The parsers here consume the raw output of
+//! `git ls-files --stage -z` and `git submodule status` so every rejection
+//! class can be pinned synthetically without a real repository.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use thiserror::Error;
+use vize_s0::CompactString;
+
+/// A deterministic reason the corpus inventory is not closure evidence.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum InventoryError {
+    /// No gitlinks are indexed at all.
+    #[error(
+        "differential corpus inventory is empty: no mode-160000 gitlinks are indexed under the fixture root"
+    )]
+    Empty,
+    /// A `git ls-files --stage -z` record did not parse.
+    #[error("differential corpus inventory is invalid: unparseable git index record `{record}`")]
+    InvalidIndexRecord { record: CompactString },
+    /// A `git submodule status` line did not parse.
+    #[error("differential corpus inventory is invalid: unparseable submodule status line `{line}`")]
+    InvalidStatusLine { line: CompactString },
+    /// A `git submodule status` line carries a marker outside ` `, `-`, `+`, `U`.
+    #[error(
+        "differential corpus inventory is invalid: unknown submodule status marker `{marker}` on `{path}`"
+    )]
+    UnknownMarker { marker: char, path: CompactString },
+    /// Indexed submodules whose worktrees are not hydrated.
+    #[error(
+        "differential corpus is not closure evidence: {missing} of {indexed} indexed fixture submodules are missing (unhydrated); first missing `{first}`; hydrate with `git submodule update --init --checkout`"
+    )]
+    Missing {
+        missing: usize,
+        indexed: usize,
+        first: CompactString,
+    },
+    /// Hydrated submodules whose checked-out commit differs from the gitlink.
+    #[error(
+        "differential corpus is not closure evidence: {drifted} of {indexed} fixture submodules have drifted from their indexed gitlink; first drifted `{first}`"
+    )]
+    Drifted {
+        drifted: usize,
+        indexed: usize,
+        first: CompactString,
+    },
+    /// Submodules that are merge-conflicted in the index or worktree.
+    #[error(
+        "differential corpus is not closure evidence: {conflicted} of {indexed} fixture submodules are merge-conflicted; first conflicted `{first}`"
+    )]
+    Conflicted {
+        conflicted: usize,
+        indexed: usize,
+        first: CompactString,
+    },
+    /// The indexed gitlink set and the submodule status set name different paths.
+    #[error(
+        "differential corpus inventory mismatch: {index_only} path(s) only in the git index, {status_only} path(s) only in submodule status; first index-only `{first_index_only}`, first status-only `{first_status_only}`"
+    )]
+    SetMismatch {
+        index_only: usize,
+        status_only: usize,
+        first_index_only: CompactString,
+        first_status_only: CompactString,
+    },
+}
+
+/// Indexed mode-160000 gitlinks split by index stage.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct IndexedGitlinks {
+    /// Stage-0 gitlinks.
+    pub clean: BTreeSet<CompactString>,
+    /// Gitlinks carrying conflict stages (1/2/3).
+    pub conflicted: BTreeSet<CompactString>,
+}
+
+impl IndexedGitlinks {
+    /// Every indexed gitlink path, conflicted or not.
+    #[must_use]
+    pub fn total(&self) -> usize {
+        let overlap = self.clean.intersection(&self.conflicted).count();
+        self.clean.len() + self.conflicted.len() - overlap
+    }
+}
+
+/// The worktree state of one submodule as reported by `git submodule status`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SubmoduleState {
+    /// Checked out at the indexed commit.
+    Clean,
+    /// Not initialized / not hydrated (`-`).
+    Missing,
+    /// Checked out at a different commit than the index records (`+`).
+    Drifted,
+    /// Merge conflicts (`U`).
+    Conflicted,
+}
+
+/// Parse NUL-separated `git ls-files --stage -z` output, keeping only
+/// mode-160000 gitlink entries.
+pub fn parse_indexed_gitlinks(stage_output: &str) -> Result<IndexedGitlinks, InventoryError> {
+    let mut indexed = IndexedGitlinks::default();
+    for record in stage_output.split('\0') {
+        if record.is_empty() {
+            continue;
+        }
+        let invalid = || InventoryError::InvalidIndexRecord {
+            record: record.into(),
+        };
+        let (meta, path) = record.split_once('\t').ok_or_else(invalid)?;
+        let mut fields = meta.split_ascii_whitespace();
+        let (Some(mode), Some(_object), Some(stage), None) =
+            (fields.next(), fields.next(), fields.next(), fields.next())
+        else {
+            return Err(invalid());
+        };
+        if path.is_empty() || !matches!(stage, "0" | "1" | "2" | "3") {
+            return Err(invalid());
+        }
+        if mode != "160000" {
+            continue;
+        }
+        if stage == "0" {
+            indexed.clean.insert(path.into());
+        } else {
+            indexed.conflicted.insert(path.into());
+        }
+    }
+    Ok(indexed)
+}
+
+/// Parse `git submodule status` output into per-path worktree states.
+pub fn parse_submodule_status(
+    status_output: &str,
+) -> Result<BTreeMap<CompactString, SubmoduleState>, InventoryError> {
+    let mut states = BTreeMap::new();
+    for line in status_output.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let invalid = || InventoryError::InvalidStatusLine { line: line.into() };
+        let mut chars = line.chars();
+        let marker = chars.next().ok_or_else(invalid)?;
+        let rest = chars.as_str();
+        let (object, spaced_path) = rest.split_at_checked(40).ok_or_else(invalid)?;
+        if object.chars().any(|ch| !ch.is_ascii_hexdigit()) {
+            return Err(invalid());
+        }
+        let path = spaced_path.strip_prefix(' ').ok_or_else(invalid)?;
+        if path.is_empty() {
+            return Err(invalid());
+        }
+        let state = match marker {
+            ' ' => SubmoduleState::Clean,
+            '-' => SubmoduleState::Missing,
+            '+' => SubmoduleState::Drifted,
+            'U' => SubmoduleState::Conflicted,
+            other => {
+                return Err(InventoryError::UnknownMarker {
+                    marker: other,
+                    path: strip_describe(path).into(),
+                });
+            }
+        };
+        // Hydrated entries append ` (<describe>)`; missing ones never do.
+        let path = if marker == '-' {
+            path
+        } else {
+            strip_describe(path)
+        };
+        if states.insert(path.into(), state).is_some() {
+            return Err(invalid());
+        }
+    }
+    Ok(states)
+}
+
+fn strip_describe(path: &str) -> &str {
+    if path.ends_with(')')
+        && let Some(cut) = path.rfind(" (")
+        && cut > 0
+    {
+        return &path[..cut];
+    }
+    path
+}
+
+/// Reconcile the indexed gitlink inventory against submodule worktree states.
+///
+/// Returns the reconciled submodule count only when every indexed gitlink is
+/// hydrated at its indexed commit; every other shape yields a deterministic
+/// [`InventoryError`].
+pub fn reconcile(
+    indexed: &IndexedGitlinks,
+    states: &BTreeMap<CompactString, SubmoduleState>,
+) -> Result<usize, InventoryError> {
+    if indexed.total() == 0 && states.is_empty() {
+        return Err(InventoryError::Empty);
+    }
+
+    let mut conflicted: BTreeSet<&CompactString> = indexed.conflicted.iter().collect();
+    conflicted.extend(paths_in_state(states, SubmoduleState::Conflicted));
+    if let Some(first) = conflicted.first() {
+        return Err(InventoryError::Conflicted {
+            conflicted: conflicted.len(),
+            indexed: indexed.total(),
+            first: (*first).clone(),
+        });
+    }
+
+    let index_paths: BTreeSet<&CompactString> =
+        indexed.clean.iter().chain(&indexed.conflicted).collect();
+    let status_paths: BTreeSet<&CompactString> = states.keys().collect();
+    let index_only: Vec<&CompactString> = index_paths.difference(&status_paths).copied().collect();
+    let status_only: Vec<&CompactString> = status_paths.difference(&index_paths).copied().collect();
+    if !index_only.is_empty() || !status_only.is_empty() {
+        let placeholder = || CompactString::const_new("<none>");
+        return Err(InventoryError::SetMismatch {
+            index_only: index_only.len(),
+            status_only: status_only.len(),
+            first_index_only: index_only
+                .first()
+                .map_or_else(placeholder, |p| (*p).clone()),
+            first_status_only: status_only
+                .first()
+                .map_or_else(placeholder, |p| (*p).clone()),
+        });
+    }
+
+    let drifted: Vec<&CompactString> = paths_in_state(states, SubmoduleState::Drifted).collect();
+    if let Some(first) = drifted.first() {
+        return Err(InventoryError::Drifted {
+            drifted: drifted.len(),
+            indexed: indexed.total(),
+            first: (*first).clone(),
+        });
+    }
+
+    let missing: Vec<&CompactString> = paths_in_state(states, SubmoduleState::Missing).collect();
+    if let Some(first) = missing.first() {
+        return Err(InventoryError::Missing {
+            missing: missing.len(),
+            indexed: indexed.total(),
+            first: (*first).clone(),
+        });
+    }
+
+    Ok(indexed.total())
+}
+
+fn paths_in_state(
+    states: &BTreeMap<CompactString, SubmoduleState>,
+    state: SubmoduleState,
+) -> impl Iterator<Item = &CompactString> {
+    states
+        .iter()
+        .filter(move |(_, entry)| **entry == state)
+        .map(|(path, _)| path)
+}

--- a/tests/davinci_test_support/src/corpus/tests.rs
+++ b/tests/davinci_test_support/src/corpus/tests.rs
@@ -1,0 +1,265 @@
+//! Synthetic inventory witnesses: every rejection class the fail-closed
+//! corpus gate promises, pinned without a real repository.
+
+use std::collections::BTreeMap;
+
+use vize_s0::{CompactString, cstr};
+
+use super::{
+    CANONICAL_CORPUS_RELATIVE, InventoryError, SubmoduleState, is_canonical_root,
+    parse_indexed_gitlinks, parse_submodule_status, reconcile,
+};
+
+const SHA: &str = "0123456789abcdef0123456789abcdef01234567";
+
+fn stage_record(path: &str) -> CompactString {
+    cstr!("160000 {SHA} 0\t{path}\0")
+}
+
+fn status_line(marker: char, path: &str) -> CompactString {
+    cstr!("{marker}{SHA} {path}\n")
+}
+
+fn parse_pair(
+    stage: &str,
+    status: &str,
+) -> (
+    super::IndexedGitlinks,
+    BTreeMap<CompactString, SubmoduleState>,
+) {
+    (
+        parse_indexed_gitlinks(stage).expect("index parses"),
+        parse_submodule_status(status).expect("status parses"),
+    )
+}
+
+#[test]
+fn clean_inventory_reconciles() {
+    let stage = cstr!(
+        "{}{}",
+        stage_record("tests/_fixtures/_git/alpha"),
+        stage_record("tests/_fixtures/_git/beta")
+    );
+    let status = cstr!(
+        "{}{}",
+        status_line(' ', "tests/_fixtures/_git/alpha (v1.0.0)"),
+        status_line(' ', "tests/_fixtures/_git/beta (heads/main)")
+    );
+    let (indexed, states) = parse_pair(&stage, &status);
+    assert_eq!(reconcile(&indexed, &states), Ok(2));
+}
+
+#[test]
+fn partial_hydration_is_pinned_exactly() {
+    // The synthetic canonical shape: 146 indexed gitlinks, 5 hydrated clean,
+    // 141 missing. This must fail closed with the exact diagnostic below.
+    let mut stage = CompactString::default();
+    let mut status = CompactString::default();
+    for index in 0..146u32 {
+        let path = cstr!("tests/_fixtures/_git/project-{index:03}");
+        stage.push_str(&stage_record(&path));
+        if index < 5 {
+            status.push_str(&status_line(' ', &cstr!("{path} (v1.0.0)")));
+        } else {
+            status.push_str(&status_line('-', &path));
+        }
+    }
+    let (indexed, states) = parse_pair(&stage, &status);
+    assert_eq!(indexed.total(), 146);
+    let error = reconcile(&indexed, &states).unwrap_err();
+    assert_eq!(
+        error,
+        InventoryError::Missing {
+            missing: 141,
+            indexed: 146,
+            first: "tests/_fixtures/_git/project-005".into(),
+        }
+    );
+    assert_eq!(
+        cstr!("{error}"),
+        "differential corpus is not closure evidence: 141 of 146 indexed fixture submodules \
+         are missing (unhydrated); first missing `tests/_fixtures/_git/project-005`; hydrate \
+         with `git submodule update --init --checkout`"
+    );
+}
+
+#[test]
+fn drifted_submodules_are_rejected() {
+    let stage = stage_record("tests/_fixtures/_git/alpha");
+    let status = status_line('+', "tests/_fixtures/_git/alpha (v1.0.0-2-gabcdef0)");
+    let (indexed, states) = parse_pair(&stage, &status);
+    assert_eq!(
+        reconcile(&indexed, &states),
+        Err(InventoryError::Drifted {
+            drifted: 1,
+            indexed: 1,
+            first: "tests/_fixtures/_git/alpha".into(),
+        })
+    );
+}
+
+#[test]
+fn conflicted_status_is_rejected() {
+    let stage = stage_record("tests/_fixtures/_git/alpha");
+    let status = status_line('U', "tests/_fixtures/_git/alpha");
+    let (indexed, states) = parse_pair(&stage, &status);
+    assert_eq!(
+        reconcile(&indexed, &states),
+        Err(InventoryError::Conflicted {
+            conflicted: 1,
+            indexed: 1,
+            first: "tests/_fixtures/_git/alpha".into(),
+        })
+    );
+}
+
+#[test]
+fn conflicted_index_stages_are_rejected() {
+    let stage = cstr!(
+        "160000 {SHA} 1\ttests/_fixtures/_git/alpha\0160000 {SHA} 2\ttests/_fixtures/_git/alpha\0"
+    );
+    let status = status_line(' ', "tests/_fixtures/_git/alpha (v1.0.0)");
+    let (indexed, states) = parse_pair(&stage, &status);
+    assert_eq!(indexed.conflicted.len(), 1);
+    assert_eq!(
+        reconcile(&indexed, &states),
+        Err(InventoryError::Conflicted {
+            conflicted: 1,
+            indexed: 1,
+            first: "tests/_fixtures/_git/alpha".into(),
+        })
+    );
+}
+
+#[test]
+fn unknown_status_markers_are_rejected() {
+    let status = status_line('?', "tests/_fixtures/_git/alpha");
+    assert_eq!(
+        parse_submodule_status(&status),
+        Err(InventoryError::UnknownMarker {
+            marker: '?',
+            path: "tests/_fixtures/_git/alpha".into(),
+        })
+    );
+}
+
+#[test]
+fn paths_with_spaces_survive_both_parsers() {
+    let stage = stage_record("tests/_fixtures/_git/my project");
+    let status = cstr!(
+        "{}{}",
+        status_line(' ', "tests/_fixtures/_git/my project (v1.0.0)"),
+        ""
+    );
+    let (indexed, states) = parse_pair(&stage, &status);
+    assert!(indexed.clean.contains("tests/_fixtures/_git/my project"));
+    assert_eq!(
+        states.get("tests/_fixtures/_git/my project"),
+        Some(&SubmoduleState::Clean)
+    );
+    assert_eq!(reconcile(&indexed, &states), Ok(1));
+}
+
+#[test]
+fn missing_paths_with_spaces_are_not_describe_stripped() {
+    // `-` entries never carry a describe suffix; a path that happens to end
+    // in ` (x)` must survive verbatim.
+    let stage = stage_record("tests/_fixtures/_git/odd (1)");
+    let status = status_line('-', "tests/_fixtures/_git/odd (1)");
+    let (indexed, states) = parse_pair(&stage, &status);
+    assert_eq!(
+        reconcile(&indexed, &states),
+        Err(InventoryError::Missing {
+            missing: 1,
+            indexed: 1,
+            first: "tests/_fixtures/_git/odd (1)".into(),
+        })
+    );
+}
+
+#[test]
+fn empty_inventory_is_rejected() {
+    let (indexed, states) = parse_pair("", "");
+    assert_eq!(reconcile(&indexed, &states), Err(InventoryError::Empty));
+}
+
+#[test]
+fn non_gitlink_records_do_not_count() {
+    let stage = cstr!("100644 {SHA} 0\ttests/_fixtures/_git/README.md\0");
+    let indexed = parse_indexed_gitlinks(&stage).expect("index parses");
+    assert_eq!(indexed.total(), 0);
+    assert_eq!(
+        reconcile(&indexed, &BTreeMap::new()),
+        Err(InventoryError::Empty)
+    );
+}
+
+#[test]
+fn set_mismatch_is_rejected_in_both_directions() {
+    let stage = cstr!(
+        "{}{}",
+        stage_record("tests/_fixtures/_git/alpha"),
+        stage_record("tests/_fixtures/_git/beta")
+    );
+    let status = cstr!(
+        "{}{}",
+        status_line(' ', "tests/_fixtures/_git/alpha (v1.0.0)"),
+        status_line(' ', "tests/_fixtures/_git/gamma (v1.0.0)")
+    );
+    let (indexed, states) = parse_pair(&stage, &status);
+    assert_eq!(
+        reconcile(&indexed, &states),
+        Err(InventoryError::SetMismatch {
+            index_only: 1,
+            status_only: 1,
+            first_index_only: "tests/_fixtures/_git/beta".into(),
+            first_status_only: "tests/_fixtures/_git/gamma".into(),
+        })
+    );
+}
+
+#[test]
+fn invalid_records_are_rejected() {
+    assert_eq!(
+        parse_indexed_gitlinks("garbage-without-tab\0"),
+        Err(InventoryError::InvalidIndexRecord {
+            record: "garbage-without-tab".into(),
+        })
+    );
+    assert_eq!(
+        parse_submodule_status("not a status line\n"),
+        Err(InventoryError::InvalidStatusLine {
+            line: "not a status line".into(),
+        })
+    );
+    let truncated = cstr!(" {SHA}\n");
+    assert_eq!(
+        parse_submodule_status(&truncated),
+        Err(InventoryError::InvalidStatusLine {
+            line: cstr!(" {SHA}"),
+        })
+    );
+    let duplicate = cstr!(
+        "{}{}",
+        status_line('-', "tests/_fixtures/_git/alpha"),
+        status_line('-', "tests/_fixtures/_git/alpha")
+    );
+    assert!(matches!(
+        parse_submodule_status(&duplicate),
+        Err(InventoryError::InvalidStatusLine { .. })
+    ));
+}
+
+#[test]
+fn external_roots_with_canonical_suffix_are_not_canonical() {
+    let scratch = tempfile::tempdir().expect("create scratch dir");
+    let fake = scratch.path().join(CANONICAL_CORPUS_RELATIVE);
+    std::fs::create_dir_all(&fake).expect("create fake corpus root");
+    assert!(!is_canonical_root(&fake));
+}
+
+#[test]
+fn the_checkout_fixture_root_is_canonical() {
+    let root = super::workspace_root().join(CANONICAL_CORPUS_RELATIVE);
+    assert!(is_canonical_root(&root));
+}

--- a/tests/davinci_test_support/src/lib.rs
+++ b/tests/davinci_test_support/src/lib.rs
@@ -3,5 +3,6 @@
 //! Keeping cross-crate fixtures and validators in a regular dependency avoids
 //! relative `#[path]` includes while preserving one source of truth.
 
+pub mod corpus;
 pub mod schema;
 pub mod surface_fixture;


### PR DESCRIPTION
## Summary

- add shared Davinci corpus-root preflight across the corpus-runnable differential lanes
- bind closure evidence to this checkout's canonical tests/_fixtures/_git root and reject partial/mismatched submodule inventories before collecting .vue files
- keep arbitrary external roots as smoke scope with closure_evidence=false
- re-derive the existing croquis Davinci differential pins now exercised by the shared lane wiring

Closes #4831

## Verification

- cargo test -p davinci_test_support --lib -- --nocapture
- cargo clippy -p davinci_test_support -- -D warnings -D clippy::wildcard_imports
- cargo test -p vize_s1 --features davinci-differential --test davinci_surface_corpus -- --nocapture
- cargo test -p vize_croquis --features davinci-differential --test davinci_differential -- --nocapture
- cargo clippy -p vize_croquis --features davinci-differential --test davinci_differential -- -D warnings
- cargo test -p vize_ricalco --features davinci-differential --test davinci_lowering_corpus -- --nocapture
- cargo test -p vize_atelier_core --features davinci-differential --test davinci_s2_transform_corpus -- --nocapture
- cargo test -p vize_atelier_sfc --features davinci-differential --test davinci_differential -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- expected failure: env VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git cargo test -p vize_s1 --features davinci-differential --test davinci_surface_corpus -- --nocapture fails before the sweep with 146/146 missing indexed fixture submodules

## Notes

- source-length command currently fails before scanning this diff with MoonBit lexscan errors in moonbitlang/x/path/win32/path.mbt; touched files are under 350 lines by wc.
