### PR TITLE
test(matrix): tolerate non-gogocode glyph shards

### DIFF
--- a/tests/tooling/vue2-render-signature.test.ts
+++ b/tests/tooling/vue2-render-signature.test.ts
@@ -7,8 +7,8 @@ import { fileURLToPath } from "node:url";
 
 import {
   collectProjectVueFiles,
-  loadGlyphCorpusProjects,
   resolveGlyphLaunch,
+  selectGlyphCorpusProjects,
   withFormattedWorkspace,
 } from "../../tools/fixtures/glyph-corpus.mjs";
 import type { SfcDialectRoute } from "./support/sfc-baseline-routes.ts";
@@ -21,13 +21,16 @@ import {
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const gogocodeRoot = path.join(root, "tests/_fixtures/_git/gogocode");
 const require = createRequire(import.meta.url);
-
-const gogocodeProject = (
-  loadGlyphCorpusProjects() as Array<{ id: string; sfcDialectRoutes?: SfcDialectRoute[] }>
-).find((project) => project.id === "gogocode");
-const vue2Route = gogocodeProject?.sfcDialectRoutes?.find((route) => route.id === "vue2");
-assert.ok(vue2Route, "the GoGoCode fixture must declare its Vue 2 route");
-const vue2Globs = vue2Route.globs;
+const registry = JSON.parse(
+  fs.readFileSync(path.join(root, "tests/_fixtures/vue-ecosystem-fixtures.json"), "utf8"),
+) as {
+  projects: Array<{
+    coverage: string[];
+    expectedVueFileCount: number | null;
+    id: string;
+    sfcDialectRoutes?: SfcDialectRoute[];
+  }>;
+};
 
 test("Vue 2 render signatures normalize only pure attribute layout", () => {
   const before = `with(this){return _c('p',{attrs:{"name":"slide","appear":""},on:{"focus":function(){return focus()},"click":function(){return click()}}},[_v("Vue版本："+_s(version))])}`;
@@ -166,7 +169,31 @@ test("Vue 2 render signatures retain semantic handler and static-render changes"
   );
 });
 
+test("GoGoCode render signature corpus is optional outside its matrix shard", () => {
+  const gogocodeIndex = registry.projects.findIndex((project) => project.id === "gogocode");
+  assert.notEqual(gogocodeIndex, -1, "the registry must keep the GoGoCode fixture");
+  const shardCount = registry.projects.length;
+  const excludedShardIndex = (gogocodeIndex + 1) % shardCount;
+
+  const selected = resolveSelectedGogocodeVue2Route({
+    FIXTURE_SHARD_COUNT: String(shardCount),
+    FIXTURE_SHARD_INDEX: String(excludedShardIndex),
+  });
+
+  assert.equal(selected.sharded, true);
+  assert.equal(selected.project, undefined);
+  assert.equal(selected.vue2Route, undefined);
+});
+
 test("the hydrated GoGoCode Vue 2 partition has stable render signatures for all 97 SFCs", (t) => {
+  const selected = resolveSelectedGogocodeVue2Route();
+  if (selected.project == null && selected.sharded) {
+    t.skip("the GoGoCode fixture is not selected by this real-project matrix shard");
+    return;
+  }
+  assert.ok(selected.project, "the GoGoCode fixture must be selected outside matrix sharding");
+  assert.ok(selected.vue2Route, "the GoGoCode fixture must declare its Vue 2 route");
+
   if (!fs.existsSync(gogocodeRoot) || fs.readdirSync(gogocodeRoot).length === 0) {
     t.skip("the GoGoCode fixture submodule is not hydrated");
     return;
@@ -192,7 +219,7 @@ test("the hydrated GoGoCode Vue 2 partition has stable render signatures for all
     id: "gogocode-vue2-render-signature",
     fixtureDir: gogocodeRoot,
     hydrated: true,
-    vueGlobs: vue2Globs,
+    vueGlobs: selected.vue2Route.globs,
   };
   const files = collectProjectVueFiles(project) as string[];
   assert.equal(files.length, 97, "the exact Vue 2 route partition must remain complete");
@@ -237,4 +264,29 @@ function compileTemplate(
   });
   assert.deepEqual(result.errors, [], `${file}: official Vue 2.6 baseline rejected the template`);
   return vue2RenderSignature(result.render, result.staticRenderFns);
+}
+
+function resolveSelectedGogocodeVue2Route(environment = process.env): {
+  project:
+    | {
+        id: string;
+        sfcDialectRoutes?: SfcDialectRoute[];
+      }
+    | undefined;
+  sharded: boolean;
+  vue2Route: SfcDialectRoute | undefined;
+} {
+  const sharded =
+    environment.FIXTURE_SHARD_INDEX != null || environment.FIXTURE_SHARD_COUNT != null;
+  const project = (
+    selectGlyphCorpusProjects(registry.projects, environment) as Array<{
+      id: string;
+      sfcDialectRoutes?: SfcDialectRoute[];
+    }>
+  ).find((candidate) => candidate.id === "gogocode");
+  return {
+    project,
+    sharded,
+    vue2Route: project?.sfcDialectRoutes?.find((route) => route.id === "vue2"),
+  };
 }


### PR DESCRIPTION
## Summary
- defer the GoGoCode Vue 2 route assertion until the shard-selected corpus test runs
- skip that hydrated corpus check when the current real-project matrix shard does not select GoGoCode
- add a regression that proves non-GoGoCode shards do not fail at module import time

Refs #4461.

## Tests
- `node --test --test-concurrency=1 tests/tooling/sfc-baseline-routes.test.ts tests/tooling/vue2-render-signature.test.ts`
- `FIXTURE_SHARD_INDEX=3 FIXTURE_SHARD_COUNT=22 node --test --test-concurrency=1 tests/tooling/sfc-baseline-routes.test.ts tests/tooling/vue2-render-signature.test.ts`
- `FIXTURE_SHARD_INDEX=4 FIXTURE_SHARD_COUNT=22 node --test --test-concurrency=1 tests/tooling/sfc-baseline-routes.test.ts tests/tooling/vue2-render-signature.test.ts`
- `vp run --workspace-root check:repo`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790300262&installation_model_id=422833&pr_number=4941&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4941&signature=d1d9d57b594a6ceb8d00564006d6ca471ef603e8ad126bdd50b71dd0b4fe6b0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded Vue 2 render-signature coverage to support ecosystem-based project selection.
  * Added validation for shard exclusion behavior.
  * Preserved comparison coverage for all 97 SFC render signatures when the project is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->