### PR TITLE
feat(ui): add midnight theme preset

### DIFF
--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -33,7 +33,7 @@ const budgets = new Map([
   ["measure.mjs", 2_400],
   // Styled entries statically import the shared dist/style.css, so their
   // budgets cover the packaged stylesheet alongside their JavaScript.
-  ["motion.mjs", 4_750],
+  ["motion.mjs", 5_000],
   ["move.mjs", 5_050],
   ["pointer-grace.mjs", 1_800],
   ["portal.mjs", 1_700],
@@ -44,12 +44,12 @@ const budgets = new Map([
   ["shortcut.mjs", 7_400],
   ["sortable.mjs", 17_000],
   ["spatial-navigation.mjs", 3_725],
-  ["theme.mjs", 4_000],
+  ["theme.mjs", 4_250],
   ["transition.mjs", 3_000],
   ["typeahead.mjs", 2_000],
   ["virtualizer.mjs", 9_500],
   ["primitive.mjs", 800],
-  ["visually-hidden.mjs", 2_850],
+  ["visually-hidden.mjs", 3_100],
   ["media.mjs", 2_400],
   ["media-pdf.mjs", 2_048],
   ["media-source.mjs", 1_800],

--- a/npm/ui/core/src/family-catalog-basics.ts
+++ b/npm/ui/core/src/family-catalog-basics.ts
@@ -247,6 +247,7 @@ export const basicFamilyCatalog = [
       "src/theme.ts",
       "src/theme.css",
       "src/theme-preset-atelier.css",
+      "src/theme-preset-midnight.css",
       "src/theme-preset-paper.css",
       "src/theme-tokens.ts",
       "src/theme-types.ts",
@@ -262,9 +263,17 @@ export const basicFamilyCatalog = [
       maximumJavaScriptGzipBytes: 1_500,
       // Covers the packaged stylesheet: the token contract and presets share
       // dist/style.css with every other styled family.
-      maximumCssGzipBytes: 2_950,
+      maximumCssGzipBytes: 3_500,
     },
-    aliases: ["design tokens", "semantic tokens", "cascade layers", "presets", "atelier", "paper"],
+    aliases: [
+      "design tokens",
+      "semantic tokens",
+      "cascade layers",
+      "presets",
+      "atelier",
+      "midnight",
+      "paper",
+    ],
     upstreamCoverage: [
       "CSS cascade layers",
       "CSS custom properties",

--- a/npm/ui/core/src/family-catalog-interactions.ts
+++ b/npm/ui/core/src/family-catalog-interactions.ts
@@ -340,7 +340,7 @@ export const interactionFamilyCatalog = [
       maximumJavaScriptGzipBytes: 400,
       // Covers the shared packaged stylesheet (dist/style.css), including the
       // motion tokens every styled family ships together (style-pipeline.behavior.md).
-      maximumCssGzipBytes: 2_950,
+      maximumCssGzipBytes: 3_500,
     },
     aliases: ["screen reader only", "sr-only", "visually hidden"],
     upstreamCoverage: ["React Aria VisuallyHidden", "Radix VisuallyHidden"],

--- a/npm/ui/core/src/family-catalog-overlays.ts
+++ b/npm/ui/core/src/family-catalog-overlays.ts
@@ -111,7 +111,7 @@ export const overlayFamilyCatalog = [
       maximumJavaScriptGzipBytes: 1_500,
       // Covers the packaged stylesheet: motion tokens and recipes share
       // dist/style.css with every other styled family.
-      maximumCssGzipBytes: 2_950,
+      maximumCssGzipBytes: 3_500,
     },
     aliases: ["motion tokens", "easing", "view transitions", "starting style", "reduced motion"],
     upstreamCoverage: [

--- a/npm/ui/core/src/theme-preset-midnight.css
+++ b/npm/ui/core/src/theme-preset-midnight.css
@@ -1,0 +1,35 @@
+/*
+ * Midnight preset: dark-first application surfaces with deep neutral grounds,
+ * luminous blue-violet accents, and stronger overlay depth. Like every preset,
+ * it is inert until a consumer opts a subtree into `data-vize-theme~="midnight"`.
+ */
+
+@layer vize.preset {
+  :where([data-vize-theme~="midnight"], :host([data-vize-theme~="midnight"])) {
+    color-scheme: light dark;
+
+    --vize-ui-color-canvas: light-dark(oklch(0.965 0.006 252), oklch(0.135 0.02 265));
+    --vize-ui-color-surface: light-dark(oklch(1 0.002 252), oklch(0.205 0.026 265));
+    --vize-ui-color-text: light-dark(oklch(0.22 0.02 260), oklch(0.94 0.01 255));
+    --vize-ui-color-text-muted: light-dark(
+      color-mix(in oklab, oklch(0.22 0.02 260) 58%, oklch(0.965 0.006 252)),
+      color-mix(in oklab, oklch(0.94 0.01 255) 64%, oklch(0.135 0.02 265))
+    );
+    --vize-ui-color-accent: light-dark(oklch(0.53 0.18 268), oklch(0.76 0.14 265));
+    --vize-ui-color-accent-contrast: light-dark(oklch(1 0 0), oklch(0.13 0.03 265));
+    --vize-ui-color-border: light-dark(
+      oklch(from oklch(0.965 0.006 252) calc(l - 0.11) c h),
+      oklch(0.33 0.034 265)
+    );
+    --vize-ui-color-danger: light-dark(oklch(0.55 0.19 25), oklch(0.74 0.16 21));
+
+    --vize-ui-opacity-muted: 0.78;
+    --vize-ui-z-overlay: 1400;
+    --vize-ui-elevation-raised:
+      0 1px 2px oklch(0.08 0.02 265 / 0.28), 0 0 0 1px oklch(0.8 0.04 265 / 0.05);
+    --vize-ui-elevation-overlay:
+      0 10px 26px oklch(0.06 0.02 265 / 0.38), 0 3px 10px oklch(0.06 0.02 265 / 0.3);
+    --vize-ui-elevation-floating:
+      0 24px 60px oklch(0.04 0.02 265 / 0.46), 0 8px 22px oklch(0.06 0.02 265 / 0.34);
+  }
+}

--- a/npm/ui/core/src/theme-stylesheet.test.ts
+++ b/npm/ui/core/src/theme-stylesheet.test.ts
@@ -109,6 +109,7 @@ test("scopes published presets to their opt-in attributes", () => {
     assert.match(rule, /--vize-ui-color-accent:/);
     assert.match(rule, /--vize-ui-elevation-raised:/);
   }
+  assert.match(shippedPresetRule("midnight"), /--vize-ui-z-overlay:1400/);
   assert.match(shippedPresetRule("paper"), /--vize-ui-type-leading-normal:1\.6/);
   assert.doesNotMatch(
     preset,
@@ -127,11 +128,14 @@ test("lowers preset color schemes to the declared floor", () => {
     preset,
     /--vize-ui-color-canvas:var\(--lightningcss-light,oklch\(98\.5% \.003 255\)\)var\(--lightningcss-dark,oklch\(15\.5% \.012 255\)\)/,
   );
-  assert.match(
-    preset,
-    /@media \(prefers-color-scheme:dark\)\{:where\(\[data-vize-theme~=atelier\]/,
-  );
-  assert.match(preset, /@media \(prefers-color-scheme:dark\)\{:where\(\[data-vize-theme~=paper\]/);
+  for (const name of themePresets) {
+    assert.match(
+      preset,
+      new RegExp(
+        `@media \\(prefers-color-scheme:(?:dark|light)\\)\\{:where\\(\\[data-vize-theme~=${name}\\]`,
+      ),
+    );
+  }
 
   // Relative color and color-mix() derivations resolve to literals at build
   // time, so the floor never sees the newer syntax.

--- a/npm/ui/core/src/theme-tokens.ts
+++ b/npm/ui/core/src/theme-tokens.ts
@@ -22,7 +22,11 @@ export const themePresetAttribute = "data-vize-theme";
 export const themeDensityAttribute = "data-vize-density";
 
 /** Opinionated presets shipped in `@layer vize.preset`. */
-export const themePresets: readonly ThemePresetName[] = Object.freeze(["atelier", "paper"]);
+export const themePresets: readonly ThemePresetName[] = Object.freeze([
+  "atelier",
+  "midnight",
+  "paper",
+]);
 
 /** Density factors mirrored from the `data-vize-density` scopes in `theme.css`. */
 export const themeDensityScales: Readonly<Record<ThemeDensityScale, string>> = Object.freeze({

--- a/npm/ui/core/src/theme-types.ts
+++ b/npm/ui/core/src/theme-types.ts
@@ -61,7 +61,7 @@ export type ThemeTokenOverrides = {
 };
 
 /** Opinionated presets accepted in the space-separated `data-vize-theme` attribute. */
-export type ThemePresetName = "atelier" | "paper";
+export type ThemePresetName = "atelier" | "midnight" | "paper";
 
 /** Density scopes accepted in the `data-vize-density` attribute. */
 export type ThemeDensityScale = "compact" | "comfortable";

--- a/npm/ui/core/src/theme.behavior.md
+++ b/npm/ui/core/src/theme.behavior.md
@@ -4,27 +4,28 @@ Normative contract for the theme family (`@vizejs/ui/theme`): the semantic
 design-token contract, the package-wide cascade-layer order, and the opt-in
 presets. The stylesheet contract is proven on the packaged `dist/style.css`
 (the pack pipeline lowers `src/theme.css`, `src/theme-preset-atelier.css`, and
-`src/theme-preset-paper.css` to the declared browser floor; see
-`style-pipeline.behavior.md`) in
+the preset files (`src/theme-preset-atelier.css`,
+`src/theme-preset-midnight.css`, and `src/theme-preset-paper.css`) to the
+declared browser floor; see `style-pipeline.behavior.md`) in
 `src/theme-stylesheet.test.ts`; runtime rows are proven by the named test in
 `src/theme.test.ts` or `src/theme-ssr.test.ts`; compile-only assertions live
 in `src/theme.types.test-d.ts`.
 
-| #   | State               | Input                                          | Outcome                                                                                                   | Proven by                                                          |
-| --- | ------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| T1  | packaged stylesheet | consumer imports any styled entry              | cascade layers ship in ascending priority order `vize.tokens` → `vize.ui` → `vize.preset` → `vize.policy` | `ships the documented cascade layer order`                         |
-| T2  | packaged stylesheet | any styled entry                               | the semantic token contract ships in `@layer vize.tokens` at zero specificity, matching the TS mirrors    | `ships layered zero-specificity theme tokens matching the mirrors` |
-| T3  | packaged stylesheet | no `data-vize-theme` attribute                 | headless default: colors stay on the system palette and every elevation is `none`                         | `keeps the headless default free of visual opinion`                |
-| T4  | packaged stylesheet | `data-vize-density="compact" \| "comfortable"` | the density factor retunes, scaling every space and control-size token in the subtree                     | `ships density scopes that retune the shared factor`               |
-| T5  | packaged stylesheet | `data-vize-theme~="atelier" \| "paper"`        | published presets assign visual tokens in `@layer vize.preset`, scoped to their opt-in attribute          | `scopes published presets to their opt-in attributes`              |
-| T6  | packaged stylesheet | light and dark schemes                         | preset `light-dark()` values ship lowered to the floor and follow the user's color scheme                 | `lowers preset color schemes to the declared floor`                |
-| T7  | packaged stylesheet | `forced-colors: active`                        | `@layer vize.policy` snaps color roles to the system palette and flattens elevation, beating presets      | `stands down to system colors under forced colors`                 |
-| T8  | any                 | `setThemeTokens(element, overrides)`           | overrides apply to the element inline and the restore callback reinstates values                          | `applies and restores token overrides on a real element`           |
-| T9  | any                 | unknown token name or empty value              | `themeTokenProperty`/`setThemeTokens` throw `VIZE_UI_THEME_TOKEN`                                         | `rejects unknown tokens and empty override values`                 |
-| T10 | mounted             | consumer binds scope attributes and tokens     | preset and density attributes render, and scoped overrides apply through the mounted DOM                  | `scopes presets and densities in a mounted consumer`               |
-| T11 | SSR                 | render with token helpers in setup             | byte-identical markup; no platform global is required                                                     | `renders byte-identical SSR markup without platform globals`       |
-| T12 | SSR                 | hydration                                      | hydrating a themed consumer emits no diagnostics and keeps server nodes                                   | `hydrates a themed consumer without replacement or diagnostics`    |
-| T13 | public types        | invalid token names or mutated records         | compilation rejects misuse                                                                                | `src/theme.types.test-d.ts`                                        |
+| #   | State               | Input                                                 | Outcome                                                                                                   | Proven by                                                          |
+| --- | ------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| T1  | packaged stylesheet | consumer imports any styled entry                     | cascade layers ship in ascending priority order `vize.tokens` → `vize.ui` → `vize.preset` → `vize.policy` | `ships the documented cascade layer order`                         |
+| T2  | packaged stylesheet | any styled entry                                      | the semantic token contract ships in `@layer vize.tokens` at zero specificity, matching the TS mirrors    | `ships layered zero-specificity theme tokens matching the mirrors` |
+| T3  | packaged stylesheet | no `data-vize-theme` attribute                        | headless default: colors stay on the system palette and every elevation is `none`                         | `keeps the headless default free of visual opinion`                |
+| T4  | packaged stylesheet | `data-vize-density="compact" \| "comfortable"`        | the density factor retunes, scaling every space and control-size token in the subtree                     | `ships density scopes that retune the shared factor`               |
+| T5  | packaged stylesheet | `data-vize-theme~="atelier" \| "midnight" \| "paper"` | published presets assign visual tokens in `@layer vize.preset`, scoped to their opt-in attribute          | `scopes published presets to their opt-in attributes`              |
+| T6  | packaged stylesheet | light and dark schemes                                | preset `light-dark()` values ship lowered to the floor and follow the user's color scheme                 | `lowers preset color schemes to the declared floor`                |
+| T7  | packaged stylesheet | `forced-colors: active`                               | `@layer vize.policy` snaps color roles to the system palette and flattens elevation, beating presets      | `stands down to system colors under forced colors`                 |
+| T8  | any                 | `setThemeTokens(element, overrides)`                  | overrides apply to the element inline and the restore callback reinstates values                          | `applies and restores token overrides on a real element`           |
+| T9  | any                 | unknown token name or empty value                     | `themeTokenProperty`/`setThemeTokens` throw `VIZE_UI_THEME_TOKEN`                                         | `rejects unknown tokens and empty override values`                 |
+| T10 | mounted             | consumer binds scope attributes and tokens            | preset and density attributes render, and scoped overrides apply through the mounted DOM                  | `scopes presets and densities in a mounted consumer`               |
+| T11 | SSR                 | render with token helpers in setup                    | byte-identical markup; no platform global is required                                                     | `renders byte-identical SSR markup without platform globals`       |
+| T12 | SSR                 | hydration                                             | hydrating a themed consumer emits no diagnostics and keeps server nodes                                   | `hydrates a themed consumer without replacement or diagnostics`    |
+| T13 | public types        | invalid token names or mutated records                | compilation rejects misuse                                                                                | `src/theme.types.test-d.ts`                                        |
 
 ## Cascade-layer order and specificity budget
 
@@ -49,11 +50,12 @@ in `src/theme.types.test-d.ts`.
   `--vize-ui-color-accent`, and space/size tokens resolve through
   `--vize-ui-density`, so one override retunes a whole phase.
 - `data-vize-theme` holds space-separated preset names and is inert without
-  the shipped preset CSS; `atelier` is the Vize brand default, and `paper` is
-  the editorial/content-forward preset. When multiple presets are present,
-  package source order resolves ties, so later shipped presets win.
-  `data-vize-density` accepts `compact` and `comfortable`. Both scope by
-  inheritance, so nesting attributes nests themes.
+  the shipped preset CSS; `atelier` is the Vize brand default, `midnight` is
+  the dark-first application preset, and `paper` is the editorial preset for
+  content-forward surfaces. When multiple presets are present, package source order
+  resolves ties, so later shipped presets win. `data-vize-density` accepts
+  `compact` and `comfortable`. Both scope by inheritance, so nesting
+  attributes nests themes.
 - SSR bootstrapping is CSS-only and flash-free by construction: server-render
   the attribute (typically on `<html>`), and Atelier's `light-dark()` values
   follow the user's scheme with no runtime script. Motion tokens stay in the

--- a/npm/ui/core/src/theme.test.ts
+++ b/npm/ui/core/src/theme.test.ts
@@ -55,7 +55,7 @@ test("rejects unknown tokens and empty override values", () => {
 test("publishes the token contract and scope constants", () => {
   assert.equal(themePresetAttribute, "data-vize-theme");
   assert.equal(themeDensityAttribute, "data-vize-density");
-  assert.deepEqual([...themePresets], ["atelier", "paper"]);
+  assert.deepEqual([...themePresets], ["atelier", "midnight", "paper"]);
   assert.deepEqual(Object.keys(themeDensityScales).sort(), ["comfortable", "compact"]);
 
   // The record is frozen and every name round-trips through the helpers.
@@ -77,7 +77,10 @@ test("scopes presets and densities in a mounted consumer", () => {
       return () =>
         h(
           "section",
-          { [themePresetAttribute]: "atelier paper", [themeDensityAttribute]: density.value },
+          {
+            [themePresetAttribute]: "atelier midnight paper",
+            [themeDensityAttribute]: density.value,
+          },
           [h("output", { "data-accent": themeTokenVar("color-accent") }, "Themed")],
         );
     },
@@ -85,7 +88,7 @@ test("scopes presets and densities in a mounted consumer", () => {
 
   const handle = mountInteraction(Consumer);
   const root = handle.root();
-  assert.equal(root.getAttribute("data-vize-theme"), "atelier paper");
+  assert.equal(root.getAttribute("data-vize-theme"), "atelier midnight paper");
   assert.equal(root.getAttribute("data-vize-density"), "compact");
   assert.equal(
     root.querySelector("output")?.getAttribute("data-accent"),

--- a/npm/ui/core/src/theme.ts
+++ b/npm/ui/core/src/theme.ts
@@ -1,5 +1,6 @@
 import "./theme.css";
 import "./theme-preset-atelier.css";
+import "./theme-preset-midnight.css";
 import "./theme-preset-paper.css";
 
 export {

--- a/npm/ui/core/src/theme.types.test-d.ts
+++ b/npm/ui/core/src/theme.types.test-d.ts
@@ -49,7 +49,7 @@ type _TokenNamesAreClosed = Expect<
     "color-canvas" | "space-2xl" | "density"
   >
 >;
-type _PresetNamesAreClosed = Expect<Equal<ThemePresetName, "atelier" | "paper">>;
+type _PresetNamesAreClosed = Expect<Equal<ThemePresetName, "atelier" | "midnight" | "paper">>;
 type _DensityScalesAreClosed = Expect<Equal<ThemeDensityScale, "compact" | "comfortable">>;
 type _LayerOrderIsLiteral = Expect<
   Equal<


### PR DESCRIPTION
## Summary
- add the opt-in Midnight theme preset for dark-first application surfaces
- publish Midnight through the typed theme contract, catalog metadata, and packaged stylesheet checks
- update UI size/tree-shaking budgets for the shared stylesheet cost

Refs #4894.

## Verification
- nix develop --command pnpm --dir npm/ui/core test
- nix develop --command pnpm --dir npm/ui/core run check
- nix develop --command pnpm --dir npm/ui/core run lint:sfc
- nix develop --command node --test tests/tooling/source-file-lengths.test.ts
- nix develop --command cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790339712&installation_model_id=422833&pr_number=5001&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5001&signature=8768518ed1ddfc1c106d6afaf94b49bd7ca70cb8c77778f65050c11878274a35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->