### PR TITLE
fix(matrix): separate typechecker dependency coverage

### DIFF
--- a/davinci-road/plan/corpus-baseline-notes.md
+++ b/davinci-road/plan/corpus-baseline-notes.md
@@ -75,7 +75,7 @@ recursively) of the following fields of the harness run payload
   taken before the temporary output directory is deleted.
 - `file_count` mirrors `tools/fixtures/tool-matrix-metrics.mjs`:
   compiler `inputFileCount`, typechecker `fileCount` (requested +
-  transitive authored), linter file-entry count, formatter
+  transitive authored + dependency files), linter file-entry count, formatter
   `checkedFileCount`.
 
 ## Filed nondeterminism: compiler and formatter `stderr` are excluded

--- a/tests/tooling/fixture-tool-matrix-report.test.ts
+++ b/tests/tooling/fixture-tool-matrix-report.test.ts
@@ -56,7 +56,8 @@ test("fixture tool matrix plans every registered project across all four require
     assert.match(markdown, /Runtime: node \d+\.\d+\.\d+/);
     assert.match(markdown, /Machine: [^/]+\/[^,]+, \d+ logical CPUs, \d+ bytes memory/);
     assert.match(markdown, /\bRequested\b/);
-    assert.match(markdown, /\bTransitive\b/);
+    assert.match(markdown, /\bTransitive Authored\b/);
+    assert.match(markdown, /\bTransitive Dependencies\b/);
     assert.equal(report.summary.projectCount, 144);
     assert.equal(report.summary.toolCount, 4);
     assert.equal(report.summary.runCount, 576);

--- a/tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts
+++ b/tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts
@@ -38,9 +38,10 @@ test("typechecker coverage partitions requested and transitive authored sources"
 
   assert.deepEqual(coverage, {
     schema: "vize.fixtureTypecheckerCoverage",
-    version: 1,
+    version: 2,
     requested: { fileCount: 1, files: requested, sha256: digest(requested) },
     transitiveAuthored: { fileCount: 2, files: transitive, sha256: digest(transitive) },
+    transitiveDependencies: { fileCount: 0, files: [], sha256: digest([]) },
     checked: { fileCount: 3, files: checked, sha256: digest(checked) },
   });
   assert.deepEqual(summarizeTypecheckerCoverage(coverage), {
@@ -48,6 +49,8 @@ test("typechecker coverage partitions requested and transitive authored sources"
     requestedSha256: digest(requested),
     transitiveAuthoredFileCount: 2,
     transitiveAuthoredSha256: digest(transitive),
+    transitiveDependencyFileCount: 0,
+    transitiveDependencySha256: digest([]),
     checkedFileCount: 3,
     checkedSha256: digest(checked),
   });
@@ -75,6 +78,33 @@ test("typechecker coverage accepts the closed authored source extension set", ()
   ];
   const coverage = validateTypecheckerOutput(project, output(checked), 0, requested, checked);
   assert.equal(coverage.transitiveAuthored.fileCount, checked.length - requested.length);
+  assert.equal(coverage.transitiveDependencies.fileCount, 0);
+});
+
+test("typechecker coverage separates package runtime dependencies from authored sources", () => {
+  const requested = ["src/App.vue"];
+  const authored = ["packages/Dep.ts", "src/App.vue"];
+  const dependency = [
+    "node_modules/.pnpm/@vue+runtime-core@3.5.32/node_modules/@vue/runtime-core/index.js",
+    "node_modules/.pnpm/vue@3.5.32_typescript@5.7.3/node_modules/vue/index.js",
+  ];
+  const checked = [...dependency, "packages/Dep.ts", "src/App.vue"];
+  const coverage = validateTypecheckerOutput(project, output(checked), 0, requested, authored);
+
+  assert.deepEqual(coverage.requested.files, requested);
+  assert.deepEqual(coverage.transitiveAuthored.files, ["packages/Dep.ts"]);
+  assert.deepEqual(coverage.transitiveDependencies.files, dependency);
+  assert.deepEqual(coverage.checked.files, checked);
+  assert.deepEqual(summarizeTypecheckerCoverage(coverage), {
+    requestedFileCount: 1,
+    requestedSha256: digest(requested),
+    transitiveAuthoredFileCount: 1,
+    transitiveAuthoredSha256: digest(["packages/Dep.ts"]),
+    transitiveDependencyFileCount: 2,
+    transitiveDependencySha256: digest(dependency),
+    checkedFileCount: 4,
+    checkedSha256: digest(checked),
+  });
 });
 
 test("typechecker coverage fails closed on missing, substituted, or unclassified sources", () => {
@@ -104,12 +134,12 @@ test("typechecker coverage fails closed on missing, substituted, or unclassified
     () =>
       validateTypecheckerOutput(
         project,
-        output(["node_modules/pkg/Injected.ts", "src/App.vue"]),
+        output(["generated/Injected.ts", "src/App.vue"]),
         0,
         ["src/App.vue"],
         ["src/App.vue"],
       ),
-    /transitive files are not authored fixture sources: \[node_modules\/pkg\/Injected\.ts\]/,
+    /transitive files are not authored fixture sources: \[generated\/Injected\.ts\]/,
   );
   assert.throws(
     () =>
@@ -147,6 +177,18 @@ test("typechecker coverage rejects malformed manifests and digest mutations", ()
       },
       /classes do not partition checked files/,
     ],
+    [
+      "dependency-class",
+      (value: any) => {
+        value.transitiveDependencies.files = ["packages/Dep.ts"];
+        value.transitiveDependencies.fileCount = 1;
+        value.transitiveDependencies.sha256 = digest(["packages/Dep.ts"]);
+        value.transitiveAuthored.files = [];
+        value.transitiveAuthored.fileCount = 0;
+        value.transitiveAuthored.sha256 = digest([]);
+      },
+      /unsupported source extension/,
+    ],
   ] as const) {
     const mutated = structuredClone(valid);
     mutate(mutated);
@@ -172,7 +214,12 @@ test("fixture matrix writes exact raw and compact transitive coverage evidence",
   fs.writeFileSync(
     executable,
     `#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify(${JSON.stringify(
-      output([".storybook/Hidden.ts", "packages/Dep.ts", "src/App.vue"]),
+      output([
+        ".storybook/Hidden.ts",
+        "node_modules/pkg/Injected.ts",
+        "packages/Dep.ts",
+        "src/App.vue",
+      ]),
     )}));\n`,
   );
   fs.chmodSync(executable, 0o755);
@@ -195,14 +242,19 @@ test("fixture matrix writes exact raw and compact transitive coverage evidence",
       requestedSha256: digest(["src/App.vue"]),
       transitiveAuthoredFileCount: 2,
       transitiveAuthoredSha256: digest([".storybook/Hidden.ts", "packages/Dep.ts"]),
-      checkedFileCount: 3,
-      checkedSha256: digest([".storybook/Hidden.ts", "packages/Dep.ts", "src/App.vue"]),
+      transitiveDependencyFileCount: 1,
+      transitiveDependencySha256: digest(["node_modules/pkg/Injected.ts"]),
+      checkedFileCount: 4,
+      checkedSha256: digest([
+        ".storybook/Hidden.ts",
+        "node_modules/pkg/Injected.ts",
+        "packages/Dep.ts",
+        "src/App.vue",
+      ]),
     });
     const raw = JSON.parse(fs.readFileSync(path.resolve(root, run.outputPath as string), "utf8"));
-    assert.deepEqual(raw.typecheckerCoverage.checked.files, [
-      ".storybook/Hidden.ts",
-      "packages/Dep.ts",
-      "src/App.vue",
+    assert.deepEqual(raw.typecheckerCoverage.transitiveDependencies.files, [
+      "node_modules/pkg/Injected.ts",
     ]);
   } finally {
     fs.rmSync(fixtureDir, { recursive: true, force: true });
@@ -277,6 +329,8 @@ process.stdout.write(JSON.stringify(output));\n`,
       requestedSha256: digest(["src/App.vue"]),
       transitiveAuthoredFileCount: 0,
       transitiveAuthoredSha256: digest([]),
+      transitiveDependencyFileCount: 0,
+      transitiveDependencySha256: digest([]),
       checkedFileCount: 1,
       checkedSha256: digest(["src/App.vue"]),
     });

--- a/tools/fixtures/tool-matrix-report.mjs
+++ b/tools/fixtures/tool-matrix-report.mjs
@@ -190,13 +190,13 @@ function renderMarkdown(report) {
     `Runtime: ${report.evidence.runtime.name} ${report.evidence.runtime.version}`,
     `Machine: ${report.evidence.machine.platform}/${report.evidence.machine.arch}, ${report.evidence.machine.logicalCpuCount} logical CPUs, ${report.evidence.machine.totalMemoryBytes} bytes memory`,
     "",
-    "| Project | Tool | Status | Exit | Files | Requested | Transitive | Duration (ms) | Output |",
-    "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
+    "| Project | Tool | Status | Exit | Files | Requested | Transitive Authored | Transitive Dependencies | Duration (ms) | Output |",
+    "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
   ];
   for (const project of report.projects) {
     for (const run of project.runs) {
       lines.push(
-        `| ${project.id} | ${run.tool} | ${run.status} | ${run.exitCode ?? "-"} | ${run.fileCount ?? "-"} | ${run.coverage?.requestedFileCount ?? "-"} | ${run.coverage?.transitiveAuthoredFileCount ?? "-"} | ${run.durationMs} | ${run.outputPath == null ? "-" : `\`${run.outputPath}\``} |`,
+        `| ${project.id} | ${run.tool} | ${run.status} | ${run.exitCode ?? "-"} | ${run.fileCount ?? "-"} | ${run.coverage?.requestedFileCount ?? "-"} | ${run.coverage?.transitiveAuthoredFileCount ?? "-"} | ${run.coverage?.transitiveDependencyFileCount ?? "-"} | ${run.durationMs} | ${run.outputPath == null ? "-" : `\`${run.outputPath}\``} |`,
       );
     }
   }

--- a/tools/fixtures/tool-matrix-typechecker.mjs
+++ b/tools/fixtures/tool-matrix-typechecker.mjs
@@ -97,6 +97,7 @@ export function validateTypecheckerOutput(
   }
   let requestedFiles = checkedFiles;
   let transitiveAuthoredFiles = [];
+  let transitiveDependencyFiles = [];
   if (expectedFiles != null) {
     validateManifestInput(expectedFiles, "requested fixture inputs", isVueSfc);
     validateManifestInput(authoredFiles, "authored fixture sources", isTypecheckSource);
@@ -113,7 +114,9 @@ export function validateTypecheckerOutput(
         `requested fixture inputs are not authored sources: [${missingAuthoredInputs.join(", ")}]`,
       );
     }
-    transitiveAuthoredFiles = checkedFiles.filter((file) => !expectedSet.has(file));
+    const transitiveFiles = checkedFiles.filter((file) => !expectedSet.has(file));
+    transitiveAuthoredFiles = transitiveFiles.filter((file) => !isDependencySource(file));
+    transitiveDependencyFiles = transitiveFiles.filter(isDependencySource);
     const unclassified = transitiveAuthoredFiles.filter((file) => !authoredSet.has(file));
     if (unclassified.length > 0) {
       invalid(
@@ -135,9 +138,10 @@ export function validateTypecheckerOutput(
 
   return {
     schema: "vize.fixtureTypecheckerCoverage",
-    version: 1,
+    version: 2,
     requested: createManifest(requestedFiles),
     transitiveAuthored: createManifest(transitiveAuthoredFiles),
+    transitiveDependencies: createManifest(transitiveDependencyFiles),
     checked: createManifest(checkedFiles),
   };
 }
@@ -146,22 +150,29 @@ export function summarizeTypecheckerCoverage(coverage) {
   requireRecord(coverage, "typechecker coverage");
   requireExactKeys(
     coverage,
-    ["checked", "requested", "schema", "transitiveAuthored", "version"],
+    ["checked", "requested", "schema", "transitiveAuthored", "transitiveDependencies", "version"],
     "typechecker coverage",
   );
-  if (coverage.schema !== "vize.fixtureTypecheckerCoverage" || coverage.version !== 1) {
+  if (coverage.schema !== "vize.fixtureTypecheckerCoverage" || coverage.version !== 2) {
     invalid("typechecker coverage schema is unsupported");
   }
-  for (const key of ["requested", "transitiveAuthored", "checked"]) {
-    validateManifest(
-      coverage[key],
-      `typechecker coverage.${key}`,
-      key === "requested" ? isVueSfc : isTypecheckSource,
-    );
-  }
-  const combined = [...coverage.requested.files, ...coverage.transitiveAuthored.files].sort(
-    byteSort,
+  validateManifest(coverage.requested, "typechecker coverage.requested", isVueSfc);
+  validateManifest(
+    coverage.transitiveAuthored,
+    "typechecker coverage.transitiveAuthored",
+    (file) => isTypecheckSource(file) && !isDependencySource(file),
   );
+  validateManifest(
+    coverage.transitiveDependencies,
+    "typechecker coverage.transitiveDependencies",
+    (file) => isTypecheckSource(file) && isDependencySource(file),
+  );
+  validateManifest(coverage.checked, "typechecker coverage.checked", isTypecheckSource);
+  const combined = [
+    ...coverage.requested.files,
+    ...coverage.transitiveAuthored.files,
+    ...coverage.transitiveDependencies.files,
+  ].sort(byteSort);
   if (JSON.stringify(combined) !== JSON.stringify(coverage.checked.files)) {
     invalid("typechecker coverage classes do not partition checked files");
   }
@@ -170,6 +181,8 @@ export function summarizeTypecheckerCoverage(coverage) {
     requestedSha256: coverage.requested.sha256,
     transitiveAuthoredFileCount: coverage.transitiveAuthored.fileCount,
     transitiveAuthoredSha256: coverage.transitiveAuthored.sha256,
+    transitiveDependencyFileCount: coverage.transitiveDependencies.fileCount,
+    transitiveDependencySha256: coverage.transitiveDependencies.sha256,
     checkedFileCount: coverage.checked.fileCount,
     checkedSha256: coverage.checked.sha256,
   };
@@ -215,6 +228,10 @@ function isVueSfc(file) {
 
 function isTypecheckSource(file) {
   return typecheckSourcePattern.test(file);
+}
+
+function isDependencySource(file) {
+  return file.split("/").includes("node_modules");
 }
 
 function requireRecord(value, label) {


### PR DESCRIPTION
## Summary
- split checked typechecker files into requested, transitive authored, and transitive dependency coverage buckets
- bump the fixture typechecker coverage artifact to v2 and surface dependency counts in matrix summaries
- add regressions for pnpm node_modules runtime files while preserving fail-closed handling for unclassified generated files

Refs #4461.

## Tests
- node --test tests/tooling/fixture-tool-matrix-typechecker-coverage.test.ts tests/tooling/fixture-tool-matrix-typechecker.test.ts tests/tooling/fixture-tool-matrix-report.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts
- node --test tests/tooling/typecheck-divergence-report*.test.ts tests/tooling/typecheck-divergence-baseline-*.test.ts tests/tooling/typecheck-divergence-mutation-*.test.ts
- vp run --workspace-root check:repo

## Notes
- Davinci corpus baseline hashes include typecheckerCoverage, so the next TS-11 re-record must account for the v2 coverage shape; this PR does not rollout or restore the release gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790302685&installation_model_id=422833&pr_number=4943&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4943&signature=f48c197efa807b8b4e4dd2ea02937bb28c1d658570421e8f8106cb2604c5ee41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Typechecker coverage now separates transitive authored files from transitive dependency files.
  * Coverage summaries include independent counts and integrity details for dependency files.
  * Reports display authored and dependency coverage in separate columns.

* **Bug Fixes**
  * Dependency files are classified correctly rather than counted as authored sources.
  * File coverage totals consistently account for requested files, authored files, and dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->