### PR TITLE
ci(ricalco): require TS-20 lowering corpus lane

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -384,7 +384,7 @@ jobs:
         run: npm install --global @pkl-community/pkl@0.27.2
       - name: Test
         env: { VIZE_TEST_REQUIRE_TSGO: "1" }
-        run: cargo test --workspace && cargo test -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli && cargo test -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 && cargo test -p vize_vitrine --no-default-features --features wasm
+        run: cargo test --workspace && cargo test -p vize_ricalco --features davinci-differential --test davinci_lowering_corpus -- --nocapture && cargo test -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli && cargo test -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 && cargo test -p vize_vitrine --no-default-features --features wasm
 
   coverage:
     runs-on: blacksmith-32vcpu-ubuntu-2404

--- a/tests/tooling/davinci-lowering-ci-lane.test.ts
+++ b/tests/tooling/davinci-lowering-ci-lane.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
+
+const ts20LoweringCorpusCommand =
+  "cargo test -p vize_ricalco --features davinci-differential --test davinci_lowering_corpus -- --nocapture";
+
+test("TS-20 lowering corpus lane rides the required clippy-and-test job", () => {
+  const workflow = readRepoFile(".github", "workflows", "check.yml");
+  const clippyJob = workflowJobBody(workflow, "clippy-and-test");
+  const testReportJob = workflowJobBody(workflow, "test-report");
+  const manifest = readRepoFile("crates", "vize_ricalco", "Cargo.toml");
+  const suites = readRepoFile("davinci-road", "plan", "test-suites.md");
+
+  assert.match(suites, /\| TS-20 \| Lowering totality fuzz\s+\| `cargo test -p vize_ricalco`/);
+  assert.match(
+    manifest,
+    /^\[\[test\]\]\nname = "davinci_lowering_corpus"\nrequired-features = \["davinci-differential"\]$/m,
+  );
+
+  assert.doesNotMatch(
+    clippyJob,
+    /^ {4}if:/m,
+    "clippy-and-test must stay unconditional so TS-20 runs on pull requests",
+  );
+  assert.match(testReportJob, /- clippy-and-test\b/);
+  assert.match(clippyJob, /run: cargo test --workspace && /);
+  assert.ok(
+    clippyJob.includes(ts20LoweringCorpusCommand),
+    "the feature-gated TS-20 corpus entry must run explicitly after cargo test --workspace",
+  );
+});


### PR DESCRIPTION
## Summary
- run the feature-gated `davinci_lowering_corpus` TS-20 entry inside required `clippy-and-test` CI
- keep `check.yml` line count unchanged by extending the existing Test step
- add a workflow-shape guard that pins the TS-20 command on the required job

## Verification
- node --test tests/tooling/davinci-lowering-ci-lane.test.ts
- cargo test -p vize_ricalco --features davinci-differential --test davinci_lowering_corpus --locked -- --nocapture
- node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/davinci-lowering-ci-lane.test.ts tests/tooling/github-workflows-check.test.ts tests/tooling/github-workflows-check-gate.test.ts tests/tooling/davinci-portability-lane.test.ts
- git diff --check

Note: the first combined workflow-shape run failed before `vp install` because the fresh worktree lacked the `yaml` package; after `vp install --frozen-lockfile --prefer-offline`, the same command passed 27/27.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790329929&installation_model_id=422833&pr_number=4990&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4990&signature=f86f3151b8d617bcb719b9e6900da75ae268e3f700acfad7feb449898cefee76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->