### PR TITLE
test(content-mapper): pin authored declaration map sources

### DIFF
--- a/crates/vize/tests/content_mapper_declaration_map_support/mod.rs
+++ b/crates/vize/tests/content_mapper_declaration_map_support/mod.rs
@@ -1,0 +1,80 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::Value;
+
+pub struct AuthoredVueSource {
+    pub map_source: String,
+    pub content: String,
+}
+
+pub fn assert_authored_vue_source(
+    map_path: &Path,
+    map: &Value,
+    component: &str,
+) -> AuthoredVueSource {
+    let sources = map["sources"].as_array().expect("map sources");
+    let sources_content = map["sourcesContent"].as_array();
+    if let Some(sources_content) = sources_content {
+        assert_eq!(
+            sources_content.len(),
+            sources.len(),
+            "{} must keep source and sourcesContent entries aligned: {map}",
+            map_path.display()
+        );
+    }
+
+    let expected_source = format!("{component}.vue");
+    let mut matched_content = None;
+    for (index, source_value) in sources.iter().enumerate() {
+        let source = source_value
+            .as_str()
+            .unwrap_or_else(|| panic!("{} has non-string source entry: {map}", map_path.display()));
+        if !source.ends_with(&expected_source) {
+            continue;
+        }
+        let authored = std::fs::read_to_string(resolve_map_source(map_path, source))
+            .unwrap_or_else(|error| {
+                panic!(
+                    "failed to read authored source {source} for {}: {error}",
+                    map_path.display()
+                )
+            });
+        if let Some(sources_content) = sources_content {
+            let actual = sources_content[index].as_str().unwrap_or_else(|| {
+                panic!(
+                    "{} has non-string sourcesContent for {source}: {map}",
+                    map_path.display()
+                )
+            });
+            assert_eq!(
+                actual,
+                authored,
+                "{} must embed byte-exact authored source content for {source}",
+                map_path.display()
+            );
+        }
+        matched_content = Some(AuthoredVueSource {
+            map_source: source.to_string(),
+            content: authored,
+        });
+    }
+
+    matched_content.unwrap_or_else(|| {
+        panic!(
+            "{} did not resolve an authored source for {expected_source}: {map}",
+            map_path.display()
+        )
+    })
+}
+
+fn resolve_map_source(map_path: &Path, source: &str) -> PathBuf {
+    let source_path = Path::new(source);
+    if source_path.is_absolute() {
+        source_path.to_path_buf()
+    } else {
+        map_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join(source_path)
+    }
+}

--- a/crates/vize/tests/content_mapper_tsgo_build.rs
+++ b/crates/vize/tests/content_mapper_tsgo_build.rs
@@ -5,6 +5,9 @@ use std::process::{Command, Output};
 use serde_json::json;
 use vize_s0::{String as CompactString, cstr};
 
+mod content_mapper_declaration_map_support;
+use content_mapper_declaration_map_support::assert_authored_vue_source;
+
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
 const VUE_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_VUE";
 
@@ -189,12 +192,11 @@ fn standard_tsgo_emits_authored_vue_declaration_maps() {
 
     let app = project.path().join("src/App.vue");
     let source = std::fs::read_to_string(&app).unwrap().replace('\n', "\r\n");
-    std::fs::write(&app, cstr!("<!-- 💥 -->\r\n{source}")).unwrap();
+    let app_source = cstr!("<!-- 💥 -->\r\n{source}");
+    std::fs::write(&app, app_source.as_str()).unwrap();
 
     let spaced = project.path().join("src/Spaced Child.vue");
-    std::fs::write(
-        spaced,
-        r#"<script setup lang="ts">
+    let spaced_source = r#"<script setup lang="ts">
 import type { VNode } from "vue";
 
 defineProps<{
@@ -206,9 +208,8 @@ defineProps<{
 <template>
   <span>{{ unicodeLabel }}</span>
 </template>
-"#,
-    )
-    .unwrap();
+"#;
+    std::fs::write(spaced, spaced_source).unwrap();
 
     let emit = Command::new(&tsgo)
         .current_dir(project.path())
@@ -311,6 +312,21 @@ defineProps<{
                 "{} leaked a generated or virtual source path: {map}",
                 map_path.display()
             );
+        }
+        let authored_source = assert_authored_vue_source(&map_path, &map, component);
+        if component == "App" {
+            assert_eq!(authored_source.content, app_source.as_str());
+            assert!(authored_source.content.starts_with("<!-- 💥 -->\r\n"));
+            assert!(
+                authored_source.content.contains("\r\n"),
+                "{:?}",
+                authored_source.content
+            );
+            assert!(authored_source.content.contains("💥"));
+        } else if component == "Spaced Child" {
+            assert_eq!(authored_source.content, spaced_source);
+            assert!(authored_source.map_source.contains("Spaced Child.vue"));
+            assert!(authored_source.content.contains(r#"unicodeLabel: "💥""#));
         }
     }
 


### PR DESCRIPTION
## Summary
- Add a declaration-map test helper that resolves mapped Vue sources back to the authored files and checks inline sourcesContent when upstream provides it.
- Strengthen the exact tsgo declaration-map oracle so CRLF/Unicode App.vue and spaced-path Spaced Child.vue map to byte-exact authored content.

Refs #4052

## Validation
- VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/typescript-content-mapper-4052-runner/tsgo VIZE_TEST_CONTENT_MAPPER_VUE=/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue cargo test -p vize --test content_mapper_tsgo_build -- --nocapture
- VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/typescript-content-mapper-4052-runner/tsgo VIZE_TEST_CONTENT_MAPPER_VUE=/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue cargo test -p vize --test content_mapper_tsgo_declaration_lsp -- --nocapture
- cargo fmt --all -- --check
- git diff --check

## Local note
- node --test tests/tooling/source-file-lengths.test.ts is blocked locally by the MoonBit lexscan toolchain error under tools/moon/.mooncakes; touched Rust files are 337 and 80 lines.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790273876&installation_model_id=422833&pr_number=4881&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4881&signature=b27de406437c2a8899dc7fd94330b35327fafa8b813eb190ae452083d7a511bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->