### PR TITLE
refactor(relief): import s0 storage through stage alias

### DIFF
--- a/crates/vize_relief/Cargo.toml
+++ b/crates/vize_relief/Cargo.toml
@@ -23,7 +23,7 @@ metadata.vize.stability = "alpha-supported"
 _legacy = []
 
 [dependencies]
-vize_carton = { workspace = true }
+vize_s0 = { workspace = true }
 
 oxc_ast = { workspace = true }
 serde = { workspace = true }

--- a/crates/vize_relief/src/errors.rs
+++ b/crates/vize_relief/src/errors.rs
@@ -5,7 +5,7 @@ mod render;
 use crate::SourceLocation;
 pub use render::CompilerErrorWithSource;
 use thiserror::Error;
-use vize_carton::{CompactString, ToCompactString};
+use vize_s0::{CompactString, ToCompactString};
 /// Compiler error
 #[derive(Debug, Clone, Error)]
 #[error("{message}")]

--- a/crates/vize_relief/src/errors/render.rs
+++ b/crates/vize_relief/src/errors/render.rs
@@ -16,7 +16,7 @@
 use core::fmt;
 
 use crate::relief::SourceLocation;
-use vize_carton::line_index::LineIndex;
+use vize_s0::line_index::LineIndex;
 
 use super::CompilerError;
 
@@ -112,10 +112,19 @@ impl fmt::Debug for RenderedPosition {
 
 #[cfg(test)]
 mod tests {
+    use core::fmt::Write as _;
+
     use crate::relief::SourceLocation;
 
     use super::super::{CompilerError, ErrorCode};
     use super::CompilerErrorWithSource;
+    use vize_s0::String;
+
+    fn render_debug(value: impl core::fmt::Debug) -> String {
+        let mut rendered = String::new("");
+        write!(&mut rendered, "{value:?}").expect("debug rendering should write to String");
+        rendered
+    }
 
     #[test]
     fn debug_prints_single_line_positions() {
@@ -125,10 +134,7 @@ mod tests {
             "Element is missing end tag.",
             Some(loc),
         );
-        let rendered = format!(
-            "{:?}",
-            CompilerErrorWithSource::new(&error, "<div>text</div>")
-        );
+        let rendered = render_debug(CompilerErrorWithSource::new(&error, "<div>text</div>"));
         assert_eq!(
             rendered,
             "CompilerError { code: MissingEndTag, \
@@ -145,10 +151,10 @@ mod tests {
         let loc = SourceLocation::new(14, 18);
         let error =
             CompilerError::with_message(ErrorCode::InvalidExpression, "bad expression", Some(loc));
-        let rendered = format!(
-            "{:?}",
-            CompilerErrorWithSource::new(&error, "root\n  😀{{ éx }}\n</div>")
-        );
+        let rendered = render_debug(CompilerErrorWithSource::new(
+            &error,
+            "root\n  😀{{ éx }}\n</div>",
+        ));
         assert_eq!(
             rendered,
             "CompilerError { code: InvalidExpression, \
@@ -163,7 +169,7 @@ mod tests {
     #[test]
     fn debug_prints_a_missing_location_as_none() {
         let error = CompilerError::with_message(ErrorCode::MissingEndTag, "x", None);
-        let rendered = format!("{:?}", CompilerErrorWithSource::new(&error, "<div>"));
+        let rendered = render_debug(CompilerErrorWithSource::new(&error, "<div>"));
         assert_eq!(
             rendered,
             "CompilerError { code: MissingEndTag, message: \"x\", loc: None }"

--- a/crates/vize_relief/src/lib.rs
+++ b/crates/vize_relief/src/lib.rs
@@ -27,4 +27,4 @@ pub use options::*;
 pub use relief::*;
 
 /// Re-export allocator types for convenience
-pub use vize_carton::{Allocator, Box as AllocBox, CloneIn, Vec as AllocVec};
+pub use vize_s0::{Allocator, Box as AllocBox, CloneIn, Vec as AllocVec};

--- a/crates/vize_relief/src/options.rs
+++ b/crates/vize_relief/src/options.rs
@@ -1,7 +1,7 @@
 //! Compiler options.
 
-use vize_carton::String;
-use vize_carton::config::VueVersion;
+use vize_s0::String;
+use vize_s0::config::VueVersion;
 
 mod bindings;
 mod custom_elements;
@@ -105,7 +105,7 @@ impl Default for ParserOptions {
             is_native_tag: None,
             is_custom_element: None,
             custom_renderer: false,
-            is_void_tag: vize_carton::is_void_tag,
+            is_void_tag: vize_s0::is_void_tag,
             get_namespace: |_, _| crate::Namespace::Html,
             on_error: None,
             on_warn: None,

--- a/crates/vize_relief/src/options/bindings.rs
+++ b/crates/vize_relief/src/options/bindings.rs
@@ -1,6 +1,6 @@
 //! Script-setup binding metadata shared by transform and codegen.
 
-use vize_carton::{FxHashMap, String};
+use vize_s0::{FxHashMap, String};
 
 /// Binding metadata from script setup
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]

--- a/crates/vize_relief/src/options/custom_elements.rs
+++ b/crates/vize_relief/src/options/custom_elements.rs
@@ -1,7 +1,7 @@
 //! Declarative custom-element tag matching.
 
 use std::vec::Vec;
-use vize_carton::String;
+use vize_s0::String;
 
 /// Declarative matcher for tags that should compile as custom elements.
 ///
@@ -108,7 +108,7 @@ fn tag_pattern_matches(pattern: &str, tag: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::CustomElementMatcher;
-    use vize_carton::String;
+    use vize_s0::String;
 
     #[test]
     fn custom_element_matcher_supports_exact_and_wildcard_patterns() {

--- a/crates/vize_relief/src/relief.rs
+++ b/crates/vize_relief/src/relief.rs
@@ -2,7 +2,7 @@
 //!
 //! This module defines the lowered relief IR that both template and JSX lowering
 //! target. All nodes are allocated in the per-compile arena
-//! (`vize_carton::Allocator`, a wrapper over `oxc_allocator`) and hold their
+//! (`vize_s0::Allocator`, a wrapper over `oxc_allocator`) and hold their
 //! strings as `&'a str` slices into that arena or into the source text, so a
 //! tree costs one pool and no per-node heap allocation.
 

--- a/crates/vize_relief/src/relief/codegen.rs
+++ b/crates/vize_relief/src/relief/codegen.rs
@@ -3,7 +3,7 @@
 //! Contains VNodeCall, JavaScript expression nodes, SSR codegen nodes,
 //! and all types used during code generation from the template AST.
 
-use vize_carton::{Allocator, Box, PatchFlags, Vec};
+use vize_s0::{Allocator, Box, PatchFlags, Vec};
 
 use super::{
     RuntimeHelper,

--- a/crates/vize_relief/src/relief/control_flow.rs
+++ b/crates/vize_relief/src/relief/control_flow.rs
@@ -3,7 +3,7 @@
 //! Contains if (v-if/v-else-if/v-else), for (v-for),
 //! and text call node definitions.
 
-use vize_carton::{Allocator, Box, Vec};
+use vize_s0::{Allocator, Box, Vec};
 
 use super::{
     core::{NodeType, SourceLocation},

--- a/crates/vize_relief/src/relief/core.rs
+++ b/crates/vize_relief/src/relief/core.rs
@@ -4,7 +4,7 @@
 //! node type discriminants, source locations, and constant types.
 
 use serde::{Deserialize, Serialize};
-use vize_carton::Span;
+use vize_s0::Span;
 
 /// Node type discriminant
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -83,7 +83,7 @@ pub enum ConstantType {
 /// carried per-node `line`/`column` fields, but the parser never populated
 /// its newline table, so every stored value was the frozen `line: 1,
 /// column: offset + 1` shape. The few places that render line/column derive
-/// them at the edge — real values via `vize_carton::line_index` where the
+/// them at the edge — real values via `vize_s0::line_index` where the
 /// output layer already did (source maps, patina, LSP), and the frozen shape
 /// via [`crate::errors::CompilerErrorWithSource`] where byte parity pins it.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -324,7 +324,7 @@ impl RuntimeHelper {
 /// Import item for code generation
 #[derive(Debug)]
 pub struct ImportItem<'a> {
-    pub exp: vize_carton::Box<'a, super::SimpleExpressionNode<'a>>,
+    pub exp: vize_s0::Box<'a, super::SimpleExpressionNode<'a>>,
     /// Module specifier, arena-resident: an atom when it repeats across the
     /// file's imports, an arena copy otherwise (Davinci P1-10).
     pub path: &'a str,

--- a/crates/vize_relief/src/relief/elements.rs
+++ b/crates/vize_relief/src/relief/elements.rs
@@ -3,7 +3,7 @@
 //! Contains element, attribute, directive, text, comment,
 //! and interpolation node definitions.
 
-use vize_carton::{Allocator, Box, Vec, directive::DirectiveKind};
+use vize_s0::{Allocator, Box, Vec, directive::DirectiveKind};
 
 use super::{
     control_flow::ForParseResult,

--- a/crates/vize_relief/src/relief/expressions.rs
+++ b/crates/vize_relief/src/relief/expressions.rs
@@ -3,7 +3,7 @@
 //! Contains simple and compound expression nodes used in
 //! template bindings, directives, and interpolations.
 
-use vize_carton::{Allocator, Box, Vec};
+use vize_s0::{Allocator, Box, Vec};
 
 use super::{
     RuntimeHelper,

--- a/crates/vize_relief/src/relief/nodes.rs
+++ b/crates/vize_relief/src/relief/nodes.rs
@@ -3,7 +3,7 @@
 //! Contains the top-level AST nodes including RootNode and
 //! the TemplateChildNode enum that represents all template children.
 
-use vize_carton::{Allocator, Box, Vec};
+use vize_s0::{Allocator, Box, Vec};
 
 use super::{
     ForNode, IfBranchNode, IfNode, ImportItem, JsChildNode, RuntimeHelper, TextCallNode,

--- a/crates/vize_relief/src/relief/tests.rs
+++ b/crates/vize_relief/src/relief/tests.rs
@@ -6,7 +6,7 @@ use super::{
     IfNode, Namespace, NodeType, ObjectExpression, RootNode, RuntimeHelper, SimpleExpressionNode,
     SourceLocation, TemplateChildNode, TextNode,
 };
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 // ========================================================================
 // Enum discriminant tests
@@ -339,7 +339,7 @@ fn template_child_text_loc() {
     let allocator = Allocator::new();
     let loc = SourceLocation::new(5, 10);
     let text = TextNode::new("hello", loc.clone());
-    let child = TemplateChildNode::Text(vize_carton::Box::new_in(text, &&allocator));
+    let child = TemplateChildNode::Text(vize_s0::Box::new_in(text, &&allocator));
     assert_eq!(*child.loc(), loc);
     assert_eq!(child.node_type(), NodeType::Text);
 }
@@ -348,7 +348,7 @@ fn template_child_text_loc() {
 fn template_child_hoisted_loc() {
     let child = TemplateChildNode::Hoisted(0);
     // Hoisted nodes use the STUB_LOCATION
-    assert_eq!(child.loc().span, vize_carton::Span::new(0, 0));
+    assert_eq!(child.loc().span, vize_s0::Span::new(0, 0));
     assert_eq!(child.node_type(), NodeType::SimpleExpression);
 }
 
@@ -359,7 +359,7 @@ fn template_child_hoisted_loc() {
 #[test]
 fn source_location_stub() {
     let stub = SourceLocation::STUB;
-    assert_eq!(stub.span, vize_carton::Span::new(0, 0));
+    assert_eq!(stub.span, vize_s0::Span::new(0, 0));
 }
 
 #[test]
@@ -371,12 +371,12 @@ fn source_location_default_is_stub() {
 #[test]
 fn source_location_new() {
     let loc = SourceLocation::new(0, 5);
-    assert_eq!(loc.span, vize_carton::Span::new(0, 5));
+    assert_eq!(loc.span, vize_s0::Span::new(0, 5));
 }
 
 #[test]
 fn source_location_set_end() {
     let mut loc = SourceLocation::new(3, 5);
     loc.set_end(9);
-    assert_eq!(loc.span, vize_carton::Span::new(3, 9));
+    assert_eq!(loc.span, vize_s0::Span::new(3, 9));
 }

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -334,3 +334,11 @@ test("Atelier DOM compiler imports S0 storage through the stage alias", () => {
     directory: path.join(repoRoot, "crates", "vize_atelier_dom"),
   });
 });
+
+test("Relief AST imports S0 storage through the stage alias", () => {
+  assertS0AliasConsumer({
+    packageName: "vize_relief",
+    label: "Relief AST",
+    directory: path.join(repoRoot, "crates", "vize_relief"),
+  });
+});


### PR DESCRIPTION
## Summary

- import vize_relief S0 storage dependency through the vize_s0 stage alias
- replace vize_relief source references to the physical vize_carton spelling
- add a Davinci stage-dependency regression for vize_relief
- clean up relief debug-render tests so all-targets clippy stays green after the crate is touched

Closes #5026.

## Verification

- node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_relief
- cargo test -p vize_relief --features _legacy
- cargo clippy -p vize_relief --all-targets -- -D warnings
- cargo fmt --all -- --check
- vp check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

## Rollout

No rollout. Cargo still resolves the same vize_carton package through the vize_s0 alias.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal foundations for improved consistency and maintainability.
  * Preserved existing parsing, rendering, code generation, public interfaces, and allocator behavior.
* **Tests**
  * Added coverage to verify dependency aliasing and updated existing tests to use the shared runtime foundations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->