### PR TITLE
test(ricalco): pin source-block tokenizer error spans

### DIFF
--- a/crates/vize_ricalco/tests/lowering_battery.rs
+++ b/crates/vize_ricalco/tests/lowering_battery.rs
@@ -92,6 +92,39 @@ ui.element div @18:36
 }
 
 #[test]
+fn source_block_tokenizer_errors_are_file_absolute() {
+    let source = "prelude\n<template><div / a>x</div></template>";
+    let template_start = source.find("<template>").expect("template") + "<template>".len();
+    let template_end = source.find("</template>").expect("template close");
+    let template = &source[template_start..template_end];
+    let root = SourceRoot::new(source).expect("source root");
+    let block = root
+        .block(template, template_start as u32)
+        .expect("template block is a root slice");
+
+    let allocator = Allocator::new();
+    let (tree, errors) = parse(&allocator, template);
+    assert_eq!(errors.len(), 1);
+    assert_eq!(errors[0].offset, 4);
+    assert_eq!(errors[0].code.message(), "Unexpected solidus in tag.");
+
+    let lowered = vize_ricalco::lower_source_block(&allocator, &tree, &errors, block);
+    let folio = DisegnoFolio::of(&lowered.root.ops);
+
+    assert_eq!(u64::from(lowered.op_count), folio.op_count());
+    assert_eq!(verify(&folio, Rigor::Canonical), Vec::<Violation>::new());
+    assert_eq!(
+        lowered.diagnostics,
+        vec![Diagnostic::new(
+            Severity::Error,
+            Stage::Surface,
+            Span::new(22, 22),
+            "Unexpected solidus in tag.",
+        )]
+    );
+}
+
+#[test]
 fn the_battery_aggregates_are_pinned() {
     // The decision-surface census over the whole battery: ops minted,
     // diagnostics raised, provenance records written, scopes tagged.


### PR DESCRIPTION
## Summary
- add a source-block regression for tokenizer diagnostics re-anchored into file-absolute S0 spans
- pin the raw S1 error offset and the lowered S2 diagnostic span without changing lowering behavior

## Tests
- cargo test -p vize_ricalco --test lowering_battery source_block_tokenizer_errors_are_file_absolute --locked -- --nocapture
- cargo test -p vize_ricalco --test lowering_battery --locked -- --nocapture
- cargo test -p vize_ricalco --locked
- cargo clippy -p vize_ricalco --tests --locked -- -D warnings
- cargo fmt -p vize_ricalco --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790330934&installation_model_id=422833&pr_number=4993&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4993&signature=f5f12e8e93e94b1e1ef34c61eda477135188a4a46e4eb57f70686dd72ae1e841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->