### PR TITLE
test(doctor): assert s0 alias via parsed manifest

### DIFF
--- a/tests/tooling/davinci-doctor-stage-alias.test.ts
+++ b/tests/tooling/davinci-doctor-stage-alias.test.ts
@@ -3,10 +3,22 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { parse as parseToml } from "@iarna/toml";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const doctorRoot = path.join(repoRoot, "crates", "vize_doctor");
 const scannedExtensions = new Set([".md", ".rs", ".toml"]);
+
+type CargoDependency =
+  | boolean
+  | {
+      package?: unknown;
+      workspace?: unknown;
+    };
+
+type CargoManifest = {
+  dependencies?: Record<string, CargoDependency>;
+};
 
 function* walkFiles(dir: string): Generator<string> {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -21,9 +33,11 @@ function* walkFiles(dir: string): Generator<string> {
 
 test("Doctor depends on the stage-named S0 alias", () => {
   const cargoToml = fs.readFileSync(path.join(doctorRoot, "Cargo.toml"), "utf8");
+  const manifest = parseToml(cargoToml) as CargoManifest;
+  const dependencies = manifest.dependencies ?? {};
 
-  assert.match(cargoToml, /^vize_s0\.workspace = true$/m);
-  assert.doesNotMatch(cargoToml, /^vize_carton\.workspace = true$/m);
+  assert.deepEqual(dependencies.vize_s0, { workspace: true });
+  assert.equal(dependencies.vize_carton, undefined);
 });
 
 test("Doctor does not name the Carton crate directly", () => {


### PR DESCRIPTION
## Summary

- parse `crates/vize_doctor/Cargo.toml` in the doctor alias ratchet
- assert the semantic dependency entries instead of exact line formatting
- keep the direct `vize_carton` spelling scan intact

## Verification

- `node --test tests/tooling/davinci-doctor-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`
- `vp check`

Closes #5042

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790368416&installation_model_id=422833&pr_number=5043&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5043&signature=1a1263c0ee412298c75ddff7ef27911cbe6c172c510429803bd237755931f987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved validation of project dependency configuration.
  * Added checks to confirm workspace dependency settings and prevent unintended dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->