### PR TITLE
test(davinci): cover dynamic component patch flags

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
@@ -40,6 +40,16 @@ const CASES: &[Case] = &[
         sites: &["8 /* PROPS */, [\"class\"]"],
     },
     Case {
+        name: "dynamic_component_skips_is_prop",
+        src: r#"<component :is="current" :active-class="klass" />"#,
+        sites: &["8 /* PROPS */, [\"active-class\"]"],
+    },
+    Case {
+        name: "dynamic_component_object_bind",
+        src: r#"<component :is="current" v-bind="obj" />"#,
+        sites: &["16 /* FULL_PROPS */"],
+    },
+    Case {
         name: "style",
         src: r#"<div :style="style"></div>"#,
         sites: &["4 /* STYLE */"],
@@ -107,6 +117,16 @@ const CASES: &[Case] = &[
     Case {
         name: "component_v_model_props",
         src: r#"<Foo v-model="msg" />"#,
+        sites: &["8 /* PROPS */, [\"modelValue\", \"onUpdate:modelValue\"]"],
+    },
+    Case {
+        name: "named_component_v_model_props",
+        src: r#"<Foo v-model:title="pageTitle" />"#,
+        sites: &["8 /* PROPS */, [\"title\", \"onUpdate:title\"]"],
+    },
+    Case {
+        name: "component_v_model_modifier_props",
+        src: r#"<Foo v-model.lazy.trim="msg" />"#,
         sites: &["8 /* PROPS */, [\"modelValue\", \"onUpdate:modelValue\"]"],
     },
     Case {


### PR DESCRIPTION
## Summary
- add S2-vs-shipped patch-flag witnesses for dynamic component `:is` props
- cover dynamic component object bind falling back to FULL_PROPS
- cover named and modifier component `v-model` dynamic-prop arrays

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_patch_flags -- --nocapture
- cargo clippy -p vize_atelier_dom --test davinci_s2_patch_flags -- -D warnings
- cargo fmt --all -- --check
- node tools/davinci/assertion-lint.mjs
- vp check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790288329&installation_model_id=422833&pr_number=4927&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4927&signature=20afa5a5e2911f8da5b95327c0d1b89c4a444b085e0df2053a831fa9e94647a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->