### PR TITLE
refactor(atelier): import lane extensions through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/lane/extensions.rs
+++ b/crates/vize_atelier_core/src/lane/extensions.rs
@@ -1,7 +1,7 @@
 //! Specialized transform entry points layered over the shared transform lane.
 
-use vize_carton::{Allocator, String};
 use vize_croquis::Croquis;
+use vize_s0::{Allocator, String};
 
 use super::{JsxTransformCompat, TransformLaneOptions, transform_inner};
 use crate::{CompilerError, RootNode, TransformOptions, options::CustomElementMatcher};

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   332 |               585 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   333 |               584 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -98,7 +98,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	croquis	
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/element.rs	3	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/element/directive_expressions.rs	6	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/element/tests.rs	7	s0	S0	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/options.rs	1	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/patterned_template.rs	3	s0	S0	stage	vize_carton	compat	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -125,6 +125,14 @@ const laneElementModule = path.join(
   "lane",
   "element.rs",
 );
+const laneExtensionsModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "lane",
+  "extensions.rs",
+);
 const sourceMapModule = path.join(
   repoRoot,
   "crates",
@@ -279,6 +287,7 @@ test("Atelier core migrated compiler slices import S0 storage through the stage 
     laneStructuralKeysModule,
     laneContextModule,
     laneElementModule,
+    laneExtensionsModule,
     sourceMapModule,
     helpersModule,
     ...rustFiles(slotsRoot),

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -283,6 +283,7 @@ void test("Atelier core lane element imports S0 through the preferred physical n
     ["crates/vize_atelier_core/src/lane/element.rs", "source", 2],
     ["crates/vize_atelier_core/src/lane/element/directive_expressions.rs", "source", 1],
     ["crates/vize_atelier_core/src/lane/element/tests.rs", "test", 1],
+    ["crates/vize_atelier_core/src/lane/extensions.rs", "source", 1],
   ];
   for (const [relPath, mode, sites] of expectedRows) {
     expectCompilerS0PreferredRow(compiler, relPath, mode, sites);

--- a/tests/tooling/support/typed-editor-oracle-matrix.ts
+++ b/tests/tooling/support/typed-editor-oracle-matrix.ts
@@ -28,7 +28,7 @@ const toolingTestCiEvidence: Evidence = {
   label: "test-scripts runs tests/tooling with VIZE_TEST_REQUIRE_TSGO=1",
   path: "tools/vite-plus/tasks/test-benchmark.ts",
   requiredText: [
-    "VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.ts",
+    "VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.ts tests/tooling/*.test.mjs",
   ],
 };
 

--- a/tests/tooling/typecheck-dependency-gates.test.ts
+++ b/tests/tooling/typecheck-dependency-gates.test.ts
@@ -13,7 +13,7 @@ test("test:scripts requires its typecheck dependencies", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
   assert.match(
     command,
-    /&& VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests\/tooling\/\*\.test\.ts$/,
+    /&& VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests\/tooling\/\*\.test\.ts tests\/tooling\/\*\.test\.mjs$/,
   );
   assert.match(
     workflow,

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -101,7 +101,7 @@ export const testAndBenchmarkTasks = defineTasks({
   // dev profile (~1m20s). Building once in the CI profile saves both legs.
   "test:js": noCacheTask(`${runTask("build:native:test")} && ${jsPackageTestCommand}`),
   "test:scripts": noCacheTask(
-    `${runTask("build:native:test")} && VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.ts`,
+    `${runTask("build:native:test")} && VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.ts tests/tooling/*.test.mjs`,
   ),
   "test:vscode-extension:vsix": noCacheTask(
     runInVscodeExtension(


### PR DESCRIPTION
## Summary

- import Atelier core lane extensions through the preferred S0 physical alias `vize_s0`
- update the Davinci consumer migration ledger for that surface
- extend the stage-alias guards and include `.test.mjs` tooling guards in `test:scripts`

Closes #5096.

## Tests

- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --lib`
- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check --locked -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/typecheck-dependency-gates.test.ts tests/tooling/typed-editor-oracle-matrix.test.ts tests/tooling/local-default-tasks.test.ts`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.mjs`
- `vp run --workspace-root source:lengths`
- `vp run --workspace-root check:ci`

## Rollout

None. This only moves another compiler surface toward the S0 physical name; rollout remains manual.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790429286&installation_model_id=422833&pr_number=5097&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5097&signature=dbba9d04d19087a767345e4ed400645a8efea0eae67d2c3d9c51de94c734154d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated internal migration tracking to reflect the latest compiler stage naming.

* **Bug Fixes**
  * Corrected lane extension imports to use the preferred compatibility path.

* **Tests**
  * Expanded tooling test execution to include JavaScript test files.
  * Added migration coverage for lane extension imports and updated CI validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->