### PR TITLE
feat(ui): add paper theme preset

### DIFF
--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -33,7 +33,7 @@ const budgets = new Map([
   ["measure.mjs", 2_400],
   // Styled entries statically import the shared dist/style.css, so their
   // budgets cover the packaged stylesheet alongside their JavaScript.
-  ["motion.mjs", 4_600],
+  ["motion.mjs", 4_750],
   ["move.mjs", 5_050],
   ["pointer-grace.mjs", 1_800],
   ["portal.mjs", 1_700],
@@ -44,12 +44,12 @@ const budgets = new Map([
   ["shortcut.mjs", 7_400],
   ["sortable.mjs", 17_000],
   ["spatial-navigation.mjs", 3_725],
-  ["theme.mjs", 3_900],
+  ["theme.mjs", 4_000],
   ["transition.mjs", 3_000],
   ["typeahead.mjs", 2_000],
   ["virtualizer.mjs", 9_500],
   ["primitive.mjs", 800],
-  ["visually-hidden.mjs", 2_700],
+  ["visually-hidden.mjs", 2_850],
   ["media.mjs", 2_400],
   ["media-pdf.mjs", 2_048],
   ["media-source.mjs", 1_800],

--- a/npm/ui/core/src/family-catalog-basics.ts
+++ b/npm/ui/core/src/family-catalog-basics.ts
@@ -247,6 +247,7 @@ export const basicFamilyCatalog = [
       "src/theme.ts",
       "src/theme.css",
       "src/theme-preset-atelier.css",
+      "src/theme-preset-paper.css",
       "src/theme-tokens.ts",
       "src/theme-types.ts",
     ],
@@ -261,9 +262,9 @@ export const basicFamilyCatalog = [
       maximumJavaScriptGzipBytes: 1_500,
       // Covers the packaged stylesheet: the token contract and presets share
       // dist/style.css with every other styled family.
-      maximumCssGzipBytes: 2_500,
+      maximumCssGzipBytes: 2_950,
     },
-    aliases: ["design tokens", "semantic tokens", "cascade layers", "presets", "atelier"],
+    aliases: ["design tokens", "semantic tokens", "cascade layers", "presets", "atelier", "paper"],
     upstreamCoverage: [
       "CSS cascade layers",
       "CSS custom properties",

--- a/npm/ui/core/src/family-catalog-focus.ts
+++ b/npm/ui/core/src/family-catalog-focus.ts
@@ -125,7 +125,7 @@ export const focusFamilyCatalog = [
     bundleBudget: {
       exportName: "createFocusGuards",
       retainedSignature: "VIZE_UI_FOCUS_GUARDS_DISPOSED",
-      maximumJavaScriptGzipBytes: 3_500,
+      maximumJavaScriptGzipBytes: 3_525,
       maximumCssGzipBytes: 0,
     },
     aliases: ["focus sentinels", "tab guards", "focus trap guards"],

--- a/npm/ui/core/src/family-catalog-interactions.ts
+++ b/npm/ui/core/src/family-catalog-interactions.ts
@@ -340,7 +340,7 @@ export const interactionFamilyCatalog = [
       maximumJavaScriptGzipBytes: 400,
       // Covers the shared packaged stylesheet (dist/style.css), including the
       // motion tokens every styled family ships together (style-pipeline.behavior.md).
-      maximumCssGzipBytes: 2_500,
+      maximumCssGzipBytes: 2_950,
     },
     aliases: ["screen reader only", "sr-only", "visually hidden"],
     upstreamCoverage: ["React Aria VisuallyHidden", "Radix VisuallyHidden"],

--- a/npm/ui/core/src/family-catalog-overlays.ts
+++ b/npm/ui/core/src/family-catalog-overlays.ts
@@ -111,7 +111,7 @@ export const overlayFamilyCatalog = [
       maximumJavaScriptGzipBytes: 1_500,
       // Covers the packaged stylesheet: motion tokens and recipes share
       // dist/style.css with every other styled family.
-      maximumCssGzipBytes: 2_500,
+      maximumCssGzipBytes: 2_950,
     },
     aliases: ["motion tokens", "easing", "view transitions", "starting style", "reduced motion"],
     upstreamCoverage: [

--- a/npm/ui/core/src/style-pipeline.behavior.md
+++ b/npm/ui/core/src/style-pipeline.behavior.md
@@ -44,3 +44,6 @@ proven by `src/style-pipeline.test.ts` against the real package build.
   `theme.behavior.md` for the order and specificity contract — so consumer
   CSS outside a layer, or in a later layer, always wins without specificity
   fights.
+- Preset styles are authored as small native CSS files imported by
+  `src/theme.ts`. They share the same `vize.preset` layer and are lowered by
+  the package build before reaching `dist/style.css`.

--- a/npm/ui/core/src/theme-preset-paper.css
+++ b/npm/ui/core/src/theme-preset-paper.css
@@ -1,0 +1,36 @@
+/*
+ * Paper preset: editorial, content-forward surfaces with warm paper grounds,
+ * ink-toned text, and a quiet teal accent. Like every preset, it is inert until
+ * a consumer opts a subtree into `data-vize-theme~="paper"`.
+ */
+
+@layer vize.preset {
+  :where([data-vize-theme~="paper"], :host([data-vize-theme~="paper"])) {
+    color-scheme: light dark;
+
+    --vize-ui-color-canvas: light-dark(oklch(0.985 0.018 92), oklch(0.17 0.018 82));
+    --vize-ui-color-surface: light-dark(oklch(1 0.011 96), oklch(0.235 0.019 82));
+    --vize-ui-color-text: light-dark(oklch(0.25 0.026 235), oklch(0.94 0.012 90));
+    --vize-ui-color-text-muted: light-dark(
+      color-mix(in oklab, oklch(0.25 0.026 235) 62%, oklch(0.985 0.018 92)),
+      color-mix(in oklab, oklch(0.94 0.012 90) 66%, oklch(0.17 0.018 82))
+    );
+    --vize-ui-color-accent: light-dark(oklch(0.52 0.11 185), oklch(0.74 0.095 185));
+    --vize-ui-color-accent-contrast: light-dark(oklch(0.99 0.008 96), oklch(0.15 0.02 185));
+    --vize-ui-color-border: light-dark(
+      oklch(from oklch(0.985 0.018 92) calc(l - 0.13) c h),
+      oklch(0.34 0.021 82)
+    );
+    --vize-ui-color-danger: light-dark(oklch(0.54 0.17 31), oklch(0.72 0.15 28));
+
+    --vize-ui-type-leading-normal: 1.6;
+    --vize-ui-radius-md: 0.375rem;
+    --vize-ui-radius-lg: 0.75rem;
+    --vize-ui-elevation-raised:
+      0 1px 2px oklch(0.25 0.026 235 / 0.07), 0 1px 4px oklch(0.25 0.026 235 / 0.08);
+    --vize-ui-elevation-overlay:
+      0 6px 18px oklch(0.25 0.026 235 / 0.13), 0 2px 6px oklch(0.25 0.026 235 / 0.09);
+    --vize-ui-elevation-floating:
+      0 18px 44px oklch(0.25 0.026 235 / 0.16), 0 6px 16px oklch(0.25 0.026 235 / 0.1);
+  }
+}

--- a/npm/ui/core/src/theme-stylesheet.test.ts
+++ b/npm/ui/core/src/theme-stylesheet.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 
 import { test } from "vite-plus/test";
 
-import { themeCascadeLayerOrder, themeDensityScales, themeTokens } from "./theme.ts";
+import { themeCascadeLayerOrder, themeDensityScales, themePresets, themeTokens } from "./theme.ts";
 
 const stylesheet = await readFile(path.resolve("dist/style.css"), "utf8");
 
@@ -89,16 +89,27 @@ test("ships density scopes that retune the shared factor", () => {
   assert.equal(shippedToken("size-control-md"), "calc(2.25rem * var(--vize-ui-density))");
 });
 
-test("scopes the atelier preset to its opt-in attribute", () => {
+function shippedPresetRule(name: (typeof themePresets)[number]): string {
+  const preset = layerBlock("vize.preset");
+  const pattern = new RegExp(
+    `:where\\(\\[data-vize-theme~=${name}\\],:host\\(\\[data-vize-theme~=${name}\\]\\)\\)` +
+      "\\{([^}]+)\\}",
+  );
+  const match = pattern.exec(preset);
+  assert.ok(match?.[1], `the ${name} preset must ship`);
+  return match[1];
+}
+
+test("scopes published presets to their opt-in attributes", () => {
   const preset = layerBlock("vize.preset");
 
-  assert.match(
-    preset,
-    /:where\(\[data-vize-theme~=atelier\],:host\(\[data-vize-theme~=atelier\]\)\)\{/,
-  );
-  assert.match(preset, /color-scheme:light dark/);
-  assert.match(preset, /--vize-ui-color-accent:/);
-  assert.match(preset, /--vize-ui-elevation-raised:0 1px 2px oklch\(/);
+  for (const name of themePresets) {
+    const rule = shippedPresetRule(name);
+    assert.match(rule, /color-scheme:light dark/);
+    assert.match(rule, /--vize-ui-color-accent:/);
+    assert.match(rule, /--vize-ui-elevation-raised:/);
+  }
+  assert.match(shippedPresetRule("paper"), /--vize-ui-type-leading-normal:1\.6/);
   assert.doesNotMatch(
     preset,
     /:where\(:root,:host\)/,
@@ -106,7 +117,7 @@ test("scopes the atelier preset to its opt-in attribute", () => {
   );
 });
 
-test("lowers the atelier color schemes to the declared floor", () => {
+test("lowers preset color schemes to the declared floor", () => {
   const preset = layerBlock("vize.preset");
 
   // light-dark() is newer than the floor and must ship as the lowered
@@ -120,6 +131,7 @@ test("lowers the atelier color schemes to the declared floor", () => {
     preset,
     /@media \(prefers-color-scheme:dark\)\{:where\(\[data-vize-theme~=atelier\]/,
   );
+  assert.match(preset, /@media \(prefers-color-scheme:dark\)\{:where\(\[data-vize-theme~=paper\]/);
 
   // Relative color and color-mix() derivations resolve to literals at build
   // time, so the floor never sees the newer syntax.

--- a/npm/ui/core/src/theme-tokens.ts
+++ b/npm/ui/core/src/theme-tokens.ts
@@ -22,7 +22,7 @@ export const themePresetAttribute = "data-vize-theme";
 export const themeDensityAttribute = "data-vize-density";
 
 /** Opinionated presets shipped in `@layer vize.preset`. */
-export const themePresets: readonly ThemePresetName[] = Object.freeze(["atelier"]);
+export const themePresets: readonly ThemePresetName[] = Object.freeze(["atelier", "paper"]);
 
 /** Density factors mirrored from the `data-vize-density` scopes in `theme.css`. */
 export const themeDensityScales: Readonly<Record<ThemeDensityScale, string>> = Object.freeze({

--- a/npm/ui/core/src/theme-types.ts
+++ b/npm/ui/core/src/theme-types.ts
@@ -61,7 +61,7 @@ export type ThemeTokenOverrides = {
 };
 
 /** Opinionated presets accepted in the space-separated `data-vize-theme` attribute. */
-export type ThemePresetName = "atelier";
+export type ThemePresetName = "atelier" | "paper";
 
 /** Density scopes accepted in the `data-vize-density` attribute. */
 export type ThemeDensityScale = "compact" | "comfortable";

--- a/npm/ui/core/src/theme.behavior.md
+++ b/npm/ui/core/src/theme.behavior.md
@@ -3,8 +3,9 @@
 Normative contract for the theme family (`@vizejs/ui/theme`): the semantic
 design-token contract, the package-wide cascade-layer order, and the opt-in
 presets. The stylesheet contract is proven on the packaged `dist/style.css`
-(the pack pipeline lowers `src/theme.css` and `src/theme-preset-atelier.css`
-to the declared browser floor; see `style-pipeline.behavior.md`) in
+(the pack pipeline lowers `src/theme.css`, `src/theme-preset-atelier.css`, and
+`src/theme-preset-paper.css` to the declared browser floor; see
+`style-pipeline.behavior.md`) in
 `src/theme-stylesheet.test.ts`; runtime rows are proven by the named test in
 `src/theme.test.ts` or `src/theme-ssr.test.ts`; compile-only assertions live
 in `src/theme.types.test-d.ts`.
@@ -15,8 +16,8 @@ in `src/theme.types.test-d.ts`.
 | T2  | packaged stylesheet | any styled entry                               | the semantic token contract ships in `@layer vize.tokens` at zero specificity, matching the TS mirrors    | `ships layered zero-specificity theme tokens matching the mirrors` |
 | T3  | packaged stylesheet | no `data-vize-theme` attribute                 | headless default: colors stay on the system palette and every elevation is `none`                         | `keeps the headless default free of visual opinion`                |
 | T4  | packaged stylesheet | `data-vize-density="compact" \| "comfortable"` | the density factor retunes, scaling every space and control-size token in the subtree                     | `ships density scopes that retune the shared factor`               |
-| T5  | packaged stylesheet | `data-vize-theme~="atelier"`                   | the Atelier preset assigns brand tokens in `@layer vize.preset`, scoped to the attribute                  | `scopes the atelier preset to its opt-in attribute`                |
-| T6  | packaged stylesheet | light and dark schemes                         | Atelier's `light-dark()` values ship lowered to the floor and follow the user's color scheme              | `lowers the atelier color schemes to the declared floor`           |
+| T5  | packaged stylesheet | `data-vize-theme~="atelier" \| "paper"`        | published presets assign visual tokens in `@layer vize.preset`, scoped to their opt-in attribute          | `scopes published presets to their opt-in attributes`              |
+| T6  | packaged stylesheet | light and dark schemes                         | preset `light-dark()` values ship lowered to the floor and follow the user's color scheme                 | `lowers preset color schemes to the declared floor`                |
 | T7  | packaged stylesheet | `forced-colors: active`                        | `@layer vize.policy` snaps color roles to the system palette and flattens elevation, beating presets      | `stands down to system colors under forced colors`                 |
 | T8  | any                 | `setThemeTokens(element, overrides)`           | overrides apply to the element inline and the restore callback reinstates values                          | `applies and restores token overrides on a real element`           |
 | T9  | any                 | unknown token name or empty value              | `themeTokenProperty`/`setThemeTokens` throw `VIZE_UI_THEME_TOKEN`                                         | `rejects unknown tokens and empty override values`                 |
@@ -48,9 +49,11 @@ in `src/theme.types.test-d.ts`.
   `--vize-ui-color-accent`, and space/size tokens resolve through
   `--vize-ui-density`, so one override retunes a whole phase.
 - `data-vize-theme` holds space-separated preset names and is inert without
-  the shipped preset CSS; `data-vize-density` accepts `compact` and
-  `comfortable`. Both scope by inheritance, so nesting attributes nests
-  themes.
+  the shipped preset CSS; `atelier` is the Vize brand default, and `paper` is
+  the editorial/content-forward preset. When multiple presets are present,
+  package source order resolves ties, so later shipped presets win.
+  `data-vize-density` accepts `compact` and `comfortable`. Both scope by
+  inheritance, so nesting attributes nests themes.
 - SSR bootstrapping is CSS-only and flash-free by construction: server-render
   the attribute (typically on `<html>`), and Atelier's `light-dark()` values
   follow the user's scheme with no runtime script. Motion tokens stay in the

--- a/npm/ui/core/src/theme.test.ts
+++ b/npm/ui/core/src/theme.test.ts
@@ -55,7 +55,7 @@ test("rejects unknown tokens and empty override values", () => {
 test("publishes the token contract and scope constants", () => {
   assert.equal(themePresetAttribute, "data-vize-theme");
   assert.equal(themeDensityAttribute, "data-vize-density");
-  assert.deepEqual([...themePresets], ["atelier"]);
+  assert.deepEqual([...themePresets], ["atelier", "paper"]);
   assert.deepEqual(Object.keys(themeDensityScales).sort(), ["comfortable", "compact"]);
 
   // The record is frozen and every name round-trips through the helpers.
@@ -77,7 +77,7 @@ test("scopes presets and densities in a mounted consumer", () => {
       return () =>
         h(
           "section",
-          { [themePresetAttribute]: "atelier", [themeDensityAttribute]: density.value },
+          { [themePresetAttribute]: "atelier paper", [themeDensityAttribute]: density.value },
           [h("output", { "data-accent": themeTokenVar("color-accent") }, "Themed")],
         );
     },
@@ -85,7 +85,7 @@ test("scopes presets and densities in a mounted consumer", () => {
 
   const handle = mountInteraction(Consumer);
   const root = handle.root();
-  assert.equal(root.getAttribute("data-vize-theme"), "atelier");
+  assert.equal(root.getAttribute("data-vize-theme"), "atelier paper");
   assert.equal(root.getAttribute("data-vize-density"), "compact");
   assert.equal(
     root.querySelector("output")?.getAttribute("data-accent"),

--- a/npm/ui/core/src/theme.ts
+++ b/npm/ui/core/src/theme.ts
@@ -1,5 +1,6 @@
 import "./theme.css";
 import "./theme-preset-atelier.css";
+import "./theme-preset-paper.css";
 
 export {
   setThemeTokens,

--- a/npm/ui/core/src/theme.types.test-d.ts
+++ b/npm/ui/core/src/theme.types.test-d.ts
@@ -49,7 +49,7 @@ type _TokenNamesAreClosed = Expect<
     "color-canvas" | "space-2xl" | "density"
   >
 >;
-type _PresetNamesAreClosed = Expect<Equal<ThemePresetName, "atelier">>;
+type _PresetNamesAreClosed = Expect<Equal<ThemePresetName, "atelier" | "paper">>;
 type _DensityScalesAreClosed = Expect<Equal<ThemeDensityScale, "compact" | "comfortable">>;
 type _LayerOrderIsLiteral = Expect<
   Equal<


### PR DESCRIPTION
## Summary
- add the opt-in Paper theme preset alongside Atelier
- publish the preset in the typed theme contract and packaged stylesheet checks
- update UI size/tree-shaking budgets for the shared stylesheet cost

Refs #4894.

## Verification
- nix develop --command pnpm --dir npm/ui/core test
- nix develop --command pnpm --dir npm/ui/core run check
- nix develop --command pnpm --dir npm/ui/core run lint:sfc
- nix develop --command node --test tests/tooling/source-file-lengths.test.ts
- nix develop --command cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/4999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790338572&installation_model_id=422833&pr_number=4999&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F4999&signature=02c39af53f5f3372f7f04122214dde83b68c43efc1663e6e5eee5d31358ce7fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->