### PR TITLE
refactor(atelier): import runtime helpers through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/runtime_helpers.rs
+++ b/crates/vize_atelier_core/src/runtime_helpers.rs
@@ -1,7 +1,7 @@
 //! Runtime helper registration and lookup.
 
 use crate::RuntimeHelper;
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 /// Runtime helper set for tracking used helpers
 #[derive(Debug, Default)]

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   316 |               601 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   317 |               600 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -117,7 +117,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/retained/tests.rs	20	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/runtime_helpers.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/runtime_helpers.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/element.rs	5	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/element.rs	307	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression.rs	16	s0	S0	stage	vize_carton	compat	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -86,6 +86,13 @@ const patchFlagStaticLiteralModule = path.join(
   "static_literal.rs",
 );
 const rootModule = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "root.rs");
+const runtimeHelpersModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "runtime_helpers.rs",
+);
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -172,7 +179,7 @@ function* rustFiles(directory: string): Generator<string> {
   }
 }
 
-test("Atelier core migrated codegen slices import S0 storage through the stage alias", () => {
+test("Atelier core migrated compiler slices import S0 storage through the stage alias", () => {
   const rootManifest = readToml("Cargo.toml");
   const coreManifest = readToml("crates", "vize_atelier_core", "Cargo.toml");
   const workspaceDependencies = asRecord(asRecord(rootManifest.workspace).dependencies);
@@ -218,6 +225,7 @@ test("Atelier core migrated codegen slices import S0 storage through the stage a
     patchFlagModule,
     patchFlagStaticLiteralModule,
     rootModule,
+    runtimeHelpersModule,
     sourceMapModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -256,6 +256,19 @@ void test("Atelier core root codegen imports S0 through the preferred physical n
   );
 });
 
+void test("Atelier core runtime helpers import S0 through the preferred physical name", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
+  assert.ok(compiler);
+
+  expectCompilerS0PreferredRow(
+    compiler,
+    "crates/vize_atelier_core/src/runtime_helpers.rs",
+    "source",
+    1,
+  );
+});
+
 void test("consumer migration scan keeps every rollout consumer and surface class visible", () => {
   const scan = scanConsumerMigrationSurfaces();
   const consumers = new Map(scan.consumers.map((consumer) => [consumer.id, consumer]));


### PR DESCRIPTION
## Summary

- move Atelier core runtime helper storage from the S0 code-name import to the preferred physical `vize_s0` alias
- extend the Atelier core S0 alias ratchet to cover `runtime_helpers.rs`
- regenerate the Davinci consumer migration surface inventory so the compiler S0 preferred/compat split reflects the migration

Closes #5084

## Verification

- `vp install --frozen-lockfile --prefer-offline`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts`
- `git diff --check`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc snapshot_tests::test_patches_ts_snapshots -- --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc snapshot_tests::test_patches_js_snapshots -- --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_test_runner tests::vdom_component -- --ignored --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_test_runner tests::vdom_directives -- --ignored --exact`
- `vp check`
- `vp run --workspace-root source:lengths`
- `vp run --workspace-root check:ci`
- `nix develop --command vp check`
- `nix develop --command vp run --workspace-root check:ci`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p davinci_harness --test stage_aliases`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc --test custom_directive_patch_flag --test dynamic_slot_setup_binding --test setup_component_unref`
- `git archive HEAD` into `/private/tmp/vize-package-check.FOLgkS`, then `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo package -p vize_atelier_core --locked --manifest-path /private/tmp/vize-package-check.FOLgkS/Cargo.toml`

Note: direct `cargo package` from the repo currently fails before packaging because Cargo cannot read stale fixture submodule metadata for `tests/_fixtures/_git/misskey/fluent-emojis`; the archive-based check removes Git metadata only and verified the committed package contents.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790415395&installation_model_id=422833&pr_number=5085&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5085&signature=1fce05aae73e8127fb6337154626d4667a601774c9789650737ed7b7cfd83d77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated internal compiler naming classifications to reflect one additional preferred stage name.
  * Preserved existing runtime helper tracking behavior while aligning imports with the preferred naming.

* **Tests**
  * Expanded migration checks to cover runtime helper imports.
  * Added verification that the runtime helper uses the preferred physical name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->