### PR TITLE
refactor(atelier): import compiler source map through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/source_map.rs
+++ b/crates/vize_atelier_core/src/codegen/source_map.rs
@@ -32,9 +32,9 @@
 //! [`names`]: https://tc39.es/ecma426/#json-names
 //! [VLQ]: https://en.wikipedia.org/wiki/Variable-length_quantity
 
-use vize_carton::FxHashMap;
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_s0::FxHashMap;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 /// A recorded mapping anchor, as raw byte offsets.
 ///

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   280 |               637 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   283 |               634 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -77,7 +77,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/slots/tests.rs	5	s0	S0	stage	vize_s0	preferred	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/source_map.rs	35	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/source_map.rs	35	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	s0	S0	stage	vize_carton	compat	20
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for.rs	20	s0	S0	stage	vize_s0	preferred	2

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -34,6 +34,14 @@ const contextModule = path.join(
   "codegen",
   "context.rs",
 );
+const sourceMapModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "codegen",
+  "source_map.rs",
+);
 const slotsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "slots");
 const propsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "props");
 const vIfRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_if");
@@ -133,6 +141,7 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     vIfModule,
     vForModule,
     contextModule,
+    sourceMapModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),
     ...rustFiles(vIfRoot),


### PR DESCRIPTION
Closes #5064

## Summary
- migrate compiler `codegen/source_map.rs` S0 storage imports from the compatibility `vize_carton` name to the physical `vize_s0` alias
- extend the atelier-core stage-alias ratchet over `codegen/source_map.rs`
- refresh Davinci consumer migration inventory: Compiler preferred stage names `280 -> 283`, compat code names `637 -> 634`, total `917` unchanged

## Verification
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `nix develop --command node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core source_map --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core --locked source_map --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core --locked --features legacy --test davinci_s2_transform_vue2`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core --locked --features davinci-differential --test davinci_s2_transform_corpus -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --locked -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --locked --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `vp install --frozen-lockfile --prefer-offline`
- `vp check`
- `vp run --workspace-root check:ci`
- `nix develop --command vp check`

## Notes
- no rollout flag or manifest change
- no source-map behavior, compiler output, or user-visible behavior change intended

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5065"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790394230&installation_model_id=422833&pr_number=5065&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5065&signature=1b0e238116e0840d9e1cb7d6b529d8e91e7210dd9e68af5c596bfec300d6485f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated source map processing to use the current internal utility package without changing behavior.

* **Tests**
  * Expanded migration checks to include source map code and verify consistent utility imports.

* **Documentation**
  * Updated migration tracking counts to reflect the latest preferred and compatibility naming coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->