### PR TITLE
test(lsp): add ant-design-vue authored oracle

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -168,6 +168,42 @@ pub fn pascal_to_kebab(name: &str) -> String {
     result
 }
 
+/// Candidate local binding names for a component tag.
+pub(crate) fn component_name_candidates(name: &str) -> Vec<String> {
+    let Some(first) = name.chars().next() else {
+        return Vec::new();
+    };
+    if !name.contains('-') && !first.is_ascii_uppercase() {
+        return vec![name.to_string()];
+    }
+
+    let pascal = kebab_to_pascal(name);
+    let camel = lower_first_ascii(&pascal);
+    let mut names = Vec::with_capacity(3);
+    push_unique_name(&mut names, name.to_string());
+    push_unique_name(&mut names, pascal);
+    push_unique_name(&mut names, camel);
+    names
+}
+
+fn lower_first_ascii(name: &str) -> String {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return String::new();
+    };
+
+    let mut result = String::with_capacity(name.len());
+    result.push(first.to_ascii_lowercase());
+    result.extend(chars);
+    result
+}
+
+fn push_unique_name(names: &mut Vec<String>, candidate: String) {
+    if !names.iter().any(|name| name == &candidate) {
+        names.push(candidate);
+    }
+}
+
 /// Check if a tag name is a component (starts with uppercase or contains hyphen).
 #[inline]
 pub fn is_component_tag(name: &str) -> bool {

--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -24,6 +24,8 @@ pub(crate) mod template;
 #[cfg(test)]
 mod component_alias_props_tests;
 #[cfg(test)]
+mod component_lower_camel_props_tests;
+#[cfg(test)]
 mod component_props_tests;
 #[cfg(test)]
 mod dedup_tests;

--- a/crates/vize_maestro/src/ide/completion/component_lower_camel_props_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/component_lower_camel_props_tests.rs
@@ -1,0 +1,77 @@
+use std::fs;
+
+use tower_lsp::lsp_types::CompletionResponse;
+
+use super::CompletionService;
+use crate::{ide::IdeContext, server::ServerState};
+
+#[test]
+fn template_component_prop_completion_resolves_lower_camel_import_as_kebab_tag() {
+    let dir = tempfile::tempdir().unwrap();
+    let child_dir = dir.path().join("descriptionItem");
+    fs::create_dir_all(&child_dir).unwrap();
+    let child_path = child_dir.join("index.vue");
+    fs::write(
+        &child_path,
+        r#"<script setup lang="ts">
+defineProps<{
+  someMessage: string
+  disabled?: boolean
+}>()
+</script>
+"#,
+    )
+    .unwrap();
+
+    let source = r#"<script setup lang="ts">
+import descriptionItem from './descriptionItem/index.vue'
+</script>
+
+<template>
+  <description-item  />
+</template>
+"#;
+    let parent_path = dir.path().join("Parent.vue");
+    fs::write(&parent_path, source).unwrap();
+
+    let parent_uri = tower_lsp::lsp_types::Url::from_file_path(&parent_path).unwrap();
+    let child_uri = tower_lsp::lsp_types::Url::from_file_path(&child_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(parent_uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&parent_uri, source);
+
+    let offset = source.find("<description-item  />").unwrap() + "<description-item ".len();
+    let ctx = IdeContext::new(&state, &parent_uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+    assert!(has_label(&labels, "some-message"), "{labels:?}");
+    assert!(has_label(&labels, "disabled"), "{labels:?}");
+
+    let changed_child_source =
+        "<script setup lang=\"ts\">defineProps<{ freshProbe: string }>()</script>";
+    state.documents.open(
+        child_uri.clone(),
+        changed_child_source.to_string(),
+        2,
+        "vue".to_string(),
+    );
+    state.update_virtual_docs(&child_uri, changed_child_source);
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+    assert!(has_label(&labels, "fresh-probe"), "{labels:?}");
+    assert!(!has_label(&labels, "some-message"), "{labels:?}");
+}
+
+fn completion_labels(response: CompletionResponse) -> Vec<String> {
+    match response {
+        CompletionResponse::Array(items) => items,
+        CompletionResponse::List(list) => list.items,
+    }
+    .into_iter()
+    .map(|item| item.label)
+    .collect()
+}
+
+fn has_label(labels: &[String], expected: &str) -> bool {
+    labels.iter().any(|label| label == expected)
+}

--- a/crates/vize_maestro/src/ide/completion/template/component_meta.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_meta.rs
@@ -9,7 +9,9 @@ use tower_lsp::lsp_types::{
 use vize_relief::BindingType;
 
 use crate::ide::definition::helpers as definition_helpers;
-use crate::ide::{IdeContext, is_component_tag, kebab_to_pascal, pascal_to_kebab};
+use crate::ide::{
+    IdeContext, component_name_candidates, is_component_tag, kebab_to_pascal, pascal_to_kebab,
+};
 
 use super::component_cache::cached_component_metadata;
 use super::component_docs;
@@ -92,11 +94,7 @@ pub(crate) fn component_metadata(
         return Some(metadata);
     }
 
-    let mut names = vec![component_name.to_string()];
-    let pascal = kebab_to_pascal(component_name);
-    if !names.iter().any(|name| name == &pascal) {
-        names.push(pascal);
-    }
+    let names = component_name_candidates(component_name);
 
     for name in &names {
         if let Some(resolved) =

--- a/crates/vize_maestro/src/ide/definition/component_import.rs
+++ b/crates/vize_maestro/src/ide/definition/component_import.rs
@@ -27,6 +27,18 @@ struct ComponentImport {
 }
 
 fn find_component_import(ctx: &IdeContext<'_>, component_name: &str) -> Option<ComponentImport> {
+    for name in crate::ide::component_name_candidates(component_name) {
+        if let Some(component_import) = find_component_import_by_name(ctx, &name) {
+            return Some(component_import);
+        }
+    }
+    None
+}
+
+fn find_component_import_by_name(
+    ctx: &IdeContext<'_>,
+    component_name: &str,
+) -> Option<ComponentImport> {
     for (pos, _) in ctx.content.match_indices("import ") {
         let rest = &ctx.content[pos..];
         let Some(from_pos) = rest.find(" from") else {
@@ -231,4 +243,43 @@ fn ident_at_start(value: &str) -> Option<&str> {
 
 fn is_vue_path(path: &Path) -> bool {
     path.extension().is_some_and(|extension| extension == "vue")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tower_lsp::lsp_types::Url;
+
+    use super::*;
+    use crate::server::ServerState;
+
+    #[test]
+    fn resolve_component_file_prefers_exact_binding_over_lower_camel_fallback() {
+        let workspace = tempfile::tempdir().expect("temporary workspace");
+        let lower_camel_path = workspace.path().join("lower.vue");
+        let exact_path = workspace.path().join("exact.vue");
+        fs::write(&lower_camel_path, "<template><span /></template>\n").expect("lower component");
+        fs::write(&exact_path, "<template><strong /></template>\n").expect("exact component");
+
+        let importer_path = workspace.path().join("App.vue");
+        let source = r#"<script setup lang="ts">
+import descriptionItem from "./lower.vue";
+import DescriptionItem from "./exact.vue";
+</script>
+<template><DescriptionItem /></template>
+"#;
+        fs::write(&importer_path, source).expect("importer");
+
+        let state = ServerState::new();
+        let uri = Url::from_file_path(importer_path).expect("importer URI");
+        let offset = source.rfind("DescriptionItem").expect("component tag");
+        let ctx = IdeContext::with_content(&state, &uri, offset, source.to_owned());
+        let resolved = resolve_component_file(&ctx, "DescriptionItem").expect("component file");
+
+        assert_eq!(
+            resolved.canonicalize().expect("canonical resolved path"),
+            exact_path.canonicalize().expect("canonical exact path")
+        );
+    }
 }

--- a/crates/vize_maestro/src/ide/definition/service/import_target.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target.rs
@@ -45,13 +45,12 @@ pub(super) fn component_tag_definition(ctx: &IdeContext<'_>) -> Option<GotoDefin
     if !crate::ide::is_component_tag(&tag_name) {
         return None;
     }
-    let pascal = crate::ide::kebab_to_pascal(&tag_name);
-    for name in [tag_name.as_str(), pascal.as_str()] {
+    for name in crate::ide::component_name_candidates(&tag_name) {
         // `import { Widget as LocalWidget }` declares `Widget` in the target,
         // so the lookup key is the exported name, not the local alias.
-        let exported = bound_import(&ctx.content, name)
-            .map_or_else(|| name.to_owned(), |(_, exported)| exported);
-        if let Some(specifier) = helpers::find_import_path(ctx, name)
+        let exported = bound_import(&ctx.content, &name)
+            .map_or_else(|| name.clone(), |(_, exported)| exported);
+        if let Some(specifier) = helpers::find_import_path(ctx, &name)
             && let Some(target) = resolve_import_specifier(ctx.uri, &specifier)
             && let Some(location) = locate_export(ctx, &target, &exported, MAX_REEXPORT_HOPS)
         {

--- a/crates/vize_maestro/src/ide/definition/service/import_target/tests.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target/tests.rs
@@ -131,8 +131,13 @@ import AccountSearchResult from '~/components/AccountSearchResult.vue'
     };
 
     assert_eq!(
-        location.uri,
-        Url::from_file_path(target_path).expect("target URI")
+        location
+            .uri
+            .to_file_path()
+            .expect("definition path")
+            .canonicalize()
+            .expect("canonical definition path"),
+        target_path.canonicalize().expect("canonical target path")
     );
 }
 
@@ -173,6 +178,46 @@ import { Widget } from "@/components";
     let offset = source.rfind("Widget").expect("component tag");
     let ctx = IdeContext::new(&state, &importer_uri, offset).expect("IDE context");
     let definition = DefinitionService::definition(&ctx).expect("component definition");
+    let GotoDefinitionResponse::Scalar(location) = definition else {
+        panic!("component definition must be scalar");
+    };
+
+    assert_eq!(
+        location
+            .uri
+            .to_file_path()
+            .expect("definition path")
+            .canonicalize()
+            .expect("canonical definition path"),
+        target_path.canonicalize().expect("canonical target path")
+    );
+}
+
+#[test]
+fn component_definition_resolves_lower_camel_import_as_kebab_tag() {
+    let workspace = tempfile::tempdir().expect("temporary workspace");
+    let component_dir = workspace.path().join("descriptionItem");
+    fs::create_dir_all(&component_dir).expect("component directory");
+    let target_path = component_dir.join("index.vue");
+    fs::write(&target_path, "<template><dl /></template>\n").expect("component");
+
+    let importer_path = workspace.path().join("App.vue");
+    let source = r#"<script setup lang="ts">
+import descriptionItem from "./descriptionItem/index.vue";
+</script>
+<template><description-item title="Full Name" /></template>
+"#;
+    fs::write(&importer_path, source).expect("importer");
+
+    let importer_uri = Url::from_file_path(&importer_path).expect("importer URI");
+    let state = ServerState::new();
+    state
+        .documents
+        .open(importer_uri.clone(), source.to_owned(), 1, "vue".to_owned());
+    state.update_virtual_docs(&importer_uri, source);
+    let offset = source.rfind("description-item").expect("component tag");
+    let ctx = IdeContext::new(&state, &importer_uri, offset).expect("IDE context");
+    let definition = super::component_tag_definition(&ctx).expect("component definition");
     let GotoDefinitionResponse::Scalar(location) = definition else {
         panic!("component definition must be scalar");
     };

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -6,7 +6,7 @@ use vize_croquis::{Drawer, DrawerOptions};
 use vize_relief::BindingType;
 
 use super::{IdeContext, helpers};
-use crate::ide::{is_component_tag, kebab_to_pascal, template_scope};
+use crate::ide::{component_name_candidates, is_component_tag, template_scope};
 
 /// Find definition for a symbol in template context.
 pub(crate) fn definition_in_template(ctx: &IdeContext) -> Option<GotoDefinitionResponse> {
@@ -551,19 +551,16 @@ pub(crate) fn find_component_definition(
 
     let summary = analyzer.finish();
 
-    let pascal_name = kebab_to_pascal(tag_name);
-    let names_to_try = [tag_name.to_string(), pascal_name];
-
-    for name in &names_to_try {
-        if let Some(resolved) = super::component_import::resolve_component_file(ctx, name)
+    for name in component_name_candidates(tag_name) {
+        if let Some(resolved) = super::component_import::resolve_component_file(ctx, &name)
             && let Some(location) = component_file_location(ctx, &resolved)
         {
             return Some(GotoDefinitionResponse::Scalar(location));
         }
 
-        if let Some(binding_type) = summary.get_binding_type(name)
+        if let Some(binding_type) = summary.get_binding_type(&name)
             && binding_type == BindingType::ExternalModule
-            && let Some(resolved) = super::component_import::resolve_component_file(ctx, name)
+            && let Some(resolved) = super::component_import::resolve_component_file(ctx, &name)
             && let Some(location) = component_file_location(ctx, &resolved)
         {
             return Some(GotoDefinitionResponse::Scalar(location));

--- a/crates/vize_maestro/src/ide/tests.rs
+++ b/crates/vize_maestro/src/ide/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    is_component_tag, kebab_to_pascal, offset_to_position, pascal_to_kebab, position_to_offset,
-    standalone_html_block_at_offset, token_at_offset, token_span_at_offset,
+    component_name_candidates, is_component_tag, kebab_to_pascal, offset_to_position,
+    pascal_to_kebab, position_to_offset, standalone_html_block_at_offset, token_at_offset,
+    token_span_at_offset,
 };
 use crate::virtual_code::BlockType;
 
@@ -77,6 +78,22 @@ fn test_pascal_to_kebab() {
     assert_eq!(pascal_to_kebab("Button"), "button");
     assert_eq!(pascal_to_kebab("VForItem"), "v-for-item");
     assert_eq!(pascal_to_kebab("ABC"), "a-b-c");
+}
+
+#[test]
+fn test_component_name_candidates_preserve_existing_order() {
+    assert_eq!(
+        component_name_candidates("description-item"),
+        vec!["description-item", "DescriptionItem", "descriptionItem"]
+    );
+    assert_eq!(
+        component_name_candidates("DescriptionItem"),
+        vec!["DescriptionItem", "descriptionItem"]
+    );
+    assert_eq!(
+        component_name_candidates("descriptionItem"),
+        vec!["descriptionItem"]
+    );
 }
 
 #[test]

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -337,27 +337,26 @@ impl LanguageServer for MaestroServer {
             return Ok(None);
         }
 
+        #[cfg(feature = "native")]
         {
-            #[cfg(feature = "native")]
-            {
-                let corsa_bridge = self.state.get_corsa_bridge().await;
-                if let Some(locations) = ReferencesService::references_with_corsa(
+            let locations = if self.state.lsp_features().cross_file {
+                ReferencesService::references_with_corsa(
                     &ctx,
                     include_declaration,
-                    corsa_bridge,
+                    self.state.get_corsa_bridge().await,
                 )
                 .await
-                {
-                    return Ok(Some(locations));
-                }
+            } else {
+                ReferencesService::references(&ctx, include_declaration)
+            };
+            if let Some(locations) = locations {
+                return Ok(Some(locations));
             }
+        }
 
-            #[cfg(not(feature = "native"))]
-            {
-                if let Some(locations) = ReferencesService::references(&ctx, include_declaration) {
-                    return Ok(Some(locations));
-                }
-            }
+        #[cfg(not(feature = "native"))]
+        if let Some(locations) = ReferencesService::references(&ctx, include_declaration) {
+            return Ok(Some(locations));
         }
 
         Ok(None)

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -50,7 +50,7 @@ observational guard for planning only. It does not change rollout state.
 | Typechecker                |           879 |                   108 |               771 |             393 |     187 |             804 |      655 |           460 |           650 |
 | Typechecker content-mapper |             8 |                     3 |                 5 |               1 |       0 |               9 |        0 |             7 |            18 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
-| LSP                        |           271 |                     0 |               271 |             113 |      44 |             323 |      105 |           166 |           387 |
+| LSP                        |           271 |                     0 |               271 |             113 |      44 |             323 |      105 |           166 |           388 |
 
 ## Consumer details
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -2380,7 +2380,7 @@ lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	raw_oxc	raw OXC	raw	oxc_ast_v
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 lsp	LSP	source	crates/vize_maestro/src/document/store.rs	79	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide.rs	174	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide.rs	210	s0	S0/carton	stage	vize_carton	compat	1
 lsp	LSP	source	crates/vize_maestro/src/ide/auto_insert.rs	77	s0	S0/carton	stage	vize_carton	compat	2
 lsp	LSP	source	crates/vize_maestro/src/ide/code_action.rs	14	s0	S0/carton	stage	vize_carton	compat	1
 lsp	LSP	source	crates/vize_maestro/src/ide/code_action.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	5

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -764,6 +764,7 @@
       "selection": {
         "type": "fixtures",
         "fixturePaths": [
+          "tests/_fixtures/_git/ant-design-vue",
           "tests/_fixtures/_git/reka-ui",
           "tests/_fixtures/_git/elk",
           "tests/_fixtures/_git/misskey",

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 7,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 12,
+    "minimumProjectCount": 13,
     "trackingIssue": 3952
   },
   "projects": [
@@ -159,7 +159,70 @@
         "syntax-highlighter",
         "lsp"
       ],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "components/comment/demo/editor.vue",
+          "symbol": "handleSubmit",
+          "usageAnchor": "@click=\"handleSubmit\"",
+          "declarationAnchor": "const handleSubmit = () => {",
+          "hoverContains": ["const handleSubmit: () => void"],
+          "renameTo": "__vizeRenamedHandleSubmit"
+        },
+        "componentBoundary": {
+          "importerFile": "components/drawer/demo/user-profile.vue",
+          "componentFile": "components/drawer/demo/descriptionItem/index.vue",
+          "tagName": "description-item",
+          "tagAnchor": "<description-item title=\"Full Name\" ",
+          "completionItemCount": 30,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "title", "rank": 28 },
+            { "label": "content", "rank": 29 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  content?: string;\n",
+            "replacement": "  content?: string;\n  vizeOracleProbe?: boolean;\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "components/drawer/demo/descriptionItem/__VizeOracleDescriptionItem.vue",
+          "renamedFile": "components/drawer/demo/descriptionItem/__VizeOracleRenamedDescriptionItem.vue",
+          "originalImportSpecifier": "./descriptionItem/index.vue",
+          "copiedImportSpecifier": "./descriptionItem/__VizeOracleDescriptionItem.vue",
+          "renamedImportSpecifier": "./descriptionItem/__VizeOracleRenamedDescriptionItem.vue",
+          "markerInsertionAnchor": "<script lang=\"ts\" setup>\n",
+          "markerSymbol": "__vizeAntDesignVueFileLifecycleMarker__"
+        }
+      }
     },
     {
       "id": "reka-ui",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 12,
+      "authored-lsp": 13,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tests/tooling/playwright-app-config.test.ts
+++ b/tests/tooling/playwright-app-config.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
@@ -77,9 +78,17 @@ test("fixture install child cannot discover or mutate the parent Git repository"
 });
 
 function snapshotParentGitState() {
-  const hooksDir = path.join(root, ".git", "hooks");
+  const gitCommonDir = execFileSync(
+    "git",
+    ["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    {
+      cwd: root,
+      encoding: "utf8",
+    },
+  ).trim();
+  const hooksDir = path.join(gitCommonDir, "hooks");
   return {
-    config: fs.readFileSync(path.join(root, ".git", "config")),
+    config: fs.readFileSync(path.join(gitCommonDir, "config")),
     hooks: fs.existsSync(hooksDir)
       ? fs
           .readdirSync(hooksDir)

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 12, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 13, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
Summary
- Add ant-design-vue to the authored LSP oracle gate and compatibility ledger.
- Resolve kebab/Pascal component tags against lower-camel local imports while preserving existing candidate precedence.
- Keep default references on the local path when cross-file LSP references are disabled, and harden a tooling test for linked git worktrees.

Verification
- cargo build --profile ci -p vize
- cargo test -p vize_maestro component
- cargo fmt --all -- --check
- git diff --check
- node --test --test-concurrency=1 tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/typecheck-dependency-gates.test.ts
- VIZE_LSP_BIN=target/ci/vize CORSA_PATH=node_modules/.bin/tsgo REAL_PROJECT_LSP_TIMEOUT_MS=600000 FIXTURE_SHARD_COUNT=999 FIXTURE_SHARD_INDEX=3 FIXTURE_REPORT_DIR=target/vize-tests/real-project-lsp-4836 node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts
- vp run --workspace-root test:scripts

Closes #4836

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790270075&installation_model_id=422833&pr_number=4875&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4875&signature=c757d36cd447f2fa4a2b5e34618eb39278bdf348c0df9cd4670afb2744916690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vue component recognition across kebab-case, PascalCase, and camelCase naming styles.
  - Fixed component definitions and imports resolving correctly from kebab-case template tags.
  - Improved component prop completion by offering kebab-case attribute names.
  - Native reference lookup now respects cross-file support settings.

- **Tests**
  - Added coverage for component naming, imports, definitions, props, and reference behavior.
  - Expanded real-project LSP compatibility coverage with an additional ecosystem fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->