### PR TITLE
fix(cli): fail closed when the resolved oxlint binary is a non-lint wrapper shim

### DIFF
--- a/npm/oxint/src/cli.ts
+++ b/npm/oxint/src/cli.ts
@@ -1,9 +1,9 @@
 import { spawn } from "node:child_process";
 import type { Writable } from "node:stream";
 
-import { getLintTargets } from "./cli/args.js";
+import { expectsLintReport, getLintTargets } from "./cli/args.js";
 import { collectVueLikeFilesFromTargets } from "./cli/files.js";
-import { resolveOxlintCliEntrypoint } from "./cli/oxlint.js";
+import { resolveOxlintCliEntrypoint, verifyOxlintCliEntrypoint } from "./cli/oxlint.js";
 import { rewriteReportedPaths } from "./cli/output.js";
 import { prepareScriptlessWorkaroundFiles } from "./cli/workaround-files.js";
 
@@ -12,8 +12,9 @@ async function main(): Promise<void> {
   const forwardedArgs = process.argv.slice(2);
   const targets = getLintTargets(forwardedArgs);
   const lintFiles = collectVueLikeFilesFromTargets(cwd, targets);
-  const prepared = prepareScriptlessWorkaroundFiles(cwd, lintFiles);
   const oxlintEntrypoint = resolveOxlintCliEntrypoint(cwd);
+  verifyOxlintCliEntrypoint(process.execPath, oxlintEntrypoint);
+  const prepared = prepareScriptlessWorkaroundFiles(cwd, lintFiles);
   const args = [oxlintEntrypoint, ...forwardedArgs, ...prepared.appendedArgs];
 
   try {
@@ -27,6 +28,17 @@ async function main(): Promise<void> {
 
     if (stderr) {
       await writeStream(process.stderr, stderr);
+    }
+
+    if (result.status === 0 && stdout === "" && stderr === "" && expectsLintReport(forwardedArgs)) {
+      await writeStream(
+        process.stderr,
+        `The oxlint run at ${oxlintEntrypoint} exited 0 but produced no report, ` +
+          "although the requested format always emits one. " +
+          "Refusing to treat the silent run as a clean lint result.\n",
+      );
+      process.exitCode = 1;
+      return;
     }
 
     if (prepared.usedScriptlessWorkaround && forwardedArgs.includes("--fix")) {

--- a/npm/oxint/src/cli/args.ts
+++ b/npm/oxint/src/cli/args.ts
@@ -27,6 +27,40 @@ const OPTION_NAMES_WITH_VALUES = new Set([
   "--warn",
 ]);
 
+/**
+ * Formats whose reports contain output even for a completely clean run.
+ *
+ * The auto, stylish, and unix formats legitimately print nothing when no
+ * diagnostics are found, so an empty report proves nothing for them. These
+ * formats always emit at least a summary or document skeleton, which makes a
+ * fully silent exit-0 run attributable to a child that never linted at all.
+ */
+const ALWAYS_REPORTING_FORMATS = new Set(["checkstyle", "default", "github", "json", "junit"]);
+
+/** Whether the requested output format guarantees a non-empty report. */
+export function expectsLintReport(argv: readonly string[]): boolean {
+  let format: string | null = null;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") {
+      break;
+    }
+
+    if (arg === "-f" || arg === "--format") {
+      format = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--format=")) {
+      format = arg.slice("--format=".length);
+    }
+  }
+
+  return format != null && ALWAYS_REPORTING_FORMATS.has(format);
+}
+
 export function getLintTargets(argv: readonly string[]): string[] {
   const targets: string[] = [];
   let collectEverything = false;

--- a/npm/oxint/src/cli/oxlint.test.ts
+++ b/npm/oxint/src/cli/oxlint.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { expectsLintReport } from "./args.ts";
+import { verifyOxlintCliEntrypoint } from "./oxlint.ts";
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const cliEntry = path.join(packageDir, "dist", "cli.mjs");
+
+/** The vite-plus LSP-only wrapper, reduced to the behavior that matters here. */
+const LSP_ONLY_SHIM = `console.error("This oxlint wrapper is for IDE extension use only (--lsp mode).");
+process.exit(0);
+`;
+
+const SILENT_SHIM = "process.exit(0);\n";
+
+/** Answers the handshake like real oxlint but swallows every lint run. */
+const HANDSHAKE_ONLY_SHIM = `if (process.argv.includes("--version")) {
+  console.log("Version: 9.9.9");
+}
+process.exit(0);
+`;
+
+const REAL_LOOKING_OXLINT = 'console.log("Version: 1.78.0");\nprocess.exit(0);\n';
+
+function withTempWorkspace<T>(run: (root: string) => T): T {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "oxint-oxlint-shim-"));
+  try {
+    return run(root);
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+}
+
+function writeFakeOxlintEntrypoint(root: string, source: string): string {
+  const entrypoint = path.join(root, "node_modules", "oxlint", "bin", "oxlint");
+  fs.mkdirSync(path.dirname(entrypoint), { recursive: true });
+  fs.writeFileSync(entrypoint, source);
+  return entrypoint;
+}
+
+function writeVueFixture(root: string): void {
+  fs.writeFileSync(
+    path.join(root, "App.vue"),
+    `<script setup lang="ts">
+const items = [1]
+</script>
+<template>
+  <ul>
+    <li v-for="item in items">{{ item }}</li>
+  </ul>
+</template>
+`,
+  );
+}
+
+function runOxlintVize(root: string, args: readonly string[]) {
+  try {
+    const stdout = String(
+      execFileSync(process.execPath, [cliEntry, ...args], {
+        cwd: root,
+        encoding: "utf8",
+        stdio: "pipe",
+      }),
+    );
+    return { exitCode: 0, stderr: "", stdout };
+  } catch (error) {
+    const execError = error as {
+      status?: number;
+      stderr?: string | Buffer;
+      stdout?: string | Buffer;
+    };
+    return {
+      exitCode: execError.status ?? 1,
+      stderr: String(execError.stderr ?? ""),
+      stdout: String(execError.stdout ?? ""),
+    };
+  }
+}
+
+void test("verifyOxlintCliEntrypoint accepts a binary that answers the --version handshake", () => {
+  withTempWorkspace((root) => {
+    const entrypoint = writeFakeOxlintEntrypoint(root, REAL_LOOKING_OXLINT);
+    verifyOxlintCliEntrypoint(process.execPath, entrypoint);
+  });
+});
+
+void test("verifyOxlintCliEntrypoint rejects the LSP-only wrapper shim", () => {
+  withTempWorkspace((root) => {
+    const entrypoint = writeFakeOxlintEntrypoint(root, LSP_ONLY_SHIM);
+    assert.throws(
+      () => {
+        verifyOxlintCliEntrypoint(process.execPath, entrypoint);
+      },
+      (error: unknown) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /--version/u);
+        assert.ok(error.message.includes(entrypoint), "the diagnostic should name the shim path");
+        return true;
+      },
+    );
+  });
+});
+
+void test("verifyOxlintCliEntrypoint rejects a shim that exits 0 with no output", () => {
+  withTempWorkspace((root) => {
+    const entrypoint = writeFakeOxlintEntrypoint(root, SILENT_SHIM);
+    assert.throws(() => {
+      verifyOxlintCliEntrypoint(process.execPath, entrypoint);
+    }, /--version/u);
+  });
+});
+
+void test("expectsLintReport recognizes the formats that always produce output", () => {
+  assert.equal(expectsLintReport([]), false);
+  assert.equal(expectsLintReport(["src"]), false);
+  assert.equal(expectsLintReport(["-f", "json", "src"]), true);
+  assert.equal(expectsLintReport(["--format", "junit"]), true);
+  assert.equal(expectsLintReport(["--format=github"]), true);
+  assert.equal(expectsLintReport(["-f", "stylish", "src"]), false);
+  assert.equal(expectsLintReport(["-f", "unix"]), false);
+  // After `--` everything is a lint target, not an option.
+  assert.equal(expectsLintReport(["--", "-f", "json"]), false);
+});
+
+void test("a workspace whose oxlint is a non-lint wrapper shim fails the run closed", () => {
+  withTempWorkspace((root) => {
+    const entrypoint = writeFakeOxlintEntrypoint(root, LSP_ONLY_SHIM);
+    writeVueFixture(root);
+
+    const run = runOxlintVize(root, ["App.vue"]);
+    assert.notEqual(
+      run.exitCode,
+      0,
+      "a shim that lints nothing must not be reported as a clean run",
+    );
+    assert.match(run.stderr, /--version/u);
+    assert.ok(run.stderr.includes(entrypoint), "the diagnostic should name the shim path");
+  });
+});
+
+void test("a child that answers the handshake but swallows the report fails closed", () => {
+  withTempWorkspace((root) => {
+    writeFakeOxlintEntrypoint(root, HANDSHAKE_ONLY_SHIM);
+    writeVueFixture(root);
+
+    const jsonRun = runOxlintVize(root, ["-f", "json", "App.vue"]);
+    assert.notEqual(
+      jsonRun.exitCode,
+      0,
+      "an empty run must not pass when the requested format always produces a report",
+    );
+    assert.match(jsonRun.stderr, /no report|produced no/iu);
+
+    // The auto format legitimately prints nothing on a clean run, so a silent
+    // exit-0 child stays trusted once it has answered the handshake.
+    const autoRun = runOxlintVize(root, ["App.vue"]);
+    assert.equal(autoRun.exitCode, 0);
+  });
+});

--- a/npm/oxint/src/cli/oxlint.ts
+++ b/npm/oxint/src/cli/oxlint.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
@@ -30,4 +31,38 @@ export function resolveOxlintCliEntrypoint(cwd: string): string {
 
     currentDir = parentDir;
   }
+}
+
+/** Real oxlint prints `Version: <semver>`; any semver-shaped token passes. */
+const VERSION_HANDSHAKE_PATTERN = /\b\d+\.\d+\.\d+/u;
+
+/**
+ * Confirms the resolved entrypoint actually behaves like the oxlint CLI.
+ *
+ * Workspaces can place a non-lint wrapper at the oxlint bin path — vite-plus
+ * ships an LSP-only shim there, for example. Spawning such a wrapper yields no
+ * diagnostics, which the caller would otherwise forward as a clean lint run: a
+ * silent false green. A `--version` handshake separates the real CLI from
+ * wrappers before any lint output is trusted.
+ */
+export function verifyOxlintCliEntrypoint(executable: string, entrypoint: string): void {
+  const handshake = spawnSync(executable, [entrypoint, "--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const output = `${handshake.stdout ?? ""}${handshake.stderr ?? ""}`.trim();
+
+  if (handshake.error == null && handshake.status === 0 && VERSION_HANDSHAKE_PATTERN.test(output)) {
+    return;
+  }
+
+  const detail =
+    handshake.error == null
+      ? `exit ${String(handshake.status)}${output === "" ? " with no output" : `: ${output.split("\n", 1)[0]}`}`
+      : handshake.error.message;
+  throw new Error(
+    `The oxlint entrypoint at ${entrypoint} did not answer the \`--version\` handshake (${detail}). ` +
+      "It appears to be a non-lint wrapper shim, so its runs cannot be trusted as lint results. " +
+      "Install the real `oxlint` package where `oxlint-vize` can resolve it.",
+  );
 }

--- a/npm/oxint/src/test-support/suites.ts
+++ b/npm/oxint/src/test-support/suites.ts
@@ -8,6 +8,7 @@
 await Promise.all([
   import("../cli/files.test.ts"),
   import("../cli/output.test.ts"),
+  import("../cli/oxlint.test.ts"),
   import("../vite-plus-lint.test.ts"),
   import("../nuxt-preset.test.ts"),
 ]);


### PR DESCRIPTION
## Summary

`oxlint-vize` resolves `node_modules/**/oxlint/bin/oxlint` and spawns the first match. When that path holds a non-lint wrapper — vite-plus ships an LSP-only shim there — the child produces no diagnostics and the CLI forwarded its empty exit-0 run as a clean lint result: a silent false green in CI (#4956).

The CLI now fails closed, following the detection the issue proposes:

- **`--version` handshake** (`verifyOxlintCliEntrypoint` in `npm/oxint/src/cli/oxlint.ts`): before any lint output is trusted, the resolved entrypoint must exit 0 on `--version` and print a semver-shaped version (real oxlint prints `Version: <semver>`). A shim that cannot answer exits the CLI non-zero with a diagnostic naming the shim path and the handshake failure. Verification runs before the scriptless-workaround preparation so a failed handshake cannot strand temporary files.
- **Empty-report guard** (`expectsLintReport` in `npm/oxint/src/cli/args.ts`): a child that exits 0 with no output on either stream while the requested format always emits a report (`json`, `junit`, `checkstyle`, `github`, `default`) is refused with a non-zero exit. The auto, stylish, and unix formats stay exempt — probing real oxlint 1.78.0 shows they are legitimately silent on clean piped runs, so an empty report proves nothing for them.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [x] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

- Fix request: #4956 (repro: vite-plus's LSP-only `bin/oxlint` shim, which refuses non-`--lsp` invocations without linting)
- Oxlint CLI behavior probed on oxlint 1.78.0: `--version` prints `Version: 1.78.0`; clean piped runs emit output under `-f json|junit|checkstyle|github|default` and nothing under auto/stylish/unix.

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained (no snapshot changes)
- [x] Parity or real-world fixture coverage considered (shim fixture mirrors the vite-plus wrapper's observable behavior)
- [x] Security/audit impact considered (removes a silent false-green path in CI lint gates)
- [x] Performance status or PR benchmark impact considered (one extra short-lived `--version` child per CLI invocation)
- [ ] Fuzzing target or crash-reproducer coverage considered (not applicable)
- [ ] Editor/LSP scenario coverage considered (the LSP shim itself is untouched; only `oxlint-vize` resolution changes)
- [x] Ecosystem or broad app compatibility impact considered (real oxlint installs pass the handshake unchanged; existing suite green)
- [ ] Docs, release, or stability notes updated when public behavior changed (failure modes only became louder)

Commands (in `npm/oxint`, after `vp pack`):

- `node src/cli/oxlint.test.ts` — new suite, written failing-first: against the unfixed CLI both integration scenarios exited 0 (the issue's false green); now 6/6 pass. Covers: handshake accept/reject (LSP shim, silent exit-0 shim), `expectsLintReport` format table, a shim workspace failing the run closed end-to-end, and a handshake-passing child that swallows a `-f json` report failing closed while an auto-format silent clean run stays trusted.
- Full package suite green: `vp test run src/file-state.test.ts` (7/7), `node src/test.ts` (integration + 22 node:test suite tests, fail 0), `node src/script-location.test.ts`. The new file is registered in `src/test-support/suites.ts` (unlisted test files never run).
- `vp check src vite.config.ts` — clean.

## Risk

- A wrapper that proxies `--version` to real oxlint but swallows lint runs would still pass the handshake; the empty-report guard catches it only under always-emitting formats. No such wrapper is known.
- If a future oxlint stops printing a semver-shaped `--version`, the handshake would fail loudly (never silently) — the pattern accepts any semver token to keep that unlikely.

Closes #4956

🤖 Generated with [Claude Code](https://claude.com/claude-code)