### PR TITLE
fix(matrix): follow package extends through parent configs

### DIFF
--- a/tests/tooling/typecheck-baseline-isolation-package-extends.test.ts
+++ b/tests/tooling/typecheck-baseline-isolation-package-extends.test.ts
@@ -120,6 +120,30 @@ test("unique isolation links the fixture copy of a package-name extends", () => 
   }
 });
 
+test("unique isolation records package-name extends from a relative parent", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    writeStoreCopy(fixtureRoot);
+    fs.writeFileSync(
+      path.join(fixtureRoot, "tsconfig.app.json"),
+      `${JSON.stringify({
+        extends: "@vue/tsconfig",
+        compilerOptions: { paths: { vue: ["./node_modules/vue"] } },
+      })}\n`,
+    );
+    const configPath = path.join(fixtureRoot, "tsconfig.check.json");
+    fs.writeFileSync(configPath, `// check-only\n{ "extends": "./tsconfig.app.json", }\n`);
+    assert.deepEqual(isolateUniqueLocalTypePackages(fixtureRoot, configPath), [
+      {
+        name: "@vue/tsconfig",
+        target: "node_modules/.pnpm/@vue+tsconfig@0.5.0/node_modules/@vue/tsconfig",
+      },
+    ]);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
 test("paths still win when the same name is also a package-name extends", () => {
   const { fixtureRoot, outer } = scaffold();
   try {

--- a/tools/fixtures/typecheck-baseline-isolation.mjs
+++ b/tools/fixtures/typecheck-baseline-isolation.mjs
@@ -114,16 +114,8 @@ export function readDeclaredPackagePaths(fixtureRoot, sourceConfigPath) {
 
 function mergePackageExtends(declared, conflicts, configPaths, fixtureRoot) {
   for (const configPath of configPaths) {
-    const config = parseTsconfig(configPath);
-    if (config == null) continue;
-    for (const specifier of extendsSpecifiers(config.extends)) {
-      const name = packageNameFromExtendsSpecifier(specifier);
-      if (name == null || conflicts.has(name) || declared.has(name)) continue;
-      const ancestor = ancestorPackagePath(fixtureRoot, name);
-      if (ancestor == null) continue;
-      declared.set(name, ancestor);
-    }
     const chain = loadExtendsChain(configPath);
+    recordPackageExtends(declared, conflicts, fixtureRoot, chain);
     let types;
     for (const { config: chained } of [...chain].reverse()) {
       const candidate = chained?.compilerOptions?.types;
@@ -137,6 +129,18 @@ function mergePackageExtends(declared, conflicts, configPaths, fixtureRoot) {
       chain.map(({ config }) => config),
     );
     recordCompilerOptionJsxImportSource(declared, conflicts, fixtureRoot, chain);
+  }
+}
+
+function recordPackageExtends(declared, conflicts, fixtureRoot, chain) {
+  for (const { config } of chain) {
+    for (const specifier of extendsSpecifiers(config.extends)) {
+      const name = packageNameFromExtendsSpecifier(specifier);
+      if (name == null || conflicts.has(name) || declared.has(name)) continue;
+      const ancestor = ancestorPackagePath(fixtureRoot, name);
+      if (ancestor == null) continue;
+      declared.set(name, ancestor);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- record package-name `extends` specifiers from the whole relative tsconfig chain
- keep `compilerOptions.paths` precedence when the same package name is declared there
- add a regression for a JSONC check config extending a parent app config that extends `@vue/tsconfig`

Part of #4461.

## Tests
- `node --test tests/tooling/typecheck-baseline-isolation-package-extends.test.ts tests/tooling/typecheck-baseline-isolation.test.ts tests/tooling/typecheck-baseline-isolation-unique.test.ts tests/tooling/typecheck-baseline-isolation-references.test.ts tests/tooling/typecheck-baseline-isolation-types.test.ts tests/tooling/typecheck-baseline-isolation-plugins.test.ts`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `node --test tests/tooling/typecheck-baseline-isolation*.test.ts tests/tooling/typecheck-dependency-prepare-isolation-tsconfigs.test.ts`
- `vp run --workspace-root check:repo`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790304376&installation_model_id=422833&pr_number=4944&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4944&signature=f6643aee4a1ac78139aef8b1dc05c3c41d0c33e9fa8030df243d7179e588a3de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of inherited package configuration references during type-checking.
  * Preserved parent path mappings while resolving extended configurations.
  * Ensured linked package copies are correctly associated with isolated configuration records.

* **Tests**
  * Added coverage for package-based extensions inherited through relative parent configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->