### PR TITLE
fix(matrix): retarget outside jsxImportSource paths

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-jsx.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-jsx.test.ts
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  applyIsolatedJsxBaseline,
+  applyIsolatedJsxOverlay,
+  rewriteOutsideJsxImportSource,
+} from "../../tools/fixtures/typecheck-baseline-outside-jsx.mjs";
+import { applyIsolatedTypecheckOverlays } from "../../tools/fixtures/typecheck-baseline-outside-overlays.mjs";
+
+/**
+ * Unique isolation cannot retarget `jsxImportSource: "../../node_modules/vue"`
+ * (#4461). Package-name sources stay with unique-link. Overlay rewrite is the
+ * repair for path specifiers, and the vue-tsc baseline must apply the same
+ * rewrite so both tools measure one program.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-jsx-")));
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  const outsideVue = path.join(outer, "node_modules", "vue");
+  fs.mkdirSync(outsideVue, { recursive: true });
+  fs.writeFileSync(path.join(outsideVue, "package.json"), `{"name":"vue"}\n`);
+  return { fixtureRoot, outer, outsideVue };
+}
+
+function writeLocalVue(fixtureRoot: string) {
+  const local = path.join(fixtureRoot, "node_modules", "vue");
+  fs.mkdirSync(local, { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue"}\n`);
+  return local;
+}
+
+test("an outside jsxImportSource path is retargeted to the fixture copy", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { jsxImportSource: path.relative(fixtureRoot, outsideVue) },
+      })}\n`,
+    );
+    assert.equal(
+      rewriteOutsideJsxImportSource(fixtureRoot, sourcePath, fixtureRoot),
+      "./node_modules/vue",
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a package-name jsxImportSource is left for unique isolation", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({ compilerOptions: { jsxImportSource: "vue" } })}\n`,
+    );
+    assert.equal(rewriteOutsideJsxImportSource(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an inside jsxImportSource path is left for inheritance", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { jsxImportSource: "./node_modules/vue" },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideJsxImportSource(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("an outside jsxImportSource is left alone when the fixture has no local package", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { jsxImportSource: path.relative(fixtureRoot, outsideVue) },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideJsxImportSource(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("child jsxImportSource replaces a parent path specifier", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.app.json"),
+      `${JSON.stringify({
+        compilerOptions: { jsxImportSource: path.relative(fixtureRoot, outsideVue) },
+      })}\n`,
+    );
+    const sourcePath = path.join(fixtureRoot, "tsconfig.check.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        extends: "./tsconfig.app.json",
+        compilerOptions: { jsxImportSource: "preact" },
+      })}\n`,
+    );
+    assert.equal(rewriteOutsideJsxImportSource(fixtureRoot, sourcePath, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("overlay write keeps existing compilerOptions and vueCompilerOptions", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { jsxImportSource: path.relative(fixtureRoot, outsideVue) },
+      })}\n`,
+    );
+    const overlayPath = path.join(fixtureRoot, ".vize-isolated-tsconfig.json");
+    fs.writeFileSync(
+      overlayPath,
+      `${JSON.stringify({
+        extends: "./tsconfig.json",
+        compilerOptions: { paths: { vue: ["./node_modules/vue"] } },
+        vueCompilerOptions: { strictTemplates: true },
+      })}\n`,
+    );
+    const overlay = applyIsolatedJsxOverlay(fixtureRoot, sourcePath, { path: overlayPath });
+    assert.equal(overlay.path, overlayPath);
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlayPath, "utf8")), {
+      extends: "./tsconfig.json",
+      compilerOptions: {
+        paths: { vue: ["./node_modules/vue"] },
+        jsxImportSource: "./node_modules/vue",
+      },
+      vueCompilerOptions: { strictTemplates: true },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("shared overlay helper writes jsxImportSource when path overlay is empty", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { jsxImportSource: path.relative(fixtureRoot, outsideVue) },
+      })}\n`,
+    );
+    const overlay = applyIsolatedTypecheckOverlays(fixtureRoot, sourcePath);
+    assert.equal(overlay.path, path.join(fixtureRoot, ".vize-isolated-tsconfig.json"));
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.json",
+      compilerOptions: { jsxImportSource: "./node_modules/vue" },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("baseline post-process retargets jsxImportSource relative to the generated config", () => {
+  const { fixtureRoot, outer, outsideVue } = scaffold();
+  try {
+    writeLocalVue(fixtureRoot);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: { jsxImportSource: path.relative(fixtureRoot, outsideVue) },
+      })}\n`,
+    );
+    const baselineDir = path.join(fixtureRoot, ".vize-baseline");
+    fs.mkdirSync(baselineDir);
+    const baselinePath = path.join(baselineDir, "tsconfig.json");
+    fs.writeFileSync(
+      baselinePath,
+      `${JSON.stringify({
+        extends: "../tsconfig.json",
+        compilerOptions: { rootDir: ".." },
+      })}\n`,
+    );
+    assert.equal(
+      applyIsolatedJsxBaseline(fixtureRoot, sourcePath, baselinePath),
+      "../node_modules/vue",
+    );
+    assert.deepEqual(JSON.parse(fs.readFileSync(baselinePath, "utf8")), {
+      extends: "../tsconfig.json",
+      compilerOptions: { rootDir: "..", jsxImportSource: "../node_modules/vue" },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-outside-jsx.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-jsx.mjs
@@ -1,0 +1,154 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, dirname, join, relative, resolve } from "node:path";
+
+import { resolveWithConfigDir } from "./typecheck-baseline-config-dir.mjs";
+import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs";
+import {
+  isolatedTsconfigOverlayPath,
+  resolvePackageExtends,
+} from "./typecheck-baseline-outside-paths.mjs";
+
+/**
+ * Close the jsx-runtime walk unique isolation cannot retarget (#4461).
+ *
+ * Unique-link answers `require("vue/jsx-runtime")`. Generated configs also
+ * write `jsxImportSource: "../../node_modules/vue"`, which TypeScript resolves
+ * from the tsconfig directory and loads Vize's Vue beside the fixture.
+ * Overlay `paths` cannot rewrite `compilerOptions.jsxImportSource`. When the
+ * fixture already has that package, retarget path specifiers. Package-name
+ * sources stay with unique-link. Child replaces parent, matching tsc.
+ */
+
+export function rewriteOutsideJsxImportSource(fixtureRoot, sourceConfigPath, configDir) {
+  const root = resolve(fixtureRoot);
+  const declared = winningJsxImportSource(sourceConfigPath, root);
+  if (declared == null) return null;
+  if (!isPathSpecifier(declared.specifier)) return null;
+  return retargetJsxImportSourcePath(root, declared.dir, configDir, declared.specifier);
+}
+
+export function applyIsolatedJsxOverlay(fixtureRoot, sourceConfigPath, overlay) {
+  const sourcePath = resolve(sourceConfigPath);
+  const rewritten = rewriteOutsideJsxImportSource(fixtureRoot, sourcePath, dirname(sourcePath));
+  if (rewritten == null) return overlay ?? null;
+  const overlayPath = overlay?.path ?? isolatedTsconfigOverlayPath(sourcePath);
+  const document = existsSync(overlayPath)
+    ? JSON.parse(readFileSync(overlayPath, "utf8"))
+    : { extends: `./${basename(sourcePath)}` };
+  document.compilerOptions = { ...(document.compilerOptions ?? {}), jsxImportSource: rewritten };
+  writeFileSync(overlayPath, `${JSON.stringify(document, null, 2)}\n`);
+  return { ...(overlay ?? {}), path: overlayPath, jsxImportSource: rewritten };
+}
+
+export function applyIsolatedJsxBaseline(fixtureRoot, sourceConfigPath, baselinePath) {
+  const rewritten = rewriteOutsideJsxImportSource(
+    fixtureRoot,
+    resolve(sourceConfigPath),
+    dirname(resolve(baselinePath)),
+  );
+  if (rewritten == null) return null;
+  const document = JSON.parse(readFileSync(baselinePath, "utf8"));
+  document.compilerOptions = { ...(document.compilerOptions ?? {}), jsxImportSource: rewritten };
+  writeFileSync(baselinePath, `${JSON.stringify(document, null, 2)}\n`);
+  return rewritten;
+}
+
+function retargetJsxImportSourcePath(fixtureRoot, sourceDir, configDir, entry) {
+  const original = resolveWithConfigDir(sourceDir, sourceDir, entry);
+  if (isInside(fixtureRoot, original)) return null;
+  const owned = owningNodeModulePackage(original);
+  if (owned == null) return null;
+  return localPackageTarget(fixtureRoot, configDir, owned.name, relative(owned.root, original));
+}
+
+function localPackageTarget(fixtureRoot, configDir, name, subpath) {
+  const local = join(fixtureRoot, "node_modules", ...name.split("/"));
+  if (!existsSync(join(local, "package.json"))) return null;
+  const nested = typeof subpath === "string" ? subpath.replaceAll("\\", "/") : "";
+  if (nested.startsWith("..") || nested.startsWith("/")) return null;
+  const target = nested === "" ? local : join(local, nested);
+  if (nested !== "" && !existsSync(target)) return null;
+  return configRelativePath(configDir, target);
+}
+
+function isPathSpecifier(entry) {
+  return (
+    entry.startsWith("./") ||
+    entry.startsWith("../") ||
+    entry.startsWith("/") ||
+    entry.includes("/node_modules/") ||
+    entry.includes("${configDir}")
+  );
+}
+
+function winningJsxImportSource(sourceConfigPath, fixtureRoot) {
+  let specifier = null;
+  let dir = null;
+  for (const { config, dir: configDir } of [
+    ...loadTsconfigExtendsChain(
+      sourceConfigPath,
+      (fromConfig, specifier) =>
+        resolveRelativeExtends(fromConfig, specifier, fixtureRoot) ??
+        resolvePackageExtends(fromConfig, specifier, fixtureRoot),
+    ),
+  ].reverse()) {
+    const candidate = config?.compilerOptions?.jsxImportSource;
+    if (typeof candidate !== "string") continue;
+    specifier = candidate;
+    dir = configDir;
+  }
+  return specifier == null ? null : { specifier, dir };
+}
+
+function resolveRelativeExtends(fromConfig, specifier, fixtureRoot) {
+  if (typeof specifier !== "string") return null;
+  if (!(specifier.startsWith("./") || specifier.startsWith("../"))) return null;
+  const resolved = resolve(dirname(fromConfig), specifier);
+  const file = existsSync(resolved)
+    ? resolved
+    : !resolved.endsWith(".json") && existsSync(`${resolved}.json`)
+      ? `${resolved}.json`
+      : null;
+  if (file == null || !isInside(fixtureRoot, file)) return null;
+  return file;
+}
+
+function owningNodeModulePackage(resolvedPath) {
+  let directory = resolvedPath;
+  let previous = null;
+  while (directory !== previous) {
+    if (existsSync(join(directory, "package.json"))) {
+      const owned = nodeModulePackageName(directory);
+      if (owned != null) return owned;
+    }
+    previous = directory;
+    directory = dirname(directory);
+  }
+  return null;
+}
+
+function nodeModulePackageName(packageRoot) {
+  const parent = dirname(packageRoot);
+  const grandparent = dirname(parent);
+  if (basename(parent) === "node_modules") {
+    return { name: basename(packageRoot), root: packageRoot };
+  }
+  if (basename(grandparent) === "node_modules" && basename(parent).startsWith("@")) {
+    return {
+      name: `${basename(parent)}/${basename(packageRoot)}`,
+      root: packageRoot,
+    };
+  }
+  return null;
+}
+
+function isInside(root, target) {
+  const path = relative(root, target);
+  return path !== "" && !path.startsWith("..") && !path.startsWith("/");
+}
+
+function configRelativePath(from, to) {
+  const path = relative(from, to).replaceAll("\\", "/");
+  if (path.startsWith("/") || /^[A-Za-z]:\//u.test(path)) return path;
+  return path.startsWith(".") ? path : `./${path}`;
+}

--- a/tools/fixtures/typecheck-baseline-outside-jsx.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-jsx.mjs
@@ -35,9 +35,9 @@ export function applyIsolatedJsxOverlay(fixtureRoot, sourceConfigPath, overlay) 
   const document = existsSync(overlayPath)
     ? JSON.parse(readFileSync(overlayPath, "utf8"))
     : { extends: `./${basename(sourcePath)}` };
-  document.compilerOptions = { ...(document.compilerOptions ?? {}), jsxImportSource: rewritten };
+  document.compilerOptions = { ...document.compilerOptions, jsxImportSource: rewritten };
   writeFileSync(overlayPath, `${JSON.stringify(document, null, 2)}\n`);
-  return { ...(overlay ?? {}), path: overlayPath, jsxImportSource: rewritten };
+  return { ...overlay, path: overlayPath, jsxImportSource: rewritten };
 }
 
 export function applyIsolatedJsxBaseline(fixtureRoot, sourceConfigPath, baselinePath) {
@@ -48,7 +48,7 @@ export function applyIsolatedJsxBaseline(fixtureRoot, sourceConfigPath, baseline
   );
   if (rewritten == null) return null;
   const document = JSON.parse(readFileSync(baselinePath, "utf8"));
-  document.compilerOptions = { ...(document.compilerOptions ?? {}), jsxImportSource: rewritten };
+  document.compilerOptions = { ...document.compilerOptions, jsxImportSource: rewritten };
   writeFileSync(baselinePath, `${JSON.stringify(document, null, 2)}\n`);
   return rewritten;
 }

--- a/tools/fixtures/typecheck-baseline-outside-overlays.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-overlays.mjs
@@ -1,0 +1,20 @@
+import { applyIsolatedAliasOverlay } from "./typecheck-baseline-outside-aliases.mjs";
+import { applyIsolatedJsxOverlay } from "./typecheck-baseline-outside-jsx.mjs";
+import { writeIsolatedTsconfigOverlay } from "./typecheck-baseline-outside-paths.mjs";
+
+/**
+ * Write every isolated tsconfig overlay Vize and vue-tsc share (#4461).
+ * JSX retargeting runs after path/alias rewrite so it can merge into the
+ * same untracked overlay without growing `typecheck-dependency-prepare.mjs`.
+ */
+export function applyIsolatedTypecheckOverlays(fixtureRoot, sourceConfigPath) {
+  return applyIsolatedJsxOverlay(
+    fixtureRoot,
+    sourceConfigPath,
+    applyIsolatedAliasOverlay(
+      fixtureRoot,
+      sourceConfigPath,
+      writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfigPath),
+    ),
+  );
+}

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -17,8 +17,7 @@ import {
   isolateUniqueVueRuntimePackages,
   isolateUniqueVueUsePackages,
 } from "./typecheck-baseline-isolation-unique.mjs";
-import { applyIsolatedAliasOverlay } from "./typecheck-baseline-outside-aliases.mjs";
-import { writeIsolatedTsconfigOverlay } from "./typecheck-baseline-outside-paths.mjs";
+import { applyIsolatedTypecheckOverlays } from "./typecheck-baseline-outside-overlays.mjs";
 import { selectTypecheckPerformanceProjects } from "./typecheck-performance-shard.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -180,11 +179,7 @@ function isolateFixture(project, fixtureRoot) {
   }
   for (const relativeConfig of isolationTsconfigPaths(project)) {
     const sourceConfig = resolve(fixtureRoot, relativeConfig);
-    const overlay = applyIsolatedAliasOverlay(
-      fixtureRoot,
-      sourceConfig,
-      writeIsolatedTsconfigOverlay(fixtureRoot, sourceConfig),
-    );
+    const overlay = applyIsolatedTypecheckOverlays(fixtureRoot, sourceConfig);
     if (overlay != null) {
       process.stdout.write(
         `Rewrote ${project.id} tsconfig overlay -> ${relative(fixtureRoot, overlay.path)}\n`,

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -11,6 +11,8 @@ import { selectTypecheckPerformanceProjects } from "./typecheck-performance-shar
 import { evaluateBaselineAmbientEnvironment } from "./typecheck-baseline-ambient.mjs";
 import { evaluateBaselineConfiguration } from "./typecheck-baseline-configuration.mjs";
 import { materializeBaselineProject } from "./typecheck-baseline-project.mjs";
+import { applyIsolatedJsxBaseline } from "./typecheck-baseline-outside-jsx.mjs";
+import { typecheckSourceTsconfig } from "./tool-matrix-command.mjs";
 import { runVueTscBaseline } from "./typecheck-baseline-run.mjs";
 import { evaluateVueProgramCoverage } from "./typecheck-baseline-coverage.mjs";
 import { assertBudgetsPassed, evaluateBudget } from "./typecheck-divergence-budget.mjs";
@@ -68,6 +70,14 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
       project,
       vizeRun.payload.parsed,
     );
+    const sourceTsconfig = typecheckSourceTsconfig(project);
+    if (sourceTsconfig != null) {
+      applyIsolatedJsxBaseline(
+        fixtureRoot,
+        resolve(fixtureRoot, sourceTsconfig),
+        baselineProject.path,
+      );
+    }
     const baselineArgs = ["--noEmit", "--pretty", "false", "-p", baselineProject.path];
     const coverageArgs = [
       "--noEmit",


### PR DESCRIPTION
## Summary
- Unique-link cannot retarget `compilerOptions.jsxImportSource: "../../node_modules/vue"` from generated tsconfigs, so TypeScript still loads Vize's Vue beside the fixture (#4461).
- Overlay and vue-tsc baseline now rewrite path-form `jsxImportSource` onto the fixture copy. Package-name sources stay with unique-link; child still replaces parent, matching tsc.
- Wired through a shared overlay helper so `typecheck-dependency-prepare.mjs` stays under the 350-line budget. Independent of #4883 (`vueCompilerOptions.plugins`) and #4884 (`compilerOptions.plugins`); those overlay writes are preserved when this merge lands.

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-outside-*.test.ts tests/tooling/typecheck-baseline-isolation-jsx.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790276382&installation_model_id=422833&pr_number=4885&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4885&signature=78e1dbf89eb591fa234de8f9d2f1f56737d7076396ad8c642adfb1f11367fa56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->