### PR TITLE
test(matrix): expect jsx runtime path overlays

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-jsx.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-jsx.test.ts
@@ -162,7 +162,7 @@ test("overlay write keeps existing compilerOptions and vueCompilerOptions", () =
   }
 });
 
-test("shared overlay helper writes jsxImportSource when path overlay is empty", () => {
+test("shared overlay helper writes jsxImportSource with the Vue runtime path", () => {
   const { fixtureRoot, outer, outsideVue } = scaffold();
   try {
     writeLocalVue(fixtureRoot);
@@ -177,7 +177,10 @@ test("shared overlay helper writes jsxImportSource when path overlay is empty", 
     assert.equal(overlay.path, path.join(fixtureRoot, ".vize-isolated-tsconfig.json"));
     assert.deepEqual(JSON.parse(fs.readFileSync(overlay.path, "utf8")), {
       extends: "./tsconfig.json",
-      compilerOptions: { jsxImportSource: "./node_modules/vue" },
+      compilerOptions: {
+        paths: { vue: ["./node_modules/vue"] },
+        jsxImportSource: "./node_modules/vue",
+      },
     });
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- update the shared JSX overlay helper oracle for the Vue runtime path overlay added in #4886
- keep the expectation pinned to one generated `.vize-isolated-tsconfig.json` document

Refs #4886

## Validation

- `node --test tests/tooling/typecheck-baseline-outside-jsx.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790278813&installation_model_id=422833&pr_number=4916&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4916&signature=8a922cef0c6ebd35d15a0acc88f36a7cdb112ccb87b5e6e102716f7171452b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->