### PR TITLE
test(davinci): cover model listener patch order

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
@@ -130,6 +130,16 @@ const CASES: &[Case] = &[
         sites: &["8 /* PROPS */, [\"modelValue\", \"onUpdate:modelValue\"]"],
     },
     Case {
+        name: "component_v_model_update_listener_order",
+        src: r#"<Foo v-model="msg" @update:modelValue="track" />"#,
+        sites: &["8 /* PROPS */, [\"modelValue\", \"onUpdate:modelValue\"]"],
+    },
+    Case {
+        name: "component_listener_before_v_model_order",
+        src: r#"<Foo @update:modelValue="track" v-model="msg" />"#,
+        sites: &["8 /* PROPS */, [\"onUpdate:modelValue\", \"modelValue\"]"],
+    },
+    Case {
         name: "directive_need_patch",
         src: r#"<div v-example></div>"#,
         sites: &["512 /* NEED_PATCH */"],
@@ -213,8 +223,8 @@ fn s2_patch_flags_match_the_shipped_dom_lane_per_node() {
         let new = emit_dom_source(&allocator, case.src)
             .unwrap_or_else(|error| panic!("{}: S2 emit refused: {error:?}", case.name))
             .assembled();
-        let old_sites = patch_sites(&old);
-        let new_sites = patch_sites(&new);
+        let old_sites = support::patch_sites(&old);
+        let new_sites = support::patch_sites(&new);
 
         if old_sites != expected || new_sites != expected {
             mismatches.push(format!(
@@ -275,8 +285,8 @@ fn s2_vue2_filter_patch_flags_match_the_shipped_dom_lane_per_node() {
         )
         .unwrap_or_else(|error| panic!("{}: S2 emit refused: {error:?}", case.name))
         .assembled();
-        let old_sites = patch_sites(&old);
-        let new_sites = patch_sites(&new);
+        let old_sites = support::patch_sites(&old);
+        let new_sites = support::patch_sites(&new);
 
         if old_sites != expected || new_sites != expected {
             mismatches.push(format!(
@@ -290,57 +300,4 @@ fn s2_vue2_filter_patch_flags_match_the_shipped_dom_lane_per_node() {
         "Vue 2 filter patch flag mismatches:\n{}",
         mismatches.join("\n")
     );
-}
-
-fn patch_sites(source: &str) -> Vec<String> {
-    let bytes = source.as_bytes();
-    let mut sites = Vec::new();
-    let mut cursor = 0usize;
-    while let Some(comment_rel) = source[cursor..].find(" /* ") {
-        let comment_start = cursor + comment_rel;
-        let Some(comment_end_rel) = source[comment_start..].find(" */") else {
-            break;
-        };
-        let comment_end = comment_start + comment_end_rel + " */".len();
-        let Some(number_start) = flag_number_start(bytes, comment_start) else {
-            cursor = comment_end;
-            continue;
-        };
-        let mut site_end = comment_end;
-        if let Some(array_end) = dynamic_props_array_end(source, comment_end) {
-            site_end = array_end;
-        }
-        sites.push(source[number_start..site_end].trim().to_string());
-        cursor = site_end;
-    }
-    sites
-}
-
-fn flag_number_start(bytes: &[u8], comment_start: usize) -> Option<usize> {
-    let mut index = comment_start;
-    while index > 0 && bytes[index - 1].is_ascii_whitespace() {
-        index -= 1;
-    }
-    if index == 0 || !bytes[index - 1].is_ascii_digit() {
-        return None;
-    }
-    while index > 0 && bytes[index - 1].is_ascii_digit() {
-        index -= 1;
-    }
-    if index > 0 && bytes[index - 1] == b'-' {
-        index -= 1;
-    }
-    Some(index)
-}
-
-fn dynamic_props_array_end(source: &str, comment_end: usize) -> Option<usize> {
-    let tail = &source[comment_end..];
-    let trimmed = tail.trim_start();
-    if !trimmed.starts_with(", [") {
-        return None;
-    }
-    let offset = tail.len() - trimmed.len();
-    let array_start = comment_end + offset + ", ".len();
-    let array_tail = &source[array_start..];
-    Some(array_start + array_tail.find(']')? + 1)
 }

--- a/crates/vize_atelier_dom/tests/support/mod.rs
+++ b/crates/vize_atelier_dom/tests/support/mod.rs
@@ -92,6 +92,59 @@ pub fn assert_s2_matches_prefixed_shipped_literals_with_dialect(
     assert_s2_matches_shipped_with_dialect_inner(battery, dialect, true)
 }
 
+pub fn patch_sites(source: &str) -> Vec<String> {
+    let bytes = source.as_bytes();
+    let mut sites = Vec::new();
+    let mut cursor = 0usize;
+    while let Some(comment_rel) = source[cursor..].find(" /* ") {
+        let comment_start = cursor + comment_rel;
+        let Some(comment_end_rel) = source[comment_start..].find(" */") else {
+            break;
+        };
+        let comment_end = comment_start + comment_end_rel + " */".len();
+        let Some(number_start) = flag_number_start(bytes, comment_start) else {
+            cursor = comment_end;
+            continue;
+        };
+        let mut site_end = comment_end;
+        if let Some(array_end) = dynamic_props_array_end(source, comment_end) {
+            site_end = array_end;
+        }
+        sites.push(source[number_start..site_end].trim().to_string());
+        cursor = site_end;
+    }
+    sites
+}
+
+fn flag_number_start(bytes: &[u8], comment_start: usize) -> Option<usize> {
+    let mut index = comment_start;
+    while index > 0 && bytes[index - 1].is_ascii_whitespace() {
+        index -= 1;
+    }
+    if index == 0 || !bytes[index - 1].is_ascii_digit() {
+        return None;
+    }
+    while index > 0 && bytes[index - 1].is_ascii_digit() {
+        index -= 1;
+    }
+    if index > 0 && bytes[index - 1] == b'-' {
+        index -= 1;
+    }
+    Some(index)
+}
+
+fn dynamic_props_array_end(source: &str, comment_end: usize) -> Option<usize> {
+    let tail = &source[comment_end..];
+    let trimmed = tail.trim_start();
+    if !trimmed.starts_with(", [") {
+        return None;
+    }
+    let offset = tail.len() - trimmed.len();
+    let array_start = comment_end + offset + ", ".len();
+    let array_tail = &source[array_start..];
+    Some(array_start + array_tail.find(']')? + 1)
+}
+
 fn assert_s2_matches_shipped_with_dialect_inner(
     battery: &[(&str, &str)],
     dialect: VueVersion,


### PR DESCRIPTION
## Summary
- add S2-vs-shipped patch-flag witnesses for component `v-model` plus `@update:modelValue`
- pin dynamic-prop array order for both `v-model`-first and listener-first source order

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_patch_flags -- --nocapture
- cargo clippy -p vize_atelier_dom --test davinci_s2_patch_flags -- -D warnings
- cargo fmt --all -- --check
- node tools/davinci/assertion-lint.mjs
- vp check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790290252&installation_model_id=422833&pr_number=4929&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4929&signature=f3795fc18c59645f801f6e4e1f57a8f763be22ed82d9ad0c2d9e08d30befbb8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for component `v-model` and `@update:modelValue` listener ordering.
  * Verified that generated patch flags preserve the order of attributes as written.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->