### PR TITLE
fix(patina): match no-lone-template slot boundaries

### DIFF
--- a/crates/vize_patina/src/rules/vue/no_lone_template.rs
+++ b/crates/vize_patina/src/rules/vue/no_lone_template.rs
@@ -27,7 +27,7 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, PropNode};
+use vize_relief::{ElementNode, ExpressionNode, PropNode};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-lone-template",
@@ -45,15 +45,36 @@ impl NoLoneTemplate {
     /// Check if the template has a valid directive that justifies its existence
     fn has_valid_directive(element: &ElementNode) -> bool {
         for prop in &element.props {
-            if let PropNode::Directive(dir) = prop {
-                let name = dir.name;
-                // Template is valid if it has v-if, v-else-if, v-else, v-for, v-slot, or #slot
-                if matches!(name, "if" | "else-if" | "else" | "for" | "slot") {
+            match prop {
+                PropNode::Directive(dir)
+                    if matches!(
+                        dir.name,
+                        "if" | "else-if" | "else" | "for" | "slot" | "slot-scope" | "scope"
+                    ) =>
+                {
                     return true;
                 }
+                PropNode::Directive(dir)
+                    if dir.name == "bind" && Self::is_static_slot_arg(&dir.arg) =>
+                {
+                    return true;
+                }
+                PropNode::Attribute(attr)
+                    if matches!(attr.name, "slot" | "slot-scope" | "scope") =>
+                {
+                    return true;
+                }
+                _ => {}
             }
         }
         false
+    }
+
+    fn is_static_slot_arg(arg: &Option<ExpressionNode<'_>>) -> bool {
+        matches!(
+            arg,
+            Some(ExpressionNode::Simple(simple)) if simple.is_static && simple.content == "slot"
+        )
     }
 }
 
@@ -122,6 +143,31 @@ mod tests {
             "test.vue",
         );
         assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_with_legacy_slot_attributes() {
+        let linter = create_linter();
+        for source in [
+            r#"<MyComponent><template slot="header"><h1>Title</h1></template></MyComponent>"#,
+            r#"<MyComponent><template slot-scope="props">{{ props.title }}</template></MyComponent>"#,
+            r#"<MyComponent><template scope="props">{{ props.title }}</template></MyComponent>"#,
+            r#"<MyComponent><template v-bind:slot="name"><h1>Title</h1></template></MyComponent>"#,
+            r#"<MyComponent><template :slot="name"><h1>Title</h1></template></MyComponent>"#,
+        ] {
+            let result = linter.lint_template(source, "test.vue");
+            assert_eq!(result.warning_count, 0, "{source}");
+        }
+    }
+
+    #[test]
+    fn test_invalid_dynamic_bound_slot() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<MyComponent><template v-bind:[slot]="name"><h1>Title</h1></template></MyComponent>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 1);
     }
 
     #[test]

--- a/tests/tooling/patina-no-lone-template-oracle.test.ts
+++ b/tests/tooling/patina-no-lone-template-oracle.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const requireFromBench = createRequire(path.join(repoRoot, "bench", "package.json"));
+const { ESLint } = requireFromBench("eslint") as typeof import("eslint");
+const pluginVue = requireFromBench("eslint-plugin-vue");
+const vueParser = requireFromBench("vue-eslint-parser");
+const typescriptParser = requireFromBench("@typescript-eslint/parser");
+
+const cases = [
+  {
+    id: "legacy-slot-attribute",
+    source: `<template><MyComponent><template slot="header">Title</template></MyComponent></template>`,
+    diagnostics: 0,
+  },
+  {
+    id: "legacy-slot-scope-attribute",
+    source: `<template><MyComponent><template slot-scope="props">{{ props.title }}</template></MyComponent></template>`,
+    diagnostics: 0,
+  },
+  {
+    id: "legacy-scope-attribute",
+    source: `<template><MyComponent><template scope="props">{{ props.title }}</template></MyComponent></template>`,
+    diagnostics: 0,
+  },
+  {
+    id: "static-bound-slot",
+    source: `<template><MyComponent><template v-bind:slot="name">Title</template></MyComponent></template>`,
+    diagnostics: 0,
+  },
+  {
+    id: "static-bound-slot-shorthand",
+    source: `<template><MyComponent><template :slot="name">Title</template></MyComponent></template>`,
+    diagnostics: 0,
+  },
+  {
+    id: "dynamic-bound-slot",
+    source: `<template><MyComponent><template v-bind:[slot]="name">Title</template></MyComponent></template>`,
+    diagnostics: 1,
+  },
+] as const;
+
+test("no-lone-template slot boundary stays pinned to eslint-plugin-vue 10.9.2", async () => {
+  assert.equal(requireFromBench("eslint-plugin-vue/package.json").version, "10.9.2");
+  assert.equal(requireFromBench("vue-eslint-parser/package.json").version, "10.4.1");
+
+  const eslint = new ESLint({
+    cwd: repoRoot,
+    overrideConfigFile: true,
+    overrideConfig: [
+      {
+        files: ["**/*.vue"],
+        languageOptions: {
+          parser: vueParser,
+          parserOptions: {
+            parser: typescriptParser,
+            ecmaVersion: "latest",
+            sourceType: "module",
+            extraFileExtensions: [".vue"],
+          },
+        },
+        plugins: { vue: pluginVue },
+        rules: { "vue/no-lone-template": "warn" },
+      },
+    ],
+  });
+
+  for (const fixture of cases) {
+    const [result] = await eslint.lintText(fixture.source, {
+      filePath: path.join(repoRoot, "oracle", `${fixture.id}.vue`),
+    });
+    const diagnostics = result.messages.filter(
+      (message) => message.ruleId === "vue/no-lone-template",
+    );
+    const parserErrors = result.messages.filter((message) => message.ruleId == null);
+
+    assert.deepEqual(parserErrors, [], `${fixture.id}: parser errors`);
+    assert.equal(diagnostics.length, fixture.diagnostics, fixture.id);
+  }
+});


### PR DESCRIPTION
## Summary
- Treat legacy static slot syntaxes as structural `<template>` uses in `vue/no-lone-template`
- Keep dynamic `v-bind:[slot]` reported, matching `eslint-plugin-vue@10.9.2`
- Add a pinned eslint-plugin-vue oracle test for the slot boundary

## Tests
- `cargo test -p vize_patina no_lone_template --locked`
- `node --test tests/tooling/patina-no-lone-template-oracle.test.ts`
- `node --test tests/tooling/patina-no-lone-template-oracle.test.ts tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_patina --locked`
- `cargo check -p vize_patina --all-targets --locked`
- `cargo clippy -p vize_patina --lib --tests --locked -- -D warnings`

## Notes
- `cargo clippy -p vize_patina --all-targets --locked -- -D warnings` still hits pre-existing `clippy::drop_non_drop` in `crates/vize_patina/benches/davinci_markup.rs`, outside this rule change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790320514&installation_model_id=422833&pr_number=4977&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4977&signature=aa54cf543b151c5800da6b85a368f15b74ac150f4c2431c02e9c808b324262cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Vue template validation to recognize additional valid slot syntax, including legacy attributes and static slot bindings.
  - Dynamic slot bindings continue to receive appropriate warnings.

- **Tests**
  - Added coverage for legacy, static-bound, and dynamic-bound slot syntax.
  - Added compatibility checks against the corresponding Vue ESLint parser and plugin versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->