### PR TITLE
test(dom): pin modified v-on patch flags

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
@@ -90,6 +90,31 @@ const CASES: &[Case] = &[
         sites: &["8 /* PROPS */, [\"onClick\"]"],
     },
     Case {
+        name: "click_stop_event_props",
+        src: r#"<div @click.stop="handler"></div>"#,
+        sites: &["8 /* PROPS */, [\"onClick\"]"],
+    },
+    Case {
+        name: "click_prevent_stop_event_props",
+        src: r#"<div @click.prevent.stop="handler"></div>"#,
+        sites: &["8 /* PROPS */, [\"onClick\"]"],
+    },
+    Case {
+        name: "click_once_capture_event_props",
+        src: r#"<div @click.once.capture="handler"></div>"#,
+        sites: &["40 /* PROPS, NEED_HYDRATION */, [\"onClickOnceCapture\"]"],
+    },
+    Case {
+        name: "click_right_event_props",
+        src: r#"<div @click.right="handler"></div>"#,
+        sites: &["40 /* PROPS, NEED_HYDRATION */, [\"onContextmenu\"]"],
+    },
+    Case {
+        name: "click_middle_event_props",
+        src: r#"<div @click.middle="handler"></div>"#,
+        sites: &["40 /* PROPS, NEED_HYDRATION */, [\"onMouseup\"]"],
+    },
+    Case {
         name: "component_keyup_props",
         src: r#"<Foo @keyup="handler" />"#,
         sites: &["8 /* PROPS */, [\"onKeyup\"]"],
@@ -97,6 +122,11 @@ const CASES: &[Case] = &[
     Case {
         name: "hydrating_key_event",
         src: r#"<div @keyup.enter="handler"></div>"#,
+        sites: &["40 /* PROPS, NEED_HYDRATION */, [\"onKeyup\"]"],
+    },
+    Case {
+        name: "hydrating_key_stop_event",
+        src: r#"<div @keyup.enter.stop="handler"></div>"#,
         sites: &["40 /* PROPS, NEED_HYDRATION */, [\"onKeyup\"]"],
     },
     Case {
@@ -148,6 +178,11 @@ const CASES: &[Case] = &[
         name: "component_listener_before_v_model_order",
         src: r#"<Foo @update:modelValue="track" v-model="msg" />"#,
         sites: &["8 /* PROPS */, [\"onUpdate:modelValue\", \"modelValue\"]"],
+    },
+    Case {
+        name: "component_click_stop_props",
+        src: r#"<Foo @click.stop="h" />"#,
+        sites: &["8 /* PROPS */, [\"onClick\"]"],
     },
     Case {
         name: "directive_need_patch",

--- a/tests/tooling/davinci-v-on-storage.test.ts
+++ b/tests/tooling/davinci-v-on-storage.test.ts
@@ -170,7 +170,7 @@ test("the natural committed v-on corpus fits the two-entry inline buckets", () =
     { options: 0, event: 0, keys: 0 },
   );
 
-  assert.equal(spellings.length, 181, "update the measured corpus evidence intentionally");
+  assert.equal(spellings.length, 188, "update the measured corpus evidence intentionally");
   assert.deepEqual(maxima, { options: 2, event: 2, keys: 2 });
 });
 


### PR DESCRIPTION
## Summary
- add S2 patch-flag oracle cases for modified native v-on handlers
- pin existing hydration/prop-array behavior for click/key modifiers
- cover component @click.stop patch props alongside existing byte-for-byte DOM oracle
- ratchet the committed modified v-on corpus count for the new inline fixtures

## Validation
- cargo +1.95.0 test -p vize_atelier_dom --locked
- cargo +1.95.0 clippy -p vize_atelier_dom --test davinci_s2_patch_flags --locked -- -D warnings
- cargo fmt -p vize_atelier_dom --check
- node --test tests/tooling/davinci-v-on-storage.test.ts
- node tools/davinci/assertion-lint.mjs
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check