### PR TITLE
refactor(atelier): import SSR S0 storage through stage alias

### DIFF
--- a/crates/vize_atelier_ssr/Cargo.toml
+++ b/crates/vize_atelier_ssr/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 legacy = ["vize_armature/legacy", "vize_atelier_core/legacy"]
 
 [dependencies]
-vize_carton = { workspace = true }
+vize_s0 = { workspace = true }
 vize_relief = { workspace = true }
 vize_armature = { workspace = true }
 vize_atelier_core = { workspace = true }

--- a/crates/vize_atelier_ssr/benches/davinci.rs
+++ b/crates/vize_atelier_ssr/benches/davinci.rs
@@ -19,7 +19,7 @@ use vize_atelier_core::lane::transform;
 use vize_atelier_core::options::TransformOptions;
 use vize_atelier_core::parser::Parser;
 use vize_atelier_ssr::{SsrCodegenContext, SsrCompilerOptions, compile_ssr};
-use vize_carton::{Allocator, cstr};
+use vize_s0::{Allocator, cstr};
 
 fn ssr_transform_options() -> TransformOptions {
     TransformOptions {

--- a/crates/vize_atelier_ssr/src/codegen.rs
+++ b/crates/vize_atelier_ssr/src/codegen.rs
@@ -10,7 +10,7 @@ mod scope_prefix;
 
 use crate::options::SsrCompilerOptions;
 use vize_atelier_core::{RootNode, RuntimeHelper, TemplateChildNode};
-use vize_carton::{Allocator, FxHashSet, SmallVec, String, ToCompactString, camelize, capitalize};
+use vize_s0::{Allocator, FxHashSet, SmallVec, String, ToCompactString, camelize, capitalize};
 
 /// SSR codegen result
 #[derive(Debug, Default)]

--- a/crates/vize_atelier_ssr/src/codegen/component_binding.rs
+++ b/crates/vize_atelier_ssr/src/codegen/component_binding.rs
@@ -1,6 +1,6 @@
 use super::SsrCodegenContext;
 use vize_atelier_core::{BindingType, RuntimeHelper};
-use vize_carton::{String, ToCompactString, camelize, capitalize};
+use vize_s0::{String, ToCompactString, camelize, capitalize};
 
 struct ComponentBinding {
     name: String,

--- a/crates/vize_atelier_ssr/src/codegen/element.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element.rs
@@ -14,10 +14,10 @@ use vize_atelier_core::{
     DirectiveNode, ElementNode, ElementType, ExpressionNode, ForNode, IfNode, PropNode,
     RuntimeHelper, TemplateChildNode,
 };
-use vize_carton::{FxHashSet, String, ToCompactString};
+use vize_s0::{FxHashSet, String, ToCompactString};
 
 use super::{SsrCodegenContext, helpers::escape_html_attr, helpers::extract_destructure_params};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 /// One JavaScript property emitted into a generated SSR prop object.
 #[derive(Clone, Debug)]

--- a/crates/vize_atelier_ssr/src/codegen/element/component_props.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/component_props.rs
@@ -223,7 +223,7 @@ impl SsrCodegenContext<'_> {
             .unwrap_or_else(|| "undefined".to_compact_string());
         let (key, update_key, dynamic) = match &dir.arg {
             Some(ExpressionNode::Simple(arg)) if arg.is_static => {
-                let key = vize_carton::camelize(arg.content);
+                let key = vize_s0::camelize(arg.content);
                 let update_key = cstr!("onUpdate:{key}");
                 (key, update_key, false)
             }

--- a/crates/vize_atelier_ssr/src/codegen/element/plain.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/plain.rs
@@ -58,7 +58,7 @@ impl<'a> SsrCodegenContext<'a> {
         }
 
         // Check if void element
-        if vize_carton::is_void_tag(tag) {
+        if vize_s0::is_void_tag(tag) {
             self.push_string_part_static(">");
             return;
         }
@@ -430,7 +430,7 @@ impl<'a> SsrCodegenContext<'a> {
                 self.push_string_part_dynamic(&style_exp);
                 self.push_string_part_static("\"");
             }
-            Some(name) if vize_carton::is_boolean_attr(name) => {
+            Some(name) if vize_s0::is_boolean_attr(name) => {
                 self.use_ssr_helper(RuntimeHelper::SsrIncludeBooleanAttr);
                 self.push_string_part_dynamic(&cstr!(
                     "(_ssrIncludeBooleanAttr({exp})) ? \" {name}\" : \"\""

--- a/crates/vize_atelier_ssr/src/codegen/element/props.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/props.rs
@@ -1,7 +1,7 @@
 //! Shared JavaScript expression and prop-object builders for SSR element codegen.
 
 use super::{DirectiveNode, ExpressionNode, PropNode, String, ToCompactString, VNodePropEntry};
-use vize_carton::{FxHashMap, is_on};
+use vize_s0::{FxHashMap, is_on};
 
 /// Build an object literal from normalized prop entries.
 pub(super) fn component_props_object(entries: &[VNodePropEntry]) -> String {
@@ -126,7 +126,7 @@ pub(super) fn merge_prop_values(values: std::vec::Vec<String>) -> String {
 /// Apply `v-bind` key modifiers before emitting the JavaScript object key.
 pub(super) fn transform_bound_prop_key(key: &str, dir: &DirectiveNode) -> String {
     if dir.modifiers.iter().any(|m| m.content == "camel") {
-        return vize_carton::camelize(key);
+        return vize_s0::camelize(key);
     }
     if dir.modifiers.iter().any(|m| m.content == "prop") {
         let mut out = String::from(".");
@@ -142,11 +142,11 @@ pub(super) fn transform_bound_prop_key(key: &str, dir: &DirectiveNode) -> String
 }
 
 pub(super) fn static_slot_outlet_prop_key(key: &str) -> String {
-    vize_carton::camelize(key)
+    vize_s0::camelize(key)
 }
 
 pub(super) fn transform_slot_outlet_bound_prop_key(key: &str, dir: &DirectiveNode) -> String {
-    let base = vize_carton::camelize(key);
+    let base = vize_s0::camelize(key);
     if dir.modifiers.iter().any(|m| m.content == "prop") {
         let mut out = String::from(".");
         out.push_str(&base);

--- a/crates/vize_atelier_ssr/src/codegen/helpers.rs
+++ b/crates/vize_atelier_ssr/src/codegen/helpers.rs
@@ -9,7 +9,7 @@ use vize_atelier_core::{
 
 use super::SsrCodegenContext;
 pub(crate) use destructure::{collect_for_scoped_params, extract_destructure_params};
-use vize_carton::{String, ToCompactString, cstr};
+use vize_s0::{String, ToCompactString, cstr};
 
 impl<'a> SsrCodegenContext<'a> {
     /// Process a list of children nodes

--- a/crates/vize_atelier_ssr/src/codegen/helpers/destructure.rs
+++ b/crates/vize_atelier_ssr/src/codegen/helpers/destructure.rs
@@ -1,7 +1,7 @@
 //! Destructuring-pattern parameter extraction for SSR codegen scopes.
 
 use vize_atelier_core::{CompoundExpressionChild, ExpressionNode, ForNode};
-use vize_carton::{FxHashSet, SmallVec, String, ToCompactString};
+use vize_s0::{FxHashSet, SmallVec, String, ToCompactString};
 
 pub(crate) fn collect_for_scoped_params(for_node: &ForNode, source: &str) -> FxHashSet<String> {
     let mut params = FxHashSet::default();
@@ -129,7 +129,7 @@ fn is_valid_identifier(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::extract_destructure_params;
-    use vize_carton::{FxHashSet, String};
+    use vize_s0::{FxHashSet, String};
 
     #[test]
     fn extracts_nested_params_and_rejects_unsplit_malformed_aliases() {

--- a/crates/vize_atelier_ssr/src/codegen/scope_prefix.rs
+++ b/crates/vize_atelier_ssr/src/codegen/scope_prefix.rs
@@ -1,6 +1,6 @@
 //! Generated scope-prefix cleanup for SSR template locals.
 
-use vize_carton::{FxHashSet, String, ToCompactString};
+use vize_s0::{FxHashSet, String, ToCompactString};
 
 const SCOPED_PARAM_PREFIXES: [&str; 6] = [
     "_ctx.",

--- a/crates/vize_atelier_ssr/src/compile.rs
+++ b/crates/vize_atelier_ssr/src/compile.rs
@@ -5,7 +5,7 @@ use vize_atelier_core::{
     options::{CustomElementMatcher, TemplateSyntaxMode},
     parser::parse_with_options_custom_elements_and_template_syntax,
 };
-use vize_carton::{Allocator, String, profile};
+use vize_s0::{Allocator, String, profile};
 
 /// Compile a Vue template for SSR with default options
 pub fn compile_ssr<'a>(
@@ -129,19 +129,17 @@ fn compile_ssr_inner<'a>(
 }
 
 pub(crate) fn get_namespace(tag: &str, parent: Option<&str>) -> Namespace {
-    if vize_carton::is_svg_tag(tag) {
+    if vize_s0::is_svg_tag(tag) {
         return Namespace::Svg;
     }
-    if vize_carton::is_math_ml_tag(tag) {
+    if vize_s0::is_math_ml_tag(tag) {
         return Namespace::MathMl;
     }
     if let Some(parent_tag) = parent {
-        if vize_carton::is_svg_tag(parent_tag) && tag != "foreignObject" {
+        if vize_s0::is_svg_tag(parent_tag) && tag != "foreignObject" {
             return Namespace::Svg;
         }
-        if vize_carton::is_math_ml_tag(parent_tag)
-            && tag != "annotation-xml"
-            && tag != "foreignObject"
+        if vize_s0::is_math_ml_tag(parent_tag) && tag != "annotation-xml" && tag != "foreignObject"
         {
             return Namespace::MathMl;
         }

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -48,7 +48,7 @@ mod tests {
         SsrCompilerOptions, compile_ssr, compile_ssr_with_options, compile_ssr_with_template_syntax,
     };
     use vize_atelier_core::TemplateSyntaxMode;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn test_compile_simple_element() {

--- a/crates/vize_atelier_ssr/src/options.rs
+++ b/crates/vize_atelier_ssr/src/options.rs
@@ -2,9 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 use vize_atelier_core::BindingMetadata;
-use vize_carton::String;
-use vize_carton::config::VueVersion;
 use vize_croquis::Croquis;
+use vize_s0::String;
+use vize_s0::config::VueVersion;
 
 /// SSR compiler options
 #[derive(Debug, Default, Serialize, Deserialize)]

--- a/crates/vize_atelier_ssr/src/stage_options.rs
+++ b/crates/vize_atelier_ssr/src/stage_options.rs
@@ -11,8 +11,8 @@ use crate::options::SsrCompilerOptions;
 /// Parser options for the SSR pipeline.
 pub(crate) fn parser_options(options: &SsrCompilerOptions) -> ParserOptions {
     ParserOptions {
-        is_void_tag: vize_carton::is_void_tag,
-        is_native_tag: Some(vize_carton::is_native_tag),
+        is_void_tag: vize_s0::is_void_tag,
+        is_native_tag: Some(vize_s0::is_native_tag),
         custom_renderer: options.custom_renderer,
         is_pre_tag: |tag| tag == "pre",
         get_namespace,

--- a/crates/vize_atelier_ssr/src/steps.rs
+++ b/crates/vize_atelier_ssr/src/steps.rs
@@ -90,7 +90,7 @@ mod tests {
     use vize_atelier_core::{
         DirectiveNode, ElementNode, ExpressionNode, PropNode, SimpleExpressionNode, SourceLocation,
     };
-    use vize_carton::{Allocator, Box};
+    use vize_s0::{Allocator, Box};
 
     fn make_element_with_directive<'a>(
         allocator: &'a Allocator,

--- a/crates/vize_atelier_ssr/tests/component_spread_props.rs
+++ b/crates/vize_atelier_ssr/tests/component_spread_props.rs
@@ -7,7 +7,7 @@
 //! started server-rendering with `name` undefined and crashed SSR.
 
 use vize_atelier_ssr::compile_ssr;
-use vize_carton::{Allocator, String};
+use vize_s0::{Allocator, String};
 
 fn compile(src: &str) -> String {
     let allocator = Allocator::new();

--- a/crates/vize_atelier_ssr/tests/davinci_expr_reparse_floor.rs
+++ b/crates/vize_atelier_ssr/tests/davinci_expr_reparse_floor.rs
@@ -17,7 +17,7 @@
 use davinci_harness::fixtures::{LADDER, template_block};
 use vize_atelier_core::expr_parse_probe;
 use vize_atelier_ssr::compile_ssr;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 /// fixture name → surviving legacy re-parses per fused SSR compile.
 const FLOOR: [(&str, u64); 6] = [

--- a/crates/vize_atelier_ssr/tests/davinci_walk_baseline.rs
+++ b/crates/vize_atelier_ssr/tests/davinci_walk_baseline.rs
@@ -22,8 +22,8 @@
 use davinci_harness::fixtures::{LADDER, template_block};
 use vize_atelier_core::walk_probe::{WALK_STAGES, WalkCounts};
 use vize_atelier_ssr::compile_ssr;
-use vize_carton::Allocator;
 use vize_davinci::legacy_plan;
+use vize_s0::Allocator;
 
 /// fixture name -> (stage tree-walks, template-node visits) per fused compile.
 const BASELINE: [(&str, u64, u64); 6] = [

--- a/crates/vize_atelier_ssr/tests/event_props.rs
+++ b/crates/vize_atelier_ssr/tests/event_props.rs
@@ -1,7 +1,7 @@
 //! Regression tests for duplicate component event properties.
 
 use vize_atelier_ssr::compile_ssr;
-use vize_carton::{Allocator, String};
+use vize_s0::{Allocator, String};
 
 fn compile(src: &str) -> String {
     let allocator = Allocator::new();

--- a/crates/vize_atelier_ssr/tests/setup_component_parity.rs
+++ b/crates/vize_atelier_ssr/tests/setup_component_parity.rs
@@ -1,6 +1,6 @@
 use vize_atelier_core::options::{BindingMetadata, BindingType};
 use vize_atelier_ssr::{SsrCompilerOptions, compile_ssr_with_options};
-use vize_carton::{Allocator, FxHashMap};
+use vize_s0::{Allocator, FxHashMap};
 
 fn binding_matrix() -> BindingMetadata {
     let mut bindings = FxHashMap::default();

--- a/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+++ b/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::disallowed_macros)]
 
 use vize_atelier_ssr::compile_ssr;
-use vize_carton::{Allocator, String};
+use vize_s0::{Allocator, String};
 
 /// Helper to get the compiled string content (the template literal part)
 fn get_compiled_string(src: &str) -> String {
@@ -313,7 +313,7 @@ mod v_show {
 mod component {
     use super::compile_full;
     use vize_atelier_ssr::{SsrCompilerOptions, compile_ssr_with_options};
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn basic_component() {
@@ -553,7 +553,7 @@ mod v_text {
 
 mod scope_id {
     use vize_atelier_ssr::{SsrCompilerOptions, compile_ssr_with_options};
-    use vize_carton::{Allocator, String};
+    use vize_s0::{Allocator, String};
 
     fn compile_with_scope_id(src: &str) -> String {
         let allocator = Allocator::new();
@@ -587,7 +587,7 @@ mod scope_id {
 
 mod css_vars {
     use vize_atelier_ssr::{SsrCompilerOptions, compile_ssr_with_options};
-    use vize_carton::{Allocator, String};
+    use vize_s0::{Allocator, String};
 
     fn compile_with_css_vars(src: &str) -> String {
         let allocator = Allocator::new();

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           916 |                   100 |               816 |             139 |     371 |             951 |      475 |           477 |           584 |
+| Compiler                   |           916 |                   137 |               779 |             139 |     371 |             951 |      475 |           477 |           584 |
 | Linter                     |           302 |                    16 |               286 |             268 |     222 |             670 |      122 |           339 |           478 |
 | Typechecker                |           883 |                   139 |               744 |             394 |     187 |             806 |      658 |           461 |           651 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            18 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -736,35 +736,35 @@ compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/module_mode_setup_bindi
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/module_mode_setup_bindings.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/parse_facade.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/workspace_prop_types.rs	6	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/benches/davinci.rs	22	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/benches/davinci.rs	22	s0	S0/carton	stage	vize_s0	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	s0	S0/carton	stage	vize_s0	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	old_ast	old AST/parser	old	vize_armature	legacy	2
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/component_binding.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element.rs	17	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element/component_props.rs	226	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element/plain.rs	61	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element/props.rs	4	s0	S0/carton	stage	vize_carton	compat	4
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/helpers.rs	12	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/helpers/destructure.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/codegen/helpers/destructure.rs	132	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/scope_prefix.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/compile.rs	8	s0	S0/carton	stage	vize_carton	compat	5
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/lib.rs	51	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/options.rs	5	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/component_binding.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element.rs	17	s0	S0/carton	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element/component_props.rs	226	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element/plain.rs	61	s0	S0/carton	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element/props.rs	4	s0	S0/carton	stage	vize_s0	preferred	4
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/helpers.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/helpers/destructure.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/codegen/helpers/destructure.rs	132	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/scope_prefix.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/compile.rs	8	s0	S0/carton	stage	vize_s0	preferred	5
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/lib.rs	51	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/options.rs	5	s0	S0/carton	stage	vize_s0	preferred	2
 compiler	Compiler	source	crates/vize_atelier_ssr/src/options.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/stage_options.rs	14	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/steps.rs	93	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/component_spread_props.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/davinci_expr_reparse_floor.rs	20	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/stage_options.rs	14	s0	S0/carton	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/steps.rs	93	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/component_spread_props.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/davinci_expr_reparse_floor.rs	20	s0	S0/carton	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/davinci_walk_baseline.rs	25	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/davinci_walk_baseline.rs	25	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/event_props.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/setup_component_parity.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/ssr_snapshot.rs	9	s0	S0/carton	stage	vize_carton	compat	4
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/davinci_walk_baseline.rs	25	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/event_props.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/setup_component_parity.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/ssr_snapshot.rs	9	s0	S0/carton	stage	vize_s0	preferred	4
 compiler	Compiler	test/dev	crates/vize_atelier_vapor/benches/davinci.rs	30	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	davinci	Davinci	stage	vize_davinci	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	s0	S0/carton	stage	vize_carton	compat	1

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -78,6 +78,47 @@ function s2DomWitnessFiles(): string[] {
   return [...witnesses, path.join("support", "mod.rs")];
 }
 
+function assertS0AliasConsumer(options: {
+  packageName: string;
+  label: string;
+  directory: string;
+  filter?: (fullPath: string) => boolean;
+}) {
+  const { packageName, label, directory, filter = () => true } = options;
+  const dependencies = workspacePackage(metadata, packageName).dependencies;
+  assert.ok(
+    dependencies.some(
+      (dependency) =>
+        dependency.kind === null &&
+        dependency.name === "vize_carton" &&
+        dependency.rename === "vize_s0",
+    ),
+    `${packageName} must import vize_carton as vize_s0 for S0 storage`,
+  );
+  assert.ok(
+    dependencies.every(
+      (dependency) => dependency.name !== "vize_carton" || dependency.rename === "vize_s0",
+    ),
+    `${packageName} must not depend on vize_carton through its physical name`,
+  );
+
+  const offenders = [];
+  let aliasImports = 0;
+  for (const fullPath of walkRustFiles(directory)) {
+    if (!filter(fullPath)) continue;
+    const source = fs.readFileSync(fullPath, "utf8");
+    if (/\bvize_carton::|use vize_carton\b/u.test(source)) {
+      offenders.push(path.relative(repoRoot, fullPath));
+    }
+    if (/\bvize_s0::|use vize_s0\b/u.test(source)) {
+      aliasImports += 1;
+    }
+  }
+
+  assert.ok(aliasImports > 0, `${label} should use the vize_s0 alias`);
+  assert.deepEqual(offenders, []);
+}
+
 const aliases = new Map<string, ReadonlyArray<readonly [string, string | null]>>([
   ["vize_davinci", [["vize_carton", "vize_s0"]]],
   ["vize_s1", [["vize_carton", "vize_s0"]]],
@@ -211,118 +252,37 @@ test("Davinci atelier core S2 witnesses import lowering through the stage alias"
 });
 
 test("Vize CLI package imports S0 storage through the stage alias", () => {
-  const dependencies = workspacePackage(metadata, "vize").dependencies;
-  assert.ok(
-    dependencies.some(
-      (dependency) =>
-        dependency.kind === null &&
-        dependency.name === "vize_carton" &&
-        dependency.rename === "vize_s0",
-    ),
-    "vize must import vize_carton as vize_s0 for S0 storage",
-  );
-  assert.ok(
-    dependencies.every(
-      (dependency) => dependency.name !== "vize_carton" || dependency.rename === "vize_s0",
-    ),
-    "vize must not depend on vize_carton through its physical name",
-  );
-
-  const vizeDir = path.join(repoRoot, "crates", "vize");
-  const offenders = [];
-  let aliasImports = 0;
-  for (const fullPath of walkRustFiles(vizeDir)) {
-    const source = fs.readFileSync(fullPath, "utf8");
-    if (/\bvize_carton::/u.test(source)) {
-      offenders.push(path.relative(repoRoot, fullPath));
-    }
-    if (/\bvize_s0::|use vize_s0\b/u.test(source)) {
-      aliasImports += 1;
-    }
-  }
-
-  assert.ok(aliasImports > 0, "vize package should use the vize_s0 alias");
-  assert.deepEqual(offenders, []);
+  assertS0AliasConsumer({
+    packageName: "vize",
+    label: "vize package",
+    directory: path.join(repoRoot, "crates", "vize"),
+  });
 });
 
 test("Canon content-mapper imports S0 storage through the stage alias", () => {
-  const dependencies = workspacePackage(metadata, "vize_canon").dependencies;
-  assert.ok(
-    dependencies.some(
-      (dependency) =>
-        dependency.kind === null &&
-        dependency.name === "vize_carton" &&
-        dependency.rename === "vize_s0",
-    ),
-    "vize_canon must import vize_carton as vize_s0 for S0 storage",
-  );
-  assert.ok(
-    dependencies.every(
-      (dependency) => dependency.name !== "vize_carton" || dependency.rename === "vize_s0",
-    ),
-    "vize_canon must not depend on vize_carton through its physical name",
-  );
-
   const manifest = readRepoFile("crates", "vize_canon", "Cargo.toml");
   assert.match(manifest, /^vize_s0\.workspace = true$/m);
   assert.doesNotMatch(manifest, /^vize_carton\.workspace = true$/m);
-
-  const contentMapperDir = path.join(
-    repoRoot,
-    "crates",
-    "vize_canon",
-    "src",
-    "batch",
-    "virtual_project",
-  );
-  const offenders = [];
-  let aliasImports = 0;
-  for (const fullPath of walkRustFiles(contentMapperDir)) {
-    if (!path.basename(fullPath).startsWith("content_mapper")) continue;
-    const source = fs.readFileSync(fullPath, "utf8");
-    if (/\bvize_carton::|use vize_carton\b/u.test(source)) {
-      offenders.push(path.relative(repoRoot, fullPath));
-    }
-    if (/\bvize_s0::|use vize_s0\b/u.test(source)) {
-      aliasImports += 1;
-    }
-  }
-
-  assert.ok(aliasImports > 0, "Canon content-mapper should use the vize_s0 alias");
-  assert.deepEqual(offenders, []);
+  assertS0AliasConsumer({
+    packageName: "vize_canon",
+    label: "Canon content-mapper",
+    directory: path.join(repoRoot, "crates", "vize_canon", "src", "batch", "virtual_project"),
+    filter: (fullPath) => path.basename(fullPath).startsWith("content_mapper"),
+  });
 });
 
 test("Maestro LSP imports S0 storage through the stage alias", () => {
-  const dependencies = workspacePackage(metadata, "vize_maestro").dependencies;
-  assert.ok(
-    dependencies.some(
-      (dependency) =>
-        dependency.kind === null &&
-        dependency.name === "vize_carton" &&
-        dependency.rename === "vize_s0",
-    ),
-    "vize_maestro must import vize_carton as vize_s0 for S0 storage",
-  );
-  assert.ok(
-    dependencies.every(
-      (dependency) => dependency.name !== "vize_carton" || dependency.rename === "vize_s0",
-    ),
-    "vize_maestro must not depend on vize_carton through its physical name",
-  );
+  assertS0AliasConsumer({
+    packageName: "vize_maestro",
+    label: "Maestro LSP",
+    directory: path.join(repoRoot, "crates", "vize_maestro"),
+  });
+});
 
-  const maestroDir = path.join(repoRoot, "crates", "vize_maestro");
-  const offenders = [];
-  let aliasImports = 0;
-  for (const fullPath of walkRustFiles(maestroDir)) {
-    const source = fs.readFileSync(fullPath, "utf8");
-    if (/\bvize_carton::|use vize_carton\b/u.test(source)) {
-      offenders.push(path.relative(repoRoot, fullPath));
-    }
-    if (/\bvize_s0::|use vize_s0\b/u.test(source)) {
-      aliasImports += 1;
-    }
-  }
-
-  assert.ok(aliasImports > 0, "Maestro LSP should use the vize_s0 alias");
-  assert.deepEqual(offenders, []);
+test("Atelier SSR compiler imports S0 storage through the stage alias", () => {
+  assertS0AliasConsumer({
+    packageName: "vize_atelier_ssr",
+    label: "Atelier SSR compiler",
+    directory: path.join(repoRoot, "crates", "vize_atelier_ssr"),
+  });
 });


### PR DESCRIPTION
## Summary
- import vize_atelier_ssr S0 storage through the vize_s0 workspace alias
- extend the Davinci stage dependency guard to cover SSR compiler consumers
- regenerate davinci-road consumer migration surfaces

## Verification
- node tools/davinci/consumer-migration-surfaces.mjs --check
- node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_atelier_ssr
- cargo fmt --all -- --check
- vp run --workspace-root check:repo
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790307140&installation_model_id=422833&pr_number=4947&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4947&signature=1532e4cc264eeca82c8b10f06e7b71402a6647cc10ad412c1acfef492cf48517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the SSR compiler’s internal dependency integration without changing compilation behavior or public APIs.
  * Preserved existing code generation, tag detection, prop handling, snapshots, and benchmark behavior.

* **Tests**
  * Expanded tooling checks to verify consistent dependency alias usage across compiler components.
  * Consolidated repeated validation logic and added coverage for the SSR compiler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->