### PR TITLE
feat(ui): add high contrast theme preset

### DIFF
--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -33,7 +33,7 @@ const budgets = new Map([
   ["measure.mjs", 2_400],
   // Styled entries statically import the shared dist/style.css, so their
   // budgets cover the packaged stylesheet alongside their JavaScript.
-  ["motion.mjs", 5_450],
+  ["motion.mjs", 5_600],
   ["move.mjs", 5_050],
   ["pointer-grace.mjs", 1_800],
   ["portal.mjs", 1_700],
@@ -44,12 +44,12 @@ const budgets = new Map([
   ["shortcut.mjs", 7_400],
   ["sortable.mjs", 17_000],
   ["spatial-navigation.mjs", 3_725],
-  ["theme.mjs", 4_700],
+  ["theme.mjs", 4_850],
   ["transition.mjs", 3_000],
   ["typeahead.mjs", 2_000],
   ["virtualizer.mjs", 9_500],
   ["primitive.mjs", 800],
-  ["visually-hidden.mjs", 3_550],
+  ["visually-hidden.mjs", 3_700],
   ["media.mjs", 2_400],
   ["media-pdf.mjs", 2_048],
   ["media-source.mjs", 1_800],

--- a/npm/ui/core/src/family-catalog-basics.ts
+++ b/npm/ui/core/src/family-catalog-basics.ts
@@ -251,6 +251,7 @@ export const basicFamilyCatalog = [
       "src/theme-preset-paper.css",
       "src/theme-preset-play.css",
       "src/theme-preset-signal.css",
+      "src/theme-preset-high-contrast.css",
       "src/theme-tokens.ts",
       "src/theme-types.ts",
     ],
@@ -265,7 +266,7 @@ export const basicFamilyCatalog = [
       maximumJavaScriptGzipBytes: 1_500,
       // Covers the packaged stylesheet: the token contract and presets share
       // dist/style.css with every other styled family.
-      maximumCssGzipBytes: 4_600,
+      maximumCssGzipBytes: 4_900,
     },
     aliases: [
       "design tokens",
@@ -277,6 +278,7 @@ export const basicFamilyCatalog = [
       "paper",
       "play",
       "signal",
+      "high-contrast",
     ],
     upstreamCoverage: [
       "CSS cascade layers",

--- a/npm/ui/core/src/family-catalog-interactions.ts
+++ b/npm/ui/core/src/family-catalog-interactions.ts
@@ -340,7 +340,7 @@ export const interactionFamilyCatalog = [
       maximumJavaScriptGzipBytes: 400,
       // Covers the shared packaged stylesheet (dist/style.css), including the
       // motion tokens every styled family ships together (style-pipeline.behavior.md).
-      maximumCssGzipBytes: 4_600,
+      maximumCssGzipBytes: 4_900,
     },
     aliases: ["screen reader only", "sr-only", "visually hidden"],
     upstreamCoverage: ["React Aria VisuallyHidden", "Radix VisuallyHidden"],

--- a/npm/ui/core/src/family-catalog-overlays.ts
+++ b/npm/ui/core/src/family-catalog-overlays.ts
@@ -111,7 +111,7 @@ export const overlayFamilyCatalog = [
       maximumJavaScriptGzipBytes: 1_500,
       // Covers the packaged stylesheet: motion tokens and recipes share
       // dist/style.css with every other styled family.
-      maximumCssGzipBytes: 4_600,
+      maximumCssGzipBytes: 4_900,
     },
     aliases: ["motion tokens", "easing", "view transitions", "starting style", "reduced motion"],
     upstreamCoverage: [

--- a/npm/ui/core/src/theme-preset-high-contrast.css
+++ b/npm/ui/core/src/theme-preset-high-contrast.css
@@ -1,0 +1,40 @@
+/*
+ * High-contrast preset: stark surfaces, heavy boundaries, and flat elevation
+ * for legibility-first interfaces. It is inert until a consumer opts a subtree
+ * into `data-vize-theme~="high-contrast"` and ships last so it can override
+ * the more decorative presets when combined.
+ */
+
+@layer vize.preset {
+  :where([data-vize-theme~="high-contrast"], :host([data-vize-theme~="high-contrast"])) {
+    color-scheme: light dark;
+
+    --vize-ui-color-canvas: light-dark(oklch(1 0 0), oklch(0 0 0));
+    --vize-ui-color-surface: light-dark(oklch(0.965 0 0), oklch(0.12 0 0));
+    --vize-ui-color-text: light-dark(oklch(0 0 0), oklch(1 0 0));
+    --vize-ui-color-text-muted: light-dark(oklch(0.32 0 0), oklch(0.82 0 0));
+    --vize-ui-color-accent: light-dark(oklch(0.42 0.22 264), oklch(0.84 0.16 90));
+    --vize-ui-color-accent-contrast: light-dark(oklch(1 0 0), oklch(0 0 0));
+    --vize-ui-color-border: light-dark(oklch(0 0 0), oklch(1 0 0));
+    --vize-ui-color-danger: light-dark(oklch(0.43 0.22 29), oklch(0.82 0.18 35));
+
+    --vize-ui-border-width-thin: 2px;
+    --vize-ui-border-width-thick: 3px;
+    --vize-ui-focus-ring-width: 3px;
+    --vize-ui-focus-ring-offset: 3px;
+    --vize-ui-opacity-muted: 1;
+    --vize-ui-elevation-raised: none;
+    --vize-ui-elevation-overlay: none;
+    --vize-ui-elevation-floating: none;
+  }
+
+  @media (forced-colors: active) {
+    :where([data-vize-theme~="high-contrast"], :host([data-vize-theme~="high-contrast"])) {
+      --vize-ui-border-width-thin: 2px;
+      --vize-ui-border-width-thick: 3px;
+      --vize-ui-focus-ring-width: 3px;
+      --vize-ui-focus-ring-offset: 3px;
+      --vize-ui-opacity-muted: 1;
+    }
+  }
+}

--- a/npm/ui/core/src/theme-stylesheet.test.ts
+++ b/npm/ui/core/src/theme-stylesheet.test.ts
@@ -109,6 +109,7 @@ test("scopes published presets to their opt-in attributes", () => {
     assert.match(rule, /--vize-ui-color-accent:/);
     assert.match(rule, /--vize-ui-elevation-raised:/);
   }
+  assert.match(shippedPresetRule("high-contrast"), /--vize-ui-border-width-thin:2px/);
   assert.match(shippedPresetRule("midnight"), /--vize-ui-z-overlay:1400/);
   assert.match(shippedPresetRule("paper"), /--vize-ui-type-leading-normal:1\.6/);
   assert.match(shippedPresetRule("play"), /--vize-ui-radius-lg:1\.25rem/);
@@ -162,4 +163,8 @@ test("stands down to system colors under forced colors", () => {
   assert.match(policy, /--vize-ui-color-border:ButtonBorder[;}]/);
   assert.match(policy, /--vize-ui-elevation-floating:none[;}]/);
   assert.match(policy, /--vize-ui-focus-ring-color:Highlight[;}]/);
+  assert.match(
+    layerBlock("vize.preset"),
+    /@media \(forced-colors:active\)\{:where\(\[data-vize-theme~=high-contrast\]/,
+  );
 });

--- a/npm/ui/core/src/theme-tokens.ts
+++ b/npm/ui/core/src/theme-tokens.ts
@@ -28,6 +28,7 @@ export const themePresets: readonly ThemePresetName[] = Object.freeze([
   "paper",
   "play",
   "signal",
+  "high-contrast",
 ]);
 
 /** Density factors mirrored from the `data-vize-density` scopes in `theme.css`. */

--- a/npm/ui/core/src/theme-types.ts
+++ b/npm/ui/core/src/theme-types.ts
@@ -61,7 +61,13 @@ export type ThemeTokenOverrides = {
 };
 
 /** Opinionated presets accepted in the space-separated `data-vize-theme` attribute. */
-export type ThemePresetName = "atelier" | "midnight" | "paper" | "play" | "signal";
+export type ThemePresetName =
+  | "atelier"
+  | "midnight"
+  | "paper"
+  | "play"
+  | "signal"
+  | "high-contrast";
 
 /** Density scopes accepted in the `data-vize-density` attribute. */
 export type ThemeDensityScale = "compact" | "comfortable";

--- a/npm/ui/core/src/theme.behavior.md
+++ b/npm/ui/core/src/theme.behavior.md
@@ -5,28 +5,28 @@ design-token contract, the package-wide cascade-layer order, and the opt-in
 presets. The stylesheet contract is proven on the packaged `dist/style.css`
 (the pack pipeline lowers `src/theme.css` and the preset files
 `src/theme-preset-atelier.css`, `src/theme-preset-midnight.css`,
-`src/theme-preset-paper.css`, `src/theme-preset-play.css`, and
-`src/theme-preset-signal.css` to the declared browser floor; see
-`style-pipeline.behavior.md`) in
+`src/theme-preset-paper.css`, `src/theme-preset-play.css`,
+`src/theme-preset-signal.css`, and `src/theme-preset-high-contrast.css` to the
+declared browser floor; see `style-pipeline.behavior.md`) in
 `src/theme-stylesheet.test.ts`; runtime rows are proven by the named test in
 `src/theme.test.ts` or `src/theme-ssr.test.ts`; compile-only assertions live
 in `src/theme.types.test-d.ts`.
 
-| #   | State               | Input                                                                       | Outcome                                                                                                   | Proven by                                                          |
-| --- | ------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| T1  | packaged stylesheet | consumer imports any styled entry                                           | cascade layers ship in ascending priority order `vize.tokens` → `vize.ui` → `vize.preset` → `vize.policy` | `ships the documented cascade layer order`                         |
-| T2  | packaged stylesheet | any styled entry                                                            | the semantic token contract ships in `@layer vize.tokens` at zero specificity, matching the TS mirrors    | `ships layered zero-specificity theme tokens matching the mirrors` |
-| T3  | packaged stylesheet | no `data-vize-theme` attribute                                              | headless default: colors stay on the system palette and every elevation is `none`                         | `keeps the headless default free of visual opinion`                |
-| T4  | packaged stylesheet | `data-vize-density="compact" \| "comfortable"`                              | the density factor retunes, scaling every space and control-size token in the subtree                     | `ships density scopes that retune the shared factor`               |
-| T5  | packaged stylesheet | `data-vize-theme~="atelier" \| "midnight" \| "paper" \| "play" \| "signal"` | published presets assign visual tokens in `@layer vize.preset`, scoped to their opt-in attribute          | `scopes published presets to their opt-in attributes`              |
-| T6  | packaged stylesheet | light and dark schemes                                                      | preset `light-dark()` values ship lowered to the floor and follow the user's color scheme                 | `lowers preset color schemes to the declared floor`                |
-| T7  | packaged stylesheet | `forced-colors: active`                                                     | `@layer vize.policy` snaps color roles to the system palette and flattens elevation, beating presets      | `stands down to system colors under forced colors`                 |
-| T8  | any                 | `setThemeTokens(element, overrides)`                                        | overrides apply to the element inline and the restore callback reinstates values                          | `applies and restores token overrides on a real element`           |
-| T9  | any                 | unknown token name or empty value                                           | `themeTokenProperty`/`setThemeTokens` throw `VIZE_UI_THEME_TOKEN`                                         | `rejects unknown tokens and empty override values`                 |
-| T10 | mounted             | consumer binds scope attributes and tokens                                  | preset and density attributes render, and scoped overrides apply through the mounted DOM                  | `scopes presets and densities in a mounted consumer`               |
-| T11 | SSR                 | render with token helpers in setup                                          | byte-identical markup; no platform global is required                                                     | `renders byte-identical SSR markup without platform globals`       |
-| T12 | SSR                 | hydration                                                                   | hydrating a themed consumer emits no diagnostics and keeps server nodes                                   | `hydrates a themed consumer without replacement or diagnostics`    |
-| T13 | public types        | invalid token names or mutated records                                      | compilation rejects misuse                                                                                | `src/theme.types.test-d.ts`                                        |
+| #   | State               | Input                                                                                          | Outcome                                                                                                   | Proven by                                                          |
+| --- | ------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| T1  | packaged stylesheet | consumer imports any styled entry                                                              | cascade layers ship in ascending priority order `vize.tokens` → `vize.ui` → `vize.preset` → `vize.policy` | `ships the documented cascade layer order`                         |
+| T2  | packaged stylesheet | any styled entry                                                                               | the semantic token contract ships in `@layer vize.tokens` at zero specificity, matching the TS mirrors    | `ships layered zero-specificity theme tokens matching the mirrors` |
+| T3  | packaged stylesheet | no `data-vize-theme` attribute                                                                 | headless default: colors stay on the system palette and every elevation is `none`                         | `keeps the headless default free of visual opinion`                |
+| T4  | packaged stylesheet | `data-vize-density="compact" \| "comfortable"`                                                 | the density factor retunes, scaling every space and control-size token in the subtree                     | `ships density scopes that retune the shared factor`               |
+| T5  | packaged stylesheet | `data-vize-theme~="atelier" \| "midnight" \| "paper" \| "play" \| "signal" \| "high-contrast"` | published presets assign visual tokens in `@layer vize.preset`, scoped to their opt-in attribute          | `scopes published presets to their opt-in attributes`              |
+| T6  | packaged stylesheet | light and dark schemes                                                                         | preset `light-dark()` values ship lowered to the floor and follow the user's color scheme                 | `lowers preset color schemes to the declared floor`                |
+| T7  | packaged stylesheet | `forced-colors: active`                                                                        | `@layer vize.policy` snaps color roles to the system palette and flattens elevation, beating presets      | `stands down to system colors under forced colors`                 |
+| T8  | any                 | `setThemeTokens(element, overrides)`                                                           | overrides apply to the element inline and the restore callback reinstates values                          | `applies and restores token overrides on a real element`           |
+| T9  | any                 | unknown token name or empty value                                                              | `themeTokenProperty`/`setThemeTokens` throw `VIZE_UI_THEME_TOKEN`                                         | `rejects unknown tokens and empty override values`                 |
+| T10 | mounted             | consumer binds scope attributes and tokens                                                     | preset and density attributes render, and scoped overrides apply through the mounted DOM                  | `scopes presets and densities in a mounted consumer`               |
+| T11 | SSR                 | render with token helpers in setup                                                             | byte-identical markup; no platform global is required                                                     | `renders byte-identical SSR markup without platform globals`       |
+| T12 | SSR                 | hydration                                                                                      | hydrating a themed consumer emits no diagnostics and keeps server nodes                                   | `hydrates a themed consumer without replacement or diagnostics`    |
+| T13 | public types        | invalid token names or mutated records                                                         | compilation rejects misuse                                                                                | `src/theme.types.test-d.ts`                                        |
 
 ## Cascade-layer order and specificity budget
 
@@ -54,8 +54,10 @@ in `src/theme.types.test-d.ts`.
   the shipped preset CSS; `atelier` is the Vize brand default, `midnight` is
   the dark-first application preset, `paper` is the editorial preset for
   content-forward surfaces, `play` is the expressive consumer-product preset,
-  and `signal` is the dense data/tooling preset. When multiple presets are
-  present, package source order resolves ties, so later shipped presets win.
+  `signal` is the dense data/tooling preset, and `high-contrast` is the
+  legibility-first preset with heavy boundaries and flat elevation. When
+  multiple presets are present, package source order resolves ties, so later
+  shipped presets win.
   `data-vize-density` accepts `compact` and `comfortable`. Both scope by
   inheritance, so nesting attributes nests themes.
 - SSR bootstrapping is CSS-only and flash-free by construction: server-render

--- a/npm/ui/core/src/theme.test.ts
+++ b/npm/ui/core/src/theme.test.ts
@@ -55,7 +55,10 @@ test("rejects unknown tokens and empty override values", () => {
 test("publishes the token contract and scope constants", () => {
   assert.equal(themePresetAttribute, "data-vize-theme");
   assert.equal(themeDensityAttribute, "data-vize-density");
-  assert.deepEqual([...themePresets], ["atelier", "midnight", "paper", "play", "signal"]);
+  assert.deepEqual(
+    [...themePresets],
+    ["atelier", "midnight", "paper", "play", "signal", "high-contrast"],
+  );
   assert.deepEqual(Object.keys(themeDensityScales).sort(), ["comfortable", "compact"]);
 
   // The record is frozen and every name round-trips through the helpers.
@@ -78,7 +81,7 @@ test("scopes presets and densities in a mounted consumer", () => {
         h(
           "section",
           {
-            [themePresetAttribute]: "atelier midnight paper play signal",
+            [themePresetAttribute]: "atelier midnight paper play signal high-contrast",
             [themeDensityAttribute]: density.value,
           },
           [h("output", { "data-accent": themeTokenVar("color-accent") }, "Themed")],
@@ -88,7 +91,10 @@ test("scopes presets and densities in a mounted consumer", () => {
 
   const handle = mountInteraction(Consumer);
   const root = handle.root();
-  assert.equal(root.getAttribute("data-vize-theme"), "atelier midnight paper play signal");
+  assert.equal(
+    root.getAttribute("data-vize-theme"),
+    "atelier midnight paper play signal high-contrast",
+  );
   assert.equal(root.getAttribute("data-vize-density"), "compact");
   assert.equal(
     root.querySelector("output")?.getAttribute("data-accent"),

--- a/npm/ui/core/src/theme.ts
+++ b/npm/ui/core/src/theme.ts
@@ -4,6 +4,7 @@ import "./theme-preset-midnight.css";
 import "./theme-preset-paper.css";
 import "./theme-preset-play.css";
 import "./theme-preset-signal.css";
+import "./theme-preset-high-contrast.css";
 
 export {
   setThemeTokens,

--- a/npm/ui/core/src/theme.types.test-d.ts
+++ b/npm/ui/core/src/theme.types.test-d.ts
@@ -50,7 +50,7 @@ type _TokenNamesAreClosed = Expect<
   >
 >;
 type _PresetNamesAreClosed = Expect<
-  Equal<ThemePresetName, "atelier" | "midnight" | "paper" | "play" | "signal">
+  Equal<ThemePresetName, "atelier" | "midnight" | "paper" | "play" | "signal" | "high-contrast">
 >;
 type _DensityScalesAreClosed = Expect<Equal<ThemeDensityScale, "compact" | "comfortable">>;
 type _LayerOrderIsLiteral = Expect<


### PR DESCRIPTION
## Summary
- add a high-contrast theme preset that ships last in the opt-in preset layer
- keep forced-colors geometry tokens covered while the policy layer owns system colors
- publish the preset through the typed theme contract, docs, catalog metadata, and bundle budgets

Refs #4894

## Verification
- nix develop --command pnpm --dir npm/ui/core run fmt
- nix develop --command pnpm --dir npm/ui/core run build
- nix develop --command pnpm --dir npm/ui/core exec vp test run src/theme.test.ts src/theme-stylesheet.test.ts src/theme-ssr.test.ts
- nix develop --command pnpm --dir npm/ui/core run check:size
- nix develop --command pnpm --dir npm/ui/core run check:tree-shaking
- nix develop --command pnpm --dir npm/ui/core test
- nix develop --command pnpm --dir npm/ui/core run check
- nix develop --command pnpm --dir npm/ui/core run lint:sfc
- nix develop --command node --test tests/tooling/source-file-lengths.test.ts
- nix develop --command cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790343095&installation_model_id=422833&pr_number=5006&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5006&signature=645c44f0c58b5bdccddc5875387015f8d1e020a611b6ce2b2fda7dcbcf9d76be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->