### PR TITLE
refactor(atelier): import compiler context through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -7,8 +7,8 @@ use crate::runtime_helpers::RuntimeHelpers;
 use crate::{Namespace, RuntimeHelper};
 
 use super::source_map::SourceMapBuilder;
-use vize_carton::FxHashSet;
-use vize_carton::String;
+use vize_s0::FxHashSet;
+use vize_s0::String;
 
 /// Code generation context using a UTF-8 string buffer for performance.
 pub struct CodegenContext {

--- a/crates/vize_atelier_core/src/codegen/context/vnode_factory.rs
+++ b/crates/vize_atelier_core/src/codegen/context/vnode_factory.rs
@@ -1,4 +1,4 @@
-use vize_carton::{FxHashSet, String, ToCompactString};
+use vize_s0::{FxHashSet, String, ToCompactString};
 
 use crate::codegen::helpers::default_helper_alias;
 use crate::codegen::source_map::SourceMapBuilder;

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   277 |               640 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   280 |               637 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -17,8 +17,8 @@ compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	raw_oxc	raw OX
 compiler	Compiler	manifest	crates/vize_atelier_core/Cargo.toml	17	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/children.rs	14	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/component_binding.rs	3	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/context.rs	10	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/context/vnode_factory.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/context.rs	10	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/context/vnode_factory.rs	1	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/block.rs	35	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/directives.rs	136	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/helpers.rs	9	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -26,10 +26,19 @@ const propsModule = path.join(
 );
 const vIfModule = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_if.rs");
 const vForModule = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_for.rs");
+const contextModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "codegen",
+  "context.rs",
+);
 const slotsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "slots");
 const propsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "props");
 const vIfRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_if");
 const vForRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_for");
+const contextRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "context");
 const elementRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "element");
 const testRoot = path.join(repoRoot, "crates", "vize_atelier_core", "tests");
 const benchPath = path.join(repoRoot, "crates", "vize_atelier_core", "benches", "davinci.rs");
@@ -123,10 +132,12 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     propsModule,
     vIfModule,
     vForModule,
+    contextModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),
     ...rustFiles(vIfRoot),
     ...rustFiles(vForRoot),
+    ...rustFiles(contextRoot),
     ...rustFiles(elementRoot),
     ...rustFiles(testRoot),
     benchPath,


### PR DESCRIPTION
Closes #5062

## Summary
- migrate compiler `codegen/context{.rs,/**}` S0 storage imports from the compatibility `vize_carton` name to the physical `vize_s0` alias
- extend the atelier-core stage-alias ratchet over `codegen/context.rs` and `codegen/context/**`
- refresh Davinci consumer migration inventory: Compiler preferred stage names `277 -> 280`, compat code names `640 -> 637`, total `917` unchanged

## Verification
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `NODE_PATH=/private/tmp/vize-core-context-s0-alias/node_modules node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `nix develop --command node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `vp install --frozen-lockfile --prefer-offline`
- `vp check`
- `vp run --workspace-root check:ci`
- `nix develop --command vp check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --locked -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --locked --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core --locked --features legacy --test davinci_s2_transform_vue2`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core --locked --features davinci-differential --test davinci_s2_transform_corpus -- --nocapture`

## Notes
- no rollout flag or manifest change
- no compiler output or user-visible behavior change intended
