### PR TITLE
refactor(atelier): import root codegen through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/root.rs
+++ b/crates/vize_atelier_core/src/codegen/root.rs
@@ -8,7 +8,7 @@ use crate::{RootNode, RuntimeHelper, TemplateChildNode};
 use super::context::CodegenContext;
 use super::element::helpers::is_dynamic_component_tag;
 use super::helpers::to_valid_asset_identifier;
-use vize_carton::{String, camelize, capitalize};
+use vize_s0::{String, camelize, capitalize};
 
 /// Check if a root-level text node is ignorable whitespace.
 pub(super) fn is_ignorable_root_text(child: &TemplateChildNode<'_>) -> bool {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   315 |               602 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   316 |               601 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -65,7 +65,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/generate.rs	
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/generate.rs	4	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/scan.rs	9	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/props/v_model.rs	29	s0	S0	stage	vize_s0	preferred	3
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/root.rs	11	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/root.rs	11	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/create_slots.rs	11	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/detect.rs	6	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/generate.rs	5	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -85,6 +85,7 @@ const patchFlagStaticLiteralModule = path.join(
   "patch_flag",
   "static_literal.rs",
 );
+const rootModule = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "root.rs");
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -216,6 +217,7 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     nodeModule,
     patchFlagModule,
     patchFlagStaticLiteralModule,
+    rootModule,
     sourceMapModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -243,6 +243,19 @@ void test("Atelier core patch flag codegen imports S0 through the preferred phys
   }
 });
 
+void test("Atelier core root codegen imports S0 through the preferred physical name", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
+  assert.ok(compiler);
+
+  expectCompilerS0PreferredRow(
+    compiler,
+    "crates/vize_atelier_core/src/codegen/root.rs",
+    "source",
+    1,
+  );
+});
+
 void test("consumer migration scan keeps every rollout consumer and surface class visible", () => {
   const scan = scanConsumerMigrationSurfaces();
   const consumers = new Map(scan.consumers.map((consumer) => [consumer.id, consumer]));


### PR DESCRIPTION
## Summary

- import root-level atelier codegen S0 helpers through the preferred `vize_s0` physical alias
- guard `root.rs` in the davinci migrated codegen alias test
- refresh the consumer migration surface report so compiler preferred/compat counters reflect the move

Closes #5082

## Verification

- `vp install --frozen-lockfile --prefer-offline`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts`
- `git diff --check`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_sfc --test custom_directive_patch_flag`
- `vp check`
- `vp run --workspace-root source:lengths`
- `vp run --workspace-root check:ci`
- `nix develop --command vp check`
- `nix develop --command vp run --workspace-root check:ci`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core codegen::tests::test_codegen_self_component_resolve_marks_maybe_self_reference -- --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc compile::tests::test_script_setup_self_component_resolves_for_recursion -- --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc --test component_tag_binding`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc snapshot_tests::test_patches_ts_snapshots -- --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc snapshot_tests::test_patches_js_snapshots -- --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_test_runner tests::vdom_component -- --ignored --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_test_runner tests::vdom_directives -- --ignored --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core codegen::tests::test_codegen_pascal_case_dynamic_component -- --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core codegen::tests::test_codegen_pascal_case_dynamic_component_inside_v_for -- --exact`

## Rollout

No rollout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790412949&installation_model_id=422833&pr_number=5083&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5083&signature=32fe15fec4d9ebdbab853f014aa09c77d8101873c656c426ae0f5a6004fe3d88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated compiler internals to use the preferred S0 import source for code generation helpers.
  * Refined migration tracking to reflect the updated compiler import classification.

* **Tests**
  * Expanded tooling checks to cover the root code-generation module.
  * Added validation ensuring the compiler uses the preferred import path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->