### PR TITLE
fix(matrix): pin Vue runtime overlay paths onto the fixture copy

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-vue-runtime.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-vue-runtime.test.ts
@@ -161,3 +161,32 @@ test("an ancestor @vue/runtime-core with exactly one in-fixture copy is linked",
     fs.rmSync(outer, { recursive: true, force: true });
   }
 });
+
+test("a nested runtime-dom store copy is hoisted when no ancestor is hoisted", () => {
+  const { fixtureRoot, outer } = scaffold([]);
+  try {
+    writeStoreCopy(fixtureRoot, "@vue+runtime-dom@3.5.30", "@vue/runtime-dom");
+    assert.deepEqual(isolateUniqueVueRuntimePackages(fixtureRoot), [
+      {
+        name: "@vue/runtime-dom",
+        target: "node_modules/.pnpm/@vue+runtime-dom@3.5.30/node_modules/@vue/runtime-dom",
+      },
+    ]);
+    assert.equal(
+      fs.realpathSync(path.join(fixtureRoot, "node_modules", "@vue", "runtime-dom")),
+      fs.realpathSync(
+        path.join(
+          fixtureRoot,
+          "node_modules",
+          ".pnpm",
+          "@vue+runtime-dom@3.5.30",
+          "node_modules",
+          "@vue",
+          "runtime-dom",
+        ),
+      ),
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/typecheck-baseline-outside-vue-runtime-paths.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-vue-runtime-paths.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { applyIsolatedAliasOverlay } from "../../tools/fixtures/typecheck-baseline-outside-aliases.mjs";
+import { rewriteLocalVueRuntimePaths } from "../../tools/fixtures/typecheck-baseline-outside-vue-runtime-paths.mjs";
+import { materializeBaselineProject } from "../../tools/fixtures/typecheck-baseline-project.mjs";
+
+/**
+ * vue-tsc language-core still resolves `@vue/runtime-dom` from Vize's store
+ * beside the fixture Vue (#4461). Overlay `paths` pin the program onto the
+ * fixture copy when unique isolation has already placed that package.
+ */
+
+function scaffold() {
+  const outer = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "vize-baseline-vue-runtime-paths-")),
+  );
+  const fixtureRoot = path.join(outer, "fixture");
+  fs.mkdirSync(path.join(fixtureRoot, "src"), { recursive: true });
+  return { fixtureRoot, outer };
+}
+
+function writeLocalRuntime(fixtureRoot: string, name: string) {
+  const local = path.join(fixtureRoot, "node_modules", ...name.split("/"));
+  fs.mkdirSync(local, { recursive: true });
+  fs.writeFileSync(path.join(local, "package.json"), `{"name":"${name}"}\n`);
+  return local;
+}
+
+test("local Vue runtime packages are pinned onto overlay paths", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalRuntime(fixtureRoot, "vue");
+    writeLocalRuntime(fixtureRoot, "@vue/runtime-dom");
+    writeLocalRuntime(fixtureRoot, "@vue/runtime-core");
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(sourcePath, `{}\n`);
+    assert.deepEqual(rewriteLocalVueRuntimePaths(fixtureRoot, fixtureRoot), {
+      "@vue/runtime-core": ["./node_modules/@vue/runtime-core"],
+      "@vue/runtime-dom": ["./node_modules/@vue/runtime-dom"],
+      vue: ["./node_modules/vue"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a missing local Vue runtime package is not guessed", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(sourcePath, `{}\n`);
+    assert.equal(rewriteLocalVueRuntimePaths(fixtureRoot, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("alias overlay writes Vue runtime paths and keeps hash aliases", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalRuntime(fixtureRoot, "@vue/runtime-dom");
+    const outsideNuxt = path.join(outer, "node_modules", "nuxt");
+    fs.mkdirSync(path.join(outsideNuxt, "dist", "app"), { recursive: true });
+    fs.writeFileSync(path.join(outsideNuxt, "package.json"), `{"name":"nuxt"}\n`);
+    const localNuxt = path.join(fixtureRoot, "node_modules", "nuxt");
+    fs.mkdirSync(path.join(localNuxt, "dist", "app"), { recursive: true });
+    fs.writeFileSync(path.join(localNuxt, "package.json"), `{"name":"nuxt"}\n`);
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(
+      sourcePath,
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: { "#app": [path.relative(fixtureRoot, path.join(outsideNuxt, "dist", "app"))] },
+        },
+      })}\n`,
+    );
+    const overlay = applyIsolatedAliasOverlay(fixtureRoot, sourcePath, null);
+    assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
+      extends: "./tsconfig.json",
+      compilerOptions: {
+        paths: {
+          "#app": ["./node_modules/nuxt/dist/app"],
+          "@vue/runtime-dom": ["./node_modules/@vue/runtime-dom"],
+        },
+      },
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("materialized baseline pins Vue runtime paths relative to the generated config", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    writeLocalRuntime(fixtureRoot, "@vue/runtime-dom");
+    fs.writeFileSync(path.join(fixtureRoot, "src/App.vue"), "<template />\n");
+    const sourcePath = path.join(fixtureRoot, "tsconfig.json");
+    fs.writeFileSync(sourcePath, `{}\n`);
+    const reportDir = path.join(outer, "report");
+    fs.mkdirSync(reportDir);
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      { id: "fixture", tsconfig: "tsconfig.json" },
+      { fileCount: 1, files: [{ file: "src/App.vue" }] },
+    );
+    const parsed = JSON.parse(project.source);
+    assert.deepEqual(parsed.compilerOptions.paths, {
+      "@vue/runtime-dom": ["../node_modules/@vue/runtime-dom"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/tools/fixtures/typecheck-baseline-isolation-unique.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation-unique.mjs
@@ -34,6 +34,9 @@ import { ancestorPackagePath } from "./typecheck-baseline-isolation-package-exte
  * Undeclared Vue compiler packages (`@vue/compiler-sfc` and friends) and
  * class-component helpers live in Vize's `tests/package.json`, so TypeScript
  * can still climb into them and load Vize's Vue beside the fixture.
+ * `@vue/runtime-dom` and `@vue/runtime-core` are nested under pnpm's `vue`
+ * rather than hoisted, so ancestor walks miss them; a fixture store copy is
+ * still linked so overlay paths can pin the vue-tsc program onto one Vue.
  */
 
 const vueRuntimePackages = [
@@ -48,6 +51,8 @@ const vueRuntimePackages = [
   "vue-router",
 ];
 
+const vueRuntimeNestedPackages = ["@vue/runtime-core", "@vue/runtime-dom"];
+
 export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {
   const root = resolve(fixtureRoot);
   return isolateUniqueDeclaredLocalTypePackages(
@@ -59,6 +64,7 @@ export function isolateUniqueLocalTypePackages(fixtureRoot, sourceConfigPath) {
 export function isolateUniqueVueRuntimePackages(fixtureRoot) {
   return [
     ...isolateUniqueNamedLocalTypePackages(fixtureRoot, vueRuntimePackages),
+    ...isolateUniqueStoreLocalTypePackages(fixtureRoot, vueRuntimeNestedPackages),
     ...isolateUniqueVueVisualizationPackages(fixtureRoot),
   ];
 }
@@ -76,6 +82,22 @@ function isolateUniqueNamedLocalTypePackages(fixtureRoot, names) {
     declared.set(name, ancestor);
   }
   return isolateUniqueDeclaredLocalTypePackages(root, declared);
+}
+
+function isolateUniqueStoreLocalTypePackages(fixtureRoot, names) {
+  const root = resolve(fixtureRoot);
+  const shadowed = [];
+  for (const name of names) {
+    const link = join(root, "node_modules", ...name.split("/"));
+    if (existsSync(link) || isDanglingLink(link)) continue;
+    const copies = findLocalCopies(root, name);
+    const local = selectLocalCopy(root, name, copies);
+    if (local == null) continue;
+    mkdirSync(dirname(link), { recursive: true });
+    symlinkSync(relative(dirname(link), local), link);
+    shadowed.push({ name, target: relative(root, local).replaceAll("\\", "/") });
+  }
+  return shadowed.sort((left, right) => compare(left.name, right.name));
 }
 
 function isolateUniqueDeclaredLocalTypePackages(root, declared) {

--- a/tools/fixtures/typecheck-baseline-outside-aliases.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-aliases.mjs
@@ -11,6 +11,10 @@ import {
 } from "./typecheck-baseline-outside-paths.mjs";
 import { rewriteOutsideVueCompilerOptions } from "./typecheck-baseline-outside-vue-compiler.mjs";
 import { rewriteOutsideCompilerPlugins } from "./typecheck-baseline-outside-compiler-plugins.mjs";
+import {
+  mergeLocalVueRuntimePaths,
+  rewriteLocalVueRuntimePaths,
+} from "./typecheck-baseline-outside-vue-runtime-paths.mjs";
 
 /**
  * Close the remaining `compilerOptions.paths` escape for keys that are not
@@ -68,8 +72,14 @@ export function applyIsolatedAliasOverlay(fixtureRoot, sourceConfigPath, overlay
   const aliases = rewriteOutsideAliasPaths(fixtureRoot, sourcePath, configDir);
   const vueCompilerOptions = rewriteOutsideVueCompilerOptions(fixtureRoot, sourcePath, configDir);
   const plugins = rewriteOutsideCompilerPlugins(fixtureRoot, sourcePath, configDir);
-  if (aliases == null && vueCompilerOptions == null && plugins == null) return overlay ?? null;
-  const paths = mergePathRewrites(overlay?.paths ?? null, aliases);
+  const runtimePaths = rewriteLocalVueRuntimePaths(fixtureRoot, configDir);
+  if (aliases == null && vueCompilerOptions == null && plugins == null && runtimePaths == null) {
+    return overlay ?? null;
+  }
+  const paths = mergeLocalVueRuntimePaths(
+    mergePathRewrites(overlay?.paths ?? null, aliases),
+    runtimePaths,
+  );
   const typeRoots = overlay?.typeRoots ?? null;
   const rootDirs = overlay?.rootDirs ?? null;
   const overlayPath = overlay?.path ?? isolatedTsconfigOverlayPath(sourcePath);

--- a/tools/fixtures/typecheck-baseline-outside-vue-runtime-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-vue-runtime-paths.mjs
@@ -1,0 +1,41 @@
+import { existsSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+/**
+ * Pin the Vue runtime vue-tsc injects onto the fixture copy (#4461).
+ *
+ * Unique-link answers climbing from fixture files. vue-tsc's language-core
+ * still resolves `@vue/runtime-dom` from Vize's pnpm store, so elk and reka-ui
+ * load two Vue identities in one program. Overlay `paths` apply to the whole
+ * program. When the fixture already has that package, this writes the mapping.
+ * Overlay replaces `compilerOptions.paths`, so these keys must win over any
+ * outside mapping the source tsconfig still carries.
+ */
+
+const vueRuntimePackages = ["@vue/runtime-core", "@vue/runtime-dom", "vue"];
+
+export function rewriteLocalVueRuntimePaths(fixtureRoot, configDir) {
+  const root = resolve(fixtureRoot);
+  const from = resolve(configDir);
+  const rewritten = {};
+  let changed = false;
+  for (const name of vueRuntimePackages) {
+    const local = join(root, "node_modules", ...name.split("/"));
+    if (!existsSync(join(local, "package.json"))) continue;
+    rewritten[name] = [configRelativePath(from, local)];
+    changed = true;
+  }
+  return changed ? rewritten : null;
+}
+
+export function mergeLocalVueRuntimePaths(paths, runtimePaths) {
+  if (runtimePaths == null) return paths;
+  if (paths == null) return runtimePaths;
+  return { ...paths, ...runtimePaths };
+}
+
+function configRelativePath(from, to) {
+  const path = relative(from, to).replaceAll("\\", "/");
+  if (path.startsWith("/") || /^[A-Za-z]:\//u.test(path)) return path;
+  return path.startsWith(".") ? path : `./${path}`;
+}

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -13,6 +13,10 @@ import {
 } from "./typecheck-baseline-outside-paths.mjs";
 import { rewriteOutsideVueCompilerOptions } from "./typecheck-baseline-outside-vue-compiler.mjs";
 import { rewriteOutsideCompilerPlugins } from "./typecheck-baseline-outside-compiler-plugins.mjs";
+import {
+  mergeLocalVueRuntimePaths,
+  rewriteLocalVueRuntimePaths,
+} from "./typecheck-baseline-outside-vue-runtime-paths.mjs";
 import { typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
 
 /**
@@ -130,9 +134,12 @@ export function materializeBaselineProject(fixtureRoot, reportDir, project, vize
 
 function outsideCompilerOptions(fixtureRoot, sourcePath, configDir) {
   const options = {};
-  const paths = mergePathRewrites(
-    rewriteOutsidePackagePaths(fixtureRoot, sourcePath, configDir),
-    rewriteOutsideAliasPaths(fixtureRoot, sourcePath, configDir),
+  const paths = mergeLocalVueRuntimePaths(
+    mergePathRewrites(
+      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, configDir),
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, configDir),
+    ),
+    rewriteLocalVueRuntimePaths(fixtureRoot, configDir),
   );
   if (paths != null) options.paths = paths;
   if (paths != null && isolatedOverlayBaseUrl(sourcePath, fixtureRoot) != null) {


### PR DESCRIPTION
## Summary
- Real Project Matrix still reports dual-Vue for elk (`@vue/runtime-dom` 3.6.0-beta.10 beside 3.5.30) and reka-ui (`@vue/runtime-core`). vue-tsc language-core resolves those names from Vize's pnpm store; unique-link cannot see them because they are nested under `vue`, not hoisted (#4461).
- Unique isolation now hoists a fixture store copy of `@vue/runtime-dom` / `@vue/runtime-core` even when no ancestor is hoisted. Overlay and vue-tsc baseline then pin `compilerOptions.paths` onto that fixture package so the whole program shares one Vue identity.
- Independent of #4883 (`vueCompilerOptions.plugins`) and #4885 (`jsxImportSource`).

## Test plan
- [x] `node --experimental-strip-types --test tests/tooling/typecheck-baseline-isolation-vue-runtime.test.ts tests/tooling/typecheck-baseline-isolation-vue-router.test.ts tests/tooling/typecheck-baseline-isolation-vue-class.test.ts tests/tooling/typecheck-baseline-outside-vue-runtime-paths.test.ts tests/tooling/typecheck-baseline-outside-aliases.test.ts tests/tooling/typecheck-baseline-outside-vue-compiler.test.ts tests/tooling/typecheck-baseline-outside-compiler-plugins.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790277261&installation_model_id=422833&pr_number=4886&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4886&signature=35941c92da4757d1fd984cd3a90a0cdef3750afe0ce652c2a1be4c144c09f8b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->