### PR TITLE
fix(davinci): re-record compact-storage wall baselines from the reference runner

### DIFF
--- a/bench/results/davinci/baseline/ricalco_emit_von_two_per_bucket.json
+++ b/bench/results/davinci/baseline/ricalco_emit_von_two_per_bucket.json
@@ -3,11 +3,11 @@
   "fixture": "synthetic:v-on-two-option-event-key-modifiers",
   "platform": "linux",
   "wall_ns": {
-    "p50": 1566,
-    "p95": 18815
+    "p50": 1691,
+    "p95": 24178
   },
   "allocs": 18,
   "alloc_bytes_peak": 648,
-  "rss_peak_bytes": 128843776,
+  "rss_peak_bytes": 140926976,
   "harness_version": "0.387.0"
 }

--- a/bench/results/davinci/baseline/ricalco_lower_vfor_three_aliases.json
+++ b/bench/results/davinci/baseline/ricalco_lower_vfor_three_aliases.json
@@ -3,11 +3,11 @@
   "fixture": "synthetic:v-for-three-aliases",
   "platform": "linux",
   "wall_ns": {
-    "p50": 764,
-    "p95": 48030
+    "p50": 855,
+    "p95": 46262
   },
   "allocs": 10,
   "alloc_bytes_peak": 1254,
-  "rss_peak_bytes": 99250176,
+  "rss_peak_bytes": 119857152,
   "harness_version": "0.387.0"
 }

--- a/davinci-road/plan/budgets.toml
+++ b/davinci-road/plan/budgets.toml
@@ -182,8 +182,8 @@ davinci_pipeline_no_observer = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0
 # Compact-storage probes. Setup is excluded with stage windows so these exact
 # allocation counts localize the v-for split and v-on emit paths; the wall
 # side uses the stage-window tolerance because the timed window is sub-2us.
-ricalco_lower_vfor_three_aliases = { wall_p50_ns = 764, allocs = 10, rss_peak_bytes = 0, wall_tolerance = 0.10 }
-ricalco_emit_von_two_per_bucket = { wall_p50_ns = 1566, allocs = 18, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+ricalco_lower_vfor_three_aliases = { wall_p50_ns = 855, allocs = 10, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+ricalco_emit_von_two_per_bucket = { wall_p50_ns = 1691, allocs = 18, rss_peak_bytes = 0, wall_tolerance = 0.10 }
 
 [allocation_peak]
 # Exact peak live bytes over each stage window. The counting allocator makes

--- a/tests/tooling/davinci-budgets.test.ts
+++ b/tests/tooling/davinci-budgets.test.ts
@@ -227,14 +227,14 @@ test("compact-storage wall budgets match the committed linux baseline reports", 
   const expected = {
     ricalco_lower_vfor_three_aliases: {
       fixture: "synthetic:v-for-three-aliases",
-      wallP50Ns: 764,
+      wallP50Ns: 855,
       wallTolerance: 0.1,
       allocs: 10,
       allocBytesPeak: 1254,
     },
     ricalco_emit_von_two_per_bucket: {
       fixture: "synthetic:v-on-two-option-event-key-modifiers",
-      wallP50Ns: 1566,
+      wallP50Ns: 1691,
       wallTolerance: 0.1,
       allocs: 18,
       allocBytesPeak: 648,


### PR DESCRIPTION
The compact-storage wall gate is failing unrelated PRs: the committed `ricalco_lower_vfor_three_aliases` p50 (764ns, re-recorded in #4857) sits in the fast tail of the sub-2µs stage window. Four independent PR runs on `blacksmith-32vcpu-ubuntu-2404` measured **844 / 848 / 853 / 855 ns**, all above the 840ns limit (baseline + 10%), so the gate flipped PRs #4872, #4873, #4874, and #4876 with no code change on that path. `ricalco_emit_von_two_per_bucket` is drifting toward its limit the same way (1691ns vs 1722ns limit on the latest run).

This PR replaces both committed baseline reports with the **verbatim reference-runner artifact** from run [32878546335](https://github.com/ubugeeei-prod/vize/actions/runs/32878546335) (`davinci-compact-storage-bench-reports`), and aligns `davinci-road/plan/budgets.toml` and the `davinci-budgets` consistency test with the recorded p50s (855ns / 1691ns). Tolerances stay at the 0.10 stage-window ceiling; **alloc budgets are untouched** — the exact alloc gate remains the deterministic side of this probe.

Ratchet note: the commit body carries the `budget-loosen:` marker; the wall side is a measurement refresh of the same machine class, not a code regression (the alloc side proves the lowering path itself is unchanged).

Verified locally: `davinci-budgets`, `davinci-bench-platform`, `davinci-bench-compare` tooling tests (22/22).

Refs #4461

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790271608&installation_model_id=422833&pr_number=4877&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4877&signature=f3741bdb94e93485a824405896cdca71b5c57392a98fb4454f6908915facf53f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->