### PR TITLE
test(tooling): add vue-bits and shadcn-vue authored lsp oracles

### DIFF
--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -776,7 +776,9 @@
           "tests/_fixtures/_git/vaul-vue",
           "tests/_fixtures/_git/vee-validate",
           "tests/_fixtures/_git/vue-draggable-plus",
-          "tests/_fixtures/_git/vue-termui"
+          "tests/_fixtures/_git/vue-termui",
+          "tests/_fixtures/_git/vue-bits",
+          "tests/_fixtures/_git/shadcn-vue"
         ]
       },
       "evidence": {

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 7,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 13,
+    "minimumProjectCount": 15,
     "trackingIssue": 3952
   },
   "projects": [
@@ -875,7 +875,73 @@
       ],
       "tsconfig": "tsconfig.json",
       "coverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "apps/v4/error.vue",
+          "symbol": "useIdFunction",
+          "usageAnchor": ":use-id=\"useIdFunction\"",
+          "declarationAnchor": "const useIdFunction = () => useId()",
+          "hoverContains": ["const useIdFunction: () => any"],
+          "renameTo": "__vizeRenamedUseIdFunction"
+        },
+        "componentBoundary": {
+          "importerFile": "apps/v4/styles/reka-luma/ui/scroll-area/ScrollArea.vue",
+          "componentFile": "apps/v4/styles/reka-luma/ui/scroll-area/ScrollBar.vue",
+          "tagName": "ScrollBar",
+          "tagAnchor": "<ScrollBar ",
+          "completionItemCount": 33,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "as-child", "rank": 28 },
+            { "label": "as", "rank": 29 },
+            { "label": "orientation", "rank": 30 },
+            { "label": "force-mount", "rank": 31 },
+            { "label": "class", "rank": 32 }
+          ],
+          "dependencyEdit": {
+            "anchor": "ScrollAreaScrollbarProps & { class?: HTMLAttributes['class'] }",
+            "replacement": "ScrollAreaScrollbarProps & { class?: HTMLAttributes['class'], vizeOracleProbe?: boolean }",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "apps/v4/styles/reka-luma/ui/scroll-area/__VizeOracleScrollBar.vue",
+          "renamedFile": "apps/v4/styles/reka-luma/ui/scroll-area/__VizeOracleRenamedScrollBar.vue",
+          "originalImportSpecifier": "./ScrollBar.vue",
+          "copiedImportSpecifier": "./__VizeOracleScrollBar.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedScrollBar.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizeShadcnVueFileLifecycleMarker__"
+        }
+      }
     },
     {
       "id": "inspira-ui",
@@ -2781,7 +2847,73 @@
         "syntax-highlighter",
         "lsp"
       ],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "src/components/landing/Features/Features.vue",
+          "symbol": "setCardRef",
+          "usageAnchor": ":ref=\"el => setCardRef(el, i)\"",
+          "declarationAnchor": "function setCardRef(el",
+          "hoverContains": [
+            "function setCardRef(el: Element | ComponentPublicInstance | null, index: number): void"
+          ],
+          "renameTo": "__vizeRenamedSetCardRef"
+        },
+        "componentBoundary": {
+          "importerFile": "src/components/landing/Features/CategorySelector.vue",
+          "componentFile": "src/components/landing/Features/FeatureIcon.vue",
+          "tagName": "FeatureIcon",
+          "tagAnchor": "--1\">\n      <div class=\"ln-feat-orbit-node--top ln-feat-orbit-node\"><FeatureIcon ",
+          "completionItemCount": 31,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "name", "rank": 28 },
+            { "label": "size", "rank": 29 },
+            { "label": "stroke-width", "rank": 30 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  strokeWidth?: number;\n",
+            "replacement": "  strokeWidth?: number;\n  vizeOracleProbe?: boolean;\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "src/components/landing/Features/__VizeOracleFeatureIcon.vue",
+          "renamedFile": "src/components/landing/Features/__VizeOracleRenamedFeatureIcon.vue",
+          "originalImportSpecifier": "./FeatureIcon.vue",
+          "copiedImportSpecifier": "./__VizeOracleFeatureIcon.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedFeatureIcon.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizeVueBitsFileLifecycleMarker__"
+        }
+      }
     },
     {
       "id": "vue-netcore",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 13,
+      "authored-lsp": 15,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 13, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 15, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
## Summary

Extend the authored real-project LSP oracle matrix (#3952 ratchet) with two more pinned `lsp`-marked fixtures, moving authored coverage from 13 to 15 projects:

- **Vue Bits** pins authored template hover/definition/references/prepareRename/rename on `src/components/landing/Features/Features.vue` (`setCardRef`), the `CategorySelector.vue -> FeatureIcon.vue` component boundary definition, and the complete 31-item prop/directive completion order at the authored tag position.
- **shadcn-vue** pins authored template hover/definition/references/prepareRename/rename on `apps/v4/error.vue` (`useIdFunction`), the `ScrollArea.vue -> ScrollBar.vue` component boundary definition, and the complete 33-item prop/directive completion order (reka-ui props resolved through the installed workspace).
- Both oracles pin the unsaved dependency prop edit probe (`vize-oracle-probe` appears and is removed exactly) and the authored create/rename/delete/repair file lifecycle, including the exact `willRenameFiles` importer edit and the TS2307 on deletion.
- The registry gate minimum, compatibility ledger membership, and ledger report expectations move from 13 to 15.

Oracle anchors were selected so both the authored component file and its importer publish identical diagnostics across the open/didChange/repair cycle; candidates whose initial-open publish and didChange republish disagree on unresolved-module diagnostics (vue-sonner, vue-tui, inspira-ui, epic-spinners were measured) were rejected rather than pinned.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [x] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

Tracks #3952 (authored per-feature LSP oracles across real-project fixtures); follows the merged oracle metadata contract from #3961 and the per-project ratchet pattern of #4797/#4802/#4804/#4805.

## Verification Evidence

- `nix develop --command node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts` — 20 pass, 0 fail
- `CORSA_PATH=.../node_modules/.bin/tsgo VIZE_LSP_BIN=.../target/debug/vize FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=15 REAL_PROJECT_LSP_TIMEOUT_MS=600000 nix develop --command node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts` — shadcn-vue: `LSP lifecycle: 1 project(s), 1 actual file(s), 1 authored feature oracle(s), 0 failed project(s)`, 5 pass
- same with `FIXTURE_SHARD_INDEX=93` — vue-bits: `LSP lifecycle: 1 project(s), 1 actual file(s), 1 authored feature oracle(s), 0 failed project(s)`, 5 pass
- `git diff --check` clean; changed `.ts`/`.mjs`/ledger files pass `vp check`

- [x] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [ ] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

Test-metadata-only change: no production code is touched. The pinned completion orders depend on the installed workspace `tests/node_modules` surface (reka-ui for shadcn-vue), matching how the existing 13 oracles are pinned. Measured but not pinned here: the initial-open publish and didChange republish can disagree on unresolved-module diagnostics (e.g. TS2307/TS2305 appearing only after an edit) in fixtures like vue-sonner and vue-tui — that divergence blocks those projects from the ratchet and is left as follow-up work under #3952.

Tracks #3952.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790315160&installation_model_id=422833&pr_number=4969&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4969&signature=3fc7511f530f5f633869b37bcf57b5bc14c6355e56ac17f7acc258e93b6288fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->