### PR TITLE
refactor(atelier): import lane context through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/lane/context.rs
+++ b/crates/vize_atelier_core/src/lane/context.rs
@@ -1,8 +1,8 @@
 //! TransformContext implementation.
 
-use vize_carton::{Allocator, Box, CompactString, String, interner::Interner};
 use vize_croquis::reactivity::ReactiveKind;
 use vize_croquis::{BindingType, Croquis, ScopeBinding, ScopeKind, VForScopeData, VSlotScopeData};
+use vize_s0::{Allocator, Box, CompactString, String, interner::Interner};
 
 use crate::errors::{CompilerError, ErrorCode};
 use crate::options::TransformOptions;
@@ -43,8 +43,8 @@ impl<'a> TransformContext<'a> {
             directives: std::vec::Vec::new(),
             #[cfg(feature = "legacy")]
             filters: std::vec::Vec::new(),
-            hoists: vize_carton::Vec::new_in(&allocator),
-            cached: vize_carton::Vec::new_in(&allocator),
+            hoists: vize_s0::Vec::new_in(&allocator),
+            cached: vize_s0::Vec::new_in(&allocator),
             temps: 0,
             scope_chain: vize_croquis::ScopeChain::new(),
             scoped_slots: 0,
@@ -371,7 +371,7 @@ impl<'a> TransformContext<'a> {
             VForScopeData {
                 value_alias: CompactString::new(value_alias.unwrap_or("")),
                 value_bindings: value_alias
-                    .map(|alias| vize_carton::smallvec![CompactString::new(alias)])
+                    .map(|alias| vize_s0::smallvec![CompactString::new(alias)])
                     .unwrap_or_default(),
                 key_alias: key_alias.map(CompactString::new),
                 index_alias: index_alias.map(CompactString::new),

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   319 |               598 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   323 |               594 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -92,7 +92,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/expr_parse_probe.rs	22	raw
 compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	s0	S0	stage	vize_carton	compat	4
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	s0	S0	stage	vize_s0	preferred	4
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	old_ast	old AST/parser	old	vize_armature	legacy	3
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	3
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/element.rs	3	s0	S0	stage	vize_carton	compat	2

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -109,6 +109,14 @@ const laneStructuralKeysModule = path.join(
   "lane",
   "structural_keys.rs",
 );
+const laneContextModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "lane",
+  "context.rs",
+);
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -244,6 +252,7 @@ test("Atelier core migrated compiler slices import S0 storage through the stage 
     runtimeHelpersModule,
     laneOptionsModule,
     laneStructuralKeysModule,
+    laneContextModule,
     sourceMapModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -253,6 +253,7 @@ void test("Atelier core singleton compiler slices import S0 through the preferre
     ["crates/vize_atelier_core/src/runtime_helpers.rs", "source", 1],
     ["crates/vize_atelier_core/src/lane/options.rs", "source", 1],
     ["crates/vize_atelier_core/src/lane/structural_keys.rs", "source", 1],
+    ["crates/vize_atelier_core/src/lane/context.rs", "source", 4],
   ];
   for (const [relPath, mode, sites] of expectedRows) {
     expectCompilerS0PreferredRow(compiler, relPath, mode, sites);


### PR DESCRIPTION
## Summary

- migrate `crates/vize_atelier_core/src/lane/context.rs` from the `vize_carton` compatibility name to the preferred `vize_s0` physical stage alias
- extend Davinci S0 alias guards to pin lane context as a migrated compiler slice
- regenerate `davinci-road/plan/consumer-migration-surfaces.{md,tsv}` so the compiler preferred/compat counters reflect the move

Closes #5090

## Verification

- `vp install --frozen-lockfile --prefer-offline`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/moonbit-publish-crates.test.ts`
- `git diff --check`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p davinci_harness --test stage_aliases`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc --test custom_directive_patch_flag --test dynamic_slot_setup_binding --test setup_component_unref`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc snapshot_tests::test_patches_ts_snapshots -- --exact`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_sfc snapshot_tests::test_patches_js_snapshots -- --exact`
- `vp check`
- `vp run --workspace-root source:lengths`
- `vp run --workspace-root check:ci`
- `nix develop --command vp check`
- `nix develop --command vp run --workspace-root check:ci`
- archive-based `cargo package -p vize_atelier_core --locked --manifest-path /private/tmp/vize-package-check.*/Cargo.toml`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790420825&installation_model_id=422833&pr_number=5091&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5091&signature=8bf80173c74a42aab872dd9a731b62fc1756bfc4fe27cc22f438e504252b2c0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated compiler internals to use the preferred S0 allocation and collection implementation.
  * Migrated additional compiler references from compatibility names to preferred stage names.

* **Tests**
  * Added migration checks to verify preferred naming and prevent direct use of legacy compatibility imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->