### PR TITLE
refactor(atelier): import lane element through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/lane/element.rs
+++ b/crates/vize_atelier_core/src/lane/element.rs
@@ -1,6 +1,6 @@
 //! Element transformation functions.
 
-use vize_carton::{Box, String, Vec, capitalize, is_builtin_directive, is_native_tag};
+use vize_s0::{Box, String, Vec, capitalize, is_builtin_directive, is_native_tag};
 
 use crate::errors::ErrorCode;
 use crate::steps::expression::process_inline_handler;
@@ -124,7 +124,7 @@ fn is_registered_component(ctx: &TransformContext<'_>, tag: &str) -> bool {
     }
 
     if tag.contains('-') || tag.contains('_') {
-        let camel = vize_carton::camelize(tag);
+        let camel = vize_s0::camelize(tag);
         if ctx.is_component_registered(camel.as_str()) {
             return true;
         }

--- a/crates/vize_atelier_core/src/lane/element/directive_expressions.rs
+++ b/crates/vize_atelier_core/src/lane/element/directive_expressions.rs
@@ -3,7 +3,7 @@
 //! Split out of [`super::element`] so that module stays inside the per-file
 //! source-length budget.
 
-use vize_carton::Box;
+use vize_s0::Box;
 
 use crate::steps::expression::{process_expression, process_inline_handler};
 use crate::{ElementNode, ExpressionNode, PropNode};

--- a/crates/vize_atelier_core/src/lane/element/tests.rs
+++ b/crates/vize_atelier_core/src/lane/element/tests.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 #[allow(clippy::disallowed_macros)]
 mod element_transform_tests {
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     use super::super::transform_element;
     use crate::{

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   328 |               589 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   332 |               585 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -95,9 +95,9 @@ compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	croquis	Croquis
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	s0	S0	stage	vize_s0	preferred	4
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	old_ast	old AST/parser	old	vize_armature	legacy	3
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	3
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/element.rs	3	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/element/directive_expressions.rs	6	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/element/tests.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/element.rs	3	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/element/directive_expressions.rs	6	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/element/tests.rs	7	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/options.rs	1	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -117,6 +117,14 @@ const laneContextModule = path.join(
   "lane",
   "context.rs",
 );
+const laneElementModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "lane",
+  "element.rs",
+);
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -156,6 +164,14 @@ const generateRoot = path.join(
   "generate",
 );
 const helpersRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "helpers");
+const laneElementRoot = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "lane",
+  "element",
+);
 const testRoot = path.join(repoRoot, "crates", "vize_atelier_core", "tests");
 const benchPath = path.join(repoRoot, "crates", "vize_atelier_core", "benches", "davinci.rs");
 const require = createRequire(import.meta.url);
@@ -262,6 +278,7 @@ test("Atelier core migrated compiler slices import S0 storage through the stage 
     laneOptionsModule,
     laneStructuralKeysModule,
     laneContextModule,
+    laneElementModule,
     sourceMapModule,
     helpersModule,
     ...rustFiles(slotsRoot),
@@ -273,6 +290,7 @@ test("Atelier core migrated compiler slices import S0 storage through the stage 
     ...rustFiles(expressionRoot),
     ...rustFiles(generateRoot),
     ...rustFiles(helpersRoot),
+    ...rustFiles(laneElementRoot),
     ...rustFiles(testRoot),
     benchPath,
   ]) {

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -274,6 +274,21 @@ void test("Atelier core singleton compiler slices import S0 through the preferre
   }
 });
 
+void test("Atelier core lane element imports S0 through the preferred physical name", () => {
+  const scan = scanConsumerMigrationSurfaces();
+  const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
+  assert.ok(compiler);
+
+  const expectedRows = [
+    ["crates/vize_atelier_core/src/lane/element.rs", "source", 2],
+    ["crates/vize_atelier_core/src/lane/element/directive_expressions.rs", "source", 1],
+    ["crates/vize_atelier_core/src/lane/element/tests.rs", "test", 1],
+  ];
+  for (const [relPath, mode, sites] of expectedRows) {
+    expectCompilerS0PreferredRow(compiler, relPath, mode, sites);
+  }
+});
+
 void test("consumer migration scan keeps every rollout consumer and surface class visible", () => {
   const scan = scanConsumerMigrationSurfaces();
   const consumers = new Map(scan.consumers.map((consumer) => [consumer.id, consumer]));


### PR DESCRIPTION
## Summary

- move atelier core lane element S0 storage/utility imports from the compatibility code name `vize_carton` to the preferred physical alias `vize_s0`
- extend the migrated compiler slice guard to cover `lane/element.rs` and `lane/element/*`
- regenerate the Davinci consumer migration inventory so Compiler preferred stage names move 328 -> 332 and compat code names move 589 -> 585

Closes #5094.

## Verification

- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core element_transform_tests`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --lib`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `vp run --workspace-root source:lengths`
- `vp run --workspace-root check:ci`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `nix develop --command vp run --workspace-root check:ci`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features legacy --test legacy_event_modifiers`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features legacy --test davinci_s2_transform -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 -- --nocapture`
- `node tools/davinci/assertion-lint.mjs`
- `node --test tests/tooling/davinci-matrices.test.ts tests/tooling/source-file-lengths.test.ts`
- normal clone package verification at `fb356a72f`: `cargo package -p vize_atelier_core --locked --list`; `cargo package -p vize_atelier_core --locked`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790425432&installation_model_id=422833&pr_number=5095&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5095&signature=b5d7217207058cfdbd6e57cd0e429739ffb2dc61d6eecbaf08067866cf917593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Atelier Core’s lane element components to use the preferred S0 utility source.
  * Aligned compiler migration tracking with the latest preferred and compatibility naming counts.

* **Tests**
  * Expanded migration checks to cover lane element modules and nested files.
  * Added validation that lane element code generation uses the preferred S0 naming consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->