### PR TITLE
fix(patina): count class array objects via parser

### DIFF
--- a/crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs
@@ -24,6 +24,10 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{ArrayExpressionElement, Expression};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
 use vize_relief::{DirectiveNode, ElementNode, ExpressionNode};
 
 static META: RuleMeta = RuleMeta {
@@ -74,41 +78,72 @@ impl Rule for NoMultipleObjectsInClass {
     }
 }
 
-/// Count the object literals (`{ ... }` groups) that sit directly at the top
-/// level of an array-literal expression string.
-///
-/// Returns `0` when the expression is not an array literal (does not start with
-/// `[` and end with `]`). Nested braces/brackets are skipped so only the
-/// array's own elements are counted; this is a pragmatic scan rather than a
-/// full parse, which is sufficient for the heuristic.
+/// Count object literals that sit directly in a `:class` array binding.
 fn count_top_level_objects_in_array(raw: &str) -> usize {
-    let s = raw.trim();
-    let bytes = s.as_bytes();
-    if bytes.len() < 2 || bytes[0] != b'[' || bytes[bytes.len() - 1] != b']' {
+    let source = raw.trim();
+    if !source.starts_with('[') || !source.ends_with(']') {
         return 0;
     }
 
-    let mut count = 0usize;
-    // Depth relative to the array body: `[` opens at depth 1, the array's own
-    // elements live at depth 1, anything deeper is nested.
-    let mut depth = 0i32;
-    for &b in bytes {
-        match b {
-            b'[' => depth += 1,
-            b']' => depth -= 1,
-            // A `{` that opens while we are directly inside the array body
-            // (depth 1) starts a top-level object literal.
-            b'{' => {
-                if depth == 1 {
-                    count += 1;
-                }
-                depth += 1;
+    let allocator = Allocator::default();
+    let source_type = SourceType::default().with_typescript(true);
+    let Ok(parsed) = Parser::new(&allocator, source, source_type).parse_expression() else {
+        return 0;
+    };
+    let Some(rest) = source.get(parsed.span().end as usize..) else {
+        return 0;
+    };
+    if !rest.trim().is_empty() {
+        return 0;
+    }
+
+    let Expression::ArrayExpression(array) = unwrap_expression(&parsed) else {
+        return 0;
+    };
+
+    array
+        .elements
+        .iter()
+        .filter(|element| array_element_is_object(element))
+        .count()
+}
+
+fn array_element_is_object<'a>(element: &'a ArrayExpressionElement<'a>) -> bool {
+    match element {
+        ArrayExpressionElement::ObjectExpression(_) => true,
+        ArrayExpressionElement::ParenthesizedExpression(paren) => {
+            expression_is_object(&paren.expression)
+        }
+        ArrayExpressionElement::TSAsExpression(ts_as) => expression_is_object(&ts_as.expression),
+        ArrayExpressionElement::TSNonNullExpression(ts_non_null) => {
+            expression_is_object(&ts_non_null.expression)
+        }
+        ArrayExpressionElement::TSSatisfiesExpression(ts_satisfies) => {
+            expression_is_object(&ts_satisfies.expression)
+        }
+        _ => false,
+    }
+}
+
+fn expression_is_object<'a>(expression: &'a Expression<'a>) -> bool {
+    matches!(
+        unwrap_expression(expression),
+        Expression::ObjectExpression(_)
+    )
+}
+
+fn unwrap_expression<'a>(mut expression: &'a Expression<'a>) -> &'a Expression<'a> {
+    loop {
+        match expression {
+            Expression::ParenthesizedExpression(paren) => expression = &paren.expression,
+            Expression::TSAsExpression(ts_as) => expression = &ts_as.expression,
+            Expression::TSNonNullExpression(ts_non_null) => expression = &ts_non_null.expression,
+            Expression::TSSatisfiesExpression(ts_satisfies) => {
+                expression = &ts_satisfies.expression;
             }
-            b'}' => depth -= 1,
-            _ => {}
+            _ => return expression,
         }
     }
-    count
 }
 
 #[cfg(test)]
@@ -155,6 +190,22 @@ mod tests {
             "App.vue",
         );
         assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn allows_template_literal_and_single_object_in_array() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            r##"<script setup lang="ts">
+defineProps<{ device: string; isVertical: boolean }>();
+</script>
+
+<template>
+  <div :class='[`rendered-${device}`, { "vertical-rendered": isVertical }]' />
+</template>"##,
+            "App.vue",
+        );
+        assert_eq!(result.warning_count, 0, "got: {:?}", result.diagnostics);
     }
 
     #[test]

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           916 |                   192 |               724 |             139 |     371 |             951 |      475 |           477 |           584 |
-| Linter                     |           302 |                   302 |                 0 |             266 |     222 |             668 |      122 |           339 |           478 |
+| Linter                     |           302 |                   302 |                 0 |             266 |     225 |             671 |      122 |           339 |           478 |
 | Typechecker                |           887 |                   139 |               748 |             396 |     187 |             807 |      663 |           463 |           653 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            18 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -102,7 +102,7 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 | S0/carton        |         302 |             225 |       77 |
 | old AST/parser   |         226 |             211 |       15 |
 | Croquis analysis |          40 |              36 |        4 |
-| raw OXC          |         222 |             196 |       26 |
+| raw OXC          |         225 |             199 |       26 |
 
 #### Top source and manifest files
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1073,6 +1073,9 @@ linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_att
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_empty_component_block.rs	40	s0	S0/carton	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_inline_style.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	raw_oxc	raw OXC	raw	oxc_ast	raw	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_negated_v_if_condition.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_preprocessor_lang.rs	20	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_root_v_if.rs	38	old_ast	old AST/parser	old	vize_relief	legacy	2


### PR DESCRIPTION
## Summary
- Parse static `:class` array bindings with OXC before counting top-level object literals.
- Keep non-array bindings on the fast early-return path.
- Add the reported template-literal + single-object regression fixture.

Closes #4955

## Verification
- `nix develop --command cargo test -p vize_patina rules::opinionated::vue::no_multiple_objects_in_class`
- `nix develop --command cargo test -p vize_patina`
- `nix develop --command cargo fmt --all -- --check`
- `nix develop --command cargo clippy -p vize_patina -- -D warnings -D clippy::wildcard_imports`
- `nix develop --command node --test tests/tooling/source-file-lengths.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790327975&installation_model_id=422833&pr_number=4984&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4984&signature=53eada9766edc955a1c21d61760259d0a22eb7f36b278323f5c02608822803d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->