### PR TITLE
test(canon): pin inherited paths under child baseUrl

### DIFF
--- a/crates/vize/src/commands/check/runner/nuxt_tsconfig/path_options_tests.rs
+++ b/crates/vize/src/commands/check/runner/nuxt_tsconfig/path_options_tests.rs
@@ -28,6 +28,30 @@ fn effective_base_url_anchors_paths_declared_by_a_child_config() {
 }
 
 #[test]
+fn child_base_url_reanchors_paths_declared_by_a_parent_config() {
+    let case = tempfile::tempdir().unwrap();
+    write(
+        case.path(),
+        "base.json",
+        r##"{ "compilerOptions": { "paths": { "~/*": ["shared/*"] } } }"##,
+    );
+    write(
+        case.path(),
+        "tsconfig.json",
+        r#"{
+  "extends": "./base.json",
+  "compilerOptions": { "baseUrl": "./src" }
+}"#,
+    );
+
+    let paths = prepared_paths(case.path(), "tsconfig.json");
+    assert_eq!(
+        paths["~/*"],
+        serde_json::json!([target(case.path(), "src/shared/*")])
+    );
+}
+
+#[test]
 fn later_extends_paths_keep_the_effective_base_url_from_an_earlier_entry() {
     let case = tempfile::tempdir().unwrap();
     write(

--- a/crates/vize_canon/src/batch/virtual_project/tests/base_url.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/base_url.rs
@@ -192,3 +192,58 @@ fn an_inherited_base_url_anchors_paths_declared_by_the_extending_config() {
 
     let _ = fs::remove_dir_all(&case_dir);
 }
+
+#[test]
+fn a_child_base_url_reanchors_paths_declared_by_the_extended_config() {
+    let case_dir = unique_case_dir("base-url-child-override-anchor");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("config")).unwrap();
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    fs::write(
+        case_dir.join("config/tsconfig.base.json"),
+        r##"{
+  "compilerOptions": {
+    "paths": {
+      "#shared/*": ["shared/*"]
+    }
+  }
+}"##,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{
+  "extends": "./config/tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "./src"
+  }
+}"#,
+    )
+    .unwrap();
+    let vue_path = case_dir.join("src/App.vue");
+    fs::write(
+        &vue_path,
+        "<script setup lang=\"ts\">const count = 1</script>",
+    )
+    .unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_path(&vue_path).unwrap();
+    project.materialize().unwrap();
+
+    let paths = generated_paths(&case_dir);
+    assert_eq!(
+        paths["#shared/*"],
+        serde_json::json!([
+            "./src/shared/*",
+            "../../../../src/shared/*",
+            "./src/shared/*.vue.ts"
+        ])
+    );
+    assert_eq!(
+        paths["*"],
+        serde_json::json!(["./src/*", "../../../../src/*", "./src/*.vue.ts"])
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -2303,7 +2303,7 @@ typechecker	Typechecker	source	crates/vize/src/commands/check/runner/invocation.
 typechecker	Typechecker	source	crates/vize/src/commands/check/runner/nuxt_tsconfig.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/nuxt_tsconfig.rs	256	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/runner/nuxt_tsconfig/cache.rs	10	s0	S0/carton	stage	vize_s0	preferred	5
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/nuxt_tsconfig/path_options_tests.rs	228	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/nuxt_tsconfig/path_options_tests.rs	252	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_declarations.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_json.rs	3	s0	S0/carton	stage	vize_s0	preferred	4
 typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_profile.rs	4	s0	S0/carton	stage	vize_s0	preferred	1


### PR DESCRIPTION
## Summary
- add virtual-project regression coverage for inherited paths reanchored by a child baseUrl
- add Nuxt tsconfig path preparation coverage for parent paths with child baseUrl

## Tests
- cargo test -p vize_canon a_child_base_url_reanchors_paths_declared_by_the_extended_config
- cargo test -p vize child_base_url_reanchors_paths_declared_by_a_parent_config
- cargo fmt --all -- --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4972"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790315911&installation_model_id=422833&pr_number=4972&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4972&signature=2d00bee47d2bc3a47c4f7e6a64ecc01bf784b13c724f38837c68b93a232ef2c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->