### PR TITLE
fix(fuzz): skip number-folding math in percentage-only slots in css_parse

### DIFF
--- a/crates/vize_atelier_sfc/tests/css_engine_panic_boundary.rs
+++ b/crates/vize_atelier_sfc/tests/css_engine_panic_boundary.rs
@@ -1,4 +1,5 @@
-//! Regression tests for the LightningCSS engine panic defense (#3276, #3280).
+//! Regression tests for the LightningCSS engine panic defense (#3276, #3280,
+//! #4961).
 //!
 //! The css_parse fuzz target found two upstream crash classes that still
 //! reproduce on the latest released lightningcss/cssparser-color versions
@@ -8,7 +9,10 @@
 //!   percentage-typed slots whose calc tree does not fold to a plain
 //!   percentage. This fires in every profile, and the release profile builds
 //!   with `panic = "abort"`, so it used to crash the shipped CLI and LSP on
-//!   inputs as small as `lch(sign(-50%)`.
+//!   inputs as small as `lch(sign(-50%)`. The same `unreachable!()` also
+//!   fires with no `%` at all when the tree folds to a bare number
+//!   (`Calc::Number`) in a percentage-only slot — `text-size-adjust:asin(5)`,
+//!   `font-stretch:calc(5)` (#4961).
 //! - `hsl_to_rgb` debug-asserts hue into `[0, 1]`, so a non-finite hue
 //!   crashes every build with debug assertions (tests, fuzzing).
 //!
@@ -106,6 +110,44 @@ fn parse_css_ast_reports_under_guarded_engine_panics_as_errors() {
     assert_eq!(result.errors, [PARSE_BOUNDARY_ERROR]);
 }
 
+/// The 66-byte css_parse fuzz artifact from #4961 (run 32932217923) plus the
+/// minimal shapes of its class: a math function whose calc tree folds to a
+/// bare number (`Calc::Number`, NaN included — `asin(5)`) in a
+/// percentage-only slot trips the `Percentage::parse` `unreachable!()` with
+/// no `%` involved. The percentage-only routes are the `text-size-adjust`
+/// and `font-stretch` longhands and `@property` `<percentage>` initial-value
+/// parsing; in unwinding profiles (this test binary) the `catch_unwind`
+/// boundary must convert the panic into an error result. Release binaries
+/// still abort on these — #3295 tracks the upstream fix.
+#[test]
+fn parse_css_ast_reports_number_folding_math_in_percentage_slots_as_errors() {
+    const NUMBER_FOLD_ARTIFACT: &str = "losrasinable-p {\n t>px`5;  text-size-adjust:asin(5\u{c})\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}\u{0}UUUrath";
+    // Pin the fixture size: the artifact must stay byte-for-byte the one the
+    // fuzzer produced.
+    assert_eq!(
+        NUMBER_FOLD_ARTIFACT.len(),
+        66,
+        "fuzz artifact must stay verbatim"
+    );
+    for source in [
+        NUMBER_FOLD_ARTIFACT,
+        "a{text-size-adjust:asin(5)}",
+        "a{text-size-adjust:calc(5)}",
+        "a{text-size-adjust:calc(1 + 1)}",
+        "a{text-size-adjust:sqrt(2)}",
+        "a{text-size-adjust:sign(5)}",
+        "a{font-stretch:calc(5)}",
+        "@property --x{syntax:\"<percentage>\";inherits:false;initial-value:calc(5);}",
+    ] {
+        let result = parse_css_ast(source, &CssCompileOptions::default());
+        assert!(
+            result.ast.is_none(),
+            "expected boundary error for {source:?}"
+        );
+        assert_eq!(result.errors, [PARSE_BOUNDARY_ERROR], "source {source:?}");
+    }
+}
+
 /// A non-finite hue trips an upstream `debug_assert`, so the boundary reports
 /// an error in debug-assertion builds; in release builds the parse currently
 /// succeeds with a folded garbage value. Either way the process must survive
@@ -171,6 +213,18 @@ fn parse_css_ast_keeps_accepting_resolvable_math_functions() {
         "a{background-image:linear-gradient(red abs(-50%), blue)}",
         "a{content:\"sign(-50%) in a string\"}",
         "a{font-size:abs(-50%)}",
+        // #4961 neighbors: percentage-folding trees, keywords, and plain
+        // percentages in the percentage-only slots parse fine, as do
+        // number-folding trees in number- and angle-typed slots.
+        "a{text-size-adjust:50%}",
+        "a{text-size-adjust:auto}",
+        "a{text-size-adjust:calc(50% + 10%)}",
+        "a{font-stretch:condensed}",
+        "a{font-stretch:calc(50% + 10%)}",
+        "a{rotate:asin(0.5)}",
+        "a{line-height:calc(exp(1))}",
+        "a{opacity:calc(sqrt(0.25))}",
+        "a{width:calc(pow(2, 3) * 1px)}",
     ] {
         let result = parse_css_ast(source, &CssCompileOptions::default());
         assert!(result.ast.is_some(), "expected clean parse for {source:?}");

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -721,7 +721,7 @@ compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/allocation_budget.rs	30
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/component_spread_props.rs	10	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/component_tag_binding.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/component_tag_binding.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/css_engine_panic_boundary.rs	72	s0	S0/carton	stage	vize_carton	compat	5
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/css_engine_panic_boundary.rs	76	s0	S0/carton	stage	vize_carton	compat	5
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/css_nesting_guard.rs	11	s0	S0/carton	stage	vize_carton	compat	6
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs	5	s0	S0/carton	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/davinci_arena_pool.rs	27	s0	S0/carton	stage	vize_carton	compat	1

--- a/tests/fuzz/fuzz_targets/css_parse.rs
+++ b/tests/fuzz/fuzz_targets/css_parse.rs
@@ -6,8 +6,9 @@
 // serialized-AST API. Syntax errors should be returned in CssAstResult; panics
 // are always a bug in the integration layer or upstream parser boundary.
 //
-// Three upstream defect classes are skip-listed below until their fixes land
-// (#3276, #3280, #3926; retirement tracked in #3295). Production is protected
+// Four upstream defect classes are skip-listed below until their fixes land
+// (#3276, #3280, #3926, #4961; retirement tracked in #3295). Production is
+// protected
 // by the `catch_unwind` boundary in
 // `vize_atelier_sfc::css::parser::engine_boundary`; the skips exist because
 // libfuzzer-sys aborts inside its panic hook (a caught-and-reported upstream
@@ -86,6 +87,37 @@ fn has_oversized_numeric_token(lower: &str) -> bool {
         }
     }
     false
+}
+
+/// Value contexts that funnel into upstream `Percentage::parse`, where a math
+/// function folding to a plain number — `calc(5)`, `sqrt(2)`, `asin(5)` (NaN)
+/// — returns `Calc::Number` and hits the same `unreachable!()` as #3276 with
+/// no `%` involved (#4961, found via `text-size-adjust:asin(5)`).
+/// `text-size-adjust` and `font-stretch` are the percentage-only typed
+/// properties; "percentage" covers `@property { syntax: "<percentage>" }`
+/// initial-value parsing. Plain substring matching, deliberately broad.
+const PERCENTAGE_SLOT_CONTEXTS: [&str; 3] = ["text-size-adjust", "font-stretch", "percentage"];
+
+/// Math-function heads whose calc tree can fold to a bare number in those
+/// slots. `sin(`/`cos(`/`tan(` also match their inverse `a…(` forms; `atan2`
+/// stays unmatched because it folds to an angle and errors out cleanly.
+const NUMBER_FOLDING_MATH_FUNCTIONS: [&str; 17] = [
+    "calc(", "min(", "max(", "clamp(", "round(", "mod(", "rem(", "sign(", "abs(", "hypot(",
+    "sqrt(", "pow(", "log(", "exp(", "sin(", "cos(", "tan(",
+];
+
+/// Returns true when a percentage-only value context and a number-capable
+/// math function co-occur (#4961). Whether the tree really folds to a number
+/// is calc type algebra a byte scan cannot reproduce, so co-occurrence is the
+/// superset: it costs fuzz coverage on shapes like
+/// `text-size-adjust: calc(50% + 10%)`, never product behavior.
+fn percentage_slot_meets_number_math(lower: &str) -> bool {
+    PERCENTAGE_SLOT_CONTEXTS
+        .iter()
+        .any(|context| lower.contains(context))
+        && NUMBER_FOLDING_MATH_FUNCTIONS
+            .iter()
+            .any(|name| lower.contains(name))
 }
 
 /// Color-entry functions recognized by the unparsed-value fallback. When one
@@ -171,9 +203,9 @@ fn function_group_unterminated(lower: &str, name: &str) -> bool {
     false
 }
 
-/// Known upstream defect shapes (#3276, #3280 panics; #3926 timeout): skip
-/// them so fuzzing keeps hunting new engine bugs without re-reporting the
-/// documented defects.
+/// Known upstream defect shapes (#3276, #3280, #4961 panics; #3926 timeout):
+/// skip them so fuzzing keeps hunting new engine bugs without re-reporting
+/// the documented defects.
 ///
 /// The #3926 class is pathological backtracking, not a hang: unterminated
 /// color functions with rule-block braces interleaved into the open groups
@@ -189,6 +221,9 @@ fn hits_known_upstream_defect_shape(source: &str) -> bool {
             .iter()
             .any(|name| function_arguments_contain_percent(&lower, name))
     {
+        return true;
+    }
+    if percentage_slot_meets_number_math(&lower) {
         return true;
     }
     if COLOR_FUNCTIONS


### PR DESCRIPTION
## Summary

The `css_parse` fuzz bot found a **crash** reproducer (#4961, run 32932217923, commit 5481407dd): 66 bytes whose payload is `text-size-adjust:asin(5\x0c)`.

## Diagnosis (no cargo-fuzz needed)

- Replayed the artifact directly against `vize_atelier_sfc::parse_css_ast`: the panic is upstream — lightningcss-1.0.0-alpha.72 `Percentage::parse` hits `unreachable!()` (`values/percentage.rs:30`) via `TextSizeAdjust::parse`. Production survives today through the `catch_unwind` engine boundary (the replay returns the boundary error, no process crash in unwinding profiles).
- Mapped the class synthetically: the trigger is a math function whose calc tree folds to a **bare number** (`Calc::Number`) in a **percentage-only** slot — `asin(5)` folds to NaN, and plain `calc(5)`, `calc(1 + 1)`, `sqrt(2)`, `sign(5)`, `min(5)`, `sin(5)`… all reproduce with **no `%` involved**, which is why the #3276 skip (keyed on `%` in the arguments) missed it.
- The percentage-only routes are the `text-size-adjust` and `font-stretch` longhands and `@property { syntax: "<percentage>"; initial-value: … }`. Angle-folding trees (`asin(0.5)`, `atan(1)`) error out cleanly, and number-accepting slots (opacity, color components including `color-mix`, and the `font` shorthand, which is keyword-only for stretch) parse fine.

## Fix

lightningcss is a pinned crates.io dependency, so per the file's documented convention for upstream defects (#3276, #3280, #3926; retirement tracked in #3295) the target now skips inputs where a percentage-only context marker (`text-size-adjust`, `font-stretch`, `percentage`) and a number-capable math-function head co-occur. Deliberately broad superset — it costs fuzz coverage on shapes like `text-size-adjust: calc(50% + 10%)`, never product behavior.

The 66-byte artifact (length-pinned, verbatim) and the minimal class shapes join `css_engine_panic_boundary.rs` as regression inputs asserting the boundary converts the panic into an error result, next to the class's nearest working neighbors that must keep parsing.

Skip-list retirement tracking in #3295 gains this fourth class.

## Verification

- Extracted-predicate test: reproducer bytes and 13 class shapes are skipped; a 12-entry valid-CSS panel (plain percentages, keywords, math in number/angle/length slots) is not.
- `cargo test -p vize_atelier_sfc --test css_engine_panic_boundary`: 8 passed (includes the new artifact pin).
- `cargo check` + `cargo clippy -- -D warnings -D clippy::wildcard_imports` from `tests/fuzz` on stable: clean. `cargo fmt --check`: clean. Both touched files remain within the 350-line budget (247 and 272 lines).

Closes #4961

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790327633&installation_model_id=422833&pr_number=4981&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4981&signature=c279459a39926e6bcd916056c1f9c032ba57c570d91c22a90c05b7814129ec48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of CSS percentage-only values that could incorrectly produce bare numbers.
  * Added safeguards for affected CSS properties and custom property definitions.
  * Preserved parsing behavior for valid neighboring inputs.

* **Tests**
  * Expanded regression coverage for CSS parsing edge cases, including text sizing, font stretching, and custom properties.
  * Enhanced fuzz testing for math functions in percentage-only contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->