### PR TITLE
fix(perf): reject mismatched davinci bench identity

### DIFF
--- a/tests/tooling/davinci-bench-identity.test.ts
+++ b/tests/tooling/davinci-bench-identity.test.ts
@@ -1,0 +1,75 @@
+// Davinci bench artifacts are only comparable when they describe the same
+// fixture, platform, and harness version.
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const comparePath = path.join(repoRoot, "tools", "davinci", "bench-compare.mjs");
+const fixtureDir = path.join(repoRoot, "tests", "_fixtures", "davinci-bench-compare");
+
+function runCompare(root: string, budgets: string, baseline: string, current: string) {
+  const env = { ...process.env };
+  delete env.DAVINCI_BASELINE_REFRESH;
+  return spawnSync(
+    process.execPath,
+    [comparePath, "--budgets", budgets, "--baseline", baseline, "--results", current],
+    { cwd: root, encoding: "utf8", env },
+  );
+}
+
+function writeBudget(pathname: string) {
+  fs.writeFileSync(
+    pathname,
+    "[bench]\nfixture_parse_small = { wall_p50_ns = 100000, allocs = 42, " +
+      "rss_peak_bytes = 8192, wall_tolerance = 0.05 }\n",
+  );
+}
+
+function runIdentityMismatch(field: string, value: string) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "davinci-bench-identity-"));
+  const baseline = path.join(root, "baseline");
+  const current = path.join(root, "current");
+  const budgets = path.join(root, "budgets.toml");
+  fs.mkdirSync(baseline);
+  fs.mkdirSync(current);
+  writeBudget(budgets);
+  const report = JSON.parse(
+    fs.readFileSync(path.join(fixtureDir, "baseline", "fixture_parse_small.json"), "utf8"),
+  );
+  fs.writeFileSync(path.join(baseline, "fixture_parse_small.json"), `${JSON.stringify(report)}\n`);
+  const changed = structuredClone(report);
+  changed[field] = value;
+  fs.writeFileSync(path.join(current, "fixture_parse_small.json"), `${JSON.stringify(changed)}\n`);
+  const result = runCompare(root, budgets, baseline, current);
+  fs.rmSync(root, { recursive: true, force: true });
+  return { budgets, baseline, current, result };
+}
+
+test("bench-compare rejects mismatched baseline/current artifact identity", () => {
+  for (const { field, value, original } of [
+    {
+      field: "fixture",
+      original: "synthetic:bench-compare-fixture",
+      value: "synthetic:other-fixture",
+    },
+    { field: "platform", original: "linux", value: "macos" },
+    { field: "harness_version", original: "0.0.0-fixture", value: "0.0.1-fixture" },
+  ]) {
+    const { budgets, baseline, current, result } = runIdentityMismatch(field, value);
+    assert.equal(result.status, 2, result.stderr);
+    assert.equal(
+      result.stdout,
+      `bench-compare: budgets=${budgets} baseline=${baseline} results=${current}\n`,
+    );
+    assert.equal(
+      result.stderr,
+      `bench-compare: fixture_parse_small baseline/current ${field} mismatch: ${original} vs ${value}\n`,
+    );
+  }
+});

--- a/tools/davinci/lib/bench-verdicts.mjs
+++ b/tools/davinci/lib/bench-verdicts.mjs
@@ -19,6 +19,10 @@
 // a budgets entry with no current result is a disappeared bench, and a result
 // with no entry is an unregistered (therefore ungated) bench.
 
+import { fail } from "./bench-config.mjs";
+
+const COMPARABLE_IDENTITY_FIELDS = ["fixture", "platform", "harness_version"];
+
 export function byBenchId(a, b) {
   return a < b ? -1 : a > b ? 1 : 0;
 }
@@ -40,6 +44,15 @@ function wallReportOnlyReason(budget, baseline) {
   if (baseline == null) return "no committed baseline report";
   if (budget.wall_p50_ns === 0) return "budgets.toml wall baseline not yet recorded";
   return null;
+}
+
+function assertComparableIdentity(id, baseline, current) {
+  if (baseline == null) return;
+  for (const field of COMPARABLE_IDENTITY_FIELDS) {
+    if (baseline[field] !== current[field]) {
+      fail(`${id} baseline/current ${field} mismatch: ${baseline[field]} vs ${current[field]}`);
+    }
+  }
 }
 
 export function compare(budgets, baselineReports, currentReports) {
@@ -67,6 +80,7 @@ export function compare(budgets, baselineReports, currentReports) {
       breaches += 1;
       continue;
     }
+    assertComparableIdentity(id, baseline, current);
     const benchRows = [];
     const wallSkipped = wallReportOnlyReason(budget, baseline);
     let limit = null;


### PR DESCRIPTION
## Summary

- Fail closed when a baseline/current davinci bench report pair has the same bench id but different fixture, platform, or harness version.
- Add a dedicated tooling regression for all three identity mismatches.

Closes #5036

## Verification

- node --test tests/tooling/davinci-bench-identity.test.ts tests/tooling/davinci-bench-compare.test.ts tests/tooling/davinci-budgets.test.ts tests/tooling/davinci-bench-platform.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check
- vp check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5037"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790365401&installation_model_id=422833&pr_number=5037&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5037&signature=31c2a958b7102eb7c9e64dadedaeb4a43ab371f98100615856968af15b5c6747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->