### PR TITLE
fix(matrix): refresh vue-storefront fixture count

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -1781,7 +1781,7 @@
       "revision": "220341f4c15d9f6ddb8d5e4c2fd225f5dd4d6f76",
       "license": { "spdx": "MIT", "files": ["LICENSE.md"] },
       "vueGlobs": ["**/*.vue"],
-      "expectedVueFileCount": 0,
+      "expectedVueFileCount": 45,
       "coverage": ["compiler","linter","typechecker","formatter","syntax-highlighter","lsp"],
       "diff": "e2e-vrt"
     },

--- a/tests/tooling/vue-ecosystem-fixtures.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures.test.ts
@@ -201,7 +201,7 @@ test("fixtures with exact Vue SFC expectations stay explicit", () => {
     projects.map((project) => ({ id: project.id, count: project.expectedVueFileCount })),
     [
       { id: "docsify", count: 0 },
-      { id: "vue-storefront", count: 0 },
+      { id: "vue-storefront", count: 45 },
       { id: "vue-native-core", count: 0 },
       { id: "vuefes-japan-speakers", count: 15 },
       { id: "wakapi", count: 0 },


### PR DESCRIPTION
## Summary
- update vue-storefront expected Vue SFC count to match the pinned fixture revision
- keep the explicit fixture-count regression in sync

## Evidence
- stale Real Project Matrix run 32924681959 reported vue-storefront syntax audit matched 45 Vue files while the manifest expected 0
- local hydrated submodule check: vue-storefront expectedVueFileCount 45, actual 45

## Verification
- node --input-type=module -e <vue-storefront count check>
- node --test tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/requested-vue-fixtures.test.ts tests/tooling/source-file-lengths.test.ts
- vp run --workspace-root check:repo
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790308117&installation_model_id=422833&pr_number=4948&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4948&signature=d58aac10a66dd4d538cb7fe0df52f6b23b0cee6b3a3e9565c1f04fae9f451bcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Vue ecosystem coverage expectations to accurately recognize 45 Vue files in the vue-storefront fixture.
  * Aligned fixture data and registry validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->