### PR TITLE
fix(atelier): normalize keyed v-bind branch spreads

### DIFF
--- a/crates/vize_atelier_core/src/codegen/v_if/props.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/props.rs
@@ -48,6 +48,15 @@ pub(super) fn generate_if_branch_props(
         return;
     }
 
+    let normalize_keyed_bind_spread = branch.user_key.is_none()
+        && scope_id.is_none()
+        && only_key_and_bind_spread(&el.props, skip_is_prop);
+    if normalize_keyed_bind_spread {
+        ctx.use_helper(RuntimeHelper::NormalizeProps);
+        ctx.use_helper(RuntimeHelper::GuardReactiveProps);
+        ctx.push(ctx.helper(RuntimeHelper::NormalizeProps));
+        ctx.push("(");
+    }
     ctx.use_helper(RuntimeHelper::MergeProps);
     ctx.push(ctx.helper(RuntimeHelper::MergeProps));
     ctx.push("(");
@@ -98,6 +107,9 @@ pub(super) fn generate_if_branch_props(
         &mut first_arg,
     );
     ctx.push(")");
+    if normalize_keyed_bind_spread {
+        ctx.push(")");
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -263,6 +275,26 @@ fn has_dynamic_binding(props: &[PropNode<'_>], name: &str) -> bool {
 
 fn is_usable_spread(prop: &PropNode<'_>) -> bool {
     usable_spread(prop).is_some()
+}
+
+fn only_key_and_bind_spread(props: &[PropNode<'_>], skip_is_prop: bool) -> bool {
+    let has_one_bind = props
+        .iter()
+        .filter(|prop| {
+            matches!(
+                usable_spread(prop),
+                Some(dir) if dir.name == "bind" && dir.exp.is_some()
+            )
+        })
+        .count()
+        == 1;
+    has_one_bind
+        && !props.iter().any(|prop| {
+            matches!(
+                usable_spread(prop),
+                Some(dir) if dir.name == "on" && dir.exp.is_some()
+            ) || has_renderable_prop(core::slice::from_ref(prop), skip_is_prop)
+        })
 }
 
 fn usable_spread<'a, 'b>(prop: &'a PropNode<'b>) -> Option<&'a crate::DirectiveNode<'b>> {

--- a/crates/vize_atelier_core/tests/v_if_spread_order.rs
+++ b/crates/vize_atelier_core/tests/v_if_spread_order.rs
@@ -55,6 +55,17 @@ fn v_if_key_precedes_a_leading_object_v_bind() {
 }
 
 #[test]
+fn v_if_key_with_only_object_v_bind_is_normalized() {
+    let output = compile(r#"<div v-if="show" v-bind="attrs"></div>"#);
+
+    assert!(
+        output.contains("_normalizeProps(_mergeProps({ key: 0 }, _ctx.attrs))"),
+        "a synthetic branch key plus only v-bind spread must match Vue's normalize wrapper:\n{output}",
+    );
+    assert!(output.contains("guardReactiveProps"), "{output}");
+}
+
+#[test]
 fn component_v_if_keeps_interleaved_object_spreads_in_source_order() {
     let output = compile(
         r#"<Widget v-if="show" id="before" v-on="listeners" title="middle" v-bind="attrs" @click="after" />"#,

--- a/crates/vize_ricalco/src/emit/merge.rs
+++ b/crates/vize_ricalco/src/emit/merge.rs
@@ -143,6 +143,13 @@ pub(super) fn emit_spread_props(
             Arg::Object { .. } => Err(EmitError::unsupported(Reason::LoneObjectArgument)),
         };
     }
+    let normalize_keyed_bind_spread = key_and_bind_spread(&args);
+    if normalize_keyed_bind_spread {
+        cx.buf.use_normalize_props();
+        cx.buf.use_guard_reactive_props();
+        cx.buf.push(Buf::normalize_props_alias());
+        cx.buf.push("(");
+    }
     cx.buf.use_merge_props();
     cx.buf.push(Buf::merge_props_alias());
     cx.buf.push("(");
@@ -166,6 +173,9 @@ pub(super) fn emit_spread_props(
         }
     }
     cx.buf.push(")");
+    if normalize_keyed_bind_spread {
+        cx.buf.push(")");
+    }
     Ok(())
 }
 
@@ -182,6 +192,19 @@ fn lone_kind_spread<'a>(args: &'a [Arg<'a>]) -> Option<&'a Arg<'a>> {
     } else {
         None
     }
+}
+
+fn key_and_bind_spread(args: &[Arg<'_>]) -> bool {
+    matches!(
+        args,
+        [
+            Arg::Object {
+                if_key: Some(_),
+                pieces,
+            },
+            Arg::BindSpread(_),
+        ] if pieces.is_empty()
+    )
 }
 
 enum Arg<'a> {

--- a/crates/vize_ricalco/tests/emit_merge.rs
+++ b/crates/vize_ricalco/tests/emit_merge.rs
@@ -140,11 +140,11 @@ fn a_v_if_with_object_bind_merges_the_branch_key() {
     assert_eq!(
         assembled(r#"<div v-if="ok" v-bind="obj">x</div>"#),
         "\
-const { mergeProps: _mergeProps, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode } = Vue
+const { normalizeProps: _normalizeProps, guardReactiveProps: _guardReactiveProps, mergeProps: _mergeProps, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode } = Vue
 
 function render(_ctx, _cache, $props, $setup, $data, $options) {
   return (ok)
-    ? (_openBlock(), _createElementBlock(\"div\", _mergeProps({ key: 0 }, obj), \"x\", 16 /* FULL_PROPS */))
+    ? (_openBlock(), _createElementBlock(\"div\", _normalizeProps(_mergeProps({ key: 0 }, obj)), \"x\", 16 /* FULL_PROPS */))
     : _createCommentVNode(\"v-if\", true)
 }"
     );

--- a/tests/expected/vdom/component.snap
+++ b/tests/expected/vdom/component.snap
@@ -202,6 +202,33 @@ export function render(_ctx, _cache) {
   ]))
 }
 ===
+name: Teleport with dynamic target and deferred transition
+options: vdom
+--- INPUT ---
+<Teleport :to="target" :defer="defer"><Transition><div v-if="open" v-bind="attrs"><slot name="content">tip</slot></div></Transition></Teleport>
+--- OUTPUT ---
+import { renderSlot as _renderSlot, createTextVNode as _createTextVNode, normalizeProps as _normalizeProps, guardReactiveProps as _guardReactiveProps, openBlock as _openBlock, createElementBlock as _createElementBlock, mergeProps as _mergeProps, createCommentVNode as _createCommentVNode, Transition as _Transition, withCtx as _withCtx, createVNode as _createVNode, Teleport as _Teleport, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_Teleport, {
+    to: _ctx.target,
+    defer: _ctx.defer
+  }, [
+    _createVNode(_Transition, null, {
+      default: _withCtx(() => [
+        (_ctx.open)
+          ? (_openBlock(), _createElementBlock("div", _normalizeProps(_mergeProps({ key: 0 }, _ctx.attrs)), [
+              _renderSlot(_ctx.$slots, "content", {}, () => [
+                _createTextVNode("tip")
+              ])
+            ], 16 /* FULL_PROPS */))
+          : _createCommentVNode("v-if", true)
+      ]),
+      _: 3 /* FORWARDED */
+    })
+  ], 8 /* PROPS */, ["to", "defer"]))
+}
+===
 name: Suspense
 options: vdom
 --- INPUT ---

--- a/tests/fixtures/vdom/component.pkl
+++ b/tests/fixtures/vdom/component.pkl
@@ -66,6 +66,10 @@ cases {
     input = #"<Teleport to="body"><div>content</div></Teleport>"#
   }
   new {
+    name = "Teleport with dynamic target and deferred transition"
+    input = #"<Teleport :to="target" :defer="defer"><Transition><div v-if="open" v-bind="attrs"><slot name="content">tip</slot></div></Transition></Teleport>"#
+  }
+  new {
     name = "Suspense"
     input = "<Suspense><Component /></Suspense>"
   }


### PR DESCRIPTION
## Summary

- normalize synthetic `v-if` branch key + lone object `v-bind` spreads with `_normalizeProps(_mergeProps(...))`
- keep the S2/ricalco emitter byte-aligned with the shipped DOM compiler for the same keyed bind-spread shape
- add a Teleport + Transition real-world VDOM fixture that pins the official Vue output

## Notes

The fixture was checked against the workspace `@vue/compiler-sfc` package after rebasing onto `origin/main` at `613ce3a5a31d22ec0dfd42feab25772e63fc54bf`.

No rollout switch is changed in this PR.

## Validation

- `cargo +1.95.0 fmt --all -- --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `node tools/davinci/assertion-lint.mjs`
- `git diff --check origin/main...HEAD`
- `cargo +1.95.0 test -p vize_atelier_core --test v_if_spread_order --locked`
- `cargo +1.95.0 test -p vize_ricalco --test emit_merge --locked`
- `cargo +1.95.0 test -p vize_test_runner -- --ignored vdom_component`
- `cargo +1.95.0 test -p vize_atelier_core --locked`
- `cargo +1.95.0 test -p vize_ricalco --locked`
- `cargo +1.95.0 test -p vize_atelier_dom --locked`
- `cargo +1.95.0 run -p vize_test_runner --bin coverage -- -vv`
- `cargo +1.95.0 clippy -p vize_atelier_core --test v_if_spread_order --locked -- -D warnings -D clippy::wildcard_imports`
- `cargo +1.95.0 clippy -p vize_ricalco --test emit_merge --locked -- -D warnings -D clippy::wildcard_imports`

`coverage -vv` exits 0 with the existing tracked v1 alpha known failure: `vapor/parity-core-directives` custom directive payload loss.

I also attempted broader `cargo +1.95.0 clippy -p vize_atelier_core -p vize_ricalco --tests --locked -- -D warnings -D clippy::wildcard_imports`; it fails on pre-existing unrelated clippy policy violations in older `vize_atelier_core` tests outside this PR's touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rendering for conditional elements that use object-based attribute binding.
  - Preserved branch keys and reactive prop behavior when bound attributes are merged.
  - Ensured generated output correctly normalizes merged properties in these scenarios.

- **Tests**
  - Added regression coverage for conditional elements containing only object-based bindings.
  - Updated rendering expectations to verify normalized properties and reactive safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->