### PR TITLE
fix(fresco): use S0 alias in panic hook tests

### DIFF
--- a/crates/vize_fresco/src/terminal/backend/lifecycle/panic_hook/tests.rs
+++ b/crates/vize_fresco/src/terminal/backend/lifecycle/panic_hook/tests.rs
@@ -271,7 +271,7 @@ fn assert_command_bytes(command_bytes: &[u8], command: impl crossterm::Command) 
     // the byte stream, so it cannot derive expectations on a headless runner.
     // `write_ansi` yields the escape sequence on every platform, which is
     // exactly what the emergency constants must reproduce.
-    let mut expected = vize_carton::String::default();
+    let mut expected = vize_s0::String::default();
     command.write_ansi(&mut expected).unwrap();
     assert_eq!(command_bytes, expected.as_bytes());
 }


### PR DESCRIPTION
## Summary
- replace the remaining physical vize_carton reference in Fresco panic-hook tests with the vize_s0 stage alias
- restore the davinci stage-dependency guard and workspace test compile after the Fresco CI-lane merge

## Tests
- node --test tests/tooling/davinci-stage-dependencies.test.ts
- cargo test -p vize_fresco panic_hook --locked
- cargo test -p vize_fresco --all-targets --locked
- cargo fmt --all -- --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790316875&installation_model_id=422833&pr_number=4975&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4975&signature=363c1ea00a6d97eede21c7f64eb457c00e7ef5f7ab1854c60b3257c5b3c63dc7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->