### PR TITLE
refactor(atelier): import emit codegen through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/emit.rs
+++ b/crates/vize_atelier_core/src/codegen/emit.rs
@@ -4,7 +4,7 @@
 //! import-ranked helper list used to build the module preamble.
 
 use crate::{RootNode, RuntimeHelper, TemplateChildNode, options::CodegenOptions};
-use vize_carton::profile;
+use vize_s0::profile;
 
 use super::children::is_directive_comment;
 use super::context::{CodegenContext, CodegenResult, CodegenResultWithSections, CodegenSections};
@@ -80,7 +80,7 @@ fn generate_with_sections_and_options(
     let mut ctx =
         CodegenContext::new_with_vnode_factory_and_merge_props(options, vnode_factory, merge_props);
     ctx.source = match source_text {
-        Some(text) => vize_carton::String::new(text),
+        Some(text) => vize_s0::String::new(text),
         None => root.source.into(),
     };
     ctx.static_cache = ctx.options.inline || !root.hoists.is_empty();

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   285 |               632 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   287 |               630 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -24,7 +24,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/directives
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/helpers.rs	9	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/inline.rs	36	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/v_once.rs	17	s0	S0	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/emit.rs	7	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/emit.rs	7	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression.rs	22	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/comment_rewrite.rs	16	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/generate.rs	14	s0	S0	stage	vize_carton	compat	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -50,6 +50,7 @@ const childrenModule = path.join(
   "codegen",
   "children.rs",
 );
+const emitModule = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "emit.rs");
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -159,6 +160,7 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     contextModule,
     componentBindingModule,
     childrenModule,
+    emitModule,
     sourceMapModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -158,6 +158,22 @@ void test("consumer migration TSV serializes every stage label and name class", 
   }
 });
 
+void test("Atelier core emit codegen imports S0 through the preferred physical name", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
+  assert.ok(compiler);
+
+  const emitRow = compiler.fileRows.find(
+    (row) =>
+      row.relPath === "crates/vize_atelier_core/src/codegen/emit.rs" && row.mode === "source",
+  );
+  assert.ok(emitRow);
+  assert.equal(emitRow.surfaceCounts.s0, 2);
+  assert.equal(emitRow.surfaceNameCounts.s0.vize_s0, 2);
+  assert.equal(emitRow.surfaceNameCounts.s0.vize_carton ?? 0, 0);
+  assert.equal(emitRow.nameKindCounts.compat, 0);
+});
+
 void test("consumer migration scan keeps every rollout consumer and surface class visible", () => {
   const scan = scanConsumerMigrationSurfaces();
   const consumers = new Map(scan.consumers.map((consumer) => [consumer.id, consumer]));


### PR DESCRIPTION
Closes #5070.

## Summary

- route `codegen/emit.rs` S0 storage/profiling references through the physical `vize_s0` alias
- extend the Atelier core alias ratchet to include `emit.rs`
- add a consumer-migration row ratchet that keeps `emit.rs` S0 usage at 2 preferred `vize_s0` sites and 0 compat `vize_carton` sites
- regenerate the Davinci consumer migration inventory

## Verification

- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `cargo test -p vize_atelier_core --features legacy,davinci-differential`
- `cargo test -p vize_atelier_core`
- `cargo clippy -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `cargo test -p vize_atelier_dom -p vize_atelier_ssr -p vize_atelier_vapor -p vize_atelier_sfc -p vize_atelier_jsx`
- `vp check`
- `vp run --workspace-root check:ci`
- `nix develop --command vp check`
- `nix develop --command vp run --workspace-root check:ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790402871&installation_model_id=422833&pr_number=5071&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5071&signature=6adefac67312d464aa55e60a796d073c94e554135e0f2788d580206501904852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated code generation to use the preferred S0 naming consistently.
  - Improved migration coverage for compiler and code-generation compatibility surfaces.

- **Tests**
  - Added validation ensuring generated code uses the preferred stage alias.
  - Updated consumer migration metrics and checks to reflect the latest naming alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->