### PR TITLE
refactor(atelier): import patch flag static literal through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs
+++ b/crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs
@@ -11,8 +11,8 @@
 use oxc_ast::ast as oxc_ast_types;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::String;
 use vize_relief::SimpleExpressionNode;
+use vize_s0::String;
 
 pub(super) fn is_string_literal(content: &str) -> bool {
     (content.starts_with('\'') && content.ends_with('\''))

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   314 |               603 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   315 |               602 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -54,7 +54,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_e
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/node.rs	11	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag.rs	9	s0	S0	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	raw_oxc	raw OXC	raw	oxc_allocator	raw	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs	11	raw_oxc	raw OXC	raw	oxc_ast	raw	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -76,6 +76,15 @@ const patchFlagModule = path.join(
   "codegen",
   "patch_flag.rs",
 );
+const patchFlagStaticLiteralModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "codegen",
+  "patch_flag",
+  "static_literal.rs",
+);
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -206,6 +215,7 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     generateModule,
     nodeModule,
     patchFlagModule,
+    patchFlagStaticLiteralModule,
     sourceMapModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -234,12 +234,13 @@ void test("Atelier core patch flag codegen imports S0 through the preferred phys
   const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
   assert.ok(compiler);
 
-  expectCompilerS0PreferredRow(
-    compiler,
-    "crates/vize_atelier_core/src/codegen/patch_flag.rs",
-    "source",
-    1,
-  );
+  const expectedRows = [
+    ["crates/vize_atelier_core/src/codegen/patch_flag.rs", "source", 1],
+    ["crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs", "source", 1],
+  ];
+  for (const [relPath, mode, sites] of expectedRows) {
+    expectCompilerS0PreferredRow(compiler, relPath, mode, sites);
+  }
 });
 
 void test("consumer migration scan keeps every rollout consumer and surface class visible", () => {


### PR DESCRIPTION
Closes #5080

## Summary

- switch `crates/vize_atelier_core/src/codegen/patch_flag/static_literal.rs` to import S0 storage through `vize_s0`
- extend the patch flag Davinci migration-surface ratchet to include `patch_flag/static_literal.rs`
- regenerate `davinci-road/plan/consumer-migration-surfaces` counters

## Verification

- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts`
- `git diff --check`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_sfc --test custom_directive_patch_flag`
- `vp check`
- `vp run --workspace-root check:ci`
- `vp run --workspace-root source:lengths`
- `nix develop --command vp check`
- `nix develop --command vp run --workspace-root check:ci`

No rollout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790411468&installation_model_id=422833&pr_number=5081&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5081&signature=780fb7f796bb69c2cd19b88181f1ef46a74707d19f745f3a7d123b7870c85506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in static-literal processing without changing its behavior.

* **Documentation**
  * Updated compiler migration guidance to reflect the latest preferred naming coverage.

* **Tests**
  * Expanded validation to cover static-literal processing and ensure naming conventions remain consistent across supported tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->