### PR TITLE
refactor(davinci): align atelier s2 witnesses with s1-to-s2

### DIFF
--- a/crates/vize_atelier_core/Cargo.toml
+++ b/crates/vize_atelier_core/Cargo.toml
@@ -60,7 +60,7 @@ insta = { workspace = true }
 # published crates exercising unpublished ones.
 vize_davinci = { workspace = true }
 vize_s2 = { workspace = true }
-vize_ricalco = { workspace = true }
+vize_s1_to_s2 = { workspace = true }
 vize_s1 = { workspace = true }
 
 # The P2-9 corpus-runnable differential entry (the P1-6/P1-7 lane shape):

--- a/crates/vize_atelier_core/tests/davinci_s2_transform.rs
+++ b/crates/vize_atelier_core/tests/davinci_s2_transform.rs
@@ -116,7 +116,7 @@ fn the_same_key_wording_never_drifts_from_relief() {
     // dependency (ricalco must not depend on the legacy AST crate);
     // this pin is what keeps the two channels from drifting.
     assert_eq!(
-        vize_ricalco::pass::vif::SAME_KEY_MESSAGE,
+        vize_s1_to_s2::pass::vif::SAME_KEY_MESSAGE,
         vize_atelier_core::ErrorCode::VIfSameKey.message()
     );
 }
@@ -127,7 +127,7 @@ fn the_v_slot_wording_never_drifts_from_relief() {
     // relief's text rather than the dependency; these pins own the
     // relief edge.
     use vize_atelier_core::ErrorCode;
-    use vize_ricalco::pass::vslot;
+    use vize_s1_to_s2::pass::vslot;
     assert_eq!(
         vslot::MISPLACED_MESSAGE,
         ErrorCode::VSlotMisplaced.message()
@@ -174,15 +174,15 @@ fn both_lanes_flag_the_duplicate_slot_name() {
 
     let s2_allocator = vize_carton::Allocator::new();
     let (tree, surface_errors) = vize_s1::parse(&s2_allocator, source);
-    let mut lowered = vize_ricalco::lower(&s2_allocator, &tree, &surface_errors);
+    let mut lowered = vize_s1_to_s2::lower(&s2_allocator, &tree, &surface_errors);
     let _facts =
-        vize_ricalco::pass::run_transform(&mut lowered, &mut vize_davinci::pass::NoObserver);
+        vize_s1_to_s2::pass::run_transform(&mut lowered, &mut vize_davinci::pass::NoObserver);
     assert!(
         lowered
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.message.as_str()
-                == vize_ricalco::pass::vslot::DUPLICATE_MESSAGE),
+                == vize_s1_to_s2::pass::vslot::DUPLICATE_MESSAGE),
         "the S2 pass must flag the duplicate: {:?}",
         lowered.diagnostics
     );
@@ -194,7 +194,7 @@ fn the_v_model_wording_never_drifts_from_relief() {
     // relief's text rather than the dependency; these pins own the
     // relief edge.
     use vize_atelier_core::ErrorCode;
-    use vize_ricalco::pass::vmodel;
+    use vize_s1_to_s2::pass::vmodel;
     assert_eq!(vmodel::ON_SCOPE_MESSAGE, ErrorCode::VModelOnScope.message());
     assert_eq!(
         vmodel::ARG_ON_ELEMENT_MESSAGE,
@@ -230,15 +230,15 @@ fn both_lanes_flag_the_scoped_model() {
 
     let s2_allocator = vize_carton::Allocator::new();
     let (tree, surface_errors) = vize_s1::parse(&s2_allocator, source);
-    let mut lowered = vize_ricalco::lower(&s2_allocator, &tree, &surface_errors);
+    let mut lowered = vize_s1_to_s2::lower(&s2_allocator, &tree, &surface_errors);
     let _facts =
-        vize_ricalco::pass::run_transform(&mut lowered, &mut vize_davinci::pass::NoObserver);
+        vize_s1_to_s2::pass::run_transform(&mut lowered, &mut vize_davinci::pass::NoObserver);
     assert!(
         lowered
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.message.as_str()
-                == vize_ricalco::pass::vmodel::ON_SCOPE_MESSAGE),
+                == vize_s1_to_s2::pass::vmodel::ON_SCOPE_MESSAGE),
         "the S2 pass must flag the scoped model: {:?}",
         lowered.diagnostics
     );
@@ -272,15 +272,15 @@ fn both_lanes_flag_the_duplicate_key() {
 
     let s2_allocator = vize_carton::Allocator::new();
     let (tree, surface_errors) = vize_s1::parse(&s2_allocator, source);
-    let mut lowered = vize_ricalco::lower(&s2_allocator, &tree, &surface_errors);
+    let mut lowered = vize_s1_to_s2::lower(&s2_allocator, &tree, &surface_errors);
     let _facts =
-        vize_ricalco::pass::run_transform(&mut lowered, &mut vize_davinci::pass::NoObserver);
+        vize_s1_to_s2::pass::run_transform(&mut lowered, &mut vize_davinci::pass::NoObserver);
     assert!(
         lowered
             .diagnostics
             .iter()
             .any(|diagnostic| diagnostic.message.as_str()
-                == vize_ricalco::pass::vif::SAME_KEY_MESSAGE),
+                == vize_s1_to_s2::pass::vif::SAME_KEY_MESSAGE),
         "the S2 pass must flag the collision: {:?}",
         lowered.diagnostics
     );
@@ -292,7 +292,7 @@ fn the_legacy_flag_disarms_the_lane_visibly() {
     // the flag's read is pinned by name here, and its disarm arm is the
     // `skipped_legacy_flag` counter the battery pin holds at zero.
     assert_eq!(
-        vize_ricalco::pass::TRANSFORM_LANE_FLAG,
+        vize_s1_to_s2::pass::TRANSFORM_LANE_FLAG,
         "VIZE_DAVINCI_TRANSFORM"
     );
 }

--- a/crates/vize_atelier_core/tests/s2_support/compare.rs
+++ b/crates/vize_atelier_core/tests/s2_support/compare.rs
@@ -11,8 +11,8 @@ use vize_carton::Allocator;
 use vize_carton::config::VueVersion;
 use vize_davinci::diagnostic::Severity;
 use vize_davinci::pass::NoObserver;
-use vize_ricalco::LegacyCaps;
-use vize_ricalco::pass::{TRANSFORM_LANE_FLAG, run_transform};
+use vize_s1_to_s2::LegacyCaps;
+use vize_s1_to_s2::pass::{TRANSFORM_LANE_FLAG, run_transform};
 use vize_s2::folio::DisegnoFolio;
 
 use super::{
@@ -85,7 +85,7 @@ pub fn compare_with(name: &str, source: &str, counters: &mut Counters, dialect: 
     // the P2-2 pass manager (verifier between passes in debug).
     let s2_allocator = Allocator::new();
     let (tree, surface_errors) = vize_s1::parse(&s2_allocator, source);
-    let mut lowered = vize_ricalco::lower_with_caps(
+    let mut lowered = vize_s1_to_s2::lower_with_caps(
         &s2_allocator,
         &tree,
         &surface_errors,

--- a/crates/vize_atelier_core/tests/s2_support/hoist.rs
+++ b/crates/vize_atelier_core/tests/s2_support/hoist.rs
@@ -49,7 +49,7 @@
 use vize_atelier_core::TemplateChildNode;
 use vize_davinci::id::NodeId;
 use vize_davinci::side_table::SideTable;
-use vize_ricalco::pass::{StaticFacts, StaticLevel};
+use vize_s1_to_s2::pass::{StaticFacts, StaticLevel};
 use vize_s2::folio::FolioOp;
 
 use super::hoist_old::Decision;

--- a/crates/vize_atelier_core/tests/s2_support/hoist_old.rs
+++ b/crates/vize_atelier_core/tests/s2_support/hoist_old.rs
@@ -17,7 +17,7 @@ use vize_atelier_core::{
     ElementNode, ElementType, ExpressionNode, PropNode, SimpleExpressionNode, TemplateChildNode,
 };
 use vize_carton::{Allocator, Span, camelize, is_native_tag};
-use vize_ricalco::pass::hoist::constant_for_hoist;
+use vize_s1_to_s2::pass::hoist::constant_for_hoist;
 use vize_s2::expr::ExprRef;
 
 use super::surface_old_help::is_excluded_builtin;

--- a/crates/vize_atelier_core/tests/s2_support/hoist_owner.rs
+++ b/crates/vize_atelier_core/tests/s2_support/hoist_owner.rs
@@ -7,7 +7,7 @@
 
 use vize_atelier_core::{ElementNode, ElementType, StaticType, TemplateChildNode, get_static_type};
 use vize_davinci::side_table::SideTable;
-use vize_ricalco::pass::StaticFacts;
+use vize_s1_to_s2::pass::StaticFacts;
 use vize_s2::folio::{FolioComponent, FolioElement, FolioOp, FolioSlot};
 
 use super::hoist::{HoistCounters, Mode, fact_of, predict, predict_for_item, replay_or_dormant};

--- a/crates/vize_atelier_core/tests/s2_support/hoist_walk.rs
+++ b/crates/vize_atelier_core/tests/s2_support/hoist_walk.rs
@@ -7,7 +7,7 @@
 
 use vize_atelier_core::{IfBranchNode, TemplateChildNode};
 use vize_davinci::side_table::SideTable;
-use vize_ricalco::pass::StaticFacts;
+use vize_s1_to_s2::pass::StaticFacts;
 use vize_s2::folio::FolioOp;
 
 use super::hoist::{HoistCounters, Mode, replay_or_dormant, walk_for_body};

--- a/crates/vize_atelier_core/tests/s2_support/s2_lane.rs
+++ b/crates/vize_atelier_core/tests/s2_support/s2_lane.rs
@@ -9,7 +9,7 @@
 use vize_carton::String;
 use vize_davinci::id::NodeId;
 use vize_davinci::side_table::SideTable;
-use vize_ricalco::pass::{BranchKeyKind, IfFacts, ModelFacts, SlotFacts, TextFacts};
+use vize_s1_to_s2::pass::{BranchKeyKind, IfFacts, ModelFacts, SlotFacts, TextFacts};
 use vize_s2::folio::{DisegnoFolio, FolioExpr, FolioOp};
 
 use super::slots::{POutlet, PUnit, has_slot_content, s2_outlet, s2_slot_active, s2_unit};

--- a/crates/vize_atelier_core/tests/s2_support/slots.rs
+++ b/crates/vize_atelier_core/tests/s2_support/slots.rs
@@ -35,8 +35,8 @@
 use vize_carton::String;
 use vize_davinci::id::NodeId;
 use vize_davinci::side_table::SideTable;
-use vize_ricalco::pass::SlotFacts;
-use vize_ricalco::pass::vslot::{SlotName, SlotParams};
+use vize_s1_to_s2::pass::SlotFacts;
+use vize_s1_to_s2::pass::vslot::{SlotName, SlotParams};
 use vize_s2::folio::{FolioBinding, FolioName, FolioOp};
 
 /// The slot half of the comparator's accounting.

--- a/crates/vize_atelier_core/tests/s2_support/surface_old_help.rs
+++ b/crates/vize_atelier_core/tests/s2_support/surface_old_help.rs
@@ -40,7 +40,7 @@ pub fn exp_text_of(exp: &ExpressionNode<'_>) -> Option<String> {
 
 /// The names the S1→S2 classifier treats as built-in directives — the
 /// exclusion set of the custom-directive kind (mirrors
-/// `vize_ricalco::lower::directive::classify`).
+/// `vize_s1_to_s2::lower::directive::classify`).
 pub fn is_builtin_name(name: &str) -> bool {
     matches!(
         name,

--- a/crates/vize_atelier_core/tests/s2_support/text.rs
+++ b/crates/vize_atelier_core/tests/s2_support/text.rs
@@ -171,7 +171,7 @@ pub fn check(name: &str, source: &str, old: &[TUnit], s2: &[TUnit], counters: &m
     }
 }
 
-/// Replay of `vize_ricalco::pass::legacy::filter` wrap: `a | f` →
+/// Replay of `vize_s1_to_s2::pass::legacy::filter` wrap: `a | f` →
 /// `_filter_f(a)`, `a | f(b)` → `_filter_f(a,b)`. Admission is
 /// [`VueFilterExpr::parse_in`] — the same splitter S2 lowering uses.
 fn legalized_filter(authored: &str) -> Option<String> {

--- a/crates/vize_atelier_core/tests/s2_support/text_old.rs
+++ b/crates/vize_atelier_core/tests/s2_support/text_old.rs
@@ -10,7 +10,7 @@ use vize_carton::String;
 
 use super::text::{TPart, TUnit};
 
-/// The rawtext-content exemption list — `vize_ricalco::lower`'s
+/// The rawtext-content exemption list — `vize_s1_to_s2::lower`'s
 /// (`RAWTEXT_TAGS`), applied to the authored tag on both sides.
 pub fn is_rawtext_tag(tag: &str) -> bool {
     matches!(

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           916 |                    76 |               840 |             139 |     371 |             951 |      475 |           477 |           584 |
+| Compiler                   |           916 |                   100 |               816 |             139 |     371 |             951 |      475 |           477 |           584 |
 | Linter                     |           302 |                    16 |               286 |             268 |     222 |             670 |      122 |           339 |           478 |
 | Typechecker                |           883 |                   139 |               744 |             394 |     187 |             806 |      658 |           461 |           651 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            18 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -4,7 +4,7 @@ compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	davinci	Davinc
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s1	S1/sinopia	stage	vize_s1	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s1_to_s2	S1->S2/ricalco	stage	vize_ricalco	compat	1
+compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	old_ast	old AST/parser	old	vize_relief	legacy	2
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	old_ast	old AST/parser	old	vize_armature	legacy	2
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	croquis	Croquis analysis	old	vize_croquis	legacy	1
@@ -197,7 +197,7 @@ compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform_v
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	davinci	Davinci	stage	vize_davinci	preferred	3
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s0	S0/carton	stage	vize_carton	compat	6
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s1	S1/sinopia	stage	vize_s1	preferred	3
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s1_to_s2	S1->S2/ricalco	stage	vize_ricalco	compat	13
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	13
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_sourcemap_prefixed_identifiers.rs	133	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/dynamic_slot_forwarding.rs	14	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/dynamic_v_model_argument.rs	14	s0	S0/carton	stage	vize_carton	compat	2
@@ -211,30 +211,30 @@ compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s0	S0/carton	stage	vize_carton	compat	4
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s1	S1/sinopia	stage	vize_s1	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s1_to_s2	S1->S2/ricalco	stage	vize_ricalco	compat	3
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	3
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s0	S0/carton	stage	vize_carton	compat	5
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s1_to_s2	S1->S2/ricalco	stage	vize_ricalco	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_owner.rs	9	davinci	Davinci	stage	vize_davinci	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_owner.rs	9	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_owner.rs	9	s1_to_s2	S1->S2/ricalco	stage	vize_ricalco	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_owner.rs	9	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_walk.rs	9	davinci	Davinci	stage	vize_davinci	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_walk.rs	9	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_walk.rs	9	s1_to_s2	S1->S2/ricalco	stage	vize_ricalco	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_walk.rs	9	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	davinci	Davinci	stage	vize_davinci	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s1_to_s2	S1->S2/ricalco	stage	vize_ricalco	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/old_lane.rs	6	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	davinci	Davinci	stage	vize_davinci	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s1_to_s2	S1->S2/ricalco	stage	vize_ricalco	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots_old.rs	11	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	davinci	Davinci	stage	vize_davinci	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s2	S2/disegno	stage	vize_s2	preferred	6
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s1_to_s2	S1->S2/ricalco	stage	vize_ricalco	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_check.rs	6	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_old_help.rs	7	s0	S0/carton	stage	vize_carton	compat	2
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_old.rs	18	s0	S0/carton	stage	vize_carton	compat	1

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -186,6 +186,30 @@ test("Davinci DOM lane tests import lowering through the stage alias", () => {
   }
 });
 
+test("Davinci atelier core S2 witnesses import lowering through the stage alias", () => {
+  const lowering = dependency(metadata, "vize_atelier_core", "vize_ricalco", "dev");
+  assert.equal(lowering.rename, "vize_s1_to_s2");
+  const dependencies = workspacePackage(metadata, "vize_atelier_core").dependencies;
+  assert.ok(
+    dependencies.every(
+      (dependency) =>
+        dependency.name !== "vize_ricalco" ||
+        (dependency.kind === "dev" && dependency.rename === "vize_s1_to_s2"),
+    ),
+    "vize_atelier_core must not depend on vize_ricalco through its physical name",
+  );
+
+  const testDir = path.join(repoRoot, "crates", "vize_atelier_core", "tests");
+  for (const fullPath of walkRustFiles(testDir)) {
+    const source = fs.readFileSync(fullPath, "utf8");
+    assert.doesNotMatch(
+      source,
+      /\bvize_ricalco::/u,
+      `${path.relative(testDir, fullPath)} must use vize_s1_to_s2`,
+    );
+  }
+});
+
 test("Vize CLI package imports S0 storage through the stage alias", () => {
   const dependencies = workspacePackage(metadata, "vize").dependencies;
   assert.ok(


### PR DESCRIPTION
## Summary
- import the atelier-core S2 transform witnesses through the `vize_s1_to_s2` workspace alias
- add a stage dependency guard for `vize_atelier_core` S2 witness imports
- regenerate the davinci consumer migration surface ledger

## Tests
- `node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `cargo test -p vize_atelier_core --test davinci_s2_transform`
- `cargo test -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2`
- `cargo test -p vize_atelier_core --features davinci-differential --test davinci_s2_transform_corpus`
- `vp run --workspace-root check:repo`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790305339&installation_model_id=422833&pr_number=4945&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4945&signature=82e68817e72bb375fe619037ab9e8c3ea34181d7e7d9e3244d1700409fd5322b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the compiler’s S2 transformation pipeline to use the current stage implementation.
  * Migrated internal test coverage and support tooling to the updated transformation APIs.
  * Refreshed migration metrics to reflect the latest stage-name adoption.

* **Tests**
  * Added validation ensuring the compiler and its tests no longer rely on the legacy transformation implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->