### PR TITLE
refactor(atelier): import node codegen through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/node.rs
+++ b/crates/vize_atelier_core/src/codegen/node.rs
@@ -8,7 +8,7 @@ use super::element::generate_element;
 use super::expression::generate_compound_expression;
 use super::v_for::generate_for;
 use super::v_if::generate_if;
-use vize_carton::{ToCompactString, ensure_sufficient_stack};
+use vize_s0::{ToCompactString, ensure_sufficient_stack};
 
 /// Generate node code
 ///
@@ -16,7 +16,7 @@ use vize_carton::{ToCompactString, ensure_sufficient_stack};
 /// the one point whose call depth tracks template nesting depth. The guard moves
 /// the descent onto a fresh stack before the thread stack runs out, because a
 /// stack overflow aborts the process instead of producing a diagnostic
-/// (`vize_carton::recursion`).
+/// (`vize_s0::recursion`).
 pub fn generate_node(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>) {
     crate::walk_probe::record_visit(crate::walk_probe::WalkStage::Codegen);
     ensure_sufficient_stack(|| match node {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   312 |               605 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   313 |               604 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -52,7 +52,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_e
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/node.rs	11	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/node.rs	11	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag.rs	9	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -67,6 +67,7 @@ const generateModule = path.join(
   "codegen",
   "generate.rs",
 );
+const nodeModule = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "node.rs");
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -195,6 +196,7 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     emitModule,
     expressionModule,
     generateModule,
+    nodeModule,
     sourceMapModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -216,6 +216,19 @@ void test("Atelier core generate codegen imports S0 through the preferred physic
   }
 });
 
+void test("Atelier core node codegen imports S0 through the preferred physical name", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
+  assert.ok(compiler);
+
+  expectCompilerS0PreferredRow(
+    compiler,
+    "crates/vize_atelier_core/src/codegen/node.rs",
+    "source",
+    1,
+  );
+});
+
 void test("consumer migration scan keeps every rollout consumer and surface class visible", () => {
   const scan = scanConsumerMigrationSurfaces();
   const consumers = new Map(scan.consumers.map((consumer) => [consumer.id, consumer]));


### PR DESCRIPTION
Closes #5076

## Summary

- switch `crates/vize_atelier_core/src/codegen/node.rs` to import S0 storage through `vize_s0`
- ratchet the Davinci migration-surface tests so the node codegen slice cannot regress to the compatibility code name
- regenerate `davinci-road/plan/consumer-migration-surfaces` counters

## Verification

- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts`
- `git diff --check`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `vp check`
- `vp run --workspace-root check:ci`
- `vp run --workspace-root source:lengths`
- `nix develop --command vp check`
- `nix develop --command vp run --workspace-root check:ci`

No rollout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790409058&installation_model_id=422833&pr_number=5077&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5077&signature=ca4a7826345d71e23dccd474f0eac723404ad24c8ac6677521577042bbb65235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code-generation compatibility by standardizing internal stage naming and formatting behavior.
  * Updated migration tracking to accurately reflect supported compiler names.

* **Tests**
  * Expanded validation to ensure generated output uses the preferred naming conventions.
  * Added coverage for source inventory counts and migration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->