### PR TITLE
fix(matrix): retarget outside vueCompilerOptions plugin paths

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-vue-plugins.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-vue-plugins.test.ts
@@ -71,6 +71,27 @@ test("an outside relative plugin path is retargeted to the fixture copy", () => 
   }
 });
 
+test("an outside Windows relative plugin path is retargeted to the fixture copy", () => {
+  const { fixtureRoot, outer, outsidePug } = scaffold();
+  try {
+    writeLocalPug(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: {
+          plugins: [path.relative(fixtureRoot, outsidePug).replaceAll("/", "\\")],
+        },
+      })}\n`,
+    );
+    assert.deepEqual(rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, fixtureRoot), {
+      plugins: ["./node_modules/@vue/language-plugin-pug"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
 test("an outside object plugin name is retargeted", () => {
   const { fixtureRoot, outer, outsidePug } = scaffold();
   try {

--- a/tests/tooling/typecheck-baseline-outside-vue-plugins.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-vue-plugins.test.ts
@@ -1,0 +1,260 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { applyIsolatedAliasOverlay } from "../../tools/fixtures/typecheck-baseline-outside-aliases.mjs";
+import { writeIsolatedTsconfigOverlay } from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+import { rewriteOutsideVueCompilerOptions } from "../../tools/fixtures/typecheck-baseline-outside-vue-compiler.mjs";
+import { materializeBaselineProject } from "../../tools/fixtures/typecheck-baseline-project.mjs";
+
+/**
+ * Unique isolation cannot retarget `require("../../node_modules/<pkg>")`
+ * from `vueCompilerOptions.plugins` (#4461). Package-name plugins stay with
+ * unique-link. Overlay rewrite is the repair for path specifiers, and the
+ * vue-tsc baseline must apply the same rewrite so both tools measure one
+ * program.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-vue-plugins-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsidePug = path.join(outer, "node_modules", "@vue", "language-plugin-pug");
+  fs.mkdirSync(outsidePug, { recursive: true });
+  fs.writeFileSync(path.join(outsidePug, "package.json"), `{"name":"@vue/language-plugin-pug"}\n`);
+  const outsideCore = path.join(outer, "node_modules", "@vue", "language-core");
+  fs.mkdirSync(path.join(outsideCore, "types"), { recursive: true });
+  fs.writeFileSync(path.join(outsideCore, "package.json"), `{"name":"@vue/language-core"}\n`);
+  fs.writeFileSync(path.join(outsideCore, "vue-global-types.d.ts"), "export {};\n");
+  return { fixtureRoot, outer, outsideCore, outsidePug };
+}
+
+function writeLocalPug(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "@vue", "language-plugin-pug");
+  fs.mkdirSync(local, { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"@vue/language-plugin-pug"}\n`);
+  return local;
+}
+
+function writeLocalCore(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "@vue", "language-core");
+  fs.mkdirSync(local, { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"@vue/language-core"}\n`);
+  fs.writeFileSync(path.join(local, "vue-global-types.d.ts"), "export {};\n");
+  return local;
+}
+
+test("an outside relative plugin path is retargeted to the fixture copy", () => {
+  const { fixtureRoot, outer, outsidePug } = scaffold();
+  try {
+    writeLocalPug(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: {
+          strictTemplates: true,
+          plugins: [path.relative(fixtureRoot, outsidePug)],
+        },
+      })}\n`,
+    );
+    assert.deepEqual(rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, fixtureRoot), {
+      strictTemplates: true,
+      plugins: ["./node_modules/@vue/language-plugin-pug"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside object plugin name is retargeted", () => {
+  const { fixtureRoot, outer, outsidePug } = scaffold();
+  try {
+    writeLocalPug(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: {
+          plugins: [{ pretty: true, name: path.relative(fixtureRoot, outsidePug) }],
+        },
+      })}\n`,
+    );
+    assert.deepEqual(rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, fixtureRoot), {
+      plugins: [{ pretty: true, name: "./node_modules/@vue/language-plugin-pug" }],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside tuple plugin name is retargeted", () => {
+  const { fixtureRoot, outer, outsidePug } = scaffold();
+  try {
+    writeLocalPug(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: {
+          plugins: [[path.relative(fixtureRoot, outsidePug), { pretty: true }]],
+        },
+      })}\n`,
+    );
+    assert.deepEqual(rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, fixtureRoot), {
+      plugins: [["./node_modules/@vue/language-plugin-pug", { pretty: true }]],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a package-name plugin is left for unique isolation", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalPug(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: { plugins: ["@vue/language-plugin-pug"] },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an inside plugin path is left for inheritance", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalPug(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: { plugins: ["./node_modules/@vue/language-plugin-pug"] },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside plugin path is left alone when the fixture has no local package", () => {
+  const { fixtureRoot, outer, outsidePug } = scaffold();
+  try {
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: { plugins: [path.relative(fixtureRoot, outsidePug)] },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("relative extends concatenates parent plugin paths onto the overlay", () => {
+  const { fixtureRoot, outer, outsidePug } = scaffold();
+  try {
+    writeLocalPug(fixtureRoot);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.app.json"),
+      `${JSON.stringify({
+        vueCompilerOptions: { plugins: [path.relative(fixtureRoot, outsidePug)] },
+      })}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.check.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        extends: "./tsconfig.app.json",
+        vueCompilerOptions: { strictTemplates: true },
+      })}\n`,
+    );
+    const overlay = applyIsolatedAliasOverlay(
+      fixtureRoot,
+      sourcePath,
+      writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath),
+    );
+    assert.equal(overlay.path, path.join(fixtureRoot, ".vize-isolated-tsconfig.check.json"));
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.check.json",
+      vueCompilerOptions: {
+        strictTemplates: true,
+        plugins: ["./node_modules/@vue/language-plugin-pug"],
+      },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("alias overlay keeps globalTypesPath when it also rewrites plugins", () => {
+  const { fixtureRoot, outer, outsideCore, outsidePug } = scaffold();
+  try {
+    writeLocalPug(fixtureRoot);
+    writeLocalCore(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: {
+          globalTypesPath: path.relative(
+            fixtureRoot,
+            path.join(outsideCore, "vue-global-types.d.ts"),
+          ),
+          plugins: [path.relative(fixtureRoot, outsidePug)],
+        },
+      })}\n`,
+    );
+    const overlay = applyIsolatedAliasOverlay(fixtureRoot, sourcePath, null);
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.json",
+      vueCompilerOptions: {
+        globalTypesPath: "./node_modules/@vue/language-core/vue-global-types.d.ts",
+        plugins: ["./node_modules/@vue/language-plugin-pug"],
+      },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("materialized baseline retargets outside plugin paths with the overlay", () => {
+  const { outer, fixtureRoot, outsidePug } = scaffold();
+  try {
+    writeLocalPug(fixtureRoot);
+    fs.writeFileSync(path.join(fixtureRoot, "src/App.vue"), "<template />\n");
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        vueCompilerOptions: { plugins: [path.relative(fixtureRoot, outsidePug)] },
+      })}\n`,
+    );
+    const reportDir = path.join(outer, "report");
+    fs.mkdirSync(reportDir);
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      { id: "fixture", tsconfig: "tsconfig.json" },
+      { fileCount: 1, files: [{ file: "src/App.vue" }] },
+    );
+    const parsed = JSON.parse(project.source);
+    assert.deepEqual(parsed.vueCompilerOptions, {
+      plugins: ["../node_modules/@vue/language-plugin-pug"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-vue-compiler.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-vue-compiler.mjs
@@ -9,12 +9,15 @@ import { resolvePackageExtends } from "./typecheck-baseline-outside-paths.mjs";
 /**
  * Close the vue-tsc option escape unique isolation cannot see (#4461).
  *
- * `vueCompilerOptions.globalTypesPath` and `typesRoot` are filesystem or
- * package walks. Overlay `compilerOptions` cannot retarget them. An outside
- * path still loads Vize's `@vue/language-core` beside the fixture Vue.
+ * `vueCompilerOptions.globalTypesPath`, `typesRoot`, and path-form `plugins`
+ * are filesystem or package walks. Overlay `compilerOptions` cannot retarget
+ * them. An outside path still loads Vize's `@vue/language-core` or
+ * `require("../../node_modules/<pkg>")` beside the fixture Vue. Unique-link
+ * answers package-name plugins; relative plugin specifiers still walk out.
  * When the fixture already has that package, this copies every winning
- * `vueCompilerOptions` key and retargets only those two paths. Overlay
- * replaces the object, so other keys must be preserved.
+ * `vueCompilerOptions` key and retargets those paths. Overlay replaces the
+ * object, so other keys must be preserved. Plugin lists are concatenated
+ * across relative extends, matching vue-tsc.
  */
 
 const pathOptionKeys = ["globalTypesPath", "typesRoot"];
@@ -33,7 +36,39 @@ export function rewriteOutsideVueCompilerOptions(fixtureRoot, sourceConfigPath, 
     rewritten[key] = retargeted;
     changed = true;
   }
+  const plugins = [];
+  for (const { plugin, dir } of declared.plugins) {
+    const next = retargetPluginEntry(root, dir, configDir, plugin);
+    if (next.changed) changed = true;
+    plugins.push(next.value);
+  }
+  if (plugins.length > 0) rewritten.plugins = plugins;
   return changed ? rewritten : null;
+}
+
+function retargetPluginEntry(fixtureRoot, sourceDir, configDir, plugin) {
+  if (typeof plugin === "string") {
+    return retargetPluginName(fixtureRoot, sourceDir, configDir, plugin, plugin);
+  }
+  if (Array.isArray(plugin) && typeof plugin[0] === "string") {
+    const next = retargetPluginName(fixtureRoot, sourceDir, configDir, plugin[0], plugin);
+    if (!next.changed) return next;
+    return { value: [next.value, ...plugin.slice(1)], changed: true };
+  }
+  if (plugin != null && typeof plugin.name === "string") {
+    const next = retargetPluginName(fixtureRoot, sourceDir, configDir, plugin.name, plugin);
+    if (!next.changed) return next;
+    return { value: { ...plugin, name: next.value }, changed: true };
+  }
+  return { value: plugin, changed: false };
+}
+
+function retargetPluginName(fixtureRoot, sourceDir, configDir, name, fallback) {
+  if (!isPathSpecifier(name)) return { value: fallback, changed: false };
+  const retargeted = retargetVueCompilerPath(fixtureRoot, sourceDir, configDir, name);
+  return retargeted == null
+    ? { value: fallback, changed: false }
+    : { value: retargeted, changed: true };
 }
 
 function retargetVueCompilerPath(fixtureRoot, sourceDir, configDir, entry) {
@@ -73,6 +108,7 @@ function isPathSpecifier(entry) {
 function winningVueCompilerOptions(sourceConfigPath, fixtureRoot) {
   const options = {};
   const dirs = {};
+  const plugins = [];
   for (const { config, dir } of [
     ...loadTsconfigExtendsChain(
       sourceConfigPath,
@@ -84,11 +120,17 @@ function winningVueCompilerOptions(sourceConfigPath, fixtureRoot) {
     const current = config?.vueCompilerOptions;
     if (current == null || typeof current !== "object" || Array.isArray(current)) continue;
     for (const [key, value] of Object.entries(current)) {
+      if (key === "plugins") continue;
       options[key] = value;
       dirs[key] = dir;
     }
+    if (Array.isArray(current.plugins)) {
+      for (const plugin of current.plugins) plugins.push({ plugin, dir });
+    }
   }
-  return Object.keys(options).length === 0 ? null : { options, dirs };
+  return Object.keys(options).length === 0 && plugins.length === 0
+    ? null
+    : { options, dirs, plugins };
 }
 
 function resolveRelativeExtends(fromConfig, specifier, fixtureRoot) {

--- a/tools/fixtures/typecheck-baseline-outside-vue-compiler.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-vue-compiler.mjs
@@ -64,8 +64,9 @@ function retargetPluginEntry(fixtureRoot, sourceDir, configDir, plugin) {
 }
 
 function retargetPluginName(fixtureRoot, sourceDir, configDir, name, fallback) {
-  if (!isPathSpecifier(name)) return { value: fallback, changed: false };
-  const retargeted = retargetVueCompilerPath(fixtureRoot, sourceDir, configDir, name);
+  const normalized = name.replaceAll("\\", "/");
+  if (!isPathSpecifier(normalized)) return { value: fallback, changed: false };
+  const retargeted = retargetVueCompilerPath(fixtureRoot, sourceDir, configDir, normalized);
   return retargeted == null
     ? { value: fallback, changed: false }
     : { value: retargeted, changed: true };


### PR DESCRIPTION
## Summary
- Unique-link cannot retarget `require("../../node_modules/<pkg>")` from generated `vueCompilerOptions.plugins`, so vue-tsc still climbs into Vize's Vue beside the fixture (#4461).
- Overlay and vue-tsc baseline now retarget path-form plugins (string, `[name, opts]`, `{ name }`) onto the fixture copy, concatenating plugin lists across relative extends. Package-name plugins stay with unique-link.
- Reuses the #4723 `rewriteOutsideVueCompilerOptions` dual-write path so Vize and vue-tsc measure one program.

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-outside-vue-compiler.test.ts tests/tooling/typecheck-baseline-outside-vue-plugins.test.ts tests/tooling/typecheck-baseline-isolation-plugins.test.ts tests/tooling/typecheck-baseline-outside-*.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790275865&installation_model_id=422833&pr_number=4883&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4883&signature=3d512c6205f3fcc548426abcc6988b7f2002f59c68787d09dd5134f2951c8a7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue compiler plugin path handling in generated baseline projects.
  * Preserved package-based and already-local plugin references while retargeting path-based entries.
  * Maintained related compiler settings and plugin configurations inherited through extended project settings.

* **Tests**
  * Added coverage for string, object, and tuple plugin configurations, missing local packages, and materialized baseline projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->