### PR TITLE
test(content-mapper): cover project reference declaration maps

### DIFF
--- a/crates/vize/tests/content_mapper_declaration_map_support/mod.rs
+++ b/crates/vize/tests/content_mapper_declaration_map_support/mod.rs
@@ -7,6 +7,33 @@ pub struct AuthoredVueSource {
     pub content: String,
 }
 
+pub fn assert_authored_vue_declaration_map(
+    project_root: &Path,
+    declaration: &str,
+    component: &str,
+) -> AuthoredVueSource {
+    let declaration_path = project_root.join(declaration);
+    let declaration_text = std::fs::read_to_string(&declaration_path).unwrap();
+    let name = declaration_path.file_name().unwrap().to_string_lossy();
+    let expected_mapping_url = format!("//# sourceMappingURL={name}.map");
+    assert_eq!(
+        declaration_text.lines().last(),
+        Some(expected_mapping_url.as_str()),
+        "declaration must end with an adjacent sourceMappingURL:\n{declaration_text}"
+    );
+
+    let map_path = declaration_path.with_file_name(format!("{name}.map"));
+    let map_text = std::fs::read_to_string(&map_path).unwrap();
+    let map: Value = serde_json::from_str(&map_text).unwrap();
+    assert_eq!(map["file"], name.as_ref());
+    let expected_source = format!("../src/{component}.vue");
+    assert_eq!(map["sources"], serde_json::json!([expected_source]));
+
+    let authored_source = assert_authored_vue_source(&map_path, &map, component);
+    assert_eq!(authored_source.map_source, expected_source);
+    authored_source
+}
+
 pub fn assert_authored_vue_source(
     map_path: &Path,
     map: &Value,

--- a/crates/vize/tests/content_mapper_tsgo_build.rs
+++ b/crates/vize/tests/content_mapper_tsgo_build.rs
@@ -6,7 +6,9 @@ use serde_json::json;
 use vize_s0::{String as CompactString, cstr};
 
 mod content_mapper_declaration_map_support;
-use content_mapper_declaration_map_support::assert_authored_vue_source;
+use content_mapper_declaration_map_support::{
+    assert_authored_vue_declaration_map, assert_authored_vue_source,
+};
 
 const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
 const VUE_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_VUE";
@@ -143,6 +145,12 @@ fn standard_tsgo_builds_vue_project_references_incrementally() {
             "missing build output {declaration}"
         );
     }
+    assert_authored_vue_declaration_map(
+        project.path(),
+        "references/ui/dist/Counter.d.vue.ts",
+        "Counter",
+    );
+    assert_authored_vue_declaration_map(project.path(), "references/app/dist/App.d.vue.ts", "App");
 
     let unchanged = run_build(&tsgo, project.path());
     assert!(unchanged.status.success(), "{}", output_text(&unchanged));

--- a/crates/vize/tests/fixtures/content_mapper_project/references/app/tsconfig.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/references/app/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "bundler",
     "composite": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": "src",
     "outDir": "dist"

--- a/crates/vize/tests/fixtures/content_mapper_project/references/ui/tsconfig.json
+++ b/crates/vize/tests/fixtures/content_mapper_project/references/ui/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "bundler",
     "composite": true,
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "rootDir": "src",
     "outDir": "dist"


### PR DESCRIPTION
## Summary

- enable declaration maps in the exact Content Mapper project-reference build fixture
- assert standard `tsgo --build` emits adjacent `.d.vue.ts.map` files for referenced Vue projects
- reuse the authored Vue declaration-map helper so emitted maps resolve exactly to `../src/<Component>.vue`

Refs #3984

## Validation

- `VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/typescript-content-mapper-4052-runner/tsgo VIZE_TEST_CONTENT_MAPPER_VUE=/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.pnpm/vue@3.6.0-beta.10_typescript@6.0.3/node_modules/vue cargo test -p vize --test content_mapper_tsgo_build -- --nocapture --test-threads=1`
- `cargo fmt --all -- --check`
- `node tools/davinci/assertion-lint.mjs`
- `git diff --check`
- source-length spot check: `content_mapper_tsgo_build.rs` is 345 lines after the change

## Local Note

- `SOURCE_LENGTH_BASE_REF=origin/main node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts` is blocked locally by the known MoonBit `lexscan` toolchain error in `tools/moon/.mooncakes/moonbitlang/x/path/win32/path.mbt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added validation for generated Vue declaration maps during incremental TypeScript builds.
  - Verified declaration files include valid source map references and correctly map back to their original Vue components.
- **Build Configuration**
  - Enabled declaration map generation for application and UI TypeScript projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->