### PR TITLE
test(content-mapper): prove declaration map LSP coordinates

### DIFF
--- a/crates/vize/tests/content_mapper_lsp_support/declaration_workspace.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/declaration_workspace.rs
@@ -1,0 +1,91 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::{copy_fixture, install_packages, output_text};
+
+pub fn emit_vue_declaration_library(
+    tsgo: &Path,
+    library_path: &Path,
+    app_source: &str,
+    index_source: &str,
+) {
+    install_packages(library_path);
+    std::fs::create_dir_all(library_path.join("src")).unwrap();
+    std::fs::write(library_path.join("src/App.vue"), app_source).unwrap();
+    std::fs::write(library_path.join("src/index.ts"), index_source).unwrap();
+    std::fs::write(
+        library_path.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "contentMappers": [{ "package": "vize", "extensions": [".vue"] }],
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    let emit = Command::new(tsgo)
+        .current_dir(library_path)
+        .args([
+            "--runExternalCode",
+            "-p",
+            "tsconfig.json",
+            "--pretty",
+            "false",
+        ])
+        .output()
+        .unwrap();
+    assert!(emit.status.success(), "{}", output_text(&emit));
+}
+
+pub fn install_packed_vue_consumer(
+    consumer_path: &Path,
+    library_path: &Path,
+    consumer_source: &str,
+) -> PathBuf {
+    install_packages(consumer_path);
+    std::fs::create_dir_all(consumer_path.join("src")).unwrap();
+    std::fs::write(consumer_path.join("src/index.ts"), consumer_source).unwrap();
+    std::fs::write(
+        consumer_path.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+
+    let package_root = consumer_path.join("node_modules/@scope/emitted-vue");
+    std::fs::create_dir_all(&package_root).unwrap();
+    std::fs::write(
+        package_root.join("package.json"),
+        r#"{
+  "name": "@scope/emitted-vue",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./index.js"
+    }
+  }
+}"#,
+    )
+    .unwrap();
+    copy_fixture(&library_path.join("dist"), &package_root.join("dist"));
+    copy_fixture(&library_path.join("src"), &package_root.join("src"));
+    package_root
+}

--- a/crates/vize/tests/content_mapper_lsp_support/leak_assertions.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/leak_assertions.rs
@@ -20,7 +20,7 @@ fn assert_no_generated_uri_at(root: &Value, value: &Value) {
             for key in ["uri", "targetUri"] {
                 if let Some(uri) = object.get(key).and_then(Value::as_str) {
                     assert!(
-                        !uri.ends_with(".vue.ts") && !uri.contains(".vue.ts?"),
+                        !uri_leaks_generated_projection(uri),
                         "response leaked generated URI {uri}: {root:#}"
                     );
                 }
@@ -64,4 +64,27 @@ fn range_starts_at_zero(range: &Value) -> bool {
 fn position_is_zero(position: &Value) -> bool {
     position.get("line").and_then(Value::as_u64) == Some(0)
         && position.get("character").and_then(Value::as_u64) == Some(0)
+}
+
+fn uri_leaks_generated_projection(uri: &str) -> bool {
+    uri.contains(".vue.ts")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::uri_leaks_generated_projection;
+
+    #[test]
+    fn detects_ts_and_tsx_projection_uris() {
+        assert!(uri_leaks_generated_projection(
+            "file:///repo/src/App.vue.ts"
+        ));
+        assert!(uri_leaks_generated_projection(
+            "file:///repo/src/App.vue.tsx"
+        ));
+        assert!(uri_leaks_generated_projection(
+            "file:///repo/src/App.vue.ts?x=1"
+        ));
+        assert!(!uri_leaks_generated_projection("file:///repo/src/App.vue"));
+    }
 }

--- a/crates/vize/tests/content_mapper_lsp_support/mod.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/mod.rs
@@ -8,6 +8,7 @@ use serde_json::{Value, json};
 use vize_s0::String as CompactString;
 
 mod component_oracles;
+mod declaration_workspace;
 mod leak_assertions;
 mod navigation;
 mod package_install;
@@ -20,11 +21,13 @@ pub use component_oracles::{
     assert_component_completions, assert_component_members, assert_component_navigation,
     assert_prop_navigation,
 };
+#[allow(unused_imports)]
+pub use declaration_workspace::{emit_vue_declaration_library, install_packed_vue_consumer};
 pub use leak_assertions::{assert_no_generated_uri, assert_no_generated_uri_or_zero_range};
 #[allow(unused_imports)]
 pub use navigation::{
-    contains_location_range, contains_range, contains_text_edit, document_highlights, references,
-    rename,
+    assert_hover, assert_location_range, contains_location_range, contains_range,
+    contains_text_edit, document_highlights, references, rename,
 };
 pub use package_install::install_packages;
 #[allow(unused_imports)]
@@ -208,6 +211,25 @@ pub fn position(source: &str, offset: usize) -> Value {
     let line = before.matches('\n').count();
     let character = before.rsplit_once('\n').map_or(before, |(_, tail)| tail);
     json!({ "line": line, "character": character.encode_utf16().count() })
+}
+
+pub fn anchored_position(source: &str, anchor: &str, label: &str) -> Value {
+    position(source, source.find(anchor).expect(label))
+}
+
+pub fn anchored_range(
+    source: &str,
+    anchor: &str,
+    offset_from_anchor: usize,
+    len: usize,
+    label: &str,
+) -> (Value, Value) {
+    let offset = source.find(anchor).expect(label) + offset_from_anchor;
+    position_range(source, offset, len)
+}
+
+pub fn position_range(source: &str, offset: usize, len: usize) -> (Value, Value) {
+    (position(source, offset), position(source, offset + len))
 }
 
 pub fn contains_location(value: &Value, uri: &str, start: &Value) -> bool {

--- a/crates/vize/tests/content_mapper_lsp_support/navigation.rs
+++ b/crates/vize/tests/content_mapper_lsp_support/navigation.rs
@@ -1,6 +1,8 @@
 use corsa_lsp::LspClient;
 use serde_json::{Value, json};
 
+use super::leak_assertions::assert_no_generated_uri;
+
 pub struct RawReferences;
 pub struct RawDocumentHighlight;
 pub struct RawRename;
@@ -103,4 +105,40 @@ pub fn contains_text_edit(
                         .is_some_and(|edits| edits.iter().any(matches))
             })
         })
+}
+
+pub fn assert_location_range(
+    response: &Value,
+    uri: &str,
+    target_start: &Value,
+    target_end: &Value,
+    label: &str,
+) {
+    assert!(
+        contains_location_range(response, uri, target_start, target_end),
+        "{label} should map to the authored source range:\n{response:#}"
+    );
+    assert_no_generated_uri(response);
+}
+
+pub fn assert_hover(
+    response: &Value,
+    expected_start: &Value,
+    expected_end: &Value,
+    expected_contents: Value,
+    label: &str,
+) {
+    assert_no_generated_uri(response);
+    assert_eq!(
+        response["contents"], expected_contents,
+        "{label} should expose the expected hover contents:\n{response:#}"
+    );
+    assert_eq!(
+        response["range"],
+        json!({
+            "start": expected_start,
+            "end": expected_end,
+        }),
+        "{label} range should cover the consumer symbol:\n{response:#}"
+    );
 }

--- a/crates/vize/tests/content_mapper_tsgo_declaration_lsp.rs
+++ b/crates/vize/tests/content_mapper_tsgo_declaration_lsp.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::process::Command;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -13,9 +12,10 @@ use content_mapper_lsp_support::raw_requests::{
     RawInitialize, RawInitialized, RawSetContentMapperContributions,
 };
 use content_mapper_lsp_support::{
-    EditorResponder, StopOnDrop, assert_no_generated_uri, contains_location, copy_fixture,
-    definition, editor_capabilities, file_uri, hover, install_packages, output_text, position,
-    workspace_root,
+    EditorResponder, StopOnDrop, anchored_position, anchored_range, assert_hover,
+    assert_location_range, assert_no_generated_uri, contains_location, definition,
+    editor_capabilities, emit_vue_declaration_library, file_uri, hover,
+    install_packed_vue_consumer, position_range, references, type_definition, workspace_root,
 };
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
@@ -32,132 +32,109 @@ fn standard_tsgo_lsp_uses_vue_declaration_maps_from_packed_consumer() {
         .prefix("content-mapper-declaration-library-")
         .tempdir_in(&cases_root)
         .unwrap();
-    install_packages(library.path());
-    std::fs::create_dir_all(library.path().join("src")).unwrap();
     let app_source = r#"<script setup lang="ts">
 export interface PublicProps {
   label: string;
+  emojiLabel?: "💥";
 }
-
 defineProps<PublicProps>();
 </script>
-
 <template>
-  <p>{{ label }}</p>
+  <p>{{ label }} {{ emojiLabel }}</p>
 </template>
 "#;
     let index_source = r#"export { default as App } from "./App.vue";
 export type { PublicProps } from "./App.vue";
 "#;
-    std::fs::write(library.path().join("src/App.vue"), app_source).unwrap();
-    std::fs::write(library.path().join("src/index.ts"), index_source).unwrap();
-    std::fs::write(
-        library.path().join("tsconfig.json"),
-        r#"{
-  "compilerOptions": {
-    "strict": true,
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "declaration": true,
-    "declarationMap": true,
-    "emitDeclarationOnly": true,
-    "rootDir": "src",
-    "outDir": "dist"
-  },
-  "contentMappers": [{ "package": "vize", "extensions": [".vue"] }],
-  "include": ["src/**/*"]
-}"#,
-    )
-    .unwrap();
-    let emit = Command::new(&tsgo)
-        .current_dir(library.path())
-        .args([
-            "--runExternalCode",
-            "-p",
-            "tsconfig.json",
-            "--pretty",
-            "false",
-        ])
-        .output()
-        .unwrap();
-    assert!(emit.status.success(), "{}", output_text(&emit));
+    emit_vue_declaration_library(&tsgo, library.path(), app_source, index_source);
 
     let consumer = tempfile::Builder::new()
         .prefix("content-mapper-declaration-consumer-")
         .tempdir_in(cases_root)
         .unwrap();
-    install_packages(consumer.path());
-    std::fs::create_dir_all(consumer.path().join("src")).unwrap();
     let consumer_source = r#"import { App } from "@scope/emitted-vue";
 import type { PublicProps } from "@scope/emitted-vue";
-
-const props: PublicProps = { label: "ok" };
+const props: PublicProps = { label: "ok", emojiLabel: "💥" };
 type ComponentProps = InstanceType<typeof App>["$props"];
 const componentProps: ComponentProps = props;
+const labelFromPublicInstance: ComponentProps["label"] = componentProps.label;
+const emojiFromPublicInstance: ComponentProps["emojiLabel"] = componentProps.emojiLabel;
 void componentProps;
+void labelFromPublicInstance;
+void emojiFromPublicInstance;
 "#;
-    std::fs::write(consumer.path().join("src/index.ts"), consumer_source).unwrap();
-    std::fs::write(
-        consumer.path().join("tsconfig.json"),
-        r#"{
-  "compilerOptions": {
-    "strict": true,
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "noEmit": true
-  },
-  "include": ["src/**/*"]
-}"#,
-    )
-    .unwrap();
-
-    let package_root = consumer.path().join("node_modules/@scope/emitted-vue");
-    std::fs::create_dir_all(&package_root).unwrap();
-    std::fs::write(
-        package_root.join("package.json"),
-        r#"{
-  "name": "@scope/emitted-vue",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./index.js"
-    }
-  }
-}"#,
-    )
-    .unwrap();
-    copy_fixture(&library.path().join("dist"), &package_root.join("dist"));
-    copy_fixture(&library.path().join("src"), &package_root.join("src"));
+    let package_root =
+        install_packed_vue_consumer(consumer.path(), library.path(), consumer_source);
 
     let consumer_path = consumer.path().join("src/index.ts");
     let consumer_uri = file_uri(&consumer_path);
     let package_app_path = package_root.join("src/App.vue");
     let package_app_uri = file_uri(&package_app_path);
     let root_uri = file_uri(consumer.path());
-    let public_props_import = position(
+    let public_props_import = anchored_position(
         consumer_source,
-        consumer_source
-            .find("PublicProps")
-            .expect("consumer imports PublicProps"),
+        "PublicProps",
+        "consumer imports PublicProps",
     );
     let public_props_usage_offset = consumer_source
         .match_indices("PublicProps")
         .nth(1)
         .expect("consumer uses PublicProps")
         .0;
-    let public_props_usage = position(consumer_source, public_props_usage_offset);
-    let public_props_usage_end = position(
+    let (public_props_usage, public_props_usage_end) = position_range(
         consumer_source,
-        public_props_usage_offset + "PublicProps".len(),
+        public_props_usage_offset,
+        "PublicProps".len(),
     );
-    let public_props_target = position(
+    let (public_props_target, public_props_target_end) = anchored_range(
         app_source,
-        app_source
-            .find("PublicProps")
-            .expect("authored Vue source exports PublicProps"),
+        "PublicProps",
+        0,
+        "PublicProps".len(),
+        "authored Vue source exports PublicProps",
+    );
+    let (label_property_usage, label_property_usage_end) = anchored_range(
+        consumer_source,
+        "componentProps.label",
+        "componentProps.".len(),
+        "label".len(),
+        "consumer reads public instance label",
+    );
+    let props_value_usage = anchored_range(
+        consumer_source,
+        "= props;",
+        2,
+        "props".len(),
+        "consumer assigns typed props",
+    )
+    .0;
+    let (label_property_target, label_property_target_end) = anchored_range(
+        app_source,
+        "label: string",
+        0,
+        "label".len(),
+        "authored Vue source declares label prop",
+    );
+    let (emoji_property_usage, emoji_property_usage_end) = anchored_range(
+        consumer_source,
+        "componentProps.emojiLabel",
+        "componentProps.".len(),
+        "emojiLabel".len(),
+        "consumer reads public instance emojiLabel",
+    );
+    let (emoji_property_target, emoji_property_target_end) = anchored_range(
+        app_source,
+        "emojiLabel?:",
+        0,
+        "emojiLabel".len(),
+        "authored Vue source declares emojiLabel prop",
+    );
+    let (emoji_template_usage, emoji_template_usage_end) = anchored_range(
+        app_source,
+        "{{ label }} {{ emojiLabel }}",
+        "{{ label }} {{ ".len(),
+        "emojiLabel".len(),
+        "authored Vue template reads emojiLabel",
     );
 
     let stop = AtomicBool::new(false);
@@ -248,6 +225,65 @@ void componentProps;
                     "end": public_props_usage_end
                 }),
                 "hover range should cover the consumer PublicProps usage:\n{mapped_hover:#}"
+            );
+            let props_value_type_definition =
+                type_definition(&client, &consumer_uri, &props_value_usage).await;
+            assert_location_range(
+                &props_value_type_definition,
+                &package_app_uri,
+                &public_props_target,
+                &public_props_target_end,
+                "typed props value typeDefinition",
+            );
+
+            let label_property_definition =
+                definition(&client, &consumer_uri, &label_property_usage).await;
+            assert_location_range(
+                &label_property_definition,
+                &package_app_uri,
+                &label_property_target,
+                &label_property_target_end,
+                "public instance label property definition",
+            );
+            let label_property_hover = hover(&client, &consumer_uri, &label_property_usage).await;
+            assert_hover(
+                &label_property_hover,
+                &label_property_usage,
+                &label_property_usage_end,
+                json!({
+                    "kind": "plaintext",
+                    "value": "(property) PublicProps.label: string"
+                }),
+                "public instance label hover",
+            );
+            let emoji_property_definition =
+                definition(&client, &consumer_uri, &emoji_property_usage).await;
+            assert_location_range(
+                &emoji_property_definition,
+                &package_app_uri,
+                &emoji_property_target,
+                &emoji_property_target_end,
+                "public instance emojiLabel property definition",
+            );
+            let emoji_property_hover = hover(&client, &consumer_uri, &emoji_property_usage).await;
+            assert_hover(
+                &emoji_property_hover,
+                &emoji_property_usage,
+                &emoji_property_usage_end,
+                json!({
+                    "kind": "plaintext",
+                    "value": "(property) PublicProps.emojiLabel?: \"💥\" | undefined"
+                }),
+                "public instance emojiLabel hover",
+            );
+            let emoji_template_references =
+                references(&client, &package_app_uri, &emoji_template_usage).await;
+            assert_location_range(
+                &emoji_template_references,
+                &package_app_uri,
+                &emoji_template_usage,
+                &emoji_template_usage_end,
+                "authored template emojiLabel references",
             );
 
             stop.store(true, Ordering::Relaxed);

--- a/davinci-road/plan/assertion-allowlist.toml
+++ b/davinci-road/plan/assertion-allowlist.toml
@@ -90,7 +90,6 @@ paths = [
   "crates/vize/tests/check_workspace_package_boundary_cli.rs",
   "crates/vize/tests/check_workspace_vue_cli.rs",
   "crates/vize/tests/content_mapper_importer_scoped_packages.rs",
-  "crates/vize/tests/content_mapper_lsp_support/leak_assertions.rs",
   "crates/vize/tests/content_mapper_lsp_support/mod.rs",
   "crates/vize/tests/content_mapper_tsgo_build.rs",
   "crates/vize/tests/content_mapper_tsgo_cli.rs",

--- a/tests/tooling/lsp-concurrent-edit-deadlock.test.ts
+++ b/tests/tooling/lsp-concurrent-edit-deadlock.test.ts
@@ -144,14 +144,16 @@ test("vize lsp keeps publishing when edits race an in-flight diagnostics pass", 
     };
 
     /**
-     * Awaits the publish for the newest version sent. Deterministic: the LSP
-     * spec makes `didChange` versions monotonic, so only one publish can carry
-     * it, and the assertion is on that publish's content — never on timing.
+     * Awaits the publish for the newest source marker. The marker is unique per
+     * revision, so it still identifies the final diagnostics even when a server
+     * or client lane omits the optional publishDiagnostics version field.
      */
     const awaitFinalPublish = async (marker: string, label: string): Promise<void> => {
       const publish = (await session.waitForNotification(
         "textDocument/publishDiagnostics",
-        (params) => isDiagnosticsForUri(params, uri) && params.version === version,
+        (params) =>
+          isDiagnosticsForUri(params, uri) &&
+          markersOf(params as PublishDiagnosticsParams).includes(marker),
         45_000,
       )) as PublishDiagnosticsParams;
       assert.deepEqual(
@@ -159,6 +161,13 @@ test("vize lsp keeps publishing when edits race an in-flight diagnostics pass", 
         [marker],
         `${label}: version ${version} must publish exactly its own revision's diagnostic`,
       );
+      if (publish.version != null) {
+        assert.equal(
+          publish.version,
+          version,
+          `${label}: versioned publish must carry the latest document version`,
+        );
+      }
       t.diagnostic(`${label}: published v${version} (${publishes.length} publishes so far)`);
     };
 


### PR DESCRIPTION
## Summary
- extend the packed Content Mapper declaration-map LSP oracle to cover public instance prop definition, strict typeDefinition, exact hover contents, and template-originated authored ranges
- share declaration-map library/consumer setup across LSP tests
- make generated URI leak assertions fail closed for .vue.tsx and remove the stale assertion allowlist entry

Fixes #4052

## Validation
- cargo fmt --all -- --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts
- node tools/davinci/assertion-lint.mjs
- VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/tsgo VIZE_TEST_CONTENT_MAPPER_VUE=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue cargo test -p vize --test content_mapper_tsgo_declaration_lsp -- --nocapture
- VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/tsgo VIZE_TEST_CONTENT_MAPPER_VUE=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue cargo test -p vize --test content_mapper_tsgo_lsp -- --nocapture
- VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/tsgo VIZE_TEST_CONTENT_MAPPER_VUE=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture
- CORSA_PATH=/private/tmp/tsgo cargo test -p vize_canon --test lsp_import_resolution -- --nocapture
- cargo test -p vize content_mapper -- --nocapture
- node --test tests/tooling/content-mapper-manifest.test.ts tests/tooling/content-mapper-package-contract.test.ts tests/tooling/davinci-module-layout.test.ts tests/tooling/davinci-stage-dependencies.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790273332&installation_model_id=422833&pr_number=4879&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4879&signature=67378bddd1426c13165e0492feea119909cab74a3824ff76fe36a1ea6887cf53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Vue language-server tests for type definitions, property definitions, hover information, and template references.
  * Added coverage for optional typed properties, including `emojiLabel`.
  * Added checks ensuring navigation results point to authored Vue sources rather than generated files.
  * Improved reusable test setup and position/range assertions for declaration consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->