### PR TITLE
test(davinci): broaden patch flag equivalence matrix

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
@@ -35,6 +35,11 @@ const CASES: &[Case] = &[
         sites: &["2 /* CLASS */"],
     },
     Case {
+        name: "component_class",
+        src: r#"<Foo :class="cls" />"#,
+        sites: &["8 /* PROPS */, [\"class\"]"],
+    },
+    Case {
         name: "style",
         src: r#"<div :style="style"></div>"#,
         sites: &["4 /* STYLE */"],
@@ -75,6 +80,11 @@ const CASES: &[Case] = &[
         sites: &["8 /* PROPS */, [\"onClick\"]"],
     },
     Case {
+        name: "component_keyup_props",
+        src: r#"<Foo @keyup="handler" />"#,
+        sites: &["8 /* PROPS */, [\"onKeyup\"]"],
+    },
+    Case {
         name: "hydrating_key_event",
         src: r#"<div @keyup.enter="handler"></div>"#,
         sites: &["40 /* PROPS, NEED_HYDRATION */, [\"onKeyup\"]"],
@@ -88,6 +98,16 @@ const CASES: &[Case] = &[
         name: "need_patch",
         src: r#"<div ref="el"></div>"#,
         sites: &["512 /* NEED_PATCH */"],
+    },
+    Case {
+        name: "native_v_model_props",
+        src: r#"<input v-model="msg">"#,
+        sites: &["8 /* PROPS */, [\"onUpdate:modelValue\"]"],
+    },
+    Case {
+        name: "component_v_model_props",
+        src: r#"<Foo v-model="msg" />"#,
+        sites: &["8 /* PROPS */, [\"modelValue\", \"onUpdate:modelValue\"]"],
     },
     Case {
         name: "directive_need_patch",
@@ -120,6 +140,21 @@ const CASES: &[Case] = &[
         sites: &["3 /* TEXT, CLASS */"],
     },
     Case {
+        name: "object_bind_named_prop",
+        src: r#"<div :id="foo" v-bind="obj"></div>"#,
+        sites: &["16 /* FULL_PROPS */, [\"id\"]"],
+    },
+    Case {
+        name: "object_bind_keyup_hydration",
+        src: r#"<div @keyup="handler" v-bind="obj"></div>"#,
+        sites: &["48 /* FULL_PROPS, NEED_HYDRATION */, [\"onKeyup\"]"],
+    },
+    Case {
+        name: "component_object_bind",
+        src: r#"<Foo v-bind="obj" />"#,
+        sites: &["16 /* FULL_PROPS */"],
+    },
+    Case {
         name: "stable_fragment",
         src: "<div></div><span></span>",
         sites: &["64 /* STABLE_FRAGMENT */"],
@@ -133,6 +168,15 @@ const CASES: &[Case] = &[
         name: "unkeyed_fragment",
         src: r#"<div v-for="item in list">{{ item.label }}</div>"#,
         sites: &["1 /* TEXT */", "256 /* UNKEYED_FRAGMENT */"],
+    },
+    Case {
+        name: "nested_dynamic_slot_fragment",
+        src: r#"<div v-for="i in n"><Foo>hello</Foo></div>"#,
+        sites: &[
+            "2 /* DYNAMIC */",
+            "1024 /* DYNAMIC_SLOTS */",
+            "256 /* UNKEYED_FRAGMENT */",
+        ],
     },
 ];
 


### PR DESCRIPTION
## Summary
- extend the S2-vs-shipped patch-flag witness across component props/listeners, native and component v-model, object-spread merge flags, component object bind, and nested dynamic slots
- keep the existing per-node site extraction so each case proves both byte output and the exact patch flag/comment plus dynamic-prop array

## Validation
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize_atelier_dom --test davinci_s2_patch_flags -- --nocapture
- CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_dom --test davinci_s2_patch_flags -- -D warnings
- cargo fmt --all -- --check
- vp check
- node tools/davinci/assertion-lint.mjs
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790285341&installation_model_id=422833&pr_number=4924&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4924&signature=14e8e3254a0bc4caa84d04ca6a006693e337e1088b33980aa44a524bc5e6c32e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->