### PR TITLE
fix(matrix): scope package-local baseline declarations

### DIFF
--- a/tests/tooling/typecheck-baseline-project-composite.test.ts
+++ b/tests/tooling/typecheck-baseline-project-composite.test.ts
@@ -155,6 +155,74 @@ test("materialized baseline include roots follow corpusGlobs instead of sibling 
   }
 });
 
+test(
+  "materialized baseline keeps sibling app declarations out of package-local typecheck",
+  vueTscOptions,
+  () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "vize-package-dts-baseline-"));
+    const fixtureRoot = path.join(temp, "fixture");
+    const reportDir = path.join(temp, "report");
+    fs.mkdirSync(path.join(fixtureRoot, "packages/common/src"), { recursive: true });
+    fs.mkdirSync(path.join(fixtureRoot, "packages/admin/src/components"), { recursive: true });
+    fs.mkdirSync(path.join(fixtureRoot, "types"), { recursive: true });
+    fs.mkdirSync(reportDir);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "packages/common/tsconfig.shared.json"),
+      '{\n  // Keep shared root declarations explicit without importing sibling apps.\n  "compilerOptions": { "strict": true, "noEmit": true },\n  "include": ["src/**/*.vue", "../../types/**/*.d.ts"]\n}\n',
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "packages/common/tsconfig.json"),
+      `${JSON.stringify({ extends: "./tsconfig.shared.json" })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "packages/common/src/App.vue"),
+      '<script setup lang="ts">const value: ROOT_GLOBAL = "ok"</script>\n',
+    );
+    fs.writeFileSync(path.join(fixtureRoot, "types/globals.d.ts"), "type ROOT_GLOBAL = string;\n");
+    fs.writeFileSync(
+      path.join(fixtureRoot, "packages/admin/src/components/global-components.d.ts"),
+      'import Header from "./Header.vue";\nexport {}\n',
+    );
+    fs.writeFileSync(
+      path.join(fixtureRoot, "packages/admin/src/components/Header.vue"),
+      "<template />\n",
+    );
+    try {
+      const project = materializeBaselineProject(
+        fixtureRoot,
+        reportDir,
+        {
+          id: "fixture",
+          tsconfig: "packages/common/tsconfig.json",
+          vueGlobs: ["packages/common/src/**/*.vue", "packages/admin/src/**/*.vue"],
+          typecheckPerformance: { corpusGlobs: ["packages/common/src/**/*.vue"] },
+        },
+        { fileCount: 1, files: [{ file: "packages/common/src/App.vue" }] },
+      );
+      const config = JSON.parse(project.source);
+      assert.deepEqual(config.files, ["../src/App.vue"]);
+      assert.equal(config.include.includes("../../../**/*.d.ts"), false);
+      assert.equal(config.include.includes("../**/*.d.ts"), true);
+      assert.equal(config.include.includes("../src/**/*.d.ts"), true);
+      assert.equal(config.include.includes("../../../types/**/*.d.ts"), true);
+      assert.equal(config.include.includes("../../admin/src/**/*.d.ts"), false);
+      const result = runVueTsc(project.path, fixtureRoot);
+      const diagnostics = result.stdout.split("\n").filter((line) => /: error TS\d+: /u.test(line));
+      assert.deepEqual(diagnostics, []);
+      assert.equal(result.status, 0, result.stderr);
+      const program = result.stdout.split("\n").map((line) => line.trimEnd());
+      assert.equal(program.includes(path.join(fixtureRoot, "packages/common/src/App.vue")), true);
+      assert.equal(program.includes(path.join(fixtureRoot, "types/globals.d.ts")), true);
+      assert.equal(
+        program.includes(path.join(fixtureRoot, "packages/admin/src/components/Header.vue")),
+        false,
+      );
+    } finally {
+      fs.rmSync(temp, { recursive: true, force: true });
+    }
+  },
+);
+
 function runVueTsc(project: string, cwd: string) {
   return spawnSync(vueTsc, ["--noEmit", "--pretty", "false", "--listFiles", "-p", project], {
     cwd,

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -179,9 +179,9 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
     // The elk shape: the baseline config is generated into a dot-directory, which
     // a TypeScript wildcard segment never descends into, so it is globbed by name.
     // The src root carries non-Vue support files without expanding the Vue corpus.
-    const fixtureBase = "../..";
     const generatedBase = "..";
-    const sourceBase = `${fixtureBase}/src`;
+    const sourceBase = "../../src";
+    const fixtureBase = "../..";
     assert.deepEqual(readJson(baselineArtifact), {
       extends: "../tsconfig.json",
       compilerOptions: {
@@ -189,11 +189,9 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
         rootDir: fixtureBase,
       },
       files: [`${fixtureBase}/src/App.vue`],
-      // #3738: ambient declarations are the fixture's type environment, and a
-      // `files`-only program drops every one of them.
       include: [
-        `${fixtureBase}/**/*.d.ts`,
         `${generatedBase}/**/*.d.ts`,
+        `${sourceBase}/**/*.d.ts`,
         `${sourceBase}/**/*.ts`,
         `${sourceBase}/**/*.tsx`,
         `${sourceBase}/**/*.mts`,
@@ -205,10 +203,10 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
         `${sourceBase}/**/*.json`,
       ],
       exclude: [
-        `${fixtureBase}/**/node_modules/**`,
-        `${fixtureBase}/**/dist/**`,
         `${generatedBase}/**/node_modules/**`,
         `${generatedBase}/**/dist/**`,
+        `${sourceBase}/**/node_modules/**`,
+        `${sourceBase}/**/dist/**`,
       ],
       references: [],
     });

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -1,12 +1,15 @@
 import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 
+import { expandConfigDir } from "./typecheck-baseline-config-dir.mjs";
+import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs";
 import {
   mergePathRewrites,
   rewriteOutsideAliasPaths,
 } from "./typecheck-baseline-outside-aliases.mjs";
 import {
   isolatedOverlayBaseUrl,
+  resolvePackageExtends,
   rewriteOutsidePackagePaths,
   rewriteOutsideRootDirs,
   rewriteOutsideTypeRoots,
@@ -36,10 +39,14 @@ import { typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
  * Declaration files are the right thing to add back and the only thing:
  * they are the fixture's type *environment*, never the comparison's subject, so
  * they cannot change which SFCs are checked, and every diagnostic reported
- * inside one is already excluded from scoring for being non-Vue. `exclude` is
- * ours rather than the fixture's for the same reason — the glob is ours, and it
- * must not reach into installed or built output. It cannot narrow the compared
- * corpus, because `exclude` never applies to `files`.
+ * inside one is already excluded from scoring for being non-Vue. Their roots
+ * follow the owning tsconfig directory and the measured corpus roots. A root
+ * tsconfig still gets the whole fixture, but a package-local tsconfig does not
+ * pull sibling app declarations that can import their own `.vue` files into the
+ * baseline program (#4461). `exclude` is ours rather than the fixture's for the
+ * same reason — the glob is ours, and it must not reach into installed or built
+ * output. It cannot narrow the compared corpus, because `exclude` never applies
+ * to `files`.
  *
  * The generated baseline lives beside the source config rather than at fixture
  * root. Several workspace fixtures, including vue-vben-admin, resolve
@@ -73,24 +80,29 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
   );
   const configDir = dirname(outputPath);
   const globRoots = vueGlobSourceRoots(fixtureRoot, project);
+  const sourceBaseRoots =
+    globRoots.length > 0 ? globRoots : vizeReportSourceRoots(fixtureRoot, vizeReport);
+  const declarationIncludes = tsconfigDeclarationIncludes(fixtureRoot, sourcePath, configDir);
   // `readdirSync` order is filesystem-dependent and `Set` keeps insertion order,
   // so the discovered roots are sorted to keep the generated config byte-stable
   // for the same fixture.
   const dotRoots = [
     ...new Set([
       ...dotDirectoryIncludeRoots(fixtureRoot, vizeReport),
-      ...discoverDotDirectoryIncludeRoots(globRoots),
+      ...discoverDotDirectoryIncludeRoots(sourceBaseRoots),
     ]),
   ].sort((a, b) => a.localeCompare(b));
   const ambientRoots = [
     ...new Set(
-      [fixtureRoot, dirname(sourcePath), ...dotRoots].map((root) =>
+      [dirname(sourcePath), ...sourceBaseRoots, ...dotRoots].map((root) =>
         configRelativePath(configDir, root),
       ),
     ),
   ];
   const sourceRoots = [
-    ...new Set([...globRoots, ...dotRoots].map((root) => configRelativePath(configDir, root))),
+    ...new Set(
+      [...sourceBaseRoots, ...dotRoots].map((root) => configRelativePath(configDir, root)),
+    ),
   ];
   const config = {
     extends: configRelativePath(configDir, sourcePath),
@@ -112,6 +124,7 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
       .map((entry) => configRelativePath(configDir, resolve(fixtureRoot, entry.file))),
     include: [
       ...ambientRoots.map((root) => `${root}/**/*.d.ts`),
+      ...declarationIncludes,
       ...sourceRoots.flatMap((root) => sourceIncludeGlobs(root)),
       ...dotRoots.map((root) => `${configRelativePath(configDir, root)}/**/*.vue`),
     ],
@@ -154,6 +167,72 @@ function vueGlobSourceRoots(fixtureRoot, project) {
   const globs = typecheckCorpusGlobs(project);
   if (!Array.isArray(globs)) return [];
   return globs.map((glob) => resolve(fixtureRoot, literalGlobRoot(glob)));
+}
+
+function vizeReportSourceRoots(fixtureRoot, vizeReport) {
+  const roots = [];
+  const files = Array.isArray(vizeReport.files)
+    ? vizeReport.files.slice(0, vizeReport.fileCount)
+    : [];
+  for (const entry of files) {
+    if (typeof entry?.file !== "string") continue;
+    const root = literalGlobRoot(entry.file);
+    roots.push(resolve(fixtureRoot, root));
+  }
+  return [...new Set(roots)].sort((a, b) => a.localeCompare(b));
+}
+
+function tsconfigDeclarationIncludes(fixtureRoot, sourcePath, configDir) {
+  const declarationIncludes = winningTsconfigInclude(sourcePath, fixtureRoot);
+  if (declarationIncludes == null) return [];
+  const roots = [];
+  for (const glob of declarationIncludes.value) {
+    if (!declarationGlobCanMatch(glob)) continue;
+    const normalized = glob.replaceAll("\\", "/");
+    const root = literalGlobRoot(normalized);
+    const suffix = normalized.slice(root.length).replace(/^\//u, "");
+    const resolved = resolve(
+      declarationIncludes.dir,
+      expandConfigDir(root, declarationIncludes.dir),
+    );
+    if (!isInsideOrEqual(fixtureRoot, resolved)) continue;
+    const relativeRoot = configRelativePath(configDir, resolved);
+    roots.push(suffix.length === 0 ? relativeRoot : `${relativeRoot}/${suffix}`);
+  }
+  return [...new Set(roots)].sort((a, b) => a.localeCompare(b));
+}
+
+function winningTsconfigInclude(sourcePath, fixtureRoot) {
+  let value;
+  let dir;
+  for (const entry of [
+    ...loadTsconfigExtendsChain(sourcePath, (fromConfig, specifier) =>
+      resolveTsconfigExtends(fromConfig, specifier, fixtureRoot),
+    ),
+  ].reverse()) {
+    if (!Array.isArray(entry.config?.include)) continue;
+    value = entry.config.include.filter((include) => typeof include === "string");
+    dir = entry.dir;
+  }
+  return value == null ? null : { value, dir };
+}
+
+function resolveTsconfigExtends(fromConfig, specifier, fixtureRoot) {
+  if (typeof specifier !== "string") return null;
+  if (specifier.startsWith("./") || specifier.startsWith("../")) {
+    const resolved = resolve(dirname(fromConfig), specifier);
+    if (existsSync(resolved)) return resolved;
+    if (!resolved.endsWith(".json") && existsSync(`${resolved}.json`)) return `${resolved}.json`;
+    return null;
+  }
+  return resolvePackageExtends(fromConfig, specifier, fixtureRoot);
+}
+
+function declarationGlobCanMatch(glob) {
+  return (
+    typeof glob === "string" &&
+    (glob.includes(".d.ts") || glob.includes(".d.mts") || glob.includes(".d.cts"))
+  );
 }
 
 function literalGlobRoot(glob) {
@@ -205,6 +284,11 @@ function ignoredDirectory(name) {
 
 function isDotDirectory(name) {
   return name.startsWith(".") && name !== "." && name !== "..";
+}
+
+function isInsideOrEqual(root, target) {
+  const path = relative(root, target);
+  return path === "" || (!path.startsWith("..") && !isAbsolute(path));
 }
 
 function sourceIncludeGlobs(root) {


### PR DESCRIPTION
## Summary

- Scope generated vue-tsc baseline declaration roots to the owning tsconfig directory plus measured corpus roots instead of the whole fixture root.
- Preserve explicitly included shared `.d.ts` roots from the source tsconfig, including JSONC/extends-shaped configs, without importing sibling app declarations into package-local baselines.
- Keep root/synthetic baseline coverage intact by falling back to roots from the Vize report when registry corpus globs are unavailable.
- Add a Hoppscotch-shaped regression proving sibling app `.d.ts` files cannot import unmeasured `.vue` files into a package-local baseline program while shared root globals still stay visible.

Refs #4461

## Verification

- `VIZE_TEST_WORKSPACE_NODE_MODULES=/Users/nishimura/Code/github.com/ubugeeei/vize/tests/node_modules node --test --test-concurrency=1 tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts tests/tooling/vue-ecosystem-typecheck-corpus.test.ts tests/tooling/fixture-tool-matrix-typecheck-target.test.ts tests/tooling/fixture-tool-matrix-typecheck-corpus.test.ts tests/tooling/fixture-tool-matrix-typecheck-tsconfig.test.ts tests/tooling/typecheck-performance-shard.test.ts tests/tooling/typecheck-dependency-prepare.test.ts tests/tooling/typecheck-dependency-prepare-isolation-tsconfigs.test.ts tests/tooling/typecheck-baseline-isolation-ui-libraries.test.ts tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-baseline-project-composite.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/typecheck-dependency-gates.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/release-preflight-matrix-evidence-rejections.test.ts`
- `PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules/.bin:$PATH oxfmt --check tools/fixtures/typecheck-baseline-project.mjs tests/tooling/typecheck-baseline-project-composite.test.ts tests/tooling/typecheck-divergence-report.test.ts`
- `PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules/.bin:$PATH oxlint tools/fixtures/typecheck-baseline-project.mjs tests/tooling/typecheck-baseline-project-composite.test.ts tests/tooling/typecheck-divergence-report.test.ts`
- `node tools/davinci/assertion-lint.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts`
- `git diff --check`
