### PR TITLE
refactor(atelier): import generate codegen through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/generate.rs
@@ -15,9 +15,9 @@ pub(super) use collect_helpers::collect_hoist_helpers;
 use static_vnode::generate_static_element_to_bytes;
 
 use super::{context::CodegenContext, helpers::escape_js_string};
-use vize_carton::String;
-use vize_carton::ToCompactString;
-use vize_carton::ensure_sufficient_stack;
+use vize_s0::String;
+use vize_s0::ToCompactString;
+use vize_s0::ensure_sufficient_stack;
 
 /// Generate hoisted variable declarations.
 pub(super) fn generate_hoists(ctx: &CodegenContext, root: &RootNode<'_>) -> String {
@@ -43,7 +43,7 @@ pub(super) fn generate_hoists(ctx: &CodegenContext, root: &RootNode<'_>) -> Stri
 /// Generate `JsChildNode` to bytes.
 ///
 /// Guarded: serializing a hoisted VNode descends one frame per level of the
-/// subtree it was hoisted from (`vize_carton::recursion`).
+/// subtree it was hoisted from (`vize_s0::recursion`).
 fn generate_js_child_node_to_bytes(ctx: &CodegenContext, node: &JsChildNode<'_>, out: &mut String) {
     ensure_sufficient_stack(|| generate_js_child_node_to_bytes_guarded(ctx, node, out));
 }
@@ -190,8 +190,7 @@ fn generate_props_expression_to_bytes(
             // parser records both nodes so the linter can flag the repeat,
             // so dedupe by key name here before emitting the props object.
             // (#958)
-            let mut seen: vize_carton::FxHashSet<vize_carton::String> =
-                vize_carton::FxHashSet::default();
+            let mut seen: vize_s0::FxHashSet<vize_s0::String> = vize_s0::FxHashSet::default();
             let mut emitted = 0usize;
             for prop in obj.properties.iter() {
                 let key_string = match &prop.key {

--- a/crates/vize_atelier_core/src/codegen/generate/collect_helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/generate/collect_helpers.rs
@@ -11,7 +11,7 @@ use crate::{
     JsChildNode, PropsExpression, RootNode, RuntimeHelper, TemplateChildNode, VNodeCall,
     VNodeChildren, VNodeTag,
 };
-use vize_carton::ensure_sufficient_stack;
+use vize_s0::ensure_sufficient_stack;
 
 /// Collect runtime helpers needed by hoisted nodes.
 pub(in crate::codegen) fn collect_hoist_helpers(
@@ -24,7 +24,7 @@ pub(in crate::codegen) fn collect_hoist_helpers(
 }
 
 /// Guarded: a hoisted subtree is as deep as the template subtree it came from,
-/// and this walk descends one frame per level (`vize_carton::recursion`).
+/// and this walk descends one frame per level (`vize_s0::recursion`).
 fn collect_helpers_from_js_child_node(node: &JsChildNode<'_>, helpers: &mut Vec<RuntimeHelper>) {
     ensure_sufficient_stack(|| match node {
         JsChildNode::VNodeCall(vnode) => collect_helpers_from_vnode_call(vnode, helpers),

--- a/crates/vize_atelier_core/src/codegen/generate/static_vnode.rs
+++ b/crates/vize_atelier_core/src/codegen/generate/static_vnode.rs
@@ -1,6 +1,6 @@
 //! Serialization for fully-static nested VNodes.
 
-use vize_carton::{String, ensure_sufficient_stack};
+use vize_s0::{String, ensure_sufficient_stack};
 
 use crate::{ElementNode, PropNode, RuntimeHelper, TemplateChildNode};
 
@@ -101,7 +101,7 @@ fn generate_static_child_array_to_bytes(
 fn build_static_props(el: &ElementNode<'_>) -> Option<String> {
     let mut buf = String::default();
     buf.push_str("{ ");
-    let mut seen: vize_carton::FxHashSet<vize_carton::String> = vize_carton::FxHashSet::default();
+    let mut seen: vize_s0::FxHashSet<vize_s0::String> = vize_s0::FxHashSet::default();
     let mut emitted = 0usize;
 
     for prop in el.props.iter() {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   301 |               616 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   312 |               605 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -41,9 +41,9 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs	7	raw_oxc	raw OXC	raw	oxc_ast	raw	15
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/prefix_visitor.rs	7	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs	4	s0	S0	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate.rs	18	s0	S0	stage	vize_carton	compat	6
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate/collect_helpers.rs	14	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate/static_vnode.rs	3	s0	S0	stage	vize_carton	compat	4
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate.rs	18	s0	S0	stage	vize_s0	preferred	6
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate/collect_helpers.rs	14	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate/static_vnode.rs	3	s0	S0	stage	vize_s0	preferred	4
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers.rs	7	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -59,6 +59,14 @@ const expressionModule = path.join(
   "codegen",
   "expression.rs",
 );
+const generateModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "codegen",
+  "generate.rs",
+);
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -80,6 +88,14 @@ const expressionRoot = path.join(
   "src",
   "codegen",
   "expression",
+);
+const generateRoot = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "codegen",
+  "generate",
 );
 const testRoot = path.join(repoRoot, "crates", "vize_atelier_core", "tests");
 const benchPath = path.join(repoRoot, "crates", "vize_atelier_core", "benches", "davinci.rs");
@@ -178,6 +194,7 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     childrenModule,
     emitModule,
     expressionModule,
+    generateModule,
     sourceMapModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),
@@ -186,6 +203,7 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     ...rustFiles(contextRoot),
     ...rustFiles(elementRoot),
     ...rustFiles(expressionRoot),
+    ...rustFiles(generateRoot),
     ...rustFiles(testRoot),
     benchPath,
   ]) {

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -201,6 +201,21 @@ void test("Atelier core expression codegen imports S0 through the preferred phys
   }
 });
 
+void test("Atelier core generate codegen imports S0 through the preferred physical name", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
+  assert.ok(compiler);
+
+  const expectedRows = [
+    ["crates/vize_atelier_core/src/codegen/generate.rs", "source", 6],
+    ["crates/vize_atelier_core/src/codegen/generate/collect_helpers.rs", "source", 1],
+    ["crates/vize_atelier_core/src/codegen/generate/static_vnode.rs", "source", 4],
+  ];
+  for (const [relPath, mode, sites] of expectedRows) {
+    expectCompilerS0PreferredRow(compiler, relPath, mode, sites);
+  }
+});
+
 void test("consumer migration scan keeps every rollout consumer and surface class visible", () => {
   const scan = scanConsumerMigrationSurfaces();
   const consumers = new Map(scan.consumers.map((consumer) => [consumer.id, consumer]));


### PR DESCRIPTION
Closes #5074.

## Summary
- imports atelier core generate codegen through the preferred `vize_s0` physical stage alias
- refreshes the Davinci consumer migration surface inventory
- extends ratchets so generate codegen cannot drift back to the S0 compatibility code name

## Verification
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_dom -p vize_atelier_ssr -p vize_atelier_vapor -p vize_atelier_sfc -p vize_atelier_jsx`
- `vp install --frozen-lockfile --prefer-offline`
- `vp check`
- `vp run --workspace-root check:ci`
- `vp run --workspace-root source:lengths`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `nix develop --command vp check`
- `nix develop --command vp run --workspace-root check:ci`

Note: `davinci-consumer-migration-surfaces.test.mjs` is run directly above because the current `test:scripts` gate does not include `.mjs` tooling tests.

No rollout is included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790406626&installation_model_id=422833&pr_number=5075&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5075&signature=4a0dbbb95aad3adf07c9ecec99f57f8a5072f1adf591fdac77e733289748c108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated compiler code generation components to use the preferred S0 dependency naming.
  * Refined migration tracking to reflect the latest compiler stage naming coverage.

* **Tests**
  * Expanded migration checks to scan all relevant code generation sources.
  * Added validation ensuring preferred S0 naming is consistently used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->