### PR TITLE
refactor(atelier): import expression codegen through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/expression.rs
+++ b/crates/vize_atelier_core/src/codegen/expression.rs
@@ -19,8 +19,8 @@ use super::{context::CodegenContext, helpers::escape_js_string};
 
 use comment_rewrite::convert_line_comments_to_block;
 use scope_prefix::{contains_slot_param_scope_prefix, strip_scope_prefixes_for_slot_params};
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 #[allow(unused_imports)]
 pub use generate::{

--- a/crates/vize_atelier_core/src/codegen/expression/comment_rewrite.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/comment_rewrite.rs
@@ -13,7 +13,7 @@ use crate::steps::expression::nesting::scan::{
     keyword_allows_regex_after, skip_identifier, skip_line_comment, skip_number, skip_quoted,
     skip_regex,
 };
-use vize_carton::String;
+use vize_s0::String;
 
 /// Convert `// …` line comments to `/* … */` block comments, copying strings,
 /// template literals, block comments, and regex literals through verbatim.

--- a/crates/vize_atelier_core/src/codegen/expression/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/generate.rs
@@ -11,7 +11,7 @@ use super::{
     prefix_context::{prefix_identifiers_with_context, prefix_identifiers_with_context_node},
     scope_prefix::{contains_slot_param_scope_prefix, strip_scope_prefixes_for_slot_params},
 };
-use vize_carton::String;
+use vize_s0::String;
 
 /// Generate a simple expression with appropriate prefix.
 /// Used for ref attribute values that need `$setup.` prefix in function mode.
@@ -174,7 +174,7 @@ mod tests {
     use crate::codegen::expression::{generate_event_handler, generate_simple_expression};
     use crate::options::{BindingMetadata, BindingType, CodegenOptions};
     use crate::{ExpressionNode, SimpleExpressionNode, SourceLocation};
-    use vize_carton::{Allocator, FxHashMap};
+    use vize_s0::{Allocator, FxHashMap};
 
     #[test]
     fn test_shorthand_property_expansion() {
@@ -294,7 +294,7 @@ mod tests {
 
         let allocator = Allocator::new();
         let mut ctx = CodegenContext::new(options);
-        let exp = ExpressionNode::Simple(vize_carton::Box::new_in(
+        let exp = ExpressionNode::Simple(vize_s0::Box::new_in(
             SimpleExpressionNode {
                 content: "$event => (selectedFolders.value = selectedFolders.value.filter((f) => f.id !== folder.value.id))",
                 is_static: false,

--- a/crates/vize_atelier_core/src/codegen/expression/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/helpers.rs
@@ -4,7 +4,7 @@
 //! line comment conversion, and slot parameter stripping.
 
 use super::super::context::CodegenContext;
-use vize_carton::String;
+use vize_s0::String;
 
 fn is_identifier_continue(c: char) -> bool {
     c.is_alphanumeric() || c == '_' || c == '$'

--- a/crates/vize_atelier_core/src/codegen/expression/prefix_context.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/prefix_context.rs
@@ -10,10 +10,10 @@
 use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::FxHashSet;
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_relief::SimpleExpressionNode;
+use vize_s0::FxHashSet;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 use super::super::context::CodegenContext;
 use super::helpers::rewrite_props_aliases;

--- a/crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs
@@ -8,10 +8,10 @@ use oxc_ast_visit::Visit;
 use oxc_ast_visit::walk::{
     walk_assignment_expression, walk_object_property, walk_update_expression,
 };
-use vize_carton::FxHashSet;
-use vize_carton::String;
-use vize_carton::ToCompactString;
 use vize_croquis::builtins::is_global_allowed;
+use vize_s0::FxHashSet;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 use super::super::context::CodegenContext;
 

--- a/crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs
@@ -1,7 +1,7 @@
 //! Generated scope-prefix cleanup for template locals.
 
 use super::super::context::CodegenContext;
-use vize_carton::String;
+use vize_s0::String;
 
 const SLOT_PARAM_SCOPE_PREFIXES: [&str; 6] = [
     "_ctx.",

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   287 |               630 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   301 |               616 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -25,22 +25,22 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/helpers.rs
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/inline.rs	36	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/element/v_once.rs	17	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/emit.rs	7	s0	S0	stage	vize_s0	preferred	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression.rs	22	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/comment_rewrite.rs	16	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/generate.rs	14	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/expression/generate.rs	177	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/helpers.rs	7	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression.rs	22	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/comment_rewrite.rs	16	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/generate.rs	14	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/expression/generate.rs	177	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/helpers.rs	7	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_context.rs	10	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs	7	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs	7	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs	7	raw_oxc	raw OXC	raw	oxc_ast	raw	15
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs	7	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate.rs	18	s0	S0	stage	vize_carton	compat	6
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate/collect_helpers.rs	14	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate/static_vnode.rs	3	s0	S0	stage	vize_carton	compat	4

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -51,6 +51,14 @@ const childrenModule = path.join(
   "children.rs",
 );
 const emitModule = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "emit.rs");
+const expressionModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "codegen",
+  "expression.rs",
+);
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -65,6 +73,14 @@ const vIfRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codeg
 const vForRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_for");
 const contextRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "context");
 const elementRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "element");
+const expressionRoot = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "codegen",
+  "expression",
+);
 const testRoot = path.join(repoRoot, "crates", "vize_atelier_core", "tests");
 const benchPath = path.join(repoRoot, "crates", "vize_atelier_core", "benches", "davinci.rs");
 const require = createRequire(import.meta.url);
@@ -161,6 +177,7 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     componentBindingModule,
     childrenModule,
     emitModule,
+    expressionModule,
     sourceMapModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),
@@ -168,6 +185,7 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     ...rustFiles(vForRoot),
     ...rustFiles(contextRoot),
     ...rustFiles(elementRoot),
+    ...rustFiles(expressionRoot),
     ...rustFiles(testRoot),
     benchPath,
   ]) {

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -36,6 +36,16 @@ function parseSurfaceRows(tsv) {
   });
 }
 
+function expectCompilerS0PreferredRow(compiler, relPath, mode, sites) {
+  const row = compiler.fileRows.find(
+    (candidate) => candidate.relPath === relPath && candidate.mode === mode,
+  );
+  assert.ok(row, `${relPath} (${mode})`);
+  assert.equal(row.surfaceCounts.s0, sites, relPath);
+  assert.equal(row.surfaceNameCounts.s0.vize_s0, sites, relPath);
+  assert.equal(row.surfaceNameCounts.s0.vize_carton ?? 0, 0, relPath);
+}
+
 void test("consumer migration scan classifies stage physical names separately from code names", () => {
   const s0 = SURFACES.find((surface) => surface.id === "s0");
   assert.ok(s0);
@@ -163,15 +173,32 @@ void test("Atelier core emit codegen imports S0 through the preferred physical n
   const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
   assert.ok(compiler);
 
-  const emitRow = compiler.fileRows.find(
-    (row) =>
-      row.relPath === "crates/vize_atelier_core/src/codegen/emit.rs" && row.mode === "source",
+  expectCompilerS0PreferredRow(
+    compiler,
+    "crates/vize_atelier_core/src/codegen/emit.rs",
+    "source",
+    2,
   );
-  assert.ok(emitRow);
-  assert.equal(emitRow.surfaceCounts.s0, 2);
-  assert.equal(emitRow.surfaceNameCounts.s0.vize_s0, 2);
-  assert.equal(emitRow.surfaceNameCounts.s0.vize_carton ?? 0, 0);
-  assert.equal(emitRow.nameKindCounts.compat, 0);
+});
+
+void test("Atelier core expression codegen imports S0 through the preferred physical name", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
+  assert.ok(compiler);
+
+  const expectedRows = [
+    ["crates/vize_atelier_core/src/codegen/expression.rs", "source", 2],
+    ["crates/vize_atelier_core/src/codegen/expression/comment_rewrite.rs", "source", 1],
+    ["crates/vize_atelier_core/src/codegen/expression/generate.rs", "source", 1],
+    ["crates/vize_atelier_core/src/codegen/expression/generate.rs", "test", 2],
+    ["crates/vize_atelier_core/src/codegen/expression/helpers.rs", "source", 1],
+    ["crates/vize_atelier_core/src/codegen/expression/prefix_context.rs", "source", 3],
+    ["crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs", "source", 3],
+    ["crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs", "source", 1],
+  ];
+  for (const [relPath, mode, sites] of expectedRows) {
+    expectCompilerS0PreferredRow(compiler, relPath, mode, sites);
+  }
 });
 
 void test("consumer migration scan keeps every rollout consumer and surface class visible", () => {


### PR DESCRIPTION
Closes #5072

## Summary
- migrate Atelier core expression codegen S0 imports from `vize_carton` to the preferred `vize_s0` Cargo alias
- regenerate the Davinci consumer migration surface inventory (`Compiler` preferred stage names +14, compat code names -14)
- extend stage-alias and consumer-migration ratchets so the expression slice cannot drift back to S0 compat imports

## Verification
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_dom -p vize_atelier_ssr -p vize_atelier_vapor -p vize_atelier_sfc -p vize_atelier_jsx`
- `vp install --frozen-lockfile --prefer-offline`
- `vp check`
- `vp run --workspace-root check:ci`
- `nix develop --command vp check`
- `nix develop --command vp run --workspace-root check:ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790404616&installation_model_id=422833&pr_number=5073&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5073&signature=6f2f3f7afa47eeb91b0d22c1b3a35d9324723c41cd9769ee5b883089a37a0963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized internal code-generation components on the preferred string and collection interfaces.
  - Improved consistency across expression processing and scope-generation workflows without changing behavior.

- **Documentation**
  - Updated migration tracking metrics to reflect progress toward preferred naming conventions.

- **Tests**
  - Expanded validation coverage for expression code generation and migration surfaces.
  - Added shared checks to ensure preferred naming is used consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->