### PR TITLE
feat(ui): design tokens, cascade layers, and the atelier preset

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -214,6 +214,11 @@
       "import": "./dist/spatial-navigation.mjs",
       "default": "./dist/spatial-navigation.mjs"
     },
+    "./theme": {
+      "types": "./dist/theme.d.mts",
+      "import": "./dist/theme.mjs",
+      "default": "./dist/theme.mjs"
+    },
     "./transition": {
       "types": "./dist/transition.d.mts",
       "import": "./dist/transition.mjs",

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 102_000],
+  ["index.mjs", 106_000],
   ["announcer.mjs", 4_100],
   ["button.mjs", 1_600],
   ["checkbox.mjs", 1_900],
@@ -33,7 +33,7 @@ const budgets = new Map([
   ["measure.mjs", 2_400],
   // Styled entries statically import the shared dist/style.css, so their
   // budgets cover the packaged stylesheet alongside their JavaScript.
-  ["motion.mjs", 3_700],
+  ["motion.mjs", 4_600],
   ["move.mjs", 5_050],
   ["pointer-grace.mjs", 1_800],
   ["portal.mjs", 1_700],
@@ -44,11 +44,12 @@ const budgets = new Map([
   ["shortcut.mjs", 7_400],
   ["sortable.mjs", 17_000],
   ["spatial-navigation.mjs", 3_725],
+  ["theme.mjs", 3_900],
   ["transition.mjs", 3_000],
   ["typeahead.mjs", 2_000],
   ["virtualizer.mjs", 9_500],
   ["primitive.mjs", 800],
-  ["visually-hidden.mjs", 1_800],
+  ["visually-hidden.mjs", 2_700],
   ["media.mjs", 2_400],
   ["media-pdf.mjs", 2_048],
   ["media-source.mjs", 1_800],

--- a/npm/ui/core/scripts/check-tree-shaking.mjs
+++ b/npm/ui/core/scripts/check-tree-shaking.mjs
@@ -118,6 +118,7 @@ for (const { canonicalName: family, bundleBudget } of treeShakingEntries) {
   // style.css); unstyled families must not retain any CSS at all.
   const styledFamilySignatures = new Map([
     ["motion", /--vize-ui-motion-duration-fast/],
+    ["theme", /--vize-ui-color-canvas/],
     ["visually-hidden", /clip-path:inset\(50%\)/],
   ]);
   const styledSignature = styledFamilySignatures.get(family);

--- a/npm/ui/core/scripts/renderer-fixtures.ts
+++ b/npm/ui/core/scripts/renderer-fixtures.ts
@@ -288,4 +288,34 @@ onMounted(() => {
 </template>
 `,
   },
+  {
+    filename: "ThemeConsumer.vue",
+    source: String.raw`<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { setThemeTokens, themeTokenVar } from "./theme.ts";
+import type { ThemeDensityScale, ThemePresetName } from "./theme.ts";
+
+const preset = ref<ThemePresetName>("atelier");
+const density = ref<ThemeDensityScale>("compact");
+const surface = ref<HTMLElement | null>(null);
+
+onMounted(() => {
+  if (surface.value) {
+    setThemeTokens(surface.value, { "radius-md": "0.75rem" });
+  }
+});
+</script>
+
+<template>
+  <section
+    ref="surface"
+    :data-vize-theme="preset"
+    :data-vize-density="density"
+    :data-accent="themeTokenVar('color-accent')"
+  >
+    Themed surface
+  </section>
+</template>
+`,
+  },
 ] as const;

--- a/npm/ui/core/src/family-catalog-basics.ts
+++ b/npm/ui/core/src/family-catalog-basics.ts
@@ -238,4 +238,40 @@ export const basicFamilyCatalog = [
     maturity: "stable",
     owner: catalogOwner,
   },
+  {
+    canonicalName: "theme",
+    title: "Design Tokens",
+    packageSubpath: "./theme",
+    entryFile: "src/theme.ts",
+    sourceFiles: [
+      "src/theme.ts",
+      "src/theme.css",
+      "src/theme-preset-atelier.css",
+      "src/theme-tokens.ts",
+      "src/theme-types.ts",
+    ],
+    behaviorContract: "src/theme.behavior.md",
+    tests: ["src/theme.test.ts", "src/theme-stylesheet.test.ts", "src/theme-ssr.test.ts"],
+    typeTests: ["src/theme.types.test-d.ts"],
+    rendererFixture: "ThemeConsumer.vue",
+    qualityGates: interactionQualityGates,
+    bundleBudget: {
+      exportName: "setThemeTokens",
+      retainedSignature: "VIZE_UI_THEME_",
+      maximumJavaScriptGzipBytes: 1_500,
+      // Covers the packaged stylesheet: the token contract and presets share
+      // dist/style.css with every other styled family.
+      maximumCssGzipBytes: 2_500,
+    },
+    aliases: ["design tokens", "semantic tokens", "cascade layers", "presets", "atelier"],
+    upstreamCoverage: [
+      "CSS cascade layers",
+      "CSS custom properties",
+      "light-dark() color scheme",
+      "forced-colors adaptations",
+    ],
+    dependencies: [],
+    maturity: "stable",
+    owner: catalogOwner,
+  },
 ] as const satisfies readonly UiFamilyCatalogEntry[];

--- a/npm/ui/core/src/family-catalog-interactions.ts
+++ b/npm/ui/core/src/family-catalog-interactions.ts
@@ -340,7 +340,7 @@ export const interactionFamilyCatalog = [
       maximumJavaScriptGzipBytes: 400,
       // Covers the shared packaged stylesheet (dist/style.css), including the
       // motion tokens every styled family ships together (style-pipeline.behavior.md).
-      maximumCssGzipBytes: 1_200,
+      maximumCssGzipBytes: 2_500,
     },
     aliases: ["screen reader only", "sr-only", "visually hidden"],
     upstreamCoverage: ["React Aria VisuallyHidden", "Radix VisuallyHidden"],

--- a/npm/ui/core/src/family-catalog-overlays.ts
+++ b/npm/ui/core/src/family-catalog-overlays.ts
@@ -111,7 +111,7 @@ export const overlayFamilyCatalog = [
       maximumJavaScriptGzipBytes: 1_500,
       // Covers the packaged stylesheet: motion tokens and recipes share
       // dist/style.css with every other styled family.
-      maximumCssGzipBytes: 1_200,
+      maximumCssGzipBytes: 2_500,
     },
     aliases: ["motion tokens", "easing", "view transitions", "starting style", "reduced motion"],
     upstreamCoverage: [

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -2,6 +2,11 @@
 // without any SFC, keeping module order identical between the root bundle and
 // the id/error-summary subpath bundles for the byte-equality packaging gate.
 export * from "./field-wiring.ts";
+// theme stays second: packaged CSS concatenates in index module order, and
+// the cascade-layer order statement in src/theme.css must lead dist/style.css
+// so the layer contract is established before any layered rule;
+// src/theme-stylesheet.test.ts pins the shipped order.
+export * from "./theme.ts";
 export * from "./announcer.ts";
 export * from "./checkbox.ts";
 export * from "./collection.ts";

--- a/npm/ui/core/src/style-pipeline.behavior.md
+++ b/npm/ui/core/src/style-pipeline.behavior.md
@@ -39,5 +39,8 @@ proven by `src/style-pipeline.test.ts` against the real package build.
   (`./dist/*.css`), so a consumer that never imports a styled component ships
   no CSS, and a consumer that overrides `sideEffects` handling can drop the
   stylesheet entirely and load `@vizejs/ui/style.css` on its own terms.
-- Every shipped rule lives inside `@layer vize.ui`, so consumer CSS outside a
-  layer — or in a later layer — always wins without specificity fights.
+- Every shipped rule lives inside a `vize.*` cascade layer — `vize.tokens`,
+  `vize.ui`, `vize.preset`, and `vize.policy`, in that ascending order; see
+  `theme.behavior.md` for the order and specificity contract — so consumer
+  CSS outside a layer, or in a later layer, always wins without specificity
+  fights.

--- a/npm/ui/core/src/theme-preset-atelier.css
+++ b/npm/ui/core/src/theme-preset-atelier.css
@@ -1,0 +1,47 @@
+/*
+ * Atelier preset: the Vize brand default. Production-ready surfaces with a
+ * violet accent on cool neutral grounds, in `@layer vize.preset` at zero
+ * specificity, scoped to the opt-in `data-vize-theme~="atelier"` attribute —
+ * without the attribute the preset is inert and the package stays headless.
+ *
+ * Scheme handling is pure CSS: `light-dark()` follows the user's color
+ * scheme, so system preference works with no runtime script and no flash —
+ * server-render the attribute (typically on `<html>`) and the first paint is
+ * already themed. `light-dark()` and the relative color deriving the light
+ * border are newer than the declared floor, so the package build lowers both
+ * (see style-pipeline.behavior.md): the shipped scheme pair tracks
+ * `prefers-color-scheme`, and the derived colors — including the
+ * `color-mix()` behind the muted text — resolve to literals at build time.
+ */
+
+@layer vize.preset {
+  :where([data-vize-theme~="atelier"], :host([data-vize-theme~="atelier"])) {
+    color-scheme: light dark;
+
+    /* Color roles. */
+    --vize-ui-color-canvas: light-dark(oklch(0.985 0.003 255), oklch(0.155 0.012 255));
+    --vize-ui-color-surface: light-dark(oklch(1 0 0), oklch(0.205 0.014 255));
+    --vize-ui-color-text: light-dark(oklch(0.245 0.02 255), oklch(0.93 0.008 255));
+    --vize-ui-color-text-muted: light-dark(
+      color-mix(in oklab, oklch(0.245 0.02 255) 62%, oklch(0.985 0.003 255)),
+      color-mix(in oklab, oklch(0.93 0.008 255) 68%, oklch(0.155 0.012 255))
+    );
+    --vize-ui-color-accent: light-dark(oklch(0.545 0.175 275), oklch(0.72 0.15 275));
+    --vize-ui-color-accent-contrast: light-dark(oklch(1 0 0), oklch(0.17 0.015 275));
+
+    /* The light border derives from the canvas through relative color. */
+    --vize-ui-color-border: light-dark(
+      oklch(from oklch(0.985 0.003 255) calc(l - 0.1) c h),
+      oklch(0.32 0.015 255)
+    );
+    --vize-ui-color-danger: light-dark(oklch(0.55 0.19 25), oklch(0.7 0.17 22));
+
+    /* Elevation: soft, cool-tinted shadows shared by both schemes. */
+    --vize-ui-elevation-raised:
+      0 1px 2px oklch(0.15 0.015 255 / 0.06), 0 1px 3px oklch(0.15 0.015 255 / 0.1);
+    --vize-ui-elevation-overlay:
+      0 4px 12px oklch(0.15 0.015 255 / 0.12), 0 2px 4px oklch(0.15 0.015 255 / 0.08);
+    --vize-ui-elevation-floating:
+      0 12px 32px oklch(0.15 0.015 255 / 0.16), 0 4px 8px oklch(0.15 0.015 255 / 0.08);
+  }
+}

--- a/npm/ui/core/src/theme-ssr.test.ts
+++ b/npm/ui/core/src/theme-ssr.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+import { createSSRApp, defineComponent, h } from "vue";
+import { renderToString } from "vue/server-renderer";
+
+import {
+  themeDensityAttribute,
+  themePresetAttribute,
+  themeTokens,
+  themeTokenVar,
+} from "./theme.ts";
+
+/** A consumer that touches the token surface during setup, exactly like real SSR. */
+const SsrProbe = defineComponent({
+  name: "ThemeSsrProbe",
+  setup() {
+    const accent = themeTokenVar("color-accent");
+    const canvas = themeTokens["color-canvas"];
+    return () =>
+      h(
+        "section",
+        {
+          [themePresetAttribute]: "atelier",
+          [themeDensityAttribute]: "compact",
+          "data-accent": accent,
+          "data-canvas": canvas,
+        },
+        "Themed",
+      );
+  },
+});
+
+/** Render with every platform global a server lacks removed. */
+async function renderWithoutPlatformGlobals(): Promise<string> {
+  const originalDocument = globalThis.document;
+  const originalMatchMedia = globalThis.matchMedia;
+  // @ts-expect-error simulating a server runtime without a document.
+  delete globalThis.document;
+  // @ts-expect-error simulating a server runtime without matchMedia.
+  delete globalThis.matchMedia;
+  try {
+    return await renderToString(createSSRApp(SsrProbe));
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.matchMedia = originalMatchMedia;
+  }
+}
+
+test("renders byte-identical SSR markup without platform globals", async () => {
+  const outputs = [await renderWithoutPlatformGlobals(), await renderWithoutPlatformGlobals()];
+  assert.equal(outputs[0], outputs[1]);
+  assert.equal(
+    outputs[0],
+    '<section data-vize-theme="atelier" data-vize-density="compact"' +
+      ' data-accent="var(--vize-ui-color-accent)" data-canvas="Canvas">Themed</section>',
+  );
+});
+
+test("hydrates a themed consumer without replacement or diagnostics", async () => {
+  const serverHtml = await renderWithoutPlatformGlobals();
+  const host = document.createElement("div");
+  host.innerHTML = serverHtml;
+  document.body.append(host);
+  const serverTarget = host.firstElementChild;
+  const diagnostics: string[] = [];
+  const originalWarn = console.warn;
+  const originalError = console.error;
+  console.warn = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  console.error = (...values: unknown[]) => diagnostics.push(values.map(String).join(" "));
+  const app = createSSRApp(SsrProbe);
+
+  try {
+    app.mount(host);
+    assert.equal(host.firstElementChild, serverTarget);
+    assert.equal(host.firstElementChild?.getAttribute("data-vize-theme"), "atelier");
+    assert.deepEqual(diagnostics, []);
+  } finally {
+    app.unmount();
+    host.remove();
+    console.warn = originalWarn;
+    console.error = originalError;
+  }
+});

--- a/npm/ui/core/src/theme-stylesheet.test.ts
+++ b/npm/ui/core/src/theme-stylesheet.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+// Paths are resolved from the package cwd: the runner virtualizes import.meta.url.
+import path from "node:path";
+
+import { test } from "vite-plus/test";
+
+import { themeCascadeLayerOrder, themeDensityScales, themeTokens } from "./theme.ts";
+
+const stylesheet = await readFile(path.resolve("dist/style.css"), "utf8");
+
+const layerStarts = new Map(
+  themeCascadeLayerOrder.map((layer) => [layer, stylesheet.indexOf(`@layer ${layer}{`)]),
+);
+
+/** Shipped rules of one vize layer block. */
+function layerBlock(layer: (typeof themeCascadeLayerOrder)[number]): string {
+  const start = layerStarts.get(layer);
+  assert.ok(start !== undefined && start >= 0, `dist/style.css must ship @layer ${layer}`);
+  const followers = [...layerStarts.values()].filter((index) => index > start);
+  return stylesheet.slice(start, followers.length === 0 ? undefined : Math.min(...followers));
+}
+
+/** Value of one custom property in the packaged stylesheet's first definition. */
+function shippedToken(name: string): string {
+  const pattern = new RegExp(`--vize-ui-${name.replaceAll("-", "\\-")}:([^;}]+)[;}]`);
+  const match = pattern.exec(stylesheet);
+  assert.ok(match?.[1], `dist/style.css must define --vize-ui-${name}`);
+  return match[1];
+}
+
+/** Normalized comparison form, tolerant of minifier whitespace and zero trims. */
+function normalizeCss(value: string): string {
+  return value.replaceAll(/\s+/g, "").replaceAll("0.", ".");
+}
+
+test("ships the documented cascade layer order", () => {
+  const indexes = themeCascadeLayerOrder.map((layer) => {
+    const index = layerStarts.get(layer) ?? -1;
+    assert.ok(index >= 0, `dist/style.css must ship @layer ${layer}`);
+    assert.equal(
+      stylesheet.indexOf(`@layer ${layer}{`, index + 1),
+      -1,
+      `@layer ${layer} must merge into a single block`,
+    );
+    return index;
+  });
+
+  assert.deepEqual(
+    indexes,
+    [...indexes].sort((left, right) => left - right),
+    "layer blocks must ship in ascending priority order",
+  );
+  assert.equal(indexes[0], 0, "the token layer must lead the stylesheet");
+});
+
+test("ships layered zero-specificity theme tokens matching the mirrors", () => {
+  assert.match(layerBlock("vize.tokens"), /^@layer vize\.tokens\{:where\(:root,:host\)\{/);
+
+  for (const [token, value] of Object.entries(themeTokens)) {
+    assert.equal(normalizeCss(shippedToken(token)), normalizeCss(value), `token ${token}`);
+  }
+});
+
+test("keeps the headless default free of visual opinion", () => {
+  const tokens = layerBlock("vize.tokens");
+
+  assert.match(tokens, /--vize-ui-color-canvas:Canvas[;}]/);
+  assert.match(tokens, /--vize-ui-color-text:CanvasText[;}]/);
+  assert.match(tokens, /--vize-ui-elevation-raised:none[;}]/);
+  assert.doesNotMatch(tokens, /oklch\(/, "headless defaults must stay on the system palette");
+});
+
+test("ships density scopes that retune the shared factor", () => {
+  const tokens = layerBlock("vize.tokens");
+
+  for (const [scale, factor] of Object.entries(themeDensityScales)) {
+    const pattern = new RegExp(
+      `:where\\(\\[data-vize-density\\]\\):where\\(\\[data-vize-density=${scale}\\]\\)` +
+        `\\{--vize-ui-density:([^;}]+)\\}`,
+    );
+    const match = pattern.exec(tokens);
+    assert.ok(match?.[1], `the ${scale} density scope must ship`);
+    assert.equal(normalizeCss(match[1]), normalizeCss(factor));
+  }
+
+  // Space and control sizes resolve through the factor, never literal steps.
+  assert.equal(shippedToken("space-md"), "calc(.75rem * var(--vize-ui-density))");
+  assert.equal(shippedToken("size-control-md"), "calc(2.25rem * var(--vize-ui-density))");
+});
+
+test("scopes the atelier preset to its opt-in attribute", () => {
+  const preset = layerBlock("vize.preset");
+
+  assert.match(
+    preset,
+    /:where\(\[data-vize-theme~=atelier\],:host\(\[data-vize-theme~=atelier\]\)\)\{/,
+  );
+  assert.match(preset, /color-scheme:light dark/);
+  assert.match(preset, /--vize-ui-color-accent:/);
+  assert.match(preset, /--vize-ui-elevation-raised:0 1px 2px oklch\(/);
+  assert.doesNotMatch(
+    preset,
+    /:where\(:root,:host\)/,
+    "presets must never assign tokens outside their opt-in scope",
+  );
+});
+
+test("lowers the atelier color schemes to the declared floor", () => {
+  const preset = layerBlock("vize.preset");
+
+  // light-dark() is newer than the floor and must ship as the lowered
+  // custom-property pair driven by the color-scheme media flip.
+  assert.doesNotMatch(stylesheet, /light-dark\(/);
+  assert.match(
+    preset,
+    /--vize-ui-color-canvas:var\(--lightningcss-light,oklch\(98\.5% \.003 255\)\)var\(--lightningcss-dark,oklch\(15\.5% \.012 255\)\)/,
+  );
+  assert.match(
+    preset,
+    /@media \(prefers-color-scheme:dark\)\{:where\(\[data-vize-theme~=atelier\]/,
+  );
+
+  // Relative color and color-mix() derivations resolve to literals at build
+  // time, so the floor never sees the newer syntax.
+  assert.doesNotMatch(stylesheet, /oklch\(from/);
+  assert.doesNotMatch(preset, /color-mix\(/);
+  assert.match(
+    preset,
+    /--vize-ui-color-border:var\(--lightningcss-light,oklch\(88\.5% \.003 255\)\)/,
+  );
+  assert.match(preset, /--vize-ui-color-text-muted:var\(--lightningcss-light,oklab\(/);
+});
+
+test("stands down to system colors under forced colors", () => {
+  const policy = layerBlock("vize.policy");
+
+  assert.match(
+    policy,
+    /@media \(forced-colors:active\)\{:where\(:root,:host,\[data-vize-theme\]\)\{/,
+  );
+  assert.match(policy, /--vize-ui-color-accent:Highlight[;}]/);
+  assert.match(policy, /--vize-ui-color-accent-contrast:HighlightText[;}]/);
+  assert.match(policy, /--vize-ui-color-border:ButtonBorder[;}]/);
+  assert.match(policy, /--vize-ui-elevation-floating:none[;}]/);
+  assert.match(policy, /--vize-ui-focus-ring-color:Highlight[;}]/);
+});

--- a/npm/ui/core/src/theme-tokens.ts
+++ b/npm/ui/core/src/theme-tokens.ts
@@ -1,0 +1,145 @@
+import type {
+  ThemeDensityScale,
+  ThemePresetName,
+  ThemeTokenName,
+  ThemeTokenOverrides,
+} from "./theme-types.ts";
+
+const invalidTokenDiagnostic = "VIZE_UI_THEME_TOKEN";
+
+/** Cascade layers shipped by the package, in ascending priority order. */
+export const themeCascadeLayerOrder = Object.freeze([
+  "vize.tokens",
+  "vize.ui",
+  "vize.preset",
+  "vize.policy",
+] as const);
+
+/** Attribute whose space-separated values opt a subtree into presets. */
+export const themePresetAttribute = "data-vize-theme";
+
+/** Attribute that retunes the density factor for a subtree. */
+export const themeDensityAttribute = "data-vize-density";
+
+/** Opinionated presets shipped in `@layer vize.preset`. */
+export const themePresets: readonly ThemePresetName[] = Object.freeze(["atelier"]);
+
+/** Density factors mirrored from the `data-vize-density` scopes in `theme.css`. */
+export const themeDensityScales: Readonly<Record<ThemeDensityScale, string>> = Object.freeze({
+  compact: "0.85",
+  comfortable: "1.15",
+});
+
+/**
+ * Semantic token contract mirrored from `theme.css`.
+ *
+ * The packaged stylesheet is the source of truth; this mirror exists so
+ * JavaScript consumers can read the same headless defaults the CSS ships
+ * with. Preset values are deliberately not mirrored: presets are opt-in
+ * cascade, not API.
+ */
+export const themeTokens: Readonly<Record<ThemeTokenName, string>> = Object.freeze({
+  "color-canvas": "Canvas",
+  "color-surface": "Canvas",
+  "color-text": "CanvasText",
+  "color-text-muted": "GrayText",
+  "color-accent": "LinkText",
+  "color-accent-contrast": "Canvas",
+  "color-border": "GrayText",
+  "color-danger": "#d92d20",
+  "type-family-sans": "system-ui, sans-serif",
+  "type-family-mono": "ui-monospace, monospace",
+  "type-size-xs": "0.75rem",
+  "type-size-sm": "0.875rem",
+  "type-size-md": "1rem",
+  "type-size-lg": "1.125rem",
+  "type-size-xl": "1.25rem",
+  "type-size-2xl": "1.5rem",
+  "type-leading-tight": "1.25",
+  "type-leading-normal": "1.5",
+  "type-leading-loose": "1.75",
+  "type-weight-regular": "400",
+  "type-weight-medium": "500",
+  "type-weight-bold": "700",
+  density: "1",
+  "space-xs": "calc(0.25rem * var(--vize-ui-density))",
+  "space-sm": "calc(0.5rem * var(--vize-ui-density))",
+  "space-md": "calc(0.75rem * var(--vize-ui-density))",
+  "space-lg": "calc(1rem * var(--vize-ui-density))",
+  "space-xl": "calc(1.5rem * var(--vize-ui-density))",
+  "space-2xl": "calc(2rem * var(--vize-ui-density))",
+  "space-3xl": "calc(3rem * var(--vize-ui-density))",
+  "size-control-sm": "calc(1.75rem * var(--vize-ui-density))",
+  "size-control-md": "calc(2.25rem * var(--vize-ui-density))",
+  "size-control-lg": "calc(2.75rem * var(--vize-ui-density))",
+  "radius-sm": "0.25rem",
+  "radius-md": "0.5rem",
+  "radius-lg": "1rem",
+  "radius-full": "9999px",
+  "border-width-thin": "1px",
+  "border-width-thick": "2px",
+  "elevation-raised": "none",
+  "elevation-overlay": "none",
+  "elevation-floating": "none",
+  "opacity-muted": "0.7",
+  "opacity-disabled": "0.45",
+  "z-sticky": "100",
+  "z-dropdown": "600",
+  "z-overlay": "1000",
+  "z-toast": "1200",
+  "focus-ring-width": "2px",
+  "focus-ring-offset": "2px",
+  "focus-ring-color": "var(--vize-ui-color-accent)",
+});
+
+function assertTokenName(name: string): void {
+  if (!Object.hasOwn(themeTokens, name)) {
+    throw new TypeError(`${invalidTokenDiagnostic}: unknown theme token "${name}"`);
+  }
+}
+
+/** Custom-property name (`--vize-ui-*`) for one theme token. */
+export function themeTokenProperty(name: ThemeTokenName): string {
+  assertTokenName(name);
+  return `--vize-ui-${name}`;
+}
+
+/** `var()` reference to one theme token for imperative style composition. */
+export function themeTokenVar(name: ThemeTokenName): string {
+  return `var(${themeTokenProperty(name)})`;
+}
+
+/**
+ * Override theme tokens on one element's subtree.
+ *
+ * Custom properties inherit, so scoping an override to an element retunes
+ * every consumer below it — a nested theme scope without forking components.
+ * Returns a restore function that reinstates the element's previous values.
+ */
+export function setThemeTokens(
+  element: ElementCSSInlineStyle,
+  overrides: ThemeTokenOverrides,
+): () => void {
+  if (typeof element?.style?.setProperty !== "function") {
+    throw new TypeError(`${invalidTokenDiagnostic}: overrides need an element with inline style`);
+  }
+
+  const previous = new Map<string, string>();
+  for (const [name, value] of Object.entries(overrides)) {
+    if (value === undefined) continue;
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new TypeError(`${invalidTokenDiagnostic}: token "${name}" needs a non-empty string`);
+    }
+    const property = themeTokenProperty(name as ThemeTokenName);
+    if (!previous.has(property)) previous.set(property, element.style.getPropertyValue(property));
+    element.style.setProperty(property, value);
+  }
+
+  return () => {
+    for (const [property, value] of previous) {
+      if (value === "") element.style.removeProperty(property);
+      else element.style.setProperty(property, value);
+    }
+    previous.clear();
+  };
+}

--- a/npm/ui/core/src/theme-types.ts
+++ b/npm/ui/core/src/theme-types.ts
@@ -1,0 +1,67 @@
+/** Semantic color roles. */
+export type ThemeColorToken =
+  | "canvas"
+  | "surface"
+  | "text"
+  | "text-muted"
+  | "accent"
+  | "accent-contrast"
+  | "border"
+  | "danger";
+
+/** Typography tokens: families, the size scale, line heights, and weights. */
+export type ThemeTypeToken =
+  | "family-sans"
+  | "family-mono"
+  | `size-${"xs" | "sm" | "md" | "lg" | "xl" | "2xl"}`
+  | `leading-${"tight" | "normal" | "loose"}`
+  | `weight-${"regular" | "medium" | "bold"}`;
+
+/** Named steps on the density-responsive space scale. */
+export type ThemeSpaceToken = "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl";
+
+/** Density-responsive control sizes. */
+export type ThemeSizeToken = "control-sm" | "control-md" | "control-lg";
+
+/** Corner radii. */
+export type ThemeRadiusToken = "sm" | "md" | "lg" | "full";
+
+/** Border widths. */
+export type ThemeBorderToken = "width-thin" | "width-thick";
+
+/** Elevation roles rendered as box shadows. */
+export type ThemeElevationToken = "raised" | "overlay" | "floating";
+
+/** Opacity roles. */
+export type ThemeOpacityToken = "muted" | "disabled";
+
+/** Layered-surface slots on the shared z-index registry. */
+export type ThemeZIndexToken = "sticky" | "dropdown" | "overlay" | "toast";
+
+/** Focus-ring geometry and color. */
+export type ThemeFocusToken = "ring-width" | "ring-offset" | "ring-color";
+
+/** Suffix of one `--vize-ui-*` theme custom property. */
+export type ThemeTokenName =
+  | `color-${ThemeColorToken}`
+  | `type-${ThemeTypeToken}`
+  | `space-${ThemeSpaceToken}`
+  | `size-${ThemeSizeToken}`
+  | `radius-${ThemeRadiusToken}`
+  | `border-${ThemeBorderToken}`
+  | `elevation-${ThemeElevationToken}`
+  | `opacity-${ThemeOpacityToken}`
+  | `z-${ThemeZIndexToken}`
+  | `focus-${ThemeFocusToken}`
+  | "density";
+
+/** Custom-property overrides applied by {@link setThemeTokens}. */
+export type ThemeTokenOverrides = {
+  readonly [Name in ThemeTokenName]?: string;
+};
+
+/** Opinionated presets accepted in the space-separated `data-vize-theme` attribute. */
+export type ThemePresetName = "atelier";
+
+/** Density scopes accepted in the `data-vize-density` attribute. */
+export type ThemeDensityScale = "compact" | "comfortable";

--- a/npm/ui/core/src/theme.behavior.md
+++ b/npm/ui/core/src/theme.behavior.md
@@ -1,0 +1,57 @@
+# Theme behavior contract
+
+Normative contract for the theme family (`@vizejs/ui/theme`): the semantic
+design-token contract, the package-wide cascade-layer order, and the opt-in
+presets. The stylesheet contract is proven on the packaged `dist/style.css`
+(the pack pipeline lowers `src/theme.css` and `src/theme-preset-atelier.css`
+to the declared browser floor; see `style-pipeline.behavior.md`) in
+`src/theme-stylesheet.test.ts`; runtime rows are proven by the named test in
+`src/theme.test.ts` or `src/theme-ssr.test.ts`; compile-only assertions live
+in `src/theme.types.test-d.ts`.
+
+| #   | State               | Input                                          | Outcome                                                                                                   | Proven by                                                          |
+| --- | ------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| T1  | packaged stylesheet | consumer imports any styled entry              | cascade layers ship in ascending priority order `vize.tokens` → `vize.ui` → `vize.preset` → `vize.policy` | `ships the documented cascade layer order`                         |
+| T2  | packaged stylesheet | any styled entry                               | the semantic token contract ships in `@layer vize.tokens` at zero specificity, matching the TS mirrors    | `ships layered zero-specificity theme tokens matching the mirrors` |
+| T3  | packaged stylesheet | no `data-vize-theme` attribute                 | headless default: colors stay on the system palette and every elevation is `none`                         | `keeps the headless default free of visual opinion`                |
+| T4  | packaged stylesheet | `data-vize-density="compact" \| "comfortable"` | the density factor retunes, scaling every space and control-size token in the subtree                     | `ships density scopes that retune the shared factor`               |
+| T5  | packaged stylesheet | `data-vize-theme~="atelier"`                   | the Atelier preset assigns brand tokens in `@layer vize.preset`, scoped to the attribute                  | `scopes the atelier preset to its opt-in attribute`                |
+| T6  | packaged stylesheet | light and dark schemes                         | Atelier's `light-dark()` values ship lowered to the floor and follow the user's color scheme              | `lowers the atelier color schemes to the declared floor`           |
+| T7  | packaged stylesheet | `forced-colors: active`                        | `@layer vize.policy` snaps color roles to the system palette and flattens elevation, beating presets      | `stands down to system colors under forced colors`                 |
+| T8  | any                 | `setThemeTokens(element, overrides)`           | overrides apply to the element inline and the restore callback reinstates values                          | `applies and restores token overrides on a real element`           |
+| T9  | any                 | unknown token name or empty value              | `themeTokenProperty`/`setThemeTokens` throw `VIZE_UI_THEME_TOKEN`                                         | `rejects unknown tokens and empty override values`                 |
+| T10 | mounted             | consumer binds scope attributes and tokens     | preset and density attributes render, and scoped overrides apply through the mounted DOM                  | `scopes presets and densities in a mounted consumer`               |
+| T11 | SSR                 | render with token helpers in setup             | byte-identical markup; no platform global is required                                                     | `renders byte-identical SSR markup without platform globals`       |
+| T12 | SSR                 | hydration                                      | hydrating a themed consumer emits no diagnostics and keeps server nodes                                   | `hydrates a themed consumer without replacement or diagnostics`    |
+| T13 | public types        | invalid token names or mutated records         | compilation rejects misuse                                                                                | `src/theme.types.test-d.ts`                                        |
+
+## Cascade-layer order and specificity budget
+
+- The package ships exactly four cascade layers, in ascending priority:
+  `vize.tokens` (semantic defaults) < `vize.ui` (behavior-critical component
+  styles) < `vize.preset` (opt-in visual presets) < `vize.policy`
+  (accessibility stand-downs such as forced colors). `src/theme.css` declares
+  the order once; packaged CSS concatenates in `src/index.ts` module order, so
+  the theme export stays directly after `field-wiring` and the statement leads
+  `dist/style.css`.
+- Specificity budget: every rule in every vize layer sits on a `:where()`
+  selector at specificity `(0,0,0)` — pseudo-elements keep only their
+  intrinsic element specificity. Consumer CSS outside the vize layers always
+  wins, and consumer `@layer` rules win by declaring their layers later.
+
+## Extension contract
+
+- Every token is a `--vize-ui-*` custom property defined at zero specificity:
+  a consumer rule outside the layers — or a `setThemeTokens` override on an
+  ancestor — replaces any role for a whole subtree without forking
+  components. `--vize-ui-focus-ring-color` resolves through
+  `--vize-ui-color-accent`, and space/size tokens resolve through
+  `--vize-ui-density`, so one override retunes a whole phase.
+- `data-vize-theme` holds space-separated preset names and is inert without
+  the shipped preset CSS; `data-vize-density` accepts `compact` and
+  `comfortable`. Both scope by inheritance, so nesting attributes nests
+  themes.
+- SSR bootstrapping is CSS-only and flash-free by construction: server-render
+  the attribute (typically on `<html>`), and Atelier's `light-dark()` values
+  follow the user's scheme with no runtime script. Motion tokens stay in the
+  motion family (`motion.behavior.md`).

--- a/npm/ui/core/src/theme.css
+++ b/npm/ui/core/src/theme.css
@@ -1,0 +1,144 @@
+/*
+ * Semantic design-token contract and cascade-layer order.
+ *
+ * Authored in the native CSS contract (nesting, cascade layers, native color
+ * functions) and down-compiled to the declared browser floor by the package
+ * build; see style-pipeline.behavior.md. The layer statement below is the
+ * package-wide cascade contract:
+ *
+ *   vize.tokens  < vize.ui < vize.preset < vize.policy < consumer CSS
+ *   (defaults)     (behavior) (opt-in look) (a11y stand-downs)
+ *
+ * Every rule sits on a `:where()` zero-specificity selector, so consumer CSS
+ * outside the vize layers always wins: replacing any token or preset value
+ * never requires forking a component. The TypeScript mirrors in
+ * theme-tokens.ts must stay value-identical with this file;
+ * src/theme-stylesheet.test.ts proves the pairing on the packaged stylesheet.
+ */
+
+@layer vize.tokens, vize.ui, vize.preset, vize.policy;
+
+@layer vize.tokens {
+  :where(:root, :host) {
+    /*
+     * Color roles. Headless defaults stay on the system palette so an
+     * unthemed page is honest native UI: correct in light and dark schemes
+     * and under forced colors, with no shipped visual opinion.
+     */
+    --vize-ui-color-canvas: Canvas;
+    --vize-ui-color-surface: Canvas;
+    --vize-ui-color-text: CanvasText;
+    --vize-ui-color-text-muted: GrayText;
+    --vize-ui-color-accent: LinkText;
+    --vize-ui-color-accent-contrast: Canvas;
+    --vize-ui-color-border: GrayText;
+    --vize-ui-color-danger: #d92d20;
+
+    /* Typography: families, size scale, line heights, and weights. */
+    --vize-ui-type-family-sans: system-ui, sans-serif;
+    --vize-ui-type-family-mono: ui-monospace, monospace;
+    --vize-ui-type-size-xs: 0.75rem;
+    --vize-ui-type-size-sm: 0.875rem;
+    --vize-ui-type-size-md: 1rem;
+    --vize-ui-type-size-lg: 1.125rem;
+    --vize-ui-type-size-xl: 1.25rem;
+    --vize-ui-type-size-2xl: 1.5rem;
+    --vize-ui-type-leading-tight: 1.25;
+    --vize-ui-type-leading-normal: 1.5;
+    --vize-ui-type-leading-loose: 1.75;
+    --vize-ui-type-weight-regular: 400;
+    --vize-ui-type-weight-medium: 500;
+    --vize-ui-type-weight-bold: 700;
+
+    /*
+     * Density factor. Space and control-size tokens multiply through it, so
+     * one scoped override retunes a whole surface; the `data-vize-density`
+     * scopes below are the declarative form.
+     */
+    --vize-ui-density: 1;
+
+    /* Space scale, density-responsive. */
+    --vize-ui-space-xs: calc(0.25rem * var(--vize-ui-density));
+    --vize-ui-space-sm: calc(0.5rem * var(--vize-ui-density));
+    --vize-ui-space-md: calc(0.75rem * var(--vize-ui-density));
+    --vize-ui-space-lg: calc(1rem * var(--vize-ui-density));
+    --vize-ui-space-xl: calc(1.5rem * var(--vize-ui-density));
+    --vize-ui-space-2xl: calc(2rem * var(--vize-ui-density));
+    --vize-ui-space-3xl: calc(3rem * var(--vize-ui-density));
+
+    /* Control sizes (block size of interactive controls), density-responsive. */
+    --vize-ui-size-control-sm: calc(1.75rem * var(--vize-ui-density));
+    --vize-ui-size-control-md: calc(2.25rem * var(--vize-ui-density));
+    --vize-ui-size-control-lg: calc(2.75rem * var(--vize-ui-density));
+
+    /* Corner radii. */
+    --vize-ui-radius-sm: 0.25rem;
+    --vize-ui-radius-md: 0.5rem;
+    --vize-ui-radius-lg: 1rem;
+    --vize-ui-radius-full: 9999px;
+
+    /* Border widths. */
+    --vize-ui-border-width-thin: 1px;
+    --vize-ui-border-width-thick: 2px;
+
+    /* Elevation. Shadows are visual opinion, so the headless default is flat. */
+    --vize-ui-elevation-raised: none;
+    --vize-ui-elevation-overlay: none;
+    --vize-ui-elevation-floating: none;
+
+    /* Opacity roles. */
+    --vize-ui-opacity-muted: 0.7;
+    --vize-ui-opacity-disabled: 0.45;
+
+    /* Z-index registry: one shared scale keeps layered surfaces ordered. */
+    --vize-ui-z-sticky: 100;
+    --vize-ui-z-dropdown: 600;
+    --vize-ui-z-overlay: 1000;
+    --vize-ui-z-toast: 1200;
+
+    /* Focus ring. The color resolves through the accent role by default. */
+    --vize-ui-focus-ring-width: 2px;
+    --vize-ui-focus-ring-offset: 2px;
+    --vize-ui-focus-ring-color: var(--vize-ui-color-accent);
+  }
+
+  /*
+   * Density scopes: the declarative counterpart of overriding
+   * `--vize-ui-density`. Custom properties inherit, so the factor retunes
+   * every space and size token in the annotated subtree.
+   */
+  :where([data-vize-density]) {
+    &:where([data-vize-density="compact"]) {
+      --vize-ui-density: 0.85;
+    }
+
+    &:where([data-vize-density="comfortable"]) {
+      --vize-ui-density: 1.15;
+    }
+  }
+}
+
+/*
+ * Forced colors: presets assign absolute colors, so the policy layer — which
+ * beats every preset — snaps the color roles back to the system palette and
+ * flattens elevation wherever tokens are defined. Properties the platform
+ * force-paints anyway stay coherent with the ones it does not.
+ */
+@layer vize.policy {
+  @media (forced-colors: active) {
+    :where(:root, :host, [data-vize-theme]) {
+      --vize-ui-color-canvas: Canvas;
+      --vize-ui-color-surface: Canvas;
+      --vize-ui-color-text: CanvasText;
+      --vize-ui-color-text-muted: GrayText;
+      --vize-ui-color-accent: Highlight;
+      --vize-ui-color-accent-contrast: HighlightText;
+      --vize-ui-color-border: ButtonBorder;
+      --vize-ui-color-danger: CanvasText;
+      --vize-ui-elevation-raised: none;
+      --vize-ui-elevation-overlay: none;
+      --vize-ui-elevation-floating: none;
+      --vize-ui-focus-ring-color: Highlight;
+    }
+  }
+}

--- a/npm/ui/core/src/theme.test.ts
+++ b/npm/ui/core/src/theme.test.ts
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { test } from "vite-plus/test";
+import { defineComponent, h, ref } from "vue";
+
+import { mountInteraction } from "./testing/mount.ts";
+import {
+  setThemeTokens,
+  themeDensityAttribute,
+  themeDensityScales,
+  themePresetAttribute,
+  themePresets,
+  themeTokenProperty,
+  themeTokens,
+  themeTokenVar,
+} from "./theme.ts";
+
+test("applies and restores token overrides on a real element", () => {
+  const element = document.createElement("section");
+  document.body.append(element);
+  element.style.setProperty("--vize-ui-color-accent", "rebeccapurple");
+
+  const restore = setThemeTokens(element, {
+    "color-accent": "oklch(0.6 0.2 300)",
+    "radius-md": "0.75rem",
+    density: "0.9",
+  });
+  assert.equal(element.style.getPropertyValue("--vize-ui-color-accent"), "oklch(0.6 0.2 300)");
+  assert.equal(element.style.getPropertyValue("--vize-ui-radius-md"), "0.75rem");
+  assert.equal(element.style.getPropertyValue("--vize-ui-density"), "0.9");
+
+  restore();
+  assert.equal(element.style.getPropertyValue("--vize-ui-color-accent"), "rebeccapurple");
+  assert.equal(element.style.getPropertyValue("--vize-ui-radius-md"), "");
+  assert.equal(element.style.getPropertyValue("--vize-ui-density"), "");
+  element.remove();
+
+  assert.equal(themeTokenProperty("color-canvas"), "--vize-ui-color-canvas");
+  assert.equal(themeTokenProperty("density"), "--vize-ui-density");
+  assert.equal(themeTokenVar("focus-ring-color"), "var(--vize-ui-focus-ring-color)");
+});
+
+test("rejects unknown tokens and empty override values", () => {
+  const element = document.createElement("div");
+  assert.throws(
+    () => themeTokenProperty("color-bogus" as Parameters<typeof themeTokenProperty>[0]),
+    /VIZE_UI_THEME_TOKEN/,
+  );
+  assert.throws(() => setThemeTokens(element, { "color-accent": "  " }), /VIZE_UI_THEME_TOKEN/);
+  assert.throws(
+    () => setThemeTokens(null as unknown as HTMLElement, { "color-accent": "red" }),
+    /VIZE_UI_THEME_TOKEN/,
+  );
+});
+
+test("publishes the token contract and scope constants", () => {
+  assert.equal(themePresetAttribute, "data-vize-theme");
+  assert.equal(themeDensityAttribute, "data-vize-density");
+  assert.deepEqual([...themePresets], ["atelier"]);
+  assert.deepEqual(Object.keys(themeDensityScales).sort(), ["comfortable", "compact"]);
+
+  // The record is frozen and every name round-trips through the helpers.
+  assert.ok(Object.isFrozen(themeTokens));
+  for (const name of Object.keys(themeTokens)) {
+    assert.equal(
+      themeTokenProperty(name as keyof typeof themeTokens),
+      `--vize-ui-${name}`,
+      `token ${name} must map onto its custom property`,
+    );
+  }
+});
+
+test("scopes presets and densities in a mounted consumer", () => {
+  const density = ref<"compact" | "comfortable">("compact");
+  const Consumer = defineComponent({
+    name: "ThemeScopeProbe",
+    setup() {
+      return () =>
+        h(
+          "section",
+          { [themePresetAttribute]: "atelier", [themeDensityAttribute]: density.value },
+          [h("output", { "data-accent": themeTokenVar("color-accent") }, "Themed")],
+        );
+    },
+  });
+
+  const handle = mountInteraction(Consumer);
+  const root = handle.root();
+  assert.equal(root.getAttribute("data-vize-theme"), "atelier");
+  assert.equal(root.getAttribute("data-vize-density"), "compact");
+  assert.equal(
+    root.querySelector("output")?.getAttribute("data-accent"),
+    "var(--vize-ui-color-accent)",
+  );
+
+  const restore = setThemeTokens(root, { "space-md": "1rem" });
+  assert.equal(root.style.getPropertyValue("--vize-ui-space-md"), "1rem");
+  restore();
+  assert.equal(root.style.getPropertyValue("--vize-ui-space-md"), "");
+  handle.unmount();
+});

--- a/npm/ui/core/src/theme.ts
+++ b/npm/ui/core/src/theme.ts
@@ -1,0 +1,31 @@
+import "./theme.css";
+import "./theme-preset-atelier.css";
+
+export {
+  setThemeTokens,
+  themeCascadeLayerOrder,
+  themeDensityAttribute,
+  themeDensityScales,
+  themePresetAttribute,
+  themePresets,
+  themeTokenProperty,
+  themeTokens,
+  themeTokenVar,
+} from "./theme-tokens.ts";
+
+export type {
+  ThemeBorderToken,
+  ThemeColorToken,
+  ThemeDensityScale,
+  ThemeElevationToken,
+  ThemeFocusToken,
+  ThemeOpacityToken,
+  ThemePresetName,
+  ThemeRadiusToken,
+  ThemeSizeToken,
+  ThemeSpaceToken,
+  ThemeTokenName,
+  ThemeTokenOverrides,
+  ThemeTypeToken,
+  ThemeZIndexToken,
+} from "./theme-types.ts";

--- a/npm/ui/core/src/theme.types.test-d.ts
+++ b/npm/ui/core/src/theme.types.test-d.ts
@@ -1,0 +1,79 @@
+/** Compile-only assertions for the public theme contract. */
+
+import {
+  setThemeTokens,
+  themeCascadeLayerOrder,
+  themeDensityScales,
+  themeTokens,
+  themeTokenVar,
+} from "./theme.ts";
+import type {
+  ThemeColorToken,
+  ThemeDensityScale,
+  ThemeElevationToken,
+  ThemePresetName,
+  ThemeRadiusToken,
+  ThemeSpaceToken,
+  ThemeTokenName,
+  ThemeZIndexToken,
+} from "./theme.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+export const colors: readonly ThemeColorToken[] = [
+  "canvas",
+  "surface",
+  "text",
+  "text-muted",
+  "accent",
+  "accent-contrast",
+  "border",
+  "danger",
+];
+export const space: readonly ThemeSpaceToken[] = ["xs", "sm", "md", "lg", "xl", "2xl", "3xl"];
+export const radii: readonly ThemeRadiusToken[] = ["sm", "md", "lg", "full"];
+export const elevations: readonly ThemeElevationToken[] = ["raised", "overlay", "floating"];
+export const layers: readonly ThemeZIndexToken[] = ["sticky", "dropdown", "overlay", "toast"];
+
+export const reference: string = themeTokenVar("color-accent");
+export const typeReference: string = themeTokenVar("type-size-md");
+export const densityReference: string = themeTokenVar("density");
+
+type _TokenNamesAreClosed = Expect<
+  Equal<
+    Extract<ThemeTokenName, "color-canvas" | "space-2xl" | "density">,
+    "color-canvas" | "space-2xl" | "density"
+  >
+>;
+type _PresetNamesAreClosed = Expect<Equal<ThemePresetName, "atelier">>;
+type _DensityScalesAreClosed = Expect<Equal<ThemeDensityScale, "compact" | "comfortable">>;
+type _LayerOrderIsLiteral = Expect<
+  Equal<
+    (typeof themeCascadeLayerOrder)[number],
+    "vize.tokens" | "vize.ui" | "vize.preset" | "vize.policy"
+  >
+>;
+
+export const restore: () => void = setThemeTokens(document.createElement("div"), {
+  "color-accent": "oklch(0.6 0.2 300)",
+  "focus-ring-width": "3px",
+});
+
+// @ts-expect-error unknown token names never compile.
+themeTokenVar("color-bogus");
+// @ts-expect-error the token record is readonly.
+themeTokens["color-canvas"] = "red";
+// @ts-expect-error the density record is readonly.
+themeDensityScales.compact = "0.5";
+// @ts-expect-error the layer order is readonly.
+themeCascadeLayerOrder[0] = "vize.ui";
+// @ts-expect-error overrides only accept known token names.
+setThemeTokens(document.createElement("div"), { "space-huge": "4rem" });
+// @ts-expect-error preset unions reject arbitrary strings.
+export const badPreset: ThemePresetName = "baroque";
+// @ts-expect-error density unions reject arbitrary strings.
+export const badDensity: ThemeDensityScale = "cozy";

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
   pack: {
     entry: {
       index: "src/index.ts",
+      theme: "src/theme.ts",
       announcer: "src/announcer.ts",
       button: "src/button.ts",
       checkbox: "src/checkbox.ts",


### PR DESCRIPTION
## Summary

Foundational slice of the design-token family for `@vizejs/ui` (Tracks #4894):

- **Semantic token contract**: `--vize-ui-*` custom properties for color, type, space, size, radius, border, elevation, opacity, z-index, focus, and density (motion already ships in its own family), defined in `@layer vize.tokens` at `:where()` zero specificity. Headless defaults stay on the system palette — no shipped visual opinion — and the TypeScript mirrors in `theme-tokens.ts` are proven value-identical against the packaged stylesheet.
- **Cascade-layer order and specificity budget**: the package-wide contract `vize.tokens < vize.ui < vize.preset < vize.policy < consumer CSS`, declared once in `theme.css`; the theme export sits directly after `field-wiring` in `src/index.ts` so the statement leads `dist/style.css`, and the shipped block order is pinned by test. Every rule in every vize layer sits at specificity `(0,0,0)`.
- **Atelier preset** (Vize brand default), scoped to the opt-in `data-vize-theme~="atelier"` attribute in `@layer vize.preset` — inert without the attribute, so the package stays headless by default. Light/dark schemes author as `light-dark()` and ship lowered to the declared browser floor (`cssBrowserFloor`); relative-color and `color-mix()` derivations resolve to literals at build time. Server-rendering the attribute gives flash-free SSR with no runtime script.
- **Density scopes**: `data-vize-density="compact" | "comfortable"` retune the shared `--vize-ui-density` factor behind every space and control-size token.
- **Forced-colors policy**: `@layer vize.policy` beats every preset, snapping color roles to the system palette and flattening elevation under `forced-colors: active`.
- **Family packaging**: catalog lane entry, `./theme` subpath export, pack entry, normative `theme.behavior.md` table (T1–T13), colocated runtime/stylesheet/SSR tests plus type tests, `ThemeConsumer.vue` renderer fixture (dom/ssr/vapor), and re-measured `check-size` / `check-tree-shaking` budgets with root-vs-subpath byte equality.

The token files exercise CSS Nesting, `@layer`, `light-dark()`, and relative color through the pack pipeline, per the issue's testbed notes.

### Remainder for #4894

- Paper, Midnight, Signal, and Play presets
- Dedicated high-contrast preset beyond the forced-colors policy layer
- Independent color, density, radius, typography, and motion packs as separately composable opt-ins
- Nested theme scopes with explicit scheme forcing, system-preference override, and persistence helpers
- Screenshot review of the default preset (visual proof lives in #4898)

## Change Class

- [x] Runtime packaging, release, or docs
- [x] Not language-facing

## Behavior Reference

- #4894 (inventory and quality gates), #3134 (parent definition of done)
- Motion-family precedent for the CSS token pattern (#4986); `style-pipeline.behavior.md` for the browser-floor policy

## Verification Evidence

In `npm/ui/core`: `vp pack`, `vp test run` (108 files / 625 tests green, including the new `theme.test.ts`, `theme-stylesheet.test.ts`, `theme-ssr.test.ts`), `vp check` + `vue-tsc --noEmit` clean, `lint-sfc` + `check-renderers` (26 fixtures × 3 lanes), `check-size` and `check-tree-shaking` green with re-measured budgets (index 104,327 gzip → 106,000 budget; shared stylesheet 2,355 gzip → 2,500 CSS budgets for the styled families).

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

- The shared `dist/style.css` grows (1.12 kB → 1.99 kB gzip); every styled family's measured CSS budget was re-measured accordingly. Consumers that import no styled entry still ship zero CSS.
- The four-layer contract supersedes the previous "everything in `@layer vize.ui`" note in `style-pipeline.behavior.md`; existing shipped rules keep their layer, so no consumer-visible cascade change without the opt-in attributes.
- At the declared floor the lowered `light-dark()` pair follows `prefers-color-scheme` (engines above the floor honor `color-scheme` natively); explicit per-subtree scheme forcing is part of the tracked remainder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790336572&installation_model_id=422833&pr_number=4998&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4998&signature=18f43ea1ad6135c3d5b4f3d77f3accfa8882f38520b03429597f64886731b0a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public theme package export with typed theme tokens and customization APIs.
  * Added semantic design tokens for colors, typography, spacing, sizing, borders, elevation, focus states, and layering.
  * Added compact and comfortable density options, an Atelier theme preset, and forced-colors accessibility support.
  * Added scoped token overrides with restoration support and SSR/hydration compatibility.

* **Documentation**
  * Documented theme layering, presets, density behavior, customization, accessibility, and rendering guarantees.

* **Tests**
  * Added coverage for theme behavior, styling, type safety, SSR, hydration, and tree-shaking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->