### PR TITLE
refactor(atelier): import compiler props through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -9,7 +9,7 @@ use super::super::{
 };
 use super::StaticMerge;
 use super::v_model::generate_vmodel_prop;
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 /// Check if an expression is a static literal (no runtime identifiers).
 /// Returns true for: object literals, array literals, string literals, numbers
@@ -210,14 +210,14 @@ fn generate_vbind_prop(
             is_class = *key == "class";
             is_style = *key == "style";
 
-            let base_key: vize_carton::String =
+            let base_key: vize_s0::String =
                 if has_camel || matches!(static_key_casing, StaticBindKeyCasing::Camelize) {
                     camelize(key)
                 } else {
                     key.to_compact_string()
                 };
 
-            let transformed_key: vize_carton::String = if has_prop {
+            let transformed_key: vize_s0::String = if has_prop {
                 // Add . prefix for DOM property binding
                 let mut name = String::with_capacity(1 + base_key.len());
                 name.push('.');

--- a/crates/vize_atelier_core/src/codegen/props/events.rs
+++ b/crates/vize_atelier_core/src/codegen/props/events.rs
@@ -8,7 +8,7 @@ use super::super::{
     expression::generate_event_handler,
     helpers::{camelize, capitalize_first},
 };
-use vize_carton::{FxHashSet, String, ToCompactString};
+use vize_s0::{FxHashSet, String, ToCompactString};
 
 /// Compute the prop key for a static v-on event, mirroring Vue's
 /// `transforms/vOn.ts` casing rules.

--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -15,7 +15,7 @@ use super::{
     object_spread::try_generate_without_merge_props,
     scan::PropsScan,
 };
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 /// Generate props object
 pub fn generate_props(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {

--- a/crates/vize_atelier_core/src/codegen/props/scan.rs
+++ b/crates/vize_atelier_core/src/codegen/props/scan.rs
@@ -6,7 +6,7 @@ use crate::{DirectiveNode, ExpressionNode, PropNode};
 use super::super::context::CodegenContext;
 use super::directives::is_supported_directive;
 use super::events::get_von_event_key;
-use vize_carton::{FxHashMap, String};
+use vize_s0::{FxHashMap, String};
 
 #[derive(Default)]
 pub(super) struct EventNameCounts {

--- a/crates/vize_atelier_core/src/codegen/props/v_model.rs
+++ b/crates/vize_atelier_core/src/codegen/props/v_model.rs
@@ -26,10 +26,10 @@ pub(super) fn generate_vmodel_prop(ctx: &mut CodegenContext, dir: &DirectiveNode
         .exp
         .as_ref()
         .map(|e| match e {
-            ExpressionNode::Simple(s) => vize_carton::String::new(s.content),
-            ExpressionNode::Compound(c) => vize_carton::String::new(c.loc.span.slice(&ctx.source)),
+            ExpressionNode::Simple(s) => vize_s0::String::new(s.content),
+            ExpressionNode::Compound(c) => vize_s0::String::new(c.loc.span.slice(&ctx.source)),
         })
-        .unwrap_or_else(|| vize_carton::String::new("undefined"));
+        .unwrap_or_else(|| vize_s0::String::new("undefined"));
 
     // [prop]: value
     ctx.push("[");

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   252 |               665 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   261 |               656 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -59,12 +59,12 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	raw_oxc	raw OXC	raw	oxc_allocator	raw	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/directives.rs	12	s0	S0	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/events.rs	11	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/generate.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/directives.rs	12	s0	S0	stage	vize_s0	preferred	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/events.rs	11	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/generate.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/generate.rs	4	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/scan.rs	9	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/v_model.rs	29	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/scan.rs	9	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/v_model.rs	29	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/root.rs	11	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/create_slots.rs	11	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/detect.rs	6	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -16,7 +16,16 @@ const slotsModule = path.join(
   "codegen",
   "slots.rs",
 );
+const propsModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "codegen",
+  "props.rs",
+);
 const slotsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "slots");
+const propsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "props");
 const testRoot = path.join(repoRoot, "crates", "vize_atelier_core", "tests");
 const benchPath = path.join(repoRoot, "crates", "vize_atelier_core", "benches", "davinci.rs");
 const require = createRequire(import.meta.url);
@@ -73,7 +82,7 @@ function* rustFiles(directory: string): Generator<string> {
   }
 }
 
-test("Atelier core slot codegen imports S0 storage through the stage alias", () => {
+test("Atelier core migrated codegen slices import S0 storage through the stage alias", () => {
   const rootManifest = readToml("Cargo.toml");
   const coreManifest = readToml("crates", "vize_atelier_core", "Cargo.toml");
   const workspaceDependencies = asRecord(asRecord(rootManifest.workspace).dependencies);
@@ -106,7 +115,9 @@ test("Atelier core slot codegen imports S0 storage through the stage alias", () 
   for (const file of [
     libPath,
     slotsModule,
+    propsModule,
     ...rustFiles(slotsRoot),
+    ...rustFiles(propsRoot),
     ...rustFiles(testRoot),
     benchPath,
   ]) {
@@ -120,5 +131,5 @@ test("Atelier core slot codegen imports S0 storage through the stage alias", () 
   }
 
   assert.deepEqual(offenders, []);
-  assert.ok(aliasImportCount > 0, "codegen/slots should use vize_s0");
+  assert.ok(aliasImportCount > 0, "migrated codegen slices should use vize_s0");
 });


### PR DESCRIPTION
Closes #5054.

## Summary
- switch compiler props codegen S0 storage imports from the compatibility `vize_carton` crate name to the physical `vize_s0` alias
- extend the migrated codegen slice ratchet to cover `codegen/props.rs` and `codegen/props/**`
- refresh the Davinci consumer migration surfaces inventory for the props slice

## Verification
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `cargo test -p vize_atelier_core props --features legacy,davinci-differential -- --nocapture`
- `cargo test -p vize_atelier_core --lib --features legacy,davinci-differential -- --nocapture`
- `cargo test -p vize_atelier_core --tests --features legacy,davinci-differential -- --nocapture`
- `cargo clippy -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `vp check`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `node --test tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `cargo test -p vize_atelier_core codegen --features legacy,davinci-differential -- --nocapture`

## Local broad-suite caveat
- `vp run --workspace-root test:scripts` was also run locally and exited 1 on unrelated hydrated fixture / pinned native binary / host Node matrix failures; the focused Davinci and atelier gates above pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790380040&installation_model_id=422833&pr_number=5055&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5055&signature=9537b0ebd25039bff452899007a47fbdd281ce5b73341522479b0d61a98b1c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated internal code generation components to use the standardized string and collection utilities.
  * No user-facing behavior changes.

* **Tests**
  * Expanded migration checks to cover both slot and prop code generation areas.
  * Updated compatibility metrics to reflect the latest migration status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->