### PR TITLE
refactor(atelier): import patch flag codegen through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/patch_flag.rs
+++ b/crates/vize_atelier_core/src/codegen/patch_flag.rs
@@ -6,7 +6,7 @@ use self::static_literal::{is_static_object_or_array_literal_node, is_string_lit
 use super::helpers::camelize;
 use crate::options::{BindingMetadata, BindingType};
 use crate::{DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, TemplateChildNode};
-use vize_carton::{FxHashSet, String, ToCompactString, is_builtin_directive};
+use vize_s0::{FxHashSet, String, ToCompactString, is_builtin_directive};
 
 /// Check whether an interpolation only references bindings constant at runtime.
 fn is_constant_interpolation(

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   313 |               604 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   314 |               603 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -53,7 +53,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_e
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/node.rs	11	s0	S0	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag.rs	9	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag.rs	9	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	raw_oxc	raw OXC	raw	oxc_allocator	raw	2

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -68,6 +68,14 @@ const generateModule = path.join(
   "generate.rs",
 );
 const nodeModule = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "node.rs");
+const patchFlagModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "codegen",
+  "patch_flag.rs",
+);
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -197,6 +205,7 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     expressionModule,
     generateModule,
     nodeModule,
+    patchFlagModule,
     sourceMapModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -229,6 +229,19 @@ void test("Atelier core node codegen imports S0 through the preferred physical n
   );
 });
 
+void test("Atelier core patch flag codegen imports S0 through the preferred physical name", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
+  assert.ok(compiler);
+
+  expectCompilerS0PreferredRow(
+    compiler,
+    "crates/vize_atelier_core/src/codegen/patch_flag.rs",
+    "source",
+    1,
+  );
+});
+
 void test("consumer migration scan keeps every rollout consumer and surface class visible", () => {
   const scan = scanConsumerMigrationSurfaces();
   const consumers = new Map(scan.consumers.map((consumer) => [consumer.id, consumer]));


### PR DESCRIPTION
Closes #5078

## Summary

- switch `crates/vize_atelier_core/src/codegen/patch_flag.rs` to import S0 storage through `vize_s0`
- ratchet the Davinci migration-surface tests so the patch flag codegen slice cannot regress to the compatibility code name
- regenerate `davinci-road/plan/consumer-migration-surfaces` counters

## Verification

- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts`
- `git diff --check`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `vp check`
- `vp run --workspace-root check:ci`
- `vp run --workspace-root source:lengths`
- `nix develop --command vp check`
- `nix develop --command vp run --workspace-root check:ci`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_sfc --test custom_directive_patch_flag`

No rollout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790410224&installation_model_id=422833&pr_number=5079&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5079&signature=d0913cecbd794d169a5b6d95beab76c7ac78ec5f9a3c2eb2bf65f92a88269e93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized an internal compiler import to use the preferred shared utility name.
  * Updated compiler migration tracking to reflect the latest preferred naming coverage.

* **Tests**
  * Expanded tooling checks to verify import consistency across compiler code.
  * Added coverage ensuring the compiler uses the preferred utility naming in source mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->