### PR TITLE
docs(davinci): render migration surfaces by physical stage

### DIFF
--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -33,10 +33,10 @@ observational guard for planning only. It does not change rollout state.
 | surface          | group | matched name classes                                                                                                                               |
 | ---------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Davinci          | stage | preferred: `vize_davinci`                                                                                                                          |
-| S0/carton        | stage | preferred: `vize_s0`<br>compat/code-name: `vize_carton`                                                                                            |
-| S1/sinopia       | stage | preferred: `vize_s1`<br>compat/code-name: `vize_sinopia`                                                                                           |
-| S2/disegno       | stage | preferred: `vize_s2`<br>compat/code-name: `vize_disegno`                                                                                           |
-| S1->S2/ricalco   | stage | preferred: `vize_s1_to_s2`<br>compat/code-name: `vize_ricalco`                                                                                     |
+| S0               | stage | preferred: `vize_s0`<br>compat/code-name: `vize_carton`                                                                                            |
+| S1               | stage | preferred: `vize_s1`<br>compat/code-name: `vize_sinopia`                                                                                           |
+| S2               | stage | preferred: `vize_s2`<br>compat/code-name: `vize_disegno`                                                                                           |
+| S1->S2           | stage | preferred: `vize_s1_to_s2`<br>compat/code-name: `vize_ricalco`                                                                                     |
 | old AST/parser   | old   | legacy: `vize_relief`, `vize_armature`                                                                                                             |
 | Croquis analysis | old   | legacy: `vize_croquis`, `vize_croquis_cf`                                                                                                          |
 | raw OXC          | raw   | raw: `oxc_allocator`, `oxc_ast`, `oxc_ast_visit`, `oxc_codegen`, `oxc_formatter`, `oxc_formatter_core`, `oxc_parser`, `oxc_semantic`, `oxc_syntax` |
@@ -61,35 +61,35 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          21 |               4 |       17 |
-| S0/carton        |         845 |             490 |      355 |
-| S1/sinopia       |           5 |               1 |        4 |
-| S2/disegno       |          15 |               1 |       14 |
-| S1->S2/ricalco   |          30 |               2 |       28 |
+| S0               |         845 |             490 |      355 |
+| S1               |           5 |               1 |        4 |
+| S2               |          15 |               1 |       14 |
+| S1->S2           |          30 |               2 |       28 |
 | old AST/parser   |          74 |              54 |       20 |
 | Croquis analysis |          65 |              56 |        9 |
 | raw OXC          |         371 |             343 |       28 |
 
 #### Top source and manifest files
 
-| file                                                                         | class    | surfaces                                                                                                                            | sites |
-| ---------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----: |
-| `crates/vize_atelier_sfc/src/rewrite_default.rs:6`                           | source   | S0/carton 1<br>raw OXC 27                                                                                                           |    28 |
-| `crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs:7`        | source   | S0/carton 3<br>Croquis analysis 1<br>raw OXC 17                                                                                     |    21 |
-| `crates/vize_atelier_core/Cargo.toml:17`                                     | manifest | Davinci 1<br>S0/carton 1<br>S1/sinopia 1<br>S2/disegno 1<br>S1->S2/ricalco 1<br>old AST/parser 4<br>Croquis analysis 1<br>raw OXC 7 |    17 |
-| `crates/vize_atelier_sfc/src/script/define_props_destructure/collector.rs:6` | source   | S0/carton 2<br>raw OXC 15                                                                                                           |    17 |
-| `crates/vize_atelier_core/src/steps/expression/prefix.rs:6`                  | source   | S0/carton 1<br>Croquis analysis 1<br>raw OXC 14                                                                                     |    16 |
+| file                                                                         | class    | surfaces                                                                                             | sites |
+| ---------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- | ----: |
+| `crates/vize_atelier_sfc/src/rewrite_default.rs:6`                           | source   | S0 1<br>raw OXC 27                                                                                   |    28 |
+| `crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs:7`        | source   | S0 3<br>Croquis analysis 1<br>raw OXC 17                                                             |    21 |
+| `crates/vize_atelier_core/Cargo.toml:17`                                     | manifest | Davinci 1<br>S0 1<br>S1 1<br>S2 1<br>S1->S2 1<br>old AST/parser 4<br>Croquis analysis 1<br>raw OXC 7 |    17 |
+| `crates/vize_atelier_sfc/src/script/define_props_destructure/collector.rs:6` | source   | S0 2<br>raw OXC 15                                                                                   |    17 |
+| `crates/vize_atelier_core/src/steps/expression/prefix.rs:6`                  | source   | S0 1<br>Croquis analysis 1<br>raw OXC 14                                                             |    16 |
 
 Additional source/manifest rows are in the TSV: 309 omitted.
 
 #### Top test/dev files
 
-| file                                                          | class    | surfaces                                                                     | sites |
-| ------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------- | ----: |
-| `crates/vize_atelier_vapor/src/tests.rs:4`                    | test/dev | S0/carton 42<br>raw OXC 2                                                    |    44 |
-| `crates/vize_atelier_core/tests/davinci_s2_transform.rs:119`  | test/dev | Davinci 3<br>S0/carton 6<br>S1/sinopia 3<br>S1->S2/ricalco 13                |    25 |
-| `crates/vize_atelier_core/src/codegen/tests.rs:5`             | test/dev | S0/carton 20<br>old AST/parser 1                                             |    21 |
-| `crates/vize_atelier_sfc/src/compile_script/props/tests.rs:4` | test/dev | S0/carton 15                                                                 |    15 |
-| `crates/vize_atelier_core/tests/s2_support/compare.rs:10`     | test/dev | Davinci 2<br>S0/carton 4<br>S1/sinopia 1<br>S2/disegno 1<br>S1->S2/ricalco 3 |    11 |
+| file                                                          | class    | surfaces                                      | sites |
+| ------------------------------------------------------------- | -------- | --------------------------------------------- | ----: |
+| `crates/vize_atelier_vapor/src/tests.rs:4`                    | test/dev | S0 42<br>raw OXC 2                            |    44 |
+| `crates/vize_atelier_core/tests/davinci_s2_transform.rs:119`  | test/dev | Davinci 3<br>S0 6<br>S1 3<br>S1->S2 13        |    25 |
+| `crates/vize_atelier_core/src/codegen/tests.rs:5`             | test/dev | S0 20<br>old AST/parser 1                     |    21 |
+| `crates/vize_atelier_sfc/src/compile_script/props/tests.rs:4` | test/dev | S0 15                                         |    15 |
+| `crates/vize_atelier_core/tests/s2_support/compare.rs:10`     | test/dev | Davinci 2<br>S0 4<br>S1 1<br>S2 1<br>S1->S2 3 |    11 |
 
 Additional test/dev rows are in the TSV: 194 omitted.
 
@@ -99,32 +99,32 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0/carton        |         302 |             225 |       77 |
+| S0               |         302 |             225 |       77 |
 | old AST/parser   |         226 |             211 |       15 |
 | Croquis analysis |          42 |              38 |        4 |
 | raw OXC          |         225 |             199 |       26 |
 
 #### Top source and manifest files
 
-| file                                                                                | class    | surfaces                                                           | sites |
-| ----------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------ | ----: |
-| `crates/vize_patina/src/linter/engine.rs:25`                                        | source   | S0/carton 5<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |    13 |
-| `crates/vize_patina/Cargo.toml:13`                                                  | manifest | S0/carton 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 6 |    10 |
-| `crates/vize_patina/src/markup.rs:49`                                               | source   | S0/carton 2<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |    10 |
-| `crates/vize_patina/src/rules/script/no_ref_as_operand.rs:29`                       | source   | S0/carton 1<br>raw OXC 9                                           |    10 |
-| `crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs:46` | source   | S0/carton 2<br>old AST/parser 4<br>Croquis analysis 3              |     9 |
+| file                                                                                | class    | surfaces                                                    | sites |
+| ----------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
+| `crates/vize_patina/src/linter/engine.rs:25`                                        | source   | S0 5<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |    13 |
+| `crates/vize_patina/Cargo.toml:13`                                                  | manifest | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 6 |    10 |
+| `crates/vize_patina/src/markup.rs:49`                                               | source   | S0 2<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |    10 |
+| `crates/vize_patina/src/rules/script/no_ref_as_operand.rs:29`                       | source   | S0 1<br>raw OXC 9                                           |    10 |
+| `crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs:46` | source   | S0 2<br>old AST/parser 4<br>Croquis analysis 3              |     9 |
 
 Additional source/manifest rows are in the TSV: 306 omitted.
 
 #### Top test/dev files
 
-| file                                                                             | class    | surfaces                                                           | sites |
-| -------------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------ | ----: |
-| `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0/carton 23                                                       |    23 |
-| `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0/carton 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:18`                                      | test/dev | S0/carton 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
-| `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0/carton 1<br>raw OXC 5                                           |     6 |
-| `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0/carton 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
+| file                                                                             | class    | surfaces                                                    | sites |
+| -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
+| `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
+| `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
+| `crates/vize_patina/src/markup/tests.rs:18`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
+| `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
 Additional test/dev rows are in the TSV: 37 omitted.
 
@@ -134,32 +134,32 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0/carton        |         890 |             502 |      388 |
+| S0               |         890 |             502 |      388 |
 | old AST/parser   |         160 |              35 |      125 |
 | Croquis analysis |         236 |             118 |      118 |
 | raw OXC          |         187 |             151 |       36 |
 
 #### Top source and manifest files
 
-| file                                                                           | class    | surfaces                                                           | sites |
-| ------------------------------------------------------------------------------ | -------- | ------------------------------------------------------------------ | ----: |
-| `crates/vize_canon/src/sfc_typecheck/checks.rs:4`                              | source   | S0/carton 1<br>Croquis analysis 11                                 |    12 |
-| `crates/vize/src/commands/check/nuxt/parsing.rs:5`                             | source   | S0/carton 1<br>raw OXC 11                                          |    12 |
-| `crates/vize_canon/Cargo.toml:16`                                              | manifest | S0/carton 1<br>old AST/parser 3<br>Croquis analysis 1<br>raw OXC 6 |    11 |
-| `crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/cache.rs:7` | source   | S0/carton 10                                                       |    10 |
-| `crates/vize_canon/src/virtual_ts/expressions/statements.rs:15`                | source   | S0/carton 6<br>Croquis analysis 3                                  |     9 |
+| file                                                                           | class    | surfaces                                                    | sites |
+| ------------------------------------------------------------------------------ | -------- | ----------------------------------------------------------- | ----: |
+| `crates/vize_canon/src/sfc_typecheck/checks.rs:4`                              | source   | S0 1<br>Croquis analysis 11                                 |    12 |
+| `crates/vize/src/commands/check/nuxt/parsing.rs:5`                             | source   | S0 1<br>raw OXC 11                                          |    12 |
+| `crates/vize_canon/Cargo.toml:16`                                              | manifest | S0 1<br>old AST/parser 3<br>Croquis analysis 1<br>raw OXC 6 |    11 |
+| `crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/cache.rs:7` | source   | S0 10                                                       |    10 |
+| `crates/vize_canon/src/virtual_ts/expressions/statements.rs:15`                | source   | S0 6<br>Croquis analysis 3                                  |     9 |
 
 Additional source/manifest rows are in the TSV: 308 omitted.
 
 #### Top test/dev files
 
-| file                                                                                         | class    | surfaces                                                 | sites |
-| -------------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------- | ----: |
-| `crates/vize_canon/src/virtual_ts/tests.rs:8`                                                | test/dev | S0/carton 37<br>old AST/parser 36<br>Croquis analysis 50 |   123 |
-| `crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs:30`                          | test/dev | S0/carton 7<br>old AST/parser 7<br>Croquis analysis 18   |    32 |
-| `crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs:1`                    | test/dev | S0/carton 8<br>old AST/parser 8<br>Croquis analysis 1    |    17 |
-| `crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_handler_ts7006.rs:41` | test/dev | S0/carton 16                                             |    16 |
-| `crates/vize_canon/src/virtual_ts/strict_template_globals_tests.rs:3`                        | test/dev | S0/carton 8<br>old AST/parser 7<br>Croquis analysis 1    |    16 |
+| file                                                                                         | class    | surfaces                                          | sites |
+| -------------------------------------------------------------------------------------------- | -------- | ------------------------------------------------- | ----: |
+| `crates/vize_canon/src/virtual_ts/tests.rs:8`                                                | test/dev | S0 37<br>old AST/parser 36<br>Croquis analysis 50 |   123 |
+| `crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs:30`                          | test/dev | S0 7<br>old AST/parser 7<br>Croquis analysis 18   |    32 |
+| `crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs:1`                    | test/dev | S0 8<br>old AST/parser 8<br>Croquis analysis 1    |    17 |
+| `crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_handler_ts7006.rs:41` | test/dev | S0 16                                             |    16 |
+| `crates/vize_canon/src/virtual_ts/strict_template_globals_tests.rs:3`                        | test/dev | S0 8<br>old AST/parser 7<br>Croquis analysis 1    |    16 |
 
 Additional test/dev rows are in the TSV: 185 omitted.
 
@@ -169,18 +169,18 @@ Scope: content-mapper command plus Canon content-mapper protocol files. This is 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0/carton        |           8 |               8 |        0 |
+| S0               |           8 |               8 |        0 |
 | Croquis analysis |           1 |               1 |        0 |
 
 #### Top source and manifest files
 
-| file                                                                          | class  | surfaces                          | sites |
-| ----------------------------------------------------------------------------- | ------ | --------------------------------- | ----: |
-| `crates/vize_canon/src/batch/virtual_project/content_mapper.rs:8`             | source | S0/carton 2<br>Croquis analysis 1 |     3 |
-| `crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs:1`       | source | S0/carton 1                       |     1 |
-| `crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs:12` | source | S0/carton 1                       |     1 |
-| `crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs:4`    | source | S0/carton 1                       |     1 |
-| `crates/vize/src/commands/content_mapper.rs:18`                               | source | S0/carton 1                       |     1 |
+| file                                                                          | class  | surfaces                   | sites |
+| ----------------------------------------------------------------------------- | ------ | -------------------------- | ----: |
+| `crates/vize_canon/src/batch/virtual_project/content_mapper.rs:8`             | source | S0 2<br>Croquis analysis 1 |     3 |
+| `crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs:1`       | source | S0 1                       |     1 |
+| `crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs:12` | source | S0 1                       |     1 |
+| `crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs:4`    | source | S0 1                       |     1 |
+| `crates/vize/src/commands/content_mapper.rs:18`                               | source | S0 1                       |     1 |
 
 Additional source/manifest rows are in the TSV: 2 omitted.
 
@@ -192,32 +192,32 @@ _No files in this class._
 
 Scope: fmt command, Glyph formatter crate, and LSP format handler. This is a lexical inventory, not a rollout gate.
 
-| surface   | total sites | source/manifest | test/dev |
-| --------- | ----------: | --------------: | -------: |
-| S0/carton |          38 |              26 |       12 |
-| raw OXC   |          21 |              14 |        7 |
+| surface | total sites | source/manifest | test/dev |
+| ------- | ----------: | --------------: | -------: |
+| S0      |          38 |              26 |       12 |
+| raw OXC |          21 |              14 |        7 |
 
 #### Top source and manifest files
 
-| file                                               | class    | surfaces                 | sites |
-| -------------------------------------------------- | -------- | ------------------------ | ----: |
-| `crates/vize_glyph/Cargo.toml:13`                  | manifest | S0/carton 1<br>raw OXC 5 |     6 |
-| `crates/vize_glyph/src/options.rs:6`               | source   | S0/carton 1<br>raw OXC 4 |     5 |
-| `crates/vize_glyph/src/script/block_identity.rs:4` | source   | S0/carton 1<br>raw OXC 3 |     4 |
-| `crates/vize_glyph/src/script.rs:10`               | source   | S0/carton 1<br>raw OXC 2 |     3 |
-| `crates/vize_glyph/src/lib.rs:53`                  | source   | S0/carton 2              |     2 |
+| file                                               | class    | surfaces          | sites |
+| -------------------------------------------------- | -------- | ----------------- | ----: |
+| `crates/vize_glyph/Cargo.toml:13`                  | manifest | S0 1<br>raw OXC 5 |     6 |
+| `crates/vize_glyph/src/options.rs:6`               | source   | S0 1<br>raw OXC 4 |     5 |
+| `crates/vize_glyph/src/script/block_identity.rs:4` | source   | S0 1<br>raw OXC 3 |     4 |
+| `crates/vize_glyph/src/script.rs:10`               | source   | S0 1<br>raw OXC 2 |     3 |
+| `crates/vize_glyph/src/lib.rs:53`                  | source   | S0 2              |     2 |
 
 Additional source/manifest rows are in the TSV: 20 omitted.
 
 #### Top test/dev files
 
-| file                                                 | class    | surfaces                 | sites |
-| ---------------------------------------------------- | -------- | ------------------------ | ----: |
-| `crates/vize_glyph/src/script.rs:56`                 | test/dev | S0/carton 1<br>raw OXC 7 |     8 |
-| `crates/vize/src/commands/fmt/files.rs:125`          | test/dev | S0/carton 4              |     4 |
-| `crates/vize_glyph/src/formatter/block_indent.rs:47` | test/dev | S0/carton 2              |     2 |
-| `crates/vize_glyph/src/template.rs:28`               | test/dev | S0/carton 2              |     2 |
-| `crates/vize_glyph/src/style/stabilization.rs:226`   | test/dev | S0/carton 1              |     1 |
+| file                                                 | class    | surfaces          | sites |
+| ---------------------------------------------------- | -------- | ----------------- | ----: |
+| `crates/vize_glyph/src/script.rs:56`                 | test/dev | S0 1<br>raw OXC 7 |     8 |
+| `crates/vize/src/commands/fmt/files.rs:125`          | test/dev | S0 4              |     4 |
+| `crates/vize_glyph/src/formatter/block_indent.rs:47` | test/dev | S0 2              |     2 |
+| `crates/vize_glyph/src/template.rs:28`               | test/dev | S0 2              |     2 |
+| `crates/vize_glyph/src/style/stabilization.rs:226`   | test/dev | S0 1              |     1 |
 
 Additional test/dev rows are in the TSV: 2 omitted.
 
@@ -227,32 +227,32 @@ Scope: lsp/ide commands plus Maestro editor/server crate. This is a lexical inve
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0/carton        |         271 |             187 |       84 |
+| S0               |         271 |             187 |       84 |
 | old AST/parser   |          61 |              48 |       13 |
 | Croquis analysis |          54 |              46 |        8 |
 | raw OXC          |          44 |              44 |        0 |
 
 #### Top source and manifest files
 
-| file                                                            | class    | surfaces                                                           | sites |
-| --------------------------------------------------------------- | -------- | ------------------------------------------------------------------ | ----: |
-| `crates/vize_maestro/src/server/state/config.rs:6`              | source   | S0/carton 30                                                       |    30 |
-| `crates/vize_maestro/src/ide/type_service/type_context.rs:229`  | source   | S0/carton 14                                                       |    14 |
-| `crates/vize_maestro/src/ide/corsa_support/html_attribute.rs:2` | source   | S0/carton 10                                                       |    10 |
-| `crates/vize_maestro/Cargo.toml:44`                             | manifest | S0/carton 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |     9 |
-| `crates/vize_maestro/src/ide/hover/declaration_keyword.rs:19`   | source   | S0/carton 1<br>old AST/parser 1<br>Croquis analysis 3<br>raw OXC 3 |     8 |
+| file                                                            | class    | surfaces                                                    | sites |
+| --------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
+| `crates/vize_maestro/src/server/state/config.rs:6`              | source   | S0 30                                                       |    30 |
+| `crates/vize_maestro/src/ide/type_service/type_context.rs:229`  | source   | S0 14                                                       |    14 |
+| `crates/vize_maestro/src/ide/corsa_support/html_attribute.rs:2` | source   | S0 10                                                       |    10 |
+| `crates/vize_maestro/Cargo.toml:44`                             | manifest | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |     9 |
+| `crates/vize_maestro/src/ide/hover/declaration_keyword.rs:19`   | source   | S0 1<br>old AST/parser 1<br>Croquis analysis 3<br>raw OXC 3 |     8 |
 
 Additional source/manifest rows are in the TSV: 115 omitted.
 
 #### Top test/dev files
 
-| file                                                             | class    | surfaces                          | sites |
-| ---------------------------------------------------------------- | -------- | --------------------------------- | ----: |
-| `crates/vize_maestro/src/server/state/virtual_docs.rs:69`        | test/dev | S0/carton 7<br>old AST/parser 2   |     9 |
-| `crates/vize_maestro/src/virtual_code/template_code_tests.rs:12` | test/dev | S0/carton 4<br>old AST/parser 4   |     8 |
-| `crates/vize_maestro/src/ide/inlay_hint.rs:21`                   | test/dev | S0/carton 4<br>Croquis analysis 3 |     7 |
-| `crates/vize_maestro/src/server/state.rs:37`                     | test/dev | S0/carton 7                       |     7 |
-| `crates/vize_maestro/src/server/state/config_tests.rs:1`         | test/dev | S0/carton 5                       |     5 |
+| file                                                             | class    | surfaces                   | sites |
+| ---------------------------------------------------------------- | -------- | -------------------------- | ----: |
+| `crates/vize_maestro/src/server/state/virtual_docs.rs:69`        | test/dev | S0 7<br>old AST/parser 2   |     9 |
+| `crates/vize_maestro/src/virtual_code/template_code_tests.rs:12` | test/dev | S0 4<br>old AST/parser 4   |     8 |
+| `crates/vize_maestro/src/ide/inlay_hint.rs:21`                   | test/dev | S0 4<br>Croquis analysis 3 |     7 |
+| `crates/vize_maestro/src/server/state.rs:37`                     | test/dev | S0 7                       |     7 |
+| `crates/vize_maestro/src/server/state/config_tests.rs:1`         | test/dev | S0 5                       |     5 |
 
 Additional test/dev rows are in the TSV: 50 omitted.
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1,10 +1,10 @@
 consumer_id	consumer	class	file	first_line	surface_id	surface	surface_group	matched_name	name_kind	sites
-compiler	Compiler	test/dev	crates/vize_atelier_core/benches/davinci.rs	17	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/benches/davinci.rs	17	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s1	S1/sinopia	stage	vize_s1	preferred	1
-compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s1	S1	stage	vize_s1	preferred	1
+compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s2	S2	stage	vize_s2	preferred	1
+compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	old_ast	old AST/parser	old	vize_relief	legacy	2
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	old_ast	old AST/parser	old	vize_armature	legacy	2
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	croquis	Croquis analysis	old	vize_croquis	legacy	1
@@ -15,295 +15,295 @@ compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	raw_oxc	raw OX
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/children.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/component_binding.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/context.rs	10	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/context/vnode_factory.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/block.rs	35	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/directives.rs	136	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/helpers.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/inline.rs	36	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/v_once.rs	17	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/emit.rs	7	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression.rs	22	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/comment_rewrite.rs	16	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/generate.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/expression/generate.rs	177	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/helpers.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	s0	S0/carton	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/children.rs	14	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/component_binding.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/context.rs	10	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/context/vnode_factory.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/block.rs	35	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/directives.rs	136	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/helpers.rs	9	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/inline.rs	36	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/v_once.rs	17	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/emit.rs	7	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression.rs	22	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/comment_rewrite.rs	16	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/generate.rs	14	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/expression/generate.rs	177	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/helpers.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs	7	s0	S0/carton	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs	7	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs	7	raw_oxc	raw OXC	raw	oxc_ast	raw	15
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs	7	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate.rs	18	s0	S0/carton	stage	vize_carton	compat	6
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate/collect_helpers.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate/static_vnode.rs	3	s0	S0/carton	stage	vize_carton	compat	4
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers.rs	7	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	s0	S0/carton	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate.rs	18	s0	S0	stage	vize_carton	compat	6
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate/collect_helpers.rs	14	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate/static_vnode.rs	3	s0	S0	stage	vize_carton	compat	4
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers.rs	7	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_allocator	raw	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/node.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/node.rs	11	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag.rs	9	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	raw_oxc	raw OXC	raw	oxc_allocator	raw	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/directives.rs	12	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/events.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/generate.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/directives.rs	12	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/events.rs	11	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/generate.rs	4	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/generate.rs	4	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/scan.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/v_model.rs	29	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/root.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/create_slots.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/detect.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/generate.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/outlet.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/scan.rs	9	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/v_model.rs	29	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/root.rs	11	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/create_slots.rs	11	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/detect.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/generate.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/outlet.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	8
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/slots/tests.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/source_map.rs	35	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	s0	S0/carton	stage	vize_carton	compat	20
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/slots/tests.rs	5	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/source_map.rs	35	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	s0	S0	stage	vize_carton	compat	20
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for.rs	20	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/generate.rs	34	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/helpers.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/v_for/helpers.rs	249	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/item_props.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if.rs	16	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if/branch.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if/props.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for.rs	20	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/generate.rs	34	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/helpers.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/v_for/helpers.rs	249	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/item_props.rs	13	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if.rs	16	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if/branch.rs	10	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if/props.rs	4	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/expr_parse_probe.rs	22	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	s0	S0/carton	stage	vize_carton	compat	4
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	s0	S0	stage	vize_carton	compat	4
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	old_ast	old AST/parser	old	vize_armature	legacy	3
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	3
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/element.rs	3	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/element/directive_expressions.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/element/tests.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/element.rs	3	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/element/directive_expressions.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/element/tests.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/options.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/patterned_template.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural_keys.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/options.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/patterned_template.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural_keys.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/structural/tests.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/tests.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/traverse.rs	8	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	33	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/structural/tests.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/tests.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/traverse.rs	8	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	33	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	4
 compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	33	old_ast	old AST/parser	old	vize_armature	legacy	3
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/retained/tests.rs	20	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/runtime_helpers.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/element.rs	5	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/element.rs	307	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression.rs	16	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/retained/tests.rs	20	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/runtime_helpers.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/element.rs	5	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/element.rs	307	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression.rs	16	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression.rs	16	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector_targets.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector.rs	6	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector.rs	6	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector.rs	6	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector.rs	6	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/inline_handler.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/inline_handler.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/inline_handler.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/inline_handler.rs	207	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/nesting.rs	10	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/parse_checks.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/inline_handler.rs	207	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/nesting.rs	10	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/parse_checks.rs	4	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/parse_checks.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/prefix.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/prefix.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/prefix.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/prefix.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	13
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/prefix.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/prefix.rs	300	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	raw_oxc	raw OXC	raw	oxc_allocator	raw	2
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	22	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	22	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	22	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	22	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	22	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	2
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	22	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/rewrite.rs	15	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/rewrite.rs	15	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/rewrite.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/shape_checks.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/shape_checks.rs	7	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/shape_checks.rs	7	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/shape_checks.rs	7	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/splice.rs	33	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/splice.rs	114	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/tests.rs	17	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/splice.rs	33	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/splice.rs	114	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/tests.rs	17	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	raw_oxc	raw OXC	raw	oxc_codegen	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/hoist_static.rs	16	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/hoist_static/props.rs	3	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/hoist_static/static_type.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/hoist_static/tests.rs	5	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy_filters.rs	23	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy.rs	45	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/hoist_static.rs	16	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/hoist_static/props.rs	3	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/hoist_static/static_type.rs	10	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/hoist_static/tests.rs	5	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy_filters.rs	23	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy.rs	45	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy.rs	45	old_ast	old AST/parser	old	vize_armature	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/legacy/tests.rs	13	s0	S0/carton	stage	vize_carton	compat	8
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/legacy/tests.rs	13	s0	S0	stage	vize_carton	compat	8
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/legacy/tests.rs	13	old_ast	old AST/parser	old	vize_armature	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/text.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_bind.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_for.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_for.rs	276	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_if.rs	69	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_memo.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_memo.rs	101	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_model.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/text.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_bind.rs	5	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_for.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_for.rs	276	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_if.rs	69	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_memo.rs	5	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_memo.rs	101	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_model.rs	5	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_model.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_model.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_model.rs	294	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_on.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_once.rs	7	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_once.rs	59	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/params.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_model.rs	294	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_on.rs	5	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_once.rs	7	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_once.rs	59	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/params.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/params.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/params.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_slot/tests.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/validate.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/test_macros.rs	17	s0	S0/carton	stage	vize_carton	compat	12
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/conditional_named_slots.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform_vue2.rs	24	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_slot/tests.rs	8	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/validate.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/test_macros.rs	17	s0	S0	stage	vize_carton	compat	12
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/conditional_named_slots.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform_vue2.rs	24	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	davinci	Davinci	stage	vize_davinci	preferred	3
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s0	S0/carton	stage	vize_carton	compat	6
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s1	S1/sinopia	stage	vize_s1	preferred	3
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	13
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_sourcemap_prefixed_identifiers.rs	133	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/dynamic_slot_forwarding.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/dynamic_v_model_argument.rs	14	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s0	S0	stage	vize_carton	compat	6
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s1	S1	stage	vize_s1	preferred	3
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	13
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_sourcemap_prefixed_identifiers.rs	133	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/dynamic_slot_forwarding.rs	14	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/dynamic_v_model_argument.rs	14	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_3712.rs	25	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_3712.rs	25	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/legacy_event_modifiers.rs	19	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/legacy_filters.rs	19	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/legacy_template_sugar.rs	19	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/checks.rs	155	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/legacy_event_modifiers.rs	19	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/legacy_filters.rs	19	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/legacy_template_sugar.rs	19	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/checks.rs	155	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	davinci	Davinci	stage	vize_davinci	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s0	S0/carton	stage	vize_carton	compat	4
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s1	S1/sinopia	stage	vize_s1	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	3
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s0	S0/carton	stage	vize_carton	compat	5
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s0	S0	stage	vize_carton	compat	4
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s1	S1	stage	vize_s1	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s2	S2	stage	vize_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	3
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s0	S0	stage	vize_carton	compat	5
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s2	S2	stage	vize_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_owner.rs	9	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_owner.rs	9	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_owner.rs	9	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_owner.rs	9	s2	S2	stage	vize_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_owner.rs	9	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_walk.rs	9	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_walk.rs	9	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_walk.rs	9	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_walk.rs	9	s2	S2	stage	vize_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_walk.rs	9	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	davinci	Davinci	stage	vize_davinci	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/old_lane.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s2	S2	stage	vize_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/old_lane.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	davinci	Davinci	stage	vize_davinci	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots_old.rs	11	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s2	S2	stage	vize_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots_old.rs	11	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	davinci	Davinci	stage	vize_davinci	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s2	S2/disegno	stage	vize_s2	preferred	6
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_check.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_old_help.rs	7	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_old.rs	18	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s2	S2	stage	vize_s2	preferred	6
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_check.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_old_help.rs	7	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_old.rs	18	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_s2.rs	7	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_s2.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_s2.rs	7	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface.rs	54	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/text_old.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/text.rs	47	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/text.rs	47	s2	S2/disegno	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/scoped_slot_shadowing.rs	16	s0	S0/carton	stage	vize_carton	compat	3
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_s2.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_s2.rs	7	s2	S2	stage	vize_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface.rs	54	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/text_old.rs	9	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/text.rs	47	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/text.rs	47	s2	S2	stage	vize_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/scoped_slot_shadowing.rs	16	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/upstream_pure_comment_assertion.rs	53	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/upstream_pure_comment_assertion.rs	53	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/upstream_tuple_type_span_assertion.rs	44	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/upstream_tuple_type_span_assertion.rs	44	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/upstream_tuple_type_span_typescript_strip.rs	36	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_if_spread_order.rs	4	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_once_prop_keys.rs	1	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/upstream_tuple_type_span_typescript_strip.rs	36	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_if_spread_order.rs	4	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_once_prop_keys.rs	1	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_once_prop_keys.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_once_prop_keys.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/benches/davinci.rs	27	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/benches/davinci.rs	27	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	15	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	15	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	15	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	15	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	15	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_dom/Cargo.toml	15	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_dom/src/compile.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_dom/src/compile.rs	13	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_dom/src/compile.rs	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_dom/src/compile/custom_elements.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_dom/src/compile/stage_options.rs	14	s0	S0/carton	stage	vize_s0	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_dom/src/experimental_tests.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_dom/src/namespace.rs	12	s0	S0/carton	stage	vize_s0	preferred	4
-compiler	Compiler	source	crates/vize_atelier_dom/src/options.rs	5	s0	S0/carton	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_dom/src/compile/custom_elements.rs	8	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_dom/src/compile/stage_options.rs	14	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_dom/src/experimental_tests.rs	2	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_dom/src/namespace.rs	12	s0	S0	stage	vize_s0	preferred	4
+compiler	Compiler	source	crates/vize_atelier_dom/src/options.rs	5	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	source	crates/vize_atelier_dom/src/options.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_dom/src/steps/v_html.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/src/steps/v_html.rs	33	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_dom/src/steps/v_model.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/src/steps/v_model.rs	191	s0	S0/carton	stage	vize_s0	preferred	2
-compiler	Compiler	source	crates/vize_atelier_dom/src/steps/v_on.rs	6	s0	S0/carton	stage	vize_s0	preferred	3
-compiler	Compiler	test/dev	crates/vize_atelier_dom/src/steps/v_on.rs	223	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_dom/src/steps/v_show.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/src/steps/v_show.rs	36	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_dom/src/steps/v_text.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/src/steps/v_text.rs	40	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/src/tests.rs	8	s0	S0/carton	stage	vize_s0	preferred	10
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/branch_keys.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/conditional_v_model_quirks.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_expr_reparse_floor.rs	20	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_dom.rs	22	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_dynamic_von_keys.rs	13	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_filters.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s0	S0/carton	stage	vize_s0	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_teardown_without_stack_guard.rs	25	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_dom/src/steps/v_html.rs	6	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/src/steps/v_html.rs	33	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_dom/src/steps/v_model.rs	6	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/src/steps/v_model.rs	191	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_dom/src/steps/v_on.rs	6	s0	S0	stage	vize_s0	preferred	3
+compiler	Compiler	test/dev	crates/vize_atelier_dom/src/steps/v_on.rs	223	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_dom/src/steps/v_show.rs	6	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/src/steps/v_show.rs	36	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_dom/src/steps/v_text.rs	6	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/src/steps/v_text.rs	40	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/src/tests.rs	8	s0	S0	stage	vize_s0	preferred	10
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/branch_keys.rs	3	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/conditional_v_model_quirks.rs	5	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_expr_reparse_floor.rs	20	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_dom.rs	22	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_dynamic_von_keys.rs	13	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_filters.rs	12	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_teardown_without_stack_guard.rs	25	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_walk_baseline.rs	25	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_walk_baseline.rs	25	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/dom_snapshot.rs	11	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/dynamic_template_ref.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/element_nesting_depth.rs	26	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/expression_nesting_guard.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/invalid_expression_diagnostics.rs	18	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/setup_component_unref.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/slot_outlet_hoist.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/support/mod.rs	11	s0	S0/carton	stage	vize_s0	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/support/mod.rs	11	s1_to_s2	S1->S2/ricalco	stage	vize_s1_to_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/table_control_flow.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/template_syntax_quirks_recovery.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/benches/jsx_compile.rs	29	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_walk_baseline.rs	25	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/dom_snapshot.rs	11	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/dynamic_template_ref.rs	4	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/element_nesting_depth.rs	26	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/expression_nesting_guard.rs	2	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/invalid_expression_diagnostics.rs	18	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/setup_component_unref.rs	3	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/slot_outlet_hoist.rs	2	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/support/mod.rs	11	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/support/mod.rs	11	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/table_control_flow.rs	3	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/template_syntax_quirks_recovery.rs	3	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/benches/jsx_compile.rs	29	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/benches/jsx_compile.rs	29	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-compiler	Compiler	manifest	crates/vize_atelier_jsx/Cargo.toml	13	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	manifest	crates/vize_atelier_jsx/Cargo.toml	13	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	manifest	crates/vize_atelier_jsx/Cargo.toml	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	manifest	crates/vize_atelier_jsx/Cargo.toml	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	manifest	crates/vize_atelier_jsx/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
@@ -314,140 +314,140 @@ compiler	Compiler	manifest	crates/vize_atelier_jsx/Cargo.toml	13	raw_oxc	raw OXC
 compiler	Compiler	manifest	crates/vize_atelier_jsx/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/analyze.rs	10	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/analyze.rs	10	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/src/compile.rs	13	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/src/compile.rs	13	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/src/compile.rs	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/compile/babel.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/compile/babel.rs	1	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/compile/babel.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/compile/preamble.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/compile/render_exports.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/diagnostics.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/compile/preamble.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/compile/render_exports.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/diagnostics.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/diagnostics.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/finder.rs	17	s0	S0/carton	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_jsx/src/finder.rs	17	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	source	crates/vize_atelier_jsx/src/finder.rs	17	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/finder.rs	17	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/finder.rs	17	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/finder/signature.rs	10	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/finder/signature.rs	10	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/finder/signature.rs	10	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/forwarded_slots.rs	11	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lib.rs	55	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lib.rs	55	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lib.rs	55	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lib.rs	55	croquis	Croquis analysis	old	vize_croquis	legacy	2
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lib.rs	55	raw_oxc	raw OXC	raw	oxc_allocator	raw	2
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lib.rs	55	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower.rs	26	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower.rs	26	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower.rs	26	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower.rs	26	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower.rs	26	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/attr.rs	14	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/attr.rs	14	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/attr.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	2
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/attr.rs	14	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/attr/compat.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/attr/compat.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/attr/compat.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/attr/compat.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/babel_slot.rs	18	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/babel_slot.rs	18	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/babel_slot.rs	18	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/babel_slot.rs	18	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/child.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/child.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/child.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	2
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/child.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/control_flow.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	2
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/control_flow.rs	25	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/element.rs	3	s0	S0/carton	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/element.rs	3	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/element.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/element.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/expr.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/expr.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/expr.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/expr.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/name.rs	3	s0	S0/carton	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/name.rs	3	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/name.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/slot.rs	16	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/slot.rs	16	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/slot.rs	16	old_ast	old AST/parser	old	vize_relief	legacy	2
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/slot.rs	16	raw_oxc	raw OXC	raw	oxc_ast	raw	4
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/style.rs	26	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/style.rs	26	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/style.rs	26	raw_oxc	raw OXC	raw	oxc_ast	raw	2
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/text.rs	9	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/text.rs	9	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/text.rs	9	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/text.rs	9	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/v_custom.rs	8	old_ast	old AST/parser	old	vize_relief	legacy	2
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/v_custom.rs	8	raw_oxc	raw OXC	raw	oxc_ast	raw	2
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/v_model.rs	13	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/v_model.rs	13	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/v_model.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	2
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/v_model.rs	13	raw_oxc	raw OXC	raw	oxc_ast	raw	5
-compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/v_models.rs	45	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/v_models.rs	45	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/v_models.rs	45	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/v_models.rs	45	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/v_slots.rs	77	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/lower/v_slots.rs	77	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/parse.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/parse.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/parse.rs	7	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/parse.rs	7	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/parse.rs	7	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/scoped.rs	19	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/scoped.rs	19	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/span.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/ssr.rs	10	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/ssr.rs	10	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/ssr.rs	10	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/vapor.rs	18	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/vapor.rs	18	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/vapor.rs	18	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_jsx/src/vdom.rs	21	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_jsx/src/vdom.rs	21	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_jsx/src/vdom.rs	21	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/adversarial_snapshots.rs	16	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/adversarial_snapshots.rs	16	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/adversarial_snapshots.rs	16	old_ast	old AST/parser	old	vize_relief	legacy	2
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/analysis.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/analysis.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/analysis.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/analysis.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/analysis.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/attributes.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_compat/mod.rs	19	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_is_custom_element.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_merge_props.rs	3	s0	S0/carton	stage	vize_carton	compat	4
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/attributes.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_compat/mod.rs	19	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_is_custom_element.rs	9	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_merge_props.rs	3	s0	S0	stage	vize_carton	compat	4
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_merge_props.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_object_slots.rs	12	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_spread_child.rs	3	s0	S0/carton	stage	vize_carton	compat	3
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_object_slots.rs	12	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_spread_child.rs	3	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_spread_child.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_tag_classification.rs	4	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_v_slots.rs	18	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/children.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_tag_classification.rs	4	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/babel_v_slots.rs	18	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/children.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/children.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/common/mod.rs	12	s0	S0/carton	stage	vize_carton	compat	5
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/common/mod.rs	12	s0	S0	stage	vize_carton	compat	5
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/common/mod.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	5
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/compat_mode.rs	10	s0	S0/carton	stage	vize_carton	compat	6
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/compat_mode.rs	10	s0	S0	stage	vize_carton	compat	6
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/compat_mode.rs	10	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/compile.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/components.rs	9	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/compile.rs	8	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/components.rs	9	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/components.rs	9	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/diagnostics.rs	7	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/diagnostics.rs	7	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/diagnostics.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/directives.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/directives.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/directives.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/ecosystem_smoke.rs	33	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/edge_cases.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/ecosystem_smoke.rs	33	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/edge_cases.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/edge_cases.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/elements.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/elements.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/elements.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/events.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/fragments.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/modes.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/module_code.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/module_props.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/parity_tsx.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/parity_vapor.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/pragma.rs	3	s0	S0/carton	stage	vize_carton	compat	9
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/events.rs	13	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/fragments.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/modes.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/module_code.rs	8	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/module_props.rs	10	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/parity_tsx.rs	10	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/parity_vapor.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/pragma.rs	3	s0	S0	stage	vize_carton	compat	9
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/pragma.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/slots.rs	13	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/slots.rs	13	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/slots.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	2
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/ssr.rs	7	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/style.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/tsx.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/ssr.rs	7	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/style.rs	8	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/tsx.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/tsx.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	2
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/v_model_argument.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/v_model_target.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/v_models.rs	18	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/v_slots_forwarding.rs	39	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/v_slots.rs	21	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/vapor_ssr.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/vapor.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/vdom.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/v_model_argument.rs	13	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/v_model_target.rs	13	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/v_models.rs	18	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/v_slots_forwarding.rs	39	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/v_slots.rs	21	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/vapor_ssr.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/vapor.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/vdom.rs	11	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	raw_oxc	raw OXC	raw	oxc_ast	raw	1
@@ -456,434 +456,434 @@ compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	raw_oxc	raw OXC
 compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite/predicates.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite/replacements.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/assets.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/blocks.rs	3	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/css.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/scope.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script.rs	38	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/artifacts.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite/replacements.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/assets.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/blocks.rs	3	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/css.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/scope.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script.rs	38	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/artifacts.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/artifacts.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/artifacts.rs	7	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/artifacts.rs	7	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/artifacts.rs	7	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs	7	s0	S0/carton	stage	vize_carton	compat	8
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs	7	s0	S0	stage	vize_carton	compat	8
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/helpers.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/helpers.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/helpers.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/helpers.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	5
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/helpers.rs	6	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/helpers.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/helpers.rs	6	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/imports.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/imports.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/imports.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/imports.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/imports.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/model.rs	3	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/module_scope.rs	3	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/import_utils.rs	6	s0	S0/carton	stage	vize_carton	compat	8
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/model.rs	3	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/function_mode/module_scope.rs	3	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/import_utils.rs	6	s0	S0	stage	vize_carton	compat	8
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/import_utils.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/import_utils.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/import_utils.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs	19	s0	S0/carton	stage	vize_carton	compat	4
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs	19	s0	S0	stage	vize_carton	compat	4
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs	19	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/await_transform.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/await_transform.rs	1	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/await_transform.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/await_transform.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/await_transform.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs	3	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/component_output.rs	12	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/hoist.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs	3	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/component_output.rs	12	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/hoist.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/hoist.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/hoist.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/hoist.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/model.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/parser.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/model.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/parser.rs	1	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/parser.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/preamble.rs	1	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/render.rs	1	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/setup_emit.rs	7	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/inline/const_hoist_tests.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/inline/define_model_tests.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/helpers.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/inline/static_enum_tests.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/inline/tests.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/type_handling.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/inline/type_handling.rs	28	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/lazy_hydration.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/preamble.rs	1	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/render.rs	1	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/compiler/setup_emit.rs	7	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/inline/const_hoist_tests.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/inline/define_model_tests.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/helpers.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/inline/static_enum_tests.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/inline/tests.rs	8	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/inline/type_handling.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/inline/type_handling.rs	28	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/lazy_hydration.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/lazy_hydration.rs	7	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/lazy_hydration.rs	7	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/lazy_hydration.rs	7	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/macros.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve.rs	8	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve.rs	8	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve.rs	8	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve.rs	8	raw_oxc	raw OXC	raw	oxc_ast	raw	4
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve.rs	8	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve/indexed_access.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve/indexed_access.rs	1	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve/indexed_access.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve/indexed_access.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve/indexed_access.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve/indexed_access.rs	189	s0	S0/carton	stage	vize_carton	compat	5
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve/runtime_type_combine.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/defaults.rs	3	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve/indexed_access.rs	189	s0	S0	stage	vize_carton	compat	5
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/ast_resolve/runtime_type_combine.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/defaults.rs	3	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/defaults.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/defaults.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/defaults.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/emits.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/emits.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/emits.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/emits.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/emits.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/runtime_type.rs	3	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/props/tests.rs	4	s0	S0/carton	stage	vize_carton	compat	15
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/text_resolve.rs	7	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/types.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/validation.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/runtime_type.rs	3	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/props/tests.rs	4	s0	S0	stage	vize_carton	compat	15
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/text_resolve.rs	7	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/types.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/validation.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/validation.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/validation.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	3
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/validation.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope.rs	3	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/props/validation/macro_scope.rs	3	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/runtime_bindings.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/runtime_bindings.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/runtime_bindings.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/statement_sections.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/statement_sections.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/statement_sections.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/statement_sections.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/statement_sections.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	3
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/statement_sections.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/tests.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/typescript.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script/tests.rs	13	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/typescript.rs	5	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/typescript.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/typescript.rs	5	raw_oxc	raw OXC	raw	oxc_codegen	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/typescript.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/typescript.rs	5	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_template.rs	21	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_template.rs	21	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_template.rs	21	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template/extraction.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template/string_tracking.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_template/tests.rs	371	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template/vapor.rs	8	s0	S0/carton	stage	vize_carton	compat	5
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_tests.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile.rs	59	s0	S0/carton	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template/extraction.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template/string_tracking.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_template/tests.rs	371	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template/vapor.rs	8	s0	S0	stage	vize_carton	compat	5
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_tests.rs	8	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile.rs	59	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile.rs	59	croquis	Croquis analysis	old	vize_croquis	legacy	2
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile.rs	59	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/diagnostics.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/empty_component.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/helpers.rs	3	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/diagnostics.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/empty_component.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/helpers.rs	3	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/helpers.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/helpers.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/helpers.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/helpers.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/normal_script.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/normal_script.rs	4	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/normal_script.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/normal_script.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	3
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/normal_script.rs	4	raw_oxc	raw OXC	raw	oxc_codegen	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/normal_script.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/normal_script.rs	4	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/output_module.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/styles.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/template_only.rs	7	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile/tests.rs	12	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile/tests/define_props_regressions.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/croquis.rs	13	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/output_module.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/styles.rs	8	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/template_only.rs	7	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile/tests.rs	12	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile/tests/define_props_regressions.rs	8	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/croquis.rs	13	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/croquis.rs	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/croquis/drawer.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/croquis/drawer.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/croquis/drawer.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/css.rs	13	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/css.rs	32	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_sfc/src/css/parser.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/css/parser/engine_boundary.rs	37	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/css/parser/engine_boundary/value_guard.rs	23	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/css/scoped.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/css/tests.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/css.rs	13	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/css.rs	32	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_sfc/src/css/parser.rs	14	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/css/parser/engine_boundary.rs	37	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/css/parser/engine_boundary/value_guard.rs	23	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/css/scoped.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/css/tests.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/css/transform.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/lib.rs	69	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/module_shape.rs	43	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/module_shape.rs	43	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/module_shape.rs	43	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/module_shape.rs	43	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/module_shape.rs	43	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/parse_tests.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/rewrite_default.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/parse_tests.rs	8	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/rewrite_default.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/rewrite_default.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/rewrite_default.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	25
 compiler	Compiler	source	crates/vize_atelier_sfc/src/rewrite_default.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script.rs	60	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script.rs	60	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script.rs	60	croquis	Croquis analysis	old	vize_croquis	legacy	5
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script.rs	60	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script.rs	60	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script.rs	60	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/analyze_script_bindings.rs	9	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/analyze_script_bindings.rs	9	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/analyze_script_bindings.rs	9	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/analyze_script_bindings.rs	9	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/analyze_script_bindings.rs	9	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context.rs	14	s0	S0/carton	stage	vize_carton	compat	5
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context.rs	14	s0	S0	stage	vize_carton	compat	5
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context.rs	14	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/context.rs	194	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/external_types.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/context.rs	194	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/external_types.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/external_types.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/external_types.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	3
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/external_types.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/external_types/resolution/exports_patterns.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/helpers.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/external_types/resolution.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/external_types/resolution/exports_patterns.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/helpers.rs	5	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/helpers.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/helpers.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/parse.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/parse.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/parse.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/parse.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	8
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/parse.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/props.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/props.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/context/props.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_emits.rs	8	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_emits.rs	8	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_emits.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_emits.rs	8	raw_oxc	raw OXC	raw	oxc_ast	raw	7
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/define_emits.rs	344	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_expose.rs	11	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/define_emits.rs	344	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_expose.rs	11	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_expose.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_model_metadata.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_model_metadata.rs	1	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_model_metadata.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_model_metadata.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_model_metadata.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_model_metadata.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_model.rs	11	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_model.rs	11	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_model.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_options.rs	11	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_options.rs	11	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_options.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/define_props_destructure.rs	15	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props_destructure/collector.rs	6	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/define_props_destructure.rs	15	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props_destructure/collector.rs	6	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props_destructure/collector.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	15
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props_destructure/helpers.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props_destructure/process.rs	6	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props_destructure/helpers.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props_destructure/process.rs	6	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props_destructure/process.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	5
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/define_props_destructure/tests.rs	9	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props_destructure/transform.rs	10	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/define_props_destructure/tests.rs	9	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props_destructure/transform.rs	10	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props_destructure/transform.rs	10	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props_destructure/transform.rs	10	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props.rs	11	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props.rs	11	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_props.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_slots.rs	11	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_slots.rs	11	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/define_slots.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/import_usage_check.rs	8	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/import_usage_check.rs	8	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/import_usage_check.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/import_usage_check.rs	8	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/import_usage_check.rs	8	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/import_usage_check.rs	8	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/import_usage_check.rs	8	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/import_usage_check.rs	417	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/import_usage_check.rs	417	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/static_expression.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/static_expression.rs	69	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/static_expression.rs	69	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/static_expression.rs	69	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/type_resolution.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/script/utils.rs	8	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/type_resolution.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/script/utils.rs	8	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/script/utils.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/utils.rs	302	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/snapshot_tests.rs	15	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/source_map.rs	52	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/style.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/template_tests.rs	9	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_sfc/src/types.rs	6	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/script/utils.rs	302	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/snapshot_tests.rs	15	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/source_map.rs	52	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/style.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/template_tests.rs	9	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_sfc/src/types.rs	6	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/types.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/hmr.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/js_string.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/middleware.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/precompile.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/request.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/resolver.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/style.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/vite_plugin/tests/precompile.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/transform.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/css.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/hmr.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/js_string.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/middleware.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/precompile.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/request.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/resolver.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/style.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/vite_plugin/tests/precompile.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/transform.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/transform.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/transform.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/transform.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/transform.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/allocation_budget.rs	30	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/component_spread_props.rs	10	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/allocation_budget.rs	30	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/component_spread_props.rs	10	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/component_tag_binding.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/component_tag_binding.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/css_engine_panic_boundary.rs	76	s0	S0/carton	stage	vize_carton	compat	5
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/css_nesting_guard.rs	11	s0	S0/carton	stage	vize_carton	compat	6
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/davinci_arena_pool.rs	27	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/css_engine_panic_boundary.rs	76	s0	S0	stage	vize_carton	compat	5
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/css_nesting_guard.rs	11	s0	S0	stage	vize_carton	compat	6
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/davinci_arena_pool.rs	27	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/dynamic_template_ref.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/dynamic_template_ref.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/emitter_javascript_output.rs	19	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/imported_pick_intersection_props.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/emitter_javascript_output.rs	19	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/imported_pick_intersection_props.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/imported_prop_defaults.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/imported_prop_defaults.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/imported_type_cache.rs	8	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/imported_type_cache.rs	8	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/module_mode_setup_bindings.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/module_mode_setup_bindings.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/parse_facade.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/workspace_prop_types.rs	6	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/benches/davinci.rs	22	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/workspace_prop_types.rs	6	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/benches/davinci.rs	22	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	old_ast	old AST/parser	old	vize_armature	legacy	2
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/component_binding.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element.rs	17	s0	S0/carton	stage	vize_s0	preferred	2
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element/component_props.rs	226	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element/plain.rs	61	s0	S0/carton	stage	vize_s0	preferred	2
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element/props.rs	4	s0	S0/carton	stage	vize_s0	preferred	4
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/helpers.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/helpers/destructure.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/codegen/helpers/destructure.rs	132	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/scope_prefix.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/compile.rs	8	s0	S0/carton	stage	vize_s0	preferred	5
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/lib.rs	51	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/options.rs	5	s0	S0/carton	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen.rs	13	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/component_binding.rs	3	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element.rs	17	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element/component_props.rs	226	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element/plain.rs	61	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/element/props.rs	4	s0	S0	stage	vize_s0	preferred	4
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/helpers.rs	12	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/helpers/destructure.rs	4	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/codegen/helpers/destructure.rs	132	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/codegen/scope_prefix.rs	3	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/compile.rs	8	s0	S0	stage	vize_s0	preferred	5
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/lib.rs	51	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/options.rs	5	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	source	crates/vize_atelier_ssr/src/options.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_ssr/src/stage_options.rs	14	s0	S0/carton	stage	vize_s0	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/steps.rs	93	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/component_spread_props.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/davinci_expr_reparse_floor.rs	20	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_ssr/src/stage_options.rs	14	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/src/steps.rs	93	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/component_spread_props.rs	10	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/davinci_expr_reparse_floor.rs	20	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/davinci_walk_baseline.rs	25	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/davinci_walk_baseline.rs	25	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/event_props.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/setup_component_parity.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/ssr_snapshot.rs	9	s0	S0/carton	stage	vize_s0	preferred	4
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/benches/davinci.rs	30	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/davinci_walk_baseline.rs	25	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/event_props.rs	4	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/setup_component_parity.rs	3	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_ssr/tests/ssr_snapshot.rs	9	s0	S0	stage	vize_s0	preferred	4
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/benches/davinci.rs	30	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_vapor/Cargo.toml	12	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/compile.rs	14	s0	S0/carton	stage	vize_carton	compat	8
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate.rs	16	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/context.rs	12	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/compile.rs	14	s0	S0	stage	vize_carton	compat	8
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate.rs	16	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/context.rs	12	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/context.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/context/complex_expression.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/context/scopes.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/destructure.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/generate/destructure.rs	262	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression_retained.rs	17	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/context/complex_expression.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/context/scopes.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/destructure.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/generate/destructure.rs	262	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression_retained.rs	17	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression_retained.rs	17	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression_retained.rs	17	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression_retained.rs	17	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression.rs	1	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression.rs	1	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/expression.rs	1	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/helpers.rs	4	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations.rs	18	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/component_props.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/component_slots.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/component.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/directives.rs	3	s0	S0/carton	stage	vize_carton	compat	7
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/dom.rs	2	s0	S0/carton	stage	vize_carton	compat	4
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/events.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/for_loop.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/generate/operations/for_loop.rs	209	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/if_block.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/insertion.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/refs.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/slots.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/setup.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/generate/tests.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/block.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/component.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/directive.rs	6	s0	S0/carton	stage	vize_carton	compat	9
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/event.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/generators/event.rs	108	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/for_node.rs	5	s0	S0/carton	stage	vize_carton	compat	4
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/generate_text.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/if_node.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/prop.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/ir.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/ir/constructors.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/lower.rs	11	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/lower.rs	179	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/context.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/control.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/directive.rs	5	s0	S0/carton	stage	vize_carton	compat	4
-compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/element.rs	7	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/element/component/slots.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/element/deferred.rs	4	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/element/template.rs	8	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/text.rs	5	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/element.rs	5	s0	S0/carton	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/slot.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/slot.rs	246	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/text.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/text.rs	131	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/v_bind.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/v_bind.rs	156	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/v_for.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/v_for.rs	150	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/v_if.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/v_if.rs	182	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/v_model.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/v_model.rs	117	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/v_on.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/v_on.rs	162	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/v_show.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_davinci_differential.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_dotted_slots.rs	8	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/helpers.rs	4	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations.rs	18	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/component_props.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/component_slots.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/component.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/directives.rs	3	s0	S0	stage	vize_carton	compat	7
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/dom.rs	2	s0	S0	stage	vize_carton	compat	4
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/events.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/for_loop.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/generate/operations/for_loop.rs	209	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/if_block.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/insertion.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/refs.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/operations/slots.rs	2	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generate/setup.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/generate/tests.rs	9	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/block.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/component.rs	5	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/directive.rs	6	s0	S0	stage	vize_carton	compat	9
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/event.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/generators/event.rs	108	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/for_node.rs	5	s0	S0	stage	vize_carton	compat	4
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/generate_text.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/if_node.rs	5	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_vapor/src/generators/prop.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/ir.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/ir/constructors.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/lower.rs	11	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/lower.rs	179	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/context.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/control.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/directive.rs	5	s0	S0	stage	vize_carton	compat	4
+compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/element.rs	7	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/element/component/slots.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/element/deferred.rs	4	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/element/template.rs	8	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_vapor/src/lower/text.rs	5	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/element.rs	5	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/slot.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/slot.rs	246	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/text.rs	5	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/text.rs	131	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/v_bind.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/v_bind.rs	156	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/v_for.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/v_for.rs	150	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/v_if.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/v_if.rs	182	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/v_model.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/v_model.rs	117	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/v_on.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/steps/v_on.rs	162	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/steps/v_show.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_davinci_differential.rs	14	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_dotted_slots.rs	8	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_dotted_slots.rs	8	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_dotted_slots.rs	8	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_setup_components.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_sibling_navigation.rs	21	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_slot_outlets.rs	8	s0	S0/carton	stage	vize_carton	compat	4
+compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_setup_components.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_sibling_navigation.rs	21	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_slot_outlets.rs	8	s0	S0	stage	vize_carton	compat	4
 compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_slot_outlets.rs	8	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_slot_outlets.rs	8	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_template_children.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_valueless_attr.rs	4	s0	S0/carton	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_template_children.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_valueless_attr.rs	4	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_valueless_attr.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_vapor/src/tests_valueless_attr.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/tests.rs	4	s0	S0/carton	stage	vize_carton	compat	42
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/tests.rs	4	s0	S0	stage	vize_carton	compat	42
 compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/tests.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_vapor/src/tests.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/tests/davinci_expr_reparse_floor.rs	20	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/tests/davinci_teardown_without_stack_guard.rs	68	s0	S0/carton	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/tests/davinci_expr_reparse_floor.rs	20	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/tests/davinci_teardown_without_stack_guard.rs	68	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_vapor/tests/davinci_walk_baseline.rs	25	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_vapor/tests/davinci_walk_baseline.rs	25	s0	S0/carton	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize/src/commands/build/config.rs	16	s0	S0/carton	stage	vize_s0	preferred	2
-compiler	Compiler	source	crates/vize/src/commands/build/runner.rs	22	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize/src/commands/build/runner/cache.rs	11	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/cache/tests.rs	11	s0	S0/carton	stage	vize_s0	preferred	2
-compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/collect/tests.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize/src/commands/build/runner/compile_stats.rs	16	s0	S0/carton	stage	vize_s0	preferred	6
-compiler	Compiler	source	crates/vize/src/commands/build/runner/compile.rs	41	s0	S0/carton	stage	vize_s0	preferred	5
-compiler	Compiler	source	crates/vize/src/commands/build/runner/declarations.rs	65	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize/src/commands/build/runner/output.rs	11	s0	S0/carton	stage	vize_s0	preferred	2
-compiler	Compiler	source	crates/vize/src/commands/build/runner/output/plan.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/output/tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize/src/commands/build/runner/profile_facts.rs	6	s0	S0/carton	stage	vize_s0	preferred	3
-compiler	Compiler	source	crates/vize/src/commands/build/runner/settings.rs	5	s0	S0/carton	stage	vize_s0	preferred	3
-linter	Linter	test/dev	crates/vize_patina/benches/davinci_markup.rs	16	s0	S0/carton	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_vapor/tests/davinci_walk_baseline.rs	25	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize/src/commands/build/config.rs	16	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize/src/commands/build/runner.rs	22	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize/src/commands/build/runner/cache.rs	11	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/cache/tests.rs	11	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/collect/tests.rs	12	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize/src/commands/build/runner/compile_stats.rs	16	s0	S0	stage	vize_s0	preferred	6
+compiler	Compiler	source	crates/vize/src/commands/build/runner/compile.rs	41	s0	S0	stage	vize_s0	preferred	5
+compiler	Compiler	source	crates/vize/src/commands/build/runner/declarations.rs	65	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize/src/commands/build/runner/output.rs	11	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize/src/commands/build/runner/output/plan.rs	3	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize/src/commands/build/runner/output/tests.rs	5	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize/src/commands/build/runner/profile_facts.rs	6	s0	S0	stage	vize_s0	preferred	3
+compiler	Compiler	source	crates/vize/src/commands/build/runner/settings.rs	5	s0	S0	stage	vize_s0	preferred	3
+linter	Linter	test/dev	crates/vize_patina/benches/davinci_markup.rs	16	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/benches/davinci_markup.rs	16	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
-linter	Linter	test/dev	crates/vize_patina/benches/lint_bench.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/benches/markup_ir_bench.rs	19	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	test/dev	crates/vize_patina/benches/lint_bench.rs	9	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/benches/markup_ir_bench.rs	19	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	test/dev	crates/vize_patina/benches/markup_ir_bench.rs	19	old_ast	old AST/parser	old	vize_armature	legacy	1
-linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
@@ -893,105 +893,105 @@ linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_
 linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
 linter	Linter	manifest	crates/vize_patina/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/context.rs	21	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/context.rs	21	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/context.rs	21	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/context/directives.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/context/eslint_directive.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/context/helpers.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/context/directives.rs	3	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/context/eslint_directive.rs	3	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/context/helpers.rs	9	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/context/helpers.rs	9	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/context/reporting.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/context/sfc_directives.rs	7	s0	S0/carton	stage	vize_s0	preferred	2
-linter	Linter	source	crates/vize_patina/src/context/state.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/diagnostic.rs	18	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/diagnostic/compact_help.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/diagnostic/formatting.rs	6	s0	S0/carton	stage	vize_s0	preferred	2
-linter	Linter	source	crates/vize_patina/src/diagnostic/types.rs	12	s0	S0/carton	stage	vize_s0	preferred	3
-linter	Linter	source	crates/vize_patina/src/ir.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/lib.rs	135	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/category_config.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/compatibility.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/config.rs	20	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/corsa_session.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/corsa_session/errors.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/corsa_session/paths.rs	5	s0	S0/carton	stage	vize_s0	preferred	2
-linter	Linter	test/dev	crates/vize_patina/src/linter/corsa_session/paths.rs	203	s0	S0/carton	stage	vize_s0	preferred	2
-linter	Linter	source	crates/vize_patina/src/linter/corsa_session/probe.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/corsa_session/session.rs	16	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/corsa_session/session/tests.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/css_rules.rs	20	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	s0	S0/carton	stage	vize_s0	preferred	5
+linter	Linter	source	crates/vize_patina/src/context/reporting.rs	5	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/context/sfc_directives.rs	7	s0	S0	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/context/state.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/diagnostic.rs	18	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/diagnostic/compact_help.rs	3	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/diagnostic/formatting.rs	6	s0	S0	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/diagnostic/types.rs	12	s0	S0	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/ir.rs	8	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/lib.rs	135	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/category_config.rs	8	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/compatibility.rs	2	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/config.rs	20	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/corsa_session.rs	3	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/corsa_session/errors.rs	2	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/corsa_session/paths.rs	5	s0	S0	stage	vize_s0	preferred	2
+linter	Linter	test/dev	crates/vize_patina/src/linter/corsa_session/paths.rs	203	s0	S0	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/linter/corsa_session/probe.rs	8	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/corsa_session/session.rs	16	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/corsa_session/session/tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/css_rules.rs	20	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	s0	S0	stage	vize_s0	preferred	5
 linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	raw_oxc	raw OXC	raw	oxc_allocator	raw	4
 linter	Linter	source	crates/vize_patina/src/linter/engine.rs	25	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/linter/engine/parse_diagnostics.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/engine/parse_diagnostics.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/engine/parse_diagnostics.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/linter/engine/script.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/engine/template_extract.rs	4	s0	S0/carton	stage	vize_s0	preferred	2
-linter	Linter	test/dev	crates/vize_patina/src/linter/engine/template_extract.rs	113	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/native_type_aware.rs	173	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/driver.rs	17	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/linter/engine/script.rs	1	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/engine/template_extract.rs	4	s0	S0	stage	vize_s0	preferred	2
+linter	Linter	test/dev	crates/vize_patina/src/linter/engine/template_extract.rs	113	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware.rs	10	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/native_type_aware.rs	173	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/driver.rs	17	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/driver.rs	17	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/driver.rs	17	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/markers.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/markers.rs	2	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/markers.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/parsing.rs	1	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/reactivity_loss.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/reactivity_loss.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/reactivity_loss.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/rule_queries.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/script_options.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs	1	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs	7	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs	7	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-linter	Linter	source	crates/vize_patina/src/linter/restricted_rules.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/linter/script_rules.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/restricted_rules.rs	12	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/script_rules.rs	3	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/script_rules.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/linter/script_rules.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/script_rules.rs	150	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/script_rules.rs	150	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/linter/script_rules.rs	150	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/linter/script_rules/template_ast.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/linter/script_rules/template_ast.rs	14	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/linter/script_rules/template_ast.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/linter/script_rules/template_ast.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	1
-linter	Linter	source	crates/vize_patina/src/linter/severity.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/tests.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/tests/jsx_streaming.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/tests/nuxt.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/linter/tests/recovered_parse_analysis.rs	11	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/markup.rs	49	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/linter/severity.rs	3	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/tests.rs	3	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/tests/jsx_streaming.rs	13	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/tests/nuxt.rs	2	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/linter/tests/recovered_parse_analysis.rs	11	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/markup.rs	49	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	18	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	18	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	18	old_ast	old AST/parser	old	vize_armature	legacy	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	18	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
-linter	Linter	test/dev	crates/vize_patina/src/output.rs	20	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/output/agent.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/output/html.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/output/json.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/output/markdown.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/output/plain.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/output/shared.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/output/stylish.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/output/tests.rs	4	s0	S0/carton	stage	vize_s0	preferred	23
-linter	Linter	source	crates/vize_patina/src/output/text.rs	12	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	test/dev	crates/vize_patina/src/output.rs	20	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/agent.rs	5	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/html.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/json.rs	7	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/markdown.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/plain.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/shared.rs	5	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/output/stylish.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/output/tests.rs	4	s0	S0	stage	vize_s0	preferred	23
+linter	Linter	source	crates/vize_patina/src/output/text.rs	12	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rule.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/alt_text.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/anchor_has_content.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	2
@@ -1002,7 +1002,7 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/aria_unsupported_elements
 linter	Linter	source	crates/vize_patina/src/rules/a11y/click_events_have_key_events.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/form_control_has_label.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/heading_has_content.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/iframe_has_title.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/a11y/img_alt.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	4
@@ -1016,16 +1016,16 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/no_autofocus.rs	15	old_as
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_distracting_elements.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_i_for_icon.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_redundant_roles.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_role_presentation_on_focusable.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_static_element_interactions.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/role_has_required_aria_props.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/tabindex_no_positive.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/css.rs	44	s0	S0/carton	stage	vize_s0	preferred	3
-linter	Linter	source	crates/vize_patina/src/rules/css/prefer_logical_properties.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/ecosystem/i18n_no_missing_key.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/css.rs	44	s0	S0	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/rules/css/prefer_logical_properties.rs	9	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/ecosystem/i18n_no_missing_key.rs	15	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/ecosystem/nuxt_prefer_nuxt_link.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/ecosystem/router_link_require_to.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/ecosystem/void_link_require_href.rs	11	old_ast	old AST/parser	old	vize_relief	legacy	1
@@ -1034,43 +1034,43 @@ linter	Linter	source	crates/vize_patina/src/rules/ecosystem/vue_router_prefer_na
 linter	Linter	source	crates/vize_patina/src/rules/html/deprecated_attr.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/deprecated_element.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/helpers.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/html/id_duplication.rs	31	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/rules/html/id_duplication.rs	31	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/html/id_duplication.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/no_consecutive_br.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	35	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	35	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	35	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/no_empty_palpable_content.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/html/require_datetime.rs	28	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/html/require_datetime.rs	28	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/html/require_datetime.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	2
-linter	Linter	source	crates/vize_patina/src/rules/musea.rs	31	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/musea.rs	31	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/musea.rs	31	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/musea/prefer_design_tokens.rs	26	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/rules/musea/prefer_design_tokens.rs	26	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/musea/require_component.rs	62	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/musea/require_title.rs	83	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/musea/unique_variant_names.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/musea/unique_variant_names.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/heading_levels.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/placeholder_label_option.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/use_list.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	30	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	30	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	27	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	27	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/no_inline_template.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs	28	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs	28	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/require_vapor_attribute.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs	23	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs	23	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs	23	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs	23	croquis	Croquis analysis	old	vize_croquis	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/html_button_has_type.rs	37	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/html_self_closing.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/multi_word_component_names.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_array_index_key.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	2
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	31	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	31	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_empty_component_block.rs	40	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_empty_component_block.rs	40	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_inline_style.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
@@ -1083,17 +1083,17 @@ linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_script_non_
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_src_attribute.rs	43	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_template_lang.rs	36	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_template_shadow.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_unused_refs.rs	57	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_unused_refs.rs	57	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_unused_refs.rs	57	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_useless_mustaches.rs	35	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_useless_v_bind.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_v_text.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/prefer_props_shorthand.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/prefer_props_shorthand.rs	32	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/opinionated/vue/prefer_props_shorthand.rs	103	s0	S0/carton	stage	vize_s0	preferred	2
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/prefer_true_attribute_shorthand.rs	35	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/opinionated/vue/prefer_props_shorthand.rs	103	s0	S0	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/prefer_true_attribute_shorthand.rs	35	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/prefer_true_attribute_shorthand.rs	35	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs	46	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs	46	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	4
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs	46	croquis	Croquis analysis	old	vize_croquis	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/require_component_registration/self_name.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	2
@@ -1102,111 +1102,111 @@ linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/slot_name_casi
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/this_in_template.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/use_unique_element_ids.rs	51	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/use_v_on_exact.rs	26	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_bind_style.rs	27	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_bind_style.rs	27	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_bind_style.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	5
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_on_event_hyphenation.rs	32	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_on_event_hyphenation.rs	32	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_on_event_hyphenation.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/v_on_handler_style.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/warn_custom_block.rs	48	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/warn_custom_block.rs	48	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/warn_custom_directive.rs	38	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/petite_vue/no_unsupported_directive.rs	41	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/petite_vue/no_unsupported_directive.rs	41	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/petite_vue/no_unsupported_directive.rs	41	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/petite_vue/valid_v_effect.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/petite_vue/valid_v_scope.rs	39	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/petite_vue/valid_v_scope.rs	39	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/petite_vue/valid_v_scope.rs	39	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/petite_vue/valid_v_scope.rs	39	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script.rs	72	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script.rs	72	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script.rs	72	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script.rs	72	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script.rs	72	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/component_options_name_casing.rs	38	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/component_options_name_casing.rs	38	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/component_options_name_casing.rs	38	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/custom_event_name_casing.rs	55	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/custom_event_name_casing.rs	55	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/custom_event_name_casing.rs	55	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/custom_event_name_casing.rs	55	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/define_emits_declaration.rs	32	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/define_macros_order.rs	42	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/define_macros_order.rs	42	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/define_macros_order.rs	42	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/define_props_declaration.rs	37	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/define_props_declaration.rs	37	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/define_props_destructuring.rs	30	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/define_props_destructuring.rs	30	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_arrow_functions_in_watch.rs	51	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_arrow_functions_in_watch.rs	51	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_arrow_functions_in_watch.rs	51	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_async_in_computed.rs	40	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_async_in_computed.rs	40	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_boolean_default.rs	47	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_boolean_default.rs	47	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_boolean_default.rs	47	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deep_destructure_in_props.rs	31	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deep_destructure_in_props.rs	31	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration.rs	41	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration.rs	41	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration.rs	41	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle.rs	12	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle.rs	12	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle/tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle/tests.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle/tests.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_deprecated_destroyed_lifecycle/tests.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_dollar_listeners_api.rs	33	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_dollar_listeners_api.rs	33	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_dollar_scopedslots_api.rs	30	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_dollar_scopedslots_api.rs	30	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_events_api.rs	37	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_events_api.rs	37	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_events_api.rs	37	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_events_api.rs	37	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_props_default_this.rs	62	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_props_default_this.rs	62	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_props_default_this.rs	62	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_props_default_this.rs	62	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_deprecated_props_default_this.rs	62	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_dupe_keys.rs	47	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_dupe_keys.rs	47	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_dupe_keys.rs	47	croquis	Croquis analysis	old	vize_croquis	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_dupe_keys.rs	47	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance.rs	68	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/options.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/options.rs	9	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/options.rs	9	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_duplicate_attr_inheritance/template.rs	35	old_ast	old AST/parser	old	vize_relief	legacy	4
 linter	Linter	source	crates/vize_patina/src/rules/script/no_export_in_script_setup.rs	48	raw_oxc	raw OXC	raw	oxc_ast	raw	2
-linter	Linter	source	crates/vize_patina/src/rules/script/no_get_current_instance.rs	28	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_get_current_instance.rs	28	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_get_current_instance.rs	28	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_get_current_instance.rs	28	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_import_compiler_macros.rs	33	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_internal_imports.rs	26	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_multiple_slot_args.rs	54	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_multiple_slot_args.rs	54	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_next_tick.rs	30	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_next_tick.rs	30	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_next_tick.rs	30	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_next_tick.rs	30	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_nuxt_config_test_key.rs	11	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_options_api.rs	35	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/script/no_options_api.rs	35	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_options_api.rs	35	raw_oxc	raw OXC	raw	oxc_ast	raw	3
-linter	Linter	source	crates/vize_patina/src/rules/script/no_page_meta_runtime_values.rs	11	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/script/no_page_meta_runtime_values.rs	11	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_page_meta_runtime_values.rs	11	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_page_meta_runtime_values.rs	11	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_page_meta_runtime_values.rs	11	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_potential_component_option_typo.rs	16	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_potential_component_option_typo.rs	16	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_potential_component_option_typo.rs	16	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_potential_component_option_typo.rs	16	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_reactive_destructure.rs	42	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_ref_as_operand.rs	29	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_reactive_destructure.rs	42	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_ref_as_operand.rs	29	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_ref_as_operand.rs	29	raw_oxc	raw OXC	raw	oxc_ast	raw	5
 linter	Linter	source	crates/vize_patina/src/rules/script/no_ref_as_operand.rs	29	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_ref_as_operand.rs	29	raw_oxc	raw OXC	raw	oxc_syntax	raw	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_identifiers.rs	36	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_identifiers.rs	36	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_identifiers.rs	36	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_keys.rs	27	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_keys.rs	27	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_keys.rs	27	croquis	Croquis analysis	old	vize_croquis	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_reserved_keys.rs	27	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_globals.rs	53	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_globals.rs	53	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_globals.rs	53	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_globals.rs	53	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_restricted_globals.rs	254	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_members.rs	49	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_restricted_globals.rs	254	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_members.rs	49	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_members.rs	49	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_restricted_members.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_restricted_members.rs	190	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_side_effects_in_computed.rs	58	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_restricted_members.rs	190	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_side_effects_in_computed.rs	58	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_side_effects_in_computed.rs	58	raw_oxc	raw OXC	raw	oxc_ast	raw	4
 linter	Linter	source	crates/vize_patina/src/rules/script/no_side_effects_in_computed.rs	58	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_side_effects_in_computed.rs	58	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
@@ -1216,102 +1216,102 @@ linter	Linter	source	crates/vize_patina/src/rules/script/no_top_level_ref_in_scr
 linter	Linter	source	crates/vize_patina/src/rules/script/no_unstable_nested_components.rs	9	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_unstable_nested_components.rs	9	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_unstable_nested_components.rs	9	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs	36	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs	36	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs	36	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs	36	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	2
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs	36	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/no_use_computed_property_like_method/computed_names.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/no_use_computed_property_like_method/computed_names.rs	7	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/no_use_computed_property_like_method/computed_names.rs	7	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs	10	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/nuxt_config_keys_order.rs	10	raw_oxc	raw OXC	raw	oxc_ast	raw	2
-linter	Linter	source	crates/vize_patina/src/rules/script/nuxt_config_keys_order/support.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/nuxt_config_keys_order/support.rs	3	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/nuxt_config_keys_order/support.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/nuxt_config_keys_order/tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/nuxt_config_keys_order/tests.rs	5	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs	12	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs	12	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs	12	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/prefer_computed.rs	29	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/prefer_computed.rs	29	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_computed.rs	29	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_computed.rs	29	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_computed.rs	29	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_define_options.rs	46	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_from_vue.rs	26	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_from_vue.rs	26	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_from_vue.rs	26	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_meta.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_meta.rs	10	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_meta.rs	10	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_import_meta.rs	10	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/prefer_import_meta/tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/prefer_import_meta/tests.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_attrs.rs	32	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_attrs.rs	32	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_slots.rs	32	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_slots.rs	32	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_template_ref.rs	59	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_template_ref.rs	59	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_template_ref.rs	59	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_template_ref.rs	59	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_template_ref/template_refs.rs	19	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/emits_source.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/prefer_use_template_ref/template_refs.rs	19	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/emits_source.rs	10	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/emits_source.rs	10	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_required_prop_with_default.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_required_prop_with_default.rs	14	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_required_prop_with_default.rs	14	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_reserved_props.rs	44	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_reserved_props.rs	44	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_reserved_props.rs	44	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_unused_emit_declarations.rs	55	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_unused_emit_declarations.rs	55	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_unused_emit_declarations.rs	55	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/no_unused_emit_declarations.rs	55	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/props_source.rs	21	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/props_source.rs	21	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/props_source.rs	21	raw_oxc	raw OXC	raw	oxc_ast	raw	2
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_default_prop.rs	49	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_default_prop.rs	49	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_default_prop.rs	49	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs	50	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs	50	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs	50	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs	50	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/declared.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/declared.rs	8	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/declared.rs	8	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_prop_types.rs	49	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_prop_types.rs	49	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_prop_types.rs	49	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop.rs	54	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop.rs	54	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop.rs	54	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop.rs	59	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop.rs	59	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop.rs	59	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/return_in_emits_validator.rs	48	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/return_in_emits_validator.rs	48	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/return_in_emits_validator.rs	48	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/template_emits.rs	21	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/script/require_explicit_slots.rs	82	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/script/props_emits/template_emits.rs	21	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/script/require_explicit_slots.rs	82	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	test/dev	crates/vize_patina/src/rules/script/require_explicit_slots.rs	82	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/declared.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/declared.rs	3	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/declared.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/declared.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/template.rs	31	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/template.rs	31	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_explicit_slots/template.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/script/require_function_return_type.rs	45	s0	S0/carton	stage	vize_s0	preferred	2
-linter	Linter	source	crates/vize_patina/src/rules/script/require_prop_type_constructor.rs	53	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/require_function_return_type.rs	45	s0	S0	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/script/require_prop_type_constructor.rs	53	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_prop_type_constructor.rs	53	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 linter	Linter	source	crates/vize_patina/src/rules/script/require_symbol_provide.rs	33	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_symbol_provide.rs	33	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/require_typed_ref.rs	43	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/require_typed_ref.rs	43	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_typed_ref.rs	43	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/require_typed_ref.rs	43	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/return_in_computed_property.rs	20	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/return_in_computed_property.rs	20	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/return_in_computed_property.rs	20	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/sfc_context.rs	43	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/script/template_scan.rs	41	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/template_scan.rs	41	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/template_scan.rs	41	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/script/template_scan/calls.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/template_scan/calls.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/template_scan/calls.rs	4	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/template_scan/calls.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_emits.rs	38	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_emits.rs	38	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_emits.rs	38	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_emits.rs	38	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_options.rs	34	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_options.rs	34	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_options.rs	34	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_options.rs	34	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_props.rs	37	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_props.rs	37	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_props.rs	37	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_define_props.rs	37	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/script/valid_next_tick.rs	43	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/script/valid_next_tick.rs	43	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_next_tick.rs	43	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_next_tick.rs	43	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/valid_next_tick.rs	43	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
@@ -1320,92 +1320,92 @@ linter	Linter	source	crates/vize_patina/src/rules/script/vue_router_prefer_named
 linter	Linter	source	crates/vize_patina/src/rules/script/vue_test_utils_no_html_snapshot.rs	12	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/script/vue_test_utils_no_html_snapshot.rs	12	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs	48	old_ast	old AST/parser	old	vize_relief	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs	481	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	test/dev	crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs	481	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	test/dev	crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs	481	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/ssr/no_hydration_mismatch.rs	52	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/type_aware/require_typed_emits.rs	52	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/type_aware/require_typed_emits.rs	52	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/type_aware/require_typed_props.rs	55	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/type_aware/require_typed_props.rs	55	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/url.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/url.rs	1	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vapor/no_vue_lifecycle_events.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/a11y_img_alt.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	4
-linter	Linter	source	crates/vize_patina/src/rules/vue/attribute_hyphenation.rs	22	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/attribute_hyphenation.rs	22	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/attribute_hyphenation.rs	22	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/attribute_order.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/component_definition_name_casing.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/html_quotes.rs	46	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/html_quotes.rs	46	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/html_quotes.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/html_quotes/value_range.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/html_quotes/value_range.rs	86	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/mustache_interpolation_spacing.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_bare_strings_in_template.rs	44	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_child_content.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_filter.rs	42	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_filter.rs	42	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_filter.rs	42	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_functional_template.rs	54	s0	S0/carton	stage	vize_s0	preferred	2
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_html_element_is.rs	36	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_functional_template.rs	54	s0	S0	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_html_element_is.rs	36	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_html_element_is.rs	36	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_router_link_tag_prop.rs	34	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_router_link_tag_prop.rs	34	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_router_link_tag_prop.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_scope_attribute.rs	35	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_scope_attribute.rs	35	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_scope_attribute.rs	35	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs	35	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs	35	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs	35	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs	81	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_slot_scope_attribute.rs	30	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_deprecated_slot_attribute.rs	81	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_slot_scope_attribute.rs	30	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_slot_scope_attribute.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_bind_sync.rs	39	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_bind_sync.rs	39	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_bind_sync.rs	39	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_on_native_modifier.rs	40	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_on_native_modifier.rs	40	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_on_native_modifier.rs	40	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_on_number_modifiers.rs	40	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_on_number_modifiers.rs	40	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_v_on_number_modifiers.rs	40	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_dupe_v_else_if.rs	27	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_dupe_v_else_if.rs	27	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_dupe_v_else_if.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_duplicate_attributes.rs	24	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_duplicate_attributes.rs	24	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_duplicate_attributes.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_invalid_html_attribute.rs	10	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_lone_template.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_multi_spaces.rs	22	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root.rs	23	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root.rs	23	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root.rs	23	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root/tests.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props.rs	62	s0	S0/carton	stage	vize_s0	preferred	3
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root/tests.rs	13	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props.rs	62	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props.rs	62	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props.rs	62	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs	43	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs	43	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs	43	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs	43	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/mutation_targets.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props/mutation_targets.rs	95	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/scope.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/mutation_targets.rs	7	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props/mutation_targets.rs	95	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/scope.rs	3	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/scope.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs	9	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props/tests/script_mutations.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names.rs	39	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_mutating_props/tests/script_mutations.rs	3	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names.rs	39	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names.rs	39	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names.rs	39	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names.rs	39	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names/extract.rs	7	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names/extract.rs	7	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names/extract.rs	7	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_names/extract.rs	7	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_template_key.rs	27	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_template_key.rs	27	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_template_key.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	4
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_template_target_blank.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_textarea_mustache.rs	23	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_undefined_refs.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_undefined_refs.rs	8	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_undefined_refs.rs	8	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unsafe_url.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unsandboxed_iframe.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_components.rs	39	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_components.rs	39	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_components.rs	39	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_components.rs	39	croquis	Croquis analysis	old	vize_croquis	legacy	3
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_components.rs	39	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
@@ -1417,39 +1417,39 @@ linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_components/dynam
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_components/dynamic_is.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_components/dynamic_is.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_components/dynamic_is.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_properties.rs	84	s0	S0/carton	stage	vize_s0	preferred	4
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_properties.rs	84	s0	S0	stage	vize_s0	preferred	4
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_unused_properties.rs	84	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_properties/usage.rs	29	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_properties/usage.rs	29	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_properties/usage.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_vars.rs	44	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_vars.rs	44	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_vars.rs	44	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unused_vars.rs	44	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for.rs	15	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for/tests.rs	9	s0	S0/carton	stage	vize_s0	preferred	2
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_use_v_if_with_v_for.rs	31	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_use_v_else_with_v_for/tests.rs	9	s0	S0	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_use_v_if_with_v_for.rs	31	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_use_v_if_with_v_for.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_useless_template_attributes.rs	30	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_useless_template_attributes.rs	30	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_useless_template_attributes.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_for_template_key_on_child.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_v_for_template_key_on_child.rs	115	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_v_for_template_key_on_child.rs	115	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_html.rs	41	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs	27	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs	27	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/permitted_contents.rs	33	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/permitted_contents.rs	33	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/permitted_contents.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/prop_name_casing.rs	40	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/prop_name_casing/declarations.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/prop_name_casing/declarations.rs	13	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_component_is.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/require_scoped_style.rs	47	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/require_scoped_style.rs	47	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_toggle_inside_transition.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_v_for_key.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_v_for_key.rs	25	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_v_for_key.rs	25	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_v_for_key.rs	25	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/sfc_element_order.rs	41	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/single_style_block.rs	39	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/v_on_style.rs	25	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/sfc_element_order.rs	41	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/single_style_block.rs	39	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/v_on_style.rs	25	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/v_on_style.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/v_slot_style.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/v_slot_style/position.rs	10	old_ast	old AST/parser	old	vize_relief	legacy	1
@@ -1462,7 +1462,7 @@ linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_for.rs	29	old_ast	
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_html.rs	26	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_if.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_memo.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_model.rs	29	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_model.rs	29	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_model.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_model.rs	29	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_model.rs	29	raw_oxc	raw OXC	raw	oxc_ast	raw	1
@@ -1470,32 +1470,32 @@ linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_model.rs	29	raw_ox
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_on.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_once.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_show.rs	26	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_slot.rs	24	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_slot.rs	24	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_slot.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/valid_v_text.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/telegraph.rs	31	s0	S0/carton	stage	vize_s0	preferred	4
-linter	Linter	test/dev	crates/vize_patina/src/telegraph/tests.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/visitor_scope.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/telegraph.rs	31	s0	S0	stage	vize_s0	preferred	4
+linter	Linter	test/dev	crates/vize_patina/src/telegraph/tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/visitor_scope.rs	7	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/visitor_scope.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/visitor_scope.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	test/dev	crates/vize_patina/src/visitor_scope.rs	46	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	test/dev	crates/vize_patina/src/visitor_scope.rs	46	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	test/dev	crates/vize_patina/src/visitor_scope.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	2
-linter	Linter	source	crates/vize_patina/src/visitor.rs	7	s0	S0/carton	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/visitor.rs	7	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/visitor.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	3
-linter	Linter	test/dev	crates/vize/src/commands/lint.rs	34	s0	S0/carton	stage	vize_s0	preferred	2
-linter	Linter	source	crates/vize/src/commands/lint/args.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize/src/commands/lint/collect.rs	6	s0	S0/carton	stage	vize_s0	preferred	3
-linter	Linter	source	crates/vize/src/commands/lint/cross_file.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize/src/commands/lint.rs	34	s0	S0	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize/src/commands/lint/args.rs	5	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize/src/commands/lint/collect.rs	6	s0	S0	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize/src/commands/lint/cross_file.rs	4	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize/src/commands/lint/cross_file.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	source	crates/vize/src/commands/lint/cross_file.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize/src/commands/lint/cross_file.rs	4	croquis	Croquis analysis	old	vize_croquis_cf	legacy	1
-linter	Linter	test/dev	crates/vize/src/commands/lint/entry_rules_tests.rs	7	s0	S0/carton	stage	vize_s0	preferred	2
-linter	Linter	source	crates/vize/src/commands/lint/entry_rules.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize/src/commands/lint/fix.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize/src/commands/lint/patterns.rs	22	s0	S0/carton	stage	vize_s0	preferred	4
-linter	Linter	source	crates/vize/src/commands/lint/stdout.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize_canon/benches/package_route.rs	40	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	s0	S0/carton	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize/src/commands/lint/entry_rules_tests.rs	7	s0	S0	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize/src/commands/lint/entry_rules.rs	5	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize/src/commands/lint/fix.rs	8	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize/src/commands/lint/patterns.rs	22	s0	S0	stage	vize_s0	preferred	4
+linter	Linter	source	crates/vize/src/commands/lint/stdout.rs	4	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/benches/package_route.rs	40	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	old_ast	old AST/parser	old	vize_armature	legacy	2
 typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	croquis	Croquis analysis	old	vize_croquis	legacy	1
@@ -1505,887 +1505,887 @@ typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	raw_oxc	raw OXC
 typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
 typechecker	Typechecker	manifest	crates/vize_canon/Cargo.toml	16	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch.rs	64	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/error.rs	4	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor.rs	20	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/cli.rs	13	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/cli/diagnostic_paths.rs	15	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/cli/diagnostic_paths.rs	204	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/cli/import_resolution.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/cli/import_resolution.rs	47	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/cli/tests.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/declaration_maps.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/declaration_maps.rs	195	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/diagnostics.rs	255	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/dedup.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/keyof_indexed_assignment.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch.rs	64	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/error.rs	4	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor.rs	20	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/cli.rs	13	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/cli/diagnostic_paths.rs	15	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/cli/diagnostic_paths.rs	204	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/cli/import_resolution.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/cli/import_resolution.rs	47	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/cli/tests.rs	10	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/declaration_maps.rs	8	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/declaration_maps.rs	195	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics.rs	8	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/diagnostics.rs	255	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/dedup.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/keyof_indexed_assignment.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/keyof_indexed_assignment.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/keyof_indexed_assignment.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/keyof_indexed_assignment.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/keyof_indexed_assignment.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/module_resolution.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs	20	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs	141	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/virtual_path_message.rs	28	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/fallback.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/option_probe.rs	20	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/session.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/session/diagnostic_paths.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/session/snapshot.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/session/tests.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/tests.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_collect.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/module_resolution.rs	11	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs	20	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/diagnostics/module_specifier.rs	141	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/diagnostics/virtual_path_message.rs	28	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/fallback.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/option_probe.rs	20	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/session.rs	6	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/session/diagnostic_paths.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/executor/session/snapshot.rs	6	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/session/tests.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/executor/tests.rs	10	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_collect.rs	4	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_collect.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_collect.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_collect.rs	4	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_collect.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/import_rewriter_dts_tests.rs	5	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_dts.rs	13	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_source_map.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/import_rewriter_tests.rs	5	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/import_rewriter_virtual_tests.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_virtual.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/import_rewriter_dts_tests.rs	5	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_dts.rs	13	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_source_map.rs	3	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/import_rewriter_tests.rs	5	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/import_rewriter_virtual_tests.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_virtual.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_virtual.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_virtual.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter_virtual.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/import_rewriter_virtual.rs	204	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter.rs	5	s0	S0/carton	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/import_rewriter_virtual.rs	204	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter.rs	5	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter.rs	5	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/import_rewriter.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/materialize_fs.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/materialize_lock.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/runtime_deps.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/runtime_deps.rs	58	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/type_checker.rs	185	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/type_checker/declarations.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/type_checker/incremental.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/type_checker/paths.rs	6	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/paths.rs	259	s0	S0/carton	stage	vize_carton	compat	5
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests.rs	13	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/emit_object_recursion.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload.rs	2	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_guarded_props.rs	22	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_props.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_union_props.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_check_props.rs	100	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_unused.rs	5	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_unused/css_v_bind.rs	182	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_unused/define_emits_unused.rs	111	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/options_api_required_props.rs	173	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/package_exports_types.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/component_options_index_signature.rs	39	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/css_side_effect_import.rs	19	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/diagnostic_normalization.rs	1	s0	S0/carton	stage	vize_carton	compat	5
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_anchors.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_values.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/exact_optional_props.rs	17	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/external_slot_payloads.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/fallthrough_unknown_attrs.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/generic_emit_guard.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/global_component_callbacks.rs	49	s0	S0/carton	stage	vize_carton	compat	8
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/global_html_fallthrough_attrs.rs	21	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/literal_union_props.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/options_api_bridge_anchors.rs	21	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/single_required_camel_prop.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/split_script_diagnostic_anchors.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/strict_route_instance_global.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_handler_ts7006.rs	41	s0	S0/carton	stage	vize_carton	compat	16
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_instance_props.rs	24	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_instance_props/options_api.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_instance_props/type_only.rs	9	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_key_expressions.rs	26	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_key_expressions/dialect_baselines.rs	12	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/ts_extension_substitution.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/unmapped_template_fallback.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/v_for_source_callbacks.rs	32	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/wide_props_type_complexity.rs	17	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/tsgo.rs	39	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project.rs	21	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project.rs	268	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/art_usage.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/build.rs	8	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/build/css_modules.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/css_var_usage.rs	20	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/materialize_fs.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/materialize_lock.rs	9	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/runtime_deps.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/runtime_deps.rs	58	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/type_checker.rs	185	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/type_checker/declarations.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/type_checker/incremental.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/type_checker/paths.rs	6	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/paths.rs	259	s0	S0	stage	vize_carton	compat	5
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests.rs	13	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/emit_object_recursion.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/generic_component_listener_payload.rs	2	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_guarded_props.rs	22	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_props.rs	10	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/generic_props/inline_callback_union_props.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_check_props.rs	100	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_unused.rs	5	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_unused/css_v_bind.rs	182	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_unused/define_emits_unused.rs	111	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/options_api_required_props.rs	173	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/package_exports_types.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/component_options_index_signature.rs	39	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/css_side_effect_import.rs	19	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/diagnostic_normalization.rs	1	s0	S0	stage	vize_carton	compat	5
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_anchors.rs	11	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_values.rs	9	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/exact_optional_props.rs	17	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/external_slot_payloads.rs	11	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/fallthrough_unknown_attrs.rs	14	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/generic_emit_guard.rs	6	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/global_component_callbacks.rs	49	s0	S0	stage	vize_carton	compat	8
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/global_html_fallthrough_attrs.rs	21	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/literal_union_props.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/options_api_bridge_anchors.rs	21	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/single_required_camel_prop.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/split_script_diagnostic_anchors.rs	8	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/strict_route_instance_global.rs	14	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_handler_ts7006.rs	41	s0	S0	stage	vize_carton	compat	16
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_instance_props.rs	24	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_instance_props/options_api.rs	14	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_instance_props/type_only.rs	9	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_key_expressions.rs	26	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_key_expressions/dialect_baselines.rs	12	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/ts_extension_substitution.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/unmapped_template_fallback.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/v_for_source_callbacks.rs	32	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/wide_props_type_complexity.rs	17	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/tsgo.rs	39	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project.rs	21	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project.rs	268	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/art_usage.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/build.rs	8	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/build/css_modules.rs	6	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/css_var_usage.rs	20	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/css_var_usage.rs	20	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/css_var_usage.rs	41	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/declaration_emit.rs	7	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/declaration_emit/tsx_shims.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/css_var_usage.rs	41	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/declaration_emit.rs	7	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/declaration_emit/tsx_shims.rs	6	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/declaration_emit/tsx_shims.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/declaration_emit/tsx_shims.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/declaration_emit/tsx_shims.rs	6	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/declaration_emit/tsx_shims.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/dependency_scan.rs	29	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/dependency_scan/resolution.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/diagnostics.rs	7	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/document.rs	8	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/external_mirror.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/identity.rs	29	s0	S0/carton	stage	vize_carton	compat	8
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/identity.rs	181	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/incremental_graph.rs	10	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_build.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs	75	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_codegen/collect.rs	9	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/dependency_scan.rs	29	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/dependency_scan/resolution.rs	5	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/diagnostics.rs	7	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/document.rs	8	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/external_mirror.rs	14	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/identity.rs	29	s0	S0	stage	vize_carton	compat	8
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/identity.rs	181	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/incremental_graph.rs	10	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_build.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs	75	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_codegen/collect.rs	9	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_codegen/collect.rs	9	old_ast	old AST/parser	old	vize_relief	legacy	4
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_codegen/component.rs	10	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_codegen/component.rs	10	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_codegen/component.rs	10	old_ast	old AST/parser	old	vize_relief	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_codegen/slot.rs	28	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_codegen/slot.rs	28	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/jsx_codegen/slot.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/mapping.rs	20	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/mapping/materialized_sources.rs	17	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/mapping/materialized_sources.rs	152	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/materialize_delta.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/materialize_delta/tests.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/materialize_links.rs	5	s0	S0/carton	stage	vize_carton	compat	6
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/materialize_stubs.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/materialize.rs	8	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/option_probe.rs	31	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_link_owners.rs	5	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/package_node_modules.rs	29	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_node_modules/merged.rs	25	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/package_node_modules/tests.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_route_discovery.rs	6	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_route_reachability_route_graph.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_route_reachability.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/package_shadow_owners.rs	225	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_shadow_runtime.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_shadow_scope.rs	23	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_shadow.rs	6	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_source_index.rs	9	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/passthrough_resolution.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/passthrough_tests.rs	3	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/passthrough.rs	8	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/passthrough.rs	165	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/paths.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/mapping.rs	20	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/mapping/materialized_sources.rs	17	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/mapping/materialized_sources.rs	152	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/materialize_delta.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/materialize_delta/tests.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/materialize_links.rs	5	s0	S0	stage	vize_carton	compat	6
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/materialize_stubs.rs	10	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/materialize.rs	8	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/option_probe.rs	31	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_link_owners.rs	5	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/package_node_modules.rs	29	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_node_modules/merged.rs	25	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/package_node_modules/tests.rs	3	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_route_discovery.rs	6	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_route_reachability_route_graph.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_route_reachability.rs	8	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/package_shadow_owners.rs	225	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_shadow_runtime.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_shadow_scope.rs	23	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_shadow.rs	6	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/package_source_index.rs	9	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/passthrough_resolution.rs	5	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/passthrough_tests.rs	3	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/passthrough.rs	8	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/passthrough.rs	165	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/paths.rs	4	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/paths/commonjs_declaration.rs	20	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/paths/commonjs_declaration.rs	20	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/paths/commonjs_declaration.rs	20	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/paths/commonjs_declaration.rs	20	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project.rs	11	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project/artifacts.rs	109	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project/config.rs	41	s0	S0/carton	stage	vize_carton	compat	5
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project/package_routes.rs	5	s0	S0/carton	stage	vize_carton	compat	5
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project.rs	11	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project/artifacts.rs	109	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project/config.rs	41	s0	S0	stage	vize_carton	compat	5
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/project/package_routes.rs	5	s0	S0	stage	vize_carton	compat	5
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/setup_props.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests.rs	6	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests/graphql_generated.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests/package_shadow_fan_out.rs	23	s0	S0/carton	stage	vize_carton	compat	6
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests/ref_arity.rs	51	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests/tsconfig_extends.rs	313	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests/windows_paths.rs	18	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests/workspace_package_routes.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/topology.rs	68	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/topology.rs	107	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs	17	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/base_url.rs	16	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/compiler_options_snapshot.rs	101	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/compiler_options.rs	6	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/control_alias.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/path_rebase.rs	130	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/references/graph.rs	4	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/references/ownership.rs	3	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/references/spec.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/references/tests.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/remap.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/vue_alias.rs	15	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/vue_compiler_options.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/vue_compiler_options.rs	138	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_paths.rs	8	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/vue_codegen.rs	7	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_specifier_message.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_ts.rs	15	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests/graphql_generated.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests/package_shadow_fan_out.rs	23	s0	S0	stage	vize_carton	compat	6
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests/ref_arity.rs	51	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests/tsconfig_extends.rs	313	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests/windows_paths.rs	18	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tests/workspace_package_routes.rs	11	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/topology.rs	68	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/topology.rs	107	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs	17	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/base_url.rs	16	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/compiler_options_snapshot.rs	101	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/compiler_options.rs	6	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/control_alias.rs	6	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/path_rebase.rs	130	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/references/graph.rs	4	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/references/ownership.rs	3	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/references/spec.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/references/tests.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/remap.rs	6	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/vue_alias.rs	15	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/vue_compiler_options.rs	11	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/virtual_project/tsconfig_gen/vue_compiler_options.rs	138	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/tsconfig_paths.rs	8	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project/vue_codegen.rs	7	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_specifier_message.rs	3	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_ts.rs	15	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_ts.rs	15	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_ts.rs	15	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/checker/reporting.rs	12	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/checker/runner.rs	12	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/context.rs	6	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge.rs	73	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/batch_checker.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/bridge.rs	8	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/bridge/documents.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/bridge/language_features.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/editor_session.rs	13	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/editor_session.rs	74	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/script_document.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/types.rs	13	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context.rs	5	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context.rs	308	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/build.rs	5	s0	S0/carton	stage	vize_carton	compat	5
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/cache.rs	7	s0	S0/carton	stage	vize_carton	compat	10
-typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/cache/tests.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes_budget_tests.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes.rs	177	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies_walk.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/checker/reporting.rs	12	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/checker/runner.rs	12	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/context.rs	6	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge.rs	73	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/batch_checker.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/bridge.rs	8	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/bridge/documents.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/bridge/language_features.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/editor_session.rs	13	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/editor_session.rs	74	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/script_document.rs	6	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/types.rs	13	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context.rs	5	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context.rs	308	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/build.rs	5	s0	S0	stage	vize_carton	compat	5
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/cache.rs	7	s0	S0	stage	vize_carton	compat	10
+typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/cache/tests.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes_budget_tests.rs	1	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes.rs	5	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes.rs	177	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies_walk.rs	6	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs	1	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_document_package_compat_tests.rs	118	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_document_package_typed_tests.rs	84	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_document_tests.rs	160	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_document.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_document/types.rs	6	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_server.rs	29	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_server/diagnostics.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_server/diagnostics.rs	146	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_server/request.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/corsa_server/sfc_semantics.rs	5	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/diagnostic.rs	4	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/file_uri.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/intelligence.rs	12	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_document_package_compat_tests.rs	118	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_document_package_typed_tests.rs	84	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_document_tests.rs	160	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_document.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_document/types.rs	6	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_server.rs	29	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_server/diagnostics.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_server/diagnostics.rs	146	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_server/request.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_server/sfc_semantics.rs	5	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/diagnostic.rs	4	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/file_uri.rs	3	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/intelligence.rs	12	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	source	crates/vize_canon/src/intelligence.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/intelligence.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/intelligence.rs	482	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/intelligence.rs	482	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/intelligence.rs	482	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/intelligence.rs	482	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/legacy.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/lib.rs	45	s0	S0/carton	stage	vize_s0	preferred	2
-typechecker	Typechecker	source	crates/vize_canon/src/lib.rs	45	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client.rs	13	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/bootstrap.rs	13	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/diagnostics_api.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/diagnostics_lsp.rs	12	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/diagnostics.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp.rs	30	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/client.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/file_rename.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/readiness.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/retry.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/lsp_client/editor_lsp/retry.rs	40	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/synchronize.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/type_definition.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/lifecycle_setup.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/lifecycle.rs	23	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/lsp_client/lifecycle/tests.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/materialized_refresh.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/queries.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/session_paths.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/session.rs	21	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/lsp_client/session.rs	225	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/session/bootstrap.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/session/canon_document.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/lsp_client/tests.rs	14	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/utils.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/workspace_project.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/options_api_setup_spread.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lib.rs	45	s0	S0	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize_canon/src/lib.rs	45	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client.rs	13	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/bootstrap.rs	13	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/diagnostics_api.rs	6	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/diagnostics_lsp.rs	12	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/diagnostics.rs	11	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp.rs	30	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/client.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/file_rename.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/readiness.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/retry.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/lsp_client/editor_lsp/retry.rs	40	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/synchronize.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/type_definition.rs	3	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/lifecycle_setup.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/lifecycle.rs	23	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/lsp_client/lifecycle/tests.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/materialized_refresh.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/queries.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/session_paths.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/session.rs	21	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/lsp_client/session.rs	225	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/session/bootstrap.rs	10	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/session/canon_document.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/lsp_client/tests.rs	14	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/utils.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/workspace_project.rs	6	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/options_api_setup_spread.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/options_api_setup_spread.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/options_api_setup_spread.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	2
 typechecker	Typechecker	source	crates/vize_canon/src/options_api_setup_spread.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/options_api_setup_spread.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/package_route_tests/lifecycle.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/package_route.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/package_route.rs	221	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/package_route/cache.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/package_route/candidates.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/package_route/model.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/package_route/search.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/package_route/shadow_mapping.rs	6	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/package_route/source.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/package_route/stamp.rs	79	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	source	crates/vize_canon/src/script_parse.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/package_route_tests/lifecycle.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/package_route.rs	11	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/package_route.rs	221	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/package_route/cache.rs	3	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/package_route/candidates.rs	6	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/package_route/model.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/package_route/search.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/package_route/shadow_mapping.rs	6	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/package_route/source.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/package_route/stamp.rs	79	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/script_parse.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/script_parse.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/script_parse.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/sfc_typecheck/analysis.rs	7	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/sfc_typecheck/checks.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/sfc_typecheck/analysis.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/sfc_typecheck/checks.rs	4	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/sfc_typecheck/checks.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	11
-typechecker	Typechecker	source	crates/vize_canon/src/sfc_typecheck/runner.rs	1	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/sfc_typecheck/virtual_ts.rs	7	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/sfc_typecheck/runner.rs	1	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/sfc_typecheck/virtual_ts.rs	7	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/sfc_typecheck/virtual_ts.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/sfc_typecheck/virtual_ts.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/tests.rs	11	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/typecheck_service.rs	11	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	source	crates/vize_canon/src/types.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/tests.rs	11	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/typecheck_service.rs	11	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/types.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts.rs	100	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts.rs	100	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/class_component_props_tests.rs	12	s0	S0/carton	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/class_component_props_tests.rs	12	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/class_component_props_tests.rs	12	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/class_component_props_tests.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/component_reference.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/component_reference.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/component_reference.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/define_emits_usage_tests.rs	4	s0	S0/carton	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/define_emits_usage_tests.rs	4	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/define_emits_usage_tests.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/define_emits_usage_tests.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/dynamic_component_names_tests.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/dynamic_component_names_tests.rs	2	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/dynamic_component_names_tests.rs	2	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/dynamic_component_names_tests.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/event_handler_tests.rs	5	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/event_handler_tests.rs	5	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/event_handler_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/event_handler_tests.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/event_handler_tests.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/event_handler_tests.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/callback_prop_resolution_tests.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/callback_prop_resolution_tests.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/callback_prop_resolution_tests.rs	1	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/callback_prop_resolution_tests.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/callback_prop_resolution.rs	11	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/callback_prop_resolution.rs	11	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/callback_prop_resolution.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs	1	s0	S0/carton	stage	vize_carton	compat	8
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs	1	s0	S0	stage	vize_carton	compat	8
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs	1	old_ast	old AST/parser	old	vize_armature	legacy	8
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/component_props_tests.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/component_props_tests/define_model_modifiers.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/component_props_tests/define_model_modifiers.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/component_props_tests/define_model_modifiers.rs	1	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/component_props_tests/define_model_modifiers.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/component_props_tests/dynamic_component_props.rs	1	s0	S0/carton	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/component_props_tests/dynamic_component_props.rs	1	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/component_props_tests/dynamic_component_props.rs	1	old_ast	old AST/parser	old	vize_armature	legacy	3
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/component_props_tests/dynamic_component_props.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/component_props.rs	13	s0	S0/carton	stage	vize_carton	compat	6
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/component_props.rs	13	s0	S0	stage	vize_carton	compat	6
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/component_props.rs	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/component_slot_contract_tests.rs	1	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/component_slot_contract_tests.rs	1	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/component_slot_contract_tests.rs	1	old_ast	old AST/parser	old	vize_armature	legacy	4
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/component_slot_contract_tests.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/directive_values_tests.rs	1	s0	S0/carton	stage	vize_carton	compat	8
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/directive_values_tests.rs	1	s0	S0	stage	vize_carton	compat	8
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/directive_values_tests.rs	1	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/directive_values_tests.rs	1	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/directive_values_tests.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/directive_values.rs	39	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/directive_values.rs	39	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/directive_values.rs	39	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/directive_values.rs	39	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/generic_props_call.rs	12	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/generic_props_call.rs	12	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/generic_props_call.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/native_props_tests.rs	1	s0	S0/carton	stage	vize_carton	compat	8
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/native_props_tests.rs	1	s0	S0	stage	vize_carton	compat	8
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/native_props_tests.rs	1	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/native_props_tests.rs	1	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/native_props_tests.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/native_props.rs	45	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/native_props.rs	45	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/native_props.rs	45	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/native_props.rs	45	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/prop_name_casing_tests.rs	8	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/prop_name_casing_tests.rs	8	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/prop_name_casing_tests.rs	8	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/prop_name_casing_tests.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/prop_sources.rs	11	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/prop_sources.rs	11	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/prop_sources.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/prop_sources.rs	11	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/prop_sources.rs	11	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/prop_sources.rs	11	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/prop_sources.rs	168	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/props_literal.rs	18	s0	S0/carton	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/prop_sources.rs	168	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/props_literal.rs	18	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/props_literal.rs	18	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/props_literal/prop_entry.rs	10	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/props_literal/prop_entry.rs	10	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/props_literal/prop_entry.rs	10	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/reserved_props.rs	10	s0	S0/carton	stage	vize_carton	compat	3
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/sequence_prop_tests.rs	1	s0	S0/carton	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/reserved_props.rs	10	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/sequence_prop_tests.rs	1	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/sequence_prop_tests.rs	1	old_ast	old AST/parser	old	vize_armature	legacy	3
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/sequence_prop_tests.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/spread_reserved_props.rs	11	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/spread_reserved_props.rs	11	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/spread_reserved_props.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/spread_reserved_props.rs	11	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/spread_reserved_props.rs	11	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/spread_reserved_props.rs	11	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/spread_reserved_props.rs	11	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/spread_reserved_props.rs	11	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/statements.rs	15	s0	S0/carton	stage	vize_carton	compat	6
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/statements.rs	15	s0	S0	stage	vize_carton	compat	6
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/statements.rs	15	croquis	Croquis analysis	old	vize_croquis	legacy	3
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/tests.rs	2	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/expressions/tests.rs	2	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/value_checks.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/vif_chain.rs	5	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/vif_chain.rs	5	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/expressions/vif_chain.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator.rs	70	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator.rs	70	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator.rs	70	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator.rs	70	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/anchors.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/anchors.rs	4	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/anchors.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/authored_events.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/authored_events.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/authored_events.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/auto_import_stubs.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/auto_import_stubs.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/auto_import_stubs.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/component_constructors.rs	8	s0	S0/carton	stage	vize_carton	compat	2
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/component_export.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/css_modules.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/component_constructors.rs	8	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/component_export.rs	1	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/css_modules.rs	5	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/css_modules.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/css_modules.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/css_modules.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/emits.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/emits.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/emits.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/entry.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	3
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/entry.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/fallthrough_tests.rs	1	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/fallthrough_tests.rs	1	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/fallthrough_tests.rs	1	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/fallthrough_tests.rs	1	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/fallthrough_tests.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/fallthrough.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/fallthrough.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/fallthrough.rs	1	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/fallthrough.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/fallthrough/attrs_expr.rs	4	old_ast	old AST/parser	old	vize_relief	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/generics.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/generics.rs	4	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/generics.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/generics.rs	259	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/global_components.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/generics.rs	259	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/global_components.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/global_components.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/imports.rs	3	s0	S0/carton	stage	vize_carton	compat	3
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/imports.rs	3	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/imports.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/imports.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/imports.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/imports.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/imports.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs	1	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs	1	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs	1	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs	251	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/macro_anchors.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/legacy_vue2.rs	251	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/macro_anchors.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/macro_anchors.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/macro_anchors.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/macro_anchors.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/macro_anchors.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/macro_anchors.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_bridge.rs	30	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_bridge.rs	30	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_bridge.rs	30	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_bridge/collect.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_bridge/collect.rs	5	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_bridge/collect.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_bridge/collect.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_bridge/collect.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_bridge/inherited.rs	26	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_bridge/inherited.rs	26	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_bridge/inherited.rs	26	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_props_identifiers.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_props_identifiers.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_props_identifiers.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_props_identifiers.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_props_identifiers.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_support.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_support.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_support.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_support.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_support.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_support.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api_support.rs	1	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/options_api.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_blocks.rs	14	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_blocks.rs	14	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_blocks.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/script_blocks.rs	163	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module.rs	6	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module.rs	6	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist.rs	28	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist.rs	28	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist.rs	28	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist.rs	28	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist.rs	28	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist.rs	28	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist/tests.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports.rs	18	s0	S0/carton	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/script_module/namespace_hoist/tests.rs	3	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports.rs	18	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports.rs	18	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports.rs	18	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports.rs	18	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports/tests.rs	61	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers.rs	9	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/script_module/plain_exports/tests.rs	61	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers.rs	9	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers.rs	9	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers.rs	9	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers/boolean_keys.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers/boolean_keys.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers/boolean_keys.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers/boolean_keys.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers/boolean_keys.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers/boolean_keys.rs	1	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers/boolean_keys.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers/template_ref_registry.rs	12	s0	S0/carton	stage	vize_carton	compat	5
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers/template_ref_registry.rs	12	s0	S0	stage	vize_carton	compat	5
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers/template_ref_registry.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_helpers/template_ref_registry.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/setup_helpers/template_ref_registry/tests.rs	1	s0	S0/carton	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/setup_helpers/template_ref_registry/tests.rs	1	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/setup_helpers/template_ref_registry/tests.rs	1	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/setup_helpers/template_ref_registry/tests.rs	1	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/setup_helpers/template_ref_registry/tests.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_props.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_props.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_props.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_scope.rs	9	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_scope.rs	9	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_scope.rs	9	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs	198	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs	198	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/setup_type_exports.rs	198	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/spans.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/spans.rs	5	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/spans.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/spans.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/template_refs.rs	6	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/template_refs.rs	6	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/template_refs.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/template_refs/auto_imports.rs	22	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/template_refs/auto_imports.rs	22	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/template_refs/auto_imports.rs	22	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/template_refs/auto_imports.rs	97	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/template_refs/auto_imports.rs	97	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/generator/template_refs/auto_imports.rs	97	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/template_refs/deferred_bindings.rs	35	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/template_refs/deferred_bindings.rs	35	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/template_refs/deferred_bindings.rs	35	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/template_refs/deferred_bindings.rs	35	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/template_refs/deferred_bindings.rs	35	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/template_refs/deferred_bindings.rs	35	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/type_only_imports.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/type_only_imports.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/type_only_imports.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/type_only_imports.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/type_only_imports.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/type_only_imports.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/unresolved_components.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/unresolved_components.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/generator/unresolved_components.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/helpers.rs	24	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/helpers.rs	24	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/helpers/preamble.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/import_meta.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/incremental.rs	13	s0	S0/carton	stage	vize_carton	compat	4
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/interface_extends_tests.rs	2	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/import_meta.rs	3	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/incremental.rs	13	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/interface_extends_tests.rs	2	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/interface_extends_tests.rs	2	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/interface_extends_tests.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs	1	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs	1	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs	1	old_ast	old AST/parser	old	vize_armature	legacy	3
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/legacy_vue2_vuetify_tests.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/macro_type_mappings.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/macro_type_mappings.rs	5	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/macro_type_mappings.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props.rs	19	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props.rs	19	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props.rs	19	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/props.rs	341	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/keyed_template_names.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/props.rs	341	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/keyed_template_names.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/keyed_template_names.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	3
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/mappings.rs	5	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/mappings.rs	5	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/mappings.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/options_api.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/setup_scoped.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/options_api.rs	1	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/setup_scoped.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/setup_scoped.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/setup_scoped.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/setup_scoped.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/setup_scoped.rs	1	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/setup_scoped.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/template_bindings.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/template_bindings.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/template_bindings.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	3
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/template_model_modifiers.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/template_model_modifiers.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/template_model_modifiers.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/template_model.rs	15	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/template_model.rs	15	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/template_model.rs	15	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/template_names.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/template_names.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/template_names.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/with_defaults.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/with_defaults.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/with_defaults.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/with_defaults.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/props/with_defaults.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/props/with_defaults.rs	89	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/children.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/props/with_defaults.rs	89	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/children.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/children.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/closures.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/closures.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/closures.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_event_navigation.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_event_navigation.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_event_navigation.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_events.rs	6	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_events.rs	6	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_events.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_events/generic_inference.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_events/generic_inference.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_events/generic_inference.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_events/handler_context.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_events/reference.rs	1	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_navigation.rs	3	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_events/reference.rs	1	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_navigation.rs	3	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_prop_checker.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_prop_expressions.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_prop_expressions.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_prop_expressions.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_prop_navigation.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_props.rs	4	s0	S0/carton	stage	vize_carton	compat	7
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_props.rs	4	s0	S0	stage	vize_carton	compat	7
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_props.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_slots.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_slots.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/component_slots.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/context.rs	3	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/context.rs	3	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/context.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/context.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	3
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/emit.rs	3	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/emit.rs	3	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/emit.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/emit.rs	3	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/empty_component_props.rs	3	s0	S0/carton	stage	vize_carton	compat	6
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/empty_component_props.rs	3	s0	S0	stage	vize_carton	compat	6
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/empty_component_props.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/event_handler.rs	5	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/event_scope.rs	17	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/event_handler.rs	5	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/event_scope.rs	17	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/event_scope.rs	17	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/event_scope/event_targets.rs	1	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/event_scope/event_targets.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/scope/event_scope/event_targets.rs	197	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/scope/event_scope/event_targets.rs	197	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/scope/event_scope/event_targets.rs	197	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/scope/event_scope/event_targets.rs	197	old_ast	old AST/parser	old	vize_armature	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals.rs	3	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals/instance.rs	21	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals/instance.rs	21	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals/instance.rs	21	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/scope/globals/instance/tests.rs	4	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/scope/globals/instance/tests.rs	4	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/scope/globals/instance/tests.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/scope/globals/instance/tests.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals/member_root.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals/strict_candidate.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals/strict_expression.rs	3	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals/strict_expression.rs	3	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals/strict_expression.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/globals/template_scope.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/inline_callback_classifier.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/inline_callback_classifier.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/inline_callback_classifier.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_outlet_props.rs	11	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_outlet_props.rs	11	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_outlet_props.rs	11	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_outlet_props.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_outlet_props/collect.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_outlet_props/collect.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_outlet_props/collect.rs	1	old_ast	old AST/parser	old	vize_relief	legacy	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_outlet_props/collect.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_outlet_props/emit.rs	3	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_outlet_props/emit.rs	3	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_outlet_props/emit.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_scope.rs	13	s0	S0/carton	stage	vize_carton	compat	6
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_scope.rs	13	s0	S0	stage	vize_carton	compat	6
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_scope.rs	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_scope/payload.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_scope/payload.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/slot_scope/payload.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/vif_guard.rs	1	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/vif_guard.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/scope/vif_guard.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/strict_template_globals_tests.rs	3	s0	S0/carton	stage	vize_carton	compat	8
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/strict_template_globals_tests.rs	3	s0	S0	stage	vize_carton	compat	8
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/strict_template_globals_tests.rs	3	old_ast	old AST/parser	old	vize_armature	legacy	7
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/strict_template_globals_tests.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/strict_template_scope_tests.rs	15	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/strict_template_scope_tests.rs	15	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/strict_template_scope_tests.rs	15	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/strict_template_scope_tests.rs	15	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests.rs	8	s0	S0/carton	stage	vize_carton	compat	37
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests.rs	8	s0	S0	stage	vize_carton	compat	37
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests.rs	8	old_ast	old AST/parser	old	vize_armature	legacy	36
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	50
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/auto_import_shadowing.rs	2	s0	S0/carton	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/auto_import_shadowing.rs	2	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/auto_import_shadowing.rs	2	old_ast	old AST/parser	old	vize_armature	legacy	3
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/auto_import_shadowing.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/component_navigation.rs	4	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/component_navigation.rs	4	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/component_navigation.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/component_navigation.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/component_spread_prop_order.rs	8	s0	S0/carton	stage	vize_carton	compat	8
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/component_spread_prop_order.rs	8	s0	S0	stage	vize_carton	compat	8
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/component_spread_prop_order.rs	8	old_ast	old AST/parser	old	vize_armature	legacy	7
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/component_spread_prop_order.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/define_props_scope.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/generic_module_type_exports.rs	10	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/generic_module_type_exports.rs	10	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/generic_module_type_exports.rs	10	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/legacy_nuxt2_page_context.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/model_update_payload.rs	9	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/model_update_payload.rs	9	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/model_update_payload.rs	9	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/model_update_payload.rs	9	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/no_check_template_bindings.rs	5	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/no_check_template_bindings.rs	5	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/no_check_template_bindings.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/no_check_template_bindings.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs	30	s0	S0/carton	stage	vize_carton	compat	7
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs	30	s0	S0	stage	vize_carton	compat	7
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs	30	old_ast	old AST/parser	old	vize_armature	legacy	7
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_instance.rs	30	croquis	Croquis analysis	old	vize_croquis	legacy	18
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs	18	s0	S0/carton	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs	18	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs	18	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs	18	croquis	Croquis analysis	old	vize_croquis	legacy	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_setup_spread.rs	26	s0	S0/carton	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_setup_spread.rs	26	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_setup_spread.rs	26	old_ast	old AST/parser	old	vize_armature	legacy	3
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_setup_spread.rs	26	croquis	Croquis analysis	old	vize_croquis	legacy	6
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_this_bridge/mixin_members.rs	10	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/slot_component_bindings.rs	2	s0	S0/carton	stage	vize_carton	compat	6
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/options_api_this_bridge/mixin_members.rs	10	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/slot_component_bindings.rs	2	s0	S0	stage	vize_carton	compat	6
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/slot_component_bindings.rs	2	old_ast	old AST/parser	old	vize_armature	legacy	5
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/slot_component_bindings.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/unused_refs.rs	4	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/unused_refs.rs	4	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/unused_refs.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/unused_refs.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/vif_chain.rs	2	s0	S0/carton	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/vif_chain.rs	2	s0	S0	stage	vize_carton	compat	4
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/vif_chain.rs	2	old_ast	old AST/parser	old	vize_armature	legacy	4
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/tests/vif_chain.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/types.rs	4	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/types.rs	327	s0	S0/carton	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/unknown_props_tests.rs	5	s0	S0/carton	stage	vize_carton	compat	2
+typechecker	Typechecker	source	crates/vize_canon/src/virtual_ts/types.rs	4	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/types.rs	327	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/unknown_props_tests.rs	5	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/unknown_props_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/virtual_ts/unknown_props_tests.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/ambient_declarations.rs	67	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/ambient_declarations.rs	67	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/auto_import_ref_unwrap.rs	13	s0	S0/carton	stage	vize_s0	preferred	3
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/auto_import_ref_unwrap.rs	13	s0	S0	stage	vize_s0	preferred	3
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/auto_import_ref_unwrap.rs	13	old_ast	old AST/parser	old	vize_armature	legacy	3
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/auto_import_ref_unwrap.rs	13	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/component_event_arity.rs	4	s0	S0/carton	stage	vize_s0	preferred	2
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/component_event_arity.rs	4	s0	S0	stage	vize_s0	preferred	2
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/component_event_arity.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/component_event_arity.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/empty_template_interpolation.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/empty_template_interpolation.rs	2	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/empty_template_interpolation.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/empty_template_interpolation.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/escaped_regex_template_expression.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/escaped_regex_template_expression.rs	2	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/escaped_regex_template_expression.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/escaped_regex_template_expression.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/leading_semicolon_event_handler.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/leading_semicolon_event_handler.rs	2	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/leading_semicolon_event_handler.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/leading_semicolon_event_handler.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/lsp_import_resolution.rs	4	s0	S0/carton	stage	vize_s0	preferred	3
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/lsp_import_resolution/shared_editor_session.rs	41	s0	S0/carton	stage	vize_s0	preferred	3
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/lsp_vue_references.rs	118	s0	S0/carton	stage	vize_s0	preferred	2
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/nested_vif_narrowing.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/no_space_default_export.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/lsp_import_resolution.rs	4	s0	S0	stage	vize_s0	preferred	3
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/lsp_import_resolution/shared_editor_session.rs	41	s0	S0	stage	vize_s0	preferred	3
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/lsp_vue_references.rs	118	s0	S0	stage	vize_s0	preferred	2
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/nested_vif_narrowing.rs	4	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/no_space_default_export.rs	2	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/no_space_default_export.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/no_space_default_export.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/options_api_runtime_props_value_scope.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/options_api_runtime_props_value_scope.rs	2	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/options_api_runtime_props_value_scope.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/options_api_runtime_props_value_scope.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/plain_script_named_exports.rs	17	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/plain_script_named_exports.rs	17	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/plain_script_namespace_hoisting.rs	70	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/plain_script_namespace_hoisting.rs	70	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/recovered_parse_codegen.rs	38	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/relative_extensionless_vue_imports.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_enum_member.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/recovered_parse_codegen.rs	38	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/relative_extensionless_vue_imports.rs	15	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_enum_member.rs	2	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_enum_member.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_enum_member.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_template_literals.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_template_literals.rs	2	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_template_literals.rs	2	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/reserved_template_literals.rs	2	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/runtime_function_prop_union.rs	43	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/runtime_function_prop_union.rs	43	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/setup_scoped_type_exports.rs	107	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 typechecker	Typechecker	test/dev	crates/vize_canon/tests/setup_scoped_type_exports.rs	107	raw_oxc	raw OXC	raw	oxc_parser	raw	3
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/support/auto_import_project.rs	128	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/support/tier_l_incremental_artifact.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/tier_l_incremental.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize_canon/tests/tsconfig_option_diagnostics.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/support/auto_import_project.rs	128	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/support/tier_l_incremental_artifact.rs	6	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/tier_l_incremental.rs	10	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize_canon/tests/tsconfig_option_diagnostics.rs	14	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_ast.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/dts_import_aliases.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/dts_import_aliases.rs	3	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_import_aliases.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_import_aliases.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/dts_import_aliases.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/dts_rewrite.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/dts.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/imports_aliases.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/imports_cache.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_generated_tests.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_js_tests.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_package_routes.rs	80	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/imports_registration.rs	3	s0	S0/carton	stage	vize_s0	preferred	2
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_registration.rs	168	s0	S0/carton	stage	vize_s0	preferred	2
-typechecker	Typechecker	source	crates/vize/src/commands/check/imports_resolution.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/imports_specifiers.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_tests.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports.rs	12	s0	S0/carton	stage	vize_s0	preferred	2
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/dts_rewrite.rs	3	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/dts.rs	7	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/imports_aliases.rs	4	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/imports_cache.rs	9	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_generated_tests.rs	3	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_js_tests.rs	2	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_package_routes.rs	80	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/imports_registration.rs	3	s0	S0	stage	vize_s0	preferred	2
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_registration.rs	168	s0	S0	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize/src/commands/check/imports_resolution.rs	5	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/imports_specifiers.rs	3	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports_tests.rs	2	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/imports.rs	12	s0	S0	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt.rs	8	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback.rs	12	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback.rs	12	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback.rs	12	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback.rs	12	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback/fallback_values.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/generated_ast_tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_ast.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/fallback/fallback_values.rs	1	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/generated_ast_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_ast.rs	3	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_ast.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_ast.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_ast.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_ast.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_dir.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_values.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/legacy_template_globals_tests.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/legacy_template_globals.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/parsing.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_dir.rs	10	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated_values.rs	5	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/generated.rs	7	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/legacy_template_globals_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/legacy_template_globals.rs	2	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/parsing.rs	5	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/parsing.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/parsing.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	9
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/parsing.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins/extract.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins.rs	6	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins/extract.rs	5	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins/extract.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins/extract.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	3
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins/extract.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/plugins/extract/bindings.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	2
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/plugins/tests.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/source_scan.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/plugins/tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/source_scan.rs	6	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/source_scan.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/source_scan.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/source_scan.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/stubs.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/tests.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/stubs.rs	5	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/tests.rs	4	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/tests.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	test/dev	crates/vize/src/commands/check/nuxt/tests.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/tsconfig_aliases.rs	9	s0	S0/carton	stage	vize_s0	preferred	2
-typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/virtual_modules.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/tsconfig_aliases.rs	9	s0	S0	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/virtual_modules.rs	6	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/virtual_modules.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/virtual_modules.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/nuxt/virtual_modules.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/path_cache.rs	5	s0	S0/carton	stage	vize_s0	preferred	2
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/path_cache.rs	47	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner.rs	145	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/collect_tests.rs	11	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/collect.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/collect.rs	273	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/default_imports_tests.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/default_imports.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/diagnostics.rs	9	s0	S0/carton	stage	vize_s0	preferred	3
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/diagnostics/source_context.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/diagnostics/source_filter.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/execution.rs	9	s0	S0/carton	stage	vize_s0	preferred	3
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/global_components.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/ignores.rs	43	s0	S0/carton	stage	vize_s0	preferred	2
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/input_scope.rs	16	s0	S0/carton	stage	vize_s0	preferred	3
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/input_scope/tests.rs	18	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/invocation.rs	31	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/nuxt_tsconfig.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/nuxt_tsconfig.rs	256	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/nuxt_tsconfig/cache.rs	10	s0	S0/carton	stage	vize_s0	preferred	5
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/nuxt_tsconfig/path_options_tests.rs	252	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_declarations.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_json.rs	3	s0	S0/carton	stage	vize_s0	preferred	4
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_profile.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output.rs	5	s0	S0/carton	stage	vize_s0	preferred	3
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/program_inputs.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/programs.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/resolve.rs	7	s0	S0/carton	stage	vize_s0	preferred	8
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/socket.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/runner/text_style.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs.rs	11	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/ambient.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/collect.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/default_exclude_tests.rs	17	s0	S0/carton	stage	vize_s0	preferred	2
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/glob.rs	94	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/hidden_include_tests.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/loader.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/nuxt_manifest_tests.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/ownership_shared_tests.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs	17	s0	S0/carton	stage	vize_s0	preferred	2
-typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/tests.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/type_references.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/type_references/tsconfig_types.rs	4	s0	S0/carton	stage	vize_s0	preferred	2
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper.rs	8	s0	S0/carton	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize/src/commands/check/path_cache.rs	5	s0	S0	stage	vize_s0	preferred	2
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/path_cache.rs	47	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner.rs	145	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/collect_tests.rs	11	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/collect.rs	10	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/collect.rs	273	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/default_imports_tests.rs	3	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/default_imports.rs	3	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/diagnostics.rs	9	s0	S0	stage	vize_s0	preferred	3
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/diagnostics/source_context.rs	3	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/diagnostics/source_filter.rs	3	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/execution.rs	9	s0	S0	stage	vize_s0	preferred	3
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/global_components.rs	15	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/ignores.rs	43	s0	S0	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/input_scope.rs	16	s0	S0	stage	vize_s0	preferred	3
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/input_scope/tests.rs	18	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/invocation.rs	31	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/nuxt_tsconfig.rs	15	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/nuxt_tsconfig.rs	256	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/nuxt_tsconfig/cache.rs	10	s0	S0	stage	vize_s0	preferred	5
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/runner/nuxt_tsconfig/path_options_tests.rs	252	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_declarations.rs	2	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_json.rs	3	s0	S0	stage	vize_s0	preferred	4
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output_profile.rs	4	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/output.rs	5	s0	S0	stage	vize_s0	preferred	3
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/program_inputs.rs	3	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/programs.rs	5	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/resolve.rs	7	s0	S0	stage	vize_s0	preferred	8
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/socket.rs	10	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/runner/text_style.rs	6	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs.rs	11	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/ambient.rs	8	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/collect.rs	6	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/default_exclude_tests.rs	17	s0	S0	stage	vize_s0	preferred	2
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/glob.rs	94	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/hidden_include_tests.rs	10	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/loader.rs	10	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/nuxt_manifest_tests.rs	10	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/ownership_shared_tests.rs	7	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/package_folder_tests.rs	17	s0	S0	stage	vize_s0	preferred	2
+typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/tests.rs	8	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/type_references.rs	9	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/type_references/tsconfig_types.rs	4	s0	S0	stage	vize_s0	preferred	2
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs	1	s0	S0	stage	vize_s0	preferred	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs	12	s0	S0	stage	vize_s0	preferred	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs	4	s0	S0	stage	vize_s0	preferred	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper.rs	8	s0	S0	stage	vize_s0	preferred	2
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper.rs	18	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper/project.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper/test_support.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	manifest	crates/vize_glyph/Cargo.toml	13	s0	S0/carton	stage	vize_s0	preferred	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper.rs	18	s0	S0	stage	vize_s0	preferred	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper/project.rs	13	s0	S0	stage	vize_s0	preferred	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper/test_support.rs	6	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	manifest	crates/vize_glyph/Cargo.toml	13	s0	S0	stage	vize_s0	preferred	1
 formatter	Formatter	manifest	crates/vize_glyph/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 formatter	Formatter	manifest	crates/vize_glyph/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 formatter	Formatter	manifest	crates/vize_glyph/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_formatter	raw	1
 formatter	Formatter	manifest	crates/vize_glyph/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_formatter_core	raw	1
 formatter	Formatter	manifest	crates/vize_glyph/Cargo.toml	13	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-formatter	Formatter	source	crates/vize_glyph/src/error.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize_glyph/src/formatter.rs	17	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	test/dev	crates/vize_glyph/src/formatter/block_indent.rs	47	s0	S0/carton	stage	vize_s0	preferred	2
-formatter	Formatter	source	crates/vize_glyph/src/json.rs	22	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize_glyph/src/json/ast.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize_glyph/src/json/number.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize_glyph/src/json/parser.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize_glyph/src/json/printer.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize_glyph/src/lib.rs	53	s0	S0/carton	stage	vize_s0	preferred	2
-formatter	Formatter	source	crates/vize_glyph/src/options.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/error.rs	4	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/formatter.rs	17	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	test/dev	crates/vize_glyph/src/formatter/block_indent.rs	47	s0	S0	stage	vize_s0	preferred	2
+formatter	Formatter	source	crates/vize_glyph/src/json.rs	22	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/json/ast.rs	4	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/json/number.rs	5	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/json/parser.rs	6	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/json/printer.rs	4	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/lib.rs	53	s0	S0	stage	vize_s0	preferred	2
+formatter	Formatter	source	crates/vize_glyph/src/options.rs	6	s0	S0	stage	vize_s0	preferred	1
 formatter	Formatter	source	crates/vize_glyph/src/options.rs	6	raw_oxc	raw OXC	raw	oxc_formatter	raw	3
 formatter	Formatter	source	crates/vize_glyph/src/options.rs	6	raw_oxc	raw OXC	raw	oxc_formatter_core	raw	1
-formatter	Formatter	source	crates/vize_glyph/src/script.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/script.rs	10	s0	S0	stage	vize_s0	preferred	1
 formatter	Formatter	source	crates/vize_glyph/src/script.rs	10	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 formatter	Formatter	source	crates/vize_glyph/src/script.rs	10	raw_oxc	raw OXC	raw	oxc_formatter	raw	1
-formatter	Formatter	test/dev	crates/vize_glyph/src/script.rs	56	s0	S0/carton	stage	vize_s0	preferred	1
+formatter	Formatter	test/dev	crates/vize_glyph/src/script.rs	56	s0	S0	stage	vize_s0	preferred	1
 formatter	Formatter	test/dev	crates/vize_glyph/src/script.rs	56	raw_oxc	raw OXC	raw	oxc_allocator	raw	7
-formatter	Formatter	source	crates/vize_glyph/src/script/block_identity.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/script/block_identity.rs	4	s0	S0	stage	vize_s0	preferred	1
 formatter	Formatter	source	crates/vize_glyph/src/script/block_identity.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 formatter	Formatter	source	crates/vize_glyph/src/script/block_identity.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 formatter	Formatter	source	crates/vize_glyph/src/script/block_identity.rs	4	raw_oxc	raw OXC	raw	oxc_formatter	raw	1
-formatter	Formatter	source	crates/vize_glyph/src/style.rs	11	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize_glyph/src/style/stabilization.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	test/dev	crates/vize_glyph/src/style/stabilization.rs	226	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	test/dev	crates/vize_glyph/src/template.rs	28	s0	S0/carton	stage	vize_s0	preferred	2
-formatter	Formatter	source	crates/vize_glyph/src/template/attributes.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize_glyph/src/template/directives.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize_glyph/src/template/formatter.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize_glyph/src/template/formatter/interpolation.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize_glyph/src/template/formatter/text.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize_glyph/src/template/helpers.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	test/dev	crates/vize_glyph/tests/sfc_block_attributes.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize/src/commands/fmt.rs	17	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize/src/commands/fmt/data.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize/src/commands/fmt/data/plain.rs	17	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	source	crates/vize/src/commands/fmt/entries.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	test/dev	crates/vize/src/commands/fmt/files_tests.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
-formatter	Formatter	test/dev	crates/vize/src/commands/fmt/files.rs	125	s0	S0/carton	stage	vize_s0	preferred	4
-formatter	Formatter	source	crates/vize/src/commands/fmt/ignores.rs	80	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	s0	S0/carton	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/style.rs	11	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/style/stabilization.rs	9	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	test/dev	crates/vize_glyph/src/style/stabilization.rs	226	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	test/dev	crates/vize_glyph/src/template.rs	28	s0	S0	stage	vize_s0	preferred	2
+formatter	Formatter	source	crates/vize_glyph/src/template/attributes.rs	5	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/template/directives.rs	7	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/template/formatter.rs	9	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/template/formatter/interpolation.rs	9	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/template/formatter/text.rs	10	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize_glyph/src/template/helpers.rs	6	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	test/dev	crates/vize_glyph/tests/sfc_block_attributes.rs	5	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize/src/commands/fmt.rs	17	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize/src/commands/fmt/data.rs	5	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize/src/commands/fmt/data/plain.rs	17	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	source	crates/vize/src/commands/fmt/entries.rs	3	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	test/dev	crates/vize/src/commands/fmt/files_tests.rs	7	s0	S0	stage	vize_s0	preferred	1
+formatter	Formatter	test/dev	crates/vize/src/commands/fmt/files.rs	125	s0	S0	stage	vize_s0	preferred	4
+formatter	Formatter	source	crates/vize/src/commands/fmt/ignores.rs	80	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	croquis	Croquis analysis	old	vize_croquis	legacy	1
@@ -2394,19 +2394,19 @@ lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	raw_oxc	raw OXC	raw	oxc_ast	r
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 lsp	LSP	manifest	crates/vize_maestro/Cargo.toml	44	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-lsp	LSP	source	crates/vize_maestro/src/document/store.rs	79	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide.rs	210	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/auto_insert.rs	77	s0	S0/carton	stage	vize_s0	preferred	2
-lsp	LSP	source	crates/vize_maestro/src/ide/code_action.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/document/store.rs	79	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide.rs	210	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/auto_insert.rs	77	s0	S0	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/code_action.rs	14	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/code_action.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	5
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/component_props_tests.rs	318	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/component_props_tests.rs	318	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/items.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/script.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/script.rs	24	croquis	Croquis analysis	old	vize_croquis	legacy	2
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/context.rs	10	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/member_access.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/member_access.rs	12	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/member_access.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal.rs	6	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
@@ -2418,237 +2418,237 @@ lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal/rece
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/object_literal/receiver_value.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/script/reactive_infer.rs	10	croquis	Croquis analysis	old	vize_croquis	legacy	2
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/script/tests.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/bindings.rs	14	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/bindings.rs	14	s0	S0	stage	vize_s0	preferred	2
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/bindings.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/bindings.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	2
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/bindings.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	2
-lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_cache.rs	90	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_meta.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_cache.rs	90	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_meta.rs	5	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_meta.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_meta.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_meta.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/component_meta.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/slot_outlets.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/slot_outlets.rs	5	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/slot_outlets.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/completion/template/slot_outlets.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/tests.rs	8	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/tests.rs	8	s0	S0	stage	vize_s0	preferred	2
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/completion/tests.rs	8	old_ast	old AST/parser	old	vize_relief	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/context.rs	88	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support.rs	52	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical.rs	3	s0	S0/carton	stage	vize_s0	preferred	5
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/open.rs	146	s0	S0/carton	stage	vize_s0	preferred	2
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/project.rs	5	s0	S0/carton	stage	vize_s0	preferred	3
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs	3	s0	S0/carton	stage	vize_s0	preferred	3
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/external_mirror.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support/external_mirror.rs	109	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/html_attribute.rs	2	s0	S0/carton	stage	vize_s0	preferred	10
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/html_tag.rs	2	s0	S0/carton	stage	vize_s0	preferred	6
-lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/virtual_document.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs	159	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/definition/art.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/definition/corsa_tests.rs	32	s0	S0/carton	stage	vize_s0	preferred	2
-lsp	LSP	source	crates/vize_maestro/src/ide/definition/import_resolver.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/definition/script.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/context.rs	88	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support.rs	52	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical.rs	3	s0	S0	stage	vize_s0	preferred	5
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/open.rs	146	s0	S0	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/project.rs	5	s0	S0	stage	vize_s0	preferred	3
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links.rs	3	s0	S0	stage	vize_s0	preferred	3
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/canonical/semantic_links/component_props.rs	5	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/external_mirror.rs	4	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support/external_mirror.rs	109	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/html_attribute.rs	2	s0	S0	stage	vize_s0	preferred	10
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/html_tag.rs	2	s0	S0	stage	vize_s0	preferred	6
+lsp	LSP	source	crates/vize_maestro/src/ide/corsa_support/virtual_document.rs	4	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs	159	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/definition/art.rs	10	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/definition/corsa_tests.rs	32	s0	S0	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/definition/import_resolver.rs	6	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/definition/script.rs	14	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/script.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/definition/slot.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/definition/slot.rs	2	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/slot.rs	2	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/slot.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/template.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/template.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/definition/tests/contexts.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/collectors.rs	12	s0	S0/carton	stage	vize_s0	preferred	3
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/definition/tests/contexts.rs	4	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/collectors.rs	12	s0	S0	stage	vize_s0	preferred	3
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/collectors.rs	12	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/collectors.rs	12	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/collectors.rs	12	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/component_props.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/component_props.rs	8	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/component_props.rs	8	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/component_props.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs	16	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/message.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/corsa/message.rs	47	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/corsa/relative_import_tests.rs	210	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs	1	s0	S0/carton	stage	vize_s0	preferred	2
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art_bindings.rs	5	s0	S0/carton	stage	vize_s0	preferred	4
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs	4	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs	16	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/message.rs	4	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/corsa/message.rs	47	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/corsa/relative_import_tests.rs	210	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs	1	s0	S0	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art_bindings.rs	5	s0	S0	stage	vize_s0	preferred	4
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art_bindings.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs	12	s0	S0/carton	stage	vize_s0	preferred	3
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs	12	s0	S0	stage	vize_s0	preferred	3
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs	12	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs	14	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/editor_typecheck_fixture.rs	212	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/line_index.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/line_index.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/vize_sfc_type.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/ecosystem/i18n.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/ecosystem/router_extension_tests.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/ecosystem/router.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/ecosystem/router.rs	612	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/ecosystem/void.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/editor_typecheck_fixture.rs	212	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs	10	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/line_index.rs	7	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/diagnostics/line_index.rs	9	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/diagnostics/vize_sfc_type.rs	5	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/ecosystem/i18n.rs	12	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/ecosystem/router_extension_tests.rs	2	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/ecosystem/router.rs	8	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/ecosystem/router.rs	612	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/ecosystem/void.rs	7	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/file_rename/manual/script.rs	5	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/file_rename/manual/script.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	3
 lsp	LSP	source	crates/vize_maestro/src/ide/file_rename/manual/script.rs	5	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/file_rename/manual/script.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover.rs	159	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/component_import.rs	118	croquis	Croquis analysis	old	vize_croquis	legacy	4
-lsp	LSP	source	crates/vize_maestro/src/ide/hover/component_tag.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/hover/component_tag.rs	2	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/component_tag.rs	2	old_ast	old AST/parser	old	vize_armature	legacy	2
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/component_tag.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	2
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/component_tag/items.rs	1	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover/component_tag/items.rs	75	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover/component_tag/items.rs	75	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover/component_tag/items.rs	75	croquis	Croquis analysis	old	vize_croquis	legacy	2
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover/corsa_tests.rs	56	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover/corsa_tests.rs	56	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	croquis	Croquis analysis	old	vize_croquis	legacy	3
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/declaration_keyword.rs	19	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-lsp	LSP	source	crates/vize_maestro/src/ide/hover/petite_vue.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/hover/petite_vue.rs	2	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/petite_vue.rs	2	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/petite_vue.rs	2	croquis	Croquis analysis	old	vize_croquis	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/script_type_infer.rs	4	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/hover/script_type_infer.rs	300	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/script.rs	11	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/script.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/hover/template.rs	12	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/hover/template.rs	12	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/template.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/template.rs	12	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/hover/template.rs	12	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/inlay_hint.rs	21	s0	S0/carton	stage	vize_s0	preferred	4
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/inlay_hint.rs	21	s0	S0	stage	vize_s0	preferred	4
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/inlay_hint.rs	21	croquis	Croquis analysis	old	vize_croquis	legacy	3
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/code_action.rs	27	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/document_symbols.rs	25	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/scoped_style.rs	20	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/code_action.rs	27	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/document_symbols.rs	25	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/scoped_style.rs	20	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/jsx/scoped_style.rs	20	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/jsx/scoped_style.rs	20	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 lsp	LSP	source	crates/vize_maestro/src/ide/jsx/scoped_style.rs	20	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/service_project.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/service.rs	32	s0	S0/carton	stage	vize_s0	preferred	3
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/jsx/virtual_ts_tests.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts.rs	24	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/service_project.rs	14	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/service.rs	32	s0	S0	stage	vize_s0	preferred	3
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/jsx/virtual_ts_tests.rs	3	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts.rs	24	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts/collect.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	4
 lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts/component.rs	8	old_ast	old AST/parser	old	vize_relief	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts/generate.rs	5	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts/generate.rs	5	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/jsx/virtual_ts/slot.rs	16	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/musea.rs	35	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/references/canonical.rs	3	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/references/canonical.rs	3	s0	S0	stage	vize_s0	preferred	2
 lsp	LSP	source	crates/vize_maestro/src/ide/references/canonical.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/references/canonical.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/references/corsa_tests.rs	237	s0	S0/carton	stage	vize_s0	preferred	2
-lsp	LSP	source	crates/vize_maestro/src/ide/references/corsa_tests/project_surface.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/references/script.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/references/corsa_tests.rs	237	s0	S0	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/references/corsa_tests/project_surface.rs	6	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/references/script.rs	9	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/references/script.rs	9	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/references/script.rs	9	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 lsp	LSP	source	crates/vize_maestro/src/ide/references/script.rs	9	raw_oxc	raw OXC	raw	oxc_parser	raw	2
-lsp	LSP	source	crates/vize_maestro/src/ide/references/template.rs	32	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/references/template.rs	32	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/references/template.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	4
 lsp	LSP	source	crates/vize_maestro/src/ide/references/template.rs	32	old_ast	old AST/parser	old	vize_armature	legacy	2
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical.rs	8	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename.rs	4	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	2
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/canonical/event_rename.rs	219	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename/model.rs	4	s0	S0/carton	stage	vize_s0	preferred	3
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/canonical/event_rename.rs	219	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename/model.rs	4	s0	S0	stage	vize_s0	preferred	3
 lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename/model.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename/model.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename/rewrite.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/execute.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs	171	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/failure.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_event_variants_tests.rs	212	s0	S0/carton	stage	vize_s0	preferred	2
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_model_tests.rs	285	s0	S0/carton	stage	vize_s0	preferred	2
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_session_tests.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/direct_first.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/assertions.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/evidence.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/executable.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_tests.rs	343	s0	S0/carton	stage	vize_s0	preferred	2
-lsp	LSP	source	crates/vize_maestro/src/ide/selection_range/markup.rs	112	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/semantic_tokens/art.rs	294	s0	S0/carton	stage	vize_s0	preferred	2
-lsp	LSP	source	crates/vize_maestro/src/ide/semantic_tokens/encoding.rs	13	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/signature_help.rs	180	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/signature_help/tests/fixture.rs	155	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/tag_pair.rs	119	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/event_rename/rewrite.rs	6	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/execute.rs	3	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs	3	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/canonical/execute/component_props.rs	171	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/canonical/failure.rs	2	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_event_variants_tests.rs	212	s0	S0	stage	vize_s0	preferred	2
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_model_tests.rs	285	s0	S0	stage	vize_s0	preferred	2
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_session_tests.rs	4	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/direct_first.rs	3	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness.rs	9	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/assertions.rs	9	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/evidence.rs	3	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol.rs	10	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/executable.rs	7	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/rename/corsa_session_tests/harness/protocol/readiness.rs	3	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/rename/corsa_tests.rs	343	s0	S0	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/selection_range/markup.rs	112	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/semantic_tokens/art.rs	294	s0	S0	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/semantic_tokens/encoding.rs	13	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/signature_help.rs	180	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/signature_help/tests/fixture.rs	155	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/tag_pair.rs	119	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/template_expression.rs	146	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_for.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_for.rs	4	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_for.rs	4	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_for.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_slot.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_slot.rs	4	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_slot.rs	4	old_ast	old AST/parser	old	vize_armature	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/template_scope/v_slot.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/ide/type_definition.rs	119	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/ide/type_definition/tests.rs	114	s0	S0/carton	stage	vize_s0	preferred	2
-lsp	LSP	source	crates/vize_maestro/src/ide/type_service.rs	141	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/type_service/diagnostics.rs	291	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/ide/type_service/type_context.rs	229	s0	S0/carton	stage	vize_s0	preferred	14
-lsp	LSP	source	crates/vize_maestro/src/ide/workspace_symbols.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/type_definition.rs	119	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/ide/type_definition/tests.rs	114	s0	S0	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/ide/type_service.rs	141	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/type_service/diagnostics.rs	291	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/type_service/type_context.rs	229	s0	S0	stage	vize_s0	preferred	14
+lsp	LSP	source	crates/vize_maestro/src/ide/workspace_symbols.rs	14	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/workspace_symbols.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	2
-lsp	LSP	source	crates/vize_maestro/src/lib.rs	154	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/runtime.rs	25	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding.rs	223	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/lib.rs	154	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/runtime.rs	25	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding.rs	223	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding/script.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding/script.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding/script.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 lsp	LSP	source	crates/vize_maestro/src/server/document_structure/folding/script.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/document_structure/folding/tests.rs	219	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/server/document_structure/symbols.rs	14	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/lifecycle.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/requests.rs	144	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/requests/params.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/server/helpers.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/helpers/supersession_tests.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/server/importers.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/server/importers/specifiers.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/document_structure/folding/tests.rs	219	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/document_structure/symbols.rs	14	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/lifecycle.rs	10	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/requests.rs	144	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/handlers/tests/requests/params.rs	3	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/helpers.rs	15	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/helpers/supersession_tests.rs	15	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/importers.rs	15	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/importers/specifiers.rs	3	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/server/importers/specifiers.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 lsp	LSP	source	crates/vize_maestro/src/server/importers/specifiers.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 lsp	LSP	source	crates/vize_maestro/src/server/importers/specifiers.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 lsp	LSP	source	crates/vize_maestro/src/server/importers/specifiers.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/importers/tests.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/server/initial_diagnostics.rs	15	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state.rs	37	s0	S0/carton	stage	vize_s0	preferred	7
-lsp	LSP	source	crates/vize_maestro/src/server/state/art_template_context.rs	79	s0	S0/carton	stage	vize_s0	preferred	3
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state/config_tests.rs	1	s0	S0/carton	stage	vize_s0	preferred	5
-lsp	LSP	source	crates/vize_maestro/src/server/state/config.rs	6	s0	S0/carton	stage	vize_s0	preferred	30
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state/corsa_overlays_perf_tests.rs	6	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state/corsa_overlays_tests.rs	10	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/server/state/corsa_overlays.rs	24	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/server/state/corsa.rs	117	s0	S0/carton	stage	vize_s0	preferred	2
-lsp	LSP	source	crates/vize_maestro/src/server/state/features.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state/virtual_docs.rs	69	s0	S0/carton	stage	vize_s0	preferred	7
+lsp	LSP	test/dev	crates/vize_maestro/src/server/importers/tests.rs	7	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/initial_diagnostics.rs	15	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state.rs	37	s0	S0	stage	vize_s0	preferred	7
+lsp	LSP	source	crates/vize_maestro/src/server/state/art_template_context.rs	79	s0	S0	stage	vize_s0	preferred	3
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state/config_tests.rs	1	s0	S0	stage	vize_s0	preferred	5
+lsp	LSP	source	crates/vize_maestro/src/server/state/config.rs	6	s0	S0	stage	vize_s0	preferred	30
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state/corsa_overlays_perf_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state/corsa_overlays_tests.rs	10	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/state/corsa_overlays.rs	24	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/state/corsa.rs	117	s0	S0	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/server/state/features.rs	4	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state/virtual_docs.rs	69	s0	S0	stage	vize_s0	preferred	7
 lsp	LSP	test/dev	crates/vize_maestro/src/server/state/virtual_docs.rs	69	old_ast	old AST/parser	old	vize_armature	legacy	2
-lsp	LSP	source	crates/vize_maestro/src/server/state/virtual_docs/art.rs	41	s0	S0/carton	stage	vize_s0	preferred	4
+lsp	LSP	source	crates/vize_maestro/src/server/state/virtual_docs/art.rs	41	s0	S0	stage	vize_s0	preferred	4
 lsp	LSP	source	crates/vize_maestro/src/server/state/virtual_docs/art.rs	41	old_ast	old AST/parser	old	vize_armature	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state/virtual_docs/tests.rs	16	s0	S0/carton	stage	vize_s0	preferred	2
-lsp	LSP	source	crates/vize_maestro/src/server/state/workspace_folders.rs	17	s0	S0/carton	stage	vize_s0	preferred	3
-lsp	LSP	test/dev	crates/vize_maestro/src/server/state/workspace_folders.rs	150	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/server/state/workspace_vue_files.rs	8	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/server/workspace_files/dependents.rs	96	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state/virtual_docs/tests.rs	16	s0	S0	stage	vize_s0	preferred	2
+lsp	LSP	source	crates/vize_maestro/src/server/state/workspace_folders.rs	17	s0	S0	stage	vize_s0	preferred	3
+lsp	LSP	test/dev	crates/vize_maestro/src/server/state/workspace_folders.rs	150	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/server/state/workspace_vue_files.rs	8	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/server/workspace_files/dependents.rs	96	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/virtual_code.rs	227	old_ast	old AST/parser	old	vize_relief	legacy	4
-lsp	LSP	test/dev	crates/vize_maestro/src/virtual_code/generator.rs	23	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	test/dev	crates/vize_maestro/src/virtual_code/generator.rs	23	s0	S0	stage	vize_s0	preferred	2
 lsp	LSP	test/dev	crates/vize_maestro/src/virtual_code/generator.rs	23	old_ast	old AST/parser	old	vize_armature	legacy	3
 lsp	LSP	source	crates/vize_maestro/src/virtual_code/generator/art_script.rs	60	croquis	Croquis analysis	old	vize_croquis	legacy	3
 lsp	LSP	source	crates/vize_maestro/src/virtual_code/generator/binding.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/virtual_code/generator/block.rs	195	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	source	crates/vize_maestro/src/virtual_code/generator/tests_semantic_bindings.rs	2	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/virtual_code/generator/block.rs	195	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/virtual_code/generator/tests_semantic_bindings.rs	2	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/virtual_code/script_code.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
-lsp	LSP	source	crates/vize_maestro/src/virtual_code/style_code.rs	11	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/src/virtual_code/template_code_tests.rs	12	s0	S0/carton	stage	vize_s0	preferred	4
+lsp	LSP	source	crates/vize_maestro/src/virtual_code/style_code.rs	11	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/src/virtual_code/template_code_tests.rs	12	s0	S0	stage	vize_s0	preferred	4
 lsp	LSP	test/dev	crates/vize_maestro/src/virtual_code/template_code_tests.rs	12	old_ast	old AST/parser	old	vize_armature	legacy	4
-lsp	LSP	source	crates/vize_maestro/src/virtual_code/template_code.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/virtual_code/template_code.rs	7	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/virtual_code/template_code.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/virtual_code/template_code.rs	7	old_ast	old AST/parser	old	vize_armature	legacy	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/canon.rs	7	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/maestro.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/matrix.rs	4	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/normalize.rs	3	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/record.rs	1	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection.rs	9	s0	S0/carton	stage	vize_s0	preferred	1
-lsp	LSP	test/dev	crates/vize_maestro/tests/file_rename_declarations.rs	9	s0	S0/carton	stage	vize_s0	preferred	2
+lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/canon.rs	7	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/maestro.rs	3	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/matrix.rs	4	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/normalize.rs	3	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection_support/record.rs	1	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/tests/davinci_ts40_projection.rs	9	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	test/dev	crates/vize_maestro/tests/file_rename_declarations.rs	9	s0	S0	stage	vize_s0	preferred	2

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -15,8 +15,16 @@ function sumValues(record) {
 void test("consumer migration scan classifies stage physical names separately from code names", () => {
   const s0 = SURFACES.find((surface) => surface.id === "s0");
   assert.ok(s0);
+  assert.equal(s0.label, "S0");
   assert.equal(surfaceNameKind(s0, "vize_s0"), "preferred");
   assert.equal(surfaceNameKind(s0, "vize_carton"), "compat");
+
+  const stageSurfaces = SURFACES.filter((surface) => surface.group === "stage");
+  assert.deepEqual(
+    stageSurfaces.map((surface) => surface.label),
+    ["Davinci", "S0", "S1", "S2", "S1->S2"],
+  );
+  assert.ok(stageSurfaces.every((surface) => !surface.label.includes("/")));
 
   const rawOxc = SURFACES.find((surface) => surface.id === "raw_oxc");
   assert.ok(rawOxc);
@@ -65,6 +73,11 @@ void test("consumer migration TSV exposes matched names and name kind", () => {
   ]);
   assert.ok(rows.every((row) => row.split("\t").length === 11));
   assert.ok(rows.some((row) => row.includes("\tvize_s0\tpreferred\t")));
+  assert.ok(rows.some((row) => row.includes("\ts0\tS0\tstage\tvize_carton\tcompat\t")));
+  assert.ok(!rows.some((row) => row.includes("\tS0/carton\t")));
+  assert.ok(!rows.some((row) => row.includes("\tS1/sinopia\t")));
+  assert.ok(!rows.some((row) => row.includes("\tS2/disegno\t")));
+  assert.ok(!rows.some((row) => row.includes("\tS1->S2/ricalco\t")));
 });
 
 void test("content-mapper S0 surface stays on the preferred physical name", () => {

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -8,8 +8,32 @@ import {
 } from "../../tools/davinci/lib/consumer-migration-scan.mjs";
 import { renderConsumerMigrationSurfaceRows } from "../../tools/davinci/lib/consumer-migration-render.mjs";
 
+const TSV_HEADERS = [
+  "consumer_id",
+  "consumer",
+  "class",
+  "file",
+  "first_line",
+  "surface_id",
+  "surface",
+  "surface_group",
+  "matched_name",
+  "name_kind",
+  "sites",
+];
+
 function sumValues(record) {
   return Object.values(record).reduce((sum, value) => sum + value, 0);
+}
+
+function parseSurfaceRows(tsv) {
+  const [header, ...lines] = tsv.trimEnd().split("\n");
+  assert.deepEqual(header.split("\t"), TSV_HEADERS);
+  return lines.map((line) => {
+    const fields = line.split("\t");
+    assert.equal(fields.length, TSV_HEADERS.length, line);
+    return Object.fromEntries(TSV_HEADERS.map((name, index) => [name, fields[index]]));
+  });
 }
 
 void test("consumer migration scan classifies stage physical names separately from code names", () => {
@@ -55,29 +79,83 @@ void test("consumer migration rows preserve surface totals when split by matched
 
 void test("consumer migration TSV exposes matched names and name kind", () => {
   const scan = scanConsumerMigrationSurfaces();
-  const tsv = renderConsumerMigrationSurfaceRows(scan);
-  const [header, ...rows] = tsv.trimEnd().split("\n");
+  const rows = parseSurfaceRows(renderConsumerMigrationSurfaceRows(scan));
 
-  assert.deepEqual(header.split("\t"), [
-    "consumer_id",
-    "consumer",
-    "class",
-    "file",
-    "first_line",
-    "surface_id",
-    "surface",
-    "surface_group",
-    "matched_name",
-    "name_kind",
-    "sites",
+  assert.ok(
+    rows.some(
+      (row) =>
+        row.surface_id === "s0" && row.matched_name === "vize_s0" && row.name_kind === "preferred",
+    ),
+  );
+
+  const physicalLabels = new Map([
+    ["s0", "S0"],
+    ["s1", "S1"],
+    ["s2", "S2"],
+    ["s1_to_s2", "S1->S2"],
   ]);
-  assert.ok(rows.every((row) => row.split("\t").length === 11));
-  assert.ok(rows.some((row) => row.includes("\tvize_s0\tpreferred\t")));
-  assert.ok(rows.some((row) => row.includes("\ts0\tS0\tstage\tvize_carton\tcompat\t")));
-  assert.ok(!rows.some((row) => row.includes("\tS0/carton\t")));
-  assert.ok(!rows.some((row) => row.includes("\tS1/sinopia\t")));
-  assert.ok(!rows.some((row) => row.includes("\tS2/disegno\t")));
-  assert.ok(!rows.some((row) => row.includes("\tS1->S2/ricalco\t")));
+  for (const row of rows.filter((row) => physicalLabels.has(row.surface_id))) {
+    assert.equal(row.surface_group, "stage");
+    assert.equal(row.surface, physicalLabels.get(row.surface_id));
+  }
+  for (const legacyLabel of ["S0/carton", "S1/sinopia", "S2/disegno", "S1->S2/ricalco"]) {
+    assert.ok(!rows.some((row) => row.surface === legacyLabel), legacyLabel);
+  }
+});
+
+void test("consumer migration TSV serializes every stage label and name class", () => {
+  const stages = [
+    { id: "s0", label: "S0", preferred: "vize_s0", compat: "vize_carton" },
+    { id: "s1", label: "S1", preferred: "vize_s1", compat: "vize_sinopia" },
+    { id: "s2", label: "S2", preferred: "vize_s2", compat: "vize_disegno" },
+    { id: "s1_to_s2", label: "S1->S2", preferred: "vize_s1_to_s2", compat: "vize_ricalco" },
+  ];
+  const surfaceNameCounts = Object.fromEntries(SURFACES.map((surface) => [surface.id, {}]));
+  for (const stage of stages) {
+    surfaceNameCounts[stage.id] = {
+      [stage.preferred]: 1,
+      [stage.compat]: 2,
+    };
+  }
+
+  const rows = parseSurfaceRows(
+    renderConsumerMigrationSurfaceRows({
+      consumers: [
+        {
+          id: "fixture",
+          label: "Fixture",
+          fileRows: [
+            {
+              relPath: "fixture.rs",
+              mode: "source",
+              firstLine: 1,
+              surfaceNameCounts,
+            },
+          ],
+        },
+      ],
+    }),
+  );
+
+  for (const stage of stages) {
+    const preferred = rows.find(
+      (row) => row.surface_id === stage.id && row.matched_name === stage.preferred,
+    );
+    assert.ok(preferred, stage.preferred);
+    assert.equal(preferred.surface, stage.label);
+    assert.equal(preferred.surface_group, "stage");
+    assert.equal(preferred.name_kind, "preferred");
+    assert.equal(preferred.sites, "1");
+
+    const compat = rows.find(
+      (row) => row.surface_id === stage.id && row.matched_name === stage.compat,
+    );
+    assert.ok(compat, stage.compat);
+    assert.equal(compat.surface, stage.label);
+    assert.equal(compat.surface_group, "stage");
+    assert.equal(compat.name_kind, "compat");
+    assert.equal(compat.sites, "2");
+  }
 });
 
 void test("content-mapper S0 surface stays on the preferred physical name", () => {

--- a/tools/davinci/lib/consumer-migration-scan.mjs
+++ b/tools/davinci/lib/consumer-migration-scan.mjs
@@ -23,10 +23,10 @@ function stageSurface(id, label, preferredName, compatNames = []) {
 
 export const SURFACES = [
   stageSurface("davinci", "Davinci", "vize_davinci"),
-  stageSurface("s0", "S0/carton", "vize_s0", ["vize_carton"]),
-  stageSurface("s1", "S1/sinopia", "vize_s1", ["vize_sinopia"]),
-  stageSurface("s2", "S2/disegno", "vize_s2", ["vize_disegno"]),
-  stageSurface("s1_to_s2", "S1->S2/ricalco", "vize_s1_to_s2", ["vize_ricalco"]),
+  stageSurface("s0", "S0", "vize_s0", ["vize_carton"]),
+  stageSurface("s1", "S1", "vize_s1", ["vize_sinopia"]),
+  stageSurface("s2", "S2", "vize_s2", ["vize_disegno"]),
+  stageSurface("s1_to_s2", "S1->S2", "vize_s1_to_s2", ["vize_ricalco"]),
   {
     id: "old_ast",
     label: "old AST/parser",


### PR DESCRIPTION
## Summary\n\n- render generated consumer migration stage surfaces as physical labels: S0, S1, S2, and S1->S2\n- keep legacy code-name crates as compatibility names in the scanner\n- pin TSV output so code-name labels cannot reappear as primary stage labels\n\nCloses #5014\n\n## Verification\n\n- node tools/davinci/consumer-migration-surfaces.mjs --check\n- node --test tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts\n- node tools/davinci/assertion-lint.mjs\n- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts\n- vp check\n- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790354774&installation_model_id=422833&pr_number=5015&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5015&signature=a95c483404a27e49797737f0b9d0c03e024e49292e83991ba7398a0d4eacb8b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the consumer migration inventory to use consistent physical stage labels: `S0`, `S1`, `S2`, and `S1->S2`.
  - Applied the terminology consistently across legends and migration-surface tables.
  - Preserved existing counts, file lists, migration slices, and compatibility names.
- **Tests**
  - Expanded validation to confirm canonical stage labels and prevent legacy slash-form labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->