### PR TITLE
refactor(atelier): import structural keys through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/lane/structural_keys.rs
+++ b/crates/vize_atelier_core/src/lane/structural_keys.rs
@@ -1,6 +1,6 @@
 //! Branch-key comparison helpers for structural directives.
 
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::{ExpressionNode, PropNode};
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   318 |               599 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   319 |               598 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -102,7 +102,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	s0	S0
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/options.rs	1	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/patterned_template.rs	3	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural_keys.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural_keys.rs	3	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/structural/tests.rs	7	s0	S0	stage	vize_carton	compat	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -101,6 +101,14 @@ const laneOptionsModule = path.join(
   "lane",
   "options.rs",
 );
+const laneStructuralKeysModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "lane",
+  "structural_keys.rs",
+);
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -235,6 +243,7 @@ test("Atelier core migrated compiler slices import S0 storage through the stage 
     rootModule,
     runtimeHelpersModule,
     laneOptionsModule,
+    laneStructuralKeysModule,
     sourceMapModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -243,43 +243,20 @@ void test("Atelier core patch flag codegen imports S0 through the preferred phys
   }
 });
 
-void test("Atelier core root codegen imports S0 through the preferred physical name", () => {
+void test("Atelier core singleton compiler slices import S0 through the preferred physical name", () => {
   const scan = scanConsumerMigrationSurfaces();
   const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
   assert.ok(compiler);
 
-  expectCompilerS0PreferredRow(
-    compiler,
-    "crates/vize_atelier_core/src/codegen/root.rs",
-    "source",
-    1,
-  );
-});
-
-void test("Atelier core runtime helpers import S0 through the preferred physical name", () => {
-  const scan = scanConsumerMigrationSurfaces();
-  const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
-  assert.ok(compiler);
-
-  expectCompilerS0PreferredRow(
-    compiler,
-    "crates/vize_atelier_core/src/runtime_helpers.rs",
-    "source",
-    1,
-  );
-});
-
-void test("Atelier core lane options import S0 through the preferred physical name", () => {
-  const scan = scanConsumerMigrationSurfaces();
-  const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
-  assert.ok(compiler);
-
-  expectCompilerS0PreferredRow(
-    compiler,
-    "crates/vize_atelier_core/src/lane/options.rs",
-    "source",
-    1,
-  );
+  const expectedRows = [
+    ["crates/vize_atelier_core/src/codegen/root.rs", "source", 1],
+    ["crates/vize_atelier_core/src/runtime_helpers.rs", "source", 1],
+    ["crates/vize_atelier_core/src/lane/options.rs", "source", 1],
+    ["crates/vize_atelier_core/src/lane/structural_keys.rs", "source", 1],
+  ];
+  for (const [relPath, mode, sites] of expectedRows) {
+    expectCompilerS0PreferredRow(compiler, relPath, mode, sites);
+  }
 });
 
 void test("consumer migration scan keeps every rollout consumer and surface class visible", () => {


### PR DESCRIPTION
## Summary

- move `vize_atelier_core::lane::structural_keys` from `vize_carton::String` to the preferred `vize_s0::String` stage alias
- regenerate the consumer migration surface inventory so the structural-keys row is S0 preferred instead of compat
- keep the consumer-surface regression compact by consolidating singleton compiler-slice assertions

Closes #5088.

## Verification

- `vp install --frozen-lockfile --prefer-offline`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/moonbit-publish-crates.test.ts`
- `git diff --check`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p davinci_harness --test stage_aliases`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc --test custom_directive_patch_flag --test dynamic_slot_setup_binding --test setup_component_unref`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc snapshot_tests::test_patches_ts_snapshots -- --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc snapshot_tests::test_patches_js_snapshots -- --exact`
- `vp check`
- `vp run --workspace-root source:lengths`
- `vp run --workspace-root check:ci`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_test_runner tests::vdom_component -- --ignored --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_test_runner tests::vdom_directives -- --ignored --exact`
- `nix develop --command vp check`
- `nix develop --command vp run --workspace-root check:ci`
- archive-based package gate: `git archive HEAD | tar -x -C /private/tmp/vize-package-check.*` then `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo package -p vize_atelier_core --locked --manifest-path /private/tmp/vize-package-check.*/Cargo.toml`

Note: package verification is run from an archive tree to isolate package content from local Git worktree/submodule state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5089"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790419327&installation_model_id=422833&pr_number=5089&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5089&signature=66352f2ec249a6025eb608951001cb8e363b196da2d4d28c914e6bf5112fdb45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Improved consistency in compiler stage naming and storage access across internal components.
  * Updated migration tracking to reflect the latest compiler compatibility status.

* **Tests**
  * Expanded automated checks to validate stage-alias usage across additional compiler areas.
  * Consolidated migration coverage for improved reliability and easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->