### PR TITLE
fix(glyph): separate unusable corpus baselines

### DIFF
--- a/tests/tooling/glyph-corpus-evidence.test.ts
+++ b/tests/tooling/glyph-corpus-evidence.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  selectGlyphCorpusProjects,
+  writeGlyphCorpusPropertyEvidence,
+} from "../../tools/fixtures/glyph-corpus.mjs";
+
+const validEntry = {
+  property: "parse-preservation",
+  category: "semantic-diff",
+  project: "fixture-a",
+  path: "src/App.vue",
+  reason: "The formatter currently removes an authored semantic token.",
+  trackingIssue: 4107,
+  expiryCondition: "Remove when the authored fixture passes without a waiver.",
+};
+
+test("formatter property artifacts retain waived and unwaived difference details", () => {
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-glyph-evidence-"));
+  try {
+    const output = writeGlyphCorpusPropertyEvidence(
+      "parse-preservation",
+      {
+        projectIds: ["fixture-b", "fixture-a"],
+        counters: { files: 7, skipped: 1 },
+        violations: [{ project: "fixture-b", file: "src/B.vue", detail: "block changed" }],
+        baselineUnusable: [
+          {
+            project: "fixture-c",
+            file: "src/Baseline.vue",
+            detail: "pristine Vue baseline failed",
+          },
+        ],
+        waivedViolations: [
+          {
+            project: "fixture-a",
+            file: "src/App.vue",
+            detail: "full comparator evidence",
+            waiver: validEntry,
+          },
+        ],
+        waiverValidationError: null,
+      },
+      reportDir,
+    );
+    assert.equal(output, path.join(reportDir, "glyph-parse-preservation.json"));
+    const artifact = JSON.parse(fs.readFileSync(output!, "utf8"));
+    assert.equal(artifact.schema, "vize.glyphCorpusPropertyEvidence");
+    assert.equal(artifact.version, 1);
+    assert.deepEqual(artifact.projectIds, ["fixture-a", "fixture-b"]);
+    assert.deepEqual(artifact.summary, {
+      cleanFileCount: 7,
+      waivedDifferenceCount: 1,
+      baselineUnusableCount: 1,
+      violationCount: 1,
+      waiverValidationError: null,
+    });
+    assert.equal(artifact.waivedDifferences[0].detail, "full comparator evidence");
+    assert.equal(artifact.baselineUnusable[0].detail, "pristine Vue baseline failed");
+    assert.equal(artifact.violations[0].detail, "block changed");
+  } finally {
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});
+
+test("glyph corpus shard selection is bound to manifest project ids before hydration", () => {
+  const projects = [
+    {
+      id: "other",
+      coverage: ["formatter"],
+      expectedVueFileCount: 1,
+      fixturePath: "tests/_fixtures/_git/other",
+    },
+    {
+      id: "primevue",
+      coverage: ["formatter"],
+      expectedVueFileCount: 1,
+      fixturePath: "tests/_fixtures/_git/primevue",
+    },
+    {
+      id: "primevue-volt",
+      coverage: ["formatter"],
+      expectedVueFileCount: 1,
+      fixturePath: "tests/_fixtures/_git/primevue",
+    },
+    {
+      id: "shared-non-formatter",
+      coverage: ["compiler"],
+      expectedVueFileCount: 1,
+      fixturePath: "tests/_fixtures/_git/primevue",
+    },
+  ];
+
+  const selected = selectGlyphCorpusProjects(projects, {
+    FIXTURE_SHARD_INDEX: "1",
+    FIXTURE_SHARD_COUNT: "2",
+  });
+  assert.deepEqual(
+    selected.map((project: { id: string }) => project.id),
+    ["primevue"],
+  );
+  assert.throws(
+    () => selectGlyphCorpusProjects(projects, { FIXTURE_SHARD_COUNT: "2" }),
+    /must be set together/,
+  );
+  assert.throws(
+    () =>
+      selectGlyphCorpusProjects(projects, {
+        FIXTURE_SHARD_INDEX: "2",
+        FIXTURE_SHARD_COUNT: "2",
+      }),
+    /must be less than/,
+  );
+});

--- a/tests/tooling/glyph-corpus-parse-preservation.test.ts
+++ b/tests/tooling/glyph-corpus-parse-preservation.test.ts
@@ -3,6 +3,7 @@
 // partition; Pug remains owned by its independent pinned semantic oracle.
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 
@@ -51,6 +52,7 @@ test("glyph corpus parse-preservation holds for every hydrated fixture", () => {
   const hydrated = projects.filter((project) => project.hydrated);
   const launch = resolveGlyphLaunch();
   const violations: Violation[] = [];
+  const baselineUnusable: Violation[] = [];
   const waivedViolations: Array<Violation & { waiver: object }> = [];
   const pugEvidence: PugEvidence[] = [];
   const sfcDialectEvidence: SfcDialectEvidence[] = [];
@@ -59,6 +61,7 @@ test("glyph corpus parse-preservation holds for every hydrated fixture", () => {
     sweepProject(project, launch, {
       waiverConsumption,
       violations,
+      baselineUnusable,
       counters,
       waivedViolations,
       pugEvidence,
@@ -112,6 +115,7 @@ test("glyph corpus parse-preservation holds for every hydrated fixture", () => {
     projectIds: hydrated.map((project) => project.id),
     counters,
     violations,
+    baselineUnusable,
     waivedViolations,
     waiverValidationError,
   });
@@ -125,9 +129,63 @@ test("glyph corpus parse-preservation holds for every hydrated fixture", () => {
   process.stderr.write(
     `glyph ${property}: ${counters.files} file(s) across ${hydrated.length} project(s), ` +
       `${projects.length - hydrated.length} project(s) not hydrated, ` +
-      `${counters.skipped} known violation(s) skipped, ${violations.length} violation(s)\n`,
+      `${counters.skipped} known violation(s) skipped, ` +
+      `${baselineUnusable.length} baseline-unusable file(s), ` +
+      `${violations.length} violation(s)\n`,
   );
   assert.equal(violations.length, 0, renderViolations(property, violations));
+});
+
+test("glyph corpus records unusable reference baselines without failing the property", () => {
+  const project = makeSyntheticProject([
+    [
+      "src/BrokenPug.vue",
+      [
+        '<template lang="pug">',
+        'template(v-for="item in items")',
+        '  div(:key="item") {{ item }}',
+        "</template>",
+        "",
+      ].join("\n"),
+    ],
+  ]);
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-glyph-noop-"));
+  const fakeFormatter = path.join(fakeDir, "fake-vize.mjs");
+  fs.writeFileSync(
+    fakeFormatter,
+    [
+      "#!/usr/bin/env node",
+      'process.stderr.write("Found 1 file(s)\\n\\nFormatted 1 file(s)\\n  1 file(s) already formatted\\n");',
+      "",
+    ].join("\n"),
+  );
+  fs.chmodSync(fakeFormatter, 0o755);
+  try {
+    const violations: Violation[] = [];
+    const baselineUnusable: Violation[] = [];
+    const counters = { files: 0, skipped: 0 };
+    const localWaivers = createKnownViolationConsumption([]);
+    sweepProject(
+      project,
+      { command: fakeFormatter, prefix: [] },
+      {
+        waiverConsumption: localWaivers,
+        violations,
+        baselineUnusable,
+        counters,
+      },
+    );
+
+    assert.deepEqual(violations, []);
+    assert.equal(baselineUnusable.length, 1);
+    assert.equal(baselineUnusable[0].project, project.id);
+    assert.equal(baselineUnusable[0].file, "src/BrokenPug.vue");
+    assert.match(baselineUnusable[0].detail, /pristine Vue baseline failed/);
+    assert.deepEqual(counters, { files: 0, skipped: 0 });
+  } finally {
+    fs.rmSync(project.fixtureDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+  }
 });
 
 test("glyph corpus parse-preservation machinery accepts the real formatter", () => {

--- a/tests/tooling/glyph-corpus-waivers.test.ts
+++ b/tests/tooling/glyph-corpus-waivers.test.ts
@@ -10,7 +10,6 @@ import {
   createKnownViolationConsumption,
   validateKnownViolationEntries,
   writeGlyphPugSemanticEvidence,
-  writeGlyphCorpusPropertyEvidence,
 } from "../../tools/fixtures/glyph-corpus.mjs";
 import { createWaiverIssueAudit } from "../../tools/fixtures/glyph-corpus-waiver-audit.mjs";
 
@@ -199,45 +198,6 @@ test("tracking Issue evidence is deduplicated and fails closed on closed Issues"
       })),
     /tracking Issue #4107 is CLOSED/,
   );
-});
-
-test("formatter property artifacts retain waived and unwaived difference details", () => {
-  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-glyph-evidence-"));
-  try {
-    const output = writeGlyphCorpusPropertyEvidence(
-      "parse-preservation",
-      {
-        projectIds: ["fixture-b", "fixture-a"],
-        counters: { files: 7, skipped: 1 },
-        violations: [{ project: "fixture-b", file: "src/B.vue", detail: "block changed" }],
-        waivedViolations: [
-          {
-            project: "fixture-a",
-            file: "src/App.vue",
-            detail: "full comparator evidence",
-            waiver: validEntry,
-          },
-        ],
-        waiverValidationError: null,
-      },
-      reportDir,
-    );
-    assert.equal(output, path.join(reportDir, "glyph-parse-preservation.json"));
-    const artifact = JSON.parse(fs.readFileSync(output!, "utf8"));
-    assert.equal(artifact.schema, "vize.glyphCorpusPropertyEvidence");
-    assert.equal(artifact.version, 1);
-    assert.deepEqual(artifact.projectIds, ["fixture-a", "fixture-b"]);
-    assert.deepEqual(artifact.summary, {
-      cleanFileCount: 7,
-      waivedDifferenceCount: 1,
-      violationCount: 1,
-      waiverValidationError: null,
-    });
-    assert.equal(artifact.waivedDifferences[0].detail, "full comparator evidence");
-    assert.equal(artifact.violations[0].detail, "block changed");
-  } finally {
-    fs.rmSync(reportDir, { recursive: true, force: true });
-  }
 });
 
 test("Pug semantic artifacts preserve fixed-baseline provenance and exact file identity", () => {

--- a/tests/tooling/support/glyph-corpus-sweep.ts
+++ b/tests/tooling/support/glyph-corpus-sweep.ts
@@ -80,6 +80,7 @@ type WaiverConsumption = {
 export type SweepSink = {
   waiverConsumption: WaiverConsumption;
   violations: Violation[];
+  baselineUnusable?: Violation[];
   counters: { files: number; skipped: number };
   waivedViolations?: Array<Violation & { waiver: object }>;
   pugEvidence?: PugEvidence[];
@@ -257,6 +258,10 @@ export function sweepProject(
         if (waiver) {
           sink.waivedViolations?.push({ project: project.id, file, detail, waiver });
           sink.counters.skipped += 1;
+          continue;
+        }
+        if (result.category === "baseline-unusable") {
+          sink.baselineUnusable?.push({ project: project.id, file, detail });
           continue;
         }
         sink.violations.push({ project: project.id, file, detail });

--- a/tools/fixtures/glyph-corpus-waivers.mjs
+++ b/tools/fixtures/glyph-corpus-waivers.mjs
@@ -166,7 +166,14 @@ export async function auditKnownViolationIssues(entries, resolveIssue) {
 
 export function writeGlyphCorpusPropertyEvidence(
   property,
-  { projectIds, counters, violations, waivedViolations, waiverValidationError },
+  {
+    projectIds,
+    counters,
+    violations,
+    baselineUnusable = [],
+    waivedViolations = [],
+    waiverValidationError,
+  },
   reportDir = process.env.FIXTURE_REPORT_DIR,
 ) {
   if (reportDir == null || reportDir === "") return null;
@@ -183,10 +190,12 @@ export function writeGlyphCorpusPropertyEvidence(
     summary: {
       cleanFileCount: counters.files,
       waivedDifferenceCount: waivedViolations.length,
+      baselineUnusableCount: baselineUnusable.length,
       violationCount: violations.length,
       waiverValidationError,
     },
     waivedDifferences: waivedViolations,
+    baselineUnusable,
     violations,
   };
   mkdirSync(dirname(output), { recursive: true });

--- a/tools/fixtures/glyph-corpus.mjs
+++ b/tools/fixtures/glyph-corpus.mjs
@@ -42,20 +42,38 @@ const maxFilesEnv = "VIZE_GLYPH_CORPUS_MAX_FILES_PER_PROJECT";
 /**
  * Registry projects the glyph property suites sweep: every project that
  * declares formatter coverage and pins at least one Vue SFC. Hydration is
- * per-project — CI lanes hydrate different subsets, so callers must filter on
- * `hydrated` and treat absent fixtures as skipped, never as failures.
+ * per-project. Matrix lanes pass `FIXTURE_SHARD_INDEX`/`FIXTURE_SHARD_COUNT`,
+ * so shared fixture paths never make sibling registry ids look selected.
  */
 export function loadGlyphCorpusProjects() {
   const registry = JSON.parse(readFileSync(registryPath, "utf8"));
-  return registry.projects
-    .filter(
-      (project) => project.coverage.includes("formatter") && project.expectedVueFileCount !== 0,
-    )
-    .map((project) => {
-      const fixtureDir = resolve(repoRoot, project.fixturePath);
-      const hydrated = existsSync(fixtureDir) && readdirSync(fixtureDir).length > 0;
-      return { ...project, fixtureDir, hydrated };
-    });
+  return selectGlyphCorpusProjects(registry.projects).map((project) => {
+    const fixtureDir = resolve(repoRoot, project.fixturePath);
+    const hydrated = existsSync(fixtureDir) && readdirSync(fixtureDir).length > 0;
+    return { ...project, fixtureDir, hydrated };
+  });
+}
+
+export function selectGlyphCorpusProjects(projects, environment = process.env) {
+  const shardIndex = environment.FIXTURE_SHARD_INDEX;
+  const shardCount = environment.FIXTURE_SHARD_COUNT;
+  if ((shardIndex == null) !== (shardCount == null)) {
+    throw new Error("FIXTURE_SHARD_INDEX and FIXTURE_SHARD_COUNT must be set together");
+  }
+  const selected =
+    shardIndex == null || shardCount == null
+      ? projects
+      : selectGlyphShard(projects, shardIndex, shardCount);
+  return selected.filter(
+    (project) => project.coverage.includes("formatter") && project.expectedVueFileCount !== 0,
+  );
+}
+
+function selectGlyphShard(projects, shardIndex, shardCount) {
+  const index = nonNegativeInteger(shardIndex, "FIXTURE_SHARD_INDEX");
+  const count = positiveInteger(shardCount, "FIXTURE_SHARD_COUNT");
+  if (index >= count) throw new Error("FIXTURE_SHARD_INDEX must be less than FIXTURE_SHARD_COUNT");
+  return projects.filter((_, projectIndex) => projectIndex % count === index);
 }
 
 /** Collect the project's registered Vue inputs, honoring the optional cap. */
@@ -268,6 +286,22 @@ export function diffExcerpt(beforeText, afterText, beforeLabel = "before", after
 
 function truncateLine(line) {
   return line.length <= 160 ? line : `${line.slice(0, 160)}...`;
+}
+
+function positiveInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return parsed;
+}
+
+function nonNegativeInteger(value, name) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  return parsed;
 }
 
 export function loadKnownViolationLedger() {


### PR DESCRIPTION
## Summary
- keep Glyph parse-preservation semantic violations failing while recording unusable reference baselines separately
- publish baselineUnusableCount/details in Glyph corpus property evidence
- bind Glyph corpus selection to matrix project ids before hydration so shared fixture paths do not pull sibling registry ids into a shard
- add synthetic regressions for unusable Pug baselines and shared fixture-path shard selection

Part of #4461.

## Verification
- node --test --test-concurrency=1 tests/tooling/glyph-corpus-parse-preservation.test.ts tests/tooling/glyph-corpus-waivers.test.ts tests/tooling/sfc-baselines.test.ts
- node --test --test-concurrency=1 tests/tooling/real-project-matrix-summary.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/glyph-sfc-evidence.test.ts
- node --test --test-concurrency=1 tests/tooling/glyph-corpus-idempotence.test.ts tests/tooling/glyph-corpus-lint-agreement.test.ts tests/tooling/glyph-sfc-evidence.test.ts tests/tooling/real-project-matrix-workflow.test.ts
- FIXTURE_SHARD_INDEX=5 FIXTURE_SHARD_COUNT=22 node --input-type=module -e 'import { loadGlyphCorpusProjects } from "./tools/fixtures/glyph-corpus.mjs"; console.log(loadGlyphCorpusProjects().map((project) => project.id).join("\\n"));'\n- git diff --check\n- cargo fmt --all -- --check\n- vp run --workspace-root check:ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CI sharding support for selecting glyph corpus projects with validated shard settings.
  * Added evidence reporting for baseline-unusable results, including counts and detailed entries.

* **Bug Fixes**
  * Baseline failures are now tracked separately from semantic violations and do not incorrectly fail properties.

* **Tests**
  * Expanded coverage for evidence generation, baseline handling, and shard selection validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->