### PR TITLE
refactor(atelier): import codegen helpers through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/helpers.rs
@@ -4,7 +4,7 @@ mod constant_expression;
 
 pub use self::constant_expression::is_constant_simple_expression;
 use crate::RuntimeHelper;
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 /// Decode HTML numeric character references in hex or decimal form.
 pub fn decode_html_entities(s: &str) -> String {
@@ -246,8 +246,8 @@ pub fn default_helper_alias(helper: RuntimeHelper) -> &'static str {
     }
 }
 
-// Re-export from vize_carton for convenience
-pub use vize_carton::{String, camelize, capitalize};
+// Re-export from S0 for convenience.
+pub use vize_s0::{String, camelize, capitalize};
 
 /// Capitalize first letter of a string (alias for capitalize)
 #[inline]

--- a/crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs
+++ b/crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs
@@ -16,8 +16,8 @@ use oxc_ast_visit::{
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use oxc_syntax::scope::ScopeFlags;
-use vize_carton::{FxHashSet, String};
 use vize_croquis::builtins::is_global_allowed;
+use vize_s0::{FxHashSet, String};
 
 fn is_constant_binding(binding_type: BindingType) -> bool {
     matches!(
@@ -51,7 +51,7 @@ fn is_runtime_helper_ident(name: &str) -> bool {
 #[derive(Default)]
 struct RuntimeDependencyVisitor<'a> {
     bindings: Option<&'a BindingMetadata>,
-    scopes: Vec<FxHashSet<vize_carton::String>>,
+    scopes: Vec<FxHashSet<vize_s0::String>>,
     has_dynamic_dependency: bool,
 }
 
@@ -80,7 +80,7 @@ impl<'a> RuntimeDependencyVisitor<'a> {
         match pattern {
             oxc_ast_types::BindingPattern::BindingIdentifier(ident) => {
                 if let Some(scope) = self.scopes.last_mut() {
-                    scope.insert(vize_carton::String::new(ident.name.as_str()));
+                    scope.insert(vize_s0::String::new(ident.name.as_str()));
                 }
             }
             oxc_ast_types::BindingPattern::ObjectPattern(obj) => {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   323 |               594 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   328 |               589 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -44,8 +44,8 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/expression/scope_p
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate.rs	18	s0	S0	stage	vize_s0	preferred	6
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate/collect_helpers.rs	14	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/generate/static_vnode.rs	3	s0	S0	stage	vize_s0	preferred	4
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers.rs	7	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers.rs	7	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_allocator	raw	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs	11	raw_oxc	raw OXC	raw	oxc_ast	raw	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -125,6 +125,14 @@ const sourceMapModule = path.join(
   "codegen",
   "source_map.rs",
 );
+const helpersModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "codegen",
+  "helpers.rs",
+);
 const slotsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "slots");
 const propsRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "props");
 const vIfRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "v_if");
@@ -147,6 +155,7 @@ const generateRoot = path.join(
   "codegen",
   "generate",
 );
+const helpersRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "helpers");
 const testRoot = path.join(repoRoot, "crates", "vize_atelier_core", "tests");
 const benchPath = path.join(repoRoot, "crates", "vize_atelier_core", "benches", "davinci.rs");
 const require = createRequire(import.meta.url);
@@ -254,6 +263,7 @@ test("Atelier core migrated compiler slices import S0 storage through the stage 
     laneStructuralKeysModule,
     laneContextModule,
     sourceMapModule,
+    helpersModule,
     ...rustFiles(slotsRoot),
     ...rustFiles(propsRoot),
     ...rustFiles(vIfRoot),
@@ -262,6 +272,7 @@ test("Atelier core migrated compiler slices import S0 storage through the stage 
     ...rustFiles(elementRoot),
     ...rustFiles(expressionRoot),
     ...rustFiles(generateRoot),
+    ...rustFiles(helpersRoot),
     ...rustFiles(testRoot),
     benchPath,
   ]) {

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -229,6 +229,20 @@ void test("Atelier core node codegen imports S0 through the preferred physical n
   );
 });
 
+void test("Atelier core helper codegen imports S0 through the preferred physical name", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
+  assert.ok(compiler);
+
+  const expectedRows = [
+    ["crates/vize_atelier_core/src/codegen/helpers.rs", "source", 2],
+    ["crates/vize_atelier_core/src/codegen/helpers/constant_expression.rs", "source", 3],
+  ];
+  for (const [relPath, mode, sites] of expectedRows) {
+    expectCompilerS0PreferredRow(compiler, relPath, mode, sites);
+  }
+});
+
 void test("Atelier core patch flag codegen imports S0 through the preferred physical name", () => {
   const scan = scanConsumerMigrationSurfaces();
   const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");


### PR DESCRIPTION
## Summary
- migrate Atelier core codegen helper S0 imports from vize_carton to the preferred vize_s0 stage alias
- guard the helper modules in the Davinci stage-alias test
- regenerate the consumer migration surface inventory so the two helper rows move from compat to preferred

## Verification
- vp install --frozen-lockfile --prefer-offline
- node tools/davinci/consumer-migration-surfaces.mjs --check
- node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/moonbit-publish-crates.test.ts
- git diff --check
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --lib codegen::helpers
- CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core
- CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports
- vp run --workspace-root source:lengths
- vp run --workspace-root check:ci
- nix develop --command vp check
- nix develop --command vp run --workspace-root check:ci
- cargo package -p vize_atelier_core --locked via clean verification clone

Closes #5092

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790424146&installation_model_id=422833&pr_number=5093&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5093&signature=a49d3b4d18d7128717438ba6d8374daf032270724eebf9e2b18833775db794e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated Atelier core code-generation helpers to use the preferred S0 compatibility layer.
  - Preserved existing helper exports and runtime behavior.

- **Documentation**
  - Updated consumer migration tracking with revised compiler usage counts.

- **Tests**
  - Expanded migration checks to cover helper modules and verify preferred import usage.
  - Added coverage for expected compiler migration metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->