### PR TITLE
fix(fixtures): isolate formatter matrix snapshots

### DIFF
--- a/tests/tooling/fixture-tool-matrix-formatter.test.ts
+++ b/tests/tooling/fixture-tool-matrix-formatter.test.ts
@@ -241,12 +241,16 @@ test("formatter oracle rejects malformed, inconsistent, or mutating checks", () 
   }
 });
 
-test("formatter input snapshot detects source and metadata changes", () => {
+test("formatter input snapshot is fixture-scoped and detects changed inputs", () => {
   const fixtureDir = fs.mkdtempSync(path.join(root, "tests", "_fixtures", "formatter-snapshot-"));
+  const siblingDir = fs.mkdtempSync(path.join(root, "tests", "_fixtures", "formatter-snapshot-"));
   const sourcePath = path.join(fixtureDir, "App.vue");
   fs.writeFileSync(sourcePath, "<template />\n");
   try {
     const before = snapshotFormatterInputs(fixtureDir, ["**/*.vue"]);
+    fs.writeFileSync(path.join(siblingDir, "Other.vue"), "<template><aside /></template>\n");
+    assert.equal(snapshotFormatterInputs(fixtureDir, ["**/*.vue"]), before);
+
     fs.writeFileSync(sourcePath, "<template><main /></template>\n");
     const afterContent = snapshotFormatterInputs(fixtureDir, ["**/*.vue"]);
     assert.notEqual(afterContent, before);
@@ -256,6 +260,7 @@ test("formatter input snapshot detects source and metadata changes", () => {
     assert.notEqual(afterMetadata, before);
   } finally {
     fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(siblingDir, { recursive: true, force: true });
   }
 });
 

--- a/tools/fixtures/tool-matrix-formatter.mjs
+++ b/tools/fixtures/tool-matrix-formatter.mjs
@@ -30,7 +30,15 @@ export function snapshotFormatterInputs(cwd, patterns) {
   }
   const status = spawnSync(
     "git",
-    ["status", "--porcelain=v1", "-z", "--untracked-files=all", "--ignore-submodules=none"],
+    [
+      "status",
+      "--porcelain=v1",
+      "-z",
+      "--untracked-files=all",
+      "--ignore-submodules=none",
+      "--",
+      ".",
+    ],
     { cwd, encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
   );
   if (status.error != null || status.status !== 0) {


### PR DESCRIPTION
## Summary
- scope formatter input snapshots to the selected fixture path
- keep unrelated sibling temporary fixtures out of formatter matrix mutation digests
- add a regression that proves sibling fixture state is ignored while local fixture mutations are still detected

## Verification
- `node --test --test-name-pattern 'formatter input snapshot ignores unrelated sibling fixtures' tests/tooling/fixture-tool-matrix-formatter.test.ts`
- `node --test tests/tooling/fixture-tool-matrix-formatter.test.ts`
- `node --test tests/tooling/fixture-tool-matrix-linter.test.ts tests/tooling/fixture-tool-matrix-formatter.test.ts tests/tooling/fixture-tool-matrix-compiler.test.ts tests/tooling/compiler-fixture-diff-report.test.ts`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790325756&installation_model_id=422833&pr_number=4980&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4980&signature=cd1410788d3030712873edd67f8816e8195a2de36d0939e6cfe708808d6838d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->