### PR TITLE
refactor(atelier): import compiler slots through s0 alias

### DIFF
--- a/crates/vize_atelier_core/Cargo.toml
+++ b/crates/vize_atelier_core/Cargo.toml
@@ -23,7 +23,7 @@ legacy = ["vize_relief/_legacy", "vize_armature/legacy"]
 davinci-differential = []
 
 [dependencies]
-vize_carton = { workspace = true }
+vize_s0 = { workspace = true }
 vize_croquis = { workspace = true }
 vize_relief = { workspace = true }
 vize_armature = { workspace = true }

--- a/crates/vize_atelier_core/benches/davinci.rs
+++ b/crates/vize_atelier_core/benches/davinci.rs
@@ -14,7 +14,7 @@ use davinci_harness::stage::bench_stage_with_metrics;
 use vize_atelier_core::lane::transform;
 use vize_atelier_core::options::TransformOptions;
 use vize_atelier_core::parser::Parser;
-use vize_carton::{Allocator, cstr};
+use vize_s0::{Allocator, cstr};
 
 fn davinci(criterion: &mut Criterion) {
     for fixture in &LADDER {

--- a/crates/vize_atelier_core/src/codegen/slots/create_slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/create_slots.rs
@@ -8,7 +8,7 @@
 
 use crate::steps::v_slot::{get_slot_name, has_v_slot};
 use crate::{ElementNode, ForNode, IfNode, PropNode, RuntimeHelper, TemplateChildNode};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use super::super::context::CodegenContext;
 use super::super::expression::generate_expression;

--- a/crates/vize_atelier_core/src/codegen/slots/detect.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/detect.rs
@@ -3,7 +3,7 @@
 use crate::codegen::context::CodegenContext;
 use crate::steps::v_slot::{collect_slots, has_v_slot};
 use crate::{ElementNode, ElementType, ExpressionNode, PropNode, TemplateChildNode};
-use vize_carton::ensure_sufficient_stack;
+use vize_s0::ensure_sufficient_stack;
 
 /// The expression a component spreads into its slots object, if it carries a
 /// `v-slots` directive (#3467).

--- a/crates/vize_atelier_core/src/codegen/slots/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/generate.rs
@@ -2,7 +2,7 @@
 
 use crate::steps::v_slot::{collect_slots, get_slot_name, has_v_slot, is_dynamic_slot};
 use crate::{ElementNode, ExpressionNode, PropNode, RuntimeHelper, TemplateChildNode};
-use vize_carton::String;
+use vize_s0::String;
 
 use super::super::context::CodegenContext;
 use super::super::expression::generate_expression;

--- a/crates/vize_atelier_core/src/codegen/slots/outlet.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/outlet.rs
@@ -1,7 +1,7 @@
 //! Slot outlet (`<slot />`) name and props generation.
 
 use crate::{DirectiveNode, ElementNode, ExpressionNode, PropNode, RuntimeHelper};
-use vize_carton::String;
+use vize_s0::String;
 
 use super::super::context::CodegenContext;
 use super::super::expression::generate_expression;

--- a/crates/vize_atelier_core/src/codegen/slots/params.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/params.rs
@@ -8,11 +8,11 @@ use oxc_ast_visit::{
 };
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{FxHashSet, String, ToCompactString};
 use vize_croquis::builtins::is_global_allowed;
+use vize_s0::{FxHashSet, String, ToCompactString};
 
 /// Get slot props expression as raw source (not transformed)
-pub(super) fn get_slot_props(dir: &DirectiveNode<'_>, source: &str) -> Option<vize_carton::String> {
+pub(super) fn get_slot_props(dir: &DirectiveNode<'_>, source: &str) -> Option<String> {
     dir.exp.as_ref().map(|exp| match exp {
         ExpressionNode::Simple(s) => String::new(s.loc.span.slice(source)),
         ExpressionNode::Compound(c) => String::new(c.loc.span.slice(source)),

--- a/crates/vize_atelier_core/src/codegen/slots/tests.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/tests.rs
@@ -2,9 +2,8 @@ use super::super::helpers::is_valid_js_identifier;
 use super::params::prefix_slot_defaults;
 use crate::compile;
 
-fn result_output(result: &super::super::CodegenResult) -> vize_carton::String {
-    let mut output =
-        vize_carton::String::with_capacity(result.preamble.len() + result.code.len() + 1);
+fn result_output(result: &super::super::CodegenResult) -> vize_s0::String {
+    let mut output = vize_s0::String::with_capacity(result.preamble.len() + result.code.len() + 1);
     output.push_str(&result.preamble);
     output.push('\n');
     output.push_str(&result.code);

--- a/crates/vize_atelier_core/src/lib.rs
+++ b/crates/vize_atelier_core/src/lib.rs
@@ -11,6 +11,8 @@
 //! `vize_atelier_core` provides the foundational infrastructure
 //! that all other Vize compilers build upon.
 
+extern crate vize_s0 as vize_carton;
+
 pub mod codegen;
 pub mod runtime_helpers;
 #[macro_use]
@@ -92,4 +94,4 @@ pub use steps::{
 };
 
 /// Re-export allocator types for convenience
-pub use vize_carton::{Allocator, Box as AllocBox, CloneIn, Vec as AllocVec};
+pub use vize_s0::{Allocator, Box as AllocBox, CloneIn, Vec as AllocVec};

--- a/crates/vize_atelier_core/tests/conditional_named_slots.rs
+++ b/crates/vize_atelier_core/tests/conditional_named_slots.rs
@@ -1,7 +1,7 @@
 use vize_atelier_core::{TransformOptions, parse, transform};
 
 fn transform_errors(source: &str) -> std::vec::Vec<vize_atelier_core::CompilerError> {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = parse(&allocator, source);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
     transform(&allocator, &mut root, TransformOptions::default(), None)

--- a/crates/vize_atelier_core/tests/davinci_s2_transform.rs
+++ b/crates/vize_atelier_core/tests/davinci_s2_transform.rs
@@ -156,7 +156,7 @@ fn both_lanes_flag_the_duplicate_slot_name() {
         .find(|(name, _)| *name == "duplicate-slot-names")
         .expect("the battery carries the duplicate template");
 
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, parse_errors) = vize_atelier_core::parser::parse(&allocator, source);
     assert!(parse_errors.is_empty(), "{parse_errors:?}");
     let transform_errors = vize_atelier_core::transform(
@@ -172,7 +172,7 @@ fn both_lanes_flag_the_duplicate_slot_name() {
         "the legacy lane must flag the duplicate: {transform_errors:?}"
     );
 
-    let s2_allocator = vize_carton::Allocator::new();
+    let s2_allocator = vize_s0::Allocator::new();
     let (tree, surface_errors) = vize_s1::parse(&s2_allocator, source);
     let mut lowered = vize_s1_to_s2::lower(&s2_allocator, &tree, &surface_errors);
     let _facts =
@@ -212,7 +212,7 @@ fn both_lanes_flag_the_scoped_model() {
         .find(|(name, _)| *name == "model-invalid-scope")
         .expect("the battery carries the invalid-scope template");
 
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, parse_errors) = vize_atelier_core::parser::parse(&allocator, source);
     assert!(parse_errors.is_empty(), "{parse_errors:?}");
     let transform_errors = vize_atelier_core::transform(
@@ -228,7 +228,7 @@ fn both_lanes_flag_the_scoped_model() {
         "the legacy lane must flag the scoped model: {transform_errors:?}"
     );
 
-    let s2_allocator = vize_carton::Allocator::new();
+    let s2_allocator = vize_s0::Allocator::new();
     let (tree, surface_errors) = vize_s1::parse(&s2_allocator, source);
     let mut lowered = vize_s1_to_s2::lower(&s2_allocator, &tree, &surface_errors);
     let _facts =
@@ -254,7 +254,7 @@ fn both_lanes_flag_the_duplicate_key() {
         .find(|(name, _)| *name == "duplicate-keys")
         .expect("the battery carries the collision template");
 
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, parse_errors) = vize_atelier_core::parser::parse(&allocator, source);
     assert!(parse_errors.is_empty(), "{parse_errors:?}");
     let transform_errors = vize_atelier_core::transform(
@@ -270,7 +270,7 @@ fn both_lanes_flag_the_duplicate_key() {
         "the legacy lane must flag the collision: {transform_errors:?}"
     );
 
-    let s2_allocator = vize_carton::Allocator::new();
+    let s2_allocator = vize_s0::Allocator::new();
     let (tree, surface_errors) = vize_s1::parse(&s2_allocator, source);
     let mut lowered = vize_s1_to_s2::lower(&s2_allocator, &tree, &surface_errors);
     let _facts =

--- a/crates/vize_atelier_core/tests/davinci_s2_transform_vue2.rs
+++ b/crates/vize_atelier_core/tests/davinci_s2_transform_vue2.rs
@@ -21,7 +21,7 @@ mod s2_support;
 use s2_support::{
     Counters, HoistCounters, SlotCounters, SurfaceCounters, TextCounters, compare_with,
 };
-use vize_carton::config::VueVersion;
+use vize_s0::config::VueVersion;
 
 /// Vue 2 sugar the two lanes both claim to legalize, plus one
 /// sugar-free template so the rest of the projection still agrees

--- a/crates/vize_atelier_core/tests/davinci_sourcemap_prefixed_identifiers.rs
+++ b/crates/vize_atelier_core/tests/davinci_sourcemap_prefixed_identifiers.rs
@@ -130,7 +130,7 @@ fn ladder_template(name: &str) -> &'static str {
 /// those surface as recoverable `ExtendPoint` notes, so only real errors
 /// are asserted away.
 fn compile_with_map(src: &str, filename: &str) -> CodegenResult {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = vize_atelier_core::parse(&allocator, src);
     let fatal: Vec<_> = errors
         .iter()

--- a/crates/vize_atelier_core/tests/dynamic_slot_forwarding.rs
+++ b/crates/vize_atelier_core/tests/dynamic_slot_forwarding.rs
@@ -11,7 +11,7 @@ fn result_output(result: &CodegenResult) -> String {
 }
 
 fn compile(source: &str) -> String {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = parse(&allocator, source);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
 

--- a/crates/vize_atelier_core/tests/dynamic_v_model_argument.rs
+++ b/crates/vize_atelier_core/tests/dynamic_v_model_argument.rs
@@ -11,7 +11,7 @@
 use vize_atelier_core::{
     CodegenOptions, CodegenResult, TransformOptions, generate, parse, transform,
 };
-use vize_carton::String;
+use vize_s0::String;
 
 const SOURCE: &str = r#"<Comp v-model:[arg]="value"/>"#;
 const SOURCE_WITH_MODIFIERS: &str = r#"<Comp v-model:[arg].trim="value"/>"#;
@@ -25,7 +25,7 @@ fn result_output(result: &CodegenResult) -> String {
 }
 
 fn compile(source: &str, prefix_identifiers: bool) -> String {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = parse(&allocator, source);
     assert!(errors.is_empty(), "Parse errors: {errors:?}");
     transform(

--- a/crates/vize_atelier_core/tests/legacy_event_modifiers.rs
+++ b/crates/vize_atelier_core/tests/legacy_event_modifiers.rs
@@ -11,15 +11,15 @@
 //!   `legacy`-enabled build.
 #![cfg(feature = "legacy")]
 // Integration test: plain `std::string::String` / `{out}` formatting is fine
-// here (the crate's internal `vize_carton::String` rule does not apply to an
+// here (the crate's internal `vize_s0::String` rule does not apply to an
 // out-of-crate test harness).
 #![allow(clippy::disallowed_types, clippy::disallowed_macros)]
 
 use vize_atelier_core::{CodegenOptions, TransformOptions, codegen, lane, parser};
-use vize_carton::config::VueVersion;
+use vize_s0::config::VueVersion;
 
 fn compile(input: &str, dialect: VueVersion) -> String {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = parser::parse(&allocator, input);
     assert!(errors.is_empty(), "parse errors: {errors:?}");
 

--- a/crates/vize_atelier_core/tests/legacy_filters.rs
+++ b/crates/vize_atelier_core/tests/legacy_filters.rs
@@ -11,15 +11,15 @@
 //!   a `legacy`-enabled build.
 #![cfg(feature = "legacy")]
 // Integration test: plain `std::string::String` / `{out}` formatting is fine
-// here (the crate's internal `vize_carton::String` rule does not apply to an
+// here (the crate's internal `vize_s0::String` rule does not apply to an
 // out-of-crate test harness).
 #![allow(clippy::disallowed_types, clippy::disallowed_macros)]
 
 use vize_atelier_core::{CodegenOptions, TransformOptions, codegen, lane, parser};
-use vize_carton::config::VueVersion;
+use vize_s0::config::VueVersion;
 
 fn compile(input: &str, dialect: VueVersion) -> String {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = parser::parse(&allocator, input);
     assert!(errors.is_empty(), "parse errors: {errors:?}");
 

--- a/crates/vize_atelier_core/tests/legacy_template_sugar.rs
+++ b/crates/vize_atelier_core/tests/legacy_template_sugar.rs
@@ -11,15 +11,15 @@
 //!   `legacy`-enabled build.
 #![cfg(feature = "legacy")]
 // Integration test: plain `std::string::String` / `{out}` formatting is fine
-// here (the crate's internal `vize_carton::String` rule does not apply to an
+// here (the crate's internal `vize_s0::String` rule does not apply to an
 // out-of-crate test harness).
 #![allow(clippy::disallowed_types, clippy::disallowed_macros)]
 
 use vize_atelier_core::{CodegenOptions, TransformOptions, codegen, lane, parser};
-use vize_carton::config::VueVersion;
+use vize_s0::config::VueVersion;
 
 fn compile(input: &str, dialect: VueVersion) -> String {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = parser::parse(&allocator, input);
     assert!(errors.is_empty(), "parse errors: {errors:?}");
 

--- a/crates/vize_atelier_core/tests/s2_support/checks.rs
+++ b/crates/vize_atelier_core/tests/s2_support/checks.rs
@@ -152,7 +152,7 @@ pub fn check_fors(name: &str, source: &str, old: &[OldFor], s2: &[S2For], counte
         }
         let alias = |position: &str,
                      old_alias: &Option<old_lane::OldText>,
-                     s2_alias: &Option<vize_carton::String>| {
+                     s2_alias: &Option<vize_s0::String>| {
             match (old_alias, s2_alias) {
                 (None, None) => Alias::BothAbsent,
                 (Some(None), Some(_)) => Alias::Compound,

--- a/crates/vize_atelier_core/tests/s2_support/compare.rs
+++ b/crates/vize_atelier_core/tests/s2_support/compare.rs
@@ -7,10 +7,10 @@
 
 use vize_atelier_core::parser::parse_with_options as old_parse_with_options;
 use vize_atelier_core::{ParserOptions, TransformOptions, transform};
-use vize_carton::Allocator;
-use vize_carton::config::VueVersion;
 use vize_davinci::diagnostic::Severity;
 use vize_davinci::pass::NoObserver;
+use vize_s0::Allocator;
+use vize_s0::config::VueVersion;
 use vize_s1_to_s2::LegacyCaps;
 use vize_s1_to_s2::pass::{TRANSFORM_LANE_FLAG, run_transform};
 use vize_s2::folio::DisegnoFolio;
@@ -178,9 +178,9 @@ pub fn compare_with(name: &str, source: &str, counters: &mut Counters, dialect: 
     } else {
         let mut scan = hoist_old::TemplateScan::default();
         hoist_old::scan_template(&root.children, &mut scan);
-        let mut old_shape = vize_carton::String::default();
+        let mut old_shape = vize_s0::String::default();
         hoist_old::shape_of(&root.children, &mut old_shape);
-        let mut s2_shape = vize_carton::String::default();
+        let mut s2_shape = vize_s0::String::default();
         hoist::shape_of_s2(&folio.ops, &mut s2_shape);
         if scan.classifier {
             counters.hoist.classifier_templates += 1;

--- a/crates/vize_atelier_core/tests/s2_support/hoist.rs
+++ b/crates/vize_atelier_core/tests/s2_support/hoist.rs
@@ -236,7 +236,7 @@ pub fn check(
 /// The S2 tree's shape projection — the pairing contract's S2 half
 /// (byte-compared against [`super::hoist_old::shape_of`] before any
 /// walk; a mismatch is `tree_templates`).
-pub fn shape_of_s2(ops: &[FolioOp], out: &mut vize_carton::String) {
+pub fn shape_of_s2(ops: &[FolioOp], out: &mut vize_s0::String) {
     for op in ops {
         match op {
             FolioOp::Element(element) => {

--- a/crates/vize_atelier_core/tests/s2_support/hoist_old.rs
+++ b/crates/vize_atelier_core/tests/s2_support/hoist_old.rs
@@ -16,7 +16,7 @@ use vize_atelier_core::codegen::is_constant_simple_expression;
 use vize_atelier_core::{
     ElementNode, ElementType, ExpressionNode, PropNode, SimpleExpressionNode, TemplateChildNode,
 };
-use vize_carton::{Allocator, Span, camelize, is_native_tag};
+use vize_s0::{Allocator, Span, camelize, is_native_tag};
 use vize_s1_to_s2::pass::hoist::constant_for_hoist;
 use vize_s2::expr::ExprRef;
 
@@ -146,7 +146,7 @@ fn const_rule_diverges(prop: &PropNode<'_>) -> bool {
     } else if has_attr {
         prefixed('^', arg.content)
     } else {
-        vize_carton::String::from(arg.content)
+        vize_s0::String::from(arg.content)
     };
     if matches!(key.as_str(), "ref" | "class") {
         return false;
@@ -157,8 +157,8 @@ fn const_rule_diverges(prop: &PropNode<'_>) -> bool {
     legacy_constant(exp) != s2_constant(exp.content)
 }
 
-fn prefixed(prefix: char, name: &str) -> vize_carton::String {
-    let mut out = vize_carton::String::with_capacity(1 + name.len());
+fn prefixed(prefix: char, name: &str) -> vize_s0::String {
+    let mut out = vize_s0::String::with_capacity(1 + name.len());
     out.push(prefix);
     out.push_str(name);
     out
@@ -185,7 +185,7 @@ fn s2_constant(content: &str) -> bool {
 /// the S2 lowering unwraps them. Compared byte-for-byte against
 /// [`super::hoist::shape_of_s2`]; a mismatch is the S1-scope
 /// tree-construction class (`tree_templates`), counted, never walked.
-pub fn shape_of(children: &[TemplateChildNode<'_>], out: &mut vize_carton::String) {
+pub fn shape_of(children: &[TemplateChildNode<'_>], out: &mut vize_s0::String) {
     for child in children {
         match child {
             TemplateChildNode::Element(el) => {

--- a/crates/vize_atelier_core/tests/s2_support/old_lane.rs
+++ b/crates/vize_atelier_core/tests/s2_support/old_lane.rs
@@ -3,7 +3,7 @@
 //! document order.
 
 use vize_atelier_core::{ExpressionNode, ForNode, IfBranchNode, PropNode, TemplateChildNode};
-use vize_carton::String;
+use vize_s0::String;
 
 /// A branch key as the legacy transform holds it (`user_key`).
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/vize_atelier_core/tests/s2_support/s2_lane.rs
+++ b/crates/vize_atelier_core/tests/s2_support/s2_lane.rs
@@ -6,9 +6,9 @@
 //! the same numbering rule the folio's `ops=` header states: op line,
 //! attached bindings, then children.
 
-use vize_carton::String;
 use vize_davinci::id::NodeId;
 use vize_davinci::side_table::SideTable;
+use vize_s0::String;
 use vize_s1_to_s2::pass::{BranchKeyKind, IfFacts, ModelFacts, SlotFacts, TextFacts};
 use vize_s2::folio::{DisegnoFolio, FolioExpr, FolioOp};
 

--- a/crates/vize_atelier_core/tests/s2_support/slots.rs
+++ b/crates/vize_atelier_core/tests/s2_support/slots.rs
@@ -5,7 +5,7 @@
 //! # The shared unit rule (applied to both trees)
 //!
 //! A **unit** is a node whose tag is not a native tag
-//! (`vize_carton::is_native_tag`, computed from the authored tag on
+//! (`vize_s0::is_native_tag`, computed from the authored tag on
 //! both trees so the lanes' differing component classifiers never enter
 //! the projection) that is **slot-active**: it carries a `v-slot`
 //! itself or has a direct `<template v-slot>` child. Its groups follow
@@ -32,9 +32,9 @@
 //! `defer.slot-props` (the `ui.bind` installment); fallback bytes are
 //! P2-11's.
 
-use vize_carton::String;
 use vize_davinci::id::NodeId;
 use vize_davinci::side_table::SideTable;
+use vize_s0::String;
 use vize_s1_to_s2::pass::SlotFacts;
 use vize_s1_to_s2::pass::vslot::{SlotName, SlotParams};
 use vize_s2::folio::{FolioBinding, FolioName, FolioOp};

--- a/crates/vize_atelier_core/tests/s2_support/slots_old.rs
+++ b/crates/vize_atelier_core/tests/s2_support/slots_old.rs
@@ -8,7 +8,7 @@ use vize_atelier_core::{
     ElementNode, ExpressionNode, PropNode, TemplateChildNode, get_slot_name, get_slot_props_string,
     has_v_slot, is_dynamic_slot,
 };
-use vize_carton::{String, is_native_tag};
+use vize_s0::{String, is_native_tag};
 
 use super::slots::{PGroup, PName, POutlet, PUnit};
 

--- a/crates/vize_atelier_core/tests/s2_support/surface.rs
+++ b/crates/vize_atelier_core/tests/s2_support/surface.rs
@@ -51,7 +51,7 @@
 //!   on-scope verdicts can differ, so the class is counted, never
 //!   compared.
 
-use vize_carton::String;
+use vize_s0::String;
 
 /// The comparator's surface accounting, part of [`super::Counters`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/crates/vize_atelier_core/tests/s2_support/surface_check.rs
+++ b/crates/vize_atelier_core/tests/s2_support/surface_check.rs
@@ -3,7 +3,7 @@
 //! divergence rule is TS-25: investigate, never average; every skip is
 //! a counted class on [`SurfaceCounters`].
 
-use vize_carton::String;
+use vize_s0::String;
 
 use super::surface::{PBind, PModel, PName, PSurface, SurfaceCounters};
 

--- a/crates/vize_atelier_core/tests/s2_support/surface_old.rs
+++ b/crates/vize_atelier_core/tests/s2_support/surface_old.rs
@@ -15,7 +15,7 @@
 use vize_atelier_core::{
     DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, TemplateChildNode,
 };
-use vize_carton::String;
+use vize_s0::String;
 
 use super::surface::{PBind, PDirective, PModel, PName, PSurface, SurfaceCounters};
 use super::surface_old_help::{

--- a/crates/vize_atelier_core/tests/s2_support/surface_old_help.rs
+++ b/crates/vize_atelier_core/tests/s2_support/surface_old_help.rs
@@ -4,7 +4,7 @@
 //! scope/ambiguity predicates.
 
 use vize_atelier_core::{DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode};
-use vize_carton::String;
+use vize_s0::String;
 
 use super::surface::{PName, is_simple_ident};
 
@@ -116,7 +116,7 @@ pub fn classifier_ambiguous(el: &ElementNode<'_>) -> bool {
     if has_is {
         return true;
     }
-    let native = vize_carton::is_native_tag(el.tag);
+    let native = vize_s0::is_native_tag(el.tag);
     let legacy_component = el.tag == "component"
         || el.tag.chars().next().is_some_and(char::is_uppercase)
         || el.tag.contains('-');

--- a/crates/vize_atelier_core/tests/s2_support/surface_s2.rs
+++ b/crates/vize_atelier_core/tests/s2_support/surface_s2.rs
@@ -4,8 +4,8 @@
 //! are positional (owner line, then bindings in order), which is how
 //! the fault table resolves and the branch-key exclusion lands.
 
-use vize_carton::String;
 use vize_davinci::id::NodeId;
+use vize_s0::String;
 use vize_s2::folio::{FolioAttribute, FolioBinding, FolioExpr, FolioName, FolioOp};
 
 use super::s2_lane::{S2Projection, Tables};

--- a/crates/vize_atelier_core/tests/s2_support/text.rs
+++ b/crates/vize_atelier_core/tests/s2_support/text.rs
@@ -44,7 +44,7 @@
 //!   pipe and compare exactly (installment 7: those parts are not
 //!   `ExprRef::Filter`).
 
-use vize_carton::{Allocator, Span, String};
+use vize_s0::{Allocator, Span, String};
 use vize_s2::expr::VueFilterExpr;
 
 /// The comparator's text accounting, part of [`super::Counters`].

--- a/crates/vize_atelier_core/tests/s2_support/text_old.rs
+++ b/crates/vize_atelier_core/tests/s2_support/text_old.rs
@@ -6,7 +6,7 @@
 //! subtrees excluded per the lane-neutral rule.
 
 use vize_atelier_core::{ExpressionNode, TemplateChildNode};
-use vize_carton::String;
+use vize_s0::String;
 
 use super::text::{TPart, TUnit};
 

--- a/crates/vize_atelier_core/tests/scoped_slot_shadowing.rs
+++ b/crates/vize_atelier_core/tests/scoped_slot_shadowing.rs
@@ -13,18 +13,18 @@ fn result_output(result: &CodegenResult) -> String {
 
 #[test]
 fn scoped_slot_props_shadow_inline_props_in_slot_outlet_vbind() {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = parse(
         &allocator,
         r#"<RouterLink v-slot="{ href }"><slot v-bind="{ href }" /></RouterLink>"#,
     );
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
 
-    let mut bindings = vize_carton::FxHashMap::default();
+    let mut bindings = vize_s0::FxHashMap::default();
     bindings.insert("href".into(), BindingType::Props);
     let binding_metadata = BindingMetadata {
         bindings,
-        props_aliases: vize_carton::FxHashMap::default(),
+        props_aliases: vize_s0::FxHashMap::default(),
         is_script_setup: true,
     };
 

--- a/crates/vize_atelier_core/tests/upstream_tuple_type_span_typescript_strip.rs
+++ b/crates/vize_atelier_core/tests/upstream_tuple_type_span_typescript_strip.rs
@@ -33,7 +33,7 @@ enum TransformOutcome {
     UpstreamSpanAssertion(String),
 }
 
-fn classify(transform: fn(&str) -> vize_carton::String, source: &str) -> TransformOutcome {
+fn classify(transform: fn(&str) -> vize_s0::String, source: &str) -> TransformOutcome {
     let previous_hook = panic::take_hook();
     panic::set_hook(Box::new(|_| {}));
     let transformed =

--- a/crates/vize_atelier_core/tests/v_if_spread_order.rs
+++ b/crates/vize_atelier_core/tests/v_if_spread_order.rs
@@ -1,7 +1,7 @@
 use vize_atelier_core::{
     CodegenOptions, CodegenResult, TransformOptions, generate, parse, transform,
 };
-use vize_carton::String;
+use vize_s0::String;
 
 fn result_output(result: &CodegenResult) -> String {
     let mut output = String::with_capacity(result.preamble.len() + result.code.len() + 1);
@@ -16,7 +16,7 @@ fn compile(source: &str) -> String {
 }
 
 fn compile_with_options(source: &str, mut codegen_options: CodegenOptions) -> String {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = parse(&allocator, source);
     assert!(errors.is_empty(), "Parse errors: {errors:?}");
     transform(

--- a/crates/vize_atelier_core/tests/v_once_prop_keys.rs
+++ b/crates/vize_atelier_core/tests/v_once_prop_keys.rs
@@ -4,10 +4,10 @@ use oxc_span::SourceType;
 use vize_atelier_core::{
     CodegenMode, CodegenOptions, TransformOptions, generate, parse, transform,
 };
-use vize_carton::String;
+use vize_s0::String;
 
 fn compile_module(source: &str) -> String {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = parse(&allocator, source);
     assert!(errors.is_empty(), "template parse errors: {errors:?}");
     transform(&allocator, &mut root, TransformOptions::default(), None);

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           916 |                   192 |               724 |             139 |     371 |             951 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   252 |               665 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
@@ -61,7 +61,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          21 |               4 |       17 |
-| S0               |         845 |             490 |      355 |
+| S0               |         846 |             491 |      355 |
 | S1               |           5 |               1 |        4 |
 | S2               |          15 |               1 |       14 |
 | S1->S2           |          30 |               2 |       28 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1,7 +1,7 @@
 consumer_id	consumer	class	file	first_line	surface_id	surface	surface_group	matched_name	name_kind	sites
-compiler	Compiler	test/dev	crates/vize_atelier_core/benches/davinci.rs	17	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/benches/davinci.rs	17	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s1	S1	stage	vize_s1	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s2	S2	stage	vize_s2	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
@@ -66,17 +66,17 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/generate.rs	
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/scan.rs	9	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/v_model.rs	29	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/root.rs	11	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/create_slots.rs	11	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/detect.rs	6	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/generate.rs	5	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/outlet.rs	4	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/create_slots.rs	11	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/detect.rs	6	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/generate.rs	5	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/outlet.rs	4	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	8
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/slots/tests.rs	5	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/slots/tests.rs	5	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/source_map.rs	35	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	s0	S0	stage	vize_carton	compat	20
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
@@ -108,9 +108,10 @@ compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	old_a
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/structural/tests.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/tests.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/traverse.rs	8	s0	S0	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	33	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	4
-compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	33	old_ast	old AST/parser	old	vize_armature	legacy	3
+compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	4
+compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	3
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
@@ -192,27 +193,27 @@ compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/params.rs	3	r
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_slot/tests.rs	8	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/validate.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/test_macros.rs	17	s0	S0	stage	vize_carton	compat	12
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/conditional_named_slots.rs	4	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform_vue2.rs	24	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/conditional_named_slots.rs	4	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform_vue2.rs	24	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	davinci	Davinci	stage	vize_davinci	preferred	3
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s0	S0	stage	vize_carton	compat	6
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s0	S0	stage	vize_s0	preferred	6
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s1	S1	stage	vize_s1	preferred	3
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	13
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_sourcemap_prefixed_identifiers.rs	133	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/dynamic_slot_forwarding.rs	14	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/dynamic_v_model_argument.rs	14	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_sourcemap_prefixed_identifiers.rs	133	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/dynamic_slot_forwarding.rs	14	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/dynamic_v_model_argument.rs	14	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_3712.rs	25	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_3712.rs	25	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/legacy_event_modifiers.rs	19	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/legacy_filters.rs	19	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/legacy_template_sugar.rs	19	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/checks.rs	155	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/legacy_event_modifiers.rs	19	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/legacy_filters.rs	19	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/legacy_template_sugar.rs	19	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/checks.rs	155	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	davinci	Davinci	stage	vize_davinci	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s0	S0	stage	vize_carton	compat	4
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s0	S0	stage	vize_s0	preferred	4
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s1	S1	stage	vize_s1	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s2	S2	stage	vize_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/compare.rs	10	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	3
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s0	S0	stage	vize_carton	compat	5
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s0	S0	stage	vize_s0	preferred	5
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s2	S2	stage	vize_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_old.rs	19	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_owner.rs	9	davinci	Davinci	stage	vize_davinci	preferred	1
@@ -222,37 +223,37 @@ compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_walk.
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_walk.rs	9	s2	S2	stage	vize_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist_walk.rs	9	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	davinci	Davinci	stage	vize_davinci	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s2	S2	stage	vize_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/hoist.rs	50	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/old_lane.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/old_lane.rs	6	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	davinci	Davinci	stage	vize_davinci	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s2	S2	stage	vize_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/s2_lane.rs	9	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots_old.rs	11	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots_old.rs	11	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	davinci	Davinci	stage	vize_davinci	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s2	S2	stage	vize_s2	preferred	6
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/slots.rs	35	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_check.rs	6	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_old_help.rs	7	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_old.rs	18	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_check.rs	6	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_old_help.rs	7	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_old.rs	18	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_s2.rs	7	davinci	Davinci	stage	vize_davinci	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_s2.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_s2.rs	7	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface_s2.rs	7	s2	S2	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface.rs	54	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/text_old.rs	9	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/text.rs	47	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/surface.rs	54	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/text_old.rs	9	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/text.rs	47	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/s2_support/text.rs	47	s2	S2	stage	vize_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/scoped_slot_shadowing.rs	16	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/scoped_slot_shadowing.rs	16	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/upstream_pure_comment_assertion.rs	53	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/upstream_pure_comment_assertion.rs	53	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/upstream_tuple_type_span_assertion.rs	44	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/upstream_tuple_type_span_assertion.rs	44	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/upstream_tuple_type_span_typescript_strip.rs	36	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_if_spread_order.rs	4	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_once_prop_keys.rs	1	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/upstream_tuple_type_span_typescript_strip.rs	36	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_if_spread_order.rs	4	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_once_prop_keys.rs	1	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_once_prop_keys.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/v_once_prop_keys.rs	1	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/benches/davinci.rs	27	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const libPath = path.join(repoRoot, "crates", "vize_atelier_core", "src", "lib.rs");
+const slotsModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "codegen",
+  "slots.rs",
+);
+const slotsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "slots");
+const testRoot = path.join(repoRoot, "crates", "vize_atelier_core", "tests");
+const benchPath = path.join(repoRoot, "crates", "vize_atelier_core", "benches", "davinci.rs");
+const require = createRequire(import.meta.url);
+const toml = require("@iarna/toml") as { parse(source: string): unknown };
+
+interface CargoDependency {
+  readonly name: string;
+  readonly rename: string | null;
+  readonly path: string | null;
+  readonly kind: string | null;
+  readonly optional: boolean;
+  readonly uses_default_features: boolean;
+  readonly req: string;
+}
+
+interface CargoPackage {
+  readonly name: string;
+  readonly version: string;
+  readonly dependencies: readonly CargoDependency[];
+}
+
+interface CargoMetadata {
+  readonly packages: readonly CargoPackage[];
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  assert.equal(typeof value, "object");
+  assert.notEqual(value, null);
+  assert.ok(!Array.isArray(value));
+  return value as Record<string, unknown>;
+}
+
+function readToml(...segments: string[]): Record<string, unknown> {
+  return asRecord(toml.parse(fs.readFileSync(path.join(repoRoot, ...segments), "utf8")));
+}
+
+function cargoMetadata(): CargoMetadata {
+  return JSON.parse(
+    execFileSync("cargo", ["metadata", "--no-deps", "--format-version", "1", "--locked"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }),
+  ) as CargoMetadata;
+}
+
+function* rustFiles(directory: string): Generator<string> {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      yield* rustFiles(fullPath);
+    } else if (entry.isFile() && entry.name.endsWith(".rs")) {
+      yield fullPath;
+    }
+  }
+}
+
+test("Atelier core slot codegen imports S0 storage through the stage alias", () => {
+  const rootManifest = readToml("Cargo.toml");
+  const coreManifest = readToml("crates", "vize_atelier_core", "Cargo.toml");
+  const workspaceDependencies = asRecord(asRecord(rootManifest.workspace).dependencies);
+  const coreDependencies = asRecord(coreManifest.dependencies);
+  const workspaceS0 = asRecord(workspaceDependencies.vize_s0);
+  const coreS0 = asRecord(coreDependencies.vize_s0);
+
+  assert.equal(workspaceS0.package, "vize_carton");
+  assert.equal(workspaceS0.path, "crates/vize_carton");
+  assert.equal(coreS0.workspace, true);
+  assert.ok(!Object.hasOwn(coreDependencies, "vize_carton"));
+
+  const metadata = cargoMetadata();
+  const cartonPackage = metadata.packages.find((pkg) => pkg.name === "vize_carton");
+  const corePackage = metadata.packages.find((pkg) => pkg.name === "vize_atelier_core");
+  assert.ok(cartonPackage);
+  assert.ok(corePackage);
+  const s0Dependency = corePackage.dependencies.find(
+    (dependency) => dependency.name === "vize_carton" && dependency.rename === "vize_s0",
+  );
+  assert.ok(s0Dependency);
+  assert.equal(s0Dependency.path, path.join(repoRoot, "crates", "vize_carton"));
+  assert.equal(s0Dependency.req, `=${cartonPackage.version}`);
+  assert.equal(s0Dependency.kind, null);
+  assert.equal(s0Dependency.optional, false);
+  assert.equal(s0Dependency.uses_default_features, true);
+
+  const offenders = [];
+  let aliasImportCount = 0;
+  for (const file of [
+    libPath,
+    slotsModule,
+    ...rustFiles(slotsRoot),
+    ...rustFiles(testRoot),
+    benchPath,
+  ]) {
+    const source = fs.readFileSync(file, "utf8");
+    if (/\bvize_carton::|use vize_carton\b/u.test(source)) {
+      offenders.push(path.relative(repoRoot, file));
+    }
+    if (/\bvize_s0::|use vize_s0\b/u.test(source)) {
+      aliasImportCount += 1;
+    }
+  }
+
+  assert.deepEqual(offenders, []);
+  assert.ok(aliasImportCount > 0, "codegen/slots should use vize_s0");
+});


### PR DESCRIPTION
Closes #5052.

## Summary

- switch `vize_atelier_core` to the workspace `vize_s0` dependency alias while keeping an internal compatibility alias for remaining incremental `vize_carton` references
- migrate `codegen/slots` and the atelier-core external test/bench witnesses to `vize_s0`
- add a tooling ratchet for the manifest, `cargo metadata`, and slot/witness source imports
- refresh `davinci-road/plan/consumer-migration-surfaces.*`

## Verification

- `vp install --frozen-lockfile --prefer-offline`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-canon-lsp-stage-alias.test.ts tests/tooling/source-file-lengths.test.ts`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `cargo test -p vize_atelier_core slots --features legacy,davinci-differential -- --nocapture`
- `cargo test -p vize_atelier_core --lib --features legacy,davinci-differential -- --nocapture`
- `cargo test -p vize_atelier_core --tests --features legacy,davinci-differential -- --nocapture`
- `cargo clippy -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `vp check`

Local `cargo semver-checks check-release --package vize_atelier_core --baseline-rev origin/main` could not complete because the installed local `cargo-semver-checks` only supports rustdoc JSON v56/v57 while this toolchain emitted v60; hosted CI installs its own tool and remains the source of truth for that gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790377330&installation_model_id=422833&pr_number=5053&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5053&signature=3a980a8f8833fc087511d8f9a766a4ea2651a27f69278be82a79ef35a037f834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the Atelier Core component to use the S0 storage interface consistently.
  * Preserved existing allocator types and behavior while transitioning internal references.
* **Documentation**
  * Refreshed the consumer migration inventory to reflect the latest adoption levels.
* **Tests**
  * Added validation ensuring the component uses the preferred S0 stage alias consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->