### PR TITLE
refactor(atelier): import compiler element through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -32,7 +32,7 @@ use super::{
     },
     v_once::generate_v_once_element,
 };
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 /// Generate element as a block
 pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {

--- a/crates/vize_atelier_core/src/codegen/element/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/element/directives.rs
@@ -133,7 +133,7 @@ fn generate_custom_directive_entry(ctx: &mut CodegenContext, dir: &crate::Direct
                 }
             }
             ExpressionNode::Compound(compound) => {
-                let text = vize_carton::String::new(compound.loc.span.slice(&ctx.source));
+                let text = vize_s0::String::new(compound.loc.span.slice(&ctx.source));
                 ctx.push(&text);
             }
         }

--- a/crates/vize_atelier_core/src/codegen/element/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/element/helpers.rs
@@ -6,7 +6,7 @@
 use crate::{
     DirectiveNode, ElementNode, ElementType, ExpressionNode, Namespace, PropNode, TemplateChildNode,
 };
-use vize_carton::{ensure_sufficient_stack, is_builtin_directive};
+use vize_s0::{ensure_sufficient_stack, is_builtin_directive};
 
 use super::super::{
     context::CodegenContext, node::generate_node, props::is_supported_directive,

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -33,7 +33,7 @@ use super::{
         is_dynamic_component, is_is_prop, is_renderable_prop, is_whitespace_or_comment,
     },
 };
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 /// Generate element code (non-block)
 pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {

--- a/crates/vize_atelier_core/src/codegen/element/v_once.rs
+++ b/crates/vize_atelier_core/src/codegen/element/v_once.rs
@@ -14,7 +14,7 @@ use super::super::{
     patch_flag::{calculate_element_patch_info, patch_flag_name},
     props::is_supported_directive,
 };
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 /// Emit a static object key using identifier syntax when JavaScript permits it.
 ///

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   272 |               645 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   277 |               640 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -19,11 +19,11 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/children.rs	14	s0	
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/component_binding.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/context.rs	10	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/context/vnode_factory.rs	1	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/block.rs	35	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/directives.rs	136	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/helpers.rs	9	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/inline.rs	36	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/v_once.rs	17	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/block.rs	35	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/directives.rs	136	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/helpers.rs	9	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/inline.rs	36	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/v_once.rs	17	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/emit.rs	7	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression.rs	22	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/comment_rewrite.rs	16	s0	S0	stage	vize_carton	compat	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -30,6 +30,7 @@ const slotsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "cod
 const propsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "props");
 const vIfRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_if");
 const vForRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_for");
+const elementRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "element");
 const testRoot = path.join(repoRoot, "crates", "vize_atelier_core", "tests");
 const benchPath = path.join(repoRoot, "crates", "vize_atelier_core", "benches", "davinci.rs");
 const require = createRequire(import.meta.url);
@@ -126,6 +127,7 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     ...rustFiles(propsRoot),
     ...rustFiles(vIfRoot),
     ...rustFiles(vForRoot),
+    ...rustFiles(elementRoot),
     ...rustFiles(testRoot),
     benchPath,
   ]) {


### PR DESCRIPTION
Closes #5060

## Summary
- import compiler element S0 storage helpers/types through the physical `vize_s0` alias
- extend the atelier-core stage-alias ratchet over `codegen/element/**`
- refresh the Davinci consumer migration surface inventory (+5 preferred / -5 compat for Compiler, total unchanged)

## Verification
- `vp install --frozen-lockfile --prefer-offline`
- `vp check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core codegen::tests::test_codegen_simple_element --features legacy,davinci-differential -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core codegen::tests::test_codegen_component --features legacy,davinci-differential -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core lane::tests::test_transform_simple_element --features legacy,davinci-differential -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `vp run --workspace-root check:ci`

## Notes
- No rollout flags, manifests, or compiler semantics changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790387885&installation_model_id=422833&pr_number=5061&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5061&signature=f6206f9bbda7845b3ef130911217301547570adc2b59edaa66bff341f81b20f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated code generation components to use the current shared utilities and string handling.
  * Preserved existing block, directive, inline, and one-time rendering behavior.

* **Tests**
  * Expanded migration checks to cover element code generation sources and verify updated import usage.

* **Documentation**
  * Updated the migration inventory to reflect five additional preferred stage-name references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->