### PR TITLE
refactor(atelier): import compiler v-for through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/v_for.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for.rs
@@ -17,8 +17,8 @@ use super::{
 
 use generate::generate_for_item;
 use helpers::extract_for_params;
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 #[allow(unused_imports)]
 pub(crate) use helpers::{

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -31,7 +31,7 @@ use super::item_props::{
     unwrap_template_single_element,
 };
 use super::slot_outlet::generate_for_slot_outlet;
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 /// Generate item for v-for (as block, not regular vnode)
 pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>, is_stable: bool) {
@@ -654,7 +654,7 @@ fn generate_for_item_props_merged(
     ctx: &mut CodegenContext,
     el: &ElementNode<'_>,
     key_exp: Option<&ExpressionNode<'_>>,
-    scope_id: &Option<vize_carton::String>,
+    scope_id: &Option<vize_s0::String>,
     has_vbind_spread: bool,
     has_von_spread: bool,
     skip_is_prop: bool,
@@ -720,7 +720,7 @@ fn flush_for_item_props_segment(
     ctx: &mut CodegenContext,
     props: &[PropNode<'_>],
     key_exp: Option<&ExpressionNode<'_>>,
-    scope_id: &Option<vize_carton::String>,
+    scope_id: &Option<vize_s0::String>,
     include_extra: bool,
     first_merge_arg: &mut bool,
     skip_is_prop: bool,

--- a/crates/vize_atelier_core/src/codegen/v_for/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/helpers.rs
@@ -4,7 +4,7 @@
 //! and utility predicates for v-for rendering.
 
 use crate::{ElementNode, ExpressionNode, PropNode};
-use vize_carton::{SmallVec, String, ToCompactString};
+use vize_s0::{SmallVec, String, ToCompactString};
 
 /// Extract parameter names from a v-for callback expression.
 /// Handles simple identifiers ("item"), destructuring patterns ("{ id, name }"),
@@ -246,7 +246,7 @@ pub(crate) fn should_skip_prop(p: &PropNode<'_>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{extract_destructure_params, is_numeric_content, split_top_level};
-    use vize_carton::String;
+    use vize_s0::String;
 
     /// Test numeric source detection for v-for range expressions.
     #[test]

--- a/crates/vize_atelier_core/src/codegen/v_for/item_props.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/item_props.rs
@@ -10,7 +10,7 @@ use crate::codegen::{
         StaticMerge, duplicate_von_event_keys, generate_merged_event_handlers, get_von_event_key,
     },
 };
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 pub(super) enum EventPropAction {
     Single,

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   264 |               653 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   272 |               645 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -80,11 +80,11 @@ compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/slots/tests.rs	5
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/source_map.rs	35	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	s0	S0	stage	vize_carton	compat	20
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for.rs	20	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/generate.rs	34	s0	S0	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/helpers.rs	7	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/v_for/helpers.rs	249	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/item_props.rs	13	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for.rs	20	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/generate.rs	34	s0	S0	stage	vize_s0	preferred	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/helpers.rs	7	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/v_for/helpers.rs	249	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/item_props.rs	13	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if.rs	16	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if/branch.rs	10	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if/props.rs	4	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -25,9 +25,11 @@ const propsModule = path.join(
   "props.rs",
 );
 const vIfModule = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_if.rs");
+const vForModule = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_for.rs");
 const slotsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "slots");
 const propsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "props");
 const vIfRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_if");
+const vForRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_for");
 const testRoot = path.join(repoRoot, "crates", "vize_atelier_core", "tests");
 const benchPath = path.join(repoRoot, "crates", "vize_atelier_core", "benches", "davinci.rs");
 const require = createRequire(import.meta.url);
@@ -119,9 +121,11 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     slotsModule,
     propsModule,
     vIfModule,
+    vForModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),
     ...rustFiles(vIfRoot),
+    ...rustFiles(vForRoot),
     ...rustFiles(testRoot),
     benchPath,
   ]) {


### PR DESCRIPTION
Closes #5058

## Summary
- import compiler v-for S0 storage types through the physical `vize_s0` alias
- extend the atelier-core stage-alias ratchet over `codegen/v_for{.rs,/**}`
- refresh the Davinci consumer migration surface inventory (+8 preferred / -8 compat for Compiler, total unchanged)

## Verification
- `vp install --frozen-lockfile --prefer-offline`
- `vp check`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `vp run --workspace-root check:ci`

## Notes
- Local `cargo clippy -p vize_atelier_core --all-targets --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports` still hits pre-existing test-side disallowed-type/macro/manual-contains warnings outside this PR's diff.
- No rollout flags or compiler semantics changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790385367&installation_model_id=422833&pr_number=5059&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5059&signature=a3b625c71dcb418d88d896fb3406c1026b7087e20e98b71d8e904917e0e10813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal code generation components to use the standardized stage alias.
  * Reclassified compiler migration surface counts to reflect the latest naming conventions.

* **Tests**
  * Expanded migration checks to cover `v-for` code generation sources and their stage aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->