### PR TITLE
refactor(davinci): add shared physical stage identifiers

### DIFF
--- a/crates/vize_davinci/src/diagnostic.rs
+++ b/crates/vize_davinci/src/diagnostic.rs
@@ -38,6 +38,7 @@
 
 use alloc::vec::Vec;
 
+pub use crate::stage::Stage;
 use vize_s0::{Span, String};
 
 /// How much a diagnostic claims.
@@ -57,42 +58,6 @@ pub enum Severity {
     Info,
     /// A suggestion the author may ignore.
     Hint,
-}
-
-/// The stage a diagnostic came from.
-///
-/// Recorded so the unified channel can attribute a message without the
-/// renderer inferring it from the text — the failure mode the single channel
-/// exists to remove. Values track the logical stage model in
-/// `architecture.md`; a stage is added here when its crate lands, not in
-/// advance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Stage {
-    /// S0: reading the authored file into source coordinates.
-    Source,
-    /// S1: the lossless surface tree (P2-7).
-    Surface,
-    /// S2: the semantic IR, Disegno (P2-5a).
-    Semantic,
-    /// S3: the lowered backend IR, Impeto (phase 3).
-    Lowered,
-    /// S4: emission.
-    Emit,
-}
-
-impl Stage {
-    /// Stable identifier used in folio pages and machine-readable output.
-    #[inline]
-    #[must_use]
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Stage::Source => "source",
-            Stage::Surface => "surface",
-            Stage::Semantic => "semantic",
-            Stage::Lowered => "lowered",
-            Stage::Emit => "emit",
-        }
-    }
 }
 
 /// What a structured part of a diagnostic is doing.
@@ -312,15 +277,6 @@ mod tests {
             exempt.witness,
             Some(Witness::LegacyExempt("vize_canon".into()))
         );
-    }
-
-    #[test]
-    fn stage_identifiers_are_stable_strings() {
-        assert_eq!(Stage::Source.as_str(), "source");
-        assert_eq!(Stage::Surface.as_str(), "surface");
-        assert_eq!(Stage::Semantic.as_str(), "semantic");
-        assert_eq!(Stage::Lowered.as_str(), "lowered");
-        assert_eq!(Stage::Emit.as_str(), "emit");
     }
 
     #[test]

--- a/crates/vize_davinci/src/stage.rs
+++ b/crates/vize_davinci/src/stage.rs
@@ -5,6 +5,52 @@
 //! names; remaining art-name packages stay visible until their own rename PRs
 //! land.
 
+/// The stage a Davinci diagnostic came from.
+///
+/// The variants retain the logical names used by existing diagnostics and
+/// folio prose. Use [`Stage::physical_id`] when a physical layer id is needed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Stage {
+    /// S0: reading the authored file into source coordinates.
+    Source,
+    /// S1: the lossless surface tree.
+    Surface,
+    /// S2: the semantic IR.
+    Semantic,
+    /// S3: the lowered backend IR.
+    Lowered,
+    /// S4: emission.
+    Emit,
+}
+
+impl Stage {
+    /// Stable logical identifier used by today's diagnostic output.
+    #[inline]
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Stage::Source => "source",
+            Stage::Surface => "surface",
+            Stage::Semantic => "semantic",
+            Stage::Lowered => "lowered",
+            Stage::Emit => "emit",
+        }
+    }
+
+    /// Physical layer identifier for implementation names and stage-local keys.
+    #[inline]
+    #[must_use]
+    pub const fn physical_id(self) -> &'static str {
+        match self {
+            Stage::Source => "s0",
+            Stage::Surface => "s1",
+            Stage::Semantic => "s2",
+            Stage::Lowered => "s3",
+            Stage::Emit => "s4",
+        }
+    }
+}
+
 /// A Davinci layer crate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LayerCrate {
@@ -88,7 +134,25 @@ pub const CONVERSIONS: &[ConversionCrate] = &[S1_TO_S2];
 
 #[cfg(test)]
 mod tests {
-    use super::{ARTIFACT_STAGES, CONVERSIONS, LAYERS, S0, S1, S1_TO_S2, S2, StageCrate};
+    use super::{ARTIFACT_STAGES, CONVERSIONS, LAYERS, S0, S1, S1_TO_S2, S2, Stage, StageCrate};
+
+    #[test]
+    fn diagnostic_stage_identifiers_remain_logical_names() {
+        assert_eq!(Stage::Source.as_str(), "source");
+        assert_eq!(Stage::Surface.as_str(), "surface");
+        assert_eq!(Stage::Semantic.as_str(), "semantic");
+        assert_eq!(Stage::Lowered.as_str(), "lowered");
+        assert_eq!(Stage::Emit.as_str(), "emit");
+    }
+
+    #[test]
+    fn physical_stage_identifiers_are_s0_to_s4() {
+        assert_eq!(Stage::Source.physical_id(), "s0");
+        assert_eq!(Stage::Surface.physical_id(), "s1");
+        assert_eq!(Stage::Semantic.physical_id(), "s2");
+        assert_eq!(Stage::Lowered.physical_id(), "s3");
+        assert_eq!(Stage::Emit.physical_id(), "s4");
+    }
 
     #[test]
     fn stage_aliases_are_the_preferred_implementation_names() {


### PR DESCRIPTION
## Summary
- move the diagnostic Stage type into the shared davinci stage module
- keep vize_davinci::diagnostic::Stage as a compatibility re-export
- add physical s0-s4 identifiers while preserving existing logical Stage::as_str() output

## Tests
- cargo test -p vize_davinci physical_stage_identifiers_are_s0_to_s4
- cargo test -p vize_davinci
- cargo build -p vize_davinci -p vize_s2 --target wasm32-wasip2
- cargo check -p vize_ricalco --locked
- cargo fmt --all -- --check
- node tools/davinci/assertion-lint.mjs
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790316679&installation_model_id=422833&pr_number=4974&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4974&signature=aa1a1ec8a2c748fa057773ceb52ed492d1cf0f926147051f3ddbbd8f55b7d680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->