### PR TITLE
refactor(davinci): align canon content mapper with s0

### DIFF
--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -16,7 +16,7 @@ native = ["dep:walkdir", "dep:dirs", "dep:corsa", "dep:corsa_lsp", "dep:lsp-type
 legacy = ["vize_armature/legacy", "vize_atelier_jsx/legacy"]
 
 [dependencies]
-vize_carton.workspace = true
+vize_s0.workspace = true
 vize_croquis.workspace = true
 vize_relief.workspace = true
 vize_armature.workspace = true

--- a/crates/vize_canon/benches/package_route.rs
+++ b/crates/vize_canon/benches/package_route.rs
@@ -37,9 +37,7 @@ fn chain(depth: usize, sources_per_package: usize) -> PackageRoute {
             package_root: root.clone(),
             package_link_root: root.clone(),
             manifest_path: root.join("package.json"),
-            package_name: Some(vize_carton::String::from(
-                format!("@ws/lib{level:03}").as_str(),
-            )),
+            package_name: Some(vize_s0::String::from(format!("@ws/lib{level:03}").as_str())),
             workspace_source: true,
             nested_routes: route.into_iter().collect(),
         });

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use vize_atelier_core::TemplateSyntaxMode;
 use vize_atelier_sfc::{SfcError, SfcParseOptions, parse_sfc};
-use vize_carton::{String as CompactString, ToCompactString, config::VueVersion};
+use vize_s0::{String as CompactString, ToCompactString, config::VueVersion};
 
 use crate::batch::Diagnostic;
 use crate::batch::error::CorsaResult;
@@ -210,7 +210,7 @@ fn sfc_parse_diagnostic(source: &str, error: &SfcError) -> ContentMapperDiagnost
 }
 
 fn generated_diagnostic(source: &str, diagnostic: &Diagnostic) -> ContentMapperDiagnostic {
-    let index = vize_carton::line_index::LineIndex::new(source);
+    let index = vize_s0::line_index::LineIndex::new(source);
     let start = index
         .line_col_to_offset(diagnostic.line, diagnostic.column)
         .unwrap_or(0);

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs
@@ -1,4 +1,4 @@
-use vize_carton::String as CompactString;
+use vize_s0::String as CompactString;
 
 pub(super) fn is_synthetic_content_mapper_identifier(text: &str) -> bool {
     text.starts_with("__vize_prop_check_")

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs
@@ -9,7 +9,7 @@
 //! works there without any directive mapping.
 
 use vize_atelier_sfc::SfcTemplateBlock;
-use vize_carton::String as CompactString;
+use vize_s0::String as CompactString;
 
 use super::protocol::{
     ContentMapperDiagnosticDirective, ContentMapperDiagnosticDirectives, ContentMapperSpan,

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs
@@ -1,7 +1,7 @@
 //! Protocol DTOs for the TypeScript content mapper.
 
 use serde::Serialize;
-use vize_carton::String as CompactString;
+use vize_s0::String as CompactString;
 
 /// The virtual extension every Vize transform output is parsed as.
 ///

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -42,6 +42,8 @@
 //! └─────────────────────────────────────────────────────────────────┘
 //! ```
 
+extern crate vize_s0 as vize_carton;
+
 mod checker;
 mod context;
 #[cfg(feature = "native")]
@@ -116,7 +118,7 @@ pub use source_map::{
     position_to_offset,
 };
 pub use types::{CompletionItem, CompletionKind, TypeInfo, TypeKind};
-pub use vize_carton::i18n::Locale;
+pub use vize_s0::i18n::Locale;
 
 #[cfg(feature = "native")]
 pub use corsa_bridge::{

--- a/crates/vize_canon/tests/auto_import_ref_unwrap.rs
+++ b/crates/vize_canon/tests/auto_import_ref_unwrap.rs
@@ -15,7 +15,7 @@ use vize_croquis::{Analyzer, AnalyzerOptions};
 const REF_STUB: &str = "declare const currentUser: typeof import('./composables')['currentUser'];";
 
 fn generate(script: &str, template: &str, options: &VirtualTsOptions) -> String {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (root, _) = vize_armature::parse(&allocator, template);
     let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
     analyzer.analyze_script_setup(script);
@@ -27,7 +27,7 @@ fn generate(script: &str, template: &str, options: &VirtualTsOptions) -> String 
 }
 
 fn generate_legacy(script: &str, template: &str, options: &VirtualTsOptions) -> String {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (root, _) = vize_armature::parse(&allocator, template);
     let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
     analyzer.analyze_script_setup(script);
@@ -165,7 +165,7 @@ export default defineComponent({
     },
 })
 "#;
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (root, _) = vize_armature::parse(&allocator, r#"<div>{{ currentUser.account }}</div>"#);
     let mut analyzer = Analyzer::with_options(AnalyzerOptions::full()).with_options_api();
     analyzer.analyze_script_plain(script);

--- a/crates/vize_canon/tests/component_event_arity.rs
+++ b/crates/vize_canon/tests/component_event_arity.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait, SfcTypeCheckOptions, type_check_sfc};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 #[test]
 fn unresolved_component_events_accept_multi_argument_handlers() {
@@ -220,7 +220,7 @@ fn event_handler_mapping_targets_the_user_operand() {
 "#;
     let template = r#"<button @click="__vize_cb">Click</button>"#;
 
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (root, _) = vize_armature::parse(&allocator, template);
 
     let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());

--- a/crates/vize_canon/tests/empty_template_interpolation.rs
+++ b/crates/vize_canon/tests/empty_template_interpolation.rs
@@ -1,5 +1,5 @@
 use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
-use vize_carton::String;
+use vize_s0::String;
 
 const SOURCE: &str = r#"<script setup lang="ts">
 const value = 'visible'

--- a/crates/vize_canon/tests/escaped_regex_template_expression.rs
+++ b/crates/vize_canon/tests/escaped_regex_template_expression.rs
@@ -1,5 +1,5 @@
 use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
-use vize_carton::String;
+use vize_s0::String;
 
 const SOURCE: &str = r#"<script setup lang="ts">
 const baseUrl = 'http://example.test'

--- a/crates/vize_canon/tests/leading_semicolon_event_handler.rs
+++ b/crates/vize_canon/tests/leading_semicolon_event_handler.rs
@@ -1,5 +1,5 @@
 use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
-use vize_carton::String;
+use vize_s0::String;
 
 const SOURCE: &str = r#"<script setup lang="ts">
 let currentFocus: object | null = null

--- a/crates/vize_canon/tests/lsp_import_resolution.rs
+++ b/crates/vize_canon/tests/lsp_import_resolution.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use vize_canon::{CorsaBridge, CorsaBridgeConfig, LspHover, LspHoverContents, LspMarkedString};
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 #[path = "lsp_import_resolution/shared_editor_session.rs"]
 mod shared_editor_session;
@@ -316,8 +316,8 @@ fn hover_contains(hover: &Option<LspHover>, expected: &str) -> bool {
 
 fn resolve_test_tsgo_binary() -> Option<PathBuf> {
     let root = workspace_root();
-    vize_carton::corsa_resolver::resolve_corsa_executable(
-        vize_carton::corsa_resolver::CorsaResolveRequest {
+    vize_s0::corsa_resolver::resolve_corsa_executable(
+        vize_s0::corsa_resolver::CorsaResolveRequest {
             project_root: Some(&root),
             ..Default::default()
         },

--- a/crates/vize_canon/tests/lsp_import_resolution/shared_editor_session.rs
+++ b/crates/vize_canon/tests/lsp_import_resolution/shared_editor_session.rs
@@ -38,7 +38,7 @@ fn bridge_diagnostics_and_hover_reuse_one_standard_editor_lsp_session() {
     let traced_tsgo = trace_dir.path().join("traced-tsgo");
     std::fs::write(
         &traced_tsgo,
-        vize_carton::cstr!(
+        vize_s0::cstr!(
             "#!/bin/sh\nprintf '%s\\n' \"$*\" >> {}\nexec {} \"$@\"\n",
             shell_quote_path(&trace_log),
             shell_quote_path(&corsa_path)
@@ -105,7 +105,7 @@ fn bridge_diagnostics_and_hover_reuse_one_standard_editor_lsp_session() {
 }
 
 #[cfg(unix)]
-fn shell_quote_path(path: &std::path::Path) -> vize_carton::String {
+fn shell_quote_path(path: &std::path::Path) -> vize_s0::String {
     let path = path.to_string_lossy();
-    vize_carton::cstr!("'{}'", path.replace('\'', "'\"'\"'"))
+    vize_s0::cstr!("'{}'", path.replace('\'', "'\"'\"'"))
 }

--- a/crates/vize_canon/tests/lsp_vue_references.rs
+++ b/crates/vize_canon/tests/lsp_vue_references.rs
@@ -115,8 +115,8 @@ fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
     let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(std::path::Path::parent)?;
-    vize_carton::corsa_resolver::resolve_corsa_executable(
-        vize_carton::corsa_resolver::CorsaResolveRequest {
+    vize_s0::corsa_resolver::resolve_corsa_executable(
+        vize_s0::corsa_resolver::CorsaResolveRequest {
             project_root: Some(workspace_root),
             ..Default::default()
         },

--- a/crates/vize_canon/tests/nested_vif_narrowing.rs
+++ b/crates/vize_canon/tests/nested_vif_narrowing.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[test]
 fn nested_else_v_for_keeps_the_outer_discriminant_narrowing() {

--- a/crates/vize_canon/tests/no_space_default_export.rs
+++ b/crates/vize_canon/tests/no_space_default_export.rs
@@ -1,5 +1,5 @@
 use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
-use vize_carton::String;
+use vize_s0::String;
 
 const LEGACY_OPTIONS_SOURCE: &str = r#"<script>
   export default{

--- a/crates/vize_canon/tests/options_api_runtime_props_value_scope.rs
+++ b/crates/vize_canon/tests/options_api_runtime_props_value_scope.rs
@@ -1,5 +1,5 @@
 use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
-use vize_carton::String;
+use vize_s0::String;
 
 const SOURCE: &str = r#"<script>
 export default {

--- a/crates/vize_canon/tests/recovered_parse_codegen.rs
+++ b/crates/vize_canon/tests/recovered_parse_codegen.rs
@@ -35,7 +35,7 @@ const wrong: number = 'not a number'
 const FALLBACK_STUB: &str =
     "declare const __vize_component: any;\nexport default __vize_component;\n";
 
-fn virtual_ts_for(source: &str) -> vize_carton::String {
+fn virtual_ts_for(source: &str) -> vize_s0::String {
     let temp_dir = tempfile::tempdir().expect("temp project should be created");
     let dir = temp_dir.path().canonicalize().unwrap();
     let path = dir.join("App.vue");

--- a/crates/vize_canon/tests/relative_extensionless_vue_imports.rs
+++ b/crates/vize_canon/tests/relative_extensionless_vue_imports.rs
@@ -12,7 +12,7 @@
 use std::path::{Path, PathBuf};
 
 use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 const CHILD: &str = r#"<script setup lang="ts">
 defineProps<{ count: number }>()

--- a/crates/vize_canon/tests/reserved_enum_member.rs
+++ b/crates/vize_canon/tests/reserved_enum_member.rs
@@ -1,5 +1,5 @@
 use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
-use vize_carton::String;
+use vize_s0::String;
 
 const SOURCE: &str = r#"<template>
   <p v-if="mode === MODES.export">{{ mode }}</p>

--- a/crates/vize_canon/tests/reserved_template_literals.rs
+++ b/crates/vize_canon/tests/reserved_template_literals.rs
@@ -1,5 +1,5 @@
 use vize_canon::{SfcTypeCheckOptions, type_check_sfc_with_options_api};
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 const EXTENDS_SOURCE: &str = r#"<script lang="ts">
 import Base from './Base'

--- a/crates/vize_canon/tests/support/auto_import_project.rs
+++ b/crates/vize_canon/tests/support/auto_import_project.rs
@@ -125,7 +125,7 @@ fn discover_corsa() -> bool {
     .any(|candidate| candidate.exists())
         // The checker resolves its own binary this way, so the guard must not
         // decline a toolchain the run would actually have used.
-        || vize_carton::corsa_resolver::discover_corsa_in_ancestors(&root).is_some()
+        || vize_s0::corsa_resolver::discover_corsa_in_ancestors(&root).is_some()
 }
 
 fn workspace_root() -> Option<PathBuf> {

--- a/crates/vize_canon/tests/support/tier_l_incremental_artifact.rs
+++ b/crates/vize_canon/tests/support/tier_l_incremental_artifact.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 use vize_canon::IncrementalCheckMetrics;
-use vize_carton::{String, append, cstr};
+use vize_s0::{String, append, cstr};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/vize_canon/tests/tier_l_incremental.rs
+++ b/crates/vize_canon/tests/tier_l_incremental.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use vize_canon::{
     BatchTypeChecker, BatchTypeCheckerOptions, BatchTypeCheckerTrait, IncrementalCheckMetrics,
 };
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 #[path = "support/tier_l_incremental_artifact.rs"]
 mod artifact;

--- a/crates/vize_canon/tests/tsconfig_option_diagnostics.rs
+++ b/crates/vize_canon/tests/tsconfig_option_diagnostics.rs
@@ -11,7 +11,7 @@
 use std::path::{Path, PathBuf};
 
 use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait, project_virtual_root};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn resolve_test_tsgo_binary() -> Option<PathBuf> {
     if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -47,8 +47,8 @@ observational guard for planning only. It does not change rollout state.
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           916 |                    76 |               840 |             139 |     371 |             951 |      475 |           477 |           584 |
 | Linter                     |           302 |                    16 |               286 |             268 |     222 |             670 |      122 |           339 |           478 |
-| Typechecker                |           881 |                   108 |               773 |             394 |     187 |             804 |      658 |           461 |           651 |
-| Typechecker content-mapper |             8 |                     3 |                 5 |               1 |       0 |               9 |        0 |             7 |            18 |
+| Typechecker                |           883 |                   139 |               744 |             394 |     187 |             806 |      658 |           461 |           651 |
+| Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            18 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
 | LSP                        |           271 |                     0 |               271 |             115 |      44 |             325 |      105 |           166 |           388 |
 
@@ -134,7 +134,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0/carton        |         881 |             500 |      381 |
+| S0/carton        |         883 |             502 |      381 |
 | old AST/parser   |         159 |              35 |      124 |
 | Croquis analysis |         235 |             118 |      117 |
 | raw OXC          |         187 |             151 |       36 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1491,8 +1491,8 @@ linter	Linter	source	crates/vize/src/commands/lint/entry_rules.rs	5	s0	S0/carton
 linter	Linter	source	crates/vize/src/commands/lint/fix.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize/src/commands/lint/patterns.rs	22	s0	S0/carton	stage	vize_s0	preferred	4
 linter	Linter	source	crates/vize/src/commands/lint/stdout.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize_canon/benches/package_route.rs	40	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/benches/package_route.rs	40	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	old_ast	old AST/parser	old	vize_armature	legacy	2
 typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	croquis	Croquis analysis	old	vize_croquis	legacy	1
@@ -1736,7 +1736,8 @@ typechecker	Typechecker	test/dev	crates/vize_canon/src/intelligence.rs	482	s0	S0
 typechecker	Typechecker	test/dev	crates/vize_canon/src/intelligence.rs	482	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/intelligence.rs	482	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/legacy.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/lib.rs	119	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lib.rs	45	s0	S0/carton	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize_canon/src/lib.rs	45	s0	S0/carton	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/lsp_client.rs	13	s0	S0/carton	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/bootstrap.rs	13	s0	S0/carton	stage	vize_carton	compat	2
 typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/diagnostics_api.rs	6	s0	S0/carton	stage	vize_carton	compat	1
@@ -2170,51 +2171,51 @@ typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/types.rs	4	s0	S0
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/types.rs	325	s0	S0/carton	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/ambient_declarations.rs	67	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/ambient_declarations.rs	67	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/auto_import_ref_unwrap.rs	13	s0	S0/carton	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/auto_import_ref_unwrap.rs	13	s0	S0/carton	stage	vize_s0	preferred	3
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/auto_import_ref_unwrap.rs	13	old_ast	old AST/parser	old	vize_armature	legacy	3
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/auto_import_ref_unwrap.rs	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/component_event_arity.rs	4	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/component_event_arity.rs	4	s0	S0/carton	stage	vize_s0	preferred	2
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/component_event_arity.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/component_event_arity.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/empty_template_interpolation.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/empty_template_interpolation.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/empty_template_interpolation.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/empty_template_interpolation.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/escaped_regex_template_expression.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/escaped_regex_template_expression.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/escaped_regex_template_expression.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/escaped_regex_template_expression.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/leading_semicolon_event_handler.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/leading_semicolon_event_handler.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/leading_semicolon_event_handler.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/leading_semicolon_event_handler.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/lsp_import_resolution.rs	4	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/lsp_import_resolution/shared_editor_session.rs	41	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/lsp_vue_references.rs	118	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/nested_vif_narrowing.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/no_space_default_export.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/lsp_import_resolution.rs	4	s0	S0/carton	stage	vize_s0	preferred	3
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/lsp_import_resolution/shared_editor_session.rs	41	s0	S0/carton	stage	vize_s0	preferred	3
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/lsp_vue_references.rs	118	s0	S0/carton	stage	vize_s0	preferred	2
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/nested_vif_narrowing.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/no_space_default_export.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/no_space_default_export.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/no_space_default_export.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/options_api_runtime_props_value_scope.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/options_api_runtime_props_value_scope.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/options_api_runtime_props_value_scope.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/options_api_runtime_props_value_scope.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/plain_script_named_exports.rs	17	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/plain_script_named_exports.rs	17	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/plain_script_namespace_hoisting.rs	70	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/plain_script_namespace_hoisting.rs	70	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/recovered_parse_codegen.rs	38	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/relative_extensionless_vue_imports.rs	15	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_enum_member.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/recovered_parse_codegen.rs	38	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/relative_extensionless_vue_imports.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_enum_member.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_enum_member.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_enum_member.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_template_literals.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_template_literals.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_template_literals.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_template_literals.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/runtime_function_prop_union.rs	43	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/runtime_function_prop_union.rs	43	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/setup_scoped_type_exports.rs	107	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/setup_scoped_type_exports.rs	107	raw_oxc	raw OXC	raw	oxc_parser	raw	3
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/support/auto_import_project.rs	128	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/support/tier_l_incremental_artifact.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/tier_l_incremental.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/tsconfig_option_diagnostics.rs	14	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/support/auto_import_project.rs	128	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/support/tier_l_incremental_artifact.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/tier_l_incremental.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/tsconfig_option_diagnostics.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	2
@@ -2320,10 +2321,10 @@ typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/
 typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/tests.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/type_references.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/type_references/tsconfig_types.rs	4	s0	S0/carton	stage	vize_s0	preferred	2
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs	12	s0	S0/carton	stage	vize_carton	compat	1
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper.rs	8	s0	S0/carton	stage	vize_carton	compat	2
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper.rs	8	s0	S0/carton	stage	vize_s0	preferred	2
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper.rs	18	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper/project.rs	13	s0	S0/carton	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -66,3 +66,19 @@ void test("consumer migration TSV exposes matched names and name kind", () => {
   assert.ok(rows.every((row) => row.split("\t").length === 11));
   assert.ok(rows.some((row) => row.includes("\tvize_s0\tpreferred\t")));
 });
+
+void test("content-mapper S0 surface stays on the preferred physical name", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const contentMapper = scan.consumers.find(
+    (consumer) => consumer.id === "typechecker-content-mapper",
+  );
+  assert.ok(contentMapper);
+  assert.equal(contentMapper.surfaceCounts.s0, 8);
+  assert.equal(contentMapper.nameKindCounts.compat, 0);
+  assert.equal(contentMapper.nameKindCounts.preferred, 8);
+  assert.ok(
+    contentMapper.sites
+      .filter((site) => site.surfaceId === "s0")
+      .every((site) => site.matchedName === "vize_s0" && site.nameKind === "preferred"),
+  );
+});

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -220,3 +220,50 @@ test("Vize CLI package imports S0 storage through the stage alias", () => {
   assert.ok(aliasImports > 0, "vize package should use the vize_s0 alias");
   assert.deepEqual(offenders, []);
 });
+
+test("Canon content-mapper imports S0 storage through the stage alias", () => {
+  const dependencies = workspacePackage(metadata, "vize_canon").dependencies;
+  assert.ok(
+    dependencies.some(
+      (dependency) =>
+        dependency.kind === null &&
+        dependency.name === "vize_carton" &&
+        dependency.rename === "vize_s0",
+    ),
+    "vize_canon must import vize_carton as vize_s0 for S0 storage",
+  );
+  assert.ok(
+    dependencies.every(
+      (dependency) => dependency.name !== "vize_carton" || dependency.rename === "vize_s0",
+    ),
+    "vize_canon must not depend on vize_carton through its physical name",
+  );
+
+  const manifest = readRepoFile("crates", "vize_canon", "Cargo.toml");
+  assert.match(manifest, /^vize_s0\.workspace = true$/m);
+  assert.doesNotMatch(manifest, /^vize_carton\.workspace = true$/m);
+
+  const contentMapperDir = path.join(
+    repoRoot,
+    "crates",
+    "vize_canon",
+    "src",
+    "batch",
+    "virtual_project",
+  );
+  const offenders = [];
+  let aliasImports = 0;
+  for (const fullPath of walkRustFiles(contentMapperDir)) {
+    if (!path.basename(fullPath).startsWith("content_mapper")) continue;
+    const source = fs.readFileSync(fullPath, "utf8");
+    if (/\bvize_carton::|use vize_carton\b/u.test(source)) {
+      offenders.push(path.relative(repoRoot, fullPath));
+    }
+    if (/\bvize_s0::|use vize_s0\b/u.test(source)) {
+      aliasImports += 1;
+    }
+  }
+
+  assert.ok(aliasImports > 0, "Canon content-mapper should use the vize_s0 alias");
+  assert.deepEqual(offenders, []);
+});


### PR DESCRIPTION
## Summary
- switch vize_canon to depend on the S0 alias while keeping an internal compatibility alias for the broader Canon source tree
- move Canon content-mapper and its Canon test/dev imports from vize_carton to vize_s0
- refresh the davinci consumer migration surface inventory and ratchet content-mapper S0 usage to preferred names

## Tests
- node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs
- node tools/davinci/consumer-migration-surfaces.mjs --check
- cargo fmt --all -- --check
- cargo check -p vize_canon --locked
- cargo test -p vize_canon content_mapper --locked
- vp run --workspace-root check:repo

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4937"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790297281&installation_model_id=422833&pr_number=4937&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4937&signature=f1f77f1a2b5732f7c79589e70d3e1523b731f2ac1a4bab77cfc728ecc0028ddb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->