### PR TITLE
fix(perf): reject malformed davinci bench reports

### DIFF
--- a/tests/tooling/davinci-bench-compare.test.ts
+++ b/tests/tooling/davinci-bench-compare.test.ts
@@ -144,6 +144,58 @@ test("bench-compare fails closed when the baseline reports path is not a directo
   assert.match(result.stderr, /ENOTDIR|not a directory/u);
 });
 
+function runMalformedReport(target: "current" | "baseline", mutate: (report: any) => void) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "davinci-bench-report-shape-"));
+  const baseline = path.join(root, "baseline");
+  const current = path.join(root, "current");
+  const budgets = path.join(root, "budgets.toml");
+  fs.mkdirSync(baseline);
+  fs.mkdirSync(current);
+  fs.writeFileSync(
+    budgets,
+    "[bench]\nfixture_parse_small = { wall_p50_ns = 100000, allocs = 42, " +
+      "rss_peak_bytes = 8192, wall_tolerance = 0.05 }\n",
+  );
+  const report = JSON.parse(
+    fs.readFileSync(path.join(fixtureDir, "baseline/fixture_parse_small.json"), "utf8"),
+  );
+  for (const dir of [baseline, current]) {
+    const copy = structuredClone(report);
+    if ((target === "baseline") === (dir === baseline)) mutate(copy);
+    fs.writeFileSync(path.join(dir, "fixture_parse_small.json"), `${JSON.stringify(copy)}\n`);
+  }
+  const result = runCompare(["--budgets", budgets, "--baseline", baseline, "--results", current]);
+  fs.rmSync(root, { recursive: true, force: true });
+  return result;
+}
+
+test("bench-compare rejects malformed bench report shapes before budget verdicts", () => {
+  const current = runMalformedReport("current", (report) => {
+    report.unexpected = true;
+  });
+  assert.equal(current.status, 2, current.stderr);
+  assert.equal(current.stdout, "");
+  assert.match(current.stderr, /current report .* has unknown fields unexpected/u);
+
+  const harness = runMalformedReport("current", (report) => {
+    report.harness_version = "";
+  });
+  assert.equal(harness.status, 2, harness.stderr);
+  assert.match(harness.stderr, /current report .* has no valid harness_version/u);
+  const wallOrder = runMalformedReport("current", (report) => {
+    report.wall_ns.p95 = report.wall_ns.p50 - 1;
+  });
+  assert.equal(wallOrder.status, 2, wallOrder.stderr);
+  assert.match(wallOrder.stderr, /current report .* has wall_ns.p95 below wall_ns.p50/u);
+
+  const baseline = runMalformedReport("baseline", (report) => {
+    report.wall_ns.p99 = 120000;
+  });
+  assert.equal(baseline.status, 2, baseline.stderr);
+  assert.match(baseline.stdout, /^bench-compare: budgets=.* baseline=.* results=.*\n/u);
+  assert.match(baseline.stderr, /baseline report .* wall_ns has unknown fields p99/u);
+});
+
 test("bench-compare reports the wall side but gates allocs when the wall baseline is unrecorded", () => {
   const overrides = { budgets: `${fixtureRel}/budgets-unrecorded.toml` };
   const result = runCompare(compareArgs("within-tolerance", overrides));

--- a/tools/davinci/lib/bench-reports.mjs
+++ b/tools/davinci/lib/bench-reports.mjs
@@ -14,6 +14,17 @@ import path from "node:path";
 import { BENCH_ID, fail } from "./bench-config.mjs";
 
 const PLATFORM = /^[a-z0-9_]+$/u;
+const REPORT_FIELDS = [
+  "alloc_bytes_peak",
+  "allocs",
+  "bench_id",
+  "fixture",
+  "harness_version",
+  "platform",
+  "rss_peak_bytes",
+  "wall_ns",
+];
+const WALL_NS_FIELDS = ["p50", "p95"];
 
 function integerOrNull(value) {
   return value === null || (Number.isSafeInteger(value) && value >= 0);
@@ -21,6 +32,15 @@ function integerOrNull(value) {
 
 function errorCode(error) {
   return error != null && typeof error === "object" && "code" in error ? error.code : undefined;
+}
+
+function assertNoExtraFields(value, allowed, where) {
+  const extras = Object.keys(value)
+    .filter((key) => !allowed.includes(key))
+    .sort();
+  if (extras.length > 0) {
+    fail(`${where} has unknown fields ${extras.join(", ")} (allowed: ${allowed.join(", ")})`);
+  }
 }
 
 export function loadReports(dir, label) {
@@ -46,25 +66,37 @@ export function loadReports(dir, label) {
     if (report == null || typeof report !== "object" || Array.isArray(report)) {
       fail(`${label} report ${file} is not an object`);
     }
+    assertNoExtraFields(report, REPORT_FIELDS, `${label} report ${file}`);
     if (report.bench_id !== stem) {
       fail(
         `${label} report ${file} has bench_id ${JSON.stringify(report.bench_id)} (must match the file name)`,
       );
     }
     if (!BENCH_ID.test(stem)) fail(`${label} report ${file} has an invalid bench id`);
+    if (typeof report.fixture !== "string" || report.fixture.length === 0) {
+      fail(`${label} report ${file} has no valid fixture`);
+    }
     if (typeof report.platform !== "string" || !PLATFORM.test(report.platform)) {
       fail(`${label} report ${file} has no valid platform`);
     }
+    if (typeof report.harness_version !== "string" || report.harness_version.length === 0) {
+      fail(`${label} report ${file} has no valid harness_version`);
+    }
     const wall = report.wall_ns;
+    if (wall == null || typeof wall !== "object" || Array.isArray(wall)) {
+      fail(`${label} report ${file} has no integer wall_ns.p50/p95`);
+    }
+    assertNoExtraFields(wall, WALL_NS_FIELDS, `${label} report ${file} wall_ns`);
     if (
-      wall == null ||
-      typeof wall !== "object" ||
       !Number.isSafeInteger(wall.p50) ||
       wall.p50 < 0 ||
       !Number.isSafeInteger(wall.p95) ||
       wall.p95 < 0
     ) {
       fail(`${label} report ${file} has no integer wall_ns.p50/p95`);
+    }
+    if (wall.p95 < wall.p50) {
+      fail(`${label} report ${file} has wall_ns.p95 below wall_ns.p50`);
     }
     if (!integerOrNull(report.allocs)) {
       fail(`${label} report ${file} has a non-integer, non-null allocs`);


### PR DESCRIPTION
## Scope

Closes #5028.

Harden the Davinci bench report loader so malformed report shapes fail before budget verdicts:

- reject unknown top-level report fields
- reject unknown wall_ns fields
- validate schema-required fixture and harness_version metadata
- reject inverted p95/p50 values
- preserve the missing-baseline report-only path and existing malformed-platform error contract

## Verification

- node --test tests/tooling/davinci-budgets.test.ts tests/tooling/davinci-bench-compare.test.ts tests/tooling/davinci-bench-platform.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo fmt --all -- --check
- git diff --check
- vp check

No rollout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790363094&installation_model_id=422833&pr_number=5029&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5029&signature=1c451449946a679ce3bd5aefeb2284177efeb4a48d5b1c2c2844650137afbf06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved benchmark report validation to reject unknown fields and malformed report structures.
  * Added checks for valid fixture names, harness versions, and wall-time percentile values.
  * Reports with invalid percentile ordering or malformed baselines now produce clear diagnostics before budget evaluation.

* **Tests**
  * Added coverage for invalid fields, harness versions, percentile values, and baseline reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->