### PR TITLE
fix(matrix): isolate shard baseline escapes

### DIFF
--- a/tests/tooling/real-project-syntax-highlighting.test.ts
+++ b/tests/tooling/real-project-syntax-highlighting.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { runRealProjectSyntaxAudit } from "./support/real-project-syntax-audit.ts";
+import { tokenizeSemanticSource } from "./support/syntax-semantic-divergence.ts";
 import { auditTextMateSource, loadVueTextMateGrammar } from "./support/vue-textmate.ts";
 
 test("shipped and pinned oracle grammars tokenize every selected real-project Vue file", async () => {
@@ -38,6 +39,21 @@ test("real-project TextMate audit exercises the shipped grammar and fail-closed 
     const result = auditTextMateSource(grammar, source, "source.vue", "synthetic/App.vue");
     assert.equal(result.lineCount, 5);
     assert.ok(result.tokenCount > 5);
+    const pugAttributeValue = [
+      '<template lang="pug">',
+      'ssh-pre(language="js").',
+      "  app.use(WaveUI, { /* Some Wave UI options */ })",
+      "</template>",
+      "",
+    ].join("\n");
+    const semantic = tokenizeSemanticSource(
+      grammar,
+      pugAttributeValue,
+      "source.vue",
+      "synthetic/wave-ui-install-cdn.vue",
+    );
+    assert.equal(semantic.lineCount, 5);
+    assert.ok(semantic.tokenCount > 5);
   } finally {
     registry.dispose();
   }

--- a/tests/tooling/support/syntax-semantic-divergence.ts
+++ b/tests/tooling/support/syntax-semantic-divergence.ts
@@ -16,7 +16,7 @@ export const semanticCategories = Object.freeze([
 ] as const);
 
 export const semanticNormalization = Object.freeze({
-  version: 2,
+  version: 3,
   categories: semanticCategories,
   coordinates: "1-based UTF-16 columns with an exclusive end",
   omittedCategories: Object.freeze([
@@ -152,7 +152,7 @@ function normalizeScopes(scopes: string[], label: string): string[] {
 
 function semanticCategory(scope: string): string | null {
   if (scope.startsWith("comment")) return "comment";
-  if (scope === "attribute_value") return "string";
+  if (/^attribute_value\d*$/u.test(scope)) return "string";
   if (scope.startsWith("string")) return "string";
   if (scope.startsWith("constant.numeric")) return "number";
   if (scope.startsWith("constant") || scope.startsWith("support.constant")) return "literal";

--- a/tests/tooling/syntax-highlighter-divergence.test.ts
+++ b/tests/tooling/syntax-highlighter-divergence.test.ts
@@ -78,7 +78,7 @@ test("semantic comparison records exact shared, false-positive, and false-negati
 
 test("published normalization evidence is immutable canonical JSON", () => {
   assert.ok(Object.isFrozen(semanticNormalization));
-  assert.equal(semanticNormalization.version, 2);
+  assert.equal(semanticNormalization.version, 3);
   assert.ok(Object.isFrozen(semanticNormalization.categories));
   assert.ok(Object.isFrozen(semanticNormalization.omittedCategories));
   assert.ok(Object.isFrozen(semanticNormalization.ignoredScopeFamilies));
@@ -136,6 +136,7 @@ test("normalization ignores structural nesting but detects changed semantic scop
       "entity.other.keyframe-offset.percentage.css",
       "entity.other.counter-name.less",
       "attribute_value",
+      "attribute_value2",
       "entity.other.attribute-selector.sass",
       "html",
       "inline.pug",

--- a/tests/tooling/typecheck-baseline-outside-vue-runtime-paths.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-vue-runtime-paths.test.ts
@@ -48,6 +48,44 @@ test("local Vue runtime packages are pinned onto overlay paths", () => {
   }
 });
 
+test("a single pnpm virtual-store Vue runtime package is pinned without a direct link", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const local = path.join(
+      fixtureRoot,
+      "node_modules/.pnpm/vue@3.5.17_typescript@5.8.3/node_modules/vue",
+    );
+    fs.mkdirSync(local, { recursive: true });
+    fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue"}\n`);
+    assert.equal(fs.existsSync(path.join(fixtureRoot, "node_modules/vue")), false);
+    assert.deepEqual(rewriteLocalVueRuntimePaths(fixtureRoot, fixtureRoot), {
+      vue: ["./node_modules/.pnpm/vue@3.5.17_typescript@5.8.3/node_modules/vue"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("multiple pnpm virtual-store Vue runtime copies are not guessed", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeLocalRuntime(fixtureRoot, "@vue/runtime-dom");
+    for (const version of ["3.5.17", "3.6.0-beta.10"]) {
+      const local = path.join(
+        fixtureRoot,
+        `node_modules/.pnpm/vue@${version}_typescript@5.8.3/node_modules/vue`,
+      );
+      fs.mkdirSync(local, { recursive: true });
+      fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue"}\n`);
+    }
+    assert.deepEqual(rewriteLocalVueRuntimePaths(fixtureRoot, fixtureRoot), {
+      "@vue/runtime-dom": ["./node_modules/@vue/runtime-dom"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
 test("a missing local Vue runtime package is not guessed", () => {
   const { fixtureRoot, outer } = scaffold();
   try {
@@ -111,6 +149,34 @@ test("materialized baseline pins Vue runtime paths relative to the generated con
     const parsed = JSON.parse(project.source);
     assert.deepEqual(parsed.compilerOptions.paths, {
       "@vue/runtime-dom": ["../node_modules/@vue/runtime-dom"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("materialized baseline pins pnpm virtual-store Vue without a direct package link", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    const local = path.join(
+      fixtureRoot,
+      "node_modules/.pnpm/vue@3.5.17_typescript@5.8.3/node_modules/vue",
+    );
+    fs.mkdirSync(local, { recursive: true });
+    fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue"}\n`);
+    fs.writeFileSync(path.join(fixtureRoot, "src/App.vue"), "<template />\n");
+    fs.writeFileSync(path.join(fixtureRoot, "tsconfig.json"), `{}\n`);
+    const reportDir = path.join(outer, "report");
+    fs.mkdirSync(reportDir);
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      { id: "fixture", tsconfig: "tsconfig.json" },
+      { fileCount: 1, files: [{ file: "src/App.vue" }] },
+    );
+    const parsed = JSON.parse(project.source);
+    assert.deepEqual(parsed.compilerOptions.paths, {
+      vue: ["../node_modules/.pnpm/vue@3.5.17_typescript@5.8.3/node_modules/vue"],
     });
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });

--- a/tools/fixtures/typecheck-baseline-outside-vue-runtime-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-vue-runtime-paths.mjs
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 
 /**
@@ -7,7 +7,9 @@ import { join, relative, resolve } from "node:path";
  * Unique-link answers climbing from fixture files. vue-tsc's language-core
  * still resolves `@vue/runtime-dom` from Vize's pnpm store, so elk and reka-ui
  * load two Vue identities in one program. Overlay `paths` apply to the whole
- * program. When the fixture already has that package, this writes the mapping.
+ * program. When the fixture already has a direct package link, or exactly one
+ * pnpm virtual-store copy for a package without that link, this writes the
+ * mapping.
  * Overlay replaces `compilerOptions.paths`, so these keys must win over any
  * outside mapping the source tsconfig still carries.
  */
@@ -20,8 +22,8 @@ export function rewriteLocalVueRuntimePaths(fixtureRoot, configDir) {
   const rewritten = {};
   let changed = false;
   for (const name of vueRuntimePackages) {
-    const local = join(root, "node_modules", ...name.split("/"));
-    if (!existsSync(join(local, "package.json"))) continue;
+    const local = localPackageRoot(root, name);
+    if (local == null) continue;
     rewritten[name] = [configRelativePath(from, local)];
     changed = true;
   }
@@ -38,4 +40,27 @@ function configRelativePath(from, to) {
   const path = relative(from, to).replaceAll("\\", "/");
   if (path.startsWith("/") || /^[A-Za-z]:\//u.test(path)) return path;
   return path.startsWith(".") ? path : `./${path}`;
+}
+
+function localPackageRoot(root, name) {
+  const linked = join(root, "node_modules", ...name.split("/"));
+  if (existsSync(join(linked, "package.json"))) return linked;
+  return uniquePnpmStorePackageRoot(root, name);
+}
+
+function uniquePnpmStorePackageRoot(root, name) {
+  const store = join(root, "node_modules", ".pnpm");
+  if (!existsSync(store)) return null;
+  const matches = [];
+  for (const entry of readdirSync(store, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const candidate = join(store, entry.name, "node_modules", ...name.split("/"));
+    if (existsSync(join(candidate, "package.json"))) matches.push(candidate);
+  }
+  matches.sort(codeUnitOrder);
+  return matches.length === 1 ? matches[0] : null;
+}
+
+function codeUnitOrder(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
 }


### PR DESCRIPTION
## Summary
- normalize legacy TextMate `attribute_valueN` scopes as omitted string spans so Wave UI Pug fixtures keep syntax-highlighter evidence fail-closed without crashing on `attribute_value2`
- pin Vue runtime paths from a unique pnpm virtual-store package when a fixture has no direct `node_modules/vue` link
- add regression coverage for the Wave UI Pug pattern and ambiguous pnpm virtual-store copies

Refs #4461

## Verification
- `node --test --test-concurrency=1 tests/tooling/real-project-syntax-highlighting.test.ts tests/tooling/syntax-highlighter-divergence.test.ts tests/tooling/syntax-divergence-artifact.test.ts`
- `VIZE_TEST_WORKSPACE_NODE_MODULES=/Users/nishimura/Code/github.com/ubugeeei/vize/tests/node_modules node --test --test-concurrency=1 tests/tooling/typecheck-baseline-ambient.test.ts tests/tooling/typecheck-baseline-outside-paths.test.ts tests/tooling/typecheck-baseline-outside-vue-runtime-paths.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-budget.test.ts`
- `VIZE_TEST_WORKSPACE_NODE_MODULES=/Users/nishimura/Code/github.com/ubugeeei/vize/tests/node_modules node --test --test-concurrency=1 tests/tooling/typecheck-baseline-project.test.ts`
- `git diff --check`
- `cargo fmt --all -- --check`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts`
- `vp run --workspace-root check:ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790285138&installation_model_id=422833&pr_number=4923&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4923&signature=0f9b7db13d49af46ca4d45d84857dfed002c2c8645603ccb90c6d856c47383e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vue runtime resolution for projects using pnpm virtual-store paths.
  - Prevented incorrect baseline mappings when multiple Vue package versions are present.
  - Preserved accurate relative paths in generated type-checking baselines.
  - Improved syntax highlighting support for numbered attribute-value scopes and JavaScript in Pug attributes.

- **Tests**
  - Added coverage for Pug semantic tokenization and pnpm virtual-store resolution scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->