### PR TITLE
refactor(fresco): import S0 storage through stage alias

### DIFF
--- a/crates/vize_fresco/Cargo.toml
+++ b/crates/vize_fresco/Cargo.toml
@@ -17,7 +17,7 @@ default = []
 napi = ["dep:napi", "dep:napi-derive"]
 
 [dependencies]
-vize_carton = { workspace = true }
+vize_s0.workspace = true
 
 # Terminal control
 crossterm.workspace = true

--- a/crates/vize_fresco/src/component/diagnostic_workspace/keymap.rs
+++ b/crates/vize_fresco/src/component/diagnostic_workspace/keymap.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use super::DiagnosticWorkspaceCommand;
 use crate::input::{Key, KeyEvent, KeyEventKind, KeyModifiers};

--- a/crates/vize_fresco/src/input/ime/candidate.rs
+++ b/crates/vize_fresco/src/input/ime/candidate.rs
@@ -220,7 +220,7 @@ impl CandidateList {
 #[cfg(test)]
 mod tests {
     use super::{Candidate, CandidateList};
-    use vize_carton::cstr;
+    use vize_s0::cstr;
 
     #[test]
     fn test_candidate_new() {

--- a/crates/vize_fresco/src/input/ime/preedit.rs
+++ b/crates/vize_fresco/src/input/ime/preedit.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 use crate::text::{SegmentedText, TextWidth};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 /// Preedit text with cursor and segments.
 #[derive(Debug, Clone, Default)]

--- a/crates/vize_fresco/src/terminal/backend/lifecycle_failure_tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle_failure_tests.rs
@@ -2,7 +2,7 @@
 
 use std::io::{self, Write};
 
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 use super::{Backend, TerminalMode, TerminalOptions, TerminalRestorationError};
 

--- a/crates/vize_fresco/src/terminal/backend/lifecycle_tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle_tests.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 use super::{Backend, TerminalMode, TerminalOptions};
 

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -267,6 +267,14 @@ test("Patina linter imports S0 storage through the stage alias", () => {
   });
 });
 
+test("Fresco TUI imports S0 storage through the stage alias", () => {
+  assertS0AliasConsumer({
+    packageName: "vize_fresco",
+    label: "Fresco TUI",
+    directory: path.join(repoRoot, "crates", "vize_fresco"),
+  });
+});
+
 test("Canon content-mapper imports S0 storage through the stage alias", () => {
   const manifest = readRepoFile("crates", "vize_canon", "Cargo.toml");
   assert.match(manifest, /^vize_s0\.workspace = true$/m);


### PR DESCRIPTION
## Summary
- rename Fresco's retained S0 storage dependency to the physical stage alias
- update Fresco Rust imports from vize_carton to vize_s0
- add a davinci dependency guard for Fresco as an S0 consumer

## Tests
- cargo test -p vize_fresco --all-targets --locked
- cargo check -p vize_fresco --features napi --locked
- node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts
- node tools/davinci/consumer-migration-surfaces.mjs --check
- cargo fmt --all -- --check
- git diff --check HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790315442&installation_model_id=422833&pr_number=4971&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4971&signature=9d021d8e96da55aa9d18ba04e652f7ee005a85d496ddd60fd35094be07a2de27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->