### PR TITLE
feat(ui): add play theme preset

### DIFF
--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -33,7 +33,7 @@ const budgets = new Map([
   ["measure.mjs", 2_400],
   // Styled entries statically import the shared dist/style.css, so their
   // budgets cover the packaged stylesheet alongside their JavaScript.
-  ["motion.mjs", 5_200],
+  ["motion.mjs", 5_450],
   ["move.mjs", 5_050],
   ["pointer-grace.mjs", 1_800],
   ["portal.mjs", 1_700],
@@ -44,12 +44,12 @@ const budgets = new Map([
   ["shortcut.mjs", 7_400],
   ["sortable.mjs", 17_000],
   ["spatial-navigation.mjs", 3_725],
-  ["theme.mjs", 4_450],
+  ["theme.mjs", 4_700],
   ["transition.mjs", 3_000],
   ["typeahead.mjs", 2_000],
   ["virtualizer.mjs", 9_500],
   ["primitive.mjs", 800],
-  ["visually-hidden.mjs", 3_300],
+  ["visually-hidden.mjs", 3_550],
   ["media.mjs", 2_400],
   ["media-pdf.mjs", 2_048],
   ["media-source.mjs", 1_800],

--- a/npm/ui/core/src/family-catalog-basics.ts
+++ b/npm/ui/core/src/family-catalog-basics.ts
@@ -249,6 +249,7 @@ export const basicFamilyCatalog = [
       "src/theme-preset-atelier.css",
       "src/theme-preset-midnight.css",
       "src/theme-preset-paper.css",
+      "src/theme-preset-play.css",
       "src/theme-preset-signal.css",
       "src/theme-tokens.ts",
       "src/theme-types.ts",
@@ -264,7 +265,7 @@ export const basicFamilyCatalog = [
       maximumJavaScriptGzipBytes: 1_500,
       // Covers the packaged stylesheet: the token contract and presets share
       // dist/style.css with every other styled family.
-      maximumCssGzipBytes: 4_050,
+      maximumCssGzipBytes: 4_600,
     },
     aliases: [
       "design tokens",
@@ -274,6 +275,7 @@ export const basicFamilyCatalog = [
       "atelier",
       "midnight",
       "paper",
+      "play",
       "signal",
     ],
     upstreamCoverage: [

--- a/npm/ui/core/src/family-catalog-interactions.ts
+++ b/npm/ui/core/src/family-catalog-interactions.ts
@@ -340,7 +340,7 @@ export const interactionFamilyCatalog = [
       maximumJavaScriptGzipBytes: 400,
       // Covers the shared packaged stylesheet (dist/style.css), including the
       // motion tokens every styled family ships together (style-pipeline.behavior.md).
-      maximumCssGzipBytes: 4_050,
+      maximumCssGzipBytes: 4_600,
     },
     aliases: ["screen reader only", "sr-only", "visually hidden"],
     upstreamCoverage: ["React Aria VisuallyHidden", "Radix VisuallyHidden"],

--- a/npm/ui/core/src/family-catalog-overlays.ts
+++ b/npm/ui/core/src/family-catalog-overlays.ts
@@ -111,7 +111,7 @@ export const overlayFamilyCatalog = [
       maximumJavaScriptGzipBytes: 1_500,
       // Covers the packaged stylesheet: motion tokens and recipes share
       // dist/style.css with every other styled family.
-      maximumCssGzipBytes: 4_050,
+      maximumCssGzipBytes: 4_600,
     },
     aliases: ["motion tokens", "easing", "view transitions", "starting style", "reduced motion"],
     upstreamCoverage: [

--- a/npm/ui/core/src/theme-preset-play.css
+++ b/npm/ui/core/src/theme-preset-play.css
@@ -1,0 +1,37 @@
+/*
+ * Play preset: expressive consumer-product surfaces with bright chroma,
+ * friendly rounded geometry, and buoyant depth. Like every preset, it is inert
+ * until a consumer opts a subtree into `data-vize-theme~="play"`.
+ */
+
+@layer vize.preset {
+  :where([data-vize-theme~="play"], :host([data-vize-theme~="play"])) {
+    color-scheme: light dark;
+
+    --vize-ui-color-canvas: light-dark(oklch(0.973 0.032 330), oklch(0.17 0.035 296));
+    --vize-ui-color-surface: light-dark(oklch(0.998 0.015 88), oklch(0.235 0.042 303));
+    --vize-ui-color-text: light-dark(oklch(0.22 0.035 286), oklch(0.945 0.016 84));
+    --vize-ui-color-text-muted: light-dark(
+      color-mix(in oklab, oklch(0.22 0.035 286) 58%, oklch(0.973 0.032 330)),
+      color-mix(in oklab, oklch(0.945 0.016 84) 64%, oklch(0.17 0.035 296))
+    );
+    --vize-ui-color-accent: light-dark(oklch(0.61 0.205 355), oklch(0.78 0.17 18));
+    --vize-ui-color-accent-contrast: light-dark(oklch(1 0 0), oklch(0.16 0.035 18));
+    --vize-ui-color-border: light-dark(
+      oklch(from oklch(0.973 0.032 330) calc(l - 0.11) c h),
+      oklch(0.39 0.046 303)
+    );
+    --vize-ui-color-danger: light-dark(oklch(0.55 0.2 28), oklch(0.76 0.16 32));
+
+    --vize-ui-type-leading-normal: 1.55;
+    --vize-ui-radius-md: 0.75rem;
+    --vize-ui-radius-lg: 1.25rem;
+    --vize-ui-z-toast: 1600;
+    --vize-ui-elevation-raised:
+      0 2px 4px oklch(0.25 0.06 310 / 0.1), 0 8px 18px oklch(0.55 0.16 355 / 0.1);
+    --vize-ui-elevation-overlay:
+      0 8px 24px oklch(0.25 0.06 310 / 0.16), 0 3px 8px oklch(0.62 0.18 24 / 0.12);
+    --vize-ui-elevation-floating:
+      0 20px 54px oklch(0.25 0.06 310 / 0.22), 0 8px 22px oklch(0.62 0.18 24 / 0.14);
+  }
+}

--- a/npm/ui/core/src/theme-stylesheet.test.ts
+++ b/npm/ui/core/src/theme-stylesheet.test.ts
@@ -111,6 +111,7 @@ test("scopes published presets to their opt-in attributes", () => {
   }
   assert.match(shippedPresetRule("midnight"), /--vize-ui-z-overlay:1400/);
   assert.match(shippedPresetRule("paper"), /--vize-ui-type-leading-normal:1\.6/);
+  assert.match(shippedPresetRule("play"), /--vize-ui-radius-lg:1\.25rem/);
   assert.match(shippedPresetRule("signal"), /--vize-ui-opacity-muted:\.82/);
   assert.doesNotMatch(
     preset,

--- a/npm/ui/core/src/theme-tokens.ts
+++ b/npm/ui/core/src/theme-tokens.ts
@@ -26,6 +26,7 @@ export const themePresets: readonly ThemePresetName[] = Object.freeze([
   "atelier",
   "midnight",
   "paper",
+  "play",
   "signal",
 ]);
 

--- a/npm/ui/core/src/theme-types.ts
+++ b/npm/ui/core/src/theme-types.ts
@@ -61,7 +61,7 @@ export type ThemeTokenOverrides = {
 };
 
 /** Opinionated presets accepted in the space-separated `data-vize-theme` attribute. */
-export type ThemePresetName = "atelier" | "midnight" | "paper" | "signal";
+export type ThemePresetName = "atelier" | "midnight" | "paper" | "play" | "signal";
 
 /** Density scopes accepted in the `data-vize-density` attribute. */
 export type ThemeDensityScale = "compact" | "comfortable";

--- a/npm/ui/core/src/theme.behavior.md
+++ b/npm/ui/core/src/theme.behavior.md
@@ -5,27 +5,28 @@ design-token contract, the package-wide cascade-layer order, and the opt-in
 presets. The stylesheet contract is proven on the packaged `dist/style.css`
 (the pack pipeline lowers `src/theme.css` and the preset files
 `src/theme-preset-atelier.css`, `src/theme-preset-midnight.css`,
-`src/theme-preset-paper.css`, and `src/theme-preset-signal.css` to the
-declared browser floor; see `style-pipeline.behavior.md`) in
+`src/theme-preset-paper.css`, `src/theme-preset-play.css`, and
+`src/theme-preset-signal.css` to the declared browser floor; see
+`style-pipeline.behavior.md`) in
 `src/theme-stylesheet.test.ts`; runtime rows are proven by the named test in
 `src/theme.test.ts` or `src/theme-ssr.test.ts`; compile-only assertions live
 in `src/theme.types.test-d.ts`.
 
-| #   | State               | Input                                                             | Outcome                                                                                                   | Proven by                                                          |
-| --- | ------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| T1  | packaged stylesheet | consumer imports any styled entry                                 | cascade layers ship in ascending priority order `vize.tokens` → `vize.ui` → `vize.preset` → `vize.policy` | `ships the documented cascade layer order`                         |
-| T2  | packaged stylesheet | any styled entry                                                  | the semantic token contract ships in `@layer vize.tokens` at zero specificity, matching the TS mirrors    | `ships layered zero-specificity theme tokens matching the mirrors` |
-| T3  | packaged stylesheet | no `data-vize-theme` attribute                                    | headless default: colors stay on the system palette and every elevation is `none`                         | `keeps the headless default free of visual opinion`                |
-| T4  | packaged stylesheet | `data-vize-density="compact" \| "comfortable"`                    | the density factor retunes, scaling every space and control-size token in the subtree                     | `ships density scopes that retune the shared factor`               |
-| T5  | packaged stylesheet | `data-vize-theme~="atelier" \| "midnight" \| "paper" \| "signal"` | published presets assign visual tokens in `@layer vize.preset`, scoped to their opt-in attribute          | `scopes published presets to their opt-in attributes`              |
-| T6  | packaged stylesheet | light and dark schemes                                            | preset `light-dark()` values ship lowered to the floor and follow the user's color scheme                 | `lowers preset color schemes to the declared floor`                |
-| T7  | packaged stylesheet | `forced-colors: active`                                           | `@layer vize.policy` snaps color roles to the system palette and flattens elevation, beating presets      | `stands down to system colors under forced colors`                 |
-| T8  | any                 | `setThemeTokens(element, overrides)`                              | overrides apply to the element inline and the restore callback reinstates values                          | `applies and restores token overrides on a real element`           |
-| T9  | any                 | unknown token name or empty value                                 | `themeTokenProperty`/`setThemeTokens` throw `VIZE_UI_THEME_TOKEN`                                         | `rejects unknown tokens and empty override values`                 |
-| T10 | mounted             | consumer binds scope attributes and tokens                        | preset and density attributes render, and scoped overrides apply through the mounted DOM                  | `scopes presets and densities in a mounted consumer`               |
-| T11 | SSR                 | render with token helpers in setup                                | byte-identical markup; no platform global is required                                                     | `renders byte-identical SSR markup without platform globals`       |
-| T12 | SSR                 | hydration                                                         | hydrating a themed consumer emits no diagnostics and keeps server nodes                                   | `hydrates a themed consumer without replacement or diagnostics`    |
-| T13 | public types        | invalid token names or mutated records                            | compilation rejects misuse                                                                                | `src/theme.types.test-d.ts`                                        |
+| #   | State               | Input                                                                       | Outcome                                                                                                   | Proven by                                                          |
+| --- | ------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| T1  | packaged stylesheet | consumer imports any styled entry                                           | cascade layers ship in ascending priority order `vize.tokens` → `vize.ui` → `vize.preset` → `vize.policy` | `ships the documented cascade layer order`                         |
+| T2  | packaged stylesheet | any styled entry                                                            | the semantic token contract ships in `@layer vize.tokens` at zero specificity, matching the TS mirrors    | `ships layered zero-specificity theme tokens matching the mirrors` |
+| T3  | packaged stylesheet | no `data-vize-theme` attribute                                              | headless default: colors stay on the system palette and every elevation is `none`                         | `keeps the headless default free of visual opinion`                |
+| T4  | packaged stylesheet | `data-vize-density="compact" \| "comfortable"`                              | the density factor retunes, scaling every space and control-size token in the subtree                     | `ships density scopes that retune the shared factor`               |
+| T5  | packaged stylesheet | `data-vize-theme~="atelier" \| "midnight" \| "paper" \| "play" \| "signal"` | published presets assign visual tokens in `@layer vize.preset`, scoped to their opt-in attribute          | `scopes published presets to their opt-in attributes`              |
+| T6  | packaged stylesheet | light and dark schemes                                                      | preset `light-dark()` values ship lowered to the floor and follow the user's color scheme                 | `lowers preset color schemes to the declared floor`                |
+| T7  | packaged stylesheet | `forced-colors: active`                                                     | `@layer vize.policy` snaps color roles to the system palette and flattens elevation, beating presets      | `stands down to system colors under forced colors`                 |
+| T8  | any                 | `setThemeTokens(element, overrides)`                                        | overrides apply to the element inline and the restore callback reinstates values                          | `applies and restores token overrides on a real element`           |
+| T9  | any                 | unknown token name or empty value                                           | `themeTokenProperty`/`setThemeTokens` throw `VIZE_UI_THEME_TOKEN`                                         | `rejects unknown tokens and empty override values`                 |
+| T10 | mounted             | consumer binds scope attributes and tokens                                  | preset and density attributes render, and scoped overrides apply through the mounted DOM                  | `scopes presets and densities in a mounted consumer`               |
+| T11 | SSR                 | render with token helpers in setup                                          | byte-identical markup; no platform global is required                                                     | `renders byte-identical SSR markup without platform globals`       |
+| T12 | SSR                 | hydration                                                                   | hydrating a themed consumer emits no diagnostics and keeps server nodes                                   | `hydrates a themed consumer without replacement or diagnostics`    |
+| T13 | public types        | invalid token names or mutated records                                      | compilation rejects misuse                                                                                | `src/theme.types.test-d.ts`                                        |
 
 ## Cascade-layer order and specificity budget
 
@@ -52,11 +53,11 @@ in `src/theme.types.test-d.ts`.
 - `data-vize-theme` holds space-separated preset names and is inert without
   the shipped preset CSS; `atelier` is the Vize brand default, `midnight` is
   the dark-first application preset, `paper` is the editorial preset for
-  content-forward surfaces, and `signal` is the dense data/tooling preset.
-  When multiple presets are present, package source order resolves ties, so
-  later shipped presets win. `data-vize-density` accepts `compact` and
-  `comfortable`. Both scope by inheritance, so nesting attributes nests
-  themes.
+  content-forward surfaces, `play` is the expressive consumer-product preset,
+  and `signal` is the dense data/tooling preset. When multiple presets are
+  present, package source order resolves ties, so later shipped presets win.
+  `data-vize-density` accepts `compact` and `comfortable`. Both scope by
+  inheritance, so nesting attributes nests themes.
 - SSR bootstrapping is CSS-only and flash-free by construction: server-render
   the attribute (typically on `<html>`), and preset `light-dark()` values
   follow the user's scheme with no runtime script. Motion tokens stay in the

--- a/npm/ui/core/src/theme.test.ts
+++ b/npm/ui/core/src/theme.test.ts
@@ -55,7 +55,7 @@ test("rejects unknown tokens and empty override values", () => {
 test("publishes the token contract and scope constants", () => {
   assert.equal(themePresetAttribute, "data-vize-theme");
   assert.equal(themeDensityAttribute, "data-vize-density");
-  assert.deepEqual([...themePresets], ["atelier", "midnight", "paper", "signal"]);
+  assert.deepEqual([...themePresets], ["atelier", "midnight", "paper", "play", "signal"]);
   assert.deepEqual(Object.keys(themeDensityScales).sort(), ["comfortable", "compact"]);
 
   // The record is frozen and every name round-trips through the helpers.
@@ -78,7 +78,7 @@ test("scopes presets and densities in a mounted consumer", () => {
         h(
           "section",
           {
-            [themePresetAttribute]: "atelier midnight paper signal",
+            [themePresetAttribute]: "atelier midnight paper play signal",
             [themeDensityAttribute]: density.value,
           },
           [h("output", { "data-accent": themeTokenVar("color-accent") }, "Themed")],
@@ -88,7 +88,7 @@ test("scopes presets and densities in a mounted consumer", () => {
 
   const handle = mountInteraction(Consumer);
   const root = handle.root();
-  assert.equal(root.getAttribute("data-vize-theme"), "atelier midnight paper signal");
+  assert.equal(root.getAttribute("data-vize-theme"), "atelier midnight paper play signal");
   assert.equal(root.getAttribute("data-vize-density"), "compact");
   assert.equal(
     root.querySelector("output")?.getAttribute("data-accent"),

--- a/npm/ui/core/src/theme.ts
+++ b/npm/ui/core/src/theme.ts
@@ -2,6 +2,7 @@ import "./theme.css";
 import "./theme-preset-atelier.css";
 import "./theme-preset-midnight.css";
 import "./theme-preset-paper.css";
+import "./theme-preset-play.css";
 import "./theme-preset-signal.css";
 
 export {

--- a/npm/ui/core/src/theme.types.test-d.ts
+++ b/npm/ui/core/src/theme.types.test-d.ts
@@ -50,7 +50,7 @@ type _TokenNamesAreClosed = Expect<
   >
 >;
 type _PresetNamesAreClosed = Expect<
-  Equal<ThemePresetName, "atelier" | "midnight" | "paper" | "signal">
+  Equal<ThemePresetName, "atelier" | "midnight" | "paper" | "play" | "signal">
 >;
 type _DensityScalesAreClosed = Expect<Equal<ThemeDensityScale, "compact" | "comfortable">>;
 type _LayerOrderIsLiteral = Expect<


### PR DESCRIPTION
## Summary
- add the opt-in Play theme preset for expressive consumer-product surfaces
- publish Play through the typed theme contract, catalog metadata, and packaged stylesheet checks
- update UI size/tree-shaking budgets for the shared stylesheet cost

Refs #4894.

## Verification
- nix develop --command pnpm --dir npm/ui/core test
- nix develop --command pnpm --dir npm/ui/core run check
- nix develop --command pnpm --dir npm/ui/core run lint:sfc
- nix develop --command node --test tests/tooling/source-file-lengths.test.ts
- nix develop --command cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790341881&installation_model_id=422833&pr_number=5003&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5003&signature=ca38ce85f89b3f56c760e0277c1ae5c9edfe123f65added6ebf7e3796e057959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the new **Play** theme preset with expressive colors, typography, rounded corners, stacking, and elevation styles.
  * Play is now available through the theme configuration and opt-in theme attribute.

* **Documentation**
  * Updated theme guidance and preset listings to include Play.

* **Tests**
  * Added coverage validating Play theme availability and styling tokens.
  * Updated theme contract checks for the new preset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->