### PR TITLE
refactor(atelier): import lane options through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/lane/options.rs
+++ b/crates/vize_atelier_core/src/lane/options.rs
@@ -1,4 +1,4 @@
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 use crate::options::CustomElementMatcher;
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   317 |               600 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   318 |               599 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -100,7 +100,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/lane/element/directive_exp
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/element/tests.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/options.rs	1	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/options.rs	1	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/patterned_template.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural_keys.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	s0	S0	stage	vize_carton	compat	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -93,6 +93,14 @@ const runtimeHelpersModule = path.join(
   "src",
   "runtime_helpers.rs",
 );
+const laneOptionsModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "lane",
+  "options.rs",
+);
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -226,6 +234,7 @@ test("Atelier core migrated compiler slices import S0 storage through the stage 
     patchFlagStaticLiteralModule,
     rootModule,
     runtimeHelpersModule,
+    laneOptionsModule,
     sourceMapModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -269,6 +269,19 @@ void test("Atelier core runtime helpers import S0 through the preferred physical
   );
 });
 
+void test("Atelier core lane options import S0 through the preferred physical name", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
+  assert.ok(compiler);
+
+  expectCompilerS0PreferredRow(
+    compiler,
+    "crates/vize_atelier_core/src/lane/options.rs",
+    "source",
+    1,
+  );
+});
+
 void test("consumer migration scan keeps every rollout consumer and surface class visible", () => {
   const scan = scanConsumerMigrationSurfaces();
   const consumers = new Map(scan.consumers.map((consumer) => [consumer.id, consumer]));


### PR DESCRIPTION
## Summary

- move `vize_atelier_core::lane::options` storage imports from `vize_carton` to the preferred `vize_s0` stage alias
- regenerate the consumer migration surface inventory so the lane options row is S0 preferred instead of compat
- pin the migrated row in the stage-alias and consumer-surface tooling tests

Closes #5086.

## Verification

- `vp install --frozen-lockfile --prefer-offline`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts`
- `git diff --check`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p davinci_harness --test stage_aliases`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc --test custom_directive_patch_flag --test dynamic_slot_setup_binding --test setup_component_unref`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc snapshot_tests::test_patches_ts_snapshots -- --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc snapshot_tests::test_patches_js_snapshots -- --exact`
- `vp check`
- `vp run --workspace-root source:lengths`
- `vp run --workspace-root check:ci`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_test_runner tests::vdom_component -- --ignored --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_test_runner tests::vdom_directives -- --ignored --exact`
- `nix develop --command vp run --workspace-root check:ci`
- `nix develop --command vp check`
- `node --test tests/tooling/moonbit-publish-crates.test.ts`
- archive-based package gate: `git archive HEAD | tar -x -C /private/tmp/vize-package-check.*` then `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo package -p vize_atelier_core --locked --manifest-path /private/tmp/vize-package-check.*/Cargo.toml`

Note: direct `cargo package -p vize_atelier_core --locked --list` in the Git worktree fails before packaging with `No such file or directory (os error 2)` while checking repository state; the archive-based package verification above passes and isolates the package content from local worktree/submodule state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790417799&installation_model_id=422833&pr_number=5087&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5087&signature=0ad777a9dad6983600bd86d2a50a3b5f493faec05b9ffc80ac50a1acb62db009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Atelier core lane options to use the preferred S0 storage import.

* **Tests**
  * Added migration checks covering lane options and verifying consistent use of the preferred import.
  * Added regression coverage for the reported source occurrence.

* **Documentation**
  * Updated the consumer migration summary to reflect the revised preferred and compatibility stage-name counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->