### PR TITLE
feat(ui): add headless theme preset

### DIFF
--- a/npm/ui/core/src/family-catalog-basics.ts
+++ b/npm/ui/core/src/family-catalog-basics.ts
@@ -246,6 +246,7 @@ export const basicFamilyCatalog = [
     sourceFiles: [
       "src/theme.ts",
       "src/theme.css",
+      "src/theme-preset-headless.css",
       "src/theme-preset-atelier.css",
       "src/theme-preset-midnight.css",
       "src/theme-preset-paper.css",
@@ -273,6 +274,7 @@ export const basicFamilyCatalog = [
       "semantic tokens",
       "cascade layers",
       "presets",
+      "headless",
       "atelier",
       "midnight",
       "paper",

--- a/npm/ui/core/src/theme-preset-headless.css
+++ b/npm/ui/core/src/theme-preset-headless.css
@@ -1,0 +1,11 @@
+/*
+ * Headless preset: an explicit no-visual-opinion scope. It ships as a named
+ * preset so applications can persist a "headless" choice without importing a
+ * decorative look. Semantic system-palette tokens stay owned by theme.css.
+ */
+
+@layer vize.preset {
+  :where([data-vize-theme~="headless"], :host([data-vize-theme~="headless"])) {
+    color-scheme: light dark;
+  }
+}

--- a/npm/ui/core/src/theme-stylesheet.test.ts
+++ b/npm/ui/core/src/theme-stylesheet.test.ts
@@ -8,6 +8,7 @@ import { test } from "vite-plus/test";
 import { themeCascadeLayerOrder, themeDensityScales, themePresets, themeTokens } from "./theme.ts";
 
 const stylesheet = await readFile(path.resolve("dist/style.css"), "utf8");
+const opinionatedThemePresets = themePresets.filter((name) => name !== "headless");
 
 const layerStarts = new Map(
   themeCascadeLayerOrder.map((layer) => [layer, stylesheet.indexOf(`@layer ${layer}{`)]),
@@ -64,11 +65,18 @@ test("ships layered zero-specificity theme tokens matching the mirrors", () => {
 
 test("keeps the headless default free of visual opinion", () => {
   const tokens = layerBlock("vize.tokens");
+  const headlessPreset = shippedPresetRule("headless");
 
   assert.match(tokens, /--vize-ui-color-canvas:Canvas[;}]/);
   assert.match(tokens, /--vize-ui-color-text:CanvasText[;}]/);
   assert.match(tokens, /--vize-ui-elevation-raised:none[;}]/);
   assert.doesNotMatch(tokens, /oklch\(/, "headless defaults must stay on the system palette");
+  assert.match(headlessPreset, /color-scheme:light dark/);
+  assert.doesNotMatch(
+    headlessPreset,
+    /--vize-ui-/,
+    "the explicit headless preset must not add visual token opinion",
+  );
 });
 
 test("ships density scopes that retune the shared factor", () => {
@@ -103,7 +111,7 @@ function shippedPresetRule(name: (typeof themePresets)[number]): string {
 test("scopes published presets to their opt-in attributes", () => {
   const preset = layerBlock("vize.preset");
 
-  for (const name of themePresets) {
+  for (const name of opinionatedThemePresets) {
     const rule = shippedPresetRule(name);
     assert.match(rule, /color-scheme:light dark/);
     assert.match(rule, /--vize-ui-color-accent:/);
@@ -131,7 +139,7 @@ test("lowers preset color schemes to the declared floor", () => {
     preset,
     /--vize-ui-color-canvas:var\(--lightningcss-light,oklch\(98\.5% \.003 255\)\)var\(--lightningcss-dark,oklch\(15\.5% \.012 255\)\)/,
   );
-  for (const name of themePresets) {
+  for (const name of opinionatedThemePresets) {
     assert.match(
       preset,
       new RegExp(

--- a/npm/ui/core/src/theme-tokens.ts
+++ b/npm/ui/core/src/theme-tokens.ts
@@ -21,8 +21,9 @@ export const themePresetAttribute = "data-vize-theme";
 /** Attribute that retunes the density factor for a subtree. */
 export const themeDensityAttribute = "data-vize-density";
 
-/** Opinionated presets shipped in `@layer vize.preset`. */
+/** Presets shipped in `@layer vize.preset`, ordered from least to most opinionated. */
 export const themePresets: readonly ThemePresetName[] = Object.freeze([
+  "headless",
   "atelier",
   "midnight",
   "paper",

--- a/npm/ui/core/src/theme-types.ts
+++ b/npm/ui/core/src/theme-types.ts
@@ -60,8 +60,9 @@ export type ThemeTokenOverrides = {
   readonly [Name in ThemeTokenName]?: string;
 };
 
-/** Opinionated presets accepted in the space-separated `data-vize-theme` attribute. */
+/** Presets accepted in the space-separated `data-vize-theme` attribute. */
 export type ThemePresetName =
+  | "headless"
   | "atelier"
   | "midnight"
   | "paper"

--- a/npm/ui/core/src/theme.behavior.md
+++ b/npm/ui/core/src/theme.behavior.md
@@ -4,29 +4,30 @@ Normative contract for the theme family (`@vizejs/ui/theme`): the semantic
 design-token contract, the package-wide cascade-layer order, and the opt-in
 presets. The stylesheet contract is proven on the packaged `dist/style.css`
 (the pack pipeline lowers `src/theme.css` and the preset files
-`src/theme-preset-atelier.css`, `src/theme-preset-midnight.css`,
-`src/theme-preset-paper.css`, `src/theme-preset-play.css`,
-`src/theme-preset-signal.css`, and `src/theme-preset-high-contrast.css` to the
-declared browser floor; see `style-pipeline.behavior.md`) in
+`src/theme-preset-headless.css`, `src/theme-preset-atelier.css`,
+`src/theme-preset-midnight.css`, `src/theme-preset-paper.css`,
+`src/theme-preset-play.css`, `src/theme-preset-signal.css`, and
+`src/theme-preset-high-contrast.css` to the declared browser floor; see
+`style-pipeline.behavior.md`) in
 `src/theme-stylesheet.test.ts`; runtime rows are proven by the named test in
 `src/theme.test.ts` or `src/theme-ssr.test.ts`; compile-only assertions live
 in `src/theme.types.test-d.ts`.
 
-| #   | State               | Input                                                                                          | Outcome                                                                                                   | Proven by                                                          |
-| --- | ------------------- | ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| T1  | packaged stylesheet | consumer imports any styled entry                                                              | cascade layers ship in ascending priority order `vize.tokens` → `vize.ui` → `vize.preset` → `vize.policy` | `ships the documented cascade layer order`                         |
-| T2  | packaged stylesheet | any styled entry                                                                               | the semantic token contract ships in `@layer vize.tokens` at zero specificity, matching the TS mirrors    | `ships layered zero-specificity theme tokens matching the mirrors` |
-| T3  | packaged stylesheet | no `data-vize-theme` attribute                                                                 | headless default: colors stay on the system palette and every elevation is `none`                         | `keeps the headless default free of visual opinion`                |
-| T4  | packaged stylesheet | `data-vize-density="compact" \| "comfortable"`                                                 | the density factor retunes, scaling every space and control-size token in the subtree                     | `ships density scopes that retune the shared factor`               |
-| T5  | packaged stylesheet | `data-vize-theme~="atelier" \| "midnight" \| "paper" \| "play" \| "signal" \| "high-contrast"` | published presets assign visual tokens in `@layer vize.preset`, scoped to their opt-in attribute          | `scopes published presets to their opt-in attributes`              |
-| T6  | packaged stylesheet | light and dark schemes                                                                         | preset `light-dark()` values ship lowered to the floor and follow the user's color scheme                 | `lowers preset color schemes to the declared floor`                |
-| T7  | packaged stylesheet | `forced-colors: active`                                                                        | `@layer vize.policy` snaps color roles to the system palette and flattens elevation, beating presets      | `stands down to system colors under forced colors`                 |
-| T8  | any                 | `setThemeTokens(element, overrides)`                                                           | overrides apply to the element inline and the restore callback reinstates values                          | `applies and restores token overrides on a real element`           |
-| T9  | any                 | unknown token name or empty value                                                              | `themeTokenProperty`/`setThemeTokens` throw `VIZE_UI_THEME_TOKEN`                                         | `rejects unknown tokens and empty override values`                 |
-| T10 | mounted             | consumer binds scope attributes and tokens                                                     | preset and density attributes render, and scoped overrides apply through the mounted DOM                  | `scopes presets and densities in a mounted consumer`               |
-| T11 | SSR                 | render with token helpers in setup                                                             | byte-identical markup; no platform global is required                                                     | `renders byte-identical SSR markup without platform globals`       |
-| T12 | SSR                 | hydration                                                                                      | hydrating a themed consumer emits no diagnostics and keeps server nodes                                   | `hydrates a themed consumer without replacement or diagnostics`    |
-| T13 | public types        | invalid token names or mutated records                                                         | compilation rejects misuse                                                                                | `src/theme.types.test-d.ts`                                        |
+| #   | State               | Input                                                                                                        | Outcome                                                                                                   | Proven by                                                          |
+| --- | ------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| T1  | packaged stylesheet | consumer imports any styled entry                                                                            | cascade layers ship in ascending priority order `vize.tokens` → `vize.ui` → `vize.preset` → `vize.policy` | `ships the documented cascade layer order`                         |
+| T2  | packaged stylesheet | any styled entry                                                                                             | the semantic token contract ships in `@layer vize.tokens` at zero specificity, matching the TS mirrors    | `ships layered zero-specificity theme tokens matching the mirrors` |
+| T3  | packaged stylesheet | no `data-vize-theme` attribute or `data-vize-theme~="headless"`                                              | headless default and explicit preset stay on the system palette, flat, and free of visual token opinion   | `keeps the headless default free of visual opinion`                |
+| T4  | packaged stylesheet | `data-vize-density="compact" \| "comfortable"`                                                               | the density factor retunes, scaling every space and control-size token in the subtree                     | `ships density scopes that retune the shared factor`               |
+| T5  | packaged stylesheet | `data-vize-theme~="headless" \| "atelier" \| "midnight" \| "paper" \| "play" \| "signal" \| "high-contrast"` | published presets are scoped to their opt-in attribute; only non-headless presets assign visual tokens    | `scopes published presets to their opt-in attributes`              |
+| T6  | packaged stylesheet | light and dark schemes                                                                                       | preset `light-dark()` values ship lowered to the floor and follow the user's color scheme                 | `lowers preset color schemes to the declared floor`                |
+| T7  | packaged stylesheet | `forced-colors: active`                                                                                      | `@layer vize.policy` snaps color roles to the system palette and flattens elevation, beating presets      | `stands down to system colors under forced colors`                 |
+| T8  | any                 | `setThemeTokens(element, overrides)`                                                                         | overrides apply to the element inline and the restore callback reinstates values                          | `applies and restores token overrides on a real element`           |
+| T9  | any                 | unknown token name or empty value                                                                            | `themeTokenProperty`/`setThemeTokens` throw `VIZE_UI_THEME_TOKEN`                                         | `rejects unknown tokens and empty override values`                 |
+| T10 | mounted             | consumer binds scope attributes and tokens                                                                   | preset and density attributes render, and scoped overrides apply through the mounted DOM                  | `scopes presets and densities in a mounted consumer`               |
+| T11 | SSR                 | render with token helpers in setup                                                                           | byte-identical markup; no platform global is required                                                     | `renders byte-identical SSR markup without platform globals`       |
+| T12 | SSR                 | hydration                                                                                                    | hydrating a themed consumer emits no diagnostics and keeps server nodes                                   | `hydrates a themed consumer without replacement or diagnostics`    |
+| T13 | public types        | invalid token names or mutated records                                                                       | compilation rejects misuse                                                                                | `src/theme.types.test-d.ts`                                        |
 
 ## Cascade-layer order and specificity budget
 
@@ -51,8 +52,9 @@ in `src/theme.types.test-d.ts`.
   `--vize-ui-color-accent`, and space/size tokens resolve through
   `--vize-ui-density`, so one override retunes a whole phase.
 - `data-vize-theme` holds space-separated preset names and is inert without
-  the shipped preset CSS; `atelier` is the Vize brand default, `midnight` is
-  the dark-first application preset, `paper` is the editorial preset for
+  the shipped preset CSS; `headless` is an explicit no-visual-opinion preset
+  for persisted theme choice, `atelier` is the Vize brand default, `midnight`
+  is the dark-first application preset, `paper` is the editorial preset for
   content-forward surfaces, `play` is the expressive consumer-product preset,
   `signal` is the dense data/tooling preset, and `high-contrast` is the
   legibility-first preset with heavy boundaries and flat elevation. When

--- a/npm/ui/core/src/theme.test.ts
+++ b/npm/ui/core/src/theme.test.ts
@@ -57,7 +57,7 @@ test("publishes the token contract and scope constants", () => {
   assert.equal(themeDensityAttribute, "data-vize-density");
   assert.deepEqual(
     [...themePresets],
-    ["atelier", "midnight", "paper", "play", "signal", "high-contrast"],
+    ["headless", "atelier", "midnight", "paper", "play", "signal", "high-contrast"],
   );
   assert.deepEqual(Object.keys(themeDensityScales).sort(), ["comfortable", "compact"]);
 
@@ -81,7 +81,7 @@ test("scopes presets and densities in a mounted consumer", () => {
         h(
           "section",
           {
-            [themePresetAttribute]: "atelier midnight paper play signal high-contrast",
+            [themePresetAttribute]: "headless atelier midnight paper play signal high-contrast",
             [themeDensityAttribute]: density.value,
           },
           [h("output", { "data-accent": themeTokenVar("color-accent") }, "Themed")],
@@ -93,7 +93,7 @@ test("scopes presets and densities in a mounted consumer", () => {
   const root = handle.root();
   assert.equal(
     root.getAttribute("data-vize-theme"),
-    "atelier midnight paper play signal high-contrast",
+    "headless atelier midnight paper play signal high-contrast",
   );
   assert.equal(root.getAttribute("data-vize-density"), "compact");
   assert.equal(

--- a/npm/ui/core/src/theme.ts
+++ b/npm/ui/core/src/theme.ts
@@ -1,4 +1,5 @@
 import "./theme.css";
+import "./theme-preset-headless.css";
 import "./theme-preset-atelier.css";
 import "./theme-preset-midnight.css";
 import "./theme-preset-paper.css";

--- a/npm/ui/core/src/theme.types.test-d.ts
+++ b/npm/ui/core/src/theme.types.test-d.ts
@@ -50,7 +50,10 @@ type _TokenNamesAreClosed = Expect<
   >
 >;
 type _PresetNamesAreClosed = Expect<
-  Equal<ThemePresetName, "atelier" | "midnight" | "paper" | "play" | "signal" | "high-contrast">
+  Equal<
+    ThemePresetName,
+    "headless" | "atelier" | "midnight" | "paper" | "play" | "signal" | "high-contrast"
+  >
 >;
 type _DensityScalesAreClosed = Expect<Equal<ThemeDensityScale, "compact" | "comfortable">>;
 type _LayerOrderIsLiteral = Expect<


### PR DESCRIPTION
## Summary
- add an explicit `headless` theme preset scoped in `@layer vize.preset`
- keep the explicit preset free of visual token opinion while retaining `color-scheme` behavior
- update theme contracts, tests, types, and catalog metadata

Refs #4894

## Verification
- `nix develop --command pnpm --dir npm/ui/core run fmt`
- `nix develop --command pnpm --dir npm/ui/core run build`
- `nix develop --command pnpm --dir npm/ui/core exec vp test run src/theme.test.ts src/theme-stylesheet.test.ts src/theme-ssr.test.ts`
- `nix develop --command pnpm --dir npm/ui/core run check:size` (`@vizejs/ui/theme` 4823/4850 gzip; root index 105768/106000 gzip)
- `nix develop --command pnpm --dir npm/ui/core run check:tree-shaking` (shared CSS 4844/4900 gzip)
- `nix develop --command pnpm --dir npm/ui/core test`
- `nix develop --command pnpm --dir npm/ui/core run check`
- `nix develop --command pnpm --dir npm/ui/core run lint:sfc`
- `nix develop --command node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790344273&installation_model_id=422833&pr_number=5008&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5008&signature=7f8006adfad5cbe99c35b7e34770f68d5a413b41dffa436b35daa7f12b2170b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new **Headless** theme preset.
  - Supports light and dark system color schemes without imposing visual styles or color tokens.
  - Added `headless` as a recognized theme option and alias.
- **Documentation**
  - Updated theme guidance to describe preset customization levels and identify the default branded theme.
- **Tests**
  - Added coverage validating headless theme behavior and availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->