### PR TITLE
refactor(atelier): import compiler v-if through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/v_if.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if.rs
@@ -13,7 +13,7 @@ use crate::{IfBranchNode, IfNode, PropNode, RuntimeHelper};
 use super::{context::CodegenContext, expression::generate_expression, helpers::escape_js_string};
 
 use branch::generate_if_branch;
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 /// Generate if node.
 pub fn generate_if(ctx: &mut CodegenContext, if_node: &IfNode<'_>) {

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -7,7 +7,7 @@ use crate::{
     ElementNode, ElementType, ExpressionNode, ForNode, IfBranchNode, PropNode, RuntimeHelper,
     TemplateChildNode,
 };
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 use super::{
     super::{

--- a/crates/vize_atelier_core/src/codegen/v_if/props.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/props.rs
@@ -1,7 +1,7 @@
 //! Source-ordered props generation for v-if branches.
 
 use crate::{ElementNode, ExpressionNode, IfBranchNode, PropNode, RuntimeHelper};
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 use super::{
     super::{

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   261 |               656 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   264 |               653 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -85,9 +85,9 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/generate.rs	
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/helpers.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/v_for/helpers.rs	249	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/item_props.rs	13	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if.rs	16	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if/branch.rs	10	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if/props.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if.rs	16	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if/branch.rs	10	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if/props.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/expr_parse_probe.rs	22	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -24,8 +24,10 @@ const propsModule = path.join(
   "codegen",
   "props.rs",
 );
+const vIfModule = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_if.rs");
 const slotsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "slots");
 const propsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "props");
+const vIfRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_if");
 const testRoot = path.join(repoRoot, "crates", "vize_atelier_core", "tests");
 const benchPath = path.join(repoRoot, "crates", "vize_atelier_core", "benches", "davinci.rs");
 const require = createRequire(import.meta.url);
@@ -116,8 +118,10 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     libPath,
     slotsModule,
     propsModule,
+    vIfModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),
+    ...rustFiles(vIfRoot),
     ...rustFiles(testRoot),
     benchPath,
   ]) {


### PR DESCRIPTION
Closes #5056.

## Summary
- switch compiler v-if codegen S0 storage imports from the compatibility `vize_carton` crate name to the physical `vize_s0` alias
- extend the migrated codegen slice ratchet to cover `codegen/v_if.rs` and `codegen/v_if/**`
- refresh the Davinci consumer migration surfaces inventory for the v-if slice

## Verification
- `vp install --frozen-lockfile --prefer-offline`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `git diff --check`
- `cargo fmt --all -- --check`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `node --test tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `cargo check -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `cargo test -p vize_atelier_core v_if --features legacy,davinci-differential -- --nocapture`
- `cargo test -p vize_atelier_core --lib --features legacy,davinci-differential -- --nocapture`
- `cargo test -p vize_atelier_core --tests --features legacy,davinci-differential -- --nocapture`
- `cargo test -p vize_atelier_core codegen --features legacy,davinci-differential -- --nocapture`
- `cargo test -p vize_atelier_core --test v_if_spread_order --features legacy,davinci-differential -- --nocapture`
- `cargo test -p vize_atelier_core --no-run --features legacy,davinci-differential`
- `cargo clippy -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `cargo test -p vize_atelier_core`
- `cargo clippy -p vize_atelier_core -- -D warnings -D clippy::wildcard_imports`
- `vp check`
- `vp run --workspace-root check:ci`

## Risk
Import-path-only migration. No compiler output snapshots changed, no rollout flag changed, and no Cargo manifest changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790382370&installation_model_id=422833&pr_number=5057&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5057&signature=7fd0668844d6bb47a30b03507f49ebf3731b0c8858b438d3faddc9fa64ea5d9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved internal compatibility by standardizing shared utility usage in conditional rendering code generation.
  * Maintained consistent behavior while transitioning supported compiler components to the preferred utility source.

* **Tests**
  * Expanded validation to cover conditional-rendering code generation modules and prevent outdated imports.

* **Documentation**
  * Updated compiler migration tracking to reflect the latest stage-name and compatibility-code counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->