### PR TITLE
fix(matrix): pin fixture-local pnpm vue runtime paths

### DIFF
--- a/tests/tooling/typecheck-baseline-outside-vue-runtime-paths.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-vue-runtime-paths.test.ts
@@ -66,6 +66,40 @@ test("a single pnpm virtual-store Vue runtime package is pinned without a direct
   }
 });
 
+test("a symlinked pnpm virtual-store Vue runtime package is pinned", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const realEntry = path.join(fixtureRoot, "node_modules/.pnpm-real/vue-entry");
+    const local = path.join(realEntry, "node_modules/vue");
+    fs.mkdirSync(local, { recursive: true });
+    fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue"}\n`);
+    const store = path.join(fixtureRoot, "node_modules/.pnpm");
+    fs.mkdirSync(store, { recursive: true });
+    fs.symlinkSync(realEntry, path.join(store, "vue@3.5.17_typescript@5.8.3"), "dir");
+    assert.deepEqual(rewriteLocalVueRuntimePaths(fixtureRoot, fixtureRoot), {
+      vue: ["./node_modules/.pnpm/vue@3.5.17_typescript@5.8.3/node_modules/vue"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("a pnpm virtual-store Vue runtime symlink outside the fixture is not pinned", () => {
+  const { fixtureRoot, outer } = scaffold();
+  try {
+    const realEntry = path.join(outer, "store/vue-entry");
+    const local = path.join(realEntry, "node_modules/vue");
+    fs.mkdirSync(local, { recursive: true });
+    fs.writeFileSync(path.join(local, "package.json"), `{"name":"vue"}\n`);
+    const store = path.join(fixtureRoot, "node_modules/.pnpm");
+    fs.mkdirSync(store, { recursive: true });
+    fs.symlinkSync(realEntry, path.join(store, "vue@3.5.17_typescript@5.8.3"), "dir");
+    assert.equal(rewriteLocalVueRuntimePaths(fixtureRoot, fixtureRoot), null);
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
 test("multiple pnpm virtual-store Vue runtime copies are not guessed", () => {
   const { fixtureRoot, outer } = scaffold();
   try {

--- a/tools/fixtures/typecheck-baseline-outside-vue-runtime-paths.mjs
+++ b/tools/fixtures/typecheck-baseline-outside-vue-runtime-paths.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, realpathSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 
 /**
@@ -51,14 +51,35 @@ function localPackageRoot(root, name) {
 function uniquePnpmStorePackageRoot(root, name) {
   const store = join(root, "node_modules", ".pnpm");
   if (!existsSync(store)) return null;
-  const matches = [];
-  for (const entry of readdirSync(store, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const candidate = join(store, entry.name, "node_modules", ...name.split("/"));
-    if (existsSync(join(candidate, "package.json"))) matches.push(candidate);
+  let rootReal;
+  try {
+    rootReal = realpathSync(root);
+  } catch {
+    return null;
   }
-  matches.sort(codeUnitOrder);
-  return matches.length === 1 ? matches[0] : null;
+  const matches = new Map();
+  for (const entry of readdirSync(store, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    const candidate = join(store, entry.name, "node_modules", ...name.split("/"));
+    if (!existsSync(join(candidate, "package.json"))) continue;
+    let real;
+    try {
+      real = realpathSync(candidate);
+    } catch {
+      continue;
+    }
+    if (!isInsideOrEqual(rootReal, real)) continue;
+    matches.set(real, candidate);
+  }
+  const unique = [...matches.values()].sort(codeUnitOrder);
+  return unique.length === 1 ? unique[0] : null;
+}
+
+function isInsideOrEqual(parent, child) {
+  const path = relative(parent, child);
+  return (
+    path === "" || (!path.startsWith("..") && !path.startsWith("/") && !/^[A-Za-z]:\//u.test(path))
+  );
 }
 
 function codeUnitOrder(left, right) {


### PR DESCRIPTION
## Summary
- detect fixture-local Vue runtime packages when pnpm virtual-store entries are symlinked
- dedupe virtual-store matches by realpath and reject external realpaths before pinning
- add regression coverage for fixture-local symlinked entries and external symlink rejection

## Verification
- node --test tests/tooling/typecheck-baseline-outside-vue-runtime-paths.test.ts tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-baseline-isolation-vue-runtime.test.ts tests/tooling/typecheck-dependency-prepare-isolation-tsconfigs.test.ts
- node --test tests/tooling/source-file-lengths.test.ts
- vp run --workspace-root check:repo
- git diff --check