### PR TITLE
refactor(doctor): import s0 storage through stage alias

### DIFF
--- a/crates/vize_doctor/Cargo.toml
+++ b/crates/vize_doctor/Cargo.toml
@@ -17,7 +17,7 @@ globset.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-vize_carton.workspace = true
+vize_s0.workspace = true
 vize_croquis_cf = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/vize_doctor/src/ai_context/builder.rs
+++ b/crates/vize_doctor/src/ai_context/builder.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use crate::{DoctorFinding, DoctorReport, SourceLocation};
 

--- a/crates/vize_doctor/src/ai_context/contract.rs
+++ b/crates/vize_doctor/src/ai_context/contract.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::{
     AnalysisProvenance, DoctorCategory, EvidenceKind, FindingAssessment, FindingContext, FixSafety,

--- a/crates/vize_doctor/src/ai_context/snippet.rs
+++ b/crates/vize_doctor/src/ai_context/snippet.rs
@@ -1,4 +1,4 @@
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::SourceLocation;
 

--- a/crates/vize_doctor/src/ai_context/validation.rs
+++ b/crates/vize_doctor/src/ai_context/validation.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use serde::{Deserialize, Deserializer, de};
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use crate::{DOCTOR_REPORT_FORMAT_VERSION, DOCTOR_SCORING_VERSION};
 

--- a/crates/vize_doctor/src/ai_context/validation/graph.rs
+++ b/crates/vize_doctor/src/ai_context/validation/graph.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::{AiContextError, integrity, runtime_limit};
 use crate::ai_context::{

--- a/crates/vize_doctor/src/application_analysis.rs
+++ b/crates/vize_doctor/src/application_analysis.rs
@@ -11,8 +11,8 @@ use std::{
     path::{Component, Path},
 };
 
-use vize_carton::{String, cstr};
 use vize_croquis_cf::{CrossFileAnalyzer, CrossFileDiagnostic, CrossFileResult, FileId};
+use vize_s0::{String, cstr};
 
 use crate::{
     AnalysisProvenance, DoctorFinding, DoctorReport, FindingEvidence, FindingFix, FixSafety,

--- a/crates/vize_doctor/src/cache_identity.rs
+++ b/crates/vize_doctor/src/cache_identity.rs
@@ -10,7 +10,7 @@ use std::cmp::Ordering;
 
 use serde::{Deserialize, Deserializer, Serialize, de};
 use sha2::{Digest, Sha256};
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::{ContentFingerprint, contract::is_stable_id};
 

--- a/crates/vize_doctor/src/cache_identity/error.rs
+++ b/crates/vize_doctor/src/cache_identity/error.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt};
 
-use vize_carton::String;
+use vize_s0::String;
 
 use super::DOCTOR_CAPABILITY_CACHE_IDENTITY_VERSION;
 

--- a/crates/vize_doctor/src/cache_identity/invalidation.rs
+++ b/crates/vize_doctor/src/cache_identity/invalidation.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
 use serde::Serialize;
-use vize_carton::String;
+use vize_s0::String;
 
 use super::CapabilityCacheIdentity;
 

--- a/crates/vize_doctor/src/cache_identity/invalidation/telemetry.rs
+++ b/crates/vize_doctor/src/cache_identity/invalidation/telemetry.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use vize_carton::String;
+use vize_s0::String;
 
 use super::CapabilityInvalidation;
 

--- a/crates/vize_doctor/src/cache_identity/tests.rs
+++ b/crates/vize_doctor/src/cache_identity/tests.rs
@@ -1,5 +1,5 @@
 use serde_json::json;
-use vize_carton::{ToCompactString, cstr};
+use vize_s0::{ToCompactString, cstr};
 
 use super::{
     CAPABILITY_CACHE_KEY_PREFIX, CapabilityCacheIdentity, CapabilityCacheIdentityError,

--- a/crates/vize_doctor/src/capability_execution/telemetry.rs
+++ b/crates/vize_doctor/src/capability_execution/telemetry.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use vize_carton::String;
+use vize_s0::String;
 
 use super::CapabilityExecutionOutcome;
 use crate::{CapabilityCacheKey, ContentFingerprint};

--- a/crates/vize_doctor/src/capability_snapshot.rs
+++ b/crates/vize_doctor/src/capability_snapshot.rs
@@ -8,7 +8,7 @@ use std::io::{self, Write};
 
 use serde::{Deserialize, Deserializer, Serialize, de};
 use sha2::{Digest, Sha256};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use crate::{
     CapabilityCacheIdentity, CapabilityCacheKey, ContentFingerprint, DoctorFinding, DoctorReport,

--- a/crates/vize_doctor/src/capability_snapshot/error.rs
+++ b/crates/vize_doctor/src/capability_snapshot/error.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt};
 
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::{CapabilityCacheKey, ContentFingerprint};
 

--- a/crates/vize_doctor/src/capability_snapshot/tests.rs
+++ b/crates/vize_doctor/src/capability_snapshot/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use serde_json::json;
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 use super::{
     CapabilityCacheIdentity, CapabilitySnapshot, CapabilitySnapshotError, ContentFingerprint,

--- a/crates/vize_doctor/src/filter.rs
+++ b/crates/vize_doctor/src/filter.rs
@@ -8,7 +8,7 @@ mod tests;
 use std::fmt;
 
 use serde::{Deserialize, Serialize};
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::{DoctorCategory, DoctorFinding, DoctorReport, FindingConfidence, FindingSeverity};
 

--- a/crates/vize_doctor/src/filter/matcher.rs
+++ b/crates/vize_doctor/src/filter/matcher.rs
@@ -1,5 +1,5 @@
 use globset::{GlobBuilder, GlobMatcher};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use super::{DoctorFilterDimension, DoctorFilterError};
 

--- a/crates/vize_doctor/src/filter/tests.rs
+++ b/crates/vize_doctor/src/filter/tests.rs
@@ -3,7 +3,7 @@ use crate::{
     FindingConfidence, FindingContext, FindingEvidence, FindingFix, FindingImpact, FindingSeverity,
     FixSafety, HealthPenalty, RelatedLocation, RuleCost, SourceLocation, TextEdit,
 };
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use super::{DoctorFilterDimension, DoctorFilterSpec};
 

--- a/crates/vize_doctor/src/fingerprint.rs
+++ b/crates/vize_doctor/src/fingerprint.rs
@@ -174,7 +174,7 @@ const fn decode_lower_hex(byte: u8) -> Option<u8> {
 #[cfg(test)]
 mod tests {
     use super::{ContentFingerprint, ContentFingerprintParseError};
-    use vize_carton::{String, ToCompactString, cstr};
+    use vize_s0::{String, ToCompactString, cstr};
 
     #[test]
     fn digest_matches_standard_sha256_vectors() {

--- a/crates/vize_doctor/src/model/assessment.rs
+++ b/crates/vize_doctor/src/model/assessment.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use vize_carton::String;
+use vize_s0::String;
 
 /// Health category used for reporting, scoring, ownership, and policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]

--- a/crates/vize_doctor/src/model/evidence.rs
+++ b/crates/vize_doctor/src/model/evidence.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Deserializer, Serialize, de};
-use vize_carton::String;
+use vize_s0::String;
 
 use super::assessment::{EvidenceKind, RuleCost};
 use crate::ContentFingerprint;
@@ -168,7 +168,7 @@ impl<'de> Deserialize<'de> for AnalysisProvenance {
             .keys()
             .find(|input| provenance.invalidation_inputs.binary_search(input).is_err())
         {
-            return Err(de::Error::custom(vize_carton::cstr!(
+            return Err(de::Error::custom(vize_s0::cstr!(
                 "invalidation fingerprint {input:?} has no declared input"
             )));
         }

--- a/crates/vize_doctor/src/model/finding.rs
+++ b/crates/vize_doctor/src/model/finding.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use vize_carton::{String, cstr};
+use vize_s0::{String, cstr};
 
 use super::{
     assessment::{DoctorCategory, FindingAssessment, FixSafety, SuppressionPolicy},

--- a/crates/vize_doctor/src/report.rs
+++ b/crates/vize_doctor/src/report.rs
@@ -4,7 +4,7 @@ mod tests;
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Deserializer, Serialize, de};
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::{
     DEFAULT_UNAVAILABLE_FIX_REASON, DoctorCategory, DoctorFinding, FindingConfidence, FindingFix,

--- a/crates/vize_doctor/src/reporter/contract.rs
+++ b/crates/vize_doctor/src/reporter/contract.rs
@@ -4,7 +4,7 @@ mod validation;
 mod wire;
 
 use serde::Serialize;
-use vize_carton::String;
+use vize_s0::String;
 
 pub use validation::ReporterContractError;
 

--- a/crates/vize_doctor/src/reporter/contract/wire.rs
+++ b/crates/vize_doctor/src/reporter/contract/wire.rs
@@ -1,7 +1,7 @@
 //! Validated deserialization for the reporter descriptor wire shape.
 
 use serde::{Deserialize, Deserializer, de};
-use vize_carton::String;
+use vize_s0::String;
 
 use super::{ReporterAudience, ReporterCapability, ReporterDescriptor, ReporterTransport};
 

--- a/crates/vize_doctor/src/reporter/execution.rs
+++ b/crates/vize_doctor/src/reporter/execution.rs
@@ -6,7 +6,7 @@ use std::{
     io::{self, IoSlice, Write},
 };
 
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use super::ReporterDescriptor;
 use crate::DoctorReport;

--- a/crates/vize_doctor/src/reporter/registry.rs
+++ b/crates/vize_doctor/src/reporter/registry.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::BTreeMap, error::Error, fmt};
 
-use vize_carton::String;
+use vize_s0::String;
 
 use super::{DoctorReporter, ReporterContractError, ReporterDescriptor};
 

--- a/crates/vize_doctor/src/reporter/sarif/plan.rs
+++ b/crates/vize_doctor/src/reporter/sarif/plan.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use vize_carton::{String, ToCompactString, cstr};
+use vize_s0::{String, ToCompactString, cstr};
 
 use super::source::{IndexedSource, SarifMissingSourcePolicy, validate_path};
 use crate::{

--- a/crates/vize_doctor/src/reporter/sarif/source.rs
+++ b/crates/vize_doctor/src/reporter/sarif/source.rs
@@ -2,7 +2,7 @@
 
 use std::{error::Error, fmt};
 
-use vize_carton::String;
+use vize_s0::String;
 
 /// One analyzed UTF-8 source supplied explicitly to the SARIF reporter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/vize_doctor/src/reporter/sarif/tests.rs
+++ b/crates/vize_doctor/src/reporter/sarif/tests.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use vize_carton::{ToCompactString, cstr};
+use vize_s0::{ToCompactString, cstr};
 
 use super::*;
 use crate::{

--- a/crates/vize_doctor/src/reporter/sarif/wire.rs
+++ b/crates/vize_doctor/src/reporter/sarif/wire.rs
@@ -6,7 +6,7 @@ mod properties;
 use std::collections::BTreeMap;
 
 use serde::{Serialize, Serializer, ser::SerializeSeq};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::plan::{SarifPlan, SarifRegion};
 use crate::{DoctorFinding, EvidenceKind, FindingEvidence, FindingSeverity, SourceLocation};
@@ -197,7 +197,7 @@ impl<'finding> SarifResult<'finding> {
 #[derive(Serialize)]
 struct SarifPartialFingerprints {
     #[serde(rename = "vizeBaselineKey/v1")]
-    baseline_key: vize_carton::String,
+    baseline_key: vize_s0::String,
 }
 
 #[derive(Serialize)]
@@ -243,7 +243,7 @@ struct SarifPhysicalLocation {
 
 #[derive(Serialize)]
 struct SarifArtifactLocation {
-    uri: vize_carton::String,
+    uri: vize_s0::String,
 }
 
 #[derive(Serialize)]
@@ -251,7 +251,7 @@ struct SarifLocationProperties<'finding> {
     #[serde(rename = "vizeEvidenceKind")]
     evidence_kind: EvidenceKind,
     #[serde(rename = "vizeEvidenceDetails")]
-    evidence_details: &'finding BTreeMap<vize_carton::String, vize_carton::String>,
+    evidence_details: &'finding BTreeMap<vize_s0::String, vize_s0::String>,
 }
 
 #[derive(Serialize)]
@@ -261,7 +261,7 @@ struct SarifMessage<'text> {
 
 enum SarifMessageText<'text> {
     Borrowed(&'text str),
-    Owned(vize_carton::String),
+    Owned(vize_s0::String),
 }
 
 impl Serialize for SarifMessageText<'_> {
@@ -283,7 +283,7 @@ impl<'text> SarifMessage<'text> {
         }
     }
 
-    fn owned(text: vize_carton::String) -> Self {
+    fn owned(text: vize_s0::String) -> Self {
         Self {
             text: SarifMessageText::Owned(text),
         }

--- a/crates/vize_doctor/src/reporter/sarif/wire/fix.rs
+++ b/crates/vize_doctor/src/reporter/sarif/wire/fix.rs
@@ -68,7 +68,7 @@ struct SarifArtifactChange<'finding> {
 
 #[derive(Serialize)]
 struct SarifArtifactLocation {
-    uri: vize_carton::String,
+    uri: vize_s0::String,
 }
 
 #[derive(Serialize)]
@@ -88,5 +88,5 @@ struct SarifFixProperties<'finding> {
     #[serde(rename = "vizeSafety")]
     safety: crate::FixSafety,
     #[serde(rename = "vizeVerification", skip_serializing_if = "Vec::is_empty")]
-    verification: &'finding Vec<vize_carton::String>,
+    verification: &'finding Vec<vize_s0::String>,
 }

--- a/crates/vize_doctor/src/reporter/sarif/wire/properties.rs
+++ b/crates/vize_doctor/src/reporter/sarif/wire/properties.rs
@@ -33,7 +33,7 @@ pub(super) struct SarifResultProperties<'finding> {
     #[serde(rename = "vizeFixTitle", skip_serializing_if = "Option::is_none")]
     fix_title: Option<&'finding str>,
     #[serde(rename = "vizeVerification", skip_serializing_if = "Option::is_none")]
-    verification: Option<&'finding [vize_carton::String]>,
+    verification: Option<&'finding [vize_s0::String]>,
     #[serde(rename = "vizeSuppressionPolicy")]
     suppression_policy: SuppressionPolicy,
     #[serde(rename = "vizeProvenance")]

--- a/tests/tooling/davinci-doctor-stage-alias.test.ts
+++ b/tests/tooling/davinci-doctor-stage-alias.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const doctorRoot = path.join(repoRoot, "crates", "vize_doctor");
+const scannedExtensions = new Set([".md", ".rs", ".toml"]);
+
+function* walkFiles(dir: string): Generator<string> {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkFiles(fullPath);
+    } else if (entry.isFile() && scannedExtensions.has(path.extname(entry.name))) {
+      yield fullPath;
+    }
+  }
+}
+
+test("Doctor depends on the stage-named S0 alias", () => {
+  const cargoToml = fs.readFileSync(path.join(doctorRoot, "Cargo.toml"), "utf8");
+
+  assert.match(cargoToml, /^vize_s0\.workspace = true$/m);
+  assert.doesNotMatch(cargoToml, /^vize_carton\.workspace = true$/m);
+});
+
+test("Doctor does not name the Carton crate directly", () => {
+  const offenders = [];
+
+  for (const file of walkFiles(doctorRoot)) {
+    const source = fs.readFileSync(file, "utf8");
+    if (source.includes("vize_carton")) {
+      offenders.push(path.relative(repoRoot, file));
+    }
+  }
+
+  assert.deepEqual(offenders, []);
+});


### PR DESCRIPTION
## Summary

- import the doctor crate's Carton dependency through the `vize_s0` stage alias
- rewrite doctor source imports and qualified storage paths to the stage spelling
- add a tooling ratchet that rejects direct `vize_carton` spelling in `vize_doctor`

## Verification

- `node --test tests/tooling/davinci-doctor-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts`
- `cargo test -p vize_doctor --all-features --locked`
- `cargo fmt --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`
- `cargo clippy -p vize_doctor --all-targets --all-features --locked -- -D warnings`
- `vp check`

Closes #5040

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790367465&installation_model_id=422833&pr_number=5041&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5041&signature=4553af695cd20a3314bfc75310876c2a6d52a73d409c5b129671aca377d38d59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal string and formatting support across diagnostic, reporting, filtering, and validation features.
  * Standardized the application on the current stage-specific foundation, with no intended changes to runtime behavior or workflows.

* **Tests**
  * Added coverage to verify the updated foundation is used consistently and legacy references are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->