### PR TITLE
test(ricalco): pin source-block lowering spans

### DIFF
--- a/crates/vize_ricalco/tests/lowering_battery.rs
+++ b/crates/vize_ricalco/tests/lowering_battery.rs
@@ -12,6 +12,12 @@ mod support;
 
 use davinci_test_support::surface_fixture as battery;
 use support::{assert_sound, with_lowered};
+use vize_davinci::diagnostic::{Diagnostic, Severity, Stage};
+use vize_davinci::folio::{Folio, FolioMode};
+use vize_s0::{Allocator, SourceRoot, Span};
+use vize_s1::parse;
+use vize_s2::folio::DisegnoFolio;
+use vize_s2::verify::{Rigor, Violation, verify};
 
 #[test]
 fn the_battery_scope_is_pinned() {
@@ -41,6 +47,48 @@ fn every_truncation_of_every_fixture_lowers_soundly() {
             assert_sound(&source[start..], fixture.name);
         }
     }
+}
+
+#[test]
+fn a_source_block_lowering_keeps_file_absolute_spans() {
+    let source = "prelude\n<template><div><span>x</div></template>";
+    let template_start = source.find("<template>").expect("template") + "<template>".len();
+    let template_end = source.find("</template>").expect("template close");
+    let template = &source[template_start..template_end];
+    let root = SourceRoot::new(source).expect("source root");
+    let block = root
+        .block(template, template_start as u32)
+        .expect("template block is a root slice");
+
+    let allocator = Allocator::new();
+    let (tree, errors) = parse(&allocator, template);
+    let lowered = vize_ricalco::lower_source_block(&allocator, &tree, &errors, block);
+    let folio = DisegnoFolio::of(&lowered.root.ops);
+
+    assert_eq!(u64::from(lowered.op_count), folio.op_count());
+    assert_eq!(verify(&folio, Rigor::Canonical), Vec::<Violation>::new());
+    assert_eq!(
+        folio.print_to_string(FolioMode::Full).as_str(),
+        "\
+[disegno]
+ops=3
+
+[disegno.ops]
+ui.element div @18:36
+  ui.element span @23:30
+    ui.text \"x\" @29:30
+
+"
+    );
+    assert_eq!(
+        lowered.diagnostics,
+        vec![Diagnostic::new(
+            Severity::Error,
+            Stage::Surface,
+            Span::new(23, 28),
+            "Element is missing end tag.",
+        )]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add a P2-8 lowering battery regression for nested source blocks
- pin file-absolute S0 spans in the S2 folio and malformed diagnostic output
- keep the verifier/op-count soundness oracle on the lowered fragment

## Verification
- cargo test -p vize_ricalco --test lowering_battery a_source_block_lowering_keeps_file_absolute_spans --locked -- --nocapture
- cargo fmt -p vize_ricalco --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check
- cargo test -p vize_ricalco --locked
- cargo test -p vize_ricalco --features davinci-differential --test davinci_lowering_corpus --locked -- --nocapture
- cargo clippy -p vize_ricalco --lib --tests --locked -- -D warnings
- node --test tests/tooling/davinci-matrices.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790327841&installation_model_id=422833&pr_number=4983&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4983&signature=82f343d07e94e88351a2e00d513d633c78ce087df7bff8c82bf80939e6490b4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->