### PR TITLE
test(davinci): pin formatter corpus evidence hashing

### DIFF
--- a/tests/tooling/davinci-corpus-formatter-contract.test.ts
+++ b/tests/tooling/davinci-corpus-formatter-contract.test.ts
@@ -1,0 +1,105 @@
+// Davinci corpus baseline hashing for the formatter lane: stderr ordering is
+// filed nondeterminism, while formatterCheck is the deterministic evidence.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  EXCLUDED_FIELDS,
+  HASHED_FIELDS,
+  SURFACES,
+} from "../../tools/davinci/lib/corpus-baseline-contract.mjs";
+import { reduceShards } from "../../tools/davinci/lib/corpus-baseline-run.mjs";
+
+const projectId = "synthetic-formatter";
+
+function formatterPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    schema: "vize.fixtureToolRun",
+    version: 1,
+    project: projectId,
+    tool: "formatter",
+    status: "findings",
+    exitCode: 1,
+    stdout: "",
+    stderr: "Would reformat: src/App.vue\nWould reformat: src/Card.vue\n",
+    spawnError: null,
+    parseError: null,
+    validationError: null,
+    formatterCheck: {
+      checkedFileCount: 2,
+      changedFileCount: 2,
+      unchangedFileCount: 0,
+      changedPathsSha256: "paths-a",
+    },
+    ...overrides,
+  };
+}
+
+function writeFormatterShard(payload: Record<string, unknown>) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "davinci-formatter-corpus-"));
+  fs.writeFileSync(
+    path.join(dir, "summary.json"),
+    `${JSON.stringify({
+      summary: {
+        failedRuns: 0,
+        missingFixtureRuns: 0,
+        plannedRuns: 0,
+        okRuns: 0,
+        findingsRuns: 1,
+        runCount: 1,
+      },
+      projects: [{ id: projectId, runs: [{ tool: "formatter", fileCount: 2 }] }],
+    })}\n`,
+  );
+  fs.writeFileSync(path.join(dir, `${projectId}-formatter.json`), `${JSON.stringify(payload)}\n`);
+  return dir;
+}
+
+function reduceFormatter(payload: Record<string, unknown>) {
+  const dir = writeFormatterShard(payload);
+  try {
+    return reduceShards([dir], ["formatter"])[0];
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("formatter corpus baseline hashes formatterCheck and excludes stderr ordering", () => {
+  assert.ok(SURFACES.includes("formatter"), "formatter must be a corpus surface");
+  assert.deepEqual(HASHED_FIELDS.formatter, ["exitCode", "formatterCheck", "stdout"]);
+  assert.deepEqual(EXCLUDED_FIELDS.formatter, ["stderr"]);
+
+  const first = reduceFormatter(formatterPayload());
+  const reorderedStderr = reduceFormatter(
+    formatterPayload({
+      stderr: "Would reformat: src/Card.vue\nWould reformat: src/App.vue\n",
+    }),
+  );
+  assert.deepEqual(reorderedStderr, first);
+
+  const changedEvidence = reduceFormatter(
+    formatterPayload({
+      formatterCheck: {
+        checkedFileCount: 2,
+        changedFileCount: 2,
+        unchangedFileCount: 0,
+        changedPathsSha256: "paths-b",
+      },
+    }),
+  );
+  assert.equal(changedEvidence.file_count, 2);
+  assert.notEqual(changedEvidence.content_hash, first.content_hash);
+});
+
+test("formatter corpus baseline requires formatterCheck evidence", () => {
+  const payload = formatterPayload();
+  delete payload.formatterCheck;
+  assert.throws(
+    () => reduceFormatter(payload),
+    /synthetic-formatter\/formatter payload has no formatterCheck field/u,
+  );
+});


### PR DESCRIPTION
## Summary

- Add a synthetic reducer regression for the formatter corpus baseline hash contract.
- Pin that formatter hashes `exitCode`, `formatterCheck`, and `stdout`, while excluding nondeterministic `stderr` ordering.
- Prove formatterCheck evidence changes still move the content hash.

Closes #5038

## Verification

- node --test tests/tooling/davinci-corpus-formatter-contract.test.ts tests/tooling/fixture-tool-matrix-formatter.test.ts tests/tooling/fixture-tool-matrix-report.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check
- vp check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added contract coverage for formatter corpus baselines.
  * Verified content hashing reflects formatter evidence while ignoring stderr ordering.
  * Confirmed changes to formatter evidence update hashes.
  * Added validation for missing formatter-check data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->