### PR TITLE
feat(ui): add signal theme preset

### DIFF
--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -33,7 +33,7 @@ const budgets = new Map([
   ["measure.mjs", 2_400],
   // Styled entries statically import the shared dist/style.css, so their
   // budgets cover the packaged stylesheet alongside their JavaScript.
-  ["motion.mjs", 5_000],
+  ["motion.mjs", 5_200],
   ["move.mjs", 5_050],
   ["pointer-grace.mjs", 1_800],
   ["portal.mjs", 1_700],
@@ -44,12 +44,12 @@ const budgets = new Map([
   ["shortcut.mjs", 7_400],
   ["sortable.mjs", 17_000],
   ["spatial-navigation.mjs", 3_725],
-  ["theme.mjs", 4_250],
+  ["theme.mjs", 4_450],
   ["transition.mjs", 3_000],
   ["typeahead.mjs", 2_000],
   ["virtualizer.mjs", 9_500],
   ["primitive.mjs", 800],
-  ["visually-hidden.mjs", 3_100],
+  ["visually-hidden.mjs", 3_300],
   ["media.mjs", 2_400],
   ["media-pdf.mjs", 2_048],
   ["media-source.mjs", 1_800],

--- a/npm/ui/core/src/family-catalog-basics.ts
+++ b/npm/ui/core/src/family-catalog-basics.ts
@@ -249,6 +249,7 @@ export const basicFamilyCatalog = [
       "src/theme-preset-atelier.css",
       "src/theme-preset-midnight.css",
       "src/theme-preset-paper.css",
+      "src/theme-preset-signal.css",
       "src/theme-tokens.ts",
       "src/theme-types.ts",
     ],
@@ -263,7 +264,7 @@ export const basicFamilyCatalog = [
       maximumJavaScriptGzipBytes: 1_500,
       // Covers the packaged stylesheet: the token contract and presets share
       // dist/style.css with every other styled family.
-      maximumCssGzipBytes: 3_500,
+      maximumCssGzipBytes: 4_050,
     },
     aliases: [
       "design tokens",
@@ -273,6 +274,7 @@ export const basicFamilyCatalog = [
       "atelier",
       "midnight",
       "paper",
+      "signal",
     ],
     upstreamCoverage: [
       "CSS cascade layers",

--- a/npm/ui/core/src/family-catalog-interactions.ts
+++ b/npm/ui/core/src/family-catalog-interactions.ts
@@ -340,7 +340,7 @@ export const interactionFamilyCatalog = [
       maximumJavaScriptGzipBytes: 400,
       // Covers the shared packaged stylesheet (dist/style.css), including the
       // motion tokens every styled family ships together (style-pipeline.behavior.md).
-      maximumCssGzipBytes: 3_500,
+      maximumCssGzipBytes: 4_050,
     },
     aliases: ["screen reader only", "sr-only", "visually hidden"],
     upstreamCoverage: ["React Aria VisuallyHidden", "Radix VisuallyHidden"],

--- a/npm/ui/core/src/family-catalog-overlays.ts
+++ b/npm/ui/core/src/family-catalog-overlays.ts
@@ -111,7 +111,7 @@ export const overlayFamilyCatalog = [
       maximumJavaScriptGzipBytes: 1_500,
       // Covers the packaged stylesheet: motion tokens and recipes share
       // dist/style.css with every other styled family.
-      maximumCssGzipBytes: 3_500,
+      maximumCssGzipBytes: 4_050,
     },
     aliases: ["motion tokens", "easing", "view transitions", "starting style", "reduced motion"],
     upstreamCoverage: [

--- a/npm/ui/core/src/theme-preset-signal.css
+++ b/npm/ui/core/src/theme-preset-signal.css
@@ -1,0 +1,36 @@
+/*
+ * Signal preset: dense data and tooling surfaces with quiet graphite grounds,
+ * crisp separators, and a legible cyan-green accent. Like every preset, it is
+ * inert until a consumer opts a subtree into `data-vize-theme~="signal"`.
+ */
+
+@layer vize.preset {
+  :where([data-vize-theme~="signal"], :host([data-vize-theme~="signal"])) {
+    color-scheme: light dark;
+
+    --vize-ui-color-canvas: light-dark(oklch(0.975 0.004 225), oklch(0.16 0.012 230));
+    --vize-ui-color-surface: light-dark(oklch(0.995 0.002 225), oklch(0.215 0.014 230));
+    --vize-ui-color-text: light-dark(oklch(0.21 0.013 230), oklch(0.92 0.007 225));
+    --vize-ui-color-text-muted: light-dark(
+      color-mix(in oklab, oklch(0.21 0.013 230) 60%, oklch(0.975 0.004 225)),
+      color-mix(in oklab, oklch(0.92 0.007 225) 62%, oklch(0.16 0.012 230))
+    );
+    --vize-ui-color-accent: light-dark(oklch(0.49 0.11 184), oklch(0.78 0.105 176));
+    --vize-ui-color-accent-contrast: light-dark(oklch(1 0 0), oklch(0.13 0.025 180));
+    --vize-ui-color-border: light-dark(
+      oklch(from oklch(0.975 0.004 225) calc(l - 0.12) c h),
+      oklch(0.36 0.016 230)
+    );
+    --vize-ui-color-danger: light-dark(oklch(0.53 0.17 30), oklch(0.73 0.14 27));
+
+    --vize-ui-type-leading-normal: 1.42;
+    --vize-ui-radius-md: 0.3125rem;
+    --vize-ui-opacity-muted: 0.82;
+    --vize-ui-elevation-raised:
+      0 1px 1px oklch(0.12 0.012 230 / 0.08), 0 0 0 1px oklch(0.12 0.012 230 / 0.06);
+    --vize-ui-elevation-overlay:
+      0 6px 16px oklch(0.1 0.012 230 / 0.18), 0 0 0 1px oklch(0.1 0.012 230 / 0.08);
+    --vize-ui-elevation-floating:
+      0 16px 36px oklch(0.08 0.012 230 / 0.24), 0 3px 10px oklch(0.08 0.012 230 / 0.16);
+  }
+}

--- a/npm/ui/core/src/theme-stylesheet.test.ts
+++ b/npm/ui/core/src/theme-stylesheet.test.ts
@@ -111,6 +111,7 @@ test("scopes published presets to their opt-in attributes", () => {
   }
   assert.match(shippedPresetRule("midnight"), /--vize-ui-z-overlay:1400/);
   assert.match(shippedPresetRule("paper"), /--vize-ui-type-leading-normal:1\.6/);
+  assert.match(shippedPresetRule("signal"), /--vize-ui-opacity-muted:\.82/);
   assert.doesNotMatch(
     preset,
     /:where\(:root,:host\)/,

--- a/npm/ui/core/src/theme-tokens.ts
+++ b/npm/ui/core/src/theme-tokens.ts
@@ -26,6 +26,7 @@ export const themePresets: readonly ThemePresetName[] = Object.freeze([
   "atelier",
   "midnight",
   "paper",
+  "signal",
 ]);
 
 /** Density factors mirrored from the `data-vize-density` scopes in `theme.css`. */

--- a/npm/ui/core/src/theme-types.ts
+++ b/npm/ui/core/src/theme-types.ts
@@ -61,7 +61,7 @@ export type ThemeTokenOverrides = {
 };
 
 /** Opinionated presets accepted in the space-separated `data-vize-theme` attribute. */
-export type ThemePresetName = "atelier" | "midnight" | "paper";
+export type ThemePresetName = "atelier" | "midnight" | "paper" | "signal";
 
 /** Density scopes accepted in the `data-vize-density` attribute. */
 export type ThemeDensityScale = "compact" | "comfortable";

--- a/npm/ui/core/src/theme.behavior.md
+++ b/npm/ui/core/src/theme.behavior.md
@@ -3,29 +3,29 @@
 Normative contract for the theme family (`@vizejs/ui/theme`): the semantic
 design-token contract, the package-wide cascade-layer order, and the opt-in
 presets. The stylesheet contract is proven on the packaged `dist/style.css`
-(the pack pipeline lowers `src/theme.css`, `src/theme-preset-atelier.css`, and
-the preset files (`src/theme-preset-atelier.css`,
-`src/theme-preset-midnight.css`, and `src/theme-preset-paper.css`) to the
+(the pack pipeline lowers `src/theme.css` and the preset files
+`src/theme-preset-atelier.css`, `src/theme-preset-midnight.css`,
+`src/theme-preset-paper.css`, and `src/theme-preset-signal.css` to the
 declared browser floor; see `style-pipeline.behavior.md`) in
 `src/theme-stylesheet.test.ts`; runtime rows are proven by the named test in
 `src/theme.test.ts` or `src/theme-ssr.test.ts`; compile-only assertions live
 in `src/theme.types.test-d.ts`.
 
-| #   | State               | Input                                                 | Outcome                                                                                                   | Proven by                                                          |
-| --- | ------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| T1  | packaged stylesheet | consumer imports any styled entry                     | cascade layers ship in ascending priority order `vize.tokens` → `vize.ui` → `vize.preset` → `vize.policy` | `ships the documented cascade layer order`                         |
-| T2  | packaged stylesheet | any styled entry                                      | the semantic token contract ships in `@layer vize.tokens` at zero specificity, matching the TS mirrors    | `ships layered zero-specificity theme tokens matching the mirrors` |
-| T3  | packaged stylesheet | no `data-vize-theme` attribute                        | headless default: colors stay on the system palette and every elevation is `none`                         | `keeps the headless default free of visual opinion`                |
-| T4  | packaged stylesheet | `data-vize-density="compact" \| "comfortable"`        | the density factor retunes, scaling every space and control-size token in the subtree                     | `ships density scopes that retune the shared factor`               |
-| T5  | packaged stylesheet | `data-vize-theme~="atelier" \| "midnight" \| "paper"` | published presets assign visual tokens in `@layer vize.preset`, scoped to their opt-in attribute          | `scopes published presets to their opt-in attributes`              |
-| T6  | packaged stylesheet | light and dark schemes                                | preset `light-dark()` values ship lowered to the floor and follow the user's color scheme                 | `lowers preset color schemes to the declared floor`                |
-| T7  | packaged stylesheet | `forced-colors: active`                               | `@layer vize.policy` snaps color roles to the system palette and flattens elevation, beating presets      | `stands down to system colors under forced colors`                 |
-| T8  | any                 | `setThemeTokens(element, overrides)`                  | overrides apply to the element inline and the restore callback reinstates values                          | `applies and restores token overrides on a real element`           |
-| T9  | any                 | unknown token name or empty value                     | `themeTokenProperty`/`setThemeTokens` throw `VIZE_UI_THEME_TOKEN`                                         | `rejects unknown tokens and empty override values`                 |
-| T10 | mounted             | consumer binds scope attributes and tokens            | preset and density attributes render, and scoped overrides apply through the mounted DOM                  | `scopes presets and densities in a mounted consumer`               |
-| T11 | SSR                 | render with token helpers in setup                    | byte-identical markup; no platform global is required                                                     | `renders byte-identical SSR markup without platform globals`       |
-| T12 | SSR                 | hydration                                             | hydrating a themed consumer emits no diagnostics and keeps server nodes                                   | `hydrates a themed consumer without replacement or diagnostics`    |
-| T13 | public types        | invalid token names or mutated records                | compilation rejects misuse                                                                                | `src/theme.types.test-d.ts`                                        |
+| #   | State               | Input                                                             | Outcome                                                                                                   | Proven by                                                          |
+| --- | ------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| T1  | packaged stylesheet | consumer imports any styled entry                                 | cascade layers ship in ascending priority order `vize.tokens` → `vize.ui` → `vize.preset` → `vize.policy` | `ships the documented cascade layer order`                         |
+| T2  | packaged stylesheet | any styled entry                                                  | the semantic token contract ships in `@layer vize.tokens` at zero specificity, matching the TS mirrors    | `ships layered zero-specificity theme tokens matching the mirrors` |
+| T3  | packaged stylesheet | no `data-vize-theme` attribute                                    | headless default: colors stay on the system palette and every elevation is `none`                         | `keeps the headless default free of visual opinion`                |
+| T4  | packaged stylesheet | `data-vize-density="compact" \| "comfortable"`                    | the density factor retunes, scaling every space and control-size token in the subtree                     | `ships density scopes that retune the shared factor`               |
+| T5  | packaged stylesheet | `data-vize-theme~="atelier" \| "midnight" \| "paper" \| "signal"` | published presets assign visual tokens in `@layer vize.preset`, scoped to their opt-in attribute          | `scopes published presets to their opt-in attributes`              |
+| T6  | packaged stylesheet | light and dark schemes                                            | preset `light-dark()` values ship lowered to the floor and follow the user's color scheme                 | `lowers preset color schemes to the declared floor`                |
+| T7  | packaged stylesheet | `forced-colors: active`                                           | `@layer vize.policy` snaps color roles to the system palette and flattens elevation, beating presets      | `stands down to system colors under forced colors`                 |
+| T8  | any                 | `setThemeTokens(element, overrides)`                              | overrides apply to the element inline and the restore callback reinstates values                          | `applies and restores token overrides on a real element`           |
+| T9  | any                 | unknown token name or empty value                                 | `themeTokenProperty`/`setThemeTokens` throw `VIZE_UI_THEME_TOKEN`                                         | `rejects unknown tokens and empty override values`                 |
+| T10 | mounted             | consumer binds scope attributes and tokens                        | preset and density attributes render, and scoped overrides apply through the mounted DOM                  | `scopes presets and densities in a mounted consumer`               |
+| T11 | SSR                 | render with token helpers in setup                                | byte-identical markup; no platform global is required                                                     | `renders byte-identical SSR markup without platform globals`       |
+| T12 | SSR                 | hydration                                                         | hydrating a themed consumer emits no diagnostics and keeps server nodes                                   | `hydrates a themed consumer without replacement or diagnostics`    |
+| T13 | public types        | invalid token names or mutated records                            | compilation rejects misuse                                                                                | `src/theme.types.test-d.ts`                                        |
 
 ## Cascade-layer order and specificity budget
 
@@ -51,12 +51,13 @@ in `src/theme.types.test-d.ts`.
   `--vize-ui-density`, so one override retunes a whole phase.
 - `data-vize-theme` holds space-separated preset names and is inert without
   the shipped preset CSS; `atelier` is the Vize brand default, `midnight` is
-  the dark-first application preset, and `paper` is the editorial preset for
-  content-forward surfaces. When multiple presets are present, package source order
-  resolves ties, so later shipped presets win. `data-vize-density` accepts
-  `compact` and `comfortable`. Both scope by inheritance, so nesting
-  attributes nests themes.
+  the dark-first application preset, `paper` is the editorial preset for
+  content-forward surfaces, and `signal` is the dense data/tooling preset.
+  When multiple presets are present, package source order resolves ties, so
+  later shipped presets win. `data-vize-density` accepts `compact` and
+  `comfortable`. Both scope by inheritance, so nesting attributes nests
+  themes.
 - SSR bootstrapping is CSS-only and flash-free by construction: server-render
-  the attribute (typically on `<html>`), and Atelier's `light-dark()` values
+  the attribute (typically on `<html>`), and preset `light-dark()` values
   follow the user's scheme with no runtime script. Motion tokens stay in the
   motion family (`motion.behavior.md`).

--- a/npm/ui/core/src/theme.test.ts
+++ b/npm/ui/core/src/theme.test.ts
@@ -55,7 +55,7 @@ test("rejects unknown tokens and empty override values", () => {
 test("publishes the token contract and scope constants", () => {
   assert.equal(themePresetAttribute, "data-vize-theme");
   assert.equal(themeDensityAttribute, "data-vize-density");
-  assert.deepEqual([...themePresets], ["atelier", "midnight", "paper"]);
+  assert.deepEqual([...themePresets], ["atelier", "midnight", "paper", "signal"]);
   assert.deepEqual(Object.keys(themeDensityScales).sort(), ["comfortable", "compact"]);
 
   // The record is frozen and every name round-trips through the helpers.
@@ -78,7 +78,7 @@ test("scopes presets and densities in a mounted consumer", () => {
         h(
           "section",
           {
-            [themePresetAttribute]: "atelier midnight paper",
+            [themePresetAttribute]: "atelier midnight paper signal",
             [themeDensityAttribute]: density.value,
           },
           [h("output", { "data-accent": themeTokenVar("color-accent") }, "Themed")],
@@ -88,7 +88,7 @@ test("scopes presets and densities in a mounted consumer", () => {
 
   const handle = mountInteraction(Consumer);
   const root = handle.root();
-  assert.equal(root.getAttribute("data-vize-theme"), "atelier midnight paper");
+  assert.equal(root.getAttribute("data-vize-theme"), "atelier midnight paper signal");
   assert.equal(root.getAttribute("data-vize-density"), "compact");
   assert.equal(
     root.querySelector("output")?.getAttribute("data-accent"),

--- a/npm/ui/core/src/theme.ts
+++ b/npm/ui/core/src/theme.ts
@@ -2,6 +2,7 @@ import "./theme.css";
 import "./theme-preset-atelier.css";
 import "./theme-preset-midnight.css";
 import "./theme-preset-paper.css";
+import "./theme-preset-signal.css";
 
 export {
   setThemeTokens,

--- a/npm/ui/core/src/theme.types.test-d.ts
+++ b/npm/ui/core/src/theme.types.test-d.ts
@@ -49,7 +49,9 @@ type _TokenNamesAreClosed = Expect<
     "color-canvas" | "space-2xl" | "density"
   >
 >;
-type _PresetNamesAreClosed = Expect<Equal<ThemePresetName, "atelier" | "midnight" | "paper">>;
+type _PresetNamesAreClosed = Expect<
+  Equal<ThemePresetName, "atelier" | "midnight" | "paper" | "signal">
+>;
 type _DensityScalesAreClosed = Expect<Equal<ThemeDensityScale, "compact" | "comfortable">>;
 type _LayerOrderIsLiteral = Expect<
   Equal<


### PR DESCRIPTION
## Summary
- add the opt-in Signal theme preset for dense data and tooling surfaces
- publish Signal through the typed theme contract, catalog metadata, and packaged stylesheet checks
- update UI size/tree-shaking budgets for the shared stylesheet cost

Refs #4894.

## Verification
- nix develop --command pnpm --dir npm/ui/core test
- nix develop --command pnpm --dir npm/ui/core run check
- nix develop --command pnpm --dir npm/ui/core run lint:sfc
- nix develop --command node --test tests/tooling/source-file-lengths.test.ts
- nix develop --command cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790340819&installation_model_id=422833&pr_number=5002&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5002&signature=9e735a595efbbe4e0a60851eeb92308c1d5b7978d28cb561939256b03886e051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the **Signal** theme preset with light and dark colors, typography, spacing, opacity, and elevation tokens.
  * Signal is now available through the theme configuration and packaged stylesheet.
  * Documented Signal as a dense theme for data and tooling interfaces.

* **Tests**
  * Added coverage confirming Signal tokens and published theme behavior.
  * Updated size budgets to accommodate the new theme styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->