### PR TITLE
fix(matrix): isolate no-tsconfig typecheck fixtures

### DIFF
--- a/tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts
@@ -210,3 +210,83 @@ test("fixture matrix writes exact raw and compact transitive coverage evidence",
     fs.rmSync(reportDir, { recursive: true, force: true });
   }
 });
+
+test("fixture matrix isolates no-tsconfig typechecker projects from ancestor discovery", () => {
+  const fixtureDir = fs.mkdtempSync(path.join(root, "tests", "_fixtures", "matrix-no-tsconfig-"));
+  const fakeDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-matrix-no-tsconfig-"));
+  const reportDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-matrix-no-tsconfig-report-"));
+  const executable = path.join(fakeDir, "fake-vize.mjs");
+  const invocationPath = path.join(fakeDir, "invocation.json");
+  fs.mkdirSync(path.join(fixtureDir, "src"), { recursive: true });
+  fs.writeFileSync(path.join(fixtureDir, "src", "App.vue"), "<template />\n");
+  fs.writeFileSync(
+    executable,
+    `#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+const args = process.argv.slice(2);
+const tsconfigIndex = args.indexOf("--tsconfig");
+const tsconfig = tsconfigIndex === -1 ? null : args[tsconfigIndex + 1];
+const source = tsconfig == null ? null : fs.readFileSync(path.resolve(process.cwd(), tsconfig), "utf8");
+fs.writeFileSync(${JSON.stringify(invocationPath)}, JSON.stringify({ args, tsconfig, source }));
+const output =
+  tsconfig == null
+    ? {
+        files: [{ file: "src/App.vue", diagnostics: [] }],
+        programs: [
+          {
+            root: ".",
+            files: [
+              "src/App.vue",
+              path.resolve(process.cwd(), "../../node_modules/@types/node/assert.d.ts"),
+            ],
+          },
+        ],
+        errorCount: 0,
+        warningCount: 0,
+        fileCount: 1,
+      }
+    : {
+        files: [{ file: "src/App.vue", diagnostics: [] }],
+        programs: [
+          { root: ".", tsconfig, compilerOptions: {}, files: ["src/App.vue"] },
+        ],
+        errorCount: 0,
+        warningCount: 0,
+        fileCount: 1,
+      };
+process.stdout.write(JSON.stringify(output));\n`,
+  );
+  fs.chmodSync(executable, 0o755);
+
+  try {
+    const run = runTool(
+      {
+        id: "matrix-no-tsconfig",
+        fixturePath: path.relative(root, fixtureDir),
+        vueGlobs: ["src/**/*.vue"],
+      },
+      "typechecker",
+      { dryRun: false, timeoutMs: 5_000 },
+      { command: executable, prefix: [], label: executable },
+      reportDir,
+    );
+    assert.equal(run.status, "ok", run.failure);
+    assert.deepEqual(run.coverage, {
+      requestedFileCount: 1,
+      requestedSha256: digest(["src/App.vue"]),
+      transitiveAuthoredFileCount: 0,
+      transitiveAuthoredSha256: digest([]),
+      checkedFileCount: 1,
+      checkedSha256: digest(["src/App.vue"]),
+    });
+    const invocation = JSON.parse(fs.readFileSync(invocationPath, "utf8"));
+    assert.equal(invocation.tsconfig, ".vize-fixture-typecheck-matrix-no-tsconfig.tsconfig.json");
+    assert.deepEqual(JSON.parse(invocation.source), { compilerOptions: {} });
+    assert.equal(fs.existsSync(path.join(fixtureDir, invocation.tsconfig)), false);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(fakeDir, { recursive: true, force: true });
+    fs.rmSync(reportDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts
@@ -281,7 +281,8 @@ process.stdout.write(JSON.stringify(output));\n`,
       checkedSha256: digest(["src/App.vue"]),
     });
     const invocation = JSON.parse(fs.readFileSync(invocationPath, "utf8"));
-    assert.equal(invocation.tsconfig, ".vize-fixture-typecheck-matrix-no-tsconfig.tsconfig.json");
+    assert.equal(typeof invocation.tsconfig, "string");
+    assert.notEqual(invocation.tsconfig, "");
     assert.deepEqual(JSON.parse(invocation.source), { compilerOptions: {} });
     assert.equal(fs.existsSync(path.join(fixtureDir, invocation.tsconfig)), false);
   } finally {

--- a/tools/fixtures/tool-matrix-command.mjs
+++ b/tools/fixtures/tool-matrix-command.mjs
@@ -30,7 +30,7 @@ export function typecheckTsconfigPath(project) {
   return existsSync(overlayAbs) ? overlayRel : source;
 }
 
-export function toolArgs(project, tool, compilerOutputDir) {
+export function toolArgs(project, tool, compilerOutputDir, options = {}) {
   if (tool === "compiler") {
     return [
       "build",
@@ -62,7 +62,7 @@ export function toolArgs(project, tool, compilerOutputDir) {
     // files that config owns, or vue-tsc's baseline inherits the same
     // unresolvable aliases and the comparison reports fake FNs (#4454).
     const args = ["check", ...typecheckCorpusGlobs(project), "--format", "json", "--no-config"];
-    const tsconfig = typecheckTsconfigPath(project);
+    const tsconfig = options.typecheckTsconfigPath ?? typecheckTsconfigPath(project);
     if (tsconfig != null) args.push("--tsconfig", tsconfig);
     return args;
   }

--- a/tools/fixtures/tool-matrix-run.mjs
+++ b/tools/fixtures/tool-matrix-run.mjs
@@ -15,7 +15,12 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { expectedCompilerOutputs } from "./tool-matrix-compiler-paths.mjs";
-import { displayCommand, toolArgs, typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
+import {
+  displayCommand,
+  toolArgs,
+  typecheckCorpusGlobs,
+  typecheckSourceTsconfig,
+} from "./tool-matrix-command.mjs";
 import { snapshotFormatterInputs, validateFormatterOutput } from "./tool-matrix-formatter.mjs";
 import { collectTypecheckerAuthoredPaths, collectVueInputPaths } from "./tool-matrix-inputs.mjs";
 import { validateLinterOutput } from "./tool-matrix-linter.mjs";
@@ -72,9 +77,18 @@ function prepareToolRun(project, tool, args, launch, outputDir) {
     tool === "compiler" && !args.dryRun && fixtureExists
       ? mkdtempSync(join(tmpdir(), "vize-fixture-compiler-"))
       : null;
+  const typecheckerFixtureTsconfig = prepareTypecheckerFixtureTsconfig(
+    project,
+    tool,
+    args,
+    cwd,
+    fixtureExists,
+  );
   const commandArgs = [
     ...launch.prefix,
-    ...toolArgs(project, tool, compilerOutputDir ?? "<compiler-output>"),
+    ...toolArgs(project, tool, compilerOutputDir ?? "<compiler-output>", {
+      typecheckTsconfigPath: typecheckerFixtureTsconfig?.relativePath,
+    }),
   ];
   const base = {
     tool,
@@ -106,6 +120,7 @@ function prepareToolRun(project, tool, args, launch, outputDir) {
     formatterStateBefore,
     outputDir,
     project,
+    typecheckerFixtureTsconfig,
     tool,
   };
 }
@@ -114,6 +129,22 @@ function cleanupToolRun(prepared) {
   if (prepared.compilerOutputDir != null) {
     rmSync(prepared.compilerOutputDir, { recursive: true, force: true });
   }
+  if (prepared.typecheckerFixtureTsconfig?.absolutePath != null) {
+    rmSync(prepared.typecheckerFixtureTsconfig.absolutePath, { force: true });
+  }
+}
+
+function prepareTypecheckerFixtureTsconfig(project, tool, args, cwd, fixtureExists) {
+  if (tool !== "typechecker" || typecheckSourceTsconfig(project) != null) return null;
+  const relativePath = `.vize-fixture-typecheck-${fixtureProjectId(project)}.tsconfig.json`;
+  const absolutePath = join(cwd, relativePath);
+  if (!fixtureExists || args.dryRun) return { relativePath };
+  writeFileSync(absolutePath, `${JSON.stringify({ compilerOptions: {} }, null, 2)}\n`);
+  return { absolutePath, relativePath };
+}
+
+function fixtureProjectId(project) {
+  return String(project.id ?? "project").replaceAll(/[^A-Za-z0-9_.-]/g, "_");
 }
 
 function completeToolRun({


### PR DESCRIPTION
## Summary
- generate a temporary fixture-local tsconfig for typechecker matrix projects that do not declare a tsconfig
- pass that tsconfig only through the fixture harness so normal Vize CLI discovery semantics stay unchanged
- add a runner-boundary regression that would fail on the ancestor tests/tsconfig.json leak into /tests/node_modules/@types/node

## Issue
- Advances #4461 by removing one real-project matrix schema-failure class. Does not close the issue or restore rollout enforcement.

## Validation
- node --test --test-concurrency=1 tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts tests/tooling/fixture-tool-matrix-typecheck-tsconfig.test.ts tests/tooling/fixture-tool-matrix-typechecker.test.ts
- node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts
- git diff --check
- vp run --workspace-root check:ci
- VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.ts was attempted via vp run --workspace-root test:scripts after native build; local fixture hydration is incomplete, so it failed on missing/pinned real-project fixtures and was not used as pass evidence. CI should provide the authoritative hydrated result.

## Matrix evidence
- Latest inspected Real Project Matrix run 32899229303 on main@891e631710c5c007ebb615c22693c3bb9ac4b627 still had 47 no-source-tsconfig typechecker schema failures with root=/home/runner/_work/vize/vize/tests, tsconfig=/home/runner/_work/vize/vize/tests/tsconfig.json, and absolute programs[].files entries under /tests/node_modules/@types/node.
- No completed Real Project Matrix verdict exists yet for current origin/main b72b28b2ea39733f361a2ee87de3b7704f90febc.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790290352&installation_model_id=422833&pr_number=4930&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4930&signature=f8000d7ca7851c0252928a2578c802e3c3655a29d93e78b7688839d4d0855bca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved typechecking for fixtures without a local TypeScript configuration.
  - Prevented unintended discovery of ancestor configurations and unrelated external type files.
  - Ensured reports include only the requested Vue source files.

- **Tests**
  - Added integration coverage for isolated typechecking configuration, cleanup, dry runs, and fixture-specific path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->