### PR TITLE
refactor(patina): import S0 storage through stage alias

### DIFF
--- a/crates/vize_patina/Cargo.toml
+++ b/crates/vize_patina/Cargo.toml
@@ -12,7 +12,7 @@ metadata.vize.stability = "compatibility-preview"
 # Internal crates
 vize_relief.workspace = true
 vize_armature.workspace = true
-vize_carton.workspace = true
+vize_s0.workspace = true
 vize_croquis.workspace = true
 vize_atelier_sfc.workspace = true
 vize_atelier_jsx.workspace = true

--- a/crates/vize_patina/README.md
+++ b/crates/vize_patina/README.md
@@ -13,7 +13,7 @@ Support and deprecation guarantees are defined in the
 - Vue-focused lint rules covering correctness, style, accessibility, security, Vapor, Musea, and type-aware checks
 - Built-in presets: `happy-path`, `opinionated`, `essential`, `incremental`, `ecosystem`, `nuxt`
 - Human-readable and machine-readable reporting helpers
-- Locale support through `vize_carton::i18n::Locale`
+- Locale support through `vize_s0::i18n::Locale`
 
 ## Key Entry Points
 

--- a/crates/vize_patina/benches/davinci_markup.rs
+++ b/crates/vize_patina/benches/davinci_markup.rs
@@ -10,10 +10,10 @@
 
 use criterion::{Criterion, criterion_group};
 use davinci_harness::stage::bench_stage_with_metrics;
-use vize_carton::{Allocator, cstr};
 use vize_patina::ir::TemplateSyntax;
 use vize_patina::markup::{MarkupContext, MarkupDocument};
 use vize_patina::{JsxLang, LintContext, RuleRegistry};
+use vize_s0::{Allocator, cstr};
 
 /// One-root, diagnostic-free JSX module: a single outermost element with a
 /// nested child mix (static attribute, event, text) so the walk exercises

--- a/crates/vize_patina/benches/lint_bench.rs
+++ b/crates/vize_patina/benches/lint_bench.rs
@@ -3,10 +3,10 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
-use vize_carton::{String, append};
 use vize_patina::Linter;
 use vize_patina::rules::musea::MuseaLinter;
 use vize_patina::rules::script::{NoInternalImports, PreferImportFromVue, ScriptLinter};
+use vize_s0::{String, append};
 
 fn bench_lint_template(c: &mut Criterion) {
     let template = r#"

--- a/crates/vize_patina/benches/markup_ir_bench.rs
+++ b/crates/vize_patina/benches/markup_ir_bench.rs
@@ -12,13 +12,13 @@
 
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
-use vize_carton::Allocator;
-use vize_carton::String;
-use vize_carton::append;
 use vize_patina::ir::TemplateSyntax;
 use vize_patina::markup::{MarkupContext, MarkupDocument};
 use vize_patina::rules::a11y::ImgAlt;
 use vize_patina::{JsxLang, LintContext, Linter, RuleRegistry};
+use vize_s0::Allocator;
+use vize_s0::String;
+use vize_s0::append;
 
 /// A representative template with a mix of elements, bindings, and `<img>`
 /// nodes (the rule's trigger), large enough to exercise traversal.

--- a/crates/vize_patina/src/context.rs
+++ b/crates/vize_patina/src/context.rs
@@ -18,14 +18,14 @@ use crate::diagnostic::{HelpLevel, LintDiagnostic, Severity};
 use memchr::memchr_iter;
 use std::borrow::Cow;
 use vize_atelier_sfc::SfcDescriptor;
-use vize_carton::String;
-use vize_carton::{
+use vize_croquis::Croquis;
+use vize_s0::String;
+use vize_s0::{
     Allocator, CompactString, FxHashMap, FxHashSet,
     dialect::VueDialect,
     directive::DirectiveSeverity,
     i18n::{Locale, t, t_fmt},
 };
-use vize_croquis::Croquis;
 
 use sfc_directives::SfcDirectiveState;
 

--- a/crates/vize_patina/src/context/directives.rs
+++ b/crates/vize_patina/src/context/directives.rs
@@ -1,6 +1,6 @@
 //! Directive disable ranges and suppression pragma handling.
 
-use vize_carton::{CompactString, String, directive::DirectiveSeverity};
+use vize_s0::{CompactString, String, directive::DirectiveSeverity};
 
 use super::{
     DisabledRange, LintContext,

--- a/crates/vize_patina/src/context/eslint_directive.rs
+++ b/crates/vize_patina/src/context/eslint_directive.rs
@@ -1,6 +1,6 @@
 //! ESLint suppression pragma parsing.
 
-use vize_carton::String;
+use vize_s0::String;
 
 #[derive(Clone, Copy)]
 pub(super) enum EslintDisableKind {

--- a/crates/vize_patina/src/context/helpers.rs
+++ b/crates/vize_patina/src/context/helpers.rs
@@ -6,8 +6,8 @@
 
 use crate::diagnostic::LintDiagnostic;
 use crate::ir::ByteRange;
-use vize_carton::CompactString;
 use vize_relief::{BindingType, SourceLocation};
+use vize_s0::CompactString;
 
 use super::{LintContext, state::ElementContext};
 

--- a/crates/vize_patina/src/context/reporting.rs
+++ b/crates/vize_patina/src/context/reporting.rs
@@ -2,7 +2,7 @@
 
 use crate::diagnostic::{LintDiagnostic, Severity};
 use vize_atelier_sfc::SfcDescriptor;
-use vize_carton::directive::DirectiveSeverity;
+use vize_s0::directive::DirectiveSeverity;
 
 use super::{LintContext, SfcDirectiveState};
 

--- a/crates/vize_patina/src/context/sfc_directives.rs
+++ b/crates/vize_patina/src/context/sfc_directives.rs
@@ -4,10 +4,10 @@ mod lexer;
 
 use memchr::memchr_iter;
 use vize_atelier_sfc::SfcDescriptor;
-use vize_carton::directive::{
+use vize_s0::directive::{
     DirectiveKind, DirectiveSeverity, parse_level_severity, parse_vize_directive,
 };
-use vize_carton::{CompactString, FxHashMap, FxHashSet, String};
+use vize_s0::{CompactString, FxHashMap, FxHashSet, String};
 
 use super::DisabledRange;
 use super::eslint_directive::{EslintDisableKind, parse_eslint_disable_comment};

--- a/crates/vize_patina/src/context/state.rs
+++ b/crates/vize_patina/src/context/state.rs
@@ -3,7 +3,7 @@
 //! Provides `DisabledRange`, `SsrMode`, and `ElementContext` which are used
 //! to track rule suppression, SSR linting mode, and element traversal state.
 
-use vize_carton::CompactString;
+use vize_s0::CompactString;
 
 /// Represents a disabled range for a specific rule or all rules.
 #[derive(Debug, Clone)]

--- a/crates/vize_patina/src/diagnostic.rs
+++ b/crates/vize_patina/src/diagnostic.rs
@@ -15,7 +15,7 @@ pub use types::{Fix, HelpLevel, LintDiagnostic, LintSummary, Severity, TextEdit}
 #[cfg(test)]
 mod tests {
     use super::{HelpLevel, HelpRenderTarget, compact_help, formatting, render_help};
-    use vize_carton::ToCompactString;
+    use vize_s0::ToCompactString;
 
     #[test]
     fn test_help_level_full() {

--- a/crates/vize_patina/src/diagnostic/compact_help.rs
+++ b/crates/vize_patina/src/diagnostic/compact_help.rs
@@ -1,6 +1,6 @@
 //! Compact remediation text for terminal and CI output.
 
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 /// Return one actionable help sentence without markdown or inline examples.
 pub(super) fn compact_help_text(text: &str) -> String {

--- a/crates/vize_patina/src/diagnostic/formatting.rs
+++ b/crates/vize_patina/src/diagnostic/formatting.rs
@@ -3,8 +3,8 @@
 //! Provides functions for rendering markdown help text into different
 //! output formats: ANSI terminal codes, plain text, or raw markdown passthrough.
 
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 // ANSI escape codes
 const ANSI_BOLD: &str = "\x1b[1m";

--- a/crates/vize_patina/src/diagnostic/types.rs
+++ b/crates/vize_patina/src/diagnostic/types.rs
@@ -9,9 +9,9 @@
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_span::Span;
 use serde::Serialize;
-use vize_carton::CompactString;
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_s0::CompactString;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 use super::formatting::{HelpRenderTarget, render_help};
 

--- a/crates/vize_patina/src/ir.rs
+++ b/crates/vize_patina/src/ir.rs
@@ -5,7 +5,7 @@
 
 use oxc_span::SourceType;
 use vize_atelier_sfc::SfcDescriptor;
-use vize_carton::CompactString;
+use vize_s0::CompactString;
 
 /// Container kind that produced the lint document.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/vize_patina/src/lib.rs
+++ b/crates/vize_patina/src/lib.rs
@@ -132,7 +132,7 @@ pub use telegraph::{
     TextEmitter,
 };
 pub use vize_atelier_jsx::JsxLang;
-pub use vize_carton::i18n::Locale;
+pub use vize_s0::i18n::Locale;
 
 /// Lint a Vue template source with default rules
 ///

--- a/crates/vize_patina/src/linter/category_config.rs
+++ b/crates/vize_patina/src/linter/category_config.rs
@@ -5,7 +5,7 @@ use super::{
     config::Linter,
 };
 use crate::Severity;
-use vize_carton::String;
+use vize_s0::String;
 
 impl Linter {
     /// Disable every registered rule that belongs to one of the configured categories.

--- a/crates/vize_patina/src/linter/compatibility.rs
+++ b/crates/vize_patina/src/linter/compatibility.rs
@@ -1,5 +1,5 @@
 use super::config::Linter;
-use vize_carton::{String, config::VueVersion};
+use vize_s0::{String, config::VueVersion};
 
 impl Linter {
     /// Apply project-wide Vue dialect compatibility to lint rules.

--- a/crates/vize_patina/src/linter/config.rs
+++ b/crates/vize_patina/src/linter/config.rs
@@ -17,7 +17,7 @@ use crate::{
 use std::path::PathBuf;
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::Mutex;
-use vize_carton::{FxHashMap, FxHashSet, String, i18n::Locale};
+use vize_s0::{FxHashMap, FxHashSet, String, i18n::Locale};
 
 /// Lint result for a single file.
 #[derive(Debug, Clone)]

--- a/crates/vize_patina/src/linter/corsa_session.rs
+++ b/crates/vize_patina/src/linter/corsa_session.rs
@@ -1,6 +1,6 @@
 use corsa::api::ProjectSession;
 use std::path::PathBuf;
-use vize_carton::String;
+use vize_s0::String;
 
 mod errors;
 mod paths;

--- a/crates/vize_patina/src/linter/corsa_session/errors.rs
+++ b/crates/vize_patina/src/linter/corsa_session/errors.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 pub(super) fn io_error_message(prefix: &str, path: &Path, error: &std::io::Error) -> String {
     let mut message = prefix.to_compact_string();

--- a/crates/vize_patina/src/linter/corsa_session/paths.rs
+++ b/crates/vize_patina/src/linter/corsa_session/paths.rs
@@ -2,7 +2,7 @@ use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
 };
-use vize_carton::{
+use vize_s0::{
     String, ToCompactString,
     corsa_resolver::{CORSA_EXECUTABLE_NAMES, CorsaResolveError, CorsaResolveRequest},
     cstr,
@@ -163,7 +163,7 @@ pub(super) fn resolve_corsa_executable(
         project_root: Some(project_root),
     };
 
-    match vize_carton::corsa_resolver::resolve_corsa_executable(request) {
+    match vize_s0::corsa_resolver::resolve_corsa_executable(request) {
         Ok(path) => Ok(path),
         // Preserve the historical lenient fallback: a bare `corsa` lets the
         // spawn-time `PATH` lookup have the final word.
@@ -200,7 +200,7 @@ mod tests {
         path::{Path, PathBuf},
         sync::atomic::{AtomicU64, Ordering},
     };
-    use vize_carton::cstr;
+    use vize_s0::cstr;
 
     static NEXT_CASE_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -225,7 +225,7 @@ mod tests {
             .join("@typescript")
             .join(&*cstr!(
                 "native-preview-{}",
-                vize_carton::corsa_resolver::platform_suffix()
+                vize_s0::corsa_resolver::platform_suffix()
             ))
             .join("lib")
             .join("tsgo");

--- a/crates/vize_patina/src/linter/corsa_session/probe.rs
+++ b/crates/vize_patina/src/linter/corsa_session/probe.rs
@@ -5,7 +5,7 @@ use corsa::{
     fast::{CompactString as CorsaString, ToCompactString as _},
     runtime::block_on,
 };
-use vize_carton::{String, profile};
+use vize_s0::{String, profile};
 
 const SNAPSHOT_REGISTRY_NOT_FOUND: &str = "not found in snapshot registry";
 

--- a/crates/vize_patina/src/linter/corsa_session/session.rs
+++ b/crates/vize_patina/src/linter/corsa_session/session.rs
@@ -13,7 +13,7 @@ use corsa::{
     },
     runtime::block_on,
 };
-use vize_carton::{String, ToCompactString, profile};
+use vize_s0::{String, ToCompactString, profile};
 
 impl CorsaTypeAwareSession {
     pub(in crate::linter) fn new_with_corsa_path(

--- a/crates/vize_patina/src/linter/corsa_session/session/tests.rs
+++ b/crates/vize_patina/src/linter/corsa_session/session/tests.rs
@@ -3,7 +3,7 @@ use crate::linter::corsa_session::CorsaTypeAwareSession;
 use corsa::api::ApiMode;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use vize_carton::{corsa_resolver::platform_suffix, cstr};
+use vize_s0::{corsa_resolver::platform_suffix, cstr};
 
 static NEXT_CASE_ID: AtomicU64 = AtomicU64::new(0);
 

--- a/crates/vize_patina/src/linter/css_rules.rs
+++ b/crates/vize_patina/src/linter/css_rules.rs
@@ -17,7 +17,7 @@ use crate::rules::css::{
     PreferSlotted, RequireFontDisplay,
 };
 use vize_atelier_sfc::SfcDescriptor;
-use vize_carton::profile;
+use vize_s0::profile;
 
 pub(crate) const RULE_NO_IMPORTANT: &str = "css/no-important";
 pub(crate) const RULE_NO_ID_SELECTORS: &str = "css/no-id-selectors";

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -25,13 +25,13 @@ use crate::{
 use vize_armature::Parser;
 use vize_atelier_sfc::croquis::{SfcCroquisOptions, analyze_sfc_descriptor};
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-use vize_carton::Allocator;
-use vize_carton::String;
-use vize_carton::ToCompactString;
-use vize_carton::dialect::{VueDialect, standalone_html_dialect};
-use vize_carton::profile;
 use vize_croquis::{Croquis, Drawer};
 use vize_relief::RootNode;
+use vize_s0::Allocator;
+use vize_s0::String;
+use vize_s0::ToCompactString;
+use vize_s0::dialect::{VueDialect, standalone_html_dialect};
+use vize_s0::profile;
 
 use super::config::{LintResult, Linter};
 

--- a/crates/vize_patina/src/linter/engine/parse_diagnostics.rs
+++ b/crates/vize_patina/src/linter/engine/parse_diagnostics.rs
@@ -2,8 +2,8 @@
 
 use crate::diagnostic::{LintDiagnostic, Severity};
 use vize_atelier_sfc::SfcError;
-use vize_carton::ToCompactString;
 use vize_relief::CompilerError;
+use vize_s0::ToCompactString;
 
 use super::super::config::{LintResult, Linter};
 

--- a/crates/vize_patina/src/linter/engine/script.rs
+++ b/crates/vize_patina/src/linter/engine/script.rs
@@ -1,4 +1,4 @@
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 use crate::linter::config::{LintResult, Linter};
 

--- a/crates/vize_patina/src/linter/engine/template_extract.rs
+++ b/crates/vize_patina/src/linter/engine/template_extract.rs
@@ -1,8 +1,8 @@
 //! Ultra-fast `<template>` block extraction using memchr for
 //! SIMD-accelerated search.
 
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 use super::tag_scan::{
     closing_tag_name_at, find_closing_tag, find_start_tag_end, find_tag_end, tag_name_at,
@@ -110,7 +110,7 @@ fn find_template_block_start(bytes: &[u8]) -> Option<(usize, usize)> {
 mod tests {
     use super::extract_template_fast;
 
-    fn extract(source: &str) -> Option<vize_carton::String> {
+    fn extract(source: &str) -> Option<vize_s0::String> {
         extract_template_fast(source).map(|(content, _)| content)
     }
 

--- a/crates/vize_patina/src/linter/native_type_aware.rs
+++ b/crates/vize_patina/src/linter/native_type_aware.rs
@@ -7,7 +7,7 @@ use corsa::utils::{
     is_any_like_type_texts, is_promise_like_type_texts, is_unknown_like_type_texts,
 };
 use vize_atelier_sfc::SfcDescriptor;
-use vize_carton::{String, ToCompactString, profile};
+use vize_s0::{String, ToCompactString, profile};
 
 mod driver;
 mod markers;
@@ -170,7 +170,7 @@ pub(super) fn should_warn_for_emit_validator(probe: Option<&TypeProbe>) -> bool 
 }
 
 pub(super) fn has_promise_like_return(probe: &TypeProbe) -> bool {
-    let no_properties: &[vize_carton::CompactString] = &[];
+    let no_properties: &[vize_s0::CompactString] = &[];
     probe.return_types.iter().any(|return_type| {
         !return_type.is_empty() && is_promise_like_type_texts(return_type, no_properties)
     })

--- a/crates/vize_patina/src/linter/native_type_aware/driver.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/driver.rs
@@ -15,11 +15,11 @@ use super::{
 };
 use crate::diagnostic::LintDiagnostic;
 use vize_armature::Parser as TemplateParser;
-use vize_carton::{FxHashSet, profile};
 use vize_croquis::{
     Croquis, script_parser,
     virtual_ts::{VirtualTsConfig, generate_virtual_ts_with_croquis},
 };
+use vize_s0::{FxHashSet, profile};
 pub(super) fn lint_with_descriptor<'a>(
     linter: &Linter,
     source: &str,
@@ -27,7 +27,7 @@ pub(super) fn lint_with_descriptor<'a>(
     descriptor: &vize_atelier_sfc::SfcDescriptor<'a>,
 ) -> LintResult {
     let allocator =
-        vize_carton::Allocator::with_capacity((source.len() * 4).max(linter.initial_capacity));
+        vize_s0::Allocator::with_capacity((source.len() * 4).max(linter.initial_capacity));
     let template_ast = descriptor.template.as_ref().map(|template| {
         let parser = TemplateParser::new(&allocator, &template.content);
         let (root, parse_errors) = profile!("patina.type_aware.template_parse", parser.parse());

--- a/crates/vize_patina/src/linter/native_type_aware/markers.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/markers.rs
@@ -1,6 +1,6 @@
 use super::parsing::extract_runtime_object_property_values;
-use vize_carton::{String, ToCompactString};
 use vize_croquis::virtual_ts::VirtualTsOutput;
+use vize_s0::{String, ToCompactString};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum QueryKind {

--- a/crates/vize_patina/src/linter/native_type_aware/parsing.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/parsing.rs
@@ -7,7 +7,7 @@ use oxc_ast_visit::{Visit, walk::walk_expression_statement};
 use oxc_parser::Parser as OxcParser;
 use oxc_span::{GetSpan, SourceType};
 use oxc_syntax::operator::UnaryOperator;
-use vize_carton::{String, ToCompactString, profile};
+use vize_s0::{String, ToCompactString, profile};
 
 pub(super) fn is_runtime_array_macro(runtime_args: Option<&str>) -> bool {
     let Some(runtime_args) = runtime_args.map(str::trim_start) else {

--- a/crates/vize_patina/src/linter/native_type_aware/reactivity_loss.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/reactivity_loss.rs
@@ -2,12 +2,12 @@ use super::{
     LintResult, Linter, RULE_NO_REACTIVITY_LOSS, markers::marker_insert_offset, push_warning,
 };
 use crate::diagnostic::LintDiagnostic;
-use vize_carton::{CompactString, FxHashSet, String, ToCompactString, cstr};
 use vize_croquis::{
     reactivity::{ReactivityLoss, ReactivityLossKind},
     script_parser::ScriptParseResult,
     virtual_ts::VirtualTsOutput,
 };
+use vize_s0::{CompactString, FxHashSet, String, ToCompactString, cstr};
 
 #[derive(Clone)]
 pub(super) struct ReactivityLossQuery {

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
@@ -7,7 +7,7 @@ use oxc_ast_visit::{
 use oxc_parser::Parser as OxcParser;
 use oxc_span::{GetSpan, SourceType, Span};
 use oxc_syntax::operator::UnaryOperator;
-use vize_carton::{String, profile};
+use vize_s0::{String, profile};
 
 #[derive(Clone, Copy)]
 pub(super) struct RelativeRange {

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
@@ -6,12 +6,12 @@ use super::{
 };
 use oxc_allocator::Allocator as OxcAllocator;
 use oxc_span::SourceType;
-use vize_carton::profile;
 use vize_croquis::virtual_ts::VirtualTsOutput;
 use vize_relief::{
     DirectiveNode, ExpressionNode, ForNode, IfNode, PropNode, RootNode, TemplateChildNode,
     TextCallContent,
 };
+use vize_s0::profile;
 
 pub(super) fn collect_template_query_sets(
     virtual_ts: &VirtualTsOutput,

--- a/crates/vize_patina/src/linter/restricted_rules.rs
+++ b/crates/vize_patina/src/linter/restricted_rules.rs
@@ -9,7 +9,7 @@
 
 use super::config::Linter;
 use crate::rules::script::{NoRestrictedMembers, RestrictedGlobals};
-use vize_carton::String;
+use vize_s0::String;
 
 impl Linter {
     /// Configure the deny list for `script/no-restricted-globals`.

--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -3,7 +3,7 @@ use crate::rules::script::{ScriptLintResult, SfcScriptContext, script_source_typ
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use vize_atelier_sfc::{SfcDescriptor, SfcParseOptions, parse_sfc};
-use vize_carton::profile;
+use vize_s0::profile;
 
 mod html_scripts;
 mod prefilter;
@@ -147,7 +147,7 @@ pub(crate) fn append_builtin_script_diagnostics<'a>(
     // finding from template evidence, where an over-match would be a false
     // positive). The AST is parsed at most once, and only when some enabled
     // rule asks for it.
-    let template_allocator = vize_carton::Allocator::default();
+    let template_allocator = vize_s0::Allocator::default();
     let template_ast =
         template_ast::parse_for_script_rules(linter, descriptor, &template_allocator);
     let sfc_context = SfcScriptContext {

--- a/crates/vize_patina/src/linter/script_rules/template_ast.rs
+++ b/crates/vize_patina/src/linter/script_rules/template_ast.rs
@@ -13,8 +13,8 @@
 
 use vize_armature::Parser;
 use vize_atelier_sfc::SfcDescriptor;
-use vize_carton::{Allocator, profile};
 use vize_relief::RootNode;
+use vize_s0::{Allocator, profile};
 
 use crate::linter::Linter;
 

--- a/crates/vize_patina/src/linter/severity.rs
+++ b/crates/vize_patina/src/linter/severity.rs
@@ -1,6 +1,6 @@
 use super::LintResult;
 use crate::diagnostic::Severity;
-use vize_carton::{FxHashMap, String};
+use vize_s0::{FxHashMap, String};
 
 pub(crate) fn append_with_rule_overrides(
     result: &mut LintResult,

--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -1,6 +1,6 @@
 use super::Linter;
 use crate::LintPreset;
-use vize_carton::{Allocator, ToCompactString};
+use vize_s0::{Allocator, ToCompactString};
 
 mod basic;
 mod css;

--- a/crates/vize_patina/src/linter/tests/jsx_streaming.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_streaming.rs
@@ -10,7 +10,7 @@ use crate::linter::{LintResult, Linter};
 use crate::rule::{Rule, RuleRegistry};
 use crate::rules::a11y::ImgAlt;
 use vize_atelier_jsx::JsxLang;
-use vize_carton::CompactString;
+use vize_s0::CompactString;
 
 fn linter_with(rule: Box<dyn Rule>) -> Linter {
     let mut registry = RuleRegistry::new();

--- a/crates/vize_patina/src/linter/tests/nuxt.rs
+++ b/crates/vize_patina/src/linter/tests/nuxt.rs
@@ -1,5 +1,5 @@
 use super::{LintPreset, Linter};
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 #[test]
 fn nuxt_preset_reports_and_fixes_legacy_process_flags() {

--- a/crates/vize_patina/src/linter/tests/recovered_parse_analysis.rs
+++ b/crates/vize_patina/src/linter/tests/recovered_parse_analysis.rs
@@ -8,7 +8,7 @@
 //! skip is least acceptable.
 
 use super::Linter;
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 fn rule_names(result: &crate::linter::config::LintResult) -> Vec<&'static str> {
     result

--- a/crates/vize_patina/src/markup.rs
+++ b/crates/vize_patina/src/markup.rs
@@ -56,13 +56,13 @@ use oxc_ast_visit::{
 };
 use oxc_span::Span;
 use std::marker::PhantomData;
-use vize_carton::String;
-use vize_carton::profile;
 use vize_croquis::Croquis;
 use vize_relief::{
     AttributeNode, DirectiveNode, ElementNode, ElementType, ExpressionNode, ForNode, IfNode,
     PropNode, RootNode, SourceLocation, TemplateChildNode, TextNode,
 };
+use vize_s0::String;
+use vize_s0::profile;
 
 /// High-level classification for a markup element.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -15,7 +15,7 @@ mod markup_ir_tests {
     use crate::rules::vapor::{NoVueLifecycleEvents, PreferStaticClass};
     use crate::rules::vue::RequireVForKey;
     use vize_atelier_jsx::JsxLang;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     /// Run a markup rule over a Vue template and return the diagnostic count.
     fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {

--- a/crates/vize_patina/src/output.rs
+++ b/crates/vize_patina/src/output.rs
@@ -17,7 +17,7 @@ pub use shared::rule_docs_path;
 pub use text::*;
 
 use crate::linter::LintResult;
-use vize_carton::String;
+use vize_s0::String;
 
 /// Output format for lint results
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/crates/vize_patina/src/output/agent.rs
+++ b/crates/vize_patina/src/output/agent.rs
@@ -2,7 +2,7 @@
 
 use crate::linter::LintResult;
 use crate::output::shared::{diagnostic_views, json_quote, result_counts};
-use vize_carton::{String, ToCompactString, append};
+use vize_s0::{String, ToCompactString, append};
 
 pub(super) fn format_agent(results: &[LintResult], sources: &[(String, String)]) -> String {
     let views = diagnostic_views(results, sources);

--- a/crates/vize_patina/src/output/html.rs
+++ b/crates/vize_patina/src/output/html.rs
@@ -3,7 +3,7 @@
 use crate::linter::LintResult;
 use crate::output::format_summary;
 use crate::output::shared::{diagnostic_views, escape_html, result_counts};
-use vize_carton::{String, append};
+use vize_s0::{String, append};
 
 pub(super) fn format_html(results: &[LintResult], sources: &[(String, String)]) -> String {
     let views = diagnostic_views(results, sources);

--- a/crates/vize_patina/src/output/json.rs
+++ b/crates/vize_patina/src/output/json.rs
@@ -4,7 +4,7 @@ use crate::diagnostic::{HelpRenderTarget, render_help};
 use crate::linter::LintResult;
 use crate::output::shared::{diagnostic_location, rule_docs_path, source_indices};
 use serde::Serialize;
-use vize_carton::String;
+use vize_s0::String;
 
 /// JSON output structure for a single file
 #[derive(Debug, Serialize)]

--- a/crates/vize_patina/src/output/markdown.rs
+++ b/crates/vize_patina/src/output/markdown.rs
@@ -3,7 +3,7 @@
 use crate::linter::LintResult;
 use crate::output::format_summary;
 use crate::output::shared::{diagnostic_views, result_counts};
-use vize_carton::{String, append};
+use vize_s0::{String, append};
 
 pub(super) fn format_markdown(results: &[LintResult], sources: &[(String, String)]) -> String {
     let views = diagnostic_views(results, sources);

--- a/crates/vize_patina/src/output/plain.rs
+++ b/crates/vize_patina/src/output/plain.rs
@@ -3,7 +3,7 @@
 use crate::linter::LintResult;
 use crate::output::format_summary;
 use crate::output::shared::{diagnostic_views, push_indented_lines, result_counts};
-use vize_carton::{String, append};
+use vize_s0::{String, append};
 
 pub(super) fn format_plain(results: &[LintResult], sources: &[(String, String)]) -> String {
     let views = diagnostic_views(results, sources);

--- a/crates/vize_patina/src/output/shared.rs
+++ b/crates/vize_patina/src/output/shared.rs
@@ -2,7 +2,7 @@
 
 use crate::diagnostic::{HelpRenderTarget, render_help};
 use crate::linter::LintResult;
-use vize_carton::{FxHashMap, SmallVec, String};
+use vize_s0::{FxHashMap, SmallVec, String};
 
 /// Return the local documentation page that explains a rule namespace.
 pub fn rule_docs_path(rule_name: &str) -> &'static str {

--- a/crates/vize_patina/src/output/stylish.rs
+++ b/crates/vize_patina/src/output/stylish.rs
@@ -3,7 +3,7 @@
 use crate::linter::LintResult;
 use crate::output::format_summary;
 use crate::output::shared::{diagnostic_views, result_counts};
-use vize_carton::{String, append};
+use vize_s0::{String, append};
 
 pub(super) fn format_stylish(results: &[LintResult], sources: &[(String, String)]) -> String {
     let views = diagnostic_views(results, sources);

--- a/crates/vize_patina/src/output/tests.rs
+++ b/crates/vize_patina/src/output/tests.rs
@@ -1,7 +1,7 @@
 use crate::{
     LintDiagnostic, LintPreset, LintResult, Linter, OutputFormat, format_results, rule_docs_path,
 };
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 #[test]
 fn json_output_uses_source_line_columns() {
@@ -13,11 +13,11 @@ const items = [1]
   <div v-for="item in items">{{ item }}</div>
 </template>
 "#;
-    let filename = vize_carton::String::from("Component.vue");
+    let filename = vize_s0::String::from("Component.vue");
     let result = Linter::new().lint_sfc(source, &filename);
     let output = format_results(
         &[result],
-        &[(filename, vize_carton::String::from(source))],
+        &[(filename, vize_s0::String::from(source))],
         OutputFormat::Json,
     );
 
@@ -32,7 +32,7 @@ const items = [1]
 #[test]
 fn json_output_uses_character_columns_after_multibyte_text() {
     let source = r#"<template><div title="café" v-html="x"></div></template>"#;
-    let filename = vize_carton::String::from("Component.vue");
+    let filename = vize_s0::String::from("Component.vue");
     let start = source.find("v-html").unwrap() as u32;
     let end = start + "v-html".len() as u32;
     let result = LintResult {
@@ -48,7 +48,7 @@ fn json_output_uses_character_columns_after_multibyte_text() {
     };
     let output = format_results(
         &[result],
-        &[(filename, vize_carton::String::from(source))],
+        &[(filename, vize_s0::String::from(source))],
         OutputFormat::Json,
     );
     let json: serde_json::Value = serde_json::from_str(&output).unwrap();
@@ -72,11 +72,11 @@ const msg = "hello";
   </div>
 </template>
 "#;
-    let filename = vize_carton::String::from("Component.vue");
+    let filename = vize_s0::String::from("Component.vue");
     let result = Linter::new().lint_sfc(source, &filename);
     let output = format_results(
         &[result],
-        &[(filename, vize_carton::String::from(source))],
+        &[(filename, vize_s0::String::from(source))],
         OutputFormat::Json,
     );
     let json: serde_json::Value = serde_json::from_str(&output).unwrap();
@@ -124,7 +124,7 @@ const url = ""
   <a :href="url" />
 </template>
 "#;
-    let filename = vize_carton::String::from("Label.vue");
+    let filename = vize_s0::String::from("Label.vue");
     let result = Linter::with_preset(LintPreset::Essential).lint_sfc(source, &filename);
 
     assert!(
@@ -144,7 +144,7 @@ const url = ""
         result.diagnostics
     );
 
-    let sources = [(filename.clone(), vize_carton::String::from(source))];
+    let sources = [(filename.clone(), vize_s0::String::from(source))];
     for format in [
         OutputFormat::Text,
         OutputFormat::Ansi,
@@ -186,11 +186,11 @@ fn rule_docs_path_maps_namespaces_to_reference_pages() {
 #[test]
 fn stylish_output_includes_reference_paths() {
     let source = "<template><div v-for=\"item in items\"></div></template>";
-    let filename = vize_carton::String::from("Component.vue");
+    let filename = vize_s0::String::from("Component.vue");
     let result = Linter::new().lint_sfc(source, &filename);
     let output = format_results(
         &[result],
-        &[(filename, vize_carton::String::from(source))],
+        &[(filename, vize_s0::String::from(source))],
         OutputFormat::Stylish,
     );
 
@@ -215,8 +215,8 @@ fn text_output_includes_reference_paths() {
     let output = format_results(
         &[result],
         &[(
-            vize_carton::String::from("Component.vue"),
-            vize_carton::String::from("abc"),
+            vize_s0::String::from("Component.vue"),
+            vize_s0::String::from("abc"),
         )],
         OutputFormat::Text,
     );
@@ -238,8 +238,8 @@ fn ansi_output_includes_summary_and_ansi_help() {
     let output = format_results(
         &[result],
         &[(
-            vize_carton::String::from("Component.vue"),
-            vize_carton::String::from("abc"),
+            vize_s0::String::from("Component.vue"),
+            vize_s0::String::from("abc"),
         )],
         OutputFormat::Ansi,
     );
@@ -263,8 +263,8 @@ fn plain_output_includes_reference_paths_without_ansi() {
     let output = format_results(
         &[result],
         &[(
-            vize_carton::String::from("Component.vue"),
-            vize_carton::String::from("abc"),
+            vize_s0::String::from("Component.vue"),
+            vize_s0::String::from("abc"),
         )],
         OutputFormat::Plain,
     );
@@ -295,8 +295,8 @@ fn markdown_output_keeps_help_and_reference_paths() {
     let output = format_results(
         &[result],
         &[(
-            vize_carton::String::from("Component.vue"),
-            vize_carton::String::from(""),
+            vize_s0::String::from("Component.vue"),
+            vize_s0::String::from(""),
         )],
         OutputFormat::Markdown,
     );
@@ -328,8 +328,8 @@ fn html_output_escapes_messages() {
     let output = format_results(
         &[result],
         &[(
-            vize_carton::String::from("Component.vue"),
-            vize_carton::String::from("<center>"),
+            vize_s0::String::from("Component.vue"),
+            vize_s0::String::from("<center>"),
         )],
         OutputFormat::Html,
     );
@@ -354,8 +354,8 @@ fn agent_output_is_line_oriented() {
     let output = format_results(
         &[result],
         &[(
-            vize_carton::String::from("Component.vue"),
-            vize_carton::String::from("abc"),
+            vize_s0::String::from("Component.vue"),
+            vize_s0::String::from("abc"),
         )],
         OutputFormat::Agent,
     );

--- a/crates/vize_patina/src/output/text.rs
+++ b/crates/vize_patina/src/output/text.rs
@@ -9,9 +9,9 @@ use oxc_diagnostics::{GraphicalReportHandler, GraphicalTheme, NamedSource, OxcDi
 use oxc_span::Span;
 #[allow(clippy::disallowed_types)] // Required by oxc_diagnostics API
 use std::sync::Arc;
-use vize_carton::FxHashMap;
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_s0::FxHashMap;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 /// Format lint results as rich terminal output
 #[allow(clippy::disallowed_types)] // Arc required by oxc_diagnostics API

--- a/crates/vize_patina/src/rules/a11y/helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/helpers.rs
@@ -3,8 +3,8 @@
 //! These helpers are extracted from common patterns used across a11y rules
 //! to avoid code duplication.
 
-use vize_carton::is_native_tag;
 use vize_relief::{ElementNode, ElementType, ExpressionNode, PropNode};
+use vize_s0::is_native_tag;
 
 /// Check if an element should be treated as a component or custom element.
 ///

--- a/crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs
+++ b/crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs
@@ -28,11 +28,11 @@
 use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::FxHashSet;
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_croquis::croquis::ElementIdKind;
 use vize_relief::RootNode;
+use vize_s0::FxHashSet;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/no-refer-to-non-existent-id",

--- a/crates/vize_patina/src/rules/css.rs
+++ b/crates/vize_patina/src/rules/css.rs
@@ -41,14 +41,14 @@ mod prefer_nested_selectors;
 mod prefer_slotted;
 mod require_font_display;
 
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use lightningcss::stylesheet::{ParserOptions, StyleSheet};
 use memchr::memmem;
 
 use crate::diagnostic::{LintDiagnostic, Severity};
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 pub use no_display_none::NoDisplayNone;
 pub use no_hardcoded_values::NoHardcodedValues;

--- a/crates/vize_patina/src/rules/css/prefer_logical_properties.rs
+++ b/crates/vize_patina/src/rules/css/prefer_logical_properties.rs
@@ -6,7 +6,7 @@ use lightningcss::declaration::DeclarationBlock;
 use lightningcss::properties::PropertyId;
 use lightningcss::rules::CssRule as LCssRule;
 use lightningcss::stylesheet::StyleSheet;
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use crate::diagnostic::{LintDiagnostic, Severity};
 

--- a/crates/vize_patina/src/rules/ecosystem/i18n_no_missing_key.rs
+++ b/crates/vize_patina/src/rules/ecosystem/i18n_no_missing_key.rs
@@ -12,7 +12,7 @@ use crate::rule::{Rule, RuleCategory, RuleMeta};
 use memchr::memmem;
 use serde_json::Value;
 use vize_atelier_sfc::{SfcCustomBlock, SfcParseOptions, parse_sfc};
-use vize_carton::{CompactString, FxHashSet, String};
+use vize_s0::{CompactString, FxHashSet, String};
 
 static META: RuleMeta = RuleMeta {
     name: "ecosystem/vue-i18n-no-missing-key",

--- a/crates/vize_patina/src/rules/html/id_duplication.rs
+++ b/crates/vize_patina/src/rules/html/id_duplication.rs
@@ -28,10 +28,10 @@
 use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::FxHashMap;
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_relief::{ElementNode, PropNode, RootNode, SourceLocation, TemplateChildNode};
+use vize_s0::FxHashMap;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "html/id-duplication",

--- a/crates/vize_patina/src/rules/html/no_duplicate_dt.rs
+++ b/crates/vize_patina/src/rules/html/no_duplicate_dt.rs
@@ -32,10 +32,10 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::FxHashMap;
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_relief::{ElementNode, ElementType, TemplateChildNode};
+use vize_s0::FxHashMap;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "html/no-duplicate-dt",

--- a/crates/vize_patina/src/rules/html/require_datetime.rs
+++ b/crates/vize_patina/src/rules/html/require_datetime.rs
@@ -28,7 +28,7 @@ use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::{ElementNode, PropNode, TemplateChildNode};
 
 use super::helpers::is_valid_datetime;
-use vize_carton::String;
+use vize_s0::String;
 
 static META: RuleMeta = RuleMeta {
     name: "html/require-datetime",

--- a/crates/vize_patina/src/rules/musea.rs
+++ b/crates/vize_patina/src/rules/musea.rs
@@ -28,7 +28,7 @@ pub use unique_variant_names::UniqueVariantNames;
 pub use valid_variant::ValidVariant;
 
 use memchr::memmem;
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use crate::diagnostic::{LintDiagnostic, Severity};
 

--- a/crates/vize_patina/src/rules/musea/prefer_design_tokens.rs
+++ b/crates/vize_patina/src/rules/musea/prefer_design_tokens.rs
@@ -23,12 +23,12 @@
 #![allow(clippy::disallowed_macros)]
 
 use memchr::memmem;
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 use super::{MuseaLintResult, MuseaRuleMeta};
 use crate::diagnostic::{Fix, LintDiagnostic, Severity, TextEdit};
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: MuseaRuleMeta = MuseaRuleMeta {
     name: "musea/prefer-design-tokens",

--- a/crates/vize_patina/src/rules/musea/unique_variant_names.rs
+++ b/crates/vize_patina/src/rules/musea/unique_variant_names.rs
@@ -2,7 +2,7 @@
 //!
 //! Require unique variant names within an art file.
 
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 use super::{MuseaLintResult, MuseaRule, MuseaRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};

--- a/crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs
+++ b/crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs
@@ -31,12 +31,12 @@ use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use crate::rules::a11y::helpers::get_static_or_bound_literal_attribute_value;
-use vize_carton::FxHashMap;
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_relief::{
     ElementNode, ElementType, ExpressionNode, PropNode, RootNode, TemplateChildNode,
 };
+use vize_s0::FxHashMap;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/landmark-roles",

--- a/crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs
+++ b/crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs
@@ -27,10 +27,10 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::FxHashMap;
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_relief::{ElementNode, ElementType, PropNode};
+use vize_s0::FxHashMap;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "html/no-dupe-style-properties",

--- a/crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs
+++ b/crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs
@@ -24,8 +24,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::FxHashSet;
 use vize_relief::{ElementNode, PropNode};
+use vize_s0::FxHashSet;
 
 static META: RuleMeta = RuleMeta {
     name: "html/no-duplicate-class",

--- a/crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs
+++ b/crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs
@@ -25,8 +25,8 @@ use crate::context::LintContext;
 use crate::diagnostic::{Fix, Severity, TextEdit};
 use crate::markup::{MarkupBinding, MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::String;
 use vize_relief::{DirectiveNode, ElementNode, ExpressionNode, PropNode};
+use vize_s0::String;
 
 static META: RuleMeta = RuleMeta {
     name: "vapor/prefer-static-class",

--- a/crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs
@@ -20,10 +20,10 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::{is_html_tag, is_svg_tag};
 use vize_croquis::builtins::is_builtin_component;
 use vize_croquis::naming::{is_kebab_case_loose, is_pascal_case};
 use vize_relief::ElementNode;
+use vize_s0::{is_html_tag, is_svg_tag};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/component-name-in-template-casing",

--- a/crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs
@@ -28,8 +28,8 @@ use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use crate::rules::html::helpers::BOOLEAN_ATTRIBUTES;
-use vize_carton::is_native_tag;
 use vize_relief::{ElementNode, PropNode};
+use vize_s0::is_native_tag;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-boolean-attr-value",

--- a/crates/vize_patina/src/rules/opinionated/vue/no_empty_component_block.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/no_empty_component_block.rs
@@ -37,7 +37,7 @@ use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-use vize_carton::profile;
+use vize_s0::profile;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-empty-component-block",

--- a/crates/vize_patina/src/rules/opinionated/vue/no_unused_refs.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/no_unused_refs.rs
@@ -54,8 +54,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::{CompactString, cstr};
 use vize_relief::{ElementNode, PropNode, RootNode, SourceLocation, TemplateChildNode};
+use vize_s0::{CompactString, cstr};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-unused-refs",

--- a/crates/vize_patina/src/rules/opinionated/vue/prefer_props_shorthand.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/prefer_props_shorthand.rs
@@ -100,7 +100,7 @@ mod tests {
     use super::PreferPropsShorthand;
     use crate::linter::Linter;
     use crate::rule::RuleRegistry;
-    use vize_carton::config::VueVersion;
+    use vize_s0::config::VueVersion;
 
     fn create_linter() -> Linter {
         let mut registry = RuleRegistry::new();
@@ -153,8 +153,8 @@ mod tests {
 
     #[test]
     fn test_camelize() {
-        // Test via vize_carton::camelize (used internally by names_match)
-        use vize_carton::camelize;
+        // Test via vize_s0::camelize (used internally by names_match)
+        use vize_s0::camelize;
         assert_eq!(camelize("user-name").as_str(), "userName");
         assert_eq!(camelize("foo-bar-baz").as_str(), "fooBarBaz");
         assert_eq!(camelize("simple").as_str(), "simple");

--- a/crates/vize_patina/src/rules/opinionated/vue/prefer_true_attribute_shorthand.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/prefer_true_attribute_shorthand.rs
@@ -23,8 +23,8 @@ use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use crate::rules::html::helpers::BOOLEAN_ATTRIBUTES;
-use vize_carton::is_native_tag;
 use vize_relief::{DirectiveNode, ElementNode, ExpressionNode};
+use vize_s0::is_native_tag;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/prefer-true-attribute-shorthand",

--- a/crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs
@@ -42,13 +42,13 @@
 use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_croquis::builtins::is_builtin_component;
 use vize_croquis::naming::{names_match, to_pascal_case};
 use vize_croquis::{Croquis, ScopeData};
 use vize_relief::BindingType;
 use vize_relief::{ElementNode, RootNode};
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/require-component-registration",

--- a/crates/vize_patina/src/rules/opinionated/vue/v_bind_style.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/v_bind_style.rs
@@ -24,9 +24,9 @@
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, LintDiagnostic, Severity, TextEdit};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_relief::{DirectiveNode, ElementNode};
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/v-bind-style",

--- a/crates/vize_patina/src/rules/opinionated/vue/v_on_event_hyphenation.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/v_on_event_hyphenation.rs
@@ -29,8 +29,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::hyphenate;
 use vize_relief::{DirectiveNode, ElementNode, ElementType, ExpressionNode};
+use vize_s0::hyphenate;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/v-on-event-hyphenation",

--- a/crates/vize_patina/src/rules/opinionated/vue/warn_custom_block.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/warn_custom_block.rs
@@ -45,7 +45,7 @@ use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-use vize_carton::profile;
+use vize_s0::profile;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/warn-custom-block",

--- a/crates/vize_patina/src/rules/petite_vue/no_unsupported_directive.rs
+++ b/crates/vize_patina/src/rules/petite_vue/no_unsupported_directive.rs
@@ -38,8 +38,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::{CompactString, ToCompactString};
 use vize_relief::{DirectiveNode, ElementNode};
+use vize_s0::{CompactString, ToCompactString};
 
 static META: RuleMeta = RuleMeta {
     name: "petite-vue/no-unsupported-directive",

--- a/crates/vize_patina/src/rules/script.rs
+++ b/crates/vize_patina/src/rules/script.rs
@@ -75,7 +75,7 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 
 use crate::diagnostic::{LintDiagnostic, Severity};
-use vize_carton::profile;
+use vize_s0::profile;
 
 pub use exports::*;
 pub use sfc_context::SfcScriptContext;

--- a/crates/vize_patina/src/rules/script/component_options_name_casing.rs
+++ b/crates/vize_patina/src/rules/script/component_options_name_casing.rs
@@ -39,7 +39,7 @@ use oxc_ast::ast::{
     Argument, BindingPattern, CallExpression, ExportDefaultDeclarationKind, Expression,
     ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement, StringLiteral,
 };
-use vize_carton::{CompactString, FxHashMap};
+use vize_s0::{CompactString, FxHashMap};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/component-options-name-casing",

--- a/crates/vize_patina/src/rules/script/custom_event_name_casing.rs
+++ b/crates/vize_patina/src/rules/script/custom_event_name_casing.rs
@@ -56,7 +56,7 @@ use oxc_ast::ast::{
     Argument, BindingPattern, CallExpression, Expression, Program, Statement, StringLiteral,
 };
 use oxc_ast_visit::{Visit, walk::walk_call_expression};
-use vize_carton::CompactString;
+use vize_s0::CompactString;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/custom-event-name-casing",

--- a/crates/vize_patina/src/rules/script/define_macros_order.rs
+++ b/crates/vize_patina/src/rules/script/define_macros_order.rs
@@ -41,7 +41,7 @@ use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
 use oxc_ast::ast::{Expression, Program, Statement};
 use oxc_span::{GetSpan, Span};
-use vize_carton::{CompactString, cstr};
+use vize_s0::{CompactString, cstr};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/define-macros-order",

--- a/crates/vize_patina/src/rules/script/no_arrow_functions_in_watch.rs
+++ b/crates/vize_patina/src/rules/script/no_arrow_functions_in_watch.rs
@@ -54,7 +54,7 @@ use oxc_ast::ast::{
     PropertyKey, Statement,
 };
 use oxc_span::Span;
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-arrow-functions-in-watch",

--- a/crates/vize_patina/src/rules/script/no_boolean_default.rs
+++ b/crates/vize_patina/src/rules/script/no_boolean_default.rs
@@ -49,7 +49,7 @@ use oxc_ast::ast::{
     ObjectExpression, ObjectProperty, ObjectPropertyKind, Program, PropertyKey, Statement,
 };
 use oxc_span::Span;
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-boolean-default",

--- a/crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration.rs
+++ b/crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration.rs
@@ -43,7 +43,7 @@ use oxc_ast::ast::{
     ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
 };
 use oxc_span::Span;
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-deprecated-data-object-declaration",

--- a/crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle.rs
+++ b/crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle.rs
@@ -11,8 +11,8 @@ use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{Fix, LintDiagnostic, Severity, TextEdit};
 use oxc_ast::ast::{ObjectProperty, ObjectPropertyKind, Program, PropertyKey};
 use oxc_span::GetSpan;
-use vize_carton::{CompactString, cstr};
 use vize_croquis::script_parser::collect_options_object;
+use vize_s0::{CompactString, cstr};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-deprecated-destroyed-lifecycle",

--- a/crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle/tests.rs
+++ b/crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle/tests.rs
@@ -4,7 +4,7 @@ use crate::rules::script::{ScriptLintResult, ScriptLinter, ScriptRule, script_so
 use crate::{Linter, builtin_script_rules};
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 fn lint(source: &str) -> ScriptLintResult {
     let mut linter = ScriptLinter::new();

--- a/crates/vize_patina/src/rules/script/no_deprecated_events_api.rs
+++ b/crates/vize_patina/src/rules/script/no_deprecated_events_api.rs
@@ -37,7 +37,7 @@ use crate::diagnostic::{LintDiagnostic, Severity};
 use oxc_ast::ast::{CallExpression, Expression, Program};
 use oxc_ast_visit::{Visit, walk::walk_call_expression};
 use oxc_span::{GetSpan, Span};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-deprecated-events-api",

--- a/crates/vize_patina/src/rules/script/no_deprecated_props_default_this.rs
+++ b/crates/vize_patina/src/rules/script/no_deprecated_props_default_this.rs
@@ -66,7 +66,7 @@ use oxc_ast::ast::{
 };
 use oxc_ast_visit::Visit;
 use oxc_span::Span;
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-deprecated-props-default-this",

--- a/crates/vize_patina/src/rules/script/no_dupe_keys.rs
+++ b/crates/vize_patina/src/rules/script/no_dupe_keys.rs
@@ -45,9 +45,9 @@
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
 use oxc_ast::ast::Program;
-use vize_carton::{CompactString, FxHashMap};
 use vize_croquis::OptionMember;
 use vize_croquis::script_parser::collect_options_descriptor;
+use vize_s0::{CompactString, FxHashMap};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-dupe-keys",

--- a/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/options.rs
+++ b/crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/options.rs
@@ -10,7 +10,7 @@ use oxc_ast::ast::{
     Argument, BindingPattern, BooleanLiteral, CallExpression, ExportDefaultDeclarationKind,
     Expression, ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
 };
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 /// An `inheritAttrs` property the script states.
 pub(super) enum InheritAttrs<'a> {

--- a/crates/vize_patina/src/rules/script/no_get_current_instance.rs
+++ b/crates/vize_patina/src/rules/script/no_get_current_instance.rs
@@ -33,7 +33,7 @@ use oxc_ast_visit::{
     walk::{walk_call_expression, walk_import_declaration},
 };
 use oxc_span::{GetSpan, Span};
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-get-current-instance",

--- a/crates/vize_patina/src/rules/script/no_next_tick.rs
+++ b/crates/vize_patina/src/rules/script/no_next_tick.rs
@@ -35,7 +35,7 @@ use oxc_ast_visit::{
     walk::{walk_call_expression, walk_import_declaration},
 };
 use oxc_span::{GetSpan, Span};
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-next-tick",

--- a/crates/vize_patina/src/rules/script/no_options_api.rs
+++ b/crates/vize_patina/src/rules/script/no_options_api.rs
@@ -37,8 +37,8 @@ use oxc_ast::ast::{
     ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
 };
 use oxc_span::GetSpan;
-use vize_carton::dialect::is_petite_vue_module;
-use vize_carton::{CompactString, FxHashMap, FxHashSet};
+use vize_s0::dialect::is_petite_vue_module;
+use vize_s0::{CompactString, FxHashMap, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-options-api",

--- a/crates/vize_patina/src/rules/script/no_page_meta_runtime_values.rs
+++ b/crates/vize_patina/src/rules/script/no_page_meta_runtime_values.rs
@@ -20,7 +20,7 @@ use oxc_ast_visit::{
 };
 use oxc_span::Span;
 use oxc_syntax::scope::ScopeFlags;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "nuxt/no-page-meta-runtime-values",
@@ -137,7 +137,7 @@ impl PageMetaVisitor<'_> {
         );
     }
 
-    fn report(&mut self, span: Span, message: impl Into<vize_carton::String>) {
+    fn report(&mut self, span: Span, message: impl Into<vize_s0::String>) {
         self.result.add_diagnostic(LintDiagnostic::error(
             META.name,
             message,

--- a/crates/vize_patina/src/rules/script/no_potential_component_option_typo.rs
+++ b/crates/vize_patina/src/rules/script/no_potential_component_option_typo.rs
@@ -13,8 +13,8 @@
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
-use vize_carton::CompactString;
 use vize_croquis::script_parser::collect_options_descriptor;
+use vize_s0::CompactString;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-potential-component-option-typo",

--- a/crates/vize_patina/src/rules/script/no_reactive_destructure.rs
+++ b/crates/vize_patina/src/rules/script/no_reactive_destructure.rs
@@ -39,7 +39,7 @@ use memchr::memmem;
 use crate::diagnostic::{LintDiagnostic, Severity};
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
-use vize_carton::String;
+use vize_s0::String;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-reactive-destructure",

--- a/crates/vize_patina/src/rules/script/no_ref_as_operand.rs
+++ b/crates/vize_patina/src/rules/script/no_ref_as_operand.rs
@@ -43,7 +43,7 @@ use oxc_ast_visit::{
 use oxc_span::Span;
 use oxc_syntax::operator::UnaryOperator;
 use oxc_syntax::scope::ScopeFlags;
-use vize_carton::{CompactString, FxHashMap};
+use vize_s0::{CompactString, FxHashMap};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-ref-as-operand",

--- a/crates/vize_patina/src/rules/script/no_reserved_keys.rs
+++ b/crates/vize_patina/src/rules/script/no_reserved_keys.rs
@@ -25,9 +25,9 @@
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
 use oxc_ast::ast::Program;
-use vize_carton::CompactString;
 use vize_croquis::OptionMember;
 use vize_croquis::script_parser::collect_options_descriptor;
+use vize_s0::CompactString;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-reserved-keys",

--- a/crates/vize_patina/src/rules/script/no_restricted_globals.rs
+++ b/crates/vize_patina/src/rules/script/no_restricted_globals.rs
@@ -52,7 +52,7 @@ use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
 use oxc_ast::ast::{IdentifierReference, Program};
 use oxc_ast_visit::Visit;
-use vize_carton::String;
+use vize_s0::String;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-restricted-globals",
@@ -174,7 +174,7 @@ impl RestrictedGlobals {
             .map(|(name, message)| {
                 let message = message
                     .map(Into::into)
-                    .unwrap_or_else(|| vize_carton::cstr!("Don't reference `{name}` directly."));
+                    .unwrap_or_else(|| vize_s0::cstr!("Don't reference `{name}` directly."));
                 RestrictedEntry { name, message }
             })
             .collect();
@@ -251,7 +251,7 @@ mod tests {
     use super::{NoRestrictedGlobals, RestrictedGlobals};
     use crate::diagnostic::Severity;
     use crate::rules::script::ScriptLinter;
-    use vize_carton::String;
+    use vize_s0::String;
 
     fn create_linter() -> ScriptLinter {
         let mut linter = ScriptLinter::new();

--- a/crates/vize_patina/src/rules/script/no_restricted_members.rs
+++ b/crates/vize_patina/src/rules/script/no_restricted_members.rs
@@ -48,7 +48,7 @@ use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
 use oxc_ast::ast::{Expression, Program, StaticMemberExpression};
 use oxc_ast_visit::{Visit, walk::walk_static_member_expression};
-use vize_carton::String;
+use vize_s0::String;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-restricted-members",
@@ -91,7 +91,7 @@ impl NoRestrictedMembers {
             .into_iter()
             .map(|(object, property, message)| {
                 let message = message.map(Into::into).unwrap_or_else(|| {
-                    vize_carton::cstr!("Don't access `{object}.{property}` directly.")
+                    vize_s0::cstr!("Don't access `{object}.{property}` directly.")
                 });
                 RestrictedEntry {
                     object,
@@ -187,7 +187,7 @@ mod tests {
     use super::NoRestrictedMembers;
     use crate::diagnostic::Severity;
     use crate::rules::script::ScriptLinter;
-    use vize_carton::String;
+    use vize_s0::String;
 
     fn configured_linter(entries: Vec<(&str, &str, Option<&str>)>) -> ScriptLinter {
         let mut linter = ScriptLinter::new();

--- a/crates/vize_patina/src/rules/script/no_side_effects_in_computed.rs
+++ b/crates/vize_patina/src/rules/script/no_side_effects_in_computed.rs
@@ -65,7 +65,7 @@ use oxc_ast_visit::{
     walk::{walk_assignment_expression, walk_call_expression, walk_update_expression},
 };
 use oxc_span::Span;
-use vize_carton::{CompactString, FxHashMap};
+use vize_s0::{CompactString, FxHashMap};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-side-effects-in-computed-properties",

--- a/crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs
+++ b/crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs
@@ -36,7 +36,7 @@ use crate::diagnostic::{LintDiagnostic, Severity};
 use oxc_ast::ast::{CallExpression, Expression, Program};
 use oxc_ast_visit::{Visit, walk::walk_call_expression};
 use oxc_span::Span;
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 use self::computed_names::{collect_computed_names, find_component_options};
 

--- a/crates/vize_patina/src/rules/script/no_use_computed_property_like_method/computed_names.rs
+++ b/crates/vize_patina/src/rules/script/no_use_computed_property_like_method/computed_names.rs
@@ -8,7 +8,7 @@ use oxc_ast::ast::{
     Argument, BindingPattern, CallExpression, ExportDefaultDeclarationKind, Expression,
     ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
 };
-use vize_carton::{CompactString, FxHashMap, FxHashSet};
+use vize_s0::{CompactString, FxHashMap, FxHashSet};
 
 /// Collect the names declared in the `computed` option. Only plain
 /// (non-computed-key) properties contribute; spreads like `...mapGetters([..])`

--- a/crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs
+++ b/crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs
@@ -12,7 +12,7 @@ use oxc_ast::ast::{
     Program, PropertyKey, Statement,
 };
 use oxc_span::GetSpan;
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 mod support;
 use support::{

--- a/crates/vize_patina/src/rules/script/nuxt_config_keys_order/support.rs
+++ b/crates/vize_patina/src/rules/script/nuxt_config_keys_order/support.rs
@@ -2,7 +2,7 @@ use std::cmp::Ordering;
 
 use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, PropertyKey};
 use oxc_span::{GetSpan, Span};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 // Exact @nuxt/eslint-plugin 1.16.0 order. The differential corpus reverses
 // every entry, making this complete list an executable upstream pin.

--- a/crates/vize_patina/src/rules/script/nuxt_config_keys_order/tests.rs
+++ b/crates/vize_patina/src/rules/script/nuxt_config_keys_order/tests.rs
@@ -2,7 +2,7 @@ use super::{META, NuxtConfigKeysOrder};
 use crate::diagnostic::Severity;
 use crate::rules::script::{ScriptLintResult, ScriptLinter, ScriptRule};
 use serde_json::Value;
-use vize_carton::{String, ToCompactString, cstr};
+use vize_s0::{String, ToCompactString, cstr};
 
 const CORPUS: &str = include_str!(
     "../../../../../../npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/fixtures/corpus.json"

--- a/crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs
+++ b/crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs
@@ -15,7 +15,7 @@ use oxc_ast::ast::{
 };
 use oxc_ast_visit::{Visit, walk::walk_variable_declarator};
 use oxc_span::{GetSpan, Span};
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "ecosystem/pinia-prefer-store-to-refs",

--- a/crates/vize_patina/src/rules/script/prefer_computed.rs
+++ b/crates/vize_patina/src/rules/script/prefer_computed.rs
@@ -36,7 +36,7 @@ use oxc_ast_visit::{
 };
 use oxc_span::Span;
 use oxc_syntax::operator::AssignmentOperator;
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 use crate::diagnostic::{LintDiagnostic, Severity};
 

--- a/crates/vize_patina/src/rules/script/prefer_import_from_vue.rs
+++ b/crates/vize_patina/src/rules/script/prefer_import_from_vue.rs
@@ -28,7 +28,7 @@ use oxc_span::GetSpan;
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{Fix, LintDiagnostic, Severity, TextEdit};
-use vize_carton::String;
+use vize_s0::String;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/prefer-import-from-vue",

--- a/crates/vize_patina/src/rules/script/prefer_import_meta.rs
+++ b/crates/vize_patina/src/rules/script/prefer_import_meta.rs
@@ -13,7 +13,7 @@ use oxc_ast_visit::{
     walk::{walk_computed_member_expression, walk_static_member_expression},
 };
 use oxc_span::Span;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "nuxt/prefer-import-meta",

--- a/crates/vize_patina/src/rules/script/prefer_import_meta/tests.rs
+++ b/crates/vize_patina/src/rules/script/prefer_import_meta/tests.rs
@@ -2,7 +2,7 @@ use super::{META, PreferImportMeta};
 use crate::diagnostic::Severity;
 use crate::rules::script::{ScriptLintResult, ScriptLinter, ScriptRule};
 use serde_json::Value;
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 const CORPUS: &str = include_str!(
     "../../../../../../npm/framework/nuxt-lint-config/test/nuxt-eslint-compat/fixtures/corpus.json"

--- a/crates/vize_patina/src/rules/script/prefer_use_template_ref.rs
+++ b/crates/vize_patina/src/rules/script/prefer_use_template_ref.rs
@@ -62,7 +62,7 @@ use oxc_ast::ast::{
 };
 use oxc_ast_visit::{Visit, walk::walk_object_property};
 use oxc_span::Span;
-use vize_carton::{CompactString, cstr};
+use vize_s0::{CompactString, cstr};
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta, SfcScriptContext};
 use crate::diagnostic::{LintDiagnostic, Severity};

--- a/crates/vize_patina/src/rules/script/prefer_use_template_ref/template_refs.rs
+++ b/crates/vize_patina/src/rules/script/prefer_use_template_ref/template_refs.rs
@@ -16,7 +16,7 @@
 //! Only *static* `ref` attributes are collected. `:ref` / `v-bind:ref` bind an
 //! expression rather than a name, and upstream skips them for the same reason.
 
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 /// Collect the value of every static `ref="name"` attribute in `template`.
 pub(super) fn collect_template_ref_names(template: &str) -> FxHashSet<CompactString> {

--- a/crates/vize_patina/src/rules/script/props_emits/emits_source.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/emits_source.rs
@@ -12,7 +12,7 @@ use oxc_ast::ast::{
     Expression, ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
 };
 
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 /// The Options API `emits` option in either declared runtime form. The type
 /// (`defineEmits<...>`) and bare-identifier forms are not represented here.

--- a/crates/vize_patina/src/rules/script/props_emits/no_required_prop_with_default.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/no_required_prop_with_default.rs
@@ -17,7 +17,7 @@ use oxc_ast::ast::{
 };
 use oxc_span::GetSpan;
 
-use vize_carton::{CompactString, FxHashMap};
+use vize_s0::{CompactString, FxHashMap};
 
 use super::super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};

--- a/crates/vize_patina/src/rules/script/props_emits/no_reserved_props.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/no_reserved_props.rs
@@ -44,7 +44,7 @@
 use oxc_ast::ast::Program;
 use oxc_span::GetSpan;
 
-use vize_carton::CompactString;
+use vize_s0::CompactString;
 
 use super::super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use super::props_source::collect_runtime_props;

--- a/crates/vize_patina/src/rules/script/props_emits/no_unused_emit_declarations.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/no_unused_emit_declarations.rs
@@ -59,7 +59,7 @@ use oxc_ast::ast::{
 use oxc_ast_visit::{Visit, walk::walk_call_expression};
 use oxc_span::{GetSpan, Span};
 
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 use super::super::{ScriptLintResult, ScriptRule, ScriptRuleMeta, SfcScriptContext};
 use super::template_emits::collect_template_emitted_events;

--- a/crates/vize_patina/src/rules/script/props_emits/props_source.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/props_source.rs
@@ -23,7 +23,7 @@ use oxc_ast::ast::{
     ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement, StringLiteral,
 };
 
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 /// A single object-form prop entry: its name, the key node (for span
 /// reporting), and its value (a type shorthand or a descriptor object).

--- a/crates/vize_patina/src/rules/script/props_emits/require_default_prop.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_default_prop.rs
@@ -49,7 +49,7 @@
 use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, Program, PropertyKey};
 use oxc_span::GetSpan;
 
-use vize_carton::CompactString;
+use vize_s0::CompactString;
 
 use super::super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use super::props_source::{PropDescriptor, collect_runtime_props};

--- a/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs
@@ -51,7 +51,7 @@ use oxc_ast::ast::{Argument, CallExpression, Expression, Program};
 use oxc_ast_visit::{Visit, walk::walk_call_expression};
 use oxc_span::Span;
 
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 use self::declared::{Declared, resolve_declared_emits};
 use super::super::template_scan::{DOLLAR_EMIT, for_each_template_call};

--- a/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/declared.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/declared.rs
@@ -11,7 +11,7 @@ use oxc_ast::ast::{
     TSCallSignatureDeclaration, TSLiteral, TSSignature, TSType,
 };
 
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 use super::super::emits_source::{EmitsDeclaration, resolve_emits_declaration};
 

--- a/crates/vize_patina/src/rules/script/props_emits/require_prop_types.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_prop_types.rs
@@ -49,7 +49,7 @@
 use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, Program, PropertyKey};
 use oxc_span::GetSpan;
 
-use vize_carton::CompactString;
+use vize_s0::CompactString;
 
 use super::super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use super::props_source::{PropDescriptor, collect_runtime_props};

--- a/crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop.rs
@@ -54,7 +54,7 @@
 use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, Program, PropertyKey};
 use oxc_span::GetSpan;
 
-use vize_carton::CompactString;
+use vize_s0::CompactString;
 
 use super::super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use super::props_source::{PropDescriptor, collect_runtime_props};

--- a/crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop.rs
@@ -59,7 +59,7 @@
 use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, Program, PropertyKey};
 use oxc_span::GetSpan;
 
-use vize_carton::CompactString;
+use vize_s0::CompactString;
 
 use super::super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use super::props_source::{PropDescriptor, collect_runtime_props};

--- a/crates/vize_patina/src/rules/script/props_emits/template_emits.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/template_emits.rs
@@ -18,7 +18,7 @@
 //! which dispatches the same declared events. Dynamic event names
 //! (`emit(name)`) record nothing, matching the script-side treatment.
 
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 /// Record into `used` every event name emitted from `template` through a call
 /// of `binding` (the captured `defineEmits` function, template-visible as a

--- a/crates/vize_patina/src/rules/script/require_explicit_slots.rs
+++ b/crates/vize_patina/src/rules/script/require_explicit_slots.rs
@@ -81,7 +81,7 @@ mod tests;
 
 use oxc_ast::ast::Program;
 use oxc_span::Span;
-use vize_carton::CompactString;
+use vize_s0::CompactString;
 
 use crate::diagnostic::{LintDiagnostic, Severity};
 
@@ -169,7 +169,7 @@ fn report_missing_declaration(slots: &ScriptSlots, offset: usize, result: &mut S
 
 /// The template half: every rendered `<slot>` must be in the declared set.
 fn check_template(
-    declared: &vize_carton::FxHashSet<CompactString>,
+    declared: &vize_s0::FxHashSet<CompactString>,
     sfc: SfcScriptContext<'_>,
     result: &mut ScriptLintResult,
 ) {

--- a/crates/vize_patina/src/rules/script/require_explicit_slots/declared.rs
+++ b/crates/vize_patina/src/rules/script/require_explicit_slots/declared.rs
@@ -6,7 +6,7 @@ use oxc_ast_visit::{
     walk::{walk_call_expression, walk_ts_type},
 };
 use oxc_span::Span;
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 /// The slot contract the script states.
 pub(super) enum DeclaredSlots {

--- a/crates/vize_patina/src/rules/script/require_explicit_slots/template.rs
+++ b/crates/vize_patina/src/rules/script/require_explicit_slots/template.rs
@@ -28,10 +28,10 @@
 //!   not read, or one reached only through a dynamic name, is simply not
 //!   checked.
 
-use vize_carton::CompactString;
 use vize_relief::{
     ElementNode, ElementType, ExpressionNode, PropNode, RootNode, TemplateChildNode,
 };
+use vize_s0::CompactString;
 
 /// A `<slot>` outlet and the start-tag range to report it at, relative to the
 /// template block.

--- a/crates/vize_patina/src/rules/script/require_function_return_type.rs
+++ b/crates/vize_patina/src/rules/script/require_function_return_type.rs
@@ -42,8 +42,8 @@ use memchr::memmem;
 use crate::diagnostic::{LintDiagnostic, Severity};
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/require-function-return-type",

--- a/crates/vize_patina/src/rules/script/require_prop_type_constructor.rs
+++ b/crates/vize_patina/src/rules/script/require_prop_type_constructor.rs
@@ -54,7 +54,7 @@ use oxc_ast::ast::{
     Argument, BindingPattern, CallExpression, ExportDefaultDeclarationKind, Expression,
     ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement, StringLiteral,
 };
-use vize_carton::{CompactString, FxHashMap};
+use vize_s0::{CompactString, FxHashMap};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/require-prop-type-constructor",

--- a/crates/vize_patina/src/rules/script/require_typed_ref.rs
+++ b/crates/vize_patina/src/rules/script/require_typed_ref.rs
@@ -47,7 +47,7 @@ use oxc_ast_visit::{
     Visit,
     walk::{walk_call_expression, walk_import_declaration},
 };
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/require-typed-ref",

--- a/crates/vize_patina/src/rules/script/template_scan.rs
+++ b/crates/vize_patina/src/rules/script/template_scan.rs
@@ -38,10 +38,10 @@
 
 mod calls;
 
-use vize_carton::String;
 use vize_relief::{
     DirectiveNode, ElementNode, ExpressionNode, PropNode, RootNode, TemplateChildNode,
 };
+use vize_s0::String;
 
 pub(super) use calls::TemplateCall;
 

--- a/crates/vize_patina/src/rules/script/valid_define_emits.rs
+++ b/crates/vize_patina/src/rules/script/valid_define_emits.rs
@@ -40,7 +40,7 @@ use oxc_ast::ast::{
 };
 use oxc_ast_visit::{Visit, walk::walk_call_expression};
 use oxc_span::Span;
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/valid-define-emits",

--- a/crates/vize_patina/src/rules/script/valid_define_options.rs
+++ b/crates/vize_patina/src/rules/script/valid_define_options.rs
@@ -36,7 +36,7 @@ use oxc_ast::ast::{
 };
 use oxc_ast_visit::{Visit, walk::walk_call_expression};
 use oxc_span::{GetSpan, Span};
-use vize_carton::CompactString;
+use vize_s0::CompactString;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/valid-define-options",

--- a/crates/vize_patina/src/rules/script/valid_define_props.rs
+++ b/crates/vize_patina/src/rules/script/valid_define_props.rs
@@ -39,7 +39,7 @@ use oxc_ast::ast::{
 };
 use oxc_ast_visit::{Visit, walk::walk_call_expression};
 use oxc_span::{GetSpan, Span};
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/valid-define-props",

--- a/crates/vize_patina/src/rules/script/valid_next_tick.rs
+++ b/crates/vize_patina/src/rules/script/valid_next_tick.rs
@@ -48,7 +48,7 @@ use oxc_ast_visit::{
     walk::{walk_import_declaration, walk_statement},
 };
 use oxc_span::Span;
-use vize_carton::{CompactString, FxHashSet};
+use vize_s0::{CompactString, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/valid-next-tick",

--- a/crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs
+++ b/crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs
@@ -478,7 +478,7 @@ mod tests {
     use crate::Linter;
     use crate::context::{LintContext, SsrMode};
     use crate::rule::{Rule, RuleRegistry};
-    use vize_carton::CompactString;
+    use vize_s0::CompactString;
 
     fn lint_with_ssr(source: &str) -> Vec<CompactString> {
         let mut registry = RuleRegistry::new();
@@ -486,7 +486,7 @@ mod tests {
         let _linter = Linter::with_registry(registry);
 
         // Create allocator and context
-        use vize_carton::Allocator;
+        use vize_s0::Allocator;
         let allocator = Allocator::with_capacity(1024);
         let mut ctx = LintContext::with_locale(
             &allocator,

--- a/crates/vize_patina/src/rules/url.rs
+++ b/crates/vize_patina/src/rules/url.rs
@@ -1,4 +1,4 @@
-use vize_carton::String;
+use vize_s0::String;
 
 pub(crate) fn normalized_scheme(value: &str) -> Option<(String, &str)> {
     let mut scheme = String::default();

--- a/crates/vize_patina/src/rules/vue/attribute_hyphenation.rs
+++ b/crates/vize_patina/src/rules/vue/attribute_hyphenation.rs
@@ -19,10 +19,10 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_croquis::naming::is_camel_case;
 use vize_relief::{ElementNode, PropNode};
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/attribute-hyphenation",

--- a/crates/vize_patina/src/rules/vue/html_quotes.rs
+++ b/crates/vize_patina/src/rules/vue/html_quotes.rs
@@ -43,8 +43,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, LintDiagnostic, Severity, TextEdit};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::cstr;
 use vize_relief::{ElementNode, PropNode};
+use vize_s0::cstr;
 
 mod value_range;
 

--- a/crates/vize_patina/src/rules/vue/no_deprecated_filter.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_filter.rs
@@ -39,8 +39,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::dialect::VueDialect;
 use vize_relief::{DirectiveNode, ElementNode, ExpressionNode, InterpolationNode};
+use vize_s0::dialect::VueDialect;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-deprecated-filter",

--- a/crates/vize_patina/src/rules/vue/no_deprecated_functional_template.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_functional_template.rs
@@ -51,8 +51,8 @@ use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-use vize_carton::dialect::VueDialect;
-use vize_carton::profile;
+use vize_s0::dialect::VueDialect;
+use vize_s0::profile;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-deprecated-functional-template",

--- a/crates/vize_patina/src/rules/vue/no_deprecated_html_element_is.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_html_element_is.rs
@@ -33,8 +33,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::dialect::VueDialect;
 use vize_relief::{ElementNode, ElementType, PropNode};
+use vize_s0::dialect::VueDialect;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-deprecated-html-element-is",

--- a/crates/vize_patina/src/rules/vue/no_deprecated_router_link_tag_prop.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_router_link_tag_prop.rs
@@ -31,8 +31,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::dialect::VueDialect;
 use vize_relief::{ElementNode, ExpressionNode, PropNode};
+use vize_s0::dialect::VueDialect;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-deprecated-router-link-tag-prop",

--- a/crates/vize_patina/src/rules/vue/no_deprecated_scope_attribute.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_scope_attribute.rs
@@ -32,8 +32,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::dialect::VueDialect;
 use vize_relief::{ElementNode, PropNode};
+use vize_s0::dialect::VueDialect;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-deprecated-scope-attribute",

--- a/crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs
@@ -32,8 +32,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::dialect::VueDialect;
 use vize_relief::{ElementNode, PropNode};
+use vize_s0::dialect::VueDialect;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-deprecated-slot-attribute",
@@ -78,7 +78,7 @@ mod tests {
     use crate::linter::Linter;
     use crate::preset::LintPreset;
     use crate::rule::RuleRegistry;
-    use vize_carton::config::VueVersion;
+    use vize_s0::config::VueVersion;
 
     const RULE: &str = "vue/no-deprecated-slot-attribute";
 

--- a/crates/vize_patina/src/rules/vue/no_deprecated_slot_scope_attribute.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_slot_scope_attribute.rs
@@ -27,8 +27,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::dialect::VueDialect;
 use vize_relief::{ElementNode, PropNode};
+use vize_s0::dialect::VueDialect;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-deprecated-slot-scope-attribute",

--- a/crates/vize_patina/src/rules/vue/no_deprecated_v_bind_sync.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_v_bind_sync.rs
@@ -36,8 +36,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::dialect::VueDialect;
 use vize_relief::{DirectiveNode, ElementNode};
+use vize_s0::dialect::VueDialect;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-deprecated-v-bind-sync",

--- a/crates/vize_patina/src/rules/vue/no_deprecated_v_on_native_modifier.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_v_on_native_modifier.rs
@@ -37,8 +37,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::dialect::VueDialect;
 use vize_relief::{DirectiveNode, ElementNode};
+use vize_s0::dialect::VueDialect;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-deprecated-v-on-native-modifier",

--- a/crates/vize_patina/src/rules/vue/no_deprecated_v_on_number_modifiers.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_v_on_number_modifiers.rs
@@ -37,8 +37,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::dialect::VueDialect;
 use vize_relief::{DirectiveNode, ElementNode};
+use vize_s0::dialect::VueDialect;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-deprecated-v-on-number-modifiers",

--- a/crates/vize_patina/src/rules/vue/no_dupe_v_else_if.rs
+++ b/crates/vize_patina/src/rules/vue/no_dupe_v_else_if.rs
@@ -24,12 +24,12 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::FxHashSet;
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_relief::{
     ElementNode, ExpressionNode, PropNode, RootNode, SourceLocation, TemplateChildNode,
 };
+use vize_s0::FxHashSet;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-dupe-v-else-if",

--- a/crates/vize_patina/src/rules/vue/no_duplicate_attributes.rs
+++ b/crates/vize_patina/src/rules/vue/no_duplicate_attributes.rs
@@ -21,10 +21,10 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::FxHashSet;
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_relief::{ElementNode, PropNode};
+use vize_s0::FxHashSet;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-duplicate-attributes",

--- a/crates/vize_patina/src/rules/vue/no_multiple_template_root.rs
+++ b/crates/vize_patina/src/rules/vue/no_multiple_template_root.rs
@@ -20,8 +20,8 @@ mod tests;
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::ensure_sufficient_stack;
 use vize_relief::{ElementNode, PropNode, RootNode, SourceLocation, TemplateChildNode};
+use vize_s0::ensure_sufficient_stack;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-multiple-template-root",

--- a/crates/vize_patina/src/rules/vue/no_multiple_template_root/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_multiple_template_root/tests.rs
@@ -10,7 +10,7 @@ use super::NoMultipleTemplateRoot;
 use crate::linter::{LintResult, Linter};
 use crate::preset::LintPreset;
 use crate::rule::RuleRegistry;
-use vize_carton::String;
+use vize_s0::String;
 
 const RULE: &str = "vue/no-multiple-template-root";
 const PARSER: &str = "parser/template";

--- a/crates/vize_patina/src/rules/vue/no_mutating_props.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props.rs
@@ -59,12 +59,12 @@ use self::scope::{PropScope, expression_source, push_for_aliases, push_identifie
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::FxHashSet;
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_croquis::reactivity::ReactiveKind;
 use vize_relief::BindingType;
 use vize_relief::{DirectiveNode, ElementNode, ForNode, PropNode, RootNode, TemplateChildNode};
+use vize_s0::FxHashSet;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-mutating-props",

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/mutation_targets.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/mutation_targets.rs
@@ -4,7 +4,7 @@
 //! `user.name`, `count`), never a whole expression, so matching a prefix here
 //! cannot pick up an unrelated occurrence elsewhere in the expression.
 
-use vize_carton::FxHashSet;
+use vize_s0::FxHashSet;
 
 pub(super) fn is_prop_mutation_target(
     content: &str,
@@ -92,7 +92,7 @@ fn identifier_root(source: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::is_prop_mutation_target;
-    use vize_carton::FxHashSet;
+    use vize_s0::FxHashSet;
 
     #[test]
     fn prop_mutation_target_matches_member_roots() {

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/scope.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/scope.rs
@@ -1,7 +1,7 @@
 //! Prop-name scope for the template walk of `vue/no-mutating-props`.
 
-use vize_carton::{FxHashSet, String};
 use vize_relief::{DirectiveNode, ExpressionNode};
+use vize_s0::{FxHashSet, String};
 
 use super::mutation_targets::is_prop_mutation_target;
 

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs
@@ -19,7 +19,7 @@ use oxc_parser::Parser;
 use oxc_semantic::{Scoping, SemanticBuilder};
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::symbol::SymbolId;
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 pub(super) struct ScriptPropMutation {
     pub(super) target: String,

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/tests/script_mutations.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/tests/script_mutations.rs
@@ -1,6 +1,6 @@
 use super::{findings, lint_sfc};
 use crate::{LintPreset, Linter, Severity};
-use vize_carton::String;
+use vize_s0::String;
 
 fn expected_script_finding<'a>(
     sfc: &'a str,

--- a/crates/vize_patina/src/rules/vue/no_reserved_component_names.rs
+++ b/crates/vize_patina/src/rules/vue/no_reserved_component_names.rs
@@ -36,9 +36,9 @@ use crate::rules::script::script_source_type;
 use oxc_allocator::Allocator as OxcAllocator;
 use oxc_ast::ast::StringLiteral;
 use oxc_parser::Parser;
-use vize_carton::String;
-use vize_carton::is_html_tag;
 use vize_croquis::builtins::is_builtin_component;
+use vize_s0::String;
+use vize_s0::is_html_tag;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-reserved-component-names",

--- a/crates/vize_patina/src/rules/vue/no_reserved_component_names/extract.rs
+++ b/crates/vize_patina/src/rules/vue/no_reserved_component_names/extract.rs
@@ -8,7 +8,7 @@ use oxc_ast::ast::{
     Argument, BindingPattern, CallExpression, ExportDefaultDeclarationKind, Expression,
     ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement, StringLiteral,
 };
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 pub(super) fn name_string_literal<'a>(
     options: &'a ObjectExpression<'a>,

--- a/crates/vize_patina/src/rules/vue/no_template_key.rs
+++ b/crates/vize_patina/src/rules/vue/no_template_key.rs
@@ -24,9 +24,9 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_relief::{ElementNode, PropNode};
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-template-key",

--- a/crates/vize_patina/src/rules/vue/no_undefined_refs.rs
+++ b/crates/vize_patina/src/rules/vue/no_undefined_refs.rs
@@ -5,8 +5,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::cstr;
 use vize_relief::RootNode;
+use vize_s0::cstr;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-undefined-refs",

--- a/crates/vize_patina/src/rules/vue/no_unused_components.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_components.rs
@@ -41,11 +41,11 @@ use oxc_ast::ast::{IdentifierReference, ImportDeclaration, ImportDeclarationSpec
 use oxc_ast_visit::{Visit, walk::walk_ts_type};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{CompactString, FxHashSet, String, ToCompactString};
 use vize_croquis::naming::{is_pascal_case, to_pascal_case};
 use vize_croquis::{Croquis, ScopeData};
 use vize_relief::BindingType;
 use vize_relief::RootNode;
+use vize_s0::{CompactString, FxHashSet, String, ToCompactString};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-unused-components",

--- a/crates/vize_patina/src/rules/vue/no_unused_properties.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties.rs
@@ -81,10 +81,10 @@ mod usage;
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::String;
-use vize_carton::ToCompactString;
-use vize_carton::{CompactString, FxHashSet};
 use vize_relief::RootNode;
+use vize_s0::String;
+use vize_s0::ToCompactString;
+use vize_s0::{CompactString, FxHashSet};
 
 use self::usage::{
     PropsAccess, classify_props_access, push_identifier_tokens, template_references,
@@ -201,7 +201,7 @@ impl Rule for NoUnusedProperties {
                 .macros
                 .models()
                 .iter()
-                .map(|model| vize_carton::get_modifier_prop_name(model.name.as_str()))
+                .map(|model| vize_s0::get_modifier_prop_name(model.name.as_str()))
                 .collect();
 
             let destructured = analysis.macros.props_destructure();

--- a/crates/vize_patina/src/rules/vue/no_unused_properties/usage.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties/usage.rs
@@ -26,8 +26,8 @@
 //! compile is scanned — a directive's expression *and* its argument, an
 //! interpolation's content, and a `v-for`'s source and aliases.
 
-use vize_carton::{CompactString, FxHashSet};
 use vize_relief::{ExpressionNode, PropNode, RootNode, TemplateChildNode};
+use vize_s0::{CompactString, FxHashSet};
 
 /// How the `defineProps(...)` return value is consumed.
 pub(super) enum PropsAccess {

--- a/crates/vize_patina/src/rules/vue/no_unused_vars.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_vars.rs
@@ -41,10 +41,10 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_croquis::UnusedVarContext;
 use vize_relief::RootNode;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-unused-vars",

--- a/crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for.rs
+++ b/crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for.rs
@@ -12,8 +12,8 @@ mod tests;
 use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::ensure_sufficient_stack;
 use vize_relief::{ElementNode, PropNode, SourceLocation, TemplateChildNode};
+use vize_s0::ensure_sufficient_stack;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-use-v-else-with-v-for",

--- a/crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for/tests.rs
@@ -6,8 +6,8 @@ use crate::diagnostic::Severity;
 use crate::linter::Linter;
 use crate::preset::LintPreset;
 use crate::rule::{Rule, RuleRegistry};
-use vize_carton::String;
-use vize_carton::i18n::Translator;
+use vize_s0::String;
+use vize_s0::i18n::Translator;
 
 const RULE: &str = "vue/no-use-v-else-with-v-for";
 const ELSE_MESSAGE: &str = "Unexpected `v-else` and `v-for` on the same element. Move `v-else` to a wrapper element instead.";

--- a/crates/vize_patina/src/rules/vue/no_use_v_if_with_v_for.rs
+++ b/crates/vize_patina/src/rules/vue/no_use_v_if_with_v_for.rs
@@ -28,9 +28,9 @@ use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use crate::visitor::parse_v_for_variables;
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_relief::{ElementNode, ExpressionNode, PropNode};
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-use-v-if-with-v-for",

--- a/crates/vize_patina/src/rules/vue/no_useless_template_attributes.rs
+++ b/crates/vize_patina/src/rules/vue/no_useless_template_attributes.rs
@@ -27,8 +27,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::ToCompactString;
 use vize_relief::{ElementNode, PropNode};
+use vize_s0::ToCompactString;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-useless-template-attributes",

--- a/crates/vize_patina/src/rules/vue/no_v_for_template_key_on_child.rs
+++ b/crates/vize_patina/src/rules/vue/no_v_for_template_key_on_child.rs
@@ -112,7 +112,7 @@ mod tests {
     use super::NoVForTemplateKeyOnChild;
     use crate::linter::Linter;
     use crate::rule::RuleRegistry;
-    use vize_carton::config::VueVersion;
+    use vize_s0::config::VueVersion;
 
     fn create_linter() -> Linter {
         let mut registry = RuleRegistry::new();

--- a/crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs
+++ b/crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs
@@ -24,8 +24,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::{is_html_tag, is_native_tag};
 use vize_relief::{DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode};
+use vize_s0::{is_html_tag, is_native_tag};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-v-text-v-html-on-component",

--- a/crates/vize_patina/src/rules/vue/permitted_contents.rs
+++ b/crates/vize_patina/src/rules/vue/permitted_contents.rs
@@ -30,8 +30,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::is_html_tag;
 use vize_relief::{ElementNode, ElementType};
+use vize_s0::is_html_tag;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/permitted-contents",

--- a/crates/vize_patina/src/rules/vue/prop_name_casing/declarations.rs
+++ b/crates/vize_patina/src/rules/vue/prop_name_casing/declarations.rs
@@ -10,7 +10,7 @@ use crate::context::LintContext;
 
 /// A declared prop and where it is written.
 pub(super) struct Declaration {
-    pub(super) name: vize_carton::CompactString,
+    pub(super) name: vize_s0::CompactString,
     pub(super) start: u32,
     pub(super) end: u32,
 }

--- a/crates/vize_patina/src/rules/vue/require_scoped_style.rs
+++ b/crates/vize_patina/src/rules/vue/require_scoped_style.rs
@@ -44,7 +44,7 @@ use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-use vize_carton::profile;
+use vize_s0::profile;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/require-scoped-style",

--- a/crates/vize_patina/src/rules/vue/sfc_element_order.rs
+++ b/crates/vize_patina/src/rules/vue/sfc_element_order.rs
@@ -38,7 +38,7 @@ use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_atelier_sfc::{BlockLocation, SfcParseOptions, parse_sfc};
-use vize_carton::profile;
+use vize_s0::profile;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/sfc-element-order",

--- a/crates/vize_patina/src/rules/vue/single_style_block.rs
+++ b/crates/vize_patina/src/rules/vue/single_style_block.rs
@@ -36,7 +36,7 @@ use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-use vize_carton::profile;
+use vize_s0::profile;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/single-style-block",

--- a/crates/vize_patina/src/rules/vue/v_on_style.rs
+++ b/crates/vize_patina/src/rules/vue/v_on_style.rs
@@ -22,8 +22,8 @@
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, LintDiagnostic, Severity, TextEdit};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::String;
 use vize_relief::{DirectiveNode, ElementNode};
+use vize_s0::String;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/v-on-style",

--- a/crates/vize_patina/src/rules/vue/valid_v_model.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_model.rs
@@ -30,8 +30,8 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::Expression as OxcExpression;
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
-use vize_carton::is_html_tag;
 use vize_relief::{DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode};
+use vize_s0::is_html_tag;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/valid-v-model",

--- a/crates/vize_patina/src/rules/vue/valid_v_slot.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_slot.rs
@@ -21,10 +21,10 @@
 use crate::context::{ElementContext, LintContext};
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::{FxHashSet, String, ToCompactString, is_native_tag};
 use vize_relief::{
     DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, TemplateChildNode,
 };
+use vize_s0::{FxHashSet, String, ToCompactString, is_native_tag};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/valid-v-slot",

--- a/crates/vize_patina/src/telegraph.rs
+++ b/crates/vize_patina/src/telegraph.rs
@@ -28,10 +28,10 @@
 use crate::diagnostic::{HelpRenderTarget, Severity, render_help};
 use crate::linter::LintResult;
 use crate::output::{OutputFormat, format_results};
-use vize_carton::String;
-use vize_carton::ToCompactString;
-pub use vize_carton::telegraph::Emitter;
-use vize_carton::telegraph::Telegraph as CartonTelegraph;
+use vize_s0::String;
+use vize_s0::ToCompactString;
+pub use vize_s0::telegraph::Emitter;
+use vize_s0::telegraph::Telegraph as CartonTelegraph;
 
 /// A Patina lint result and its source text as a Telegraph message.
 #[derive(Debug, Clone)]

--- a/crates/vize_patina/src/telegraph/tests.rs
+++ b/crates/vize_patina/src/telegraph/tests.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use crate::diagnostic::LintDiagnostic;
 use crate::output::OutputFormat;
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 #[test]
 fn test_telegraph_with_text() {

--- a/crates/vize_patina/src/visitor.rs
+++ b/crates/vize_patina/src/visitor.rs
@@ -4,11 +4,11 @@
 
 use crate::context::{ElementContext, LintContext};
 use crate::rule::Rule;
-use vize_carton::directive::{DirectiveKind, parse_level_severity, parse_vize_directive};
-use vize_carton::{CompactString, cstr, profile};
 use vize_relief::{
     CommentNode, ElementNode, PropNode, RootNode, SourceLocation, TemplateChildNode,
 };
+use vize_s0::directive::{DirectiveKind, parse_level_severity, parse_vize_directive};
+use vize_s0::{CompactString, cstr, profile};
 
 pub use crate::visitor_scope::{parse_slot_scope_variables, parse_v_for_variables};
 

--- a/crates/vize_patina/src/visitor_scope.rs
+++ b/crates/vize_patina/src/visitor_scope.rs
@@ -4,9 +4,9 @@
 //! introduce into the template scope, so downstream rules can distinguish
 //! template-local bindings from unresolved identifiers.
 
-use vize_carton::CompactString;
 use vize_croquis::drawer::{extract_slot_props, parse_v_for_expression};
 use vize_relief::ExpressionNode;
+use vize_s0::CompactString;
 
 /// Parse v-for expression to extract variable names.
 ///
@@ -43,11 +43,11 @@ pub fn parse_slot_scope_variables(exp: &ExpressionNode) -> Vec<CompactString> {
 #[cfg(test)]
 mod tests {
     use super::{CompactString, ExpressionNode, parse_slot_scope_variables, parse_v_for_variables};
-    use vize_carton::Allocator;
     use vize_relief::SimpleExpressionNode;
+    use vize_s0::Allocator;
 
     fn make_simple_exp<'a>(allocator: &'a Allocator, content: &'a str) -> ExpressionNode<'a> {
-        ExpressionNode::Simple(vize_carton::Box::new_in(
+        ExpressionNode::Simple(vize_s0::Box::new_in(
             SimpleExpressionNode::new(content, false, vize_relief::SourceLocation::STUB),
             &allocator,
         ))

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           916 |                   192 |               724 |             139 |     371 |             951 |      475 |           477 |           584 |
-| Linter                     |           302 |                    16 |               286 |             268 |     222 |             670 |      122 |           339 |           478 |
+| Linter                     |           302 |                   302 |                 0 |             268 |     222 |             670 |      122 |           339 |           478 |
 | Typechecker                |           887 |                   139 |               748 |             396 |     187 |             807 |      663 |           463 |           653 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            18 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -878,12 +878,12 @@ compiler	Compiler	source	crates/vize/src/commands/build/runner/output/plan.rs	3	
 compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/output/tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize/src/commands/build/runner/profile_facts.rs	6	s0	S0/carton	stage	vize_s0	preferred	3
 compiler	Compiler	source	crates/vize/src/commands/build/runner/settings.rs	5	s0	S0/carton	stage	vize_s0	preferred	3
-linter	Linter	test/dev	crates/vize_patina/benches/davinci_markup.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/benches/davinci_markup.rs	13	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
-linter	Linter	test/dev	crates/vize_patina/benches/lint_bench.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/benches/markup_ir_bench.rs	15	s0	S0/carton	stage	vize_carton	compat	3
-linter	Linter	test/dev	crates/vize_patina/benches/markup_ir_bench.rs	15	old_ast	old AST/parser	old	vize_armature	legacy	1
-linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/benches/davinci_markup.rs	16	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/benches/davinci_markup.rs	16	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/benches/lint_bench.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/benches/markup_ir_bench.rs	19	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	test/dev	crates/vize_patina/benches/markup_ir_bench.rs	19	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
@@ -893,105 +893,105 @@ linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_
 linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
 linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/context.rs	21	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/context.rs	21	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/context.rs	21	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/context/directives.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/context/eslint_directive.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/context/helpers.rs	9	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/context/directives.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/context/eslint_directive.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/context/helpers.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/context/helpers.rs	9	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/context/reporting.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/context/sfc_directives.rs	7	s0	S0/carton	stage	vize_carton	compat	2
-linter	Linter	source	crates/vize_patina/src/context/state.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/src/diagnostic.rs	18	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/diagnostic/compact_help.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/diagnostic/formatting.rs	6	s0	S0/carton	stage	vize_carton	compat	2
-linter	Linter	source	crates/vize_patina/src/diagnostic/types.rs	12	s0	S0/carton	stage	vize_carton	compat	3
-linter	Linter	source	crates/vize_patina/src/ir.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/lib.rs	135	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/category_config.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/compatibility.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/config.rs	20	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/corsa_session.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/corsa_session/errors.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/corsa_session/paths.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-linter	Linter	test/dev	crates/vize_patina/src/linter/corsa_session/paths.rs	203	s0	S0/carton	stage	vize_carton	compat	2
-linter	Linter	source	crates/vize_patina/src/linter/corsa_session/probe.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/corsa_session/session.rs	16	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/corsa_session/session/tests.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/css_rules.rs	20	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	s0	S0/carton	stage	vize_carton	compat	5
+linter	Linter	source	crates/vize_patina/src/context/reporting.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/context/sfc_directives.rs	7	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/context/state.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/diagnostic.rs	18	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/diagnostic/compact_help.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/diagnostic/formatting.rs	6	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/diagnostic/types.rs	12	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/ir.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/lib.rs	135	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/category_config.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/compatibility.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/config.rs	20	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/corsa_session.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/corsa_session/errors.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/corsa_session/paths.rs	5	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	test/dev	crates/vize_patina/src/linter/corsa_session/paths.rs	203	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/linter/corsa_session/probe.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/corsa_session/session.rs	16	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/corsa_session/session/tests.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/css_rules.rs	20	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	s0	S0/carton	stage	vize_s0	preferred	5
 linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	raw_oxc	raw OXC	raw	oxc_allocator	raw	4
 linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/linter/engine/parse_diagnostics.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/linter/engine/parse_diagnostics.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/engine/parse_diagnostics.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/linter/engine/script.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/engine/template_extract.rs	4	s0	S0/carton	stage	vize_carton	compat	2
-linter	Linter	test/dev	crates/vize_patina/src/linter/engine/template_extract.rs	113	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/native_type_aware.rs	173	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/driver.rs	17	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/linter/engine/script.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/engine/template_extract.rs	4	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	test/dev	crates/vize_patina/src/linter/engine/template_extract.rs	113	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/native_type_aware.rs	173	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/driver.rs	17	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/driver.rs	17	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/driver.rs	17	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/markers.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/markers.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/markers.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/reactivity_loss.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/reactivity_loss.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/reactivity_loss.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/rule_queries.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/script_options.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs	7	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-linter	Linter	source	crates/vize_patina/src/linter/restricted_rules.rs	12	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/linter/script_rules.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/linter/restricted_rules.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/script_rules.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/script_rules.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/script_rules.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/script_rules.rs	150	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/script_rules.rs	150	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/linter/script_rules.rs	150	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/linter/script_rules/template_ast.rs	14	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/linter/script_rules/template_ast.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/script_rules/template_ast.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/script_rules/template_ast.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	1
-linter	Linter	source	crates/vize_patina/src/linter/severity.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/tests.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/tests/jsx_streaming.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/tests/nuxt.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/tests/recovered_parse_analysis.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/markup.rs	49	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/linter/severity.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/tests.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/tests/jsx_streaming.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/tests/nuxt.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/tests/recovered_parse_analysis.rs	11	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/markup.rs	49	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	18	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	18	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	18	old_ast	old AST/parser	old	vize_armature	legacy	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	18	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
-linter	Linter	test/dev	crates/vize_patina/src/output.rs	20	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/output/agent.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/output/html.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/output/json.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/output/markdown.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/output/plain.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/output/shared.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/output/stylish.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/src/output/tests.rs	4	s0	S0/carton	stage	vize_carton	compat	23
-linter	Linter	source	crates/vize_patina/src/output/text.rs	12	s0	S0/carton	stage	vize_carton	compat	3
+linter	Linter	test/dev	crates/vize_patina/src/output.rs	20	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/agent.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/html.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/json.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/markdown.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/plain.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/shared.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/stylish.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/output/tests.rs	4	s0	S0/carton	stage	vize_s0	preferred	23
+linter	Linter	source	crates/vize_patina/src/output/text.rs	12	s0	S0/carton	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rule.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/alt_text.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/anchor_has_content.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	2
@@ -1002,7 +1002,7 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/aria_unsupported_elements
 linter	Linter	source	crates/vize_patina/src/rules/a11y/click_events_have_key_events.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/form_control_has_label.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/heading_has_content.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/iframe_has_title.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/a11y/img_alt.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	4
@@ -1016,16 +1016,16 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/no_autofocus.rs	15	old_as
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_distracting_elements.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_i_for_icon.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_redundant_roles.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	s0	S0/carton	stage	vize_carton	compat	3
+linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	s0	S0/carton	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_role_presentation_on_focusable.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_static_element_interactions.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/role_has_required_aria_props.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/tabindex_no_positive.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/css.rs	44	s0	S0/carton	stage	vize_carton	compat	3
-linter	Linter	source	crates/vize_patina/src/rules/css/prefer_logical_properties.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/rules/ecosystem/i18n_no_missing_key.rs	15	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/css.rs	44	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/rules/css/prefer_logical_properties.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/ecosystem/i18n_no_missing_key.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/ecosystem/nuxt_prefer_nuxt_link.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/ecosystem/router_link_require_to.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/ecosystem/void_link_require_href.rs	11	old_ast	old AST/parser	old	vize_relief	legacy	1
@@ -1034,43 +1034,43 @@ linter	Linter	source	crates/vize_patina/src/rules/ecosystem/vue_router_prefer_na
 linter	Linter	source	crates/vize_patina/src/rules/html/deprecated_attr.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/deprecated_element.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/helpers.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/html/id_duplication.rs	31	s0	S0/carton	stage	vize_carton	compat	3
+linter	Linter	source	crates/vize_patina/src/rules/html/id_duplication.rs	31	s0	S0/carton	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/html/id_duplication.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/no_consecutive_br.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	35	s0	S0/carton	stage	vize_carton	compat	3
+linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	35	s0	S0/carton	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	35	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/no_empty_palpable_content.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/html/require_datetime.rs	28	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/html/require_datetime.rs	28	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/html/require_datetime.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	2
-linter	Linter	source	crates/vize_patina/src/rules/musea.rs	31	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/musea.rs	31	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/musea.rs	31	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/musea/prefer_design_tokens.rs	26	s0	S0/carton	stage	vize_carton	compat	3
+linter	Linter	source	crates/vize_patina/src/rules/musea/prefer_design_tokens.rs	26	s0	S0/carton	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/musea/require_component.rs	62	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/musea/require_title.rs	83	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/musea/unique_variant_names.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/musea/unique_variant_names.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/heading_levels.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	s0	S0/carton	stage	vize_carton	compat	3
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	s0	S0/carton	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/placeholder_label_option.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/use_list.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	30	s0	S0/carton	stage	vize_carton	compat	3
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	30	s0	S0/carton	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	27	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	27	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/no_inline_template.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs	28	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs	28	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/require_vapor_attribute.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs	23	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs	23	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs	23	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs	23	croquis	Croquis analysis	old	vize_croquis	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/html_button_has_type.rs	37	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/html_self_closing.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/multi_word_component_names.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_array_index_key.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	2
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	31	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	31	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_empty_component_block.rs	40	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_empty_component_block.rs	40	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_inline_style.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_negated_v_if_condition.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
@@ -1080,17 +1080,17 @@ linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_script_non_
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_src_attribute.rs	43	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_template_lang.rs	36	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_template_shadow.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_unused_refs.rs	57	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_unused_refs.rs	57	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_unused_refs.rs	57	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_useless_mustaches.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_useless_v_bind.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_v_text.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/prefer_props_shorthand.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/prefer_props_shorthand.rs	32	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/opinionated/vue/prefer_props_shorthand.rs	103	s0	S0/carton	stage	vize_carton	compat	2
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/prefer_true_attribute_shorthand.rs	26	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/opinionated/vue/prefer_props_shorthand.rs	103	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/prefer_true_attribute_shorthand.rs	26	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/prefer_true_attribute_shorthand.rs	26	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs	45	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs	45	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs	45	old_ast	old AST/parser	old	vize_relief	legacy	4
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs	45	croquis	Croquis analysis	old	vize_croquis	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/scoped_event_names.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
@@ -1098,111 +1098,111 @@ linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/slot_name_casi
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/this_in_template.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/use_unique_element_ids.rs	51	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/use_v_on_exact.rs	26	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_bind_style.rs	27	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_bind_style.rs	27	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_bind_style.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	5
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_on_event_hyphenation.rs	32	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_on_event_hyphenation.rs	32	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_on_event_hyphenation.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_on_handler_style.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/warn_custom_block.rs	48	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/warn_custom_block.rs	48	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/warn_custom_directive.rs	38	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/petite_vue/no_unsupported_directive.rs	41	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/petite_vue/no_unsupported_directive.rs	41	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/petite_vue/no_unsupported_directive.rs	41	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/petite_vue/valid_v_effect.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/petite_vue/valid_v_scope.rs	39	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/petite_vue/valid_v_scope.rs	39	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/petite_vue/valid_v_scope.rs	39	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/petite_vue/valid_v_scope.rs	39	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script.rs	72	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script.rs	72	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script.rs	72	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script.rs	72	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script.rs	72	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/component_options_name_casing.rs	38	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/component_options_name_casing.rs	38	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/component_options_name_casing.rs	38	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/custom_event_name_casing.rs	55	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/custom_event_name_casing.rs	55	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/custom_event_name_casing.rs	55	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/custom_event_name_casing.rs	55	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/define_emits_declaration.rs	32	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/define_macros_order.rs	42	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/define_macros_order.rs	42	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/define_macros_order.rs	42	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/define_props_declaration.rs	37	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/define_props_declaration.rs	37	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/define_props_destructuring.rs	30	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/define_props_destructuring.rs	30	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_arrow_functions_in_watch.rs	51	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_arrow_functions_in_watch.rs	51	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_arrow_functions_in_watch.rs	51	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_async_in_computed.rs	40	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_async_in_computed.rs	40	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_boolean_default.rs	47	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_boolean_default.rs	47	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_boolean_default.rs	47	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deep_destructure_in_props.rs	31	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deep_destructure_in_props.rs	31	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration.rs	41	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration.rs	41	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration.rs	41	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle.rs	12	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle.rs	12	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle/tests.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle/tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle/tests.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle/tests.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_dollar_listeners_api.rs	33	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_dollar_listeners_api.rs	33	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_dollar_scopedslots_api.rs	30	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_dollar_scopedslots_api.rs	30	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_events_api.rs	37	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_events_api.rs	37	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_events_api.rs	37	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_events_api.rs	37	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_props_default_this.rs	62	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_props_default_this.rs	62	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_props_default_this.rs	62	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_props_default_this.rs	62	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_props_default_this.rs	62	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_dupe_keys.rs	47	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_dupe_keys.rs	47	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_dupe_keys.rs	47	croquis	Croquis analysis	old	vize_croquis	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_dupe_keys.rs	47	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance.rs	68	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/options.rs	9	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/options.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/options.rs	9	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/template.rs	35	old_ast	old AST/parser	old	vize_relief	legacy	4
 linter	Linter	source	crates/vize_patina/src/rules/script/no_export_in_script_setup.rs	48	raw_oxc	raw OXC	raw	oxc_ast	raw	2
-linter	Linter	source	crates/vize_patina/src/rules/script/no_get_current_instance.rs	28	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_get_current_instance.rs	28	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_get_current_instance.rs	28	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_get_current_instance.rs	28	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_import_compiler_macros.rs	33	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_internal_imports.rs	26	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_multiple_slot_args.rs	54	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_multiple_slot_args.rs	54	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_next_tick.rs	30	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_next_tick.rs	30	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_next_tick.rs	30	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_next_tick.rs	30	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_nuxt_config_test_key.rs	11	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_options_api.rs	35	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/rules/script/no_options_api.rs	35	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_options_api.rs	35	raw_oxc	raw OXC	raw	oxc_ast	raw	3
-linter	Linter	source	crates/vize_patina/src/rules/script/no_page_meta_runtime_values.rs	11	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/rules/script/no_page_meta_runtime_values.rs	11	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_page_meta_runtime_values.rs	11	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_page_meta_runtime_values.rs	11	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_page_meta_runtime_values.rs	11	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_potential_component_option_typo.rs	16	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_potential_component_option_typo.rs	16	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_potential_component_option_typo.rs	16	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_potential_component_option_typo.rs	16	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_reactive_destructure.rs	42	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_ref_as_operand.rs	29	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_reactive_destructure.rs	42	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_ref_as_operand.rs	29	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_ref_as_operand.rs	29	raw_oxc	raw OXC	raw	oxc_ast	raw	5
 linter	Linter	source	crates/vize_patina/src/rules/script/no_ref_as_operand.rs	29	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_ref_as_operand.rs	29	raw_oxc	raw OXC	raw	oxc_syntax	raw	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_identifiers.rs	36	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_identifiers.rs	36	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_identifiers.rs	36	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_keys.rs	27	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_keys.rs	27	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_keys.rs	27	croquis	Croquis analysis	old	vize_croquis	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_keys.rs	27	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_globals.rs	53	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_globals.rs	53	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_globals.rs	53	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_globals.rs	53	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_restricted_globals.rs	254	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_members.rs	49	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_restricted_globals.rs	254	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_members.rs	49	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_members.rs	49	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_members.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_restricted_members.rs	190	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_side_effects_in_computed.rs	58	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_restricted_members.rs	190	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_side_effects_in_computed.rs	58	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_side_effects_in_computed.rs	58	raw_oxc	raw OXC	raw	oxc_ast	raw	4
 linter	Linter	source	crates/vize_patina/src/rules/script/no_side_effects_in_computed.rs	58	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_side_effects_in_computed.rs	58	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
@@ -1212,102 +1212,102 @@ linter	Linter	source	crates/vize_patina/src/rules/script/no_top_level_ref_in_scr
 linter	Linter	source	crates/vize_patina/src/rules/script/no_unstable_nested_components.rs	9	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_unstable_nested_components.rs	9	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_unstable_nested_components.rs	9	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs	36	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs	36	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs	36	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs	36	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	2
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs	36	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_use_computed_property_like_method/computed_names.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_use_computed_property_like_method/computed_names.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_use_computed_property_like_method/computed_names.rs	7	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs	10	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs	10	raw_oxc	raw OXC	raw	oxc_ast	raw	2
-linter	Linter	source	crates/vize_patina/src/rules/script/nuxt_config_keys_order/support.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/nuxt_config_keys_order/support.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/nuxt_config_keys_order/support.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/nuxt_config_keys_order/tests.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs	12	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/nuxt_config_keys_order/tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs	12	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs	12	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/prefer_computed.rs	29	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/prefer_computed.rs	29	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_computed.rs	29	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_computed.rs	29	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_computed.rs	29	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_define_options.rs	46	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_from_vue.rs	26	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_from_vue.rs	26	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_from_vue.rs	26	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_meta.rs	10	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_meta.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_meta.rs	10	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_meta.rs	10	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/prefer_import_meta/tests.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/prefer_import_meta/tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_attrs.rs	32	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_attrs.rs	32	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_slots.rs	32	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_slots.rs	32	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_template_ref.rs	59	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_template_ref.rs	59	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_template_ref.rs	59	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_template_ref.rs	59	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_template_ref/template_refs.rs	19	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/emits_source.rs	10	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_template_ref/template_refs.rs	19	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/emits_source.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/emits_source.rs	10	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_required_prop_with_default.rs	14	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_required_prop_with_default.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_required_prop_with_default.rs	14	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_reserved_props.rs	44	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_reserved_props.rs	44	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_reserved_props.rs	44	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_unused_emit_declarations.rs	55	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_unused_emit_declarations.rs	55	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_unused_emit_declarations.rs	55	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_unused_emit_declarations.rs	55	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/props_source.rs	21	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/props_source.rs	21	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/props_source.rs	21	raw_oxc	raw OXC	raw	oxc_ast	raw	2
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_default_prop.rs	49	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_default_prop.rs	49	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_default_prop.rs	49	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs	50	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs	50	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs	50	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs	50	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/declared.rs	8	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/declared.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/declared.rs	8	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_prop_types.rs	49	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_prop_types.rs	49	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_prop_types.rs	49	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop.rs	54	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop.rs	54	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop.rs	54	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop.rs	59	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop.rs	59	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop.rs	59	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/return_in_emits_validator.rs	48	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/return_in_emits_validator.rs	48	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/return_in_emits_validator.rs	48	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/template_emits.rs	21	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/require_explicit_slots.rs	82	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/template_emits.rs	21	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/require_explicit_slots.rs	82	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/require_explicit_slots.rs	82	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/declared.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/declared.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/declared.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/declared.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/template.rs	31	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/template.rs	31	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/template.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/script/require_function_return_type.rs	45	s0	S0/carton	stage	vize_carton	compat	2
-linter	Linter	source	crates/vize_patina/src/rules/script/require_prop_type_constructor.rs	53	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/require_function_return_type.rs	45	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/script/require_prop_type_constructor.rs	53	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_prop_type_constructor.rs	53	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 linter	Linter	source	crates/vize_patina/src/rules/script/require_symbol_provide.rs	33	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_symbol_provide.rs	33	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/require_typed_ref.rs	43	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/require_typed_ref.rs	43	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_typed_ref.rs	43	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_typed_ref.rs	43	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/return_in_computed_property.rs	20	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/return_in_computed_property.rs	20	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/return_in_computed_property.rs	20	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/sfc_context.rs	43	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/script/template_scan.rs	41	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/template_scan.rs	41	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/template_scan.rs	41	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/script/template_scan/calls.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/template_scan/calls.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/template_scan/calls.rs	4	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/template_scan/calls.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_emits.rs	38	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_emits.rs	38	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_emits.rs	38	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_emits.rs	38	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_options.rs	34	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_options.rs	34	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_options.rs	34	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_options.rs	34	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_props.rs	37	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_props.rs	37	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_props.rs	37	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_props.rs	37	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/valid_next_tick.rs	43	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/script/valid_next_tick.rs	43	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_next_tick.rs	43	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_next_tick.rs	43	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_next_tick.rs	43	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
@@ -1316,93 +1316,93 @@ linter	Linter	source	crates/vize_patina/src/rules/script/vue_router_prefer_named
 linter	Linter	source	crates/vize_patina/src/rules/script/vue_test_utils_no_html_snapshot.rs	12	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/vue_test_utils_no_html_snapshot.rs	12	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs	48	old_ast	old AST/parser	old	vize_relief	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs	481	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	test/dev	crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs	481	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	test/dev	crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs	481	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/ssr/no_hydration_mismatch.rs	52	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/type_aware/require_typed_emits.rs	52	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/type_aware/require_typed_emits.rs	52	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/type_aware/require_typed_props.rs	55	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/type_aware/require_typed_props.rs	55	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/url.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/url.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vapor/no_vue_lifecycle_events.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/a11y_img_alt.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	4
-linter	Linter	source	crates/vize_patina/src/rules/vue/attribute_hyphenation.rs	22	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/rules/vue/attribute_hyphenation.rs	22	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/attribute_hyphenation.rs	22	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/attribute_hyphenation.rs	22	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/attribute_order.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/component_definition_name_casing.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/html_quotes.rs	46	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/html_quotes.rs	46	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/html_quotes.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/html_quotes/value_range.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/html_quotes/value_range.rs	86	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/mustache_interpolation_spacing.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_bare_strings_in_template.rs	44	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_child_content.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_filter.rs	42	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_filter.rs	42	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_filter.rs	42	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_functional_template.rs	54	s0	S0/carton	stage	vize_carton	compat	2
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_html_element_is.rs	36	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_functional_template.rs	54	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_html_element_is.rs	36	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_html_element_is.rs	36	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_router_link_tag_prop.rs	34	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_router_link_tag_prop.rs	34	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_router_link_tag_prop.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_scope_attribute.rs	35	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_scope_attribute.rs	35	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_scope_attribute.rs	35	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs	35	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs	35	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs	35	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs	81	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_slot_scope_attribute.rs	30	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs	81	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_slot_scope_attribute.rs	30	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_slot_scope_attribute.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_bind_sync.rs	39	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_bind_sync.rs	39	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_bind_sync.rs	39	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_on_native_modifier.rs	40	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_on_native_modifier.rs	40	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_on_native_modifier.rs	40	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_on_number_modifiers.rs	40	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_on_number_modifiers.rs	40	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_on_number_modifiers.rs	40	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_dupe_v_else_if.rs	27	s0	S0/carton	stage	vize_carton	compat	3
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_dupe_v_else_if.rs	27	s0	S0/carton	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_dupe_v_else_if.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_duplicate_attributes.rs	24	s0	S0/carton	stage	vize_carton	compat	3
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_duplicate_attributes.rs	24	s0	S0/carton	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_duplicate_attributes.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_invalid_html_attribute.rs	10	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_lone_template.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_multi_spaces.rs	22	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root.rs	23	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root.rs	23	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root.rs	23	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root/tests.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props.rs	62	s0	S0/carton	stage	vize_carton	compat	3
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root/tests.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props.rs	62	s0	S0/carton	stage	vize_s0	preferred	3
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props.rs	62	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props.rs	62	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs	43	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs	43	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs	43	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs	43	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/mutation_targets.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props/mutation_targets.rs	95	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/scope.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/mutation_targets.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props/mutation_targets.rs	95	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/scope.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/scope.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props/tests/script_mutations.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names.rs	36	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props/tests/script_mutations.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names.rs	36	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names.rs	36	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names.rs	36	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names.rs	36	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names.rs	36	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names/extract.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names/extract.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names/extract.rs	7	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_template_key.rs	27	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_template_key.rs	27	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_template_key.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	4
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_template_target_blank.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_textarea_mustache.rs	23	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_undefined_refs.rs	8	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_undefined_refs.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_undefined_refs.rs	8	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unsafe_url.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unsandboxed_iframe.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_components.rs	39	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_components.rs	39	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_components.rs	39	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_components.rs	39	croquis	Croquis analysis	old	vize_croquis	legacy	3
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_components.rs	39	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
@@ -1414,39 +1414,39 @@ linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_components/dynam
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_components/dynamic_is.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_components/dynamic_is.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_components/dynamic_is.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_properties.rs	84	s0	S0/carton	stage	vize_carton	compat	4
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_properties.rs	84	s0	S0/carton	stage	vize_s0	preferred	4
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_properties.rs	84	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_properties/usage.rs	29	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_properties/usage.rs	29	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_properties/usage.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_vars.rs	44	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_vars.rs	44	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_vars.rs	44	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_vars.rs	44	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for.rs	15	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for/tests.rs	9	s0	S0/carton	stage	vize_carton	compat	2
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_use_v_if_with_v_for.rs	31	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for/tests.rs	9	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_use_v_if_with_v_for.rs	31	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_use_v_if_with_v_for.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_useless_template_attributes.rs	30	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_useless_template_attributes.rs	30	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_useless_template_attributes.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_for_template_key_on_child.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_v_for_template_key_on_child.rs	115	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_v_for_template_key_on_child.rs	115	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_html.rs	41	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs	27	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs	27	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/permitted_contents.rs	33	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/permitted_contents.rs	33	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/permitted_contents.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/prop_name_casing.rs	40	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/prop_name_casing/declarations.rs	13	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/prop_name_casing/declarations.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_component_is.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/require_scoped_style.rs	47	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/require_scoped_style.rs	47	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_toggle_inside_transition.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_v_for_key.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_v_for_key.rs	25	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_v_for_key.rs	25	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_v_for_key.rs	25	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/sfc_element_order.rs	41	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/single_style_block.rs	39	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/v_on_style.rs	25	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/sfc_element_order.rs	41	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/single_style_block.rs	39	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/v_on_style.rs	25	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/v_on_style.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/v_slot_style.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/v_slot_style/position.rs	10	old_ast	old AST/parser	old	vize_relief	legacy	1
@@ -1459,7 +1459,7 @@ linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_for.rs	29	old_ast	
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_html.rs	26	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_if.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_memo.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_model.rs	29	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_model.rs	29	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_model.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_model.rs	29	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_model.rs	29	raw_oxc	raw OXC	raw	oxc_ast	raw	1
@@ -1467,17 +1467,17 @@ linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_model.rs	29	raw_ox
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_on.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_once.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_show.rs	26	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_slot.rs	24	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_slot.rs	24	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_slot.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_text.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/telegraph.rs	31	s0	S0/carton	stage	vize_carton	compat	4
-linter	Linter	test/dev	crates/vize_patina/src/telegraph/tests.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-linter	Linter	source	crates/vize_patina/src/visitor_scope.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+linter	Linter	source	crates/vize_patina/src/telegraph.rs	31	s0	S0/carton	stage	vize_s0	preferred	4
+linter	Linter	test/dev	crates/vize_patina/src/telegraph/tests.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/visitor_scope.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/visitor_scope.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/visitor_scope.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/visitor_scope.rs	46	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	test/dev	crates/vize_patina/src/visitor_scope.rs	46	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	test/dev	crates/vize_patina/src/visitor_scope.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	2
-linter	Linter	source	crates/vize_patina/src/visitor.rs	7	s0	S0/carton	stage	vize_carton	compat	2
+linter	Linter	source	crates/vize_patina/src/visitor.rs	7	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/visitor.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	test/dev	crates/vize/src/commands/lint.rs	34	s0	S0/carton	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize/src/commands/lint/args.rs	5	s0	S0/carton	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -259,6 +259,14 @@ test("Vize CLI package imports S0 storage through the stage alias", () => {
   });
 });
 
+test("Patina linter imports S0 storage through the stage alias", () => {
+  assertS0AliasConsumer({
+    packageName: "vize_patina",
+    label: "Patina linter",
+    directory: path.join(repoRoot, "crates", "vize_patina"),
+  });
+});
+
 test("Canon content-mapper imports S0 storage through the stage alias", () => {
   const manifest = readRepoFile("crates", "vize_canon", "Cargo.toml");
   assert.match(manifest, /^vize_s0\.workspace = true$/m);


### PR DESCRIPTION
## Summary
- rename Patina's workspace dependency on vize_carton to the vize_s0 stage alias
- update Patina Rust imports and crate README to use vize_s0
- pin the linter S0 alias in davinci stage dependency guards and refresh the consumer migration inventory

## Tests
- cargo test -p vize_patina --lib
- cargo test -p vize_patina --all-targets --all-features --locked
- node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/source-file-lengths.test.ts
- node tools/davinci/consumer-migration-surfaces.mjs --check
- cargo fmt --all -- --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- vp run --workspace-root check:repo
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790312103&installation_model_id=422833&pr_number=4958&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4958&signature=e7aaf6abb80d1e4c514e49d167c3f0af34ba4c0f839dd6c70dc4fcd55832d2ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->