### PR TITLE
fix(matrix): retarget outside compilerOptions plugin paths

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-compiler-plugins.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-compiler-plugins.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { applyIsolatedAliasOverlay } from "../../tools/fixtures/typecheck-baseline-outside-aliases.mjs";
+import { rewriteOutsideCompilerPlugins } from "../../tools/fixtures/typecheck-baseline-outside-compiler-plugins.mjs";
+import { writeIsolatedTsconfigOverlay } from "../../tools/fixtures/typecheck-baseline-outside-paths.mjs";
+import { materializeBaselineProject } from "../../tools/fixtures/typecheck-baseline-project.mjs";
+
+/**
+ * Unique isolation cannot retarget `require("../../node_modules/<pkg>")` from
+ * `compilerOptions.plugins` (#4461). Package-name plugins stay with unique-link.
+ * Overlay rewrite is the repair for `{ name }` path specifiers, and the vue-tsc
+ * baseline must apply the same rewrite so both tools measure one program.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-compiler-plugins-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsidePlugin = path.join(outer, "node_modules", "typescript-plugin-css-modules");
+  fs.mkdirSync(outsidePlugin, { recursive: true });
+  fs.writeFileSync(
+    path.join(outsidePlugin, "package.json"),
+    `{"name":"typescript-plugin-css-modules"}\n`,
+  );
+  return { fixtureRoot, outer, outsidePlugin };
+}
+
+function writeLocalPlugin(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "typescript-plugin-css-modules");
+  fs.mkdirSync(local, { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"typescript-plugin-css-modules"}\n`);
+  return local;
+}
+
+test("an outside compiler plugin name is retargeted to the fixture copy", () => {
+  const { fixtureRoot, outer, outsidePlugin } = scaffold();
+  try {
+    writeLocalPlugin(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          plugins: [{ pretty: true, name: path.relative(fixtureRoot, outsidePlugin) }],
+        },
+      })}\n`,
+    );
+    assert.deepEqual(rewriteOutsideCompilerPlugins(fixtureRoot, sourcePath, fixtureRoot), [
+      { pretty: true, name: "./node_modules/typescript-plugin-css-modules" },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a package-name compiler plugin is left for unique isolation", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalPlugin(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { plugins: [{ name: "typescript-plugin-css-modules" }] },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideCompilerPlugins(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an inside compiler plugin path is left for inheritance", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalPlugin(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          plugins: [{ name: "./node_modules/typescript-plugin-css-modules" }],
+        },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideCompilerPlugins(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside compiler plugin is left alone when the fixture has no local package", () => {
+  const { fixtureRoot, outer, outsidePlugin } = scaffold();
+  try {
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { plugins: [{ name: path.relative(fixtureRoot, outsidePlugin) }] },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideCompilerPlugins(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("relative extends concatenates parent compiler plugin paths onto the overlay", () => {
+  const { fixtureRoot, outer, outsidePlugin } = scaffold();
+  try {
+    writeLocalPlugin(fixtureRoot);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.app.json"),
+      `${JSON.stringify({
+        compilerOptions: { plugins: [{ name: path.relative(fixtureRoot, outsidePlugin) }] },
+      })}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.check.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        extends: "./tsconfig.app.json",
+        compilerOptions: { strict: true },
+      })}\n`,
+    );
+    const overlay = applyIsolatedAliasOverlay(
+      fixtureRoot,
+      sourcePath,
+      writeIsolatedTsconfigOverlay(fixtureRoot, sourcePath),
+    );
+    assert.equal(overlay.path, path.join(fixtureRoot, ".vize-isolated-tsconfig.check.json"));
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.check.json",
+      compilerOptions: {
+        plugins: [{ name: "./node_modules/typescript-plugin-css-modules" }],
+      },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("materialized baseline retargets outside compiler plugin paths with the overlay", () => {
+  const { outer, fixtureRoot, outsidePlugin } = scaffold();
+  try {
+    writeLocalPlugin(fixtureRoot);
+    fs.writeFileSync(path.join(fixtureRoot, "src/App.vue"), "<template />\n");
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { plugins: [{ name: path.relative(fixtureRoot, outsidePlugin) }] },
+      })}\n`,
+    );
+    const reportDir = path.join(outer, "report");
+    fs.mkdirSync(reportDir);
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      { id: "fixture", tsconfig: "tsconfig.json" },
+      { fileCount: 1, files: [{ file: "src/App.vue" }] },
+    );
+    const parsed = JSON.parse(project.source);
+    assert.deepEqual(parsed.compilerOptions.plugins, [
+      { name: "../node_modules/typescript-plugin-css-modules" },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-aliases.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-aliases.mjs
@@ -10,6 +10,7 @@ import {
   resolvePackageExtends,
 } from "./typecheck-baseline-outside-paths.mjs";
 import { rewriteOutsideVueCompilerOptions } from "./typecheck-baseline-outside-vue-compiler.mjs";
+import { rewriteOutsideCompilerPlugins } from "./typecheck-baseline-outside-compiler-plugins.mjs";
 
 /**
  * Close the remaining `compilerOptions.paths` escape for keys that are not
@@ -66,7 +67,8 @@ export function applyIsolatedAliasOverlay(fixtureRoot, sourceConfigPath, overlay
   const configDir = dirname(sourcePath);
   const aliases = rewriteOutsideAliasPaths(fixtureRoot, sourcePath, configDir);
   const vueCompilerOptions = rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, configDir);
-  if (aliases == null && vueCompilerOptions == null) return overlay ?? null;
+  const plugins = rewriteOutsideCompilerPlugins(fixtureRoot, sourcePath, configDir);
+  if (aliases == null && vueCompilerOptions == null && plugins == null) return overlay ?? null;
   const paths = mergePathRewrites(overlay?.paths ?? null, aliases);
   const typeRoots = overlay?.typeRoots ?? null;
   const rootDirs = overlay?.rootDirs ?? null;
@@ -75,6 +77,7 @@ export function applyIsolatedAliasOverlay(fixtureRoot, sourceConfigPath, overlay
   if (paths != null) compilerOptions.paths = paths;
   if (typeRoots != null) compilerOptions.typeRoots = typeRoots;
   if (rootDirs != null) compilerOptions.rootDirs = rootDirs;
+  if (plugins != null) compilerOptions.plugins = plugins;
   if (paths != null && isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) {
     compilerOptions.baseUrl = ".";
   }
@@ -82,7 +85,7 @@ export function applyIsolatedAliasOverlay(fixtureRoot, sourceConfigPath, overlay
   if (Object.keys(compilerOptions).length > 0) document.compilerOptions = compilerOptions;
   if (vueCompilerOptions != null) document.vueCompilerOptions = vueCompilerOptions;
   writeFileSync(overlayPath, `${JSON.stringify(document, null, 2)}\n`);
-  return { path: overlayPath, paths, typeRoots, rootDirs, vueCompilerOptions };
+  return { path: overlayPath, paths, typeRoots, rootDirs, vueCompilerOptions, plugins };
 }
 
 function retargetAliasMapping(

--- a/tools/fixtures/typecheck-baseline-outside-compiler-plugins.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-compiler-plugins.mjs
@@ -1,0 +1,139 @@
+import { existsSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+
+import { resolveWithConfigDir } from "./typecheck-baseline-config-dir.mjs";
+import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs";
+import { resolvePackageExtends } from "./typecheck-baseline-outside-paths.mjs";
+
+/**
+ * Close the TypeScript plugin require unique isolation cannot retarget (#4461).
+ *
+ * Unique-link answers `require("typescript-plugin-css-modules")`. Generated
+ * configs also write `{ "name": "../../node_modules/<pkg>" }`, which loads
+ * from outside the fixture. Overlay `paths` cannot rewrite
+ * `compilerOptions.plugins`. When the fixture already has that package,
+ * retarget path-form `{ name }` specifiers. Package-name plugins stay with
+ * unique-link. Plugin lists are concatenated across relative extends,
+ * matching tsc.
+ */
+
+export function rewriteOutsideCompilerPlugins(fixtureRoot, sourceConfigPath, configDir) {
+  const root = resolve(fixtureRoot);
+  const declared = winningCompilerPlugins(sourceConfigPath, root);
+  if (declared.length === 0) return null;
+  let changed = false;
+  const plugins = declared.map(({ plugin, dir }) => {
+    const next = retargetCompilerPlugin(root, dir, configDir, plugin);
+    if (next.changed) changed = true;
+    return next.value;
+  });
+  return changed ? plugins : null;
+}
+
+function retargetCompilerPlugin(fixtureRoot, sourceDir, configDir, plugin) {
+  if (plugin == null || typeof plugin.name !== "string") {
+    return { value: plugin, changed: false };
+  }
+  if (!isPathSpecifier(plugin.name)) return { value: plugin, changed: false };
+  const retargeted = retargetCompilerPluginPath(fixtureRoot, sourceDir, configDir, plugin.name);
+  if (retargeted == null) return { value: plugin, changed: false };
+  return { value: { ...plugin, name: retargeted }, changed: true };
+}
+
+function retargetCompilerPluginPath(fixtureRoot, sourceDir, configDir, entry) {
+  const original = resolveWithConfigDir(sourceDir, sourceDir, entry);
+  if (isInside(fixtureRoot, original)) return null;
+  const owned = owningNodeModulePackage(original);
+  if (owned == null) return null;
+  return localPackageTarget(fixtureRoot, configDir, owned.name, relative(owned.root, original));
+}
+
+function localPackageTarget(fixtureRoot, configDir, name, subpath) {
+  const local = join(fixtureRoot, "node_modules", ...name.split("/"));
+  if (!existsSync(join(local, "package.json"))) return null;
+  const nested = typeof subpath === "string" ? subpath.replaceAll("\\", "/") : "";
+  if (nested.startsWith("..") || nested.startsWith("/")) return null;
+  const target = nested === "" ? local : join(local, nested);
+  if (nested !== "" && !existsSync(target)) return null;
+  return configRelativePath(configDir, target);
+}
+
+function isPathSpecifier(entry) {
+  return (
+    entry.startsWith("./") ||
+    entry.startsWith("../") ||
+    entry.startsWith("/") ||
+    entry.includes("/node_modules/") ||
+    entry.includes("${configDir}")
+  );
+}
+
+function winningCompilerPlugins(sourceConfigPath, fixtureRoot) {
+  const plugins = [];
+  for (const { config, dir } of [
+    ...loadTsconfigExtendsChain(
+      sourceConfigPath,
+      (fromConfig, specifier) =>
+        resolveRelativeExtends(fromConfig, specifier, fixtureRoot) ??
+        resolvePackageExtends(fromConfig, specifier, fixtureRoot),
+    ),
+  ].reverse()) {
+    const current = config?.compilerOptions?.plugins;
+    if (!Array.isArray(current)) continue;
+    for (const plugin of current) plugins.push({ plugin, dir });
+  }
+  return plugins;
+}
+
+function resolveRelativeExtends(fromConfig, specifier, fixtureRoot) {
+  if (typeof specifier !== "string") return null;
+  if (!(specifier.startsWith("./") || specifier.startsWith("../"))) return null;
+  const resolved = resolve(dirname(fromConfig), specifier);
+  const file = existsSync(resolved)
+    ? resolved
+    : !resolved.endsWith(".json") && existsSync(`${resolved}.json`)
+      ? `${resolved}.json`
+      : null;
+  if (file == null || !isInside(fixtureRoot, file)) return null;
+  return file;
+}
+
+function owningNodeModulePackage(resolvedPath) {
+  let directory = resolvedPath;
+  let previous = null;
+  while (directory !== previous) {
+    if (existsSync(join(directory, "package.json"))) {
+      const owned = nodeModulePackageName(directory);
+      if (owned != null) return owned;
+    }
+    previous = directory;
+    directory = dirname(directory);
+  }
+  return null;
+}
+
+function nodeModulePackageName(packageRoot) {
+  const parent = dirname(packageRoot);
+  const grandparent = dirname(parent);
+  if (basename(parent) === "node_modules") {
+    return { name: basename(packageRoot), root: packageRoot };
+  }
+  if (basename(grandparent) === "node_modules" && basename(parent).startsWith("@")) {
+    return {
+      name: `${basename(parent)}/${basename(packageRoot)}`,
+      root: packageRoot,
+    };
+  }
+  return null;
+}
+
+function isInside(root, target) {
+  const path = relative(root, target);
+  return path !== "" && !path.startsWith("..") && !path.startsWith("/");
+}
+
+function configRelativePath(from, to) {
+  const path = relative(from, to).replaceAll("\\", "/");
+  if (path.startsWith("/") || /^[A-Za-z]:\//u.test(path)) return path;
+  return path.startsWith(".") ? path : `./${path}`;
+}

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -12,6 +12,7 @@ import {
   rewriteOutsideTypeRoots,
 } from "./typecheck-baseline-outside-paths.mjs";
 import { rewriteOutsideVueCompilerOptions } from "./typecheck-baseline-outside-vue-compiler.mjs";
+import { rewriteOutsideCompilerPlugins } from "./typecheck-baseline-outside-compiler-plugins.mjs";
 import { typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
 
 /**
@@ -141,6 +142,8 @@ function outsideCompilerOptions(fixtureRoot, sourcePath, configDir) {
   if (typeRoots != null) options.typeRoots = typeRoots;
   const rootDirs = rewriteOutsideRootDirs(fixtureRoot, sourcePath, configDir);
   if (rootDirs != null) options.rootDirs = rootDirs;
+  const plugins = rewriteOutsideCompilerPlugins(fixtureRoot, sourcePath, configDir);
+  if (plugins != null) options.plugins = plugins;
   return options;
 }
 


### PR DESCRIPTION
## Summary
- Unique-link cannot retarget `require("../../node_modules/<pkg>")` from generated `compilerOptions.plugins`, so tsc/vue-tsc still climb into Vize's copy beside the fixture (#4461).
- Overlay and vue-tsc baseline now retarget path-form `{ name }` plugins onto the fixture copy, concatenating plugin lists across relative extends. Package-name plugins stay with unique-link.
- Independent of #4883 (`vueCompilerOptions.plugins`); that PR covers Vue language plugins, this one covers TypeScript `compilerOptions.plugins`.

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-outside-compiler-plugins.test.ts tests/tooling/typecheck-baseline-outside-vue-compiler.test.ts tests/tooling/typecheck-baseline-outside-aliases.test.ts tests/tooling/typecheck-baseline-isolation-plugins.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790276133&installation_model_id=422833&pr_number=4884&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4884&signature=87b9b77e24d8fc7c73768b825cc1ea67e42285440163905204ef95148ffed601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->