### PR TITLE
fix(patina): align deprecated slot attribute span

### DIFF
--- a/crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs
@@ -63,7 +63,7 @@ impl Rule for NoDeprecatedSlotAttribute {
             {
                 ctx.error_with_help(
                     ctx.t("vue/no-deprecated-slot-attribute.message"),
-                    &attr.loc,
+                    &attr.name_loc,
                     ctx.t("vue/no-deprecated-slot-attribute.help"),
                 );
             }
@@ -148,7 +148,7 @@ mod tests {
                 Severity::Error,
                 "the `slot` attribute was deprecated in Vue 2.6 and removed in Vue 3",
                 29,
-                42,
+                33,
                 Some("Use `v-slot` instead (e.g. `<template v-slot:header>`)."),
                 0,
                 false,

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_deprecated_slot_attribute__tests__reports_slot_attribute.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_deprecated_slot_attribute__tests__reports_slot_attribute.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Error,
         message: "the `slot` attribute was deprecated in Vue 2.6 and removed in Vue 3",
         start: 15,
-        end: 28,
+        end: 19,
         help: Some(
             "Use `v-slot` instead (e.g. `<template v-slot:header>`).",
         ),


### PR DESCRIPTION
## Summary
- report `vue/no-deprecated-slot-attribute` on the `slot` name range instead of the full attribute range
- update the rule unit expectation and snapshot to match eslint-plugin-vue span semantics
- targeted real-project lint evidence moves this rule from FP/FN into shared findings

## Verification
- `cargo test -p vize_patina no_deprecated_slot_attribute`
- `cargo build --profile ci -p vize`
- `VIZE_TEST_BIN=target/ci/vize node --test --test-concurrency=1 tests/tooling/lint-divergence-report.test.ts tests/tooling/lint-divergence-budget.test.ts`
- `node tools/fixtures/lint-divergence-report.mjs --project vue-element-admin,mobile-web-best-practice,element,habitica,vue-js-modal --shard-index 0 --shard-count 1 --measure-coverage-gap --budget-mode record-only --vize-bin target/ci/vize --timeout-ms 600000 --output-dir target/lint-slot-parity`
- targeted report: `vue/no-deprecated-slot-attribute` false positives/false negatives are 0 across all 5 checked projects; shared counts are 28, 2, 26, 157, and 1 respectively
- `cargo fmt --all -- --check`
- `git diff --check`
- `vp run --workspace-root check:repo`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790310869&installation_model_id=422833&pr_number=4951&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4951&signature=c3607416a6f133b98fe12092e6849af86ba6ff2ad1b60d8d2c01e48f031cfae6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deprecated slot attribute diagnostics by highlighting only the attribute name.
  * Updated diagnostic positioning for more precise editor feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->