### PR TITLE
refactor(marquette): import s0 storage through stage alias

### DIFF
--- a/crates/vize_marquette/Cargo.toml
+++ b/crates/vize_marquette/Cargo.toml
@@ -9,7 +9,7 @@ description = "Versioned application blueprints for Vize"
 metadata.vize.stability = "experimental"
 
 [dependencies]
-vize_carton.workspace = true
+vize_s0.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/vize_marquette/src/adapter/compatibility.rs
+++ b/crates/vize_marquette/src/adapter/compatibility.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use crate::{
     CompatibilityChange, CompatibilityChangeKind,

--- a/crates/vize_marquette/src/adapter/model.rs
+++ b/crates/vize_marquette/src/adapter/model.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use vize_carton::String;
+use vize_s0::String;
 
 /// Current serialized adapter-capability manifest format.
 pub const ADAPTER_CAPABILITY_FORMAT_VERSION: u32 = 1;

--- a/crates/vize_marquette/src/adapter/negotiate.rs
+++ b/crates/vize_marquette/src/adapter/negotiate.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::ApplicationContract;
 

--- a/crates/vize_marquette/src/adapter/validate.rs
+++ b/crates/vize_marquette/src/adapter/validate.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use super::{
     ADAPTER_CAPABILITY_FORMAT_VERSION, AdapterCapabilityDiagnostic,

--- a/crates/vize_marquette/src/canonical.rs
+++ b/crates/vize_marquette/src/canonical.rs
@@ -1,5 +1,5 @@
 use sha2::{Digest, Sha256};
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::ApplicationContract;
 

--- a/crates/vize_marquette/src/compatibility.rs
+++ b/crates/vize_marquette/src/compatibility.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use crate::{ApplicationContract, ContractDiagnostic, DiagnosticSeverity, validate_contract};
 

--- a/crates/vize_marquette/src/model.rs
+++ b/crates/vize_marquette/src/model.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::{ContractDiagnostic, validate_contract};
 

--- a/crates/vize_marquette/src/test_run/admission.rs
+++ b/crates/vize_marquette/src/test_run/admission.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use crate::ContractDiagnostic;
 

--- a/crates/vize_marquette/src/test_run/canonical.rs
+++ b/crates/vize_marquette/src/test_run/canonical.rs
@@ -1,5 +1,5 @@
 use sha2::{Digest, Sha256};
-use vize_carton::String;
+use vize_s0::String;
 
 use super::model::TestRunEvidence;
 

--- a/crates/vize_marquette/src/test_run/check.rs
+++ b/crates/vize_marquette/src/test_run/check.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use crate::ContractDiagnostic;
 

--- a/crates/vize_marquette/src/test_run/decision.rs
+++ b/crates/vize_marquette/src/test_run/decision.rs
@@ -208,7 +208,7 @@ mod tests {
 
     #[test]
     fn the_vocabulary_is_sorted_and_serializes_kebab_case() {
-        let serialized: [vize_carton::String; 20] = TEST_RUN_DENIAL_CODES
+        let serialized: [vize_s0::String; 20] = TEST_RUN_DENIAL_CODES
             .map(|code| serde_json::to_value(code).unwrap().as_str().unwrap().into());
         let mut sorted = serialized.clone();
         sorted.sort();

--- a/crates/vize_marquette/src/test_run/model.rs
+++ b/crates/vize_marquette/src/test_run/model.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
-use vize_carton::String;
+use vize_s0::String;
 
 /// Serialized `format` marker for test-run evidence records.
 ///

--- a/crates/vize_marquette/src/test_run/model_tests.rs
+++ b/crates/vize_marquette/src/test_run/model_tests.rs
@@ -2,21 +2,21 @@ use std::collections::BTreeSet;
 
 use super::model::*;
 
-pub(crate) fn filled(fill: char, length: usize) -> vize_carton::String {
-    let mut output = vize_carton::String::with_capacity(length);
+pub(crate) fn filled(fill: char, length: usize) -> vize_s0::String {
+    let mut output = vize_s0::String::with_capacity(length);
     for _ in 0..length {
         output.push(fill);
     }
     output
 }
 
-fn digest(fill: char) -> vize_carton::String {
+fn digest(fill: char) -> vize_s0::String {
     filled(fill, 64)
 }
 
 fn retained(fill: char) -> TestRunRetainedEvidence {
     let fingerprint = digest(fill);
-    let mut reference = vize_carton::String::from("sha256:");
+    let mut reference = vize_s0::String::from("sha256:");
     reference.push_str(&fingerprint);
     TestRunRetainedEvidence::new(reference, fingerprint)
 }

--- a/crates/vize_marquette/src/test_run/transition.rs
+++ b/crates/vize_marquette/src/test_run/transition.rs
@@ -19,7 +19,7 @@
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::validate::DiagnosticSeverity;
 

--- a/crates/vize_marquette/src/test_run/transition/checks.rs
+++ b/crates/vize_marquette/src/test_run/transition/checks.rs
@@ -1,4 +1,4 @@
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::ContractDiagnostic;
 

--- a/crates/vize_marquette/src/test_run/transition/tests.rs
+++ b/crates/vize_marquette/src/test_run/transition/tests.rs
@@ -1,4 +1,4 @@
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::test_run::decision::TestRunDenialCode;
 use crate::test_run::model_tests::example_evidence;

--- a/crates/vize_marquette/src/test_run/validate.rs
+++ b/crates/vize_marquette/src/test_run/validate.rs
@@ -1,4 +1,4 @@
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use crate::validate::rules::contract_path;
 use crate::{ContractDiagnostic, TestRunEvidence};

--- a/crates/vize_marquette/src/test_run/validate/executions.rs
+++ b/crates/vize_marquette/src/test_run/validate/executions.rs
@@ -1,4 +1,4 @@
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use crate::ContractDiagnostic;
 use crate::validate::rules::contract_path;

--- a/crates/vize_marquette/src/test_run/validate/tests.rs
+++ b/crates/vize_marquette/src/test_run/validate/tests.rs
@@ -67,7 +67,7 @@ fn record_times_must_be_ordered() {
 fn mutable_evidence_references_are_rejected() {
     let mut unbound = example_evidence();
     unbound.runner.authentication_evidence.reference = {
-        let mut reference = vize_carton::String::from("sha256:");
+        let mut reference = vize_s0::String::from("sha256:");
         reference.push_str(&filled('0', 64));
         reference
     };

--- a/crates/vize_marquette/src/validate.rs
+++ b/crates/vize_marquette/src/validate.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use crate::{ApplicationContract, CONTRACT_FORMAT_VERSION, EnvironmentConsumer, RuntimeFamily};
 

--- a/crates/vize_marquette/src/validate/rules.rs
+++ b/crates/vize_marquette/src/validate/rules.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use crate::{ApplicationContract, RenderingMode, Target};
 

--- a/crates/vize_marquette/tests/adapter_conformance.rs
+++ b/crates/vize_marquette/tests/adapter_conformance.rs
@@ -2,13 +2,13 @@ use std::{fs, path::PathBuf};
 
 use serde::Deserialize;
 use serde_json::Value;
-use vize_carton::{String, ToCompactString};
 use vize_marquette::{
     ADAPTER_CAPABILITY_MANIFEST_JSON_SCHEMA, AdapterCapabilityManifest, ApplicationContract,
     NATIVE_ENGINE_CAPABILITY_IDS, NATIVE_ENGINE_CAPABILITY_VERSION, compare_adapter_capabilities,
     contract_fingerprint, native_engine_capability_definitions, native_engine_capability_profile,
     negotiate_adapter_capabilities, validate_adapter_capability_manifest,
 };
+use vize_s0::{String, ToCompactString};
 
 fn fixture(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize_marquette/tests/cli.rs
+++ b/crates/vize_marquette/tests/cli.rs
@@ -10,8 +10,8 @@ use vize_marquette::{
     TestRunVerification, TestRunVerificationOutcome, test_run_fingerprint,
 };
 
-fn digest(fill: char) -> vize_carton::String {
-    let mut output = vize_carton::String::with_capacity(64);
+fn digest(fill: char) -> vize_s0::String {
+    let mut output = vize_s0::String::with_capacity(64);
     for _ in 0..64 {
         output.push(fill);
     }
@@ -20,13 +20,13 @@ fn digest(fill: char) -> vize_carton::String {
 
 fn retained(fill: char) -> TestRunRetainedEvidence {
     let fingerprint = digest(fill);
-    let mut reference = vize_carton::String::from("sha256:");
+    let mut reference = vize_s0::String::from("sha256:");
     reference.push_str(&fingerprint);
     TestRunRetainedEvidence::new(reference, fingerprint)
 }
 
 fn example_evidence() -> TestRunEvidence {
-    let mut revision = vize_carton::String::with_capacity(40);
+    let mut revision = vize_s0::String::with_capacity(40);
     for _ in 0..40 {
         revision.push('a');
     }

--- a/crates/vize_marquette/tests/conformance.rs
+++ b/crates/vize_marquette/tests/conformance.rs
@@ -32,7 +32,7 @@ fn returns_the_shared_invalid_diagnostic_codes() {
         .into_iter()
         .map(|diagnostic| diagnostic.code)
         .collect::<Vec<_>>();
-    let expected: Vec<vize_carton::String> =
+    let expected: Vec<vize_s0::String> =
         serde_json::from_slice(&fs::read(fixture("invalid.expected.json")).unwrap()).unwrap();
     assert_eq!(actual, expected);
 }

--- a/crates/vize_marquette/tests/test_run_conformance.rs
+++ b/crates/vize_marquette/tests/test_run_conformance.rs
@@ -49,7 +49,7 @@ fn returns_the_shared_invalid_diagnostic_codes() {
         .into_iter()
         .map(|diagnostic| diagnostic.code)
         .collect::<Vec<_>>();
-    let expected: Vec<vize_carton::String> =
+    let expected: Vec<vize_s0::String> =
         serde_json::from_slice(&fs::read(fixture("invalid.expected.json")).unwrap()).unwrap();
     assert_eq!(actual, expected);
 }

--- a/tests/tooling/davinci-marquette-stage-alias.test.ts
+++ b/tests/tooling/davinci-marquette-stage-alias.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const marquetteRoot = path.join(repoRoot, "crates", "vize_marquette");
+const scannedExtensions = new Set([".md", ".rs", ".toml"]);
+
+function* walkFiles(dir: string): Generator<string> {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkFiles(fullPath);
+    } else if (entry.isFile() && scannedExtensions.has(path.extname(entry.name))) {
+      yield fullPath;
+    }
+  }
+}
+
+test("Marquette depends on the stage-named S0 alias", () => {
+  const cargoToml = fs.readFileSync(path.join(marquetteRoot, "Cargo.toml"), "utf8");
+
+  assert.match(cargoToml, /^vize_s0\.workspace = true$/m);
+  assert.doesNotMatch(cargoToml, /^vize_carton\.workspace = true$/m);
+});
+
+test("Marquette does not name the Carton crate directly", () => {
+  const offenders = [];
+
+  for (const file of walkFiles(marquetteRoot)) {
+    const source = fs.readFileSync(file, "utf8");
+    if (source.includes("vize_carton")) {
+      offenders.push(path.relative(repoRoot, file));
+    }
+  }
+
+  assert.deepEqual(offenders, []);
+});


### PR DESCRIPTION
## Scope

Closes #5034.

Move Marquette from the direct `vize_carton` crate spelling to the stage-named `vize_s0` workspace alias:

- switch `crates/vize_marquette/Cargo.toml` to `vize_s0.workspace = true`
- update Marquette source and tests to import/use `vize_s0`
- add a tooling regression that rejects future direct `vize_carton` naming in Marquette

This is an alias-only migration. The resolved package is unchanged, and this does not change rollout state, command behavior, package exports, or user-visible behavior.

## Verification

- node --test tests/tooling/davinci-marquette-stage-alias.test.ts tests/tooling/davinci-glyph-stage-alias.test.ts tests/tooling/source-file-lengths.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_marquette --locked
- cargo clippy -p vize_marquette --all-targets --locked -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- vp check

No rollout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790364785&installation_model_id=422833&pr_number=5035&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5035&signature=3193ff7aeb0da03d729660a750ef68e4ac732907363c4cc9f17b04d78507ef63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->