### PR TITLE
test(lsp): pin davinci ts40 prop diagnostics

### DIFF
--- a/tests/tooling/lsp-davinci-ts40-projection-diagnostics.test.ts
+++ b/tests/tooling/lsp-davinci-ts40-projection-diagnostics.test.ts
@@ -1,0 +1,261 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+import {
+  loadProjectionMatrix,
+  validateProjectionMatrix,
+  type ProjectionFixture,
+} from "./support/davinci-ts40-projection.ts";
+import { requireTypecheckDependency } from "./support/typecheck-dependency.ts";
+
+test("vize lsp republishes TS-40 local-import prop diagnostics after child edits", async (t) => {
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTsgoBinary(),
+    "tsgo binary for the TS-40 LSP projection gate",
+    "tsgo binary not found; skipping TS-40 LSP projection diagnostic test",
+  );
+  if (corsaPath == null) return;
+
+  const matrix = loadProjectionMatrix(root);
+  validateProjectionMatrix(root, matrix);
+  const parentFixture = fixture(matrix.fixtures, "parent-local-import");
+  const childFixture = fixture(matrix.fixtures, "child-local-import");
+  assert.deepEqual(parentFixture.coverage, ["local-vue-import", "props", "navigation-ranges"]);
+  assert.ok(childFixture.coverage.includes("props"));
+
+  const parentSource = fs.readFileSync(path.join(root, parentFixture.file), "utf8");
+  const initialChild = fs.readFileSync(path.join(root, childFixture.file), "utf8");
+  const changedChild = initialChild.replace("message: string", "message: number");
+  assert.notEqual(changedChild, initialChild);
+
+  const testRootDir = path.join(testOutputRoot, "lsp-davinci-ts40-projection-diagnostics");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+  const diagnostics = observeDiagnostics(session);
+
+  try {
+    const sourceDir = path.join(workspaceDir, "src");
+    fs.mkdirSync(sourceDir, { recursive: true });
+    linkVuePackage(workspaceDir);
+    writeProjectConfig(workspaceDir, corsaPath);
+
+    const parentPath = path.join(sourceDir, path.basename(parentFixture.file));
+    const childPath = path.join(sourceDir, path.basename(childFixture.file));
+    const parentUri = pathToFileURL(parentPath).href;
+    const childUri = pathToFileURL(childPath).href;
+    fs.writeFileSync(parentPath, parentSource, "utf8");
+    fs.writeFileSync(childPath, initialChild, "utf8");
+
+    await session.initialize(workspaceDir, { editor: true, lint: false, typecheck: true });
+
+    let marker = diagnostics.mark();
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri: childUri, languageId: "vue", version: 1, text: initialChild },
+    });
+    const initialChildPublish = await waitForDiagnosticsAfter(
+      session,
+      diagnostics,
+      marker,
+      childUri,
+    );
+    assert.equal(initialChildPublish.version, 1);
+    assert.deepEqual(initialChildPublish.diagnostics, []);
+
+    marker = diagnostics.mark();
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri: parentUri, languageId: "vue", version: 1, text: parentSource },
+    });
+    const initialParentPublish = await waitForDiagnosticsAfter(
+      session,
+      diagnostics,
+      marker,
+      parentUri,
+    );
+    assert.equal(initialParentPublish.version, 1);
+    assert.deepEqual(initialParentPublish.diagnostics, []);
+
+    marker = diagnostics.mark();
+    session.notify("textDocument/didChange", {
+      textDocument: { uri: childUri, version: 2 },
+      contentChanges: [{ text: changedChild }],
+    });
+    const changedParent = await waitForDiagnosticsAfter(
+      session,
+      diagnostics,
+      marker,
+      parentUri,
+      (params) =>
+        params.diagnostics.some((diagnostic) =>
+          diagnostic.message?.includes("not assignable to type 'number'"),
+        ),
+    );
+    assert.equal(changedParent.version, 1);
+    assert.deepEqual(changedParent.diagnostics, [
+      expectedMessageDiagnostic(parentSource, "string", "number"),
+    ]);
+    const changedChildPublish = await waitForDiagnosticsAfter(
+      session,
+      diagnostics,
+      marker,
+      childUri,
+      (params) => params.version === 2,
+    );
+    assert.deepEqual(changedChildPublish.diagnostics, []);
+
+    marker = diagnostics.mark();
+    session.notify("textDocument/didChange", {
+      textDocument: { uri: childUri, version: 3 },
+      contentChanges: [{ text: initialChild }],
+    });
+    const repairedParent = await waitForDiagnosticsAfter(
+      session,
+      diagnostics,
+      marker,
+      parentUri,
+      (params) => params.version === 1 && params.diagnostics.length === 0,
+    );
+    assert.deepEqual(repairedParent.diagnostics, []);
+    const repairedChildPublish = await waitForDiagnosticsAfter(
+      session,
+      diagnostics,
+      marker,
+      childUri,
+      (params) => params.version === 3,
+    );
+    assert.deepEqual(repairedChildPublish.diagnostics, []);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+function fixture(fixtures: ProjectionFixture[], id: string): ProjectionFixture {
+  const found = fixtures.find((fixture) => fixture.id === id);
+  assert.ok(found, `TS-40 fixture ${id} must exist`);
+  return found;
+}
+
+function observeDiagnostics(session: LspSession) {
+  const events: unknown[] = [];
+  session.notificationObservers.push((method, params) => {
+    if (method === "textDocument/publishDiagnostics") events.push(params);
+  });
+  return {
+    mark: () => events.length,
+    isAfter: (marker: number, params: unknown) => events.indexOf(params) >= marker,
+  };
+}
+
+function waitForDiagnosticsAfter(
+  session: LspSession,
+  diagnostics: ReturnType<typeof observeDiagnostics>,
+  marker: number,
+  uri: string,
+  predicate: (params: PublishDiagnosticsParams) => boolean = () => true,
+): Promise<PublishDiagnosticsParams> {
+  return session.waitForNotification(
+    "textDocument/publishDiagnostics",
+    (params) =>
+      diagnostics.isAfter(marker, params) && isDiagnosticsForUri(params, uri) && predicate(params),
+  ) as Promise<PublishDiagnosticsParams>;
+}
+
+function expectedMessageDiagnostic(source: string, actualType: string, expectedType: string) {
+  const bindingOffset = source.indexOf(":message");
+  assert.notEqual(bindingOffset, -1);
+  const start = offsetToPosition(source, bindingOffset + ":".length);
+  return {
+    code: 2322,
+    message: `Type '${actualType}' is not assignable to type '${expectedType}'.`,
+    range: {
+      start,
+      end: { line: start.line, character: start.character + "message".length },
+    },
+    severity: 1,
+    source: "vize/types",
+  };
+}
+
+function writeProjectConfig(workspaceDir: string, corsaPath: string): void {
+  fs.writeFileSync(
+    path.join(workspaceDir, "vize.config.json"),
+    JSON.stringify({ lsp: { lint: false, typecheck: true }, typeChecker: { corsaPath } }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(workspaceDir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        module: "ESNext",
+        moduleResolution: "bundler",
+        noEmit: true,
+        strict: true,
+        target: "ES2022",
+      },
+      include: ["src/**/*"],
+    }),
+    "utf8",
+  );
+}
+
+function resolveTsgoBinary(): string | undefined {
+  const candidates = [
+    process.env.CORSA_BIN,
+    path.join(root, "../corsa-bind/.cache/tsgo"),
+    path.join(root, "node_modules/.bin/tsgo"),
+    path.join(root, "tests/node_modules/.bin/tsgo"),
+  ].filter((candidate): candidate is string => candidate != null && candidate.length > 0);
+  return candidates.find((candidate) => fs.existsSync(candidate));
+}
+
+function linkVuePackage(workspaceDir: string): void {
+  const vuePackage = path.join(root, "node_modules/vue");
+  if (!fs.existsSync(vuePackage)) {
+    writeVueShim(workspaceDir);
+    return;
+  }
+  const nodeModules = path.join(workspaceDir, "node_modules");
+  fs.mkdirSync(nodeModules, { recursive: true });
+  fs.symlinkSync(vuePackage, path.join(nodeModules, "vue"), "dir");
+  const vueNamespace = path.join(path.dirname(vuePackage), "@vue");
+  if (fs.existsSync(vueNamespace)) {
+    fs.symlinkSync(vueNamespace, path.join(nodeModules, "@vue"), "dir");
+  }
+}
+
+function writeVueShim(workspaceDir: string): void {
+  fs.writeFileSync(
+    path.join(workspaceDir, "src/vue-shim.d.ts"),
+    `declare module "vue" {
+  export interface Ref<T = any> {
+    value: T;
+  }
+
+  export interface ShallowRef<T = any> {
+    value: T;
+  }
+
+  export type DefineComponent<Props = {}> = new () => { $props: Props };
+
+  export interface ComponentPublicInstance {
+    $attrs: Record<string, unknown>;
+    $slots: Record<string, unknown>;
+    $refs: Record<string, unknown>;
+    $emit: (...args: any[]) => void;
+  }
+
+  export interface GlobalComponents {}
+}
+`,
+    "utf8",
+  );
+}


### PR DESCRIPTION
## Summary

- add a TS-40 projection-backed LSP typecheck regression for local `.vue` imports
- validate the projection matrix before exercising the fixture pair
- assert exact TS2322 publishDiagnostics on authored `:message`, then exact clearing after the child prop type is restored

## Verification

- `vp install --frozen-lockfile --prefer-offline`
- `cargo build -p vize --bin vize --locked`
- `VIZE_LSP_BIN=$(pwd)/target/debug/vize CORSA_BIN=$(pwd)/node_modules/.bin/tsgo node --test tests/tooling/lsp-davinci-ts40-projection-diagnostics.test.ts`
- `VIZE_LSP_BIN=$(pwd)/target/debug/vize CORSA_BIN=$(pwd)/node_modules/.bin/tsgo node --test tests/tooling/lsp-davinci-ts40-projection-diagnostics.test.ts tests/tooling/lsp-typecheck-template.test.ts tests/tooling/lsp-watcher-revalidation.test.ts`
- `node --test tests/tooling/davinci-ts40-projection.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`
- `git diff --cached --check`
- `vp check`

Closes #5044

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790369778&installation_model_id=422833&pr_number=5045&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5045&signature=b34730ad1488585986f271e2055d8d3c32bcd2e02027ee7739ca941eec06400b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->