### PR TITLE
fix(davinci): elide static attrs on slot templates

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
@@ -11,8 +11,6 @@
 
 mod support;
 
-use vize_s1_to_s2::UnsupportedReason as Reason;
-
 const BATTERY: &[(&str, &str)] = &[
     (
         "named_header_text",
@@ -33,6 +31,10 @@ const BATTERY: &[(&str, &str)] = &[
     (
         "named_header_span",
         "<Foo><template #header><span></span></template></Foo>",
+    ),
+    (
+        "named_header_extra_attr",
+        r#"<Foo><template #header id="x">x</template></Foo>"#,
     ),
     (
         "hyphenated_slot",
@@ -64,8 +66,16 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<Foo><template #header v-if="ok">x</template></Foo>"#,
     ),
     (
+        "create_slots_if_extra_attr",
+        r#"<Foo><template #header id="x" v-if="ok">x</template></Foo>"#,
+    ),
+    (
         "create_slots_for",
         r#"<Foo><template v-for="i in n" #header>x</template></Foo>"#,
+    ),
+    (
+        "create_slots_for_extra_attr",
+        r#"<Foo><template v-for="i in n" #header id="x">x</template></Foo>"#,
     ),
     (
         "create_slots_if_and_static",
@@ -113,18 +123,11 @@ const BATTERY: &[(&str, &str)] = &[
     ),
 ];
 
-const UNSUPPORTED_BATTERY: &[(&str, &str, support::ExpectedRefusal)] = &[
-    (
-        "mixed_component_root_and_named_template",
-        r#"<Foo v-slot><template #header>x</template></Foo>"#,
-        support::ExpectedRefusal::Diagnostics,
-    ),
-    (
-        "slot_template_extra_attr",
-        r#"<Foo><template #header id="x">x</template></Foo>"#,
-        support::ExpectedRefusal::Unsupported(Reason::SlotDefaultShape),
-    ),
-];
+const UNSUPPORTED_BATTERY: &[(&str, &str, support::ExpectedRefusal)] = &[(
+    "mixed_component_root_and_named_template",
+    r#"<Foo v-slot><template #header>x</template></Foo>"#,
+    support::ExpectedRefusal::Diagnostics,
+)];
 
 #[test]
 fn s2_named_slots_match_the_shipped_dom_lane_byte_for_byte() {

--- a/crates/vize_ricalco/src/emit/slots.rs
+++ b/crates/vize_ricalco/src/emit/slots.rs
@@ -87,7 +87,6 @@ fn walk_admit(region: &Region<'_>) -> Result<(), EmitError> {
                     .bindings
                     .iter()
                     .any(|binding| !matches!(binding, BindingOp::SlotContent(_)))
-                    || !element.attributes.is_empty()
                 {
                     return Err(EmitError::unsupported_at(
                         Reason::SlotDefaultShape,

--- a/crates/vize_ricalco/tests/emit_create_slots.rs
+++ b/crates/vize_ricalco/tests/emit_create_slots.rs
@@ -51,6 +51,14 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+fn static_attrs_on_conditional_slot_templates_are_elided() {
+    assert_eq!(
+        assembled(r#"<Foo><template #header id="x" v-if="ok">x</template></Foo>"#),
+        assembled(r#"<Foo><template #header v-if="ok">x</template></Foo>"#)
+    );
+}
+
+#[test]
 fn a_v_for_named_template_uses_render_list() {
     assert_eq!(
         assembled(r#"<Foo><template v-for="i in n" #header>x</template></Foo>"#),
@@ -71,6 +79,14 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
     })
   ]), 1024 /* DYNAMIC_SLOTS */))
 }")
+    );
+}
+
+#[test]
+fn static_attrs_on_looped_slot_templates_are_elided() {
+    assert_eq!(
+        assembled(r#"<Foo><template v-for="i in n" #header id="x">x</template></Foo>"#),
+        assembled(r#"<Foo><template v-for="i in n" #header>x</template></Foo>"#)
     );
 }
 

--- a/crates/vize_ricalco/tests/emit_slots.rs
+++ b/crates/vize_ricalco/tests/emit_slots.rs
@@ -154,6 +154,14 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+fn static_attrs_on_named_slot_templates_are_elided() {
+    assert_eq!(
+        assembled(r#"<Foo><template #header id="x">x</template></Foo>"#),
+        assembled(r#"<Foo><template #header>x</template></Foo>"#)
+    );
+}
+
+#[test]
 fn whitespace_only_children_emit_no_slot() {
     assert_eq!(assembled("<Foo>  </Foo>"), assembled("<Foo />"));
 }

--- a/crates/vize_ricalco/tests/emit_unsupported_census.rs
+++ b/crates/vize_ricalco/tests/emit_unsupported_census.rs
@@ -121,8 +121,8 @@ const SOURCE_CASES: &[Case] = &[
         Reason::DynamicOnHasModifiers,
     ),
     case(
-        "slot_template_attr",
-        r#"<Foo><template #header id="x">x</template></Foo>"#,
+        "bare_template_default_slot",
+        r#"<Foo><template>x</template></Foo>"#,
         VUE3,
         Reason::SlotDefaultShape,
     ),

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                    77 |               840 |             139 |     371 |             951 |      476 |           478 |           584 |
+| Compiler                   |           916 |                    76 |               840 |             139 |     371 |             951 |      475 |           477 |           584 |
 | Linter                     |           302 |                    16 |               286 |             268 |     222 |             670 |      122 |           339 |           478 |
 | Typechecker                |           881 |                   108 |               773 |             394 |     187 |             804 |      658 |           461 |           651 |
 | Typechecker content-mapper |             8 |                     3 |                 5 |               1 |       0 |               9 |        0 |             7 |            18 |
@@ -64,7 +64,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | S0/carton        |         845 |             490 |      355 |
 | S1/sinopia       |           5 |               1 |        4 |
 | S2/disegno       |          15 |               1 |       14 |
-| S1->S2/ricalco   |          31 |               2 |       29 |
+| S1->S2/ricalco   |          30 |               2 |       28 |
 | old AST/parser   |          74 |              54 |       20 |
 | Croquis analysis |          65 |              56 |        9 |
 | raw OXC          |         371 |             343 |       28 |
@@ -91,7 +91,7 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | `crates/vize_atelier_sfc/src/compile_script/props/tests.rs:4` | test/dev | S0/carton 15                                                                 |    15 |
 | `crates/vize_atelier_core/tests/s2_support/compare.rs:10`     | test/dev | Davinci 2<br>S0/carton 4<br>S1/sinopia 1<br>S2/disegno 1<br>S1->S2/ricalco 3 |    11 |
 
-Additional test/dev rows are in the TSV: 195 omitted.
+Additional test/dev rows are in the TSV: 194 omitted.
 
 ### Linter
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -287,7 +287,6 @@ compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_dynamic_von_
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_filters.rs	12	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s0	S0/carton	stage	vize_carton	compat	2
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_slots.rs	14	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_teardown_without_stack_guard.rs	25	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_walk_baseline.rs	25	davinci	Davinci	stage	vize_davinci	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_walk_baseline.rs	25	s0	S0/carton	stage	vize_carton	compat	1


### PR DESCRIPTION
## Summary
- allow S2 DOM slot-template carriers to ignore inert static attributes like the shipped DOM lane
- move the extra-attr slot-template witness from negative coverage into byte-for-byte S2 vs shipped coverage
- keep `SlotDefaultShape` covered with a bare-template default-slot refusal case
- refresh the consumer migration surface inventory after removing the now-unused S1->S2 import

## Validation
- `cargo test -p vize_ricalco --test emit_slots --test emit_create_slots --test emit_unsupported_census --test emit_unsupported_catalogue`
- `cargo test -p vize_atelier_dom --test davinci_s2_slots`
- `node --test tests/tooling/davinci-matrices.test.ts`
- `cargo fmt --check`
- `git diff --check`