### PR TITLE
fix(patina): align attribute order with formatter slots

### DIFF
--- a/crates/vize_glyph/src/template/attribute_priority_tests.rs
+++ b/crates/vize_glyph/src/template/attribute_priority_tests.rs
@@ -17,6 +17,8 @@ fn test_attribute_priority_order() {
     assert_eq!(attribute_priority("v-pre"), attribute_priority("v-once"));
     assert!(attribute_priority("v-once") < attribute_priority("id"));
     assert!(attribute_priority("id") < attribute_priority("ref"));
+    assert_eq!(attribute_priority("ref"), attribute_priority("slot"));
+    assert_eq!(attribute_priority("slot"), attribute_priority("slot-scope"));
     assert_eq!(attribute_priority("ref"), attribute_priority(":key"));
     assert!(attribute_priority(":key") < attribute_priority("v-model"));
     // Slots and custom directives precede plain attributes and bindings.

--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -120,12 +120,13 @@ fn attr_sort_key(name: &str, merge_bind: bool) -> (u8, String) {
 /// (the eslint-plugin-vue `vue/attributes-order` default), so default fmt
 /// output can never introduce that lint finding (#3251). Patina quirks are
 /// mirrored on purpose: `:ref`/`:id` are plain bindings, only `:key`/`:is`
-/// are special, and unmatched directives (`v-is`, `v-memo`) join the slots.
+/// are special, static Vue 2 slots are unique attributes, and unmatched
+/// directives (`v-is`, `v-memo`) join the slots.
 /// 0 `is`/`:is`; 1 `v-for`; 2 conditionals `v-if`/`v-else-if`/`v-else`/
 /// `v-show`/`v-cloak`; 3 render modifiers `v-pre`/`v-once`; 4 `id`; 5 unique
-/// `ref`/`key`/`:key`; 6 `v-model`; 7 other directives `v-slot`/`#xxx`; 8 other
-/// attributes (bound `:class` and static `class` share a priority); 9 events
-/// `@xxx`/`v-on`; 10 content `v-html`/`v-text`.
+/// `ref`/`key`/`slot`/`slot-scope`/`:key`; 6 `v-model`; 7 other directives
+/// `v-slot`/`#xxx`; 8 other attributes (bound `:class` and static `class`
+/// share a priority); 9 events `@xxx`/`v-on`; 10 content `v-html`/`v-text`.
 pub(crate) fn attribute_priority(name: &str) -> u8 {
     // Exact directive name or an `:arg`/`.mod` boundary (so `v-models` etc. fall through to 7).
     fn matches_directive(name: &str, directive: &str) -> bool {
@@ -147,7 +148,10 @@ pub(crate) fn attribute_priority(name: &str) -> u8 {
     if name == "id" {
         return 4;
     }
-    if matches!(name, "ref" | "key" | ":key" | "v-bind:key") {
+    if matches!(
+        name,
+        "ref" | "key" | "slot" | "slot-scope" | ":key" | "v-bind:key"
+    ) {
         return 5;
     }
     if matches_directive(name, "v-model") {

--- a/crates/vize_glyph/tests/template_directive_attributes.rs
+++ b/crates/vize_glyph/tests/template_directive_attributes.rs
@@ -37,6 +37,12 @@ fn default_order_matches_patina_vue_attribute_order_groups() {
     );
     assert_eq!(first, second);
 
+    let legacy_slot = r#"<div class="box" slot="header"></div>"#;
+    let first = format_template(legacy_slot, &options).unwrap();
+    let second = format_template(&first, &options).unwrap();
+    assert_eq!(first.as_str(), r#"<div slot="header" class="box"></div>"#);
+    assert_eq!(first, second);
+
     let slotted = r#"<Comp :data="d" #default="{ x }"></Comp>"#;
     let first = format_template(slotted, &options).unwrap();
     let second = format_template(&first, &options).unwrap();

--- a/crates/vize_patina/src/rules/vue/attribute_order.rs
+++ b/crates/vize_patina/src/rules/vue/attribute_order.rs
@@ -62,7 +62,7 @@ impl AttrCategory {
             PropNode::Attribute(attr) => match attr.name {
                 "is" => AttrCategory::Definition,
                 "id" => AttrCategory::GlobalAwareness,
-                "ref" | "key" => AttrCategory::UniqueAttrs,
+                "ref" | "key" | "slot" | "slot-scope" => AttrCategory::UniqueAttrs,
                 _ => AttrCategory::OtherAttrs,
             },
             PropNode::Directive(dir) => {
@@ -78,12 +78,15 @@ impl AttrCategory {
                     "model" => AttrCategory::TwoWayBinding,
                     "on" => AttrCategory::Events,
                     "html" | "text" => AttrCategory::Content,
+                    "slot" => AttrCategory::UniqueAttrs,
+                    "is" => AttrCategory::Definition,
                     "bind" => match arg {
                         Some("key") => AttrCategory::UniqueAttrs,
                         Some("is") => AttrCategory::Definition,
+                        Some("id") => AttrCategory::GlobalAwareness,
+                        Some("ref" | "slot" | "slot-scope") => AttrCategory::UniqueAttrs,
                         _ => AttrCategory::OtherAttrs,
                     },
-                    "slot" => AttrCategory::OtherDirectives,
                     _ => AttrCategory::OtherDirectives,
                 }
             }
@@ -194,20 +197,29 @@ mod tests {
     }
 
     #[test]
-    fn glyph_output_lints_clean_across_dynamic_barriers() {
-        let source =
-            r#"<div class="_button" v-tooltip:dialog="tip" v-once v-show="open" id="help"></div>"#;
-        let formatted = vize_glyph::format_template(source, &vize_glyph::FormatOptions::default())
-            .expect("formatting must succeed");
-        let result = create_linter().lint_template(&formatted, "test.vue");
-        assert_eq!(result.warning_count, 0, "{formatted}");
+    fn static_vue_two_slot_attributes_use_unique_group() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div slot="header" class="panel"></div><div class="panel" slot-scope="scope"></div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 1);
+    }
 
-        let slotted = vize_glyph::format_template(
+    #[test]
+    fn glyph_output_lints_clean_across_dynamic_barriers_and_static_slots() {
+        let cases = [
+            r#"<div class="_button" v-tooltip:dialog="tip" v-once v-show="open" id="help"></div>"#,
             r#"<Comp :data="d" #default="{ x }"></Comp>"#,
-            &vize_glyph::FormatOptions::default(),
-        )
-        .expect("formatting must succeed");
-        let result = create_linter().lint_template(&slotted, "test.vue");
-        assert_eq!(result.warning_count, 0, "{slotted}");
+            r#"<div class="panel" slot="header"></div>"#,
+        ];
+
+        for source in cases {
+            let formatted =
+                vize_glyph::format_template(source, &vize_glyph::FormatOptions::default())
+                    .expect("formatting must succeed");
+            let result = create_linter().lint_template(&formatted, "test.vue");
+            assert_eq!(result.warning_count, 0, "{formatted}");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- keep directive attributes as ordering barriers so Patina accepts Glyph formatter output
- classify static Vue 2 `slot` and `slot-scope` attributes with the unique-attribute group
- align Glyph static slot priority and cover the formatter/linter contract

## Verification
- `nix develop --command cargo test -p vize_patina attribute_order --locked`
- `nix develop --command cargo test -p vize_glyph --test template_directive_attributes --locked`
- `nix develop --command cargo test -p vize_glyph attribute_priority --locked`
- `nix develop --command cargo build -p vize --locked`
- `nix develop --command node --test tests/snapshots/lint/npmx.ts`
- `nix develop --command env FIXTURE_SHARD_INDEX=25 FIXTURE_SHARD_COUNT=144 node --test tests/tooling/glyph-corpus-lint-agreement.test.ts`
- `nix develop --command cargo fmt --all -- --check`
- `nix develop --command node --test tests/tooling/source-file-lengths.test.ts`
- `nix develop --command cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `git diff --check`

Note: an extra local `cargo clippy -p vize_patina -p vize_glyph --lib --tests --locked -- -D warnings` run hit pre-existing `vize_glyph` test-only disallowed macro/type findings outside this PR; the CI-matching workspace clippy command above passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue attribute ordering for `slot`, `slot-scope`, `is`, `id`, and `ref` attributes.
  * Corrected ordering across dynamic attributes and static slots.
  * Preserved stable, idempotent formatting for legacy Vue 2 slot attributes.

* **Tests**
  * Added regression coverage for slot-related attribute priorities and formatter output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->