### PR TITLE
test(content-mapper): pin defineModel LSP navigation

### DIFF
--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms.rs
@@ -12,6 +12,8 @@ use vize_s0::FxHashSet;
 #[path = "content_mapper_tsgo_lsp_event_forms/cases.rs"]
 mod cases;
 use cases::EVENT_CASES;
+#[path = "content_mapper_tsgo_lsp_event_forms/model_props.rs"]
+mod model_props;
 
 mod content_mapper_lsp_support;
 use content_mapper_lsp_support::{
@@ -196,6 +198,19 @@ fn standard_tsgo_lsp_maps_event_symbol_navigation() {
             }
             let app_clean = pull_diagnostics(&client, &app_uri).await;
             assert_eq!(app_clean["items"], json!([]), "{app_clean:#}");
+
+            let named_model = cases
+                .iter()
+                .find(|case| case.7 == "update:title")
+                .expect("model event case should exist");
+            model_props::assert_define_model_prop_navigation(
+                &client,
+                &app_uri,
+                &app_source,
+                &named_model.0,
+                &named_model.1,
+            )
+            .await;
 
             for (
                 uri,

--- a/crates/vize/tests/content_mapper_tsgo_lsp_event_forms/model_props.rs
+++ b/crates/vize/tests/content_mapper_tsgo_lsp_event_forms/model_props.rs
@@ -1,0 +1,97 @@
+//! defineModel-derived prop navigation covered by the standard tsgo LSP oracle.
+
+use corsa_lsp::LspClient;
+use serde_json::json;
+
+use super::content_mapper_lsp_support::{
+    assert_hover, assert_location_range, assert_no_generated_uri_or_zero_range, definition, hover,
+    position_range, references,
+};
+
+pub(crate) async fn assert_define_model_prop_navigation(
+    client: &LspClient,
+    app_uri: &str,
+    app_source: &str,
+    named_model_uri: &str,
+    named_model_source: &str,
+) {
+    let default_start_offset = app_source.find(":model-value").unwrap() + 1;
+    let (default_start, default_end) =
+        position_range(app_source, default_start_offset, "model-value".len());
+    let default_hover = hover(client, app_uri, &default_start).await;
+    assert_hover(
+        &default_hover,
+        &default_start,
+        &default_end,
+        json!({ "kind": "plaintext", "value": "(property) \"modelValue\": number" }),
+        "default defineModel prop hover",
+    );
+    let default_definition = definition(client, app_uri, &default_start).await;
+    assert_no_generated_uri_or_zero_range(&default_definition);
+    assert_location_range(
+        &default_definition,
+        app_uri,
+        &default_start,
+        &default_end,
+        "default defineModel prop definition",
+    );
+    let default_references = references(client, app_uri, &default_start).await;
+    assert_no_generated_uri_or_zero_range(&default_references);
+    assert_location_range(
+        &default_references,
+        app_uri,
+        &default_start,
+        &default_end,
+        "default defineModel prop references",
+    );
+
+    let named_prop_start_offset = app_source.find("title=\"chosen\"").unwrap();
+    let (named_prop_start, named_prop_end) =
+        position_range(app_source, named_prop_start_offset, "title".len());
+    let named_literal_offset = named_model_source.find("\"title\"").unwrap();
+    let (named_declaration_start, named_declaration_end) =
+        position_range(named_model_source, named_literal_offset, "\"title\"".len());
+    let (named_reference_start, named_reference_end) =
+        position_range(named_model_source, named_literal_offset + 1, "title".len());
+
+    let named_hover = hover(client, app_uri, &named_prop_start).await;
+    assert_hover(
+        &named_hover,
+        &named_prop_start,
+        &named_prop_end,
+        json!({ "kind": "plaintext", "value": "(property) \"title\": string" }),
+        "named defineModel prop hover",
+    );
+    let named_definition = definition(client, app_uri, &named_prop_start).await;
+    assert_no_generated_uri_or_zero_range(&named_definition);
+    assert_location_range(
+        &named_definition,
+        app_uri,
+        &named_prop_start,
+        &named_prop_end,
+        "named defineModel prop definition",
+    );
+    assert_location_range(
+        &named_definition,
+        named_model_uri,
+        &named_declaration_start,
+        &named_declaration_end,
+        "named defineModel prop definition",
+    );
+    let named_references = references(client, app_uri, &named_prop_start).await;
+    assert_no_generated_uri_or_zero_range(&named_references);
+    assert_location_range(
+        &named_references,
+        app_uri,
+        &named_prop_start,
+        &named_prop_end,
+        "named defineModel prop references",
+    );
+    assert_location_range(
+        &named_references,
+        named_model_uri,
+        &named_reference_start,
+        &named_reference_end,
+        "named defineModel prop references",
+    );
+}


### PR DESCRIPTION
## Scope
- Close #5048.
- Add exact tsgo Content Mapper LSP coverage for defineModel-derived component props.
- Pin hover, definition, references, and generated URI / zero range leak guards on authored Vue ranges.

## Local verification
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/tsgo-d6c4afddb2c55f4a9dea7b59293a99a8fdea1799 cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture`
- `cargo test -p vize --test content_mapper_tsgo_lsp_event_forms -- --nocapture`
- `node --test tests/tooling/content-mapper-workflow.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`
- `vp check`

Closes #5048

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790373064&installation_model_id=422833&pr_number=5049&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5049&signature=1a18580352036e3b5a25e25910aee654b38578612098bda6c076771aacd7d478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for navigating `defineModel`-derived props.
  * Verified hover information, definitions, and references for default and named model props.
  * Confirmed navigation resolves to the correct source locations without generated or invalid ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->