### PR TITLE
fix(matrix): harden typecheck subprocess timeouts

### DIFF
--- a/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
@@ -242,6 +242,7 @@ export function run(
   fixture: ReturnType<typeof setup>,
   env: NodeJS.ProcessEnv = {},
   extraArgs: string[] = [],
+  options: { timeoutMs?: number } = {},
 ) {
   return spawnSync(
     process.execPath,
@@ -257,7 +258,12 @@ export function run(
       fixture.vueTsc,
       ...extraArgs,
     ],
-    { cwd: root, encoding: "utf8", env: { ...process.env, GITHUB_SHA: commitSha, ...env } },
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, GITHUB_SHA: commitSha, ...env },
+      timeout: options.timeoutMs,
+    },
   );
 }
 

--- a/tests/tooling/support/typecheck-dependency-prepare-fixture.ts
+++ b/tests/tooling/support/typecheck-dependency-prepare-fixture.ts
@@ -148,7 +148,11 @@ export function expectedInvocationEnv(packageManager: PackageManager) {
   };
 }
 
-export function run(fixture: ReturnType<typeof setup>, extraArgs: string[] = []) {
+export function run(
+  fixture: ReturnType<typeof setup>,
+  extraArgs: string[] = [],
+  options: { timeoutMs?: number } = {},
+) {
   return spawnSync(
     process.execPath,
     [script, "--registry", fixture.registryPath, "--output-dir", fixture.outputDir, ...extraArgs],
@@ -160,6 +164,7 @@ export function run(fixture: ReturnType<typeof setup>, extraArgs: string[] = [])
         GITHUB_SHA: commitSha,
         PATH: `${fixture.fakeDir}${path.delimiter}${process.env.PATH}`,
       },
+      timeout: options.timeoutMs,
     },
   );
 }

--- a/tests/tooling/typecheck-dependency-prepare-timeout.test.ts
+++ b/tests/tooling/typecheck-dependency-prepare-timeout.test.ts
@@ -1,0 +1,101 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { test } from "node:test";
+
+import {
+  artifactPath,
+  cleanup,
+  commit,
+  git,
+  run,
+  setup,
+  successBody,
+  writeJson,
+  writeManager,
+} from "./support/typecheck-dependency-prepare-fixture.ts";
+
+test("dependency prepare bounds an install process that ignores SIGTERM", () => {
+  if (process.platform === "win32") return;
+
+  const fixture = setup();
+  try {
+    writeManager(
+      fixture.runner,
+      fixture.invocationPath,
+      "10.0.0",
+      `const { spawn } = await import("node:child_process");
+process.on("SIGTERM", () => {});
+spawn(process.execPath, ["-e", ${JSON.stringify(
+        "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+      )}], { stdio: "inherit" });
+setInterval(() => {}, 1000);`,
+      { spec: "pnpm@10.0.0" },
+    );
+
+    const startedAt = Date.now();
+    const result = run(fixture, ["--timeout-ms", "80"], { timeoutMs: 8_000 });
+    assert.equal(result.status, 1);
+    assert.ok(
+      Date.now() - startedAt < 8_000,
+      "timeout handling must not wait for an install process tree that ignores SIGTERM",
+    );
+    assert.match(result.stderr, /pnpm@10\.0\.0 install failed to run: spawn timed out after 80ms/);
+    assert.equal(fs.existsSync(artifactPath(fixture)), false);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("dependency prepare bounds a baseline prepare process that ignores SIGTERM", () => {
+  if (process.platform === "win32") return;
+
+  const fixture = setup();
+  try {
+    writeJson(fixture.registryPath, {
+      projects: [
+        {
+          ...fixture.project,
+          typecheckPerformance: {
+            ...fixture.project.typecheckPerformance,
+            baseline: {
+              tsconfig: ".generated/tsconfig.json",
+              prepare: ["pnpm", "exec", "fixture", "prepare"],
+            },
+          },
+        },
+      ],
+    });
+    git(fixture.fixtureRoot, ["add", "registry.json"]);
+    commit(fixture.fixtureRoot, "configure baseline prepare");
+    writeManager(
+      fixture.runner,
+      fixture.invocationPath,
+      "10.0.0",
+      `if (managerArgs[0] === "install") {
+  ${successBody}
+} else {
+  const { spawn } = await import("node:child_process");
+  fs.mkdirSync(".generated", { recursive: true });
+  fs.writeFileSync(".generated/tsconfig.json", "{}\\n");
+  process.on("SIGTERM", () => {});
+  spawn(process.execPath, ["-e", ${JSON.stringify(
+    "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+  )}], { stdio: "inherit" });
+  setInterval(() => {}, 1000);
+}`,
+      { spec: "pnpm@10.0.0" },
+    );
+
+    const startedAt = Date.now();
+    const result = run(fixture, ["--timeout-ms", "80"], { timeoutMs: 8_000 });
+    assert.equal(result.status, 1);
+    assert.ok(
+      Date.now() - startedAt < 8_000,
+      "timeout handling must not wait for a baseline prepare process tree that ignores SIGTERM",
+    );
+    assert.match(result.stderr, /baseline prepare failed to run: spawn timed out after 80ms/);
+    assert.equal(fs.existsSync(artifactPath(fixture)), false);
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tests/tooling/typecheck-divergence-mutation-oracle.test.ts
+++ b/tests/tooling/typecheck-divergence-mutation-oracle.test.ts
@@ -1,8 +1,15 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 
-import { cleanup, readJson, run, setup } from "./_helpers/typecheck-divergence-report-fixture.ts";
+import {
+  cleanup,
+  readJson,
+  run,
+  setup,
+  updateJson,
+} from "./_helpers/typecheck-divergence-report-fixture.ts";
 
 function artifactPath(fixture: ReturnType<typeof setup>, extension: string) {
   return path.join(fixture.reportDir, `fixture-typecheck-divergence.${extension}`);
@@ -34,6 +41,49 @@ test("seeded mutation oracle accepts a shared probe with shifted compiler coordi
     assert.equal(repairedState.messageMismatchCount, 0);
     assert.notEqual(brokenState.sourceSha256, cleanState.sourceSha256);
     assert.equal(repairedState.sourceSha256, cleanState.sourceSha256);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("seeded mutation oracle bounds a Vize mutation process that ignores SIGTERM", () => {
+  if (process.platform === "win32") return;
+
+  const fixture = setup();
+  const sourcePath = path.join(fixture.fixtureRoot, "src/App.vue");
+  const originalSource = fs.readFileSync(sourcePath, "utf8");
+  try {
+    updateJson(
+      fixture.registryPath,
+      (registry) => (registry.projects[0].typecheckPerformance.hangTimeoutMs = 80),
+    );
+    fs.writeFileSync(
+      fixture.vize,
+      `#!/usr/bin/env node
+import { spawn } from "node:child_process";
+if (process.argv.includes("--version")) { console.log("vize 0.0.0-test"); process.exit(0); }
+process.on("SIGTERM", () => {});
+spawn(process.execPath, ["-e", ${JSON.stringify(
+        "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+      )}], { stdio: "inherit" });
+setInterval(() => {}, 1000);
+`,
+    );
+    fs.chmodSync(fixture.vize, 0o755);
+
+    const startedAt = Date.now();
+    const result = run(fixture, {}, [], { timeoutMs: 8_000 });
+    assert.equal(result.status, 1);
+    assert.ok(
+      Date.now() - startedAt < 8_000,
+      "timeout handling must not wait for a Vize mutation process tree that ignores SIGTERM",
+    );
+    const artifact = readJson(artifactPath(fixture, "json"));
+    assert.match(
+      artifact.mutationOracle.unusableReason,
+      /Vize mutation run failed: spawn timed out after 80ms/,
+    );
+    assert.equal(fs.readFileSync(sourcePath, "utf8"), originalSource);
   } finally {
     cleanup(fixture);
   }

--- a/tests/tooling/typecheck-divergence-report-timeout.test.ts
+++ b/tests/tooling/typecheck-divergence-report-timeout.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  cleanup,
+  run,
+  setup,
+  updateJson,
+  writeVueTsc,
+} from "./_helpers/typecheck-divergence-report-fixture.ts";
+
+test("typecheck divergence report bounds a vue-tsc baseline that ignores SIGTERM", () => {
+  if (process.platform === "win32") return;
+
+  const fixture = setup();
+  try {
+    updateJson(
+      fixture.registryPath,
+      (registry) => (registry.projects[0].typecheckPerformance.hangTimeoutMs = 80),
+    );
+    writeVueTsc(
+      fixture.vueTsc,
+      `import { spawn } from "node:child_process";
+process.on("SIGTERM", () => {});
+spawn(process.execPath, ["-e", ${JSON.stringify(
+        "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+      )}], { stdio: "inherit" });
+setInterval(() => {}, 1000);`,
+      fixture.invocationPath,
+    );
+
+    const startedAt = Date.now();
+    const result = run(fixture, {}, [], { timeoutMs: 8_000 });
+    assert.equal(result.status, 1);
+    assert.ok(
+      Date.now() - startedAt < 8_000,
+      "timeout handling must not wait for a vue-tsc process tree that ignores SIGTERM",
+    );
+    assert.match(result.stderr, /vue-tsc baseline failed to run: spawn timed out after 80ms/);
+    assert.equal(
+      fs.existsSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json")),
+      false,
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tools/fixtures/typecheck-baseline-run.mjs
+++ b/tools/fixtures/typecheck-baseline-run.mjs
@@ -1,13 +1,12 @@
-import { spawnSync } from "node:child_process";
+import { runTypecheckCommand } from "./typecheck-command-runner.mjs";
 
-export function runVueTscBaseline({ vueTsc, args, cwd, timeoutMs, label }) {
+export async function runVueTscBaseline({ vueTsc, args, cwd, timeoutMs, label }) {
   const startedAt = Date.now();
-  const result = spawnSync(vueTsc.path, args, {
+  const result = await runTypecheckCommand(vueTsc.path, args, {
     cwd,
-    encoding: "utf8",
     env: { ...process.env, LANG: "C", LC_ALL: "C" },
     maxBuffer: 1024 * 1024 * 1024,
-    timeout: timeoutMs,
+    timeoutMs,
   });
   const durationMs = Date.now() - startedAt;
   if (result.error != null) {

--- a/tools/fixtures/typecheck-command-runner.mjs
+++ b/tools/fixtures/typecheck-command-runner.mjs
@@ -1,0 +1,117 @@
+import { spawn } from "node:child_process";
+
+const defaultForceKillDelayMs = 5_000;
+const defaultForceSettleDelayMs = 10_000;
+const defaultMaxBuffer = 1024 * 1024 * 1024;
+
+export function runTypecheckCommand(command, args, options) {
+  if (!Number.isSafeInteger(options.timeoutMs) || options.timeoutMs <= 0) {
+    throw new Error("timeoutMs must be a positive safe integer");
+  }
+  return new Promise((settle) => {
+    let stdout = "";
+    let stderr = "";
+    let stdoutBytes = 0;
+    let stderrBytes = 0;
+    let spawnError = null;
+    let timeoutError = null;
+    let maxBufferError = null;
+    let timeoutTimer = null;
+    let forceKillTimer = null;
+    let forceSettleTimer = null;
+    let terminating = false;
+    let settled = false;
+    const maxBuffer = options.maxBuffer ?? defaultMaxBuffer;
+    const forceKillDelayMs =
+      options.forceKillDelayMs ?? Math.min(defaultForceKillDelayMs, options.timeoutMs);
+    const forceSettleDelayMs =
+      options.forceSettleDelayMs ??
+      forceKillDelayMs + Math.min(defaultForceSettleDelayMs, options.timeoutMs);
+
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      detached: process.platform !== "win32",
+      env: options.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    function stopTimers() {
+      clearTimeout(timeoutTimer);
+      clearTimeout(forceKillTimer);
+      clearTimeout(forceSettleTimer);
+    }
+
+    function settleResult(status, signal) {
+      if (settled) return;
+      settled = true;
+      stopTimers();
+      settle({
+        error: spawnError ?? timeoutError ?? maxBufferError,
+        signal,
+        status: spawnError == null ? status : null,
+        stderr,
+        stdout,
+      });
+    }
+
+    function signalChildTree(signal) {
+      if (child.pid == null) {
+        child.kill(signal);
+        return;
+      }
+      if (process.platform !== "win32") {
+        try {
+          process.kill(-child.pid, signal);
+          return;
+        } catch (error) {
+          if (error?.code === "ESRCH") return;
+        }
+      }
+      child.kill(signal);
+    }
+
+    function beginTermination() {
+      if (terminating) return;
+      terminating = true;
+      signalChildTree("SIGTERM");
+      forceKillTimer = setTimeout(() => signalChildTree("SIGKILL"), forceKillDelayMs);
+      forceKillTimer.unref?.();
+      forceSettleTimer = setTimeout(() => settleResult(null, "SIGKILL"), forceSettleDelayMs);
+      forceSettleTimer.unref?.();
+    }
+
+    function killForMaxBuffer(streamName) {
+      if (maxBufferError != null) return;
+      maxBufferError = new Error(`${streamName} maxBuffer exceeded`);
+      maxBufferError.code = "ENOBUFS";
+      beginTermination();
+    }
+
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => {
+      stdoutBytes += Buffer.byteLength(chunk);
+      if (stdoutBytes > maxBuffer) killForMaxBuffer("stdout");
+      else stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderrBytes += Buffer.byteLength(chunk);
+      if (stderrBytes > maxBuffer) killForMaxBuffer("stderr");
+      else stderr += chunk;
+    });
+    child.once("error", (error) => {
+      spawnError = error;
+      settleResult(null, null);
+    });
+    child.once("close", (status, signal) => {
+      settleResult(status, signal);
+    });
+
+    timeoutTimer = setTimeout(() => {
+      timeoutError = new Error(`spawn timed out after ${options.timeoutMs}ms`);
+      timeoutError.code = "ETIMEDOUT";
+      beginTermination();
+    }, options.timeoutMs);
+    timeoutTimer.unref?.();
+  });
+}

--- a/tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/tools/fixtures/typecheck-dependency-prepare.mjs
@@ -6,6 +6,7 @@ import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { validateTypecheckPerformanceTarget } from "./tool-matrix-typecheck-target.mjs";
+import { runTypecheckCommand } from "./typecheck-command-runner.mjs";
 import { isolateFixtureTypePackages } from "./typecheck-baseline-isolation.mjs";
 import {
   isolateUniqueLocalTypePackages,
@@ -24,7 +25,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, "..", "..");
 const defaultRegistry = join(repoRoot, "tests", "_fixtures", "vue-ecosystem-fixtures.json");
 
-export function runTypecheckDependencyPrepare(argv = process.argv.slice(2)) {
+export async function runTypecheckDependencyPrepare(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   const registry = readJson(args.registry);
   const selected = selectTypecheckPerformanceProjects(registry, args);
@@ -36,10 +37,14 @@ export function runTypecheckDependencyPrepare(argv = process.argv.slice(2)) {
     );
     return [];
   }
-  return selected.map((project) => prepareProjectDependencies({ args, commitSha, project }));
+  const artifacts = [];
+  for (const project of selected) {
+    artifacts.push(await prepareProjectDependencies({ args, commitSha, project }));
+  }
+  return artifacts;
 }
 
-function prepareProjectDependencies({ args, commitSha, project }) {
+async function prepareProjectDependencies({ args, commitSha, project }) {
   const fixtureRoot = resolve(repoRoot, project.fixturePath);
   validateTypecheckPerformanceTarget(project, fixtureRoot);
   const performance = project.typecheckPerformance;
@@ -49,7 +54,7 @@ function prepareProjectDependencies({ args, commitSha, project }) {
 
   const manager = performance.packageManager;
   const managerRunner = packageManagerRunner(manager, performance.packageManagerVersion);
-  const probe = runPackageManager(managerRunner, ["--version"], {
+  const probe = await runPackageManager(managerRunner, ["--version"], {
     cwd: fixtureRoot,
     encoding: "utf8",
     timeout: 10_000,
@@ -68,7 +73,7 @@ function prepareProjectDependencies({ args, commitSha, project }) {
 
   const installArgs = installArguments(manager);
   const startedAt = Date.now();
-  const install = runPackageManager(managerRunner, installArgs, {
+  const install = await runPackageManager(managerRunner, installArgs, {
     cwd: fixtureRoot,
     encoding: "utf8",
     env: {
@@ -93,7 +98,12 @@ function prepareProjectDependencies({ args, commitSha, project }) {
     throw new Error(`${manager} install modified frozen lockfile ${performance.lockfile}`);
   }
   requireCleanFixture(fixtureRoot, "after dependency installation");
-  const baselinePrepare = runBaselinePrepare(project, fixtureRoot, args.timeoutMs, managerRunner);
+  const baselinePrepare = await runBaselinePrepare(
+    project,
+    fixtureRoot,
+    args.timeoutMs,
+    managerRunner,
+  );
   validateTypecheckPerformanceTarget(project, fixtureRoot, { requireBaseline: true });
   // Both tools run against this tree, so the type environment is closed here
   // rather than in the divergence report — a repair only the baseline saw would
@@ -188,11 +198,11 @@ function isolateFixture(project, fixtureRoot) {
   }
 }
 
-function runBaselinePrepare(project, fixtureRoot, timeoutMs, managerRunner) {
+async function runBaselinePrepare(project, fixtureRoot, timeoutMs, managerRunner) {
   const command = project.typecheckPerformance.baseline?.prepare;
   if (command == null) return null;
   const startedAt = Date.now();
-  const prepared = runBaselineCommand(command, fixtureRoot, timeoutMs, managerRunner);
+  const prepared = await runBaselineCommand(command, fixtureRoot, timeoutMs, managerRunner);
   const durationMs = Date.now() - startedAt;
   if (prepared.error != null) {
     throw new Error(`baseline prepare failed to run: ${errorMessage(prepared.error)}`);
@@ -209,7 +219,7 @@ function runBaselinePrepare(project, fixtureRoot, timeoutMs, managerRunner) {
   };
 }
 
-function runBaselineCommand(command, fixtureRoot, timeoutMs, managerRunner) {
+async function runBaselineCommand(command, fixtureRoot, timeoutMs, managerRunner) {
   const options = {
     cwd: fixtureRoot,
     encoding: "utf8",
@@ -220,7 +230,7 @@ function runBaselineCommand(command, fixtureRoot, timeoutMs, managerRunner) {
   if (command[0] === managerRunner.manager) {
     return runPackageManager(managerRunner, command.slice(1), options);
   }
-  return spawnSync(command[0], command.slice(1), options);
+  return runTypecheckCommand(command[0], command.slice(1), commandOptions(options));
 }
 
 export function installArguments(manager) {
@@ -245,13 +255,26 @@ function packageManagerRunner(manager, version) {
 
 function runPackageManager(runner, args, options) {
   if (runner.prefixArgs.length === 0) {
-    return spawnSync(runner.command, args, options);
+    return runTypecheckCommand(runner.command, args, commandOptions(options));
   }
   // Fixtures intentionally carry the pinned package-manager contract in the
   // registry, not package.json. Prevent Corepack from walking up to the
   // repository root and applying Vize's own packageManager field instead.
   const env = { ...process.env, ...options.env, COREPACK_ENABLE_PROJECT_SPEC: "0" };
-  return spawnSync(runner.command, [...runner.prefixArgs, ...args], { ...options, env });
+  return runTypecheckCommand(
+    runner.command,
+    [...runner.prefixArgs, ...args],
+    commandOptions({ ...options, env }),
+  );
+}
+
+function commandOptions(options) {
+  return {
+    cwd: options.cwd,
+    env: options.env ?? process.env,
+    maxBuffer: options.maxBuffer,
+    timeoutMs: options.timeout,
+  };
 }
 
 function requireCleanFixture(fixtureRoot, phase) {
@@ -336,7 +359,7 @@ const entrypoint = process.argv[1]
   : false;
 if (entrypoint) {
   try {
-    runTypecheckDependencyPrepare();
+    await runTypecheckDependencyPrepare();
   } catch (error) {
     process.stderr.write(`${errorMessage(error)}\n`);
     process.exit(1);

--- a/tools/fixtures/typecheck-divergence-mutation-runner.mjs
+++ b/tools/fixtures/typecheck-divergence-mutation-runner.mjs
@@ -1,13 +1,13 @@
-import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 
 import { displayCommand, toolArgs, typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
 import { collectTypecheckerAuthoredPaths, collectVueInputPaths } from "./tool-matrix-inputs.mjs";
 import { validateTypecheckerOutput } from "./tool-matrix-typechecker.mjs";
+import { runTypecheckCommand } from "./typecheck-command-runner.mjs";
 import { compareTypecheckDiagnostics } from "./typecheck-divergence.mjs";
 
-export function observeMutationState({
+export async function observeMutationState({
   name,
   project,
   fixtureRoot,
@@ -19,9 +19,9 @@ export function observeMutationState({
   documentedDifferences,
 }) {
   const sourceSha256 = sha256(readFileSync(sourcePath));
-  const vize = runVizeTypecheck(project, fixtureRoot, vizeLaunch);
+  const vize = await runVizeTypecheck(project, fixtureRoot, vizeLaunch);
   assertSourceUnchanged(name, file, sourcePath, sourceSha256, "Vize");
-  const baseline = runVueTsc(project, fixtureRoot, vueTsc, baselineArgs);
+  const baseline = await runVueTsc(project, fixtureRoot, vueTsc, baselineArgs);
   assertSourceUnchanged(name, file, sourcePath, sourceSha256, "vue-tsc");
   return {
     sourceSha256,
@@ -37,14 +37,13 @@ export function observeMutationState({
   };
 }
 
-function runVizeTypecheck(project, fixtureRoot, launch) {
+async function runVizeTypecheck(project, fixtureRoot, launch) {
   const args = [...launch.prefix, ...toolArgs(project, "typechecker", "<compiler-output>")];
-  const result = spawnSync(launch.command, args, {
+  const result = await runTypecheckCommand(launch.command, args, {
     cwd: fixtureRoot,
-    encoding: "utf8",
     env: { ...process.env, LANG: "C", LC_ALL: "C" },
     maxBuffer: 1024 * 1024 * 1024,
-    timeout: project.typecheckPerformance.hangTimeoutMs,
+    timeoutMs: project.typecheckPerformance.hangTimeoutMs,
   });
   if (result.error != null) {
     throw new Error(`Vize mutation run failed: ${errorMessage(result.error)}`);
@@ -74,13 +73,12 @@ function runVizeTypecheck(project, fixtureRoot, launch) {
   });
 }
 
-function runVueTsc(project, fixtureRoot, vueTsc, args) {
-  const result = spawnSync(vueTsc.path, args, {
+async function runVueTsc(project, fixtureRoot, vueTsc, args) {
+  const result = await runTypecheckCommand(vueTsc.path, args, {
     cwd: fixtureRoot,
-    encoding: "utf8",
     env: { ...process.env, LANG: "C", LC_ALL: "C" },
     maxBuffer: 1024 * 1024 * 1024,
-    timeout: project.typecheckPerformance.hangTimeoutMs,
+    timeoutMs: project.typecheckPerformance.hangTimeoutMs,
   });
   if (result.error != null) {
     throw new Error(`vue-tsc mutation run failed: ${errorMessage(result.error)}`);

--- a/tools/fixtures/typecheck-divergence-mutation.mjs
+++ b/tools/fixtures/typecheck-divergence-mutation.mjs
@@ -8,7 +8,7 @@ export {
 import { summarizeMutationObservations } from "./typecheck-divergence-mutation-delta.mjs";
 import { observeMutationState } from "./typecheck-divergence-mutation-runner.mjs";
 
-export function executeSeededMutationOracle({
+export async function executeSeededMutationOracle({
   project,
   fixtureRoot,
   file,
@@ -25,11 +25,11 @@ export function executeSeededMutationOracle({
   let primaryError;
   try {
     writeFileSync(sourcePath, cleanSource);
-    const clean = observe({ name: "clean" });
+    const clean = await observe({ name: "clean" });
     writeFileSync(sourcePath, brokenSource);
-    const broken = observe({ name: "broken" });
+    const broken = await observe({ name: "broken" });
     writeFileSync(sourcePath, cleanSource);
-    const repaired = observe({ name: "repaired" });
+    const repaired = await observe({ name: "repaired" });
     result = summarizeMutationObservations({
       clean,
       broken,
@@ -58,7 +58,7 @@ export function executeSeededMutationOracle({
   if (primaryError != null) throw primaryError;
   return result;
 
-  function observe({ name }) {
+  async function observe({ name }) {
     return observeMutationState({
       name,
       project,

--- a/tools/fixtures/typecheck-divergence-provenance.mjs
+++ b/tools/fixtures/typecheck-divergence-provenance.mjs
@@ -93,7 +93,7 @@ export function readAndValidateDependencyPreparation({
   };
 }
 
-export function createSeededMutationOracle({
+export async function createSeededMutationOracle({
   project,
   fixtureRoot,
   vizeReport,
@@ -143,7 +143,7 @@ export function createSeededMutationOracle({
   let candidateCount = 0;
   for (const candidate of selectMutationCandidates(sharedFiles, seed, fixtureRoot)) {
     candidateCount += 1;
-    const oracle = observeMutationCandidate({
+    const oracle = await observeMutationCandidate({
       project,
       fixtureRoot,
       candidate,
@@ -167,7 +167,7 @@ export function createSeededMutationOracle({
   );
 }
 
-function observeMutationCandidate({
+async function observeMutationCandidate({
   project,
   fixtureRoot,
   candidate,
@@ -190,7 +190,7 @@ function observeMutationCandidate({
 
   let observed;
   try {
-    observed = executeSeededMutationOracle({
+    observed = await executeSeededMutationOracle({
       project,
       fixtureRoot,
       file,

--- a/tools/fixtures/typecheck-divergence-report.mjs
+++ b/tools/fixtures/typecheck-divergence-report.mjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
@@ -15,6 +14,7 @@ import { applyIsolatedJsxBaseline } from "./typecheck-baseline-outside-jsx.mjs";
 import { typecheckSourceTsconfig } from "./tool-matrix-command.mjs";
 import { runVueTscBaseline } from "./typecheck-baseline-run.mjs";
 import { evaluateVueProgramCoverage } from "./typecheck-baseline-coverage.mjs";
+import { runTypecheckCommand } from "./typecheck-command-runner.mjs";
 import { assertBudgetsPassed, evaluateBudget } from "./typecheck-divergence-budget.mjs";
 import { renderMarkdown } from "./typecheck-divergence-markdown.mjs";
 import {
@@ -38,7 +38,7 @@ const documentedDifferencesPath = join(
   "compat-documented-differences.json",
 );
 
-export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
+export async function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
   const args = parseArgs(argv, { repoRoot, defaultRegistry });
   const registry = readJson(args.registry);
   const selected = selectTypecheckPerformanceProjects(registry, args);
@@ -51,7 +51,7 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
   const artifacts = [];
   const documentedDifferences = readDocumentedDifferences();
   const vizeLaunch = resolveVizeLaunch(args.vizeBin, false);
-  const vueTsc = resolveVueTsc(args.vueTscBin);
+  const vueTsc = await resolveVueTsc(args.vueTscBin);
   for (const project of selected) {
     validatePerformanceConfig(project.typecheckPerformance);
     const fixtureRoot = resolve(repoRoot, project.fixturePath);
@@ -87,14 +87,14 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
       "-p",
       baselineProject.path,
     ];
-    const baseline = runVueTscBaseline({
+    const baseline = await runVueTscBaseline({
       vueTsc,
       args: baselineArgs,
       cwd: fixtureRoot,
       timeoutMs: project.typecheckPerformance.hangTimeoutMs,
       label: "vue-tsc baseline",
     });
-    const coverageBaseline = runVueTscBaseline({
+    const coverageBaseline = await runVueTscBaseline({
       vueTsc,
       args: coverageArgs,
       cwd: fixtureRoot,
@@ -118,7 +118,7 @@ export function runTypecheckDivergenceReport(argv = process.argv.slice(2)) {
     // Coverage proves both tools loaded the same `.vue` files; this proves the
     // baseline loaded them against the fixture's own type environment.
     const ambient = evaluateBaselineAmbientEnvironment(coverageBaseline.output, fixtureRoot);
-    const mutationOracle = createSeededMutationOracle({
+    const mutationOracle = await createSeededMutationOracle({
       project,
       fixtureRoot,
       vizeReport: vizeRun.payload.parsed,
@@ -206,9 +206,14 @@ function validatePerformanceConfig(performance) {
   ratio(performance.maxFalseNegativeRatio, "maxFalseNegativeRatio");
 }
 
-function resolveVueTsc(value) {
+async function resolveVueTsc(value) {
   const candidate = isAbsolute(value) ? value : resolve(repoRoot, value);
-  const probe = spawnSync(candidate, ["--version"], { encoding: "utf8", timeout: 10_000 });
+  const probe = await runTypecheckCommand(candidate, ["--version"], {
+    cwd: repoRoot,
+    env: process.env,
+    maxBuffer: 1024 * 1024,
+    timeoutMs: 10_000,
+  });
   const version = (probe.stdout ?? "").trim();
   if (probe.error != null || probe.status !== 0 || version === "")
     throw new Error(`vue-tsc is not runnable: ${value}`);
@@ -237,7 +242,7 @@ const entrypoint =
   process.argv[1] != null && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
 if (entrypoint) {
   try {
-    runTypecheckDivergenceReport();
+    await runTypecheckDivergenceReport();
   } catch (error) {
     process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);


### PR DESCRIPTION
## Summary
- add a bounded async subprocess runner for typecheck fixture commands
- route vue-tsc/Vize divergence and dependency-prepare subprocesses through SIGTERM -> SIGKILL timeout handling
- add regressions for subprocess trees that ignore SIGTERM

## Tests
- node --test tests/tooling/typecheck-divergence*.test.ts tests/tooling/typecheck-dependency-prepare.test.ts
- node tools/davinci/consumer-migration-surfaces.mjs --check
- vp run --workspace-root check:repo

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790296153&installation_model_id=422833&pr_number=4935&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4935&signature=dde0b64f5876dd1f1819f74b495cce15a4c5c1dc60c52e9e3f12f103d3cc4b32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Type-checking and dependency preparation processes now enforce timeouts, including when child processes ignore termination signals.
  * Timed-out processes are terminated cleanly, preventing stalled runs and ensuring clear error reporting.
  * Failed operations no longer leave behind incomplete artifacts.
  * Added regression coverage for dependency preparation, mutation checks, and divergence reporting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->