### PR TITLE
fix(syntax): classify pug filter names

### DIFF
--- a/tests/tooling/support/syntax-semantic-divergence.ts
+++ b/tests/tooling/support/syntax-semantic-divergence.ts
@@ -171,6 +171,7 @@ function semanticCategory(scope: string): string | null {
   if (scope.startsWith("entity.name.function") || scope.startsWith("support.function")) {
     return "function";
   }
+  if (scope === "name.generic.filter.pug") return "function";
   if (
     /^(?:entity\.name\.(?:class|enum|interface|struct|type)|support\.(?:class|type))/.test(scope)
   ) {

--- a/tests/tooling/syntax-highlighter-divergence.test.ts
+++ b/tests/tooling/syntax-highlighter-divergence.test.ts
@@ -140,6 +140,7 @@ test("normalization ignores structural nesting but detects changed semantic scop
       "entity.other.attribute-selector.sass",
       "html",
       "inline.pug",
+      "name.generic.filter.pug",
     ]),
     "x",
     "source.vue",


### PR DESCRIPTION
## Summary
- classify the TextMate `name.generic.filter.pug` scope as an omitted function-like semantic role
- keep the semantic tokenizer fail-closed for unknown scopes while allowing Wave UI Pug filter names
- add the scope to the normalization closure regression

Refs #4461.

## Tests
- `node --test tests/tooling/syntax-highlighter-divergence.test.ts tests/tooling/real-project-syntax-highlighting.test.ts`
- `vp run --workspace-root check:repo`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790301185&installation_model_id=422833&pr_number=4942&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4942&signature=06460c24da18e0a3bef230ab299b8b736eb3173d69135d06d8a06e803fefd0c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved syntax highlighting consistency for Pug filter names.
  * Corrected semantic classification so Pug filter scopes are recognized as functions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->