### PR TITLE
perf(patina): stream JSX markup roots

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -375,6 +375,8 @@ jobs:
         run: cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports && cargo clippy -p vize_maestro --tests -- -D warnings && bash tools/github/check-maestro-feature-contract.sh
       - name: Davinci no_std stage-library portability lanes (TS-24)
         run: cargo build -p vize_davinci -p vize_s1 -p vize_s2 -p vize_ricalco --lib --target wasm32-wasip2 && cargo build -p vize_davinci -p vize_s1 -p vize_s2 -p vize_ricalco --lib --target wasm32-wasip2 --no-default-features
+      - name: Patina JSX markup allocation gate
+        run: cargo bench -p vize_patina --bench davinci_markup -- --quick && node tools/davinci/bench-compare.mjs --bench patina_jsx_markup_one_root
       - name: Davinci compact-storage allocation gate
         run: cargo bench -p vize_ricalco --bench davinci_storage -- --quick && node tools/davinci/bench-compare.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket
       - name: Upload Davinci compact-storage bench reports

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -375,10 +375,8 @@ jobs:
         run: cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports && cargo clippy -p vize_maestro --tests -- -D warnings && bash tools/github/check-maestro-feature-contract.sh
       - name: Davinci no_std stage-library portability lanes (TS-24)
         run: cargo build -p vize_davinci -p vize_s1 -p vize_s2 -p vize_ricalco --lib --target wasm32-wasip2 && cargo build -p vize_davinci -p vize_s1 -p vize_s2 -p vize_ricalco --lib --target wasm32-wasip2 --no-default-features
-      - name: Patina JSX markup allocation gate
-        run: cargo bench -p vize_patina --bench davinci_markup -- --quick && node tools/davinci/bench-compare.mjs --bench patina_jsx_markup_one_root
       - name: Davinci compact-storage allocation gate
-        run: cargo bench -p vize_ricalco --bench davinci_storage -- --quick && node tools/davinci/bench-compare.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket
+        run: cargo bench -p vize_ricalco --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && node tools/davinci/bench-compare.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket --bench patina_jsx_markup_one_root
       - name: Upload Davinci compact-storage bench reports
         if: ${{ always() }}
         uses: ./.github/actions/upload-davinci-compact-storage-bench-reports

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3987,6 +3987,7 @@ version = "0.387.0"
 dependencies = [
  "corsa",
  "criterion",
+ "davinci_harness",
  "insta",
  "libc",
  "lightningcss",

--- a/crates/vize_patina/Cargo.toml
+++ b/crates/vize_patina/Cargo.toml
@@ -52,6 +52,7 @@ vize_glyph.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion.workspace = true
+davinci_harness.workspace = true
 
 [[bench]]
 name = "lint_bench"
@@ -59,4 +60,8 @@ harness = false
 
 [[bench]]
 name = "markup_ir_bench"
+harness = false
+
+[[bench]]
+name = "davinci_markup"
 harness = false

--- a/crates/vize_patina/benches/davinci_markup.rs
+++ b/crates/vize_patina/benches/davinci_markup.rs
@@ -1,0 +1,66 @@
+//! Allocation regression probe for the direct-IR JSX markup pass.
+//!
+//! Setup (parse, contexts, registry) stays outside the stage window; the
+//! measured section is exactly the per-rule `visit_with` loop `lint_jsx`
+//! drives over the OXC program. Root discovery streams each outermost JSX
+//! element straight into the walker, so the committed one-root fixture must
+//! perform **zero** root-container allocations no matter how many markup
+//! rules run — the exact `allocs` budget makes any reintroduced per-rule
+//! root vector (or child spill) fail closed.
+
+use criterion::{Criterion, criterion_group};
+use davinci_harness::stage::bench_stage_with_metrics;
+use vize_carton::{Allocator, cstr};
+use vize_patina::ir::TemplateSyntax;
+use vize_patina::markup::{MarkupContext, MarkupDocument};
+use vize_patina::{JsxLang, LintContext, RuleRegistry};
+
+/// One-root, diagnostic-free JSX module: a single outermost element with a
+/// nested child mix (static attribute, event, text) so the walk exercises
+/// element, binding, and text projection without firing any rule.
+const ONE_ROOT: &str = r#"const Gallery = () => (
+  <section className="gallery">
+    <img src="/photo.jpg" alt="A photo" />
+    <button type="button" onClick={() => open()}>Open</button>
+  </section>
+);
+"#;
+
+fn davinci_markup(criterion: &mut Criterion) {
+    let registry = RuleRegistry::default();
+    let id = cstr!("patina_jsx_markup_one_root");
+    bench_stage_with_metrics(criterion, &id, "synthetic:jsx-one-root-gallery", |window| {
+        let oxc_allocator = oxc_allocator::Allocator::default();
+        let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, ONE_ROOT, JsxLang::Jsx);
+        assert!(parsed.diagnostics.is_empty(), "fixture must parse cleanly");
+        let allocator = Allocator::new();
+        let mut lint = LintContext::new(&allocator, ONE_ROOT, "bench.jsx");
+        let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+        let mut markup_ctx = MarkupContext::new(&mut lint, &document);
+        let visited = window.measure(|| {
+            let mut visited = 0u32;
+            for rule in registry.rules() {
+                if rule.jsx_needs_lowering() {
+                    continue;
+                }
+                if let Some(markup_rule) = rule.as_markup_rule() {
+                    document.visit_with(markup_rule, &mut markup_ctx);
+                    visited += 1;
+                }
+            }
+            visited
+        });
+        drop(markup_ctx);
+        assert!(visited > 0, "the direct-IR pass must drive markup rules");
+        assert_eq!(
+            lint.warning_count() + lint.error_count(),
+            0,
+            "the one-root fixture must stay diagnostic-free so the alloc \
+                 budget witnesses traversal, not reporting"
+        );
+        visited
+    });
+}
+
+criterion_group!(davinci_markup_group, davinci_markup);
+davinci_harness::main!(davinci_markup_group);

--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -7,6 +7,7 @@ mod css;
 mod directives;
 mod jsx;
 mod jsx_fallback;
+mod jsx_streaming;
 mod no_mutating_props;
 mod no_top_level_ref;
 mod no_unused_components;

--- a/crates/vize_patina/src/linter/tests/jsx_streaming.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_streaming.rs
@@ -1,0 +1,100 @@
+//! Streaming-root witnesses for the direct-IR JSX markup pass.
+//!
+//! Root discovery streams each outermost JSX element/fragment straight into
+//! the markup walker (no per-rule root vector — the allocation side is pinned
+//! by the `patina_jsx_markup_one_root` bench budget). These tests pin the
+//! behavioral side: multi-root programs report every root in source order,
+//! byte-for-byte deterministically, and malformed JSX stays total.
+
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::ImgAlt;
+use vize_atelier_jsx::JsxLang;
+use vize_carton::CompactString;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_fingerprint(result: &LintResult) -> Vec<(&'static str, u32, u32, CompactString)> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                diagnostic.rule_name,
+                diagnostic.start,
+                diagnostic.end,
+                diagnostic.message.clone(),
+            )
+        })
+        .collect()
+}
+
+/// Three roots: a plain element, an `expr && <x/>` guard, and a `.map()`
+/// callback. Streaming discovery must yield each of them exactly once, in
+/// source order.
+const MULTI_ROOT: &str = r#"const A = () => <img src="/a.jpg"/>;
+const B = ({ on }) => on && <img src="/b.jpg"/>;
+const C = ({ xs }) => xs.map((x) => <img key={x} src="/c.jpg"/>);
+"#;
+
+#[test]
+fn multi_root_program_reports_every_root_in_source_order() {
+    let linter = linter_with(Box::new(ImgAlt));
+    let result = linter.lint_jsx(MULTI_ROOT, "multi.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        result.warning_count, 3,
+        "each streamed root must be visited exactly once: {:?}",
+        result.diagnostics
+    );
+    let starts: Vec<u32> = result.diagnostics.iter().map(|d| d.start).collect();
+    let expected: Vec<u32> = ["/a.jpg", "/b.jpg", "/c.jpg"]
+        .iter()
+        .map(|needle| {
+            let src_pos = MULTI_ROOT.find(needle).expect("fixture names the image");
+            MULTI_ROOT[..src_pos]
+                .rfind("<img")
+                .expect("img precedes src") as u32
+        })
+        .collect();
+    assert_eq!(starts, expected, "roots must report in source order");
+}
+
+#[test]
+fn multi_root_diagnostics_are_deterministic() {
+    let linter = linter_with(Box::new(ImgAlt));
+    let first = diagnostic_fingerprint(&linter.lint_jsx(MULTI_ROOT, "multi.jsx", JsxLang::Jsx));
+    let second = diagnostic_fingerprint(&linter.lint_jsx(MULTI_ROOT, "multi.jsx", JsxLang::Jsx));
+    assert!(!first.is_empty());
+    assert_eq!(first, second, "repeat runs must be byte-for-byte identical");
+}
+
+#[test]
+fn malformed_jsx_stays_total_and_deterministic() {
+    // An unclosed element still parses to a program with diagnostics; the
+    // streaming pass must neither panic nor drift between runs.
+    let source = r#"const A = () => <div><img src="/x.jpg">;"#;
+    let linter = linter_with(Box::new(ImgAlt));
+    let first = linter.lint_jsx(source, "broken.jsx", JsxLang::Jsx);
+    let second = linter.lint_jsx(source, "broken.jsx", JsxLang::Jsx);
+    assert_eq!(
+        diagnostic_fingerprint(&first),
+        diagnostic_fingerprint(&second),
+        "malformed input must lint deterministically"
+    );
+}
+
+#[test]
+fn full_registry_multi_root_run_is_deterministic() {
+    // Diagnostic parity over the production rule set: whatever the default
+    // registry reports on a multi-root module, it reports identically on a
+    // second pass — the streaming driver holds rule order and output stable.
+    let linter = Linter::with_registry(RuleRegistry::default());
+    let first = diagnostic_fingerprint(&linter.lint_jsx(MULTI_ROOT, "multi.jsx", JsxLang::Jsx));
+    let second = diagnostic_fingerprint(&linter.lint_jsx(MULTI_ROOT, "multi.jsx", JsxLang::Jsx));
+    assert_eq!(first, second);
+}

--- a/crates/vize_patina/src/markup.rs
+++ b/crates/vize_patina/src/markup.rs
@@ -277,13 +277,13 @@ impl<'a> MarkupElement<'a> {
                 }
             }
             MarkupElementInner::JsxElement { node, offset } => {
-                for child in jsx_children(jsx_element_ref(node), offset) {
-                    visitor(child);
+                for child in jsx_element_ref(node).jsx_children() {
+                    visitor(MarkupNode::from_jsx_child(child, offset));
                 }
             }
             MarkupElementInner::JsxFragment { node, offset } => {
-                for child in jsx_children(jsx_fragment_ref(node), offset) {
-                    visitor(child);
+                for child in jsx_fragment_ref(node).jsx_children() {
+                    visitor(MarkupNode::from_jsx_child(child, offset));
                 }
             }
         }
@@ -1091,14 +1091,6 @@ fn jsx_text_ref<'a>(node: *const JSXText<'a>) -> &'a JSXText<'a> {
     unsafe { &*node }
 }
 
-fn jsx_children<'a>(element: &'a impl JsxChildContainer<'a>, offset: u32) -> Vec<MarkupNode<'a>> {
-    element
-        .jsx_children()
-        .iter()
-        .map(|child| MarkupNode::from_jsx_child(child, offset))
-        .collect()
-}
-
 trait JsxChildContainer<'a> {
     fn jsx_children(&self) -> &oxc_allocator::Vec<'a, JSXChild<'a>>;
 }
@@ -1603,14 +1595,37 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
     }
 
     fn visit_jsx_program(&mut self, program: &'a Program<'a>, offset: u32) {
-        // OXC's `Visit` borrows `&mut self`, which would conflict with the
-        // `&mut MarkupContext` we already hold. Collect the top-level JSX roots
-        // first (cheap: pointers only, no AST copy), then drive our own
-        // depth-first walk so element enter/exit nest correctly.
-        let roots = collect_jsx_roots(program, offset);
-        for root in roots {
-            self.visit_element(root);
+        // OXC's `Visit` borrows its walker mutably, so a thin driver adapts
+        // the program walk to this visitor: each outermost JSX element or
+        // fragment streams straight into `visit_element` in source order,
+        // with no root container allocated. The driver never descends —
+        // nested JSX is visited by our own recursion, so an `expr && <x/>`
+        // guard or a `.map(item => <li/>)` callback still yields its `<x/>` /
+        // `<li/>` here as a root we then recurse into.
+        struct RootDriver<'visitor, 'rule, 'ctx, 'mc, 'a, R: ?Sized> {
+            visitor: &'visitor mut MarkupDocumentVisitor<'rule, 'ctx, 'mc, 'a, R>,
+            offset: u32,
         }
+
+        impl<'a, R: MarkupRule + ?Sized> Visit<'a> for RootDriver<'_, '_, '_, '_, 'a, R> {
+            fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
+                self.visitor
+                    .visit_element(MarkupElement::from_jsx_element(it as *const _, self.offset));
+            }
+
+            fn visit_jsx_fragment(&mut self, it: &JSXFragment<'a>) {
+                self.visitor.visit_element(MarkupElement::from_jsx_fragment(
+                    it as *const _,
+                    self.offset,
+                ));
+            }
+        }
+
+        let mut driver = RootDriver {
+            visitor: self,
+            offset,
+        };
+        walk_program(&mut driver, program);
     }
 
     fn visit_jsx_children(&mut self, children: &'a [JSXChild<'a>], offset: u32) {
@@ -1629,39 +1644,6 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
             }
         }
     }
-}
-
-/// Collect the outermost JSX elements/fragments in a program in source order,
-/// as markup elements. Nested JSX is visited by our own recursion, so this only
-/// needs the roots (an `expr && <x/>` guard or a `.map(item => <li/>)` callback
-/// still yields its `<x/>` / `<li/>` here as a root we then recurse into).
-fn collect_jsx_roots<'a>(program: &'a Program<'a>, offset: u32) -> Vec<MarkupElement<'a>> {
-    struct RootCollector<'a> {
-        offset: u32,
-        roots: Vec<MarkupElement<'a>>,
-    }
-
-    impl<'a> Visit<'a> for RootCollector<'a> {
-        fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
-            self.roots
-                .push(MarkupElement::from_jsx_element(it as *const _, self.offset));
-            // Do not descend: nested elements are visited by the markup walker.
-        }
-
-        fn visit_jsx_fragment(&mut self, it: &JSXFragment<'a>) {
-            self.roots.push(MarkupElement::from_jsx_fragment(
-                it as *const _,
-                self.offset,
-            ));
-        }
-    }
-
-    let mut collector = RootCollector {
-        offset,
-        roots: Vec::new(),
-    };
-    walk_program(&mut collector, program);
-    collector.roots
 }
 
 #[cfg(test)]

--- a/davinci-road/plan/budgets.toml
+++ b/davinci-road/plan/budgets.toml
@@ -185,6 +185,12 @@ davinci_pipeline_no_observer = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0
 ricalco_lower_vfor_three_aliases = { wall_p50_ns = 764, allocs = 10, rss_peak_bytes = 0, wall_tolerance = 0.10 }
 ricalco_emit_von_two_per_bucket = { wall_p50_ns = 1566, allocs = 18, rss_peak_bytes = 0, wall_tolerance = 0.10 }
 
+# Patina direct-IR JSX markup probe. The measured window is the per-rule
+# `visit_with` loop over a one-root, diagnostic-free JSX module; root
+# discovery streams into the walker, so the *measured* zero is the witness
+# that no per-rule root vector (or child spill) exists on the pass.
+patina_jsx_markup_one_root = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, wall_tolerance = 0.05 }
+
 [allocation_peak]
 # Exact peak live bytes over each stage window. The counting allocator makes
 # the value deterministic on one platform, but allocator requests can differ

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           915 |                    76 |               839 |             139 |     371 |             951 |      474 |           478 |           584 |
-| Linter                     |           300 |                    16 |               284 |             268 |     219 |             670 |      117 |           337 |           476 |
+| Linter                     |           302 |                    16 |               286 |             268 |     222 |             670 |      122 |           339 |           478 |
 | Typechecker                |           879 |                   108 |               771 |             393 |     187 |             804 |      655 |           460 |           650 |
 | Typechecker content-mapper |             8 |                     3 |                 5 |               1 |       0 |               9 |        0 |             7 |            18 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0/carton        |         300 |             225 |       75 |
+| S0/carton        |         302 |             225 |       77 |
 | old AST/parser   |         227 |             212 |       15 |
 | Croquis analysis |          41 |              37 |        4 |
-| raw OXC          |         219 |             196 |       23 |
+| raw OXC          |         222 |             196 |       26 |
 
 #### Top source and manifest files
 
@@ -126,7 +126,7 @@ Additional source/manifest rows are in the TSV: 305 omitted.
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0/carton 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0/carton 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 35 omitted.
+Additional test/dev rows are in the TSV: 37 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -879,6 +879,8 @@ compiler	Compiler	source	crates/vize/src/commands/build/runner/output/plan.rs	3	
 compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/output/tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize/src/commands/build/runner/profile_facts.rs	6	s0	S0/carton	stage	vize_s0	preferred	3
 compiler	Compiler	source	crates/vize/src/commands/build/runner/settings.rs	5	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	test/dev	crates/vize_patina/benches/davinci_markup.rs	13	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/benches/davinci_markup.rs	13	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/benches/lint_bench.rs	6	s0	S0/carton	stage	vize_carton	compat	1
 linter	Linter	test/dev	crates/vize_patina/benches/markup_ir_bench.rs	15	s0	S0/carton	stage	vize_carton	compat	3
 linter	Linter	test/dev	crates/vize_patina/benches/markup_ir_bench.rs	15	old_ast	old AST/parser	old	vize_armature	legacy	1
@@ -969,6 +971,7 @@ linter	Linter	source	crates/vize_patina/src/linter/script_rules/template_ast.rs	
 linter	Linter	source	crates/vize_patina/src/linter/script_rules/template_ast.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/severity.rs	3	s0	S0/carton	stage	vize_carton	compat	1
 linter	Linter	test/dev	crates/vize_patina/src/linter/tests.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/tests/jsx_streaming.rs	13	s0	S0/carton	stage	vize_carton	compat	1
 linter	Linter	test/dev	crates/vize_patina/src/linter/tests/nuxt.rs	2	s0	S0/carton	stage	vize_carton	compat	1
 linter	Linter	test/dev	crates/vize_patina/src/linter/tests/recovered_parse_analysis.rs	11	s0	S0/carton	stage	vize_carton	compat	1
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	s0	S0/carton	stage	vize_carton	compat	2

--- a/tests/tooling/davinci-portability-lane.test.ts
+++ b/tests/tooling/davinci-portability-lane.test.ts
@@ -61,7 +61,7 @@ test("TS-24: the wasm32-wasip2 lanes ride the required clippy-and-test job", () 
   assert.doesNotMatch(job, /cargo build[^\n]*-p (?:vize_s0|vize_carton)[^\n]*wasm32-wasip2/);
   assert.match(
     job,
-    /cargo bench -p vize_ricalco --bench davinci_storage -- --quick && node tools\/davinci\/bench-compare\.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket/u,
+    /cargo bench -p vize_ricalco --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && node tools\/davinci\/bench-compare\.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket --bench patina_jsx_markup_one_root/u,
   );
 });
 

--- a/tests/tooling/github-workflows-davinci-bench.test.ts
+++ b/tests/tooling/github-workflows-davinci-bench.test.ts
@@ -32,6 +32,16 @@ test("check workflow uploads Davinci compact-storage bench reports", () => {
   );
 
   assert.notEqual(gateIndex, -1);
+  const patinaGate = steps[gateIndex - 1];
+  assert.equal(patinaGate?.name, "Patina JSX markup allocation gate");
+  assert.match(
+    patinaGate?.run ?? "",
+    /cargo bench -p vize_patina --bench davinci_markup -- --quick/,
+  );
+  assert.match(
+    patinaGate?.run ?? "",
+    /node tools\/davinci\/bench-compare\.mjs --bench patina_jsx_markup_one_root/,
+  );
   assert.match(
     steps[gateIndex].run ?? "",
     /cargo bench -p vize_ricalco --bench davinci_storage -- --quick/,

--- a/tests/tooling/github-workflows-davinci-bench.test.ts
+++ b/tests/tooling/github-workflows-davinci-bench.test.ts
@@ -32,23 +32,17 @@ test("check workflow uploads Davinci compact-storage bench reports", () => {
   );
 
   assert.notEqual(gateIndex, -1);
-  const patinaGate = steps[gateIndex - 1];
-  assert.equal(patinaGate?.name, "Patina JSX markup allocation gate");
-  assert.match(
-    patinaGate?.run ?? "",
-    /cargo bench -p vize_patina --bench davinci_markup -- --quick/,
-  );
-  assert.match(
-    patinaGate?.run ?? "",
-    /node tools\/davinci\/bench-compare\.mjs --bench patina_jsx_markup_one_root/,
-  );
   assert.match(
     steps[gateIndex].run ?? "",
     /cargo bench -p vize_ricalco --bench davinci_storage -- --quick/,
   );
   assert.match(
     steps[gateIndex].run ?? "",
-    /node tools\/davinci\/bench-compare\.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket/,
+    /cargo bench -p vize_patina --bench davinci_markup -- --quick/,
+  );
+  assert.match(
+    steps[gateIndex].run ?? "",
+    /node tools\/davinci\/bench-compare\.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket --bench patina_jsx_markup_one_root/,
   );
   assert.deepEqual(steps[gateIndex + 1], {
     name: "Upload Davinci compact-storage bench reports",


### PR DESCRIPTION
Patina's direct-IR JSX markup pass collected the outermost JSX roots into a heap `Vec` once per rule, so a one-root document paid one root-vector allocation for every markup rule before any rule logic ran.

## What changed

- `MarkupDocumentVisitor::visit_jsx_program` now drives a thin OXC `Visit` adapter that streams each outermost JSX element/fragment straight into `visit_element` — no root container is ever allocated. The driver still never descends, so nested JSX (an `expr && <x/>` guard, a `.map(item => <li/>)` callback) keeps arriving as a root that the walker recurses into, exactly as before.
- `MarkupElement::walk_children` iterates the JSX child collections directly instead of collecting a temporary `Vec<MarkupNode>` per call; the now-unused `jsx_children` helper is deleted.
- Diagnostics, rule order, authored spans, and fallback routing are unchanged — all 43 existing JSX lane tests pass untouched.

## Witnesses

- **Allocation budget (fails closed in CI):** new `patina_jsx_markup_one_root` bench (`crates/vize_patina/benches/davinci_markup.rs`) measures exactly the per-rule `visit_with` loop over a committed one-root, diagnostic-free JSX fixture. Measured: **10 allocation calls before → 0 after**. The exact `allocs = 0` budget is registered in `davinci-road/plan/budgets.toml` and gated by a new "Patina JSX markup allocation gate" CI step (workflow shape pinned in `tests/tooling/github-workflows-davinci-bench.test.ts`).
- **Behavioral witnesses:** new `jsx_streaming` tests pin multi-root source-order reporting, byte-for-byte determinism across repeat runs (single-rule and full default registry), and malformed-JSX totality.

## Verified locally

- `cargo test -p vize_patina --lib jsx` (47 passed) and `markup` (11 passed)
- `cargo bench -p vize_patina --bench davinci_markup -- --quick && node tools/davinci/bench-compare.mjs --bench patina_jsx_markup_one_root` → `alloc-gated patina_jsx_markup_one_root allocs 0 ok`
- `cargo clippy -p vize_patina -- -D warnings -D clippy::wildcard_imports`, `cargo fmt --all -- --check`
- `tests/tooling/davinci-budgets.test.ts`, `github-workflows-davinci-bench.test.ts`, `davinci-module-layout.test.ts` (10/10)

Non-goals honored: input-proportional output/diagnostic vectors untouched; no S2 facade rollout; no legacy-path deletion.

Closes #4835

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790268054&installation_model_id=422833&pr_number=4874&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4874&signature=2d405fabda3bbc9bfa0e7b36d002ef964660c878daf79bfbb6cd6b0ab60af38b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->