### PR TITLE
refactor(davinci): align maestro lsp with s0

### DIFF
--- a/crates/vize_maestro/Cargo.toml
+++ b/crates/vize_maestro/Cargo.toml
@@ -50,7 +50,7 @@ oxc_syntax.workspace = true
 oxc_diagnostics.workspace = true
 
 # Internal crates
-vize_carton.workspace = true
+vize_s0.workspace = true
 vize_relief.workspace = true
 vize_armature.workspace = true
 vize_atelier_sfc.workspace = true

--- a/crates/vize_maestro/src/document/store.rs
+++ b/crates/vize_maestro/src/document/store.rs
@@ -70,13 +70,13 @@ impl Document {
     }
 
     /// Whether the document structurally uses petite-vue (see
-    /// [`vize_carton::dialect::detect_petite_vue_document`]).
+    /// [`vize_s0::dialect::detect_petite_vue_document`]).
     ///
     /// Computed at most once per document version; edits invalidate the cache.
     pub fn petite_vue_detected(&self) -> bool {
         *self
             .petite_vue_detected
-            .get_or_init(|| vize_carton::dialect::detect_petite_vue_document(&self.text()))
+            .get_or_init(|| vize_s0::dialect::detect_petite_vue_document(&self.text()))
     }
 
     /// Get the document content as a string.

--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -207,7 +207,7 @@ fn push_unique_name(names: &mut Vec<String>, candidate: String) {
 /// Check if a tag name is a component (starts with uppercase or contains hyphen).
 #[inline]
 pub fn is_component_tag(name: &str) -> bool {
-    if name.is_empty() || vize_carton::is_native_tag(name) {
+    if name.is_empty() || vize_s0::is_native_tag(name) {
         return false;
     }
     let Some(first) = name.chars().next() else {

--- a/crates/vize_maestro/src/ide/auto_insert.rs
+++ b/crates/vize_maestro/src/ide/auto_insert.rs
@@ -74,7 +74,7 @@ fn auto_close_tag(ctx: &IdeContext<'_>, selection: usize) -> Option<String> {
     }
     let (name, tag_start) = start_tag_before(&ctx.content, region, end)?;
     if ctx.content[tag_start..end].trim_end().ends_with('/')
-        || vize_carton::is_void_tag(name)
+        || vize_s0::is_void_tag(name)
         || already_has_close_tag(&ctx.content, selection, name)
     {
         return None;
@@ -184,7 +184,7 @@ fn nearest_unclosed_tag(content: &str, region: (usize, usize), before: usize) ->
                 stack.truncate(index);
             }
         } else if !name.is_empty()
-            && !vize_carton::is_void_tag(name)
+            && !vize_s0::is_void_tag(name)
             && !content[cursor..tag_end]
                 .trim_end_matches('>')
                 .trim_end()

--- a/crates/vize_maestro/src/ide/code_action.rs
+++ b/crates/vize_maestro/src/ide/code_action.rs
@@ -11,7 +11,7 @@ use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, Position, Range, TextEdit, WorkspaceEdit,
 };
 // Shared, UTF-16-correct offset->(line, column) conversion (#1389).
-use vize_carton::line_index::offset_to_line_col;
+use vize_s0::line_index::offset_to_line_col;
 
 /// Code action service for providing quick fixes and refactorings.
 pub struct CodeActionService;

--- a/crates/vize_maestro/src/ide/completion/component_props_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/component_props_tests.rs
@@ -315,5 +315,5 @@ fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
         }
     }
 
-    vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
+    vize_s0::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
 }

--- a/crates/vize_maestro/src/ide/completion/script/member_access.rs
+++ b/crates/vize_maestro/src/ide/completion/script/member_access.rs
@@ -76,7 +76,7 @@ fn reactive_object_key_completions(script_content: &str, name: &str) -> Vec<Comp
 fn reactive_object_initializer<'a>(script_content: &'a str, name: &str) -> Option<&'a str> {
     for callee in ["reactive", "shallowReactive"] {
         for keyword in ["const", "let"] {
-            let needle = vize_carton::cstr!("{keyword} {name} = {callee}(");
+            let needle = vize_s0::cstr!("{keyword} {name} = {callee}(");
             let Some(pos) = script_content.find(needle.as_str()) else {
                 continue;
             };

--- a/crates/vize_maestro/src/ide/completion/script/object_literal.rs
+++ b/crates/vize_maestro/src/ide/completion/script/object_literal.rs
@@ -13,8 +13,8 @@ use oxc_span::SourceType;
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, Documentation, MarkupContent, MarkupKind,
 };
-use vize_carton::{FxHashSet, String};
 use vize_croquis::{Drawer, DrawerOptions, ScopeKind};
+use vize_s0::{FxHashSet, String};
 
 use super::context::{member_access_receiver, script_content_and_offset_for_context};
 use crate::ide::IdeContext;

--- a/crates/vize_maestro/src/ide/completion/template/bindings.rs
+++ b/crates/vize_maestro/src/ide/completion/template/bindings.rs
@@ -123,7 +123,7 @@ pub(crate) fn analyzed_template_binding_completions(
     // chain. Without the AST, `analyze_sfc_descriptor` skips template-level
     // analysis and we lose nested binding visibility.
     let template_block = descriptor.template.as_ref();
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let template_parse =
         template_block.map(|tb| (vize_armature::parse(&allocator, &tb.content), tb.loc.start));
 
@@ -291,7 +291,7 @@ pub(crate) fn analyzed_template_binding_completions(
 fn petite_vue_scope_binding_completions(ctx: &IdeContext) -> Vec<CompletionItem> {
     use vize_croquis::{Drawer, DrawerOptions};
 
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (root, _errors) = vize_armature::parse_document(&allocator, &ctx.content);
 
     let mut drawer = Drawer::with_options(DrawerOptions::full());

--- a/crates/vize_maestro/src/ide/completion/template/component_cache.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_cache.rs
@@ -87,7 +87,7 @@ fn open_component(ctx: &IdeContext<'_>, resolved: &Path) -> Option<(String, u64,
 
 fn open_stamp(document: &crate::document::Document) -> (String, u64, i32, u64) {
     let content = document.text();
-    let hash = vize_carton::hash::hash_str(&content);
+    let hash = vize_s0::hash::hash_str(&content);
     (
         content,
         document.content.len_bytes() as u64,

--- a/crates/vize_maestro/src/ide/completion/template/component_meta.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_meta.rs
@@ -125,7 +125,7 @@ fn art_component_path(ctx: &IdeContext<'_>, component_name: &str) -> Option<Stri
         return None;
     }
 
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let art_desc = vize_musea::parse_art(
         &allocator,
         &ctx.content,

--- a/crates/vize_maestro/src/ide/completion/template/slot_outlets.rs
+++ b/crates/vize_maestro/src/ide/completion/template/slot_outlets.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeSet;
 use vize_relief::{ElementNode, PropNode, TemplateChildNode};
 
 pub(super) fn extract_template_slot_names(template: &str) -> Vec<String> {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (root, _) = vize_armature::parse(&allocator, template);
     let mut names = Vec::new();
     let mut seen = BTreeSet::new();

--- a/crates/vize_maestro/src/ide/completion/tests.rs
+++ b/crates/vize_maestro/src/ide/completion/tests.rs
@@ -259,7 +259,7 @@ fn test_standalone_html_completion_respects_dialect_config() {
         .documents
         .open(uri.clone(), source.to_string(), 1, "html".to_string());
     state.update_virtual_docs(&uri, source);
-    state.set_dialect_config(Some(vize_carton::dialect::VueDialect::PetiteVue));
+    state.set_dialect_config(Some(vize_s0::dialect::VueDialect::PetiteVue));
 
     let offset = source.find("<div ").unwrap() + "<div ".len();
     let ctx = IdeContext::new(&state, &uri, offset).unwrap();
@@ -270,7 +270,7 @@ fn test_standalone_html_completion_respects_dialect_config() {
     assert!(has_label(&labels, "v-effect"));
 
     // And an explicit `vue` dialect suppresses detection-based opt-in.
-    state.set_dialect_config(Some(vize_carton::dialect::VueDialect::Vue));
+    state.set_dialect_config(Some(vize_s0::dialect::VueDialect::Vue));
     let petite_source = r#"<script src="https://unpkg.com/petite-vue" defer init></script>
 <div v-scope="{ count: 0 }" >{{ count }}</div>
 "#;

--- a/crates/vize_maestro/src/ide/context.rs
+++ b/crates/vize_maestro/src/ide/context.rs
@@ -85,7 +85,7 @@ impl<'a> IdeContext<'a> {
     /// config key wins, otherwise the structural petite-vue detection memoized
     /// on the open document is used (no per-request re-scan).
     #[inline]
-    pub fn dialect(&self) -> vize_carton::dialect::VueDialect {
+    pub fn dialect(&self) -> vize_s0::dialect::VueDialect {
         self.state.document_dialect(self.uri, &self.content)
     }
 

--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -49,7 +49,7 @@ use virtual_document::{
 pub(crate) use workspace_edit::map_corsa_workspace_edit;
 
 use vize_canon::LspLocation;
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use super::IdeContext;
 use crate::virtual_code::{SourceRange, VirtualDocument};

--- a/crates/vize_maestro/src/ide/corsa_support/canonical.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical.rs
@@ -1,6 +1,6 @@
 use tower_lsp::lsp_types::{Location, Range, Url};
 use vize_canon::LspLocation;
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use crate::ide::IdeContext;
 use crate::ide::diagnostics::VirtualTsResult;
@@ -213,8 +213,8 @@ fn file_uri_paths_match(left: &str, right: &str) -> bool {
     else {
         return false;
     };
-    vize_carton::path::canonicalize_non_verbatim(&left)
-        == vize_carton::path::canonicalize_non_verbatim(&right)
+    vize_s0::path::canonicalize_non_verbatim(&left)
+        == vize_s0::path::canonicalize_non_verbatim(&right)
 }
 
 pub(super) fn is_private_materialized_uri(doc: &CanonicalVirtualDocument, raw_uri: &str) -> bool {
@@ -226,7 +226,7 @@ pub(super) fn is_private_materialized_uri(doc: &CanonicalVirtualDocument, raw_ur
     };
     doc.session_project_roots.iter().any(|root| {
         path.starts_with(root)
-            || vize_carton::path::canonicalize_non_verbatim(&path)
-                .starts_with(vize_carton::path::canonicalize_non_verbatim(root))
+            || vize_s0::path::canonicalize_non_verbatim(&path)
+                .starts_with(vize_s0::path::canonicalize_non_verbatim(root))
     })
 }

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/open.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/open.rs
@@ -143,15 +143,15 @@ pub(super) async fn open_canonical_virtual_document_with_overlays_strict(
 }
 
 fn authored_uri(ctx: &IdeContext<'_>, source_path: &std::path::Path) -> Option<Url> {
-    let source_path = vize_carton::path::canonicalize_non_verbatim(source_path);
+    let source_path = vize_s0::path::canonicalize_non_verbatim(source_path);
     ctx.state
         .documents
         .uris()
         .into_iter()
         .find(|uri| {
-            uri.to_file_path().ok().is_some_and(|path| {
-                vize_carton::path::canonicalize_non_verbatim(&path) == source_path
-            })
+            uri.to_file_path()
+                .ok()
+                .is_some_and(|path| vize_s0::path::canonicalize_non_verbatim(&path) == source_path)
         })
         .or_else(|| Url::from_file_path(source_path).ok())
 }

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/project.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/project.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use tower_lsp::lsp_types::Url;
 use vize_canon::{CorsaBridge, CorsaBridgeError};
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 use super::{CanonicalDependencyDocument, CanonicalVirtualDocument, location_matches_uri};
 use crate::ide::IdeContext;
@@ -93,8 +93,8 @@ fn authored_uris_match(left: &Url, right: &Url) -> bool {
     }
     match (left.to_file_path(), right.to_file_path()) {
         (Ok(left), Ok(right)) => {
-            vize_carton::path::canonicalize_non_verbatim(&left)
-                == vize_carton::path::canonicalize_non_verbatim(&right)
+            vize_s0::path::canonicalize_non_verbatim(&left)
+                == vize_s0::path::canonicalize_non_verbatim(&right)
         }
         _ => false,
     }

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs
@@ -1,6 +1,6 @@
 use tower_lsp::lsp_types::{Location, Url};
 use vize_canon::{LspPosition, LspRange};
-use vize_carton::{FxHashMap, FxHashSet, String};
+use vize_s0::{FxHashMap, FxHashSet, String};
 
 use super::{CanonicalVirtualDocument, location_matches_uri};
 use crate::ide::diagnostics::VirtualTsResult;
@@ -113,8 +113,8 @@ fn same_authored_uri(left: &tower_lsp::lsp_types::Url, right: &tower_lsp::lsp_ty
     }
     match (left.to_file_path(), right.to_file_path()) {
         (Ok(left), Ok(right)) => {
-            vize_carton::path::canonicalize_non_verbatim(&left)
-                == vize_carton::path::canonicalize_non_verbatim(&right)
+            vize_s0::path::canonicalize_non_verbatim(&left)
+                == vize_s0::path::canonicalize_non_verbatim(&right)
         }
         _ => false,
     }

--- a/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use tower_lsp::lsp_types::Location;
 use vize_canon::{CorsaBridge, LspLocation};
-use vize_carton::{FxHashSet, String, camelize};
+use vize_s0::{FxHashSet, String, camelize};
 
 use super::{
     CanonicalSemanticPosition, ComponentPropNavigationIdentities, ComponentPropNavigationMatches,

--- a/crates/vize_maestro/src/ide/corsa_support/external_mirror.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/external_mirror.rs
@@ -1,7 +1,7 @@
 //! Recovery for Corsa locations inside Canon's external mirror subtree.
 
 use tower_lsp::lsp_types::{Location, Range, Url};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use crate::ide::IdeContext;
 use crate::ide::diagnostics::VirtualTsResult;
@@ -106,7 +106,7 @@ mod tests {
     use std::path::{Component, PathBuf};
 
     use tower_lsp::lsp_types::Url;
-    use vize_carton::cstr;
+    use vize_s0::cstr;
 
     use super::map_location;
     use crate::{ide::IdeContext, server::ServerState};

--- a/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_attribute.rs
@@ -1,5 +1,5 @@
 use tower_lsp::lsp_types::Url;
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use super::html_tag::native_dom_tag_info;
 use super::svg_attribute::{canonical_svg_dom_attribute_name, mapped_svg_dom_attribute_property};
@@ -58,10 +58,10 @@ pub(crate) fn native_dom_attribute_info(
     let tag_info = native_dom_tag_info(tag_name)?;
     let normalized_attr = normalize_attribute_name(tag_name, attr_name)?;
     let property_name = dom_attribute_property_name(tag_name, &normalized_attr)?;
-    let is_boolean = vize_carton::is_boolean_attr(&normalized_attr);
-    let category = if vize_carton::is_html_tag(tag_name) {
+    let is_boolean = vize_s0::is_boolean_attr(&normalized_attr);
+    let category = if vize_s0::is_html_tag(tag_name) {
         "HTML attribute"
-    } else if vize_carton::is_svg_tag(tag_name) {
+    } else if vize_s0::is_svg_tag(tag_name) {
         "SVG attribute"
     } else {
         "MathML attribute"
@@ -74,7 +74,7 @@ pub(crate) fn native_dom_attribute_info(
         String::from(
             "https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes",
         )
-    } else if vize_carton::is_svg_tag(tag_name) {
+    } else if vize_s0::is_svg_tag(tag_name) {
         cstr!(
             "https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/{normalized_attr}"
         )
@@ -130,7 +130,7 @@ fn normalize_attribute_name(tag_name: &str, attr_name: &str) -> Option<String> {
         return None;
     }
 
-    if vize_carton::is_svg_tag(tag_name)
+    if vize_s0::is_svg_tag(tag_name)
         && let Some(canonical) = canonical_svg_dom_attribute_name(tag_name, attr_name)
     {
         return Some(String::from(canonical));
@@ -152,7 +152,7 @@ fn dom_attribute_property_name(tag_name: &str, attr_name: &str) -> Option<String
         return Some(cstr!("aria{}", kebab_to_pascal(aria_name)));
     }
 
-    if vize_carton::is_svg_tag(tag_name)
+    if vize_s0::is_svg_tag(tag_name)
         && let Some(property_name) = mapped_svg_dom_attribute_property(tag_name, attr_name)
     {
         return Some(String::from(property_name));
@@ -221,14 +221,14 @@ fn mapped_dom_attribute_property(attr_name: &str) -> Option<&'static str> {
 }
 
 fn is_known_native_attribute_for_tag(tag_name: &str, attr_name: &str) -> bool {
-    if vize_carton::is_html_tag(tag_name) {
+    if vize_s0::is_html_tag(tag_name) {
         return is_html_global_native_attribute(attr_name)
             || HTML_TAG_ATTRIBUTES
                 .iter()
                 .any(|(tag, attrs)| *tag == tag_name && attrs.contains(&attr_name));
     }
 
-    if vize_carton::is_svg_tag(tag_name) || vize_carton::is_math_ml_tag(tag_name) {
+    if vize_s0::is_svg_tag(tag_name) || vize_s0::is_math_ml_tag(tag_name) {
         return is_dom_element_global_attribute(attr_name);
     }
 

--- a/crates/vize_maestro/src/ide/corsa_support/html_tag.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/html_tag.rs
@@ -1,5 +1,5 @@
 use tower_lsp::lsp_types::Url;
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 pub(crate) struct NativeDomTagInfo {
     pub(crate) category: &'static str,
@@ -75,7 +75,7 @@ pub(crate) fn native_dom_tag_info(tag_name: &str) -> Option<NativeDomTagInfo> {
             ),
         });
     }
-    if vize_carton::is_math_ml_tag(tag_name) {
+    if vize_s0::is_math_ml_tag(tag_name) {
         return Some(NativeDomTagInfo {
             category: "MathML element",
             type_expression: String::from("MathMLElement"),
@@ -94,7 +94,7 @@ fn dom_definition_symbol(tag_name: &str) -> Option<&'static str> {
         Some("SVGElementTagNameMap")
     } else if has_math_ml_element_tag_name_map_entry(tag_name) {
         Some("MathMLElementTagNameMap")
-    } else if vize_carton::is_math_ml_tag(tag_name) {
+    } else if vize_s0::is_math_ml_tag(tag_name) {
         Some("MathMLElement")
     } else {
         None
@@ -102,11 +102,11 @@ fn dom_definition_symbol(tag_name: &str) -> Option<&'static str> {
 }
 
 fn has_html_element_tag_name_map_entry(tag_name: &str) -> bool {
-    vize_carton::is_html_tag(tag_name) && !matches!(tag_name, "param")
+    vize_s0::is_html_tag(tag_name) && !matches!(tag_name, "param")
 }
 
 fn has_svg_element_tag_name_map_entry(tag_name: &str) -> bool {
-    vize_carton::is_svg_tag(tag_name)
+    vize_s0::is_svg_tag(tag_name)
         && !matches!(
             tag_name,
             "color-profile"
@@ -123,7 +123,7 @@ fn has_svg_element_tag_name_map_entry(tag_name: &str) -> bool {
 }
 
 fn has_math_ml_element_tag_name_map_entry(tag_name: &str) -> bool {
-    vize_carton::is_math_ml_tag(tag_name)
+    vize_s0::is_math_ml_tag(tag_name)
         && matches!(
             tag_name,
             "annotation"

--- a/crates/vize_maestro/src/ide/corsa_support/virtual_document.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/virtual_document.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use tower_lsp::lsp_types::Url;
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::ide::IdeContext;
 use crate::virtual_code::{VirtualDocument, VirtualDocuments};

--- a/crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs
@@ -156,7 +156,7 @@ mod tests {
         TextDocumentEdit, TextEdit, Url, WorkspaceEdit,
     };
     use vize_canon::{LspLocation, LspPosition, LspRange};
-    use vize_carton::cstr;
+    use vize_s0::cstr;
 
     use super::map_corsa_workspace_edit;
     use crate::{

--- a/crates/vize_maestro/src/ide/definition/art.rs
+++ b/crates/vize_maestro/src/ide/definition/art.rs
@@ -7,7 +7,7 @@ pub(super) fn component_path(ctx: &IdeContext<'_>, component_name: &str) -> Opti
         return None;
     }
 
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let art_desc = vize_musea::parse_art(
         &allocator,
         &ctx.content,

--- a/crates/vize_maestro/src/ide/definition/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/definition/corsa_tests.rs
@@ -29,8 +29,8 @@ fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
     let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(std::path::Path::parent)?;
-    vize_carton::corsa_resolver::resolve_corsa_executable(
-        vize_carton::corsa_resolver::CorsaResolveRequest {
+    vize_s0::corsa_resolver::resolve_corsa_executable(
+        vize_s0::corsa_resolver::CorsaResolveRequest {
             project_root: Some(workspace_root),
             ..Default::default()
         },

--- a/crates/vize_maestro/src/ide/definition/import_resolver.rs
+++ b/crates/vize_maestro/src/ide/definition/import_resolver.rs
@@ -3,7 +3,7 @@
 use std::path::{Component, Path, PathBuf};
 
 use tower_lsp::lsp_types::Url;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::module_specifier;
 

--- a/crates/vize_maestro/src/ide/definition/script.rs
+++ b/crates/vize_maestro/src/ide/definition/script.rs
@@ -11,7 +11,7 @@ use super::{
     helpers,
 };
 use crate::virtual_code::BlockType;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 /// Find definition for a symbol in script context.
 pub(crate) fn definition_in_script(ctx: &IdeContext) -> Option<GotoDefinitionResponse> {

--- a/crates/vize_maestro/src/ide/definition/slot.rs
+++ b/crates/vize_maestro/src/ide/definition/slot.rs
@@ -48,7 +48,7 @@ fn component_slot_at_offset(ctx: &IdeContext<'_>) -> Option<(String, String)> {
     let relative_offset = ctx.offset.saturating_sub(template.loc.start);
     let template_source = template.content.as_ref();
 
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (root, _) = vize_armature::parse(&allocator, template_source);
     let mut drawer = Drawer::with_options(DrawerOptions {
         analyze_template_scopes: true,

--- a/crates/vize_maestro/src/ide/definition/tests/contexts.rs
+++ b/crates/vize_maestro/src/ide/definition/tests/contexts.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use tower_lsp::lsp_types::Url;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::super::{DefinitionService, script};
 use super::scalar_location;

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -16,7 +16,7 @@ use vize_atelier_sfc::SfcDescriptor;
 use vize_patina::{HelpRenderTarget, LintPreset, render_help};
 
 use super::{DiagnosticService, LineIndex, sources};
-use vize_carton::append;
+use vize_s0::append;
 
 impl DiagnosticService {
     /// Collect diagnostics for Art files (*.art.vue) using vize_patina's MuseaLinter.
@@ -99,7 +99,7 @@ impl DiagnosticService {
     ) -> Vec<Diagnostic> {
         let lang = vize_atelier_jsx::JsxLang::from_path(uri.path());
 
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let output = vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), content, lang);
 
         output
@@ -315,7 +315,7 @@ impl DiagnosticService {
             return vec![];
         };
 
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let (_, errors) = vize_armature::parse(&allocator, &template.content);
         errors
             .iter()

--- a/crates/vize_maestro/src/ide/diagnostics/component_props.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/component_props.rs
@@ -51,7 +51,7 @@ impl DiagnosticService {
             return Vec::new();
         };
 
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let (root, _) = vize_armature::parse(&allocator, template_content);
         let mut drawer = Drawer::with_options(DrawerOptions {
             analyze_template_scopes: true,

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -13,7 +13,7 @@ use super::collect_virtual::{
     deduplicate_diagnostics,
 };
 use vize_canon::{CorsaBridgeError, CorsaVueVirtualDocumentOptions};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 /// One attempt either yields diagnostics (possibly empty for non-Corsa
 /// reasons such as unsupported documents) or fails on a bridge call.

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
@@ -1,7 +1,7 @@
 //! Mapping Corsa virtual-document diagnostics back to the host SFC.
 
 use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url};
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use super::super::{VirtualTsResult, sources};
 use super::mapping::{

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/message.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/message.rs
@@ -1,7 +1,7 @@
 //! Vue-flavored rewriting of raw Corsa/TypeScript diagnostic messages.
 
 use vize_canon::batch::restore_virtual_vue_specifiers;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 /// Rewrite a Corsa diagnostic message with a Vue-flavored hint when the
 /// raw TypeScript phrasing has a more actionable Vue interpretation.
@@ -44,7 +44,7 @@ fn property_does_not_exist_property(message: &str) -> Option<&str> {
 
 #[cfg(test)]
 mod hint_tests {
-    use vize_carton::cstr;
+    use vize_s0::cstr;
 
     use super::{property_does_not_exist_property, rewrite_corsa_message};
 

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/relative_import_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/relative_import_tests.rs
@@ -207,5 +207,5 @@ fn resolve_test_tsgo_binary() -> Option<std::path::PathBuf> {
         return Some(sibling_cache);
     }
 
-    vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
+    vize_s0::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
 }

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs
@@ -1,4 +1,4 @@
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::mapping::{line_character_to_byte_offset, source_offset_to_position};
 
@@ -321,6 +321,6 @@ const speakerOptions = computed(() =>
             return Some(sibling_cache);
         }
 
-        vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
+        vize_s0::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
     }
 }

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs
@@ -9,8 +9,8 @@ use std::path::PathBuf;
 
 use tower_lsp::lsp_types::Url;
 use vize_canon::virtual_ts::{VirtualTsOptions, generate_virtual_ts_with_offsets};
-use vize_carton::cstr;
 use vize_croquis::{Drawer, DrawerOptions};
+use vize_s0::cstr;
 
 use super::super::{DiagnosticService, VirtualTsResult};
 use super::virtual_ts::rewrite_vue_imports;
@@ -59,7 +59,7 @@ impl DiagnosticService {
         content: &str,
         base_options: &VirtualTsOptions,
     ) -> Option<ArtVirtualTsResult> {
-        let art_allocator = vize_carton::Allocator::new();
+        let art_allocator = vize_s0::Allocator::new();
         let art_desc = vize_musea::parse_art(
             &art_allocator,
             content,
@@ -138,7 +138,7 @@ impl DiagnosticService {
         base_options: &VirtualTsOptions,
     ) -> ArtVariantGeneration {
         let script_content = script.script.as_str();
-        let template_allocator = vize_carton::Allocator::new();
+        let template_allocator = vize_s0::Allocator::new();
         let (template_ast, _) = vize_armature::parse(&template_allocator, template_content);
 
         let mut analyzer = Drawer::with_options(DrawerOptions::full());

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art_bindings.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art_bindings.rs
@@ -13,21 +13,20 @@ pub(super) fn add_art_target_component_bindings(
     let mut component_ref = target.name.clone();
 
     if !has_component_binding {
-        let import_alias = vize_carton::cstr!(
+        let import_alias = vize_s0::cstr!(
             "__VizeArtTarget_{}",
             to_safe_identifier_fragment(target.name.as_str())
         );
-        options.auto_import_stubs.push(vize_carton::cstr!(
+        options.auto_import_stubs.push(vize_s0::cstr!(
             "import {import_alias} from {};",
             quote_ts_string(target.source.as_str())
         ));
         component_ref = import_alias.to_string();
 
         if is_valid_identifier(target.name.as_str()) {
-            options.auto_import_stubs.push(vize_carton::cstr!(
-                "const {} = {import_alias};",
-                target.name
-            ));
+            options
+                .auto_import_stubs
+                .push(vize_s0::cstr!("const {} = {import_alias};", target.name));
             options
                 .external_template_bindings
                 .push(target.name.clone().into());
@@ -45,7 +44,7 @@ pub(super) fn add_art_target_component_bindings(
         let kebab_ref = to_safe_identifier(kebab_name.as_str());
         options
             .auto_import_stubs
-            .push(vize_carton::cstr!("const {kebab_ref} = {component_ref};"));
+            .push(vize_s0::cstr!("const {kebab_ref} = {component_ref};"));
         options.external_template_bindings.push(kebab_name.into());
     }
 }

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs
@@ -75,7 +75,7 @@ impl DiagnosticService {
                     continue;
                 }
 
-                let template_allocator = vize_carton::Allocator::new();
+                let template_allocator = vize_s0::Allocator::new();
                 let (template_ast, _) = vize_armature::parse(&template_allocator, template_content);
                 let analysis = vize_atelier_sfc::croquis::analyze_sfc_descriptor_resolved(
                     &descriptor,

--- a/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_fixture.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_fixture.rs
@@ -209,7 +209,7 @@ pub(super) fn resolve_test_tsgo_binary() -> Option<PathBuf> {
         return Some(upstream_cache);
     }
 
-    vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
+    vize_s0::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
 }
 
 fn write_typecheck_tsconfig(root: &Path) {

--- a/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs
@@ -7,7 +7,7 @@ use super::editor_typecheck_fixture::{
 };
 use super::{DiagnosticService, sources};
 use tower_lsp::lsp_types::Url;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[test]
 fn sync_collect_does_not_surface_legacy_type_false_positives() {

--- a/crates/vize_maestro/src/ide/diagnostics/line_index.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/line_index.rs
@@ -1,9 +1,9 @@
 //! Byte-offset to (line, UTF-16 column) mapping for LSP coordinates.
 //!
-//! Re-exports the shared, UTF-16-correct utility from `vize_carton`. The column
+//! Re-exports the shared, UTF-16-correct utility from `vize_s0`. The column
 //! math (UTF-16 code units, so astral characters count as two) lives in exactly
-//! one place; see `vize_carton::line_index` and issue #1389.
+//! one place; see `vize_s0::line_index` and issue #1389.
 
-pub(in crate::ide) use vize_carton::line_index::LineIndex;
+pub(in crate::ide) use vize_s0::line_index::LineIndex;
 #[cfg(test)]
-pub(in crate::ide) use vize_carton::line_index::offset_to_line_col;
+pub(in crate::ide) use vize_s0::line_index::offset_to_line_col;

--- a/crates/vize_maestro/src/ide/diagnostics/vize_sfc_type.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/vize_sfc_type.rs
@@ -2,7 +2,7 @@
 use tower_lsp::lsp_types::{CodeDescription, DiagnosticSeverity, NumberOrString, Position, Range};
 use tower_lsp::lsp_types::{Diagnostic, Url};
 #[cfg(feature = "native")]
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[cfg(feature = "native")]
 use super::sources;

--- a/crates/vize_maestro/src/ide/ecosystem/i18n.rs
+++ b/crates/vize_maestro/src/ide/ecosystem/i18n.rs
@@ -9,7 +9,7 @@ use tower_lsp::lsp_types::{
     InlayHintLabel, Position, Range, Url,
 };
 use vize_atelier_sfc::SfcDescriptor;
-use vize_carton::{FxHashMap, String, cstr};
+use vize_s0::{FxHashMap, String, cstr};
 
 use super::context::string_literal_at_cursor;
 use crate::ide::{IdeContext, offset_to_position};

--- a/crates/vize_maestro/src/ide/ecosystem/router.rs
+++ b/crates/vize_maestro/src/ide/ecosystem/router.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, Diagnostic, Position, Range, Url};
 use vize_atelier_sfc::SfcDescriptor;
-use vize_carton::{FxHashSet, String, cstr};
+use vize_s0::{FxHashSet, String, cstr};
 
 use super::context::{preceding_property_is_name, string_literal_at_cursor};
 use crate::ide::{IdeContext, offset_to_position};
@@ -609,7 +609,7 @@ fn push_name(name: &str, seen: &mut FxHashSet<String>, names: &mut Vec<String>) 
 #[cfg(test)]
 mod tests {
     use tower_lsp::lsp_types::Url;
-    use vize_carton::{FxHashSet, String};
+    use vize_s0::{FxHashSet, String};
 
     use super::{collect_path_params, is_route_name_context, route_names, route_params_for_file};
 

--- a/crates/vize_maestro/src/ide/ecosystem/router_extension_tests.rs
+++ b/crates/vize_maestro/src/ide/ecosystem/router_extension_tests.rs
@@ -1,5 +1,5 @@
 use tower_lsp::lsp_types::Url;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::router::route_params_for_file;
 

--- a/crates/vize_maestro/src/ide/ecosystem/void.rs
+++ b/crates/vize_maestro/src/ide/ecosystem/void.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
-use vize_carton::{FxHashSet, String, cstr};
+use vize_s0::{FxHashSet, String, cstr};
 
 use super::context::{is_ident_byte, string_literal_at_cursor};
 use crate::ide::IdeContext;

--- a/crates/vize_maestro/src/ide/hover/component_tag.rs
+++ b/crates/vize_maestro/src/ide/hover/component_tag.rs
@@ -90,7 +90,7 @@ impl HoverService {
 
 fn component_usage_at_cursor(ctx: &IdeContext<'_>, tag_name: &str) -> Option<ComponentUsage> {
     let template = template_view(ctx)?;
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (root, _) = if template.is_document {
         vize_armature::parse_document(&allocator, template.content)
     } else {

--- a/crates/vize_maestro/src/ide/hover/component_tag/items.rs
+++ b/crates/vize_maestro/src/ide/hover/component_tag/items.rs
@@ -72,9 +72,9 @@ fn format_slot(slot: &SlotUsage) -> String {
 #[cfg(test)]
 mod tests {
     use super::{format_event, format_prop, format_slot, prop_items};
-    use vize_carton::{CompactString, smallvec};
     use vize_croquis::ScopeId;
     use vize_croquis::croquis::{ComponentUsage, EventListener, PassedProp, SlotUsage};
+    use vize_s0::{CompactString, smallvec};
 
     #[test]
     fn formats_runtime_directive_names_without_presenting_them_as_static() {

--- a/crates/vize_maestro/src/ide/hover/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa_tests.rs
@@ -53,5 +53,5 @@ fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
         }
     }
 
-    vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
+    vize_s0::corsa_resolver::discover_corsa_in_ancestors(workspace_root)
 }

--- a/crates/vize_maestro/src/ide/hover/declaration_keyword.rs
+++ b/crates/vize_maestro/src/ide/hover/declaration_keyword.rs
@@ -176,7 +176,7 @@ fn align_v_for_parameter(
 /// or callback's parameter named like the alias — inside the loop element or
 /// anywhere else in the template — keeps the checker's `(parameter)` answer.
 fn is_v_for_alias(template: &str, word: &str, offset: u32) -> bool {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (root, _) = vize_armature::parse(&allocator, template);
     let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full());
     analyzer.analyze_template(&root);

--- a/crates/vize_maestro/src/ide/hover/petite_vue.rs
+++ b/crates/vize_maestro/src/ide/hover/petite_vue.rs
@@ -13,7 +13,7 @@ impl HoverService {
             return None;
         }
 
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let (root, _errors) = vize_armature::parse_document(&allocator, &ctx.content);
 
         let mut drawer = Drawer::with_options(DrawerOptions::full());

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -240,7 +240,7 @@ impl HoverService {
 
         // Analyze template if present
         if let Some(ref template) = descriptor.template {
-            let allocator = vize_carton::Allocator::new();
+            let allocator = vize_s0::Allocator::new();
             let (root, _) = vize_armature::parse(&allocator, &template.content);
             drawer.analyze_template(&root);
         }

--- a/crates/vize_maestro/src/ide/inlay_hint.rs
+++ b/crates/vize_maestro/src/ide/inlay_hint.rs
@@ -171,8 +171,8 @@ impl InlayHintService {
 
             // Locate `const NAME =` in the script content. Anchoring on the
             // declaration keyword avoids matching usages inside expressions.
-            let needle_const = vize_carton::cstr!("const {} =", source.name.as_str());
-            let needle_let = vize_carton::cstr!("let {} =", source.name.as_str());
+            let needle_const = vize_s0::cstr!("const {} =", source.name.as_str());
+            let needle_let = vize_s0::cstr!("let {} =", source.name.as_str());
             let pos_in_script = script
                 .find(needle_const.as_str())
                 .map(|p| p + needle_const.len())
@@ -203,14 +203,14 @@ impl InlayHintService {
             if !Self::position_in_range(position, range) {
                 continue;
             }
-            let label = vize_carton::cstr!(": {}<{}>", wrapper, value_type.as_str());
+            let label = vize_s0::cstr!(": {}<{}>", wrapper, value_type.as_str());
             hints.push(InlayHint {
                 position,
                 label: InlayHintLabel::String(label.to_string()),
                 kind: Some(InlayHintKind::TYPE),
                 text_edits: None,
                 tooltip: Some(tower_lsp::lsp_types::InlayHintTooltip::String(
-                    vize_carton::cstr!("Vue reactive binding ({})", wrapper).to_string(),
+                    vize_s0::cstr!("Vue reactive binding ({})", wrapper).to_string(),
                 )),
                 padding_left: Some(true),
                 padding_right: None,

--- a/crates/vize_maestro/src/ide/jsx/code_action.rs
+++ b/crates/vize_maestro/src/ide/jsx/code_action.rs
@@ -24,7 +24,7 @@ use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, Position, Range, TextEdit, Url, WorkspaceEdit,
 };
 use vize_atelier_jsx::JsxLang;
-use vize_carton::line_index::offset_to_line_col;
+use vize_s0::line_index::offset_to_line_col;
 
 /// Code-action provider for `.jsx`/`.tsx` components.
 pub struct JsxCodeActionService;

--- a/crates/vize_maestro/src/ide/jsx/document_symbols.rs
+++ b/crates/vize_maestro/src/ide/jsx/document_symbols.rs
@@ -22,7 +22,7 @@
 
 use tower_lsp::lsp_types::{DocumentSymbol, Position, Range, SymbolKind, Url};
 use vize_atelier_jsx::{JsxLang, lower_source};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 use crate::ide::offset_to_position;
 

--- a/crates/vize_maestro/src/ide/jsx/scoped_style.rs
+++ b/crates/vize_maestro/src/ide/jsx/scoped_style.rs
@@ -100,7 +100,7 @@ impl JsxScopedStyleService {
         source_map.set_block_offset(style.start);
 
         VirtualDocument {
-            uri: vize_carton::cstr!("{base_path}.__jsx_style_{index}.css").to_string(),
+            uri: vize_s0::cstr!("{base_path}.__jsx_style_{index}.css").to_string(),
             content: style.css.clone(),
             language: VirtualLanguage::Style,
             source_map,

--- a/crates/vize_maestro/src/ide/jsx/service.rs
+++ b/crates/vize_maestro/src/ide/jsx/service.rs
@@ -29,7 +29,7 @@ use tower_lsp::lsp_types::{
 };
 use vize_atelier_jsx::JsxLang;
 use vize_canon::{CorsaBridge, LspLocation};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::position::{source_offset_to_virtual_position, virtual_range_to_source};
 use super::virtual_ts::{JsxVirtualTs, generate_jsx_virtual_ts};
@@ -49,7 +49,7 @@ impl JsxService {
     /// session. Shared by every type-aware JSX request (hover, completion,
     /// definition, references, rename, diagnostics) so they all key the same
     /// virtual document in the session cache.
-    pub(super) fn request_path(uri: &Url) -> vize_carton::String {
+    pub(super) fn request_path(uri: &Url) -> vize_s0::String {
         cstr!("{}.jsx.ts", uri.path())
     }
 
@@ -70,7 +70,7 @@ impl JsxService {
     pub(super) async fn prepare_request(
         ctx: &IdeContext<'_>,
         bridge: &CorsaBridge,
-    ) -> Option<(JsxVirtualTs, vize_carton::String, u32, u32)> {
+    ) -> Option<(JsxVirtualTs, vize_s0::String, u32, u32)> {
         if !bridge.is_initialized() {
             return None;
         }

--- a/crates/vize_maestro/src/ide/jsx/service_project.rs
+++ b/crates/vize_maestro/src/ide/jsx/service_project.rs
@@ -11,7 +11,7 @@ pub(super) async fn open_virtual_project(
     ctx: &IdeContext<'_>,
     bridge: &CorsaBridge,
     virtual_ts: &JsxVirtualTs,
-) -> Option<vize_carton::String> {
+) -> Option<vize_s0::String> {
     let source_path = ctx.uri.to_file_path().ok()?;
     let cached_overlays = ctx.state.corsa_overlays();
     let overlays = cached_overlays

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts.rs
@@ -21,7 +21,7 @@
 
 use vize_atelier_jsx::{JsxLang, lower_source};
 use vize_canon::virtual_ts::VizeMapping;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 mod collect;
 mod component;

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts/generate.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts/generate.rs
@@ -2,7 +2,7 @@
 
 use vize_atelier_jsx::{JsxLang, lower_source};
 use vize_canon::virtual_ts::VizeMapping;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 use super::{
     JsxEmit, collect_root_expressions, collect_style_expressions, component, push_mapped_expr, slot,

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts_tests.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts_tests.rs
@@ -1,6 +1,6 @@
 use std::ops::Range;
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::*;
 use crate::ide::jsx::position::source_offset_to_virtual_position;

--- a/crates/vize_maestro/src/ide/references/canonical.rs
+++ b/crates/vize_maestro/src/ide/references/canonical.rs
@@ -1,8 +1,8 @@
 use tower_lsp::lsp_types::Location;
 use vize_canon::CorsaBridge;
-use vize_carton::FxHashSet;
 use vize_croquis::{Drawer, DrawerOptions};
 use vize_relief::BindingType;
+use vize_s0::FxHashSet;
 
 use super::ReferencesService;
 use crate::ide::{IdeContext, corsa_support};
@@ -222,7 +222,7 @@ fn collect_style_locations(
     uri: &tower_lsp::lsp_types::Url,
     source: &str,
     offset: usize,
-    seeds: &mut FxHashSet<(tower_lsp::lsp_types::Url, vize_carton::String)>,
+    seeds: &mut FxHashSet<(tower_lsp::lsp_types::Url, vize_s0::String)>,
     locations: &mut Vec<Location>,
 ) {
     let Some(word) = crate::ide::token_at_offset(source, offset, |byte| {

--- a/crates/vize_maestro/src/ide/references/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests.rs
@@ -234,8 +234,8 @@ fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
     let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(std::path::Path::parent)?;
-    vize_carton::corsa_resolver::resolve_corsa_executable(
-        vize_carton::corsa_resolver::CorsaResolveRequest {
+    vize_s0::corsa_resolver::resolve_corsa_executable(
+        vize_s0::corsa_resolver::CorsaResolveRequest {
             project_root: Some(workspace_root),
             ..Default::default()
         },

--- a/crates/vize_maestro/src/ide/references/corsa_tests/project_surface.rs
+++ b/crates/vize_maestro/src/ide/references/corsa_tests/project_surface.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use tower_lsp::lsp_types::Url;
 use vize_canon::{CorsaBridge, CorsaBridgeConfig};
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use super::{ReferencesService, authored_text, resolve_tsgo_binary};
 use crate::ide::IdeContext;

--- a/crates/vize_maestro/src/ide/references/script.rs
+++ b/crates/vize_maestro/src/ide/references/script.rs
@@ -6,7 +6,7 @@
 use tower_lsp::lsp_types::{Location, Position, Range};
 
 use super::{IdeContext, ReferencesService};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 impl ReferencesService {
     /// Find the definition location of a symbol.

--- a/crates/vize_maestro/src/ide/references/template.rs
+++ b/crates/vize_maestro/src/ide/references/template.rs
@@ -29,7 +29,7 @@ impl ReferencesService {
         // - Directive expressions: v-if="word", :prop="word", @event="word"
 
         // Parse template to find expressions
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let (ast, _) = vize_armature::parse(&allocator, template_content);
 
         // Extract expression locations from the AST

--- a/crates/vize_maestro/src/ide/rename/canonical.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical.rs
@@ -5,7 +5,7 @@ use tower_lsp::lsp_types::{
     WorkspaceEdit,
 };
 use vize_canon::CorsaBridge;
-use vize_carton::{FxHashSet, String, cstr};
+use vize_s0::{FxHashSet, String, cstr};
 
 use crate::ide::{IdeContext, ReferencesService, corsa_support};
 

--- a/crates/vize_maestro/src/ide/rename/canonical/event_rename.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/event_rename.rs
@@ -133,7 +133,7 @@ pub(super) fn component_event_ranges(source: &str, filename: &str) -> Vec<Offset
     let Some(template_source) = source.get(template.loc.start..template.loc.end) else {
         return Vec::new();
     };
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (root, _) = vize_armature::parse(&allocator, template_source);
     let mut drawer = Drawer::with_options(DrawerOptions {
         analyze_template_scopes: true,
@@ -216,7 +216,7 @@ pub(super) fn offset_range(source: &str, range: OffsetRange<usize>) -> Range {
 #[cfg(test)]
 mod tests {
     use tower_lsp::lsp_types::Url;
-    use vize_carton::cstr;
+    use vize_s0::cstr;
 
     use super::{RenameKind, component_event_ranges, semantic_name};
     use crate::ide::IdeContext;

--- a/crates/vize_maestro/src/ide/rename/canonical/event_rename/model.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/event_rename/model.rs
@@ -1,8 +1,8 @@
 use std::ops::Range;
 
 use tower_lsp::lsp_types::{DocumentChangeOperation, DocumentChanges, OneOf, WorkspaceEdit};
-use vize_carton::FxHashSet;
 use vize_croquis::{Drawer, DrawerOptions};
+use vize_s0::FxHashSet;
 
 use crate::ide::IdeContext;
 use crate::ide::corsa_support::{CanonicalSemanticPosition, CanonicalVirtualDocument};
@@ -35,7 +35,7 @@ pub(super) fn usage_ranges(source: &str, filename: &str) -> Vec<Range<usize>> {
     let Some(template_source) = source.get(template.loc.start..template.loc.end) else {
         return Vec::new();
     };
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (root, _) = vize_armature::parse(&allocator, template_source);
     let mut drawer = Drawer::with_options(DrawerOptions {
         analyze_template_scopes: true,
@@ -204,7 +204,7 @@ fn virtual_result<'a>(
     document: &'a CanonicalVirtualDocument,
     uri: &str,
 ) -> Option<(
-    &'a vize_carton::String,
+    &'a vize_s0::String,
     &'a tower_lsp::lsp_types::Url,
     &'a str,
     &'a crate::ide::diagnostics::VirtualTsResult,

--- a/crates/vize_maestro/src/ide/rename/canonical/event_rename/rewrite.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/event_rename/rewrite.rs
@@ -3,7 +3,7 @@ use std::ops::Range as OffsetRange;
 use tower_lsp::lsp_types::{
     DocumentChangeOperation, DocumentChanges, OneOf, TextEdit, Url, WorkspaceEdit,
 };
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::{RenameKind, component_event_ranges, model, offset_range};
 use crate::ide::{IdeContext, pascal_to_kebab};

--- a/crates/vize_maestro/src/ide/rename/canonical/execute.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/execute.rs
@@ -1,6 +1,6 @@
 use tower_lsp::lsp_types::WorkspaceEdit;
 use vize_canon::CorsaBridge;
-use vize_carton::{FxHashSet, String, cstr};
+use vize_s0::{FxHashSet, String, cstr};
 
 use super::{
     Answer, CanonicalFailure, event_rename, initialized_bridge, linked_positions,

--- a/crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs
@@ -1,6 +1,6 @@
 use tower_lsp::lsp_types::{DocumentChangeOperation, DocumentChanges, OneOf, Range, WorkspaceEdit};
 use vize_canon::LspLocation;
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 use crate::ide::{IdeContext, corsa_support};
 
@@ -168,7 +168,7 @@ const greeting = "hello";
             ),
             vec![other_definition],
         );
-        let mut names = vize_carton::FxHashSet::default();
+        let mut names = vize_s0::FxHashSet::default();
         names.insert("title".into());
         let mut changes = HashMap::new();
         changes.insert(

--- a/crates/vize_maestro/src/ide/rename/canonical/failure.rs
+++ b/crates/vize_maestro/src/ide/rename/canonical/failure.rs
@@ -1,5 +1,5 @@
 use vize_canon::CorsaBridgeError;
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::ide::corsa_support::CanonicalProjectOpenError;
 

--- a/crates/vize_maestro/src/ide/rename/corsa_event_variants_tests.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_event_variants_tests.rs
@@ -209,8 +209,8 @@ fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
     let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(std::path::Path::parent)?;
-    vize_carton::corsa_resolver::resolve_corsa_executable(
-        vize_carton::corsa_resolver::CorsaResolveRequest {
+    vize_s0::corsa_resolver::resolve_corsa_executable(
+        vize_s0::corsa_resolver::CorsaResolveRequest {
             project_root: Some(workspace_root),
             ..Default::default()
         },

--- a/crates/vize_maestro/src/ide/rename/corsa_model_tests.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_model_tests.rs
@@ -282,8 +282,8 @@ fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
     let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(std::path::Path::parent)?;
-    vize_carton::corsa_resolver::resolve_corsa_executable(
-        vize_carton::corsa_resolver::CorsaResolveRequest {
+    vize_s0::corsa_resolver::resolve_corsa_executable(
+        vize_s0::corsa_resolver::CorsaResolveRequest {
             project_root: Some(workspace_root),
             ..Default::default()
         },

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Barrier};
 
 use harness::RealCorsaRenameSession;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 mod direct_first;
 pub(in crate::ide) mod harness;

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/direct_first.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/direct_first.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Barrier};
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::{harness::RealCorsaRenameSession, resolve_tsgo_binary_required};
 

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness.rs
@@ -6,7 +6,7 @@ use std::{
 
 use tower_lsp::lsp_types::Url;
 use vize_canon::{CorsaBridge, CorsaBridgeConfig};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use self::assertions::{assert_exact_event_edit, authored_text, prepare_range, strict_rename};
 use super::super::canonical;

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/assertions.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/assertions.rs
@@ -6,7 +6,7 @@
 
 use tower_lsp::lsp_types::{PrepareRenameResponse, Range, Url, WorkspaceEdit};
 use vize_canon::CorsaBridge;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::super::super::canonical;
 use crate::ide::IdeContext;

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/evidence.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/evidence.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::RealCorsaRenameSession;
 

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 mod executable;
 mod proxy;

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/executable.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/executable.rs
@@ -4,7 +4,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn immutable_wrapper() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/corsa-session-wrapper.sh")

--- a/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 pub(super) fn assert_generation_order(
     path: &Path,

--- a/crates/vize_maestro/src/ide/rename/corsa_tests.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_tests.rs
@@ -340,8 +340,8 @@ pub(super) fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
     let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(std::path::Path::parent)?;
-    vize_carton::corsa_resolver::resolve_corsa_executable(
-        vize_carton::corsa_resolver::CorsaResolveRequest {
+    vize_s0::corsa_resolver::resolve_corsa_executable(
+        vize_s0::corsa_resolver::CorsaResolveRequest {
             project_root: Some(workspace_root),
             ..Default::default()
         },

--- a/crates/vize_maestro/src/ide/selection_range/markup.rs
+++ b/crates/vize_maestro/src/ide/selection_range/markup.rs
@@ -109,7 +109,7 @@ fn start_tag<'a>(
 
     let name = &content[name_start..name_end];
     let self_closing = content[..tag_end - 1].trim_end().ends_with('/');
-    if !self_closing && !vize_carton::is_void_tag(name) {
+    if !self_closing && !vize_s0::is_void_tag(name) {
         stack.push(OpenTag {
             name,
             tag_start: cursor,

--- a/crates/vize_maestro/src/ide/semantic_tokens/art.rs
+++ b/crates/vize_maestro/src/ide/semantic_tokens/art.rs
@@ -291,7 +291,7 @@ impl SemanticTokensService {
         tokens: &mut Vec<AbsoluteToken>,
         line_index: &LineIndex<'_>,
     ) {
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let Ok(art_desc) =
             vize_musea::parse_art(&allocator, content, vize_musea::ArtParseOptions::default())
         else {
@@ -559,7 +559,7 @@ impl SemanticTokensService {
             }
         }
 
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let Ok(art_desc) =
             vize_musea::parse_art(&allocator, slice, vize_musea::ArtParseOptions::default())
         else {

--- a/crates/vize_maestro/src/ide/semantic_tokens/encoding.rs
+++ b/crates/vize_maestro/src/ide/semantic_tokens/encoding.rs
@@ -6,11 +6,11 @@ use tower_lsp::lsp_types::SemanticToken;
 
 use super::types::AbsoluteToken;
 
-// Shared, UTF-16-correct line-index utility lives in `vize_carton::line_index`
+// Shared, UTF-16-correct line-index utility lives in `vize_s0::line_index`
 // (#1389). Both the binary-search [`LineIndex`] and the single-shot
 // [`offset_to_line_col`] helper are re-exported here so existing call sites and
 // the perf characteristics are unchanged.
-pub(crate) use vize_carton::line_index::{LineIndex, offset_to_line_col};
+pub(crate) use vize_s0::line_index::{LineIndex, offset_to_line_col};
 
 /// Return the LSP token length for text, measured in UTF-16 code units.
 pub(crate) fn utf16_len(text: &str) -> u32 {

--- a/crates/vize_maestro/src/ide/signature_help.rs
+++ b/crates/vize_maestro/src/ide/signature_help.rs
@@ -177,7 +177,7 @@ impl SignatureHelpService {
         bridge: &CorsaBridge,
         document: &VirtualDocument,
         generated_offset: usize,
-        request_path: vize_carton::String,
+        request_path: vize_s0::String,
         context: Option<serde_json::Value>,
         mut trace: Option<&mut Vec<SignatureHelpStage>>,
     ) -> Option<SignatureHelp> {

--- a/crates/vize_maestro/src/ide/signature_help/tests/fixture.rs
+++ b/crates/vize_maestro/src/ide/signature_help/tests/fixture.rs
@@ -152,5 +152,5 @@ pub(super) fn resolve_tsgo_binary() -> Option<PathBuf> {
     ]
     .into_iter()
     .find(|candidate| candidate.exists())
-    .or_else(|| vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root))
+    .or_else(|| vize_s0::corsa_resolver::discover_corsa_in_ancestors(workspace_root))
 }

--- a/crates/vize_maestro/src/ide/tag_pair.rs
+++ b/crates/vize_maestro/src/ide/tag_pair.rs
@@ -116,7 +116,7 @@ pub(crate) fn names_at(content: &str, region: (usize, usize), offset: usize) -> 
             break;
         };
         let self_closing = content[..tag_end - 1].trim_end().ends_with('/');
-        if self_closing || vize_carton::is_void_tag(name) {
+        if self_closing || vize_s0::is_void_tag(name) {
             if contains(name_span, offset) {
                 return Some(TagNames {
                     first: name_span,

--- a/crates/vize_maestro/src/ide/template_scope/v_for.rs
+++ b/crates/vize_maestro/src/ide/template_scope/v_for.rs
@@ -25,7 +25,7 @@ pub(super) fn binding_at(ctx: &IdeContext<'_>, word: &str) -> Option<TemplateSco
     }
 
     let cursor = ctx.offset - template.loc.start;
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (ast, _) = vize_armature::parse(&allocator, template.content.as_ref());
 
     find_in_children(&ast.children, template.loc.start, cursor, word)

--- a/crates/vize_maestro/src/ide/template_scope/v_slot.rs
+++ b/crates/vize_maestro/src/ide/template_scope/v_slot.rs
@@ -26,7 +26,7 @@ pub(super) fn binding_at(ctx: &IdeContext<'_>, word: &str) -> Option<TemplateSco
 
     let cursor = ctx.offset - template.loc.start;
     let cursor = u32::try_from(cursor).ok()?;
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (ast, _) = vize_armature::parse(&allocator, template.content.as_ref());
     let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
     if ctx.state.legacy_vue2_enabled() {

--- a/crates/vize_maestro/src/ide/type_definition.rs
+++ b/crates/vize_maestro/src/ide/type_definition.rs
@@ -116,7 +116,7 @@ impl TypeDefinitionService {
         bridge: &CorsaBridge,
         document: &VirtualDocument,
         generated_offset: usize,
-        request_path: vize_carton::String,
+        request_path: vize_s0::String,
     ) -> Option<GotoDefinitionResponse> {
         let (line, character) = super::offset_to_position(&document.content, generated_offset);
         let uri = bridge

--- a/crates/vize_maestro/src/ide/type_definition/tests.rs
+++ b/crates/vize_maestro/src/ide/type_definition/tests.rs
@@ -111,8 +111,8 @@ fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
     let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .and_then(std::path::Path::parent)?;
-    vize_carton::corsa_resolver::resolve_corsa_executable(
-        vize_carton::corsa_resolver::CorsaResolveRequest {
+    vize_s0::corsa_resolver::resolve_corsa_executable(
+        vize_s0::corsa_resolver::CorsaResolveRequest {
             project_root: Some(workspace_root),
             ..Default::default()
         },

--- a/crates/vize_maestro/src/ide/type_service.rs
+++ b/crates/vize_maestro/src/ide/type_service.rs
@@ -138,10 +138,7 @@ impl TypeService {
             .and_then(Self::infer_literal_value_type)
             .unwrap_or("unknown");
 
-        vize_canon::TypeInfo::new(
-            vize_carton::cstr!("Ref<{inner}>"),
-            vize_canon::TypeKind::Ref,
-        )
+        vize_canon::TypeInfo::new(vize_s0::cstr!("Ref<{inner}>"), vize_canon::TypeKind::Ref)
     }
 
     fn infer_literal_value_type(value: &str) -> Option<&'static str> {

--- a/crates/vize_maestro/src/ide/type_service/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/type_service/diagnostics.rs
@@ -287,8 +287,8 @@ impl TypeService {
 
 /// Convert byte offset to (line, column), both 0-indexed for LSP.
 ///
-/// Shared, UTF-16-correct implementation in `vize_carton::line_index` (#1389).
-pub(super) use vize_carton::line_index::offset_to_line_col;
+/// Shared, UTF-16-correct implementation in `vize_s0::line_index` (#1389).
+pub(super) use vize_s0::line_index::offset_to_line_col;
 
 #[cfg(test)]
 mod diagnostics_tests;

--- a/crates/vize_maestro/src/ide/type_service/type_context.rs
+++ b/crates/vize_maestro/src/ide/type_service/type_context.rs
@@ -226,7 +226,7 @@ impl TypeService {
                 .and_then(|rest| rest.split_once('>').map(|(type_arg, _)| type_arg.trim()))
             {
                 return vize_canon::TypeInfo::new(
-                    vize_carton::cstr!("Ref<{type_arg}>"),
+                    vize_s0::cstr!("Ref<{type_arg}>"),
                     vize_canon::TypeKind::Ref,
                 );
             }
@@ -268,64 +268,64 @@ impl TypeService {
     fn add_vue_globals(ctx: &mut vize_canon::TypeContext) {
         // Template globals
         ctx.globals.insert(
-            vize_carton::cstr!("$slots"),
+            vize_s0::cstr!("$slots"),
             vize_canon::TypeInfo::new("Slots", vize_canon::TypeKind::Object),
         );
         ctx.globals.insert(
-            vize_carton::cstr!("$emit"),
+            vize_s0::cstr!("$emit"),
             vize_canon::TypeInfo::new(
                 "(event: string, ...args: any[]) => void",
                 vize_canon::TypeKind::Function,
             ),
         );
         ctx.globals.insert(
-            vize_carton::cstr!("$attrs"),
+            vize_s0::cstr!("$attrs"),
             vize_canon::TypeInfo::new("Record<string, unknown>", vize_canon::TypeKind::Object),
         );
         ctx.globals.insert(
-            vize_carton::cstr!("$refs"),
+            vize_s0::cstr!("$refs"),
             vize_canon::TypeInfo::new(
                 "Record<string, Element | ComponentPublicInstance | null>",
                 vize_canon::TypeKind::Object,
             ),
         );
         ctx.globals.insert(
-            vize_carton::cstr!("$el"),
+            vize_s0::cstr!("$el"),
             vize_canon::TypeInfo::new("Element | null", vize_canon::TypeKind::Object),
         );
         ctx.globals.insert(
-            vize_carton::cstr!("$parent"),
+            vize_s0::cstr!("$parent"),
             vize_canon::TypeInfo::new(
                 "ComponentPublicInstance | null",
                 vize_canon::TypeKind::Object,
             ),
         );
         ctx.globals.insert(
-            vize_carton::cstr!("$root"),
+            vize_s0::cstr!("$root"),
             vize_canon::TypeInfo::new("ComponentPublicInstance", vize_canon::TypeKind::Object),
         );
         ctx.globals.insert(
-            vize_carton::cstr!("$data"),
+            vize_s0::cstr!("$data"),
             vize_canon::TypeInfo::new("object", vize_canon::TypeKind::Object),
         );
         ctx.globals.insert(
-            vize_carton::cstr!("$options"),
+            vize_s0::cstr!("$options"),
             vize_canon::TypeInfo::new("ComponentOptions", vize_canon::TypeKind::Object),
         );
         ctx.globals.insert(
-            vize_carton::cstr!("$props"),
+            vize_s0::cstr!("$props"),
             vize_canon::TypeInfo::new("object", vize_canon::TypeKind::Object),
         );
         ctx.globals.insert(
-            vize_carton::cstr!("$watch"),
+            vize_s0::cstr!("$watch"),
             vize_canon::TypeInfo::new("WatchStopHandle", vize_canon::TypeKind::Function),
         );
         ctx.globals.insert(
-            vize_carton::cstr!("$forceUpdate"),
+            vize_s0::cstr!("$forceUpdate"),
             vize_canon::TypeInfo::new("() => void", vize_canon::TypeKind::Function),
         );
         ctx.globals.insert(
-            vize_carton::cstr!("$nextTick"),
+            vize_s0::cstr!("$nextTick"),
             vize_canon::TypeInfo::new(
                 "(callback?: () => void) => Promise<void>",
                 vize_canon::TypeKind::Function,

--- a/crates/vize_maestro/src/ide/workspace_symbols.rs
+++ b/crates/vize_maestro/src/ide/workspace_symbols.rs
@@ -11,7 +11,7 @@ mod disk;
 use tower_lsp::lsp_types::{Location, Position, Range, SymbolInformation, SymbolKind, Url};
 
 use crate::server::ServerState;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 /// Workspace symbols service.
 pub struct WorkspaceSymbolsService;

--- a/crates/vize_maestro/src/lib.rs
+++ b/crates/vize_maestro/src/lib.rs
@@ -151,7 +151,7 @@ pub async fn serve_tcp(port: u16) -> Result<(), Box<dyn std::error::Error + Send
 
     tracing::info!("Starting vize_maestro LSP server on port {}", port);
 
-    let addr = vize_carton::cstr!("127.0.0.1:{port}");
+    let addr = vize_s0::cstr!("127.0.0.1:{port}");
     let listener = TcpListener::bind(addr.as_str())?;
     tracing::info!("Listening on 127.0.0.1:{}", port);
 

--- a/crates/vize_maestro/src/runtime.rs
+++ b/crates/vize_maestro/src/runtime.rs
@@ -22,7 +22,7 @@ use futures::channel::{mpsc, oneshot};
 use futures::io::{AsyncRead, AsyncWrite};
 use futures::stream::StreamExt;
 use futures::task::{ArcWake, waker};
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 const IO_CHANNEL_BOUND: usize = 16;
 

--- a/crates/vize_maestro/src/server/document_structure/folding.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding.rs
@@ -220,7 +220,7 @@ fn markup_regions(content: &str, region_span: (usize, usize)) -> Vec<FoldingRang
 
         let name = &content[name_start..name_end];
         let self_closing = content[..tag_end - 1].trim_end().ends_with('/');
-        if !self_closing && !vize_carton::is_void_tag(name) {
+        if !self_closing && !vize_s0::is_void_tag(name) {
             stack.push(OpenElement {
                 name,
                 open_line: line,

--- a/crates/vize_maestro/src/server/document_structure/folding/tests.rs
+++ b/crates/vize_maestro/src/server/document_structure/folding/tests.rs
@@ -216,8 +216,7 @@ fn script_and_style_internal_work_stays_linear() {
     let mut previous_style_work = None;
 
     for count in [128, 256, 512, 1024] {
-        let mut source =
-            vize_carton::String::from("<script setup lang=\"ts\">\nconst records = [\n");
+        let mut source = vize_s0::String::from("<script setup lang=\"ts\">\nconst records = [\n");
         for _ in 0..count {
             source.push_str("  {\n    enabled: true,\n  },\n");
         }

--- a/crates/vize_maestro/src/server/document_structure/symbols.rs
+++ b/crates/vize_maestro/src/server/document_structure/symbols.rs
@@ -11,7 +11,7 @@ use tower_lsp::lsp_types::{
     DocumentSymbol, DocumentSymbolParams, DocumentSymbolResponse, Position, Range, SymbolKind,
 };
 use vize_atelier_sfc::BlockLocation;
-use vize_carton::line_index::LineIndex;
+use vize_s0::line_index::LineIndex;
 
 use crate::server::ServerState;
 

--- a/crates/vize_maestro/src/server/handlers/tests/lifecycle.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/lifecycle.rs
@@ -7,7 +7,7 @@ use tower_lsp::{
         TextDocumentItem, VersionedTextDocumentIdentifier,
     },
 };
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 fn quiet_service() -> tower_lsp::LspService<MaestroServer> {
     let (service, _socket) = LspService::new(MaestroServer::new);

--- a/crates/vize_maestro/src/server/handlers/tests/requests.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests.rs
@@ -141,7 +141,7 @@ fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
     ]
     .into_iter()
     .find(|candidate| candidate.exists())
-    .or_else(|| vize_carton::corsa_resolver::discover_corsa_in_ancestors(workspace_root))
+    .or_else(|| vize_s0::corsa_resolver::discover_corsa_in_ancestors(workspace_root))
 }
 disabled_open_doc_request_returns_none!(
     definition_disabled_returns_none,

--- a/crates/vize_maestro/src/server/handlers/tests/requests/params.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests/params.rs
@@ -1,6 +1,6 @@
 //! Shared request-parameter builders for the handler guard tests.
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::*;
 

--- a/crates/vize_maestro/src/server/helpers.rs
+++ b/crates/vize_maestro/src/server/helpers.rs
@@ -12,7 +12,7 @@ use tower_lsp::lsp_types::{
 use crate::ide::DiagnosticService;
 
 use super::MaestroServer;
-use vize_carton::append;
+use vize_s0::append;
 
 #[cfg(test)]
 mod supersession_tests;

--- a/crates/vize_maestro/src/server/helpers/supersession_tests.rs
+++ b/crates/vize_maestro/src/server/helpers/supersession_tests.rs
@@ -12,7 +12,7 @@ use super::MaestroServer;
 const LEAF: &str = "<template>\n  <div>leaf</div>\n</template>\n";
 
 fn importer_source(leaf: &str) -> String {
-    vize_carton::cstr!(
+    vize_s0::cstr!(
         "<script setup lang=\"ts\">\nimport Leaf from './{leaf}'\n</script>\n\
          <template>\n  <Leaf />\n</template>\n"
     )

--- a/crates/vize_maestro/src/server/importers.rs
+++ b/crates/vize_maestro/src/server/importers.rs
@@ -12,7 +12,7 @@ use oxc_span::SourceType;
 use parking_lot::{Mutex, RwLock};
 use tower_lsp::lsp_types::Url;
 use vize_canon::{PackageRouteResolver, PackageSourceOptions};
-use vize_carton::{FxHashMap, FxHashSet};
+use vize_s0::{FxHashMap, FxHashSet};
 
 use super::ServerState;
 pub(super) use dependents::open_typecheck_dependents;

--- a/crates/vize_maestro/src/server/importers/specifiers.rs
+++ b/crates/vize_maestro/src/server/importers/specifiers.rs
@@ -8,7 +8,7 @@ use oxc_ast::ast::{
 use oxc_ast_visit::{Visit, walk};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 pub(super) fn collect(source: &str, source_type: SourceType) -> Vec<String> {
     let allocator = Allocator::default();

--- a/crates/vize_maestro/src/server/importers/tests.rs
+++ b/crates/vize_maestro/src/server/importers/tests.rs
@@ -4,7 +4,7 @@ use super::{indexed_dependency_paths, open_importers, resolve_import};
 use crate::server::ServerState;
 use tower_lsp::lsp_types::Url;
 use vize_canon::PackageRouteResolver;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 #[test]
 fn index_tracks_and_removes_open_vue_imports() {

--- a/crates/vize_maestro/src/server/initial_diagnostics.rs
+++ b/crates/vize_maestro/src/server/initial_diagnostics.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
 use tower_lsp::lsp_types::Url;
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 use super::MaestroServer;
 

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -34,8 +34,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use dashmap::DashMap;
 use parking_lot::{Mutex, RwLock};
 use tower_lsp::lsp_types::Url;
-use vize_carton::config::{GlobalTypesConfig, LinterConfig, TypeCheckerConfig};
-use vize_carton::dialect::VueDialect;
+use vize_s0::config::{GlobalTypesConfig, LinterConfig, TypeCheckerConfig};
+use vize_s0::dialect::VueDialect;
 
 #[cfg(feature = "native")]
 use std::sync::OnceLock;
@@ -98,7 +98,7 @@ pub struct ServerState {
     type_checker_options_api: RwLock<bool>,
     /// Vue 2.7 / Nuxt 2 type checker compatibility flag from config.
     type_checker_legacy_vue2: RwLock<bool>,
-    type_checker_vue_version: RwLock<vize_carton::config::VueVersion>,
+    type_checker_vue_version: RwLock<vize_s0::config::VueVersion>,
     /// Opt-in type-aware LSP features for `.jsx`/`.tsx` Vue components (#1498).
     /// Default off: a repository may contain React `.tsx` files that must not
     /// be type-checked as Vue JSX. Set via `typeChecker.jsxTypecheck`.
@@ -107,7 +107,7 @@ pub struct ServerState {
     linter_config: RwLock<LinterConfig>,
     /// Typed per-rule lint options (`linter.ruleOptions`) for configurable
     /// script rules; loaded alongside `linter_config` (#1891).
-    linter_rule_options: RwLock<vize_carton::config::LintRuleOptions>,
+    linter_rule_options: RwLock<vize_s0::config::LintRuleOptions>,
     /// Explicit Vue dialect from config (`dialect` key). `None` means the
     /// dialect is detected structurally per document.
     dialect_config: RwLock<Option<VueDialect>>,
@@ -193,11 +193,11 @@ impl ServerState {
             // Options API matches vue-tsc by default; config may opt out.
             type_checker_options_api: RwLock::new(true),
             type_checker_legacy_vue2: RwLock::new(false),
-            type_checker_vue_version: RwLock::new(vize_carton::config::VueVersion::default()),
+            type_checker_vue_version: RwLock::new(vize_s0::config::VueVersion::default()),
             // JSX/TSX stays off so React sources remain untouched (#1498).
             type_checker_jsx_typecheck: RwLock::new(false),
             linter_config: RwLock::new(LinterConfig::default()),
-            linter_rule_options: RwLock::new(vize_carton::config::LintRuleOptions::default()),
+            linter_rule_options: RwLock::new(vize_s0::config::LintRuleOptions::default()),
             dialect_config: RwLock::new(None),
             workspace_folder_configs: RwLock::new(Vec::new()),
             #[cfg(feature = "glyph")]
@@ -303,7 +303,7 @@ impl ServerState {
         match self.documents.get(uri) {
             Some(document) if document.petite_vue_detected() => VueDialect::PetiteVue,
             Some(_) => VueDialect::Vue,
-            None => vize_carton::dialect::standalone_html_dialect(None, content),
+            None => vize_s0::dialect::standalone_html_dialect(None, content),
         }
     }
 

--- a/crates/vize_maestro/src/server/state/art_template_context.rs
+++ b/crates/vize_maestro/src/server/state/art_template_context.rs
@@ -76,15 +76,15 @@ fn build_variant_document(
         ensure_blank_line(&mut content);
 
         let function_name = if setup.isolate {
-            vize_carton::cstr!("__VIZE_art_variant_{variant_index}_setup")
+            vize_s0::cstr!("__VIZE_art_variant_{variant_index}_setup")
         } else {
             "__VIZE_art_shared_setup".into()
         };
         let generic = setup_generic.filter(|generic| !generic.trim().is_empty());
         if let Some(generic) = generic {
-            vize_carton::append!(content, "async function {function_name}<{generic}>() {{\n");
+            vize_s0::append!(content, "async function {function_name}<{generic}>() {{\n");
         } else {
-            vize_carton::append!(content, "async function {function_name}() {{\n");
+            vize_s0::append!(content, "async function {function_name}() {{\n");
         }
         content.push_str(vize_canon::virtual_ts::VUE_SETUP_HELPERS);
         content.push('\n');

--- a/crates/vize_maestro/src/server/state/config.rs
+++ b/crates/vize_maestro/src/server/state/config.rs
@@ -3,10 +3,10 @@
 use std::path::Path;
 use std::sync::atomic::Ordering;
 
-use vize_carton::config::{GlobalTypesConfig, LinterConfig, TypeCheckerConfig};
+use vize_s0::config::{GlobalTypesConfig, LinterConfig, TypeCheckerConfig};
 
 #[cfg(feature = "glyph")]
-use vize_carton::config::FormatterConfig;
+use vize_s0::config::FormatterConfig;
 
 use super::ServerState;
 use super::features::LspConfigSection;
@@ -59,19 +59,19 @@ impl ServerState {
 
     /// Get a clone of the current per-rule lint options.
     #[inline]
-    pub fn get_linter_rule_options(&self) -> vize_carton::config::LintRuleOptions {
+    pub fn get_linter_rule_options(&self) -> vize_s0::config::LintRuleOptions {
         self.linter_rule_options.read().clone()
     }
 
     /// Get the configured Vue dialect override, if any.
     #[inline]
-    pub fn get_dialect_config(&self) -> Option<vize_carton::dialect::VueDialect> {
+    pub fn get_dialect_config(&self) -> Option<vize_s0::dialect::VueDialect> {
         *self.dialect_config.read()
     }
 
     /// Set the Vue dialect override (`None` re-enables structural detection).
     #[inline]
-    pub fn set_dialect_config(&self, dialect: Option<vize_carton::dialect::VueDialect>) {
+    pub fn set_dialect_config(&self, dialect: Option<vize_s0::dialect::VueDialect>) {
         *self.dialect_config.write() = dialect;
     }
 
@@ -92,7 +92,7 @@ impl ServerState {
         tracing::info!("Loaded global types config from {}", source);
     }
 
-    fn apply_config_features(&self, features: vize_carton::config::ConfigFeatureFlags) {
+    fn apply_config_features(&self, features: vize_s0::config::ConfigFeatureFlags) {
         *self.type_checker_options_api.write() = features.type_checker_options_api;
         // `type_checker_legacy_vue2` already folds in a Vue 2 / 2.7 dialect
         // (`ConfigFeatureFlags::from`), so the LSP and `vize check` agree on
@@ -111,7 +111,7 @@ impl ServerState {
 
     /// Effective Vue language version used by every native type-check surface.
     #[cfg(feature = "native")]
-    pub(crate) fn type_checker_vue_version(&self) -> vize_carton::config::VueVersion {
+    pub(crate) fn type_checker_vue_version(&self) -> vize_s0::config::VueVersion {
         *self.type_checker_vue_version.read()
     }
 
@@ -120,8 +120,8 @@ impl ServerState {
     /// [`LspConfigSection`] rather than being applied afterwards so the
     /// `editor` bundle switch still loses to an explicit per-feature toggle.
     fn lsp_config_section_from_file(
-        config: vize_carton::config::LanguageServerConfig,
-        unstable: vize_carton::config::LanguageServerUnstableFlags,
+        config: vize_s0::config::LanguageServerConfig,
+        unstable: vize_s0::config::LanguageServerUnstableFlags,
     ) -> LspConfigSection {
         LspConfigSection::from(config).with_signature_help(unstable.signature_help)
     }
@@ -143,7 +143,7 @@ impl ServerState {
     /// Load all workspace-scoped options from `vize.config.pkl` (preferred) or JSON.
     pub fn load_workspace_config(&self, dir: &Path) {
         let (loaded, linter_config) =
-            vize_carton::config::load_config_and_linter_with_features_and_source(Some(dir));
+            vize_s0::config::load_config_and_linter_with_features_and_source(Some(dir));
         if let Some(source_path) = loaded.source_path {
             let source = source_path.display().to_string();
             let config = loaded.config;
@@ -154,14 +154,14 @@ impl ServerState {
             }
             self.apply_linter_config(linter_config, &source);
             *self.linter_rule_options.write() =
-                vize_carton::config::load_linter_rule_options(Some(dir));
+                vize_s0::config::load_linter_rule_options(Some(dir));
             self.apply_global_types_config(config.global_types, &source);
             self.apply_type_checker_config(config.type_checker, &source);
             self.apply_config_features(loaded.features);
             self.apply_lsp_config(
                 Self::lsp_config_section_from_file(
                     config.language_server,
-                    vize_carton::config::load_language_server_unstable_flags(Some(dir)),
+                    vize_s0::config::load_language_server_unstable_flags(Some(dir)),
                 ),
                 &source,
             );
@@ -172,20 +172,20 @@ impl ServerState {
     /// Load LSP options from `vize.config.pkl` (preferred) or `vize.config.json`.
     pub fn load_lsp_config(&self, dir: &Path) {
         let (loaded, linter_config) =
-            vize_carton::config::load_config_and_linter_with_features_and_source(Some(dir));
+            vize_s0::config::load_config_and_linter_with_features_and_source(Some(dir));
         if let Some(source_path) = loaded.source_path {
             let source = source_path.display().to_string();
             let config = loaded.config;
             self.apply_linter_config(linter_config, &source);
             *self.linter_rule_options.write() =
-                vize_carton::config::load_linter_rule_options(Some(dir));
+                vize_s0::config::load_linter_rule_options(Some(dir));
             self.apply_global_types_config(config.global_types, &source);
             self.apply_type_checker_config(config.type_checker, &source);
             self.apply_config_features(loaded.features);
             self.apply_lsp_config(
                 Self::lsp_config_section_from_file(
                     config.language_server,
-                    vize_carton::config::load_language_server_unstable_flags(Some(dir)),
+                    vize_s0::config::load_language_server_unstable_flags(Some(dir)),
                 ),
                 &source,
             );
@@ -203,7 +203,7 @@ impl ServerState {
     /// Load format options from `vize.config.json` in the given directory.
     #[cfg(feature = "glyph")]
     pub fn load_format_config(&self, dir: &Path) {
-        let loaded = vize_carton::config::load_config_with_source(Some(dir));
+        let loaded = vize_s0::config::load_config_with_source(Some(dir));
         if let Some(source_path) = loaded.source_path {
             *self.format_options.write() = format_options_from_config(&loaded.config.formatter);
             tracing::info!("Loaded format config from {}", source_path.display());
@@ -221,35 +221,35 @@ fn format_options_from_config(config: &FormatterConfig) -> vize_glyph::FormatOpt
         single_quote: config.single_quote,
         jsx_single_quote: config.jsx_single_quote,
         trailing_comma: match config.trailing_comma {
-            vize_carton::config::TrailingComma::None => vize_glyph::TrailingComma::None,
-            vize_carton::config::TrailingComma::Es5 => vize_glyph::TrailingComma::Es5,
-            vize_carton::config::TrailingComma::All => vize_glyph::TrailingComma::All,
+            vize_s0::config::TrailingComma::None => vize_glyph::TrailingComma::None,
+            vize_s0::config::TrailingComma::Es5 => vize_glyph::TrailingComma::Es5,
+            vize_s0::config::TrailingComma::All => vize_glyph::TrailingComma::All,
         },
         bracket_spacing: config.bracket_spacing,
         bracket_same_line: config.bracket_same_line,
         arrow_parens: match config.arrow_parens {
-            vize_carton::config::ArrowParens::Always => vize_glyph::ArrowParens::Always,
-            vize_carton::config::ArrowParens::Avoid => vize_glyph::ArrowParens::Avoid,
+            vize_s0::config::ArrowParens::Always => vize_glyph::ArrowParens::Always,
+            vize_s0::config::ArrowParens::Avoid => vize_glyph::ArrowParens::Avoid,
         },
         end_of_line: match config.end_of_line {
-            vize_carton::config::EndOfLine::Lf => vize_glyph::EndOfLine::Lf,
-            vize_carton::config::EndOfLine::Crlf => vize_glyph::EndOfLine::Crlf,
-            vize_carton::config::EndOfLine::Cr => vize_glyph::EndOfLine::Cr,
-            vize_carton::config::EndOfLine::Auto => vize_glyph::EndOfLine::Auto,
+            vize_s0::config::EndOfLine::Lf => vize_glyph::EndOfLine::Lf,
+            vize_s0::config::EndOfLine::Crlf => vize_glyph::EndOfLine::Crlf,
+            vize_s0::config::EndOfLine::Cr => vize_glyph::EndOfLine::Cr,
+            vize_s0::config::EndOfLine::Auto => vize_glyph::EndOfLine::Auto,
         },
         quote_props: match config.quote_props {
-            vize_carton::config::QuoteProps::AsNeeded => vize_glyph::QuoteProps::AsNeeded,
-            vize_carton::config::QuoteProps::Consistent => vize_glyph::QuoteProps::Consistent,
-            vize_carton::config::QuoteProps::Preserve => vize_glyph::QuoteProps::Preserve,
+            vize_s0::config::QuoteProps::AsNeeded => vize_glyph::QuoteProps::AsNeeded,
+            vize_s0::config::QuoteProps::Consistent => vize_glyph::QuoteProps::Consistent,
+            vize_s0::config::QuoteProps::Preserve => vize_glyph::QuoteProps::Preserve,
         },
         single_attribute_per_line: config.single_attribute_per_line,
         vue_indent_script_and_style: config.vue_indent_script_and_style,
         sort_attributes: config.sort_attributes,
         attribute_sort_order: match config.attribute_sort_order {
-            vize_carton::config::AttributeSortOrder::Alphabetical => {
+            vize_s0::config::AttributeSortOrder::Alphabetical => {
                 vize_glyph::AttributeSortOrder::Alphabetical
             }
-            vize_carton::config::AttributeSortOrder::AsWritten => {
+            vize_s0::config::AttributeSortOrder::AsWritten => {
                 vize_glyph::AttributeSortOrder::AsWritten
             }
         },

--- a/crates/vize_maestro/src/server/state/config_tests.rs
+++ b/crates/vize_maestro/src/server/state/config_tests.rs
@@ -1,4 +1,4 @@
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::ServerState;
 
@@ -39,7 +39,7 @@ fn language_server_legacy_vue2_reaches_logged_lsp_feature_payload() {
     assert!(state.legacy_vue2_enabled());
     assert_eq!(
         state.type_checker_vue_version(),
-        vize_carton::config::VueVersion::V3
+        vize_s0::config::VueVersion::V3
     );
     assert!(state.options_api_enabled());
 
@@ -149,7 +149,7 @@ fn vue_version_2_7_alone_enables_legacy_lowering() {
     assert!(state.legacy_vue2_enabled());
     assert_eq!(
         state.type_checker_vue_version(),
-        vize_carton::config::VueVersion::V2_7
+        vize_s0::config::VueVersion::V2_7
     );
     assert!(
         state.options_api_enabled(),
@@ -172,7 +172,7 @@ fn compiler_compatibility_vue_version_2_alone_enables_legacy_lowering() {
     assert!(state.legacy_vue2_enabled());
     assert_eq!(
         state.type_checker_vue_version(),
-        vize_carton::config::VueVersion::V2
+        vize_s0::config::VueVersion::V2
     );
 }
 
@@ -191,6 +191,6 @@ fn vue_version_3_keeps_legacy_lowering_disabled() {
     assert!(!state.legacy_vue2_enabled());
     assert_eq!(
         state.type_checker_vue_version(),
-        vize_carton::config::VueVersion::V3
+        vize_s0::config::VueVersion::V3
     );
 }

--- a/crates/vize_maestro/src/server/state/corsa.rs
+++ b/crates/vize_maestro/src/server/state/corsa.rs
@@ -114,7 +114,7 @@ impl ServerState {
                 }
             }
             Err(CorsaBridgeError::Timeout) => {
-                let reason = vize_carton::cstr!(
+                let reason = vize_s0::cstr!(
                     "spawn timed out after {CORSA_REQUEST_TIMEOUT_MS}ms (working_dir={working_dir:?}, corsa_path={corsa_path:?})"
                 );
                 tracing::warn!("corsa bridge {}", reason);
@@ -122,7 +122,7 @@ impl ServerState {
                 None
             }
             Err(e) => {
-                let reason = vize_carton::cstr!(
+                let reason = vize_s0::cstr!(
                     "spawn failed: {e} (working_dir={working_dir:?}, corsa_path={corsa_path:?})"
                 );
                 tracing::warn!("corsa bridge {}", reason);

--- a/crates/vize_maestro/src/server/state/corsa_overlays.rs
+++ b/crates/vize_maestro/src/server/state/corsa_overlays.rs
@@ -21,7 +21,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 use parking_lot::RwLock;
 use tower_lsp::lsp_types::Url;
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 use super::ServerState;
 use crate::document::DocumentStore;

--- a/crates/vize_maestro/src/server/state/corsa_overlays_perf_tests.rs
+++ b/crates/vize_maestro/src/server/state/corsa_overlays_perf_tests.rs
@@ -3,7 +3,7 @@
 //! Split from [`super::corsa_overlays_tests`] to stay inside the
 //! per-file line budget; the fixtures are shared from there.
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::ServerState;
 use super::corsa_overlays_tests::{open, rewrite, uri};

--- a/crates/vize_maestro/src/server/state/corsa_overlays_tests.rs
+++ b/crates/vize_maestro/src/server/state/corsa_overlays_tests.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use tower_lsp::lsp_types::{Position, Range, TextDocumentContentChangeEvent, Url};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::ServerState;
 

--- a/crates/vize_maestro/src/server/state/features.rs
+++ b/crates/vize_maestro/src/server/state/features.rs
@@ -1,7 +1,7 @@
 //! LSP feature flags and config-section parsing.
 
 use serde::Deserialize;
-use vize_carton::config::LanguageServerConfig;
+use vize_s0::config::LanguageServerConfig;
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -39,7 +39,7 @@ pub(super) struct LspConfigSection {
 
 impl LspConfigSection {
     /// Override the `signatureHelp` switch, which config files carry on
-    /// [`vize_carton::config::LanguageServerUnstableFlags`] instead of the
+    /// [`vize_s0::config::LanguageServerUnstableFlags`] instead of the
     /// semver-stable [`LanguageServerConfig`].
     pub(super) fn with_signature_help(mut self, signature_help: Option<bool>) -> Self {
         self.signature_help = signature_help;

--- a/crates/vize_maestro/src/server/state/virtual_docs.rs
+++ b/crates/vize_maestro/src/server/state/virtual_docs.rs
@@ -66,14 +66,14 @@ impl ServerState {
     fn update_standalone_html_virtual_docs(&self, uri: &Url, content: &str) {
         use crate::virtual_code::{TemplateCodeGenerator, VirtualDocuments};
 
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let (ast, _errors) = vize_armature::parse(&allocator, content);
         let base_uri = uri.path();
 
         let mut template_gen = TemplateCodeGenerator::new();
         template_gen.set_block_offset(0);
         let mut template_doc = template_gen.generate(&ast, content);
-        template_doc.uri = vize_carton::cstr!("{base_uri}.__template.ts").to_string();
+        template_doc.uri = vize_s0::cstr!("{base_uri}.__template.ts").to_string();
 
         let mut docs = VirtualDocuments::new();
         docs.template = Some(template_doc);
@@ -106,7 +106,7 @@ impl ServerState {
     fn update_art_virtual_docs(&self, uri: &Url, content: &str) {
         use crate::virtual_code::{ScriptCodeGenerator, TemplateCodeGenerator, VirtualDocuments};
 
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let Ok(art_desc) =
             vize_musea::parse_art(&allocator, content, vize_musea::ArtParseOptions::default())
         else {
@@ -127,7 +127,7 @@ impl ServerState {
                 continue;
             }
 
-            let template_allocator = vize_carton::Allocator::new();
+            let template_allocator = vize_s0::Allocator::new();
             let (ast, _errors) = vize_armature::parse(&template_allocator, template_content);
 
             let template_ptr = template_content.as_ptr() as usize;
@@ -138,7 +138,7 @@ impl ServerState {
             template_gen.set_block_offset(block_offset);
             let mut template_doc = template_gen.generate(&ast, template_content);
             template_doc.uri =
-                vize_carton::cstr!("{base_uri}.art_variant_{index}.template.ts").to_string();
+                vize_s0::cstr!("{base_uri}.art_variant_{index}.template.ts").to_string();
 
             if variant.is_default || docs.template.is_none() {
                 docs.template = Some(template_doc.clone());
@@ -163,13 +163,13 @@ impl ServerState {
                     art_desc.variants.len(),
                     isolate,
                 );
-                script_doc.uri = vize_carton::cstr!("{base_uri}.__script_setup.ts").to_string();
+                script_doc.uri = vize_s0::cstr!("{base_uri}.__script_setup.ts").to_string();
                 docs.script_setup = Some(script_doc);
             }
             if let Some(ref script) = descriptor.script {
                 let mut script_gen = ScriptCodeGenerator::new();
                 let mut script_doc = script_gen.generate(script, false);
-                script_doc.uri = vize_carton::cstr!("{base_uri}.__script.ts").to_string();
+                script_doc.uri = vize_s0::cstr!("{base_uri}.__script.ts").to_string();
                 docs.script = Some(script_doc);
             }
             super::art_template_context::attach(

--- a/crates/vize_maestro/src/server/state/virtual_docs/art.rs
+++ b/crates/vize_maestro/src/server/state/virtual_docs/art.rs
@@ -38,14 +38,14 @@ pub(super) fn add_inline_art_template_virtual_docs(
                 continue;
             }
 
-            let template_allocator = vize_carton::Allocator::new();
+            let template_allocator = vize_s0::Allocator::new();
             let (ast, _errors) = vize_armature::parse(&template_allocator, template_content);
 
             let mut template_gen = TemplateCodeGenerator::new();
             template_gen.set_block_offset(variant.template_start as u32);
             let mut template_doc = template_gen.generate(&ast, template_content);
             template_doc.uri =
-                vize_carton::cstr!("{base_uri}.art_variant_{current_variant_index}.template.ts")
+                vize_s0::cstr!("{base_uri}.art_variant_{current_variant_index}.template.ts")
                     .to_string();
 
             docs.art_templates[current_variant_index] = Some(template_doc);
@@ -101,7 +101,7 @@ pub(super) fn generate_art_script_setup_virtual_doc(
     if parts.isolate {
         let count = variant_count.max(1);
         for index in 0..count {
-            vize_carton::append!(content, "function __VIZE_art_variant_{index}_setup() {{\n");
+            vize_s0::append!(content, "function __VIZE_art_variant_{index}_setup() {{\n");
             for chunk in &parts.isolated_body {
                 let generated_start = content.len() as u32;
                 content.push_str(&chunk.text);
@@ -135,7 +135,7 @@ pub(super) fn generate_art_script_setup_virtual_doc(
     }
 
     VirtualDocument {
-        uri: vize_carton::cstr!("{base_uri}.__script_setup.ts").to_string(),
+        uri: vize_s0::cstr!("{base_uri}.__script_setup.ts").to_string(),
         content,
         language: VirtualLanguage::ScriptSetup,
         source_map: SourceMap::from_mappings(mappings),

--- a/crates/vize_maestro/src/server/state/virtual_docs/tests.rs
+++ b/crates/vize_maestro/src/server/state/virtual_docs/tests.rs
@@ -13,7 +13,7 @@ use crate::server::ServerState;
 use crate::virtual_code::VirtualDocuments;
 
 fn source(color: &str) -> String {
-    vize_carton::cstr!(
+    vize_s0::cstr!(
         "<script setup lang=\"ts\">\nconst message = 'hi'\n</script>\n\
          <template>\n  <div>{{{{ message }}}}</div>\n</template>\n\
          <style scoped>\n.box {{ color: {color}; }}\n</style>\n"
@@ -33,7 +33,7 @@ fn styles(docs: &VirtualDocuments) -> Vec<(String, String)> {
 fn style_documents(color: &str) -> Vec<(String, String)> {
     vec![(
         "/Snapshot.vue.__style_0.css".to_string(),
-        vize_carton::cstr!("\n.box {{ color: {color}; }}\n").to_string(),
+        vize_s0::cstr!("\n.box {{ color: {color}; }}\n").to_string(),
     )]
 }
 

--- a/crates/vize_maestro/src/server/state/workspace_folders.rs
+++ b/crates/vize_maestro/src/server/state/workspace_folders.rs
@@ -14,7 +14,7 @@
 use std::path::{Path, PathBuf};
 
 use tower_lsp::lsp_types::{InitializeParams, Url, WorkspaceFolder, WorkspaceFoldersChangeEvent};
-use vize_carton::config::{LintRuleOptions, LinterConfig};
+use vize_s0::config::{LintRuleOptions, LinterConfig};
 
 use super::ServerState;
 
@@ -29,9 +29,9 @@ impl WorkspaceFolderConfig {
     /// Load the folder's own `vize.config.*`; a folder without a config file
     /// gets the built-in defaults so contexts stay order-independent.
     fn load(root: PathBuf) -> Self {
-        let (loaded, linter) = vize_carton::config::load_config_and_linter_with_source(Some(&root));
+        let (loaded, linter) = vize_s0::config::load_config_and_linter_with_source(Some(&root));
         if loaded.source_path.is_some() {
-            let rule_options = vize_carton::config::load_linter_rule_options(Some(&root));
+            let rule_options = vize_s0::config::load_linter_rule_options(Some(&root));
             Self {
                 root,
                 linter,
@@ -147,7 +147,7 @@ fn deepest_enclosing_folder<'a>(
 #[cfg(test)]
 mod tests {
     use tower_lsp::lsp_types::{Url, WorkspaceFolder, WorkspaceFoldersChangeEvent};
-    use vize_carton::{config::LintRuleSeverity, cstr};
+    use vize_s0::{config::LintRuleSeverity, cstr};
 
     use crate::server::ServerState;
 

--- a/crates/vize_maestro/src/server/state/workspace_vue_files.rs
+++ b/crates/vize_maestro/src/server/state/workspace_vue_files.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use futures::channel::oneshot;
 use ignore::{DirEntry, WalkBuilder};
 use tower_lsp::lsp_types::Url;
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 use super::ServerState;
 use super::global_components::is_excluded_directory;

--- a/crates/vize_maestro/src/server/workspace_files/dependents.rs
+++ b/crates/vize_maestro/src/server/workspace_files/dependents.rs
@@ -93,7 +93,7 @@ mod tests {
     #![allow(clippy::disallowed_methods)]
 
     use tower_lsp::lsp_types::Url;
-    use vize_carton::cstr;
+    use vize_s0::cstr;
 
     use super::{ServerState, versioned_open_typecheck_dependents};
 

--- a/crates/vize_maestro/src/virtual_code/generator.rs
+++ b/crates/vize_maestro/src/virtual_code/generator.rs
@@ -1,6 +1,6 @@
 //! Virtual code generator that transforms SFC into virtual documents.
 //!
-//! Uses arena allocation from vize_carton for optimal performance.
+//! Uses arena allocation from vize_s0 for optimal performance.
 #![allow(clippy::disallowed_methods)]
 
 mod art_script;
@@ -20,8 +20,8 @@ mod tests;
 mod tests_semantic_bindings;
 
 use vize_atelier_sfc::SfcDescriptor;
-use vize_carton::Allocator;
-use vize_carton::cstr;
+use vize_s0::Allocator;
+use vize_s0::cstr;
 
 use binding::template_used_script_bindings;
 

--- a/crates/vize_maestro/src/virtual_code/generator/block.rs
+++ b/crates/vize_maestro/src/virtual_code/generator/block.rs
@@ -192,7 +192,7 @@ pub fn find_art_block_at_offset(source: &str, offset: usize) -> Option<BlockType
     }
 
     // Parse as art file to determine variant position
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let Ok(art_desc) =
         vize_musea::parse_art(&allocator, source, vize_musea::ArtParseOptions::default())
     else {

--- a/crates/vize_maestro/src/virtual_code/generator/tests_semantic_bindings.rs
+++ b/crates/vize_maestro/src/virtual_code/generator/tests_semantic_bindings.rs
@@ -1,5 +1,5 @@
 use super::VirtualCodeGenerator;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 const COMPLEX_BINDINGS_SFC: &str = r#"<script setup lang="ts">
 import DefaultWidget, {

--- a/crates/vize_maestro/src/virtual_code/style_code.rs
+++ b/crates/vize_maestro/src/virtual_code/style_code.rs
@@ -8,7 +8,7 @@ use vize_atelier_sfc::SfcStyleBlock;
 use super::{
     MappingFeatures, SourceMap, SourceMapping, SourceRange, VirtualDocument, VirtualLanguage,
 };
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 /// Style code generator.
 pub struct StyleCodeGenerator {

--- a/crates/vize_maestro/src/virtual_code/template_code.rs
+++ b/crates/vize_maestro/src/virtual_code/template_code.rs
@@ -11,7 +11,7 @@ use vize_relief::{
 };
 
 use super::{MappingData, SourceMap, SourceMapping, SourceRange, VirtualDocument, VirtualLanguage};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 /// Template code generator.
 pub struct TemplateCodeGenerator {

--- a/crates/vize_maestro/src/virtual_code/template_code_tests.rs
+++ b/crates/vize_maestro/src/virtual_code/template_code_tests.rs
@@ -9,7 +9,7 @@ use super::TemplateCodeGenerator;
 #[test]
 fn test_template_code_generator() {
     let source = r#"<div>{{ message }}</div>"#;
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (ast, errors) = vize_armature::parse(&allocator, source);
     assert!(errors.is_empty());
 
@@ -23,7 +23,7 @@ fn test_template_code_generator() {
 #[test]
 fn test_generator_with_directives() {
     let source = r#"<div v-if="show">test</div>"#;
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (ast, errors) = vize_armature::parse(&allocator, source);
     assert!(errors.is_empty());
 
@@ -36,7 +36,7 @@ fn test_generator_with_directives() {
 #[test]
 fn test_event_arrow_expression_is_not_prefixed_as_member() {
     let source = r#"<button @click="() => { count++ }">{{ count }}</button>"#;
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (ast, errors) = vize_armature::parse(&allocator, source);
     assert!(errors.is_empty());
 
@@ -61,7 +61,7 @@ fn test_multiline_event_arrow_expression_is_not_prefixed_as_member() {
 >
   {{ count }}
 </button>"#;
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (ast, errors) = vize_armature::parse(&allocator, source);
     assert!(errors.is_empty());
 

--- a/crates/vize_maestro/tests/davinci_ts40_projection.rs
+++ b/crates/vize_maestro/tests/davinci_ts40_projection.rs
@@ -6,7 +6,7 @@
 mod davinci_ts40_projection_support;
 
 use davinci_ts40_projection_support::{Drift, capture_fixture, load_matrix, verify_exact};
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 #[test]
 #[allow(clippy::disallowed_macros)] // `insta` expands to `format!`.

--- a/crates/vize_maestro/tests/davinci_ts40_projection_support/canon.rs
+++ b/crates/vize_maestro/tests/davinci_ts40_projection_support/canon.rs
@@ -4,7 +4,7 @@ use vize_canon::batch::{
     generate_vue_document_virtual_ts_with_options,
 };
 use vize_canon::virtual_ts::VirtualTsOptions;
-use vize_carton::{SmallVec, String, append, cstr};
+use vize_s0::{SmallVec, String, append, cstr};
 
 use super::matrix::Fixture;
 use super::normalize::{fixture_path, ordered_lines, sha256};

--- a/crates/vize_maestro/tests/davinci_ts40_projection_support/maestro.rs
+++ b/crates/vize_maestro/tests/davinci_ts40_projection_support/maestro.rs
@@ -1,6 +1,6 @@
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-use vize_carton::{SmallVec, String, cstr};
 use vize_maestro::VirtualCodeGenerator;
+use vize_s0::{SmallVec, String, cstr};
 
 use super::matrix::Fixture;
 use super::normalize::{ordered_lines, sha256};

--- a/crates/vize_maestro/tests/davinci_ts40_projection_support/matrix.rs
+++ b/crates/vize_maestro/tests/davinci_ts40_projection_support/matrix.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
-use vize_carton::String;
+use vize_s0::String;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/vize_maestro/tests/davinci_ts40_projection_support/normalize.rs
+++ b/crates/vize_maestro/tests/davinci_ts40_projection_support/normalize.rs
@@ -1,6 +1,6 @@
 use sha2::{Digest, Sha256};
 use std::fmt::Write;
-use vize_carton::{SmallVec, String, ToCompactString};
+use vize_s0::{SmallVec, String, ToCompactString};
 
 use super::matrix::Fixture;
 

--- a/crates/vize_maestro/tests/davinci_ts40_projection_support/record.rs
+++ b/crates/vize_maestro/tests/davinci_ts40_projection_support/record.rs
@@ -1,4 +1,4 @@
-use vize_carton::{SmallVec, String, append, cstr};
+use vize_s0::{SmallVec, String, append, cstr};
 
 use super::canon::{capture_canon, capture_content_mapper};
 use super::maestro::capture_maestro;

--- a/crates/vize_maestro/tests/file_rename_declarations.rs
+++ b/crates/vize_maestro/tests/file_rename_declarations.rs
@@ -3,12 +3,12 @@ use std::fs;
 use std::path::Path;
 
 use tower_lsp::lsp_types::{FileRename, RenameFilesParams, Url};
-use vize_carton::cstr;
 use vize_maestro::ide::FileRenameService;
 use vize_maestro::runtime;
 use vize_maestro::server::ServerState;
+use vize_s0::cstr;
 
-fn file_uri(path: &Path) -> vize_carton::String {
+fn file_uri(path: &Path) -> vize_s0::String {
     cstr!("{}", Url::from_file_path(path).unwrap())
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -50,7 +50,7 @@ observational guard for planning only. It does not change rollout state.
 | Typechecker                |           883 |                   139 |               744 |             394 |     187 |             806 |      658 |           461 |           651 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            18 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
-| LSP                        |           271 |                     0 |               271 |             115 |      44 |             325 |      105 |           166 |           388 |
+| LSP                        |           271 |                   271 |                 0 |             115 |      44 |             325 |      105 |           166 |           388 |
 
 ## Consumer details
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -2374,7 +2374,7 @@ formatter	Formatter	source	crates/vize/src/commands/fmt/entries.rs	3	s0	S0/carto
 formatter	Formatter	test/dev	crates/vize/src/commands/fmt/files_tests.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
 formatter	Formatter	test/dev	crates/vize/src/commands/fmt/files.rs	125	s0	S0/carton	stage	vize_s0	preferred	4
 formatter	Formatter	source	crates/vize/src/commands/fmt/ignores.rs	80	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	croquis	Croquis analysis	old	vize_croquis	legacy	1
@@ -2383,19 +2383,19 @@ lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	raw_oxc	raw OXC	raw	oxc_ast	r
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-lsp	LSP	source	crates/vize_maestro/src/document/store.rs	79	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide.rs	210	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/auto_insert.rs	77	s0	S0/carton	stage	vize_carton	compat	2
-lsp	LSP	source	crates/vize_maestro/src/ide/code_action.rs	14	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/document/store.rs	79	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide.rs	210	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/auto_insert.rs	77	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/code_action.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/code_action.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	5
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/component_props_tests.rs	318	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/component_props_tests.rs	318	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/items.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/script.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/script.rs	24	croquis	Croquis analysis	old	vize_croquis	legacy	2
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/context.rs	10	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/member_access.rs	12	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/member_access.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/member_access.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
@@ -2407,237 +2407,237 @@ lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal/rece
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal/receiver_value.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/reactive_infer.rs	10	croquis	Croquis analysis	old	vize_croquis	legacy	2
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/script/tests.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/bindings.rs	14	s0	S0/carton	stage	vize_carton	compat	2
+lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/bindings.rs	14	s0	S0/carton	stage	vize_s0	preferred	2
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/bindings.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/bindings.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	2
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/bindings.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	2
-lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_cache.rs	90	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_meta.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_cache.rs	90	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_meta.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_meta.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_meta.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_meta.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_meta.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/slot_outlets.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/slot_outlets.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/slot_outlets.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/slot_outlets.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/tests.rs	8	s0	S0/carton	stage	vize_carton	compat	2
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/tests.rs	8	s0	S0/carton	stage	vize_s0	preferred	2
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/tests.rs	8	old_ast	old AST/parser	old	vize_relief	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/context.rs	88	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support.rs	52	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical.rs	3	s0	S0/carton	stage	vize_carton	compat	5
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/open.rs	146	s0	S0/carton	stage	vize_carton	compat	2
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/project.rs	5	s0	S0/carton	stage	vize_carton	compat	3
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs	3	s0	S0/carton	stage	vize_carton	compat	3
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/external_mirror.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support/external_mirror.rs	109	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/html_attribute.rs	2	s0	S0/carton	stage	vize_carton	compat	10
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/html_tag.rs	2	s0	S0/carton	stage	vize_carton	compat	6
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/virtual_document.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs	159	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/definition/art.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/definition/corsa_tests.rs	32	s0	S0/carton	stage	vize_carton	compat	2
-lsp	LSP	source	crates/vize_maestro/src/ide/definition/import_resolver.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/definition/script.rs	14	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/context.rs	88	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support.rs	52	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical.rs	3	s0	S0/carton	stage	vize_s0	preferred	5
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/open.rs	146	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/project.rs	5	s0	S0/carton	stage	vize_s0	preferred	3
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs	3	s0	S0/carton	stage	vize_s0	preferred	3
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/external_mirror.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support/external_mirror.rs	109	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/html_attribute.rs	2	s0	S0/carton	stage	vize_s0	preferred	10
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/html_tag.rs	2	s0	S0/carton	stage	vize_s0	preferred	6
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/virtual_document.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs	159	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/definition/art.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/definition/corsa_tests.rs	32	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/definition/import_resolver.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/definition/script.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/script.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/definition/slot.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/definition/slot.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/slot.rs	2	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/slot.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/template.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/template.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/definition/tests/contexts.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/collectors.rs	12	s0	S0/carton	stage	vize_carton	compat	3
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/definition/tests/contexts.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/collectors.rs	12	s0	S0/carton	stage	vize_s0	preferred	3
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/collectors.rs	12	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/collectors.rs	12	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/collectors.rs	12	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/component_props.rs	8	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/component_props.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/component_props.rs	8	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/component_props.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs	16	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/message.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/corsa/message.rs	47	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/corsa/relative_import_tests.rs	210	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs	1	s0	S0/carton	stage	vize_carton	compat	2
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art_bindings.rs	5	s0	S0/carton	stage	vize_carton	compat	4
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs	16	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/message.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/corsa/message.rs	47	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/corsa/relative_import_tests.rs	210	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs	1	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art_bindings.rs	5	s0	S0/carton	stage	vize_s0	preferred	4
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art_bindings.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs	12	s0	S0/carton	stage	vize_carton	compat	3
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs	12	s0	S0/carton	stage	vize_s0	preferred	3
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs	12	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs	14	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/editor_typecheck_fixture.rs	212	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/line_index.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/line_index.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/vize_sfc_type.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/ecosystem/i18n.rs	12	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/ecosystem/router_extension_tests.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/ecosystem/router.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/ecosystem/router.rs	612	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/ecosystem/void.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/editor_typecheck_fixture.rs	212	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/line_index.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/line_index.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/vize_sfc_type.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/ecosystem/i18n.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/ecosystem/router_extension_tests.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/ecosystem/router.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/ecosystem/router.rs	612	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/ecosystem/void.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/file_rename/manual/script.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/file_rename/manual/script.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	3
 lsp	LSP	source	crates/vize_maestro/src/ide/file_rename/manual/script.rs	5	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/file_rename/manual/script.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover.rs	159	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/component_import.rs	118	croquis	Croquis analysis	old	vize_croquis	legacy	4
-lsp	LSP	source	crates/vize_maestro/src/ide/hover/component_tag.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/hover/component_tag.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/component_tag.rs	2	old_ast	old AST/parser	old	vize_armature	legacy	2
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/component_tag.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	2
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/component_tag/items.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover/component_tag/items.rs	75	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover/component_tag/items.rs	75	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover/component_tag/items.rs	75	croquis	Croquis analysis	old	vize_croquis	legacy	2
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover/corsa_tests.rs	56	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover/corsa_tests.rs	56	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	croquis	Croquis analysis	old	vize_croquis	legacy	3
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-lsp	LSP	source	crates/vize_maestro/src/ide/hover/petite_vue.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/hover/petite_vue.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/petite_vue.rs	2	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/petite_vue.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/script_type_infer.rs	4	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover/script_type_infer.rs	300	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/script.rs	11	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/script.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/hover/template.rs	12	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/hover/template.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/template.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/template.rs	12	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/template.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/inlay_hint.rs	21	s0	S0/carton	stage	vize_carton	compat	4
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/inlay_hint.rs	21	s0	S0/carton	stage	vize_s0	preferred	4
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/inlay_hint.rs	21	croquis	Croquis analysis	old	vize_croquis	legacy	3
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/code_action.rs	27	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/document_symbols.rs	25	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/scoped_style.rs	20	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/code_action.rs	27	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/document_symbols.rs	25	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/scoped_style.rs	20	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/jsx/scoped_style.rs	20	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/jsx/scoped_style.rs	20	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 lsp	LSP	source	crates/vize_maestro/src/ide/jsx/scoped_style.rs	20	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/service_project.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/service.rs	32	s0	S0/carton	stage	vize_carton	compat	3
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/jsx/virtual_ts_tests.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts.rs	24	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/service_project.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/service.rs	32	s0	S0/carton	stage	vize_s0	preferred	3
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/jsx/virtual_ts_tests.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts.rs	24	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts/collect.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	4
 lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts/component.rs	8	old_ast	old AST/parser	old	vize_relief	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts/generate.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts/generate.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts/slot.rs	16	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/musea.rs	35	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/references/canonical.rs	3	s0	S0/carton	stage	vize_carton	compat	2
+lsp	LSP	source	crates/vize_maestro/src/ide/references/canonical.rs	3	s0	S0/carton	stage	vize_s0	preferred	2
 lsp	LSP	source	crates/vize_maestro/src/ide/references/canonical.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/references/canonical.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/references/corsa_tests.rs	237	s0	S0/carton	stage	vize_carton	compat	2
-lsp	LSP	source	crates/vize_maestro/src/ide/references/corsa_tests/project_surface.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/references/script.rs	9	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/references/corsa_tests.rs	237	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/references/corsa_tests/project_surface.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/references/script.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/references/script.rs	9	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/references/script.rs	9	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/references/script.rs	9	raw_oxc	raw OXC	raw	oxc_parser	raw	2
-lsp	LSP	source	crates/vize_maestro/src/ide/references/template.rs	32	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/references/template.rs	32	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/references/template.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	4
 lsp	LSP	source	crates/vize_maestro/src/ide/references/template.rs	32	old_ast	old AST/parser	old	vize_armature	legacy	2
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	2
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/canonical/event_rename.rs	219	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename/model.rs	4	s0	S0/carton	stage	vize_carton	compat	3
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/canonical/event_rename.rs	219	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename/model.rs	4	s0	S0/carton	stage	vize_s0	preferred	3
 lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename/model.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename/model.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename/rewrite.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/execute.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs	171	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/failure.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_event_variants_tests.rs	212	s0	S0/carton	stage	vize_carton	compat	2
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_model_tests.rs	285	s0	S0/carton	stage	vize_carton	compat	2
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_session_tests.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/direct_first.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/assertions.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/evidence.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/executable.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_tests.rs	343	s0	S0/carton	stage	vize_carton	compat	2
-lsp	LSP	source	crates/vize_maestro/src/ide/selection_range/markup.rs	112	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/semantic_tokens/art.rs	294	s0	S0/carton	stage	vize_carton	compat	2
-lsp	LSP	source	crates/vize_maestro/src/ide/semantic_tokens/encoding.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/signature_help.rs	180	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/signature_help/tests/fixture.rs	155	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/tag_pair.rs	119	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename/rewrite.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/execute.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs	171	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/failure.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_event_variants_tests.rs	212	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_model_tests.rs	285	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_session_tests.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/direct_first.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/assertions.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/evidence.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/executable.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_tests.rs	343	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/selection_range/markup.rs	112	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/semantic_tokens/art.rs	294	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/semantic_tokens/encoding.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/signature_help.rs	180	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/signature_help/tests/fixture.rs	155	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/tag_pair.rs	119	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/template_expression.rs	146	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_for.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_for.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_for.rs	4	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_for.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_slot.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_slot.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_slot.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_slot.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/type_definition.rs	119	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/type_definition/tests.rs	114	s0	S0/carton	stage	vize_carton	compat	2
-lsp	LSP	source	crates/vize_maestro/src/ide/type_service.rs	142	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/type_service/diagnostics.rs	291	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/ide/type_service/type_context.rs	229	s0	S0/carton	stage	vize_carton	compat	14
-lsp	LSP	source	crates/vize_maestro/src/ide/workspace_symbols.rs	14	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/ide/type_definition.rs	119	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/type_definition/tests.rs	114	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/type_service.rs	141	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/type_service/diagnostics.rs	291	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/type_service/type_context.rs	229	s0	S0/carton	stage	vize_s0	preferred	14
+lsp	LSP	source	crates/vize_maestro/src/ide/workspace_symbols.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/workspace_symbols.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	2
-lsp	LSP	source	crates/vize_maestro/src/lib.rs	154	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/runtime.rs	25	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding.rs	223	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/lib.rs	154	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/runtime.rs	25	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding.rs	223	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding/script.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding/script.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding/script.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding/script.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/document_structure/folding/tests.rs	220	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/server/document_structure/symbols.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/lifecycle.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/requests.rs	144	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/requests/params.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/server/helpers.rs	15	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/helpers/supersession_tests.rs	15	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/server/importers.rs	15	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/server/importers/specifiers.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/document_structure/folding/tests.rs	219	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/document_structure/symbols.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/lifecycle.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/requests.rs	144	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/requests/params.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/helpers.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/helpers/supersession_tests.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/importers.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/importers/specifiers.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/server/importers/specifiers.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/server/importers/specifiers.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 lsp	LSP	source	crates/vize_maestro/src/server/importers/specifiers.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 lsp	LSP	source	crates/vize_maestro/src/server/importers/specifiers.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/importers/tests.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/server/initial_diagnostics.rs	15	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state.rs	37	s0	S0/carton	stage	vize_carton	compat	7
-lsp	LSP	source	crates/vize_maestro/src/server/state/art_template_context.rs	79	s0	S0/carton	stage	vize_carton	compat	3
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state/config_tests.rs	1	s0	S0/carton	stage	vize_carton	compat	5
-lsp	LSP	source	crates/vize_maestro/src/server/state/config.rs	6	s0	S0/carton	stage	vize_carton	compat	30
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state/corsa_overlays_perf_tests.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state/corsa_overlays_tests.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/server/state/corsa_overlays.rs	24	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/server/state/corsa.rs	117	s0	S0/carton	stage	vize_carton	compat	2
-lsp	LSP	source	crates/vize_maestro/src/server/state/features.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state/virtual_docs.rs	69	s0	S0/carton	stage	vize_carton	compat	7
+lsp	LSP	test/dev	crates/vize_maestro/src/server/importers/tests.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/initial_diagnostics.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state.rs	37	s0	S0/carton	stage	vize_s0	preferred	7
+lsp	LSP	source	crates/vize_maestro/src/server/state/art_template_context.rs	79	s0	S0/carton	stage	vize_s0	preferred	3
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state/config_tests.rs	1	s0	S0/carton	stage	vize_s0	preferred	5
+lsp	LSP	source	crates/vize_maestro/src/server/state/config.rs	6	s0	S0/carton	stage	vize_s0	preferred	30
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state/corsa_overlays_perf_tests.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state/corsa_overlays_tests.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/state/corsa_overlays.rs	24	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/state/corsa.rs	117	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/server/state/features.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state/virtual_docs.rs	69	s0	S0/carton	stage	vize_s0	preferred	7
 lsp	LSP	test/dev	crates/vize_maestro/src/server/state/virtual_docs.rs	69	old_ast	old AST/parser	old	vize_armature	legacy	2
-lsp	LSP	source	crates/vize_maestro/src/server/state/virtual_docs/art.rs	41	s0	S0/carton	stage	vize_carton	compat	4
+lsp	LSP	source	crates/vize_maestro/src/server/state/virtual_docs/art.rs	41	s0	S0/carton	stage	vize_s0	preferred	4
 lsp	LSP	source	crates/vize_maestro/src/server/state/virtual_docs/art.rs	41	old_ast	old AST/parser	old	vize_armature	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state/virtual_docs/tests.rs	16	s0	S0/carton	stage	vize_carton	compat	2
-lsp	LSP	source	crates/vize_maestro/src/server/state/workspace_folders.rs	17	s0	S0/carton	stage	vize_carton	compat	3
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state/workspace_folders.rs	150	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/server/state/workspace_vue_files.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/workspace_files/dependents.rs	96	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state/virtual_docs/tests.rs	16	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/server/state/workspace_folders.rs	17	s0	S0/carton	stage	vize_s0	preferred	3
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state/workspace_folders.rs	150	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/state/workspace_vue_files.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/workspace_files/dependents.rs	96	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/virtual_code.rs	227	old_ast	old AST/parser	old	vize_relief	legacy	4
-lsp	LSP	test/dev	crates/vize_maestro/src/virtual_code/generator.rs	23	s0	S0/carton	stage	vize_carton	compat	2
+lsp	LSP	test/dev	crates/vize_maestro/src/virtual_code/generator.rs	23	s0	S0/carton	stage	vize_s0	preferred	2
 lsp	LSP	test/dev	crates/vize_maestro/src/virtual_code/generator.rs	23	old_ast	old AST/parser	old	vize_armature	legacy	3
 lsp	LSP	source	crates/vize_maestro/src/virtual_code/generator/art_script.rs	60	croquis	Croquis analysis	old	vize_croquis	legacy	3
 lsp	LSP	source	crates/vize_maestro/src/virtual_code/generator/binding.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/virtual_code/generator/block.rs	195	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	source	crates/vize_maestro/src/virtual_code/generator/tests_semantic_bindings.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/virtual_code/generator/block.rs	195	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/virtual_code/generator/tests_semantic_bindings.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/virtual_code/script_code.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/virtual_code/style_code.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/src/virtual_code/template_code_tests.rs	12	s0	S0/carton	stage	vize_carton	compat	4
+lsp	LSP	source	crates/vize_maestro/src/virtual_code/style_code.rs	11	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/virtual_code/template_code_tests.rs	12	s0	S0/carton	stage	vize_s0	preferred	4
 lsp	LSP	test/dev	crates/vize_maestro/src/virtual_code/template_code_tests.rs	12	old_ast	old AST/parser	old	vize_armature	legacy	4
-lsp	LSP	source	crates/vize_maestro/src/virtual_code/template_code.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+lsp	LSP	source	crates/vize_maestro/src/virtual_code/template_code.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/virtual_code/template_code.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/virtual_code/template_code.rs	7	old_ast	old AST/parser	old	vize_armature	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/canon.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/maestro.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/matrix.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/normalize.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/record.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/file_rename_declarations.rs	6	s0	S0/carton	stage	vize_carton	compat	2
+lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/canon.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/maestro.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/matrix.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/normalize.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/record.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/tests/file_rename_declarations.rs	9	s0	S0/carton	stage	vize_s0	preferred	2

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -82,3 +82,16 @@ void test("content-mapper S0 surface stays on the preferred physical name", () =
       .every((site) => site.matchedName === "vize_s0" && site.nameKind === "preferred"),
   );
 });
+
+void test("LSP S0 surface stays on the preferred physical name", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const lsp = scan.consumers.find((consumer) => consumer.id === "lsp");
+  assert.ok(lsp);
+  assert.equal(lsp.nameKindCounts.compat, 0);
+  assert.ok(lsp.nameKindCounts.preferred > 0, "LSP should keep importing S0 explicitly");
+  assert.ok(
+    lsp.sites
+      .filter((site) => site.surfaceId === "s0")
+      .every((site) => site.matchedName === "vize_s0" && site.nameKind === "preferred"),
+  );
+});

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -267,3 +267,38 @@ test("Canon content-mapper imports S0 storage through the stage alias", () => {
   assert.ok(aliasImports > 0, "Canon content-mapper should use the vize_s0 alias");
   assert.deepEqual(offenders, []);
 });
+
+test("Maestro LSP imports S0 storage through the stage alias", () => {
+  const dependencies = workspacePackage(metadata, "vize_maestro").dependencies;
+  assert.ok(
+    dependencies.some(
+      (dependency) =>
+        dependency.kind === null &&
+        dependency.name === "vize_carton" &&
+        dependency.rename === "vize_s0",
+    ),
+    "vize_maestro must import vize_carton as vize_s0 for S0 storage",
+  );
+  assert.ok(
+    dependencies.every(
+      (dependency) => dependency.name !== "vize_carton" || dependency.rename === "vize_s0",
+    ),
+    "vize_maestro must not depend on vize_carton through its physical name",
+  );
+
+  const maestroDir = path.join(repoRoot, "crates", "vize_maestro");
+  const offenders = [];
+  let aliasImports = 0;
+  for (const fullPath of walkRustFiles(maestroDir)) {
+    const source = fs.readFileSync(fullPath, "utf8");
+    if (/\bvize_carton::|use vize_carton\b/u.test(source)) {
+      offenders.push(path.relative(repoRoot, fullPath));
+    }
+    if (/\bvize_s0::|use vize_s0\b/u.test(source)) {
+      aliasImports += 1;
+    }
+  }
+
+  assert.ok(aliasImports > 0, "Maestro LSP should use the vize_s0 alias");
+  assert.deepEqual(offenders, []);
+});


### PR DESCRIPTION
## Summary
- rename Maestro/LSP S0 imports from the Carton code-name to the `vize_s0` stage alias
- add Davinci ratchets so Maestro and the LSP consumer surface stay on preferred S0 names
- regenerate `consumer-migration-surfaces` artifacts; LSP moves from 271 compat names to 271 preferred names

## Verification
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `cargo check -p vize_maestro --locked --all-features`
- `cargo test -p vize_maestro --locked --all-features --no-run`
- `cargo test -p vize_maestro --locked --all-features`
- `vp install --frozen-lockfile --prefer-offline`
- `vp run --workspace-root check:repo`
- `env VIZE_TEST_BIN=/private/tmp/vize-davinci-next-ratchet/target/release/vize node --test tests/tooling/cli-top-level.test.ts tests/tooling/cli-check-collection.test.ts tests/tooling/cli-check-contract.test.ts tests/tooling/cli-check-json-shape.test.ts tests/tooling/cli-check-sub-package-dependency.test.ts`
- `env VIZE_TEST_BIN=/private/tmp/vize-davinci-next-ratchet/target/release/vize node --test tests/tooling/davinci-fpfn-pilots.test.ts`

`vp run --workspace-root test:scripts` was also attempted, but this local worktree picked up an old global `vize 0.217.0` for CLI tests and has an unhydrated pinned create-vue fixture; the affected subsets pass with `VIZE_TEST_BIN` pointed at the built binary, except the create-vue fixture hydration guard which is environment state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790298933&installation_model_id=422833&pr_number=4940&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4940&signature=4f51c39a2555b550ff7c78088a63d984b2540bdbc137c70bb36d752d0ce66d99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated language-service components to use the unified S0 platform surface.
  * Preserved existing parsing, diagnostics, completion, navigation, virtual-document, and configuration behavior.
  * Maintained UTF-16 position handling, tag detection, Corsa discovery, and caching behavior.

* **Tests**
  * Added coverage confirming the language service uses the preferred S0 integration surface.
  * Updated existing test utilities and fixtures accordingly.

* **Documentation**
  * Corrected migration documentation to reflect preferred naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->