### PR TITLE
fix(davinci): mirror slot outlet same-name names

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_outlets.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_outlets.rs
@@ -13,8 +13,17 @@ mod support;
 const BATTERY: &[(&str, &str)] = &[
     ("bare", "<slot></slot>"),
     ("self_close", "<slot/>"),
+    ("bare_name_attr", r#"<slot name></slot>"#),
     ("named", r#"<slot name="header"></slot>"#),
+    ("bracket_literal_name", r#"<slot name="[header]"></slot>"#),
     ("dynamic_name", r#"<slot :name="n"></slot>"#),
+    (
+        "dynamic_member_name",
+        r#"<slot :name="tabs[index]"></slot>"#,
+    ),
+    ("same_name_shorthand", r#"<slot :name></slot>"#),
+    ("same_name_longhand", r#"<slot v-bind:name></slot>"#),
+    ("blank_dynamic_name", r#"<slot :name=""></slot>"#),
     ("fallback_text", "<slot>fallback</slot>"),
     ("fallback_interp", "<slot>hello {{ msg }}</slot>"),
     ("fallback_span", "<slot><span></span></slot>"),

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -23,7 +23,8 @@
 //! fragments** (empty → `null`, multi-root / compound-root
 //! `_Fragment` + `STABLE_FRAGMENT`), **`<template v-if>` /
 //! `<template v-for>` fragments** (`STABLE_FRAGMENT` / unwrap after
-//! hoist), **object `v-on`** (`toHandlers(..., true)`), **`v-model`**
+//! hoist), **slot outlet same-name `:name` / `v-bind:name`**,
+//! **object `v-on`** (`toHandlers(..., true)`), **`v-model`**
 //! (native `withDirectives` + `vModelText`-family helpers; component
 //! `modelValue` / `onUpdate:` product props), and **custom directives**
 //! (`resolveDirective` + `_withDirectives`, merged with native

--- a/crates/vize_ricalco/src/lower/slot.rs
+++ b/crates/vize_ricalco/src/lower/slot.rs
@@ -16,10 +16,11 @@
 use vize_s0::{Box, String, Vec, cstr};
 use vize_s1::Element;
 
+use vize_s2::expr::ExprRef;
 use vize_s2::op::{Attribute, BindingOp, DynamicName, Namespace, Op, Region, SlotOp};
 
 use super::binding::{defer, lower_slot_content};
-use super::bindop::{lower_bind, lower_on};
+use super::bindop::{RULE_SAME_NAME, lower_bind, lower_on};
 use super::cx::{Cx, attr_slice, attr_span, element_span};
 use super::directive::{Arg, AttrForm, Head};
 use super::element::{Analyzed, attr_value_text};
@@ -58,29 +59,32 @@ pub(crate) fn lower_slot<'a>(
                 span: attr_span(cx, attr),
             }),
             AttrForm::Directive(directive) => match directive.head {
-                Head::Bind if directive.arg == Some(Arg::Static("name")) && name.is_none() => {
-                    // A `:name` with no expression is not a name candidate
-                    // in the shipped resolution (a later `name` attribute
-                    // may still win, else the implicit name); dropped
-                    // under a record, never silently.
+                Head::Bind
+                    if matches!(directive.arg, Some(Arg::Static("name"))) && name.is_none() =>
+                {
+                    // The shipped parser applies Vue 3.4 same-name
+                    // shorthand before slot-outlet name resolution, so
+                    // a missing or blank `:name` / `v-bind:name`
+                    // selects the runtime `name` variable.
                     match attr_value_text(element, index).map(str::trim) {
                         Some(text) if !text.is_empty() => {
                             name = Some(DynamicName::Dynamic(expr_at(cx, text)));
                         }
                         _ => {
-                            cx.info(
-                                attr_span(cx, attr),
-                                String::from(
-                                    "`:name` with no expression names no slot; the outlet keeps the implicit name",
-                                ),
-                            );
+                            let arg_text = match directive.arg {
+                                Some(Arg::Static(text)) => text,
+                                _ => "name",
+                            };
+                            let expr =
+                                ExprRef::parse_js_in(cx.allocator, arg_text, cx.span_of(arg_text));
                             cx.record(
-                                "drop.slot-name-hole",
-                                None,
+                                RULE_SAME_NAME,
+                                node,
                                 attr_slice(cx, attr),
-                                String::default(),
+                                cstr!("{arg_text}"),
                                 attr_span(cx, attr),
                             );
+                            name = Some(DynamicName::Dynamic(expr));
                         }
                     }
                 }

--- a/davinci-road/plan/phase-2-records/p2-11.md
+++ b/davinci-road/plan/phase-2-records/p2-11.md
@@ -79,11 +79,11 @@ interpolations, bindings, component slots, slot outlets, and Vue 3 pipe
 non-filter behavior. The historical installment-19 remainder is preserved in
 [`installment-19.md`](./p2-11/installment-19.md), not presented as current.
 
-Also still refused by local guards in emit modules — so the next
-increment is not implicit:
+Also still refused by local guards in emit modules — so the next increment is
+not implicit. Slot-outlet name spellings, including value-less and blank
+`:name` / `v-bind:name`, are covered by the `davinci_s2_outlets` witness.
 
-- **bracketed outlet names and malformed slot regions** —
-  `emit/slots.rs`, `emit/outlet.rs`, `emit/create_slots.rs`
+- **malformed slot regions** — `emit/slots.rs`, `emit/create_slots.rs`
 - **P2-10 style carrier** — still skip; it is not a DOM `<style>`
   vnode ([p2-10.md](./p2-10.md))
 

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -73,7 +73,7 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
 | s1_to_s2 | `alloc::vec::Vec`       |    35 |           35 |        144 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    46 |           48 |        214 |
+| s1_to_s2 | `vize_s0::String`       |    46 |           48 |        212 |
 | s1_to_s2 | `vize_s0::Vec`          |    14 |           14 |         56 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     2 |            2 |          4 |
 

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -65,7 +65,7 @@ s1_to_s2	-	crates/vize_ricalco/src/lower/expr.rs	0	0	1	3	0	0	0	0
 s1_to_s2	lower	crates/vize_ricalco/src/lower/forop.rs	1	2	1	5	1	2	0	0
 s1_to_s2	-	crates/vize_ricalco/src/lower/leaf.rs	0	0	1	5	1	4	0	0
 s1_to_s2	-	crates/vize_ricalco/src/lower/once_memo.rs	0	0	1	3	0	0	0	0
-s1_to_s2	-	crates/vize_ricalco/src/lower/slot.rs	0	0	1	6	1	4	0	0
+s1_to_s2	-	crates/vize_ricalco/src/lower/slot.rs	0	0	1	4	1	4	0	0
 s1_to_s2	lower	crates/vize_ricalco/src/lower/structural.rs	1	10	1	4	1	13	0	0
 s1_to_s2	lower	crates/vize_ricalco/src/lower/structural/wrapper.rs	1	2	1	6	0	0	0	0
 s1_to_s2	lower	crates/vize_ricalco/src/lower/sugar.rs	1	1	1	2	0	0	0	0


### PR DESCRIPTION
## Summary
- treat value-less and blank `<slot :name>` / `<slot v-bind:name>` as Vue same-name shorthand so S2 emits the runtime `name` argument like the shipped DOM lane
- extend the slot outlet parity battery across bare, bracket-literal, member, same-name, and blank dynamic name spellings
- update the P2-11 ledger and storage ratchet for the reviewed `vize_s0::String` bound-use reduction in `lower/slot.rs`

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_outlets -- --nocapture
- cargo test -p vize_ricalco --test vslot_pass -- --nocapture
- cargo test -p vize_atelier_core --test davinci_s2_transform -- --nocapture
- cargo clippy -p vize_ricalco --all-targets -- -D warnings
- cargo clippy -p vize_atelier_dom --test davinci_s2_outlets -- -D warnings
- cargo fmt --all -- --check
- vp check
- node tools/davinci/assertion-lint.mjs
- node --test tests/tooling/davinci-phase2-ledger.test.ts
- node --test tests/tooling/davinci-storage-policy.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790283236&installation_model_id=422833&pr_number=4921&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4921&signature=329979ab442aa56e3a718e2d771a71fe53a7e017f9b739fbaf7316466eb902b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->