### PR TITLE
test(davinci): ratchet consumer migration surfaces

### DIFF
--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -158,6 +158,34 @@ void test("consumer migration TSV serializes every stage label and name class", 
   }
 });
 
+void test("consumer migration scan keeps every rollout consumer and surface class visible", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const consumers = new Map(scan.consumers.map((consumer) => [consumer.id, consumer]));
+  const expected = new Map([
+    ["compiler", { stage: true, old: true, raw: true }],
+    ["linter", { stage: true, old: true, raw: true }],
+    ["typechecker", { stage: true, old: true, raw: true }],
+    ["typechecker-content-mapper", { stage: true, old: true, raw: false }],
+    ["formatter", { stage: true, old: false, raw: true }],
+    ["lsp", { stage: true, old: true, raw: true }],
+  ]);
+
+  assert.deepEqual([...consumers.keys()], [...expected.keys()]);
+  for (const [id, groups] of expected) {
+    const consumer = consumers.get(id);
+    assert.ok(consumer, id);
+    assert.ok(consumer.fileCount > 0, `${id} must scan at least one file`);
+    assert.ok(consumer.surfaceFileCount > 0, `${id} must expose surface rows`);
+    assert.ok(
+      consumer.modeCounts.source + consumer.modeCounts.manifest > 0,
+      `${id} must scan source or manifest files`,
+    );
+    for (const [group, present] of Object.entries(groups)) {
+      assert.equal(consumer.groupCounts[group] > 0, present, `${id} ${group} presence drifted`);
+    }
+  }
+});
+
 void test("content-mapper S0 surface stays on the preferred physical name", () => {
   const scan = scanConsumerMigrationSurfaces();
   const contentMapper = scan.consumers.find(


### PR DESCRIPTION
## Scope

Closes #5030.

Add a non-numeric ratchet to the Davinci consumer migration inventory tests:

- pin the exact rollout consumer ids: compiler, linter, typechecker, typechecker-content-mapper, formatter, and LSP
- require every consumer to scan files and expose surface rows
- require source or manifest coverage for every consumer
- require expected stage/old/raw class presence without freezing totals

This is test-only and does not change rollout state, command routing, package exports, or editor behavior.

## Verification

- node --test tests/tooling/davinci-consumer-migration-surfaces.test.mjs
- node tools/davinci/consumer-migration-surfaces.mjs --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check
- vp check

No rollout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790363261&installation_model_id=422833&pr_number=5031&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5031&signature=dadb8ab5d8dbe4da21401118b4e3f12a43c3bf964730a039748f63469b947939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->