### PR TITLE
fix(canon): treat vue/* subpaths as native runtime support

### DIFF
--- a/crates/vize/src/commands/check/imports_package_registration_tests.rs
+++ b/crates/vize/src/commands/check/imports_package_registration_tests.rs
@@ -256,3 +256,51 @@ fn vue_runtime_support_stays_native_without_reachability_work() {
         "runtime support is terminal"
     );
 }
+
+#[test]
+fn vue_dist_javascript_subpath_stays_native_when_allow_js() {
+    let root = tempfile::tempdir().unwrap();
+    let entry = write(
+        root.path(),
+        "src/entry.ts",
+        "import Vue from 'vue/dist/vue.cjs.js';\nexport const app = Vue;\n",
+    );
+    write(
+        root.path(),
+        "node_modules/vue/package.json",
+        r#"{"name":"vue","main":"./index.js"}"#,
+    );
+    write(
+        root.path(),
+        "node_modules/vue/index.js",
+        "module.exports = {}\n",
+    );
+    write(
+        root.path(),
+        "node_modules/vue/dist/vue.cjs.js",
+        "module.exports = {}\n",
+    );
+    write(
+        root.path(),
+        "node_modules/vue/dist/vue.cjs.prod.js",
+        "module.exports = {}\n",
+    );
+
+    let mut resolver = PackageRouteResolver::default();
+    let discovered = collect_transitive_local_imports_with_resolver(
+        &[entry],
+        root.path(),
+        &mut CanonicalPathCache::default(),
+        ImportFileOptions {
+            include_js: true,
+            include_jsx: false,
+        },
+        None,
+        &mut resolver,
+    );
+
+    assert!(discovered.registrations.is_empty());
+    assert!(discovered.authored.is_empty());
+    assert!(discovered.package_routes.is_empty());
+    assert_eq!(resolver.metrics().cache_misses, 0);
+}

--- a/crates/vize_canon/src/batch/virtual_project/package_route_discovery.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_route_discovery.rs
@@ -154,9 +154,13 @@ fn route_requires_invalidation_binding(has_route: bool, watchable_negative: bool
 ///
 /// Canon supplies these types to virtual documents. They are terminal support
 /// edges rather than importer-scoped component packages, whether the edge came
-/// from generated helpers or from a package declaration in their runtime graph.
+/// from generated helpers, a package declaration, or a `vue/...` subpath
+/// (Nuxt SSR's `vue/dist/vue.cjs.js`). `vue-router` is not a subpath.
 pub fn is_vue_runtime_support_specifier(specifier: &str) -> bool {
-    specifier == "vue" || specifier.starts_with("@vue/") || specifier == "vite/client"
+    specifier == "vue"
+        || specifier.starts_with("vue/")
+        || specifier.starts_with("@vue/")
+        || specifier == "vite/client"
 }
 
 #[cfg(test)]
@@ -169,6 +173,9 @@ mod runtime_support_tests {
     fn generated_runtime_support_filter_is_exact() {
         for specifier in [
             "vue",
+            "vue/dist/vue.cjs.js",
+            "vue/server-renderer",
+            "vue/jsx-runtime",
             "@vue/runtime-core",
             "@vue/runtime-dom",
             "vite/client",


### PR DESCRIPTION
## Summary
- Real Project Matrix shards for primevue-volt and primevue-showcase never measured typecheck divergence: Vize listed `node_modules/.pnpm/vue@.../dist/vue.cjs.js` as checked files, so coverage validation failed closed (#4461).
- `import "vue"` was already a terminal runtime-support edge. Nuxt SSR imports `vue/dist/vue.cjs.js` (and other `vue/*` subpaths); with `allowJs` those JS files were walked into the program.
- `vue-router` is unchanged (`vue/` is a subpath, not a prefix of `vue-router`).

## Test plan
- [x] `cargo test -p vize_canon --lib generated_runtime_support_filter_is_exact`
- [x] `cargo test -p vize --lib vue_dist_javascript_subpath_stays_native_when_allow_js`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790278878&installation_model_id=422833&pr_number=4917&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4917&signature=0a5c17bc2b530e4a9d2d0ea90b1ae6173b97d5e99d10028a15dd1c8bd1317015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Vue runtime support imports across distribution, server-renderer, and JSX-runtime subpaths.
  - Ensured supported Vue JavaScript imports remain native when JavaScript inclusion is enabled.
  - Prevented unnecessary virtual registrations, authored-file discovery, package routes, and cache misses during package resolution.

- **Tests**
  - Added regression coverage for Vue subpath imports and package resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->