### PR TITLE
refactor(atelier): import remaining lane modules through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/lane.rs
+++ b/crates/vize_atelier_core/src/lane.rs
@@ -11,8 +11,8 @@ pub mod structural;
 mod structural_keys;
 pub mod traverse;
 
-use vize_carton::{Allocator, Box, SmallVec, String, Vec, interner::Interner, profile};
 use vize_croquis::{Croquis, ScopeChain};
+use vize_s0::{Allocator, Box, SmallVec, String, Vec, interner::Interner, profile};
 
 use crate::errors::CompilerError;
 use crate::options::TransformOptions;

--- a/crates/vize_atelier_core/src/lane/patterned_template.rs
+++ b/crates/vize_atelier_core/src/lane/patterned_template.rs
@@ -1,6 +1,6 @@
 //! Experimental patterned template desugaring (`v-match` / `v-case`).
 
-use vize_carton::{Allocator, Box, String, Vec, cstr, ensure_sufficient_stack};
+use vize_s0::{Allocator, Box, String, Vec, cstr, ensure_sufficient_stack};
 
 use crate::{
     DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, RootNode,

--- a/crates/vize_atelier_core/src/lane/structural.rs
+++ b/crates/vize_atelier_core/src/lane/structural.rs
@@ -1,6 +1,6 @@
 //! Structural directive transforms (v-if, v-for).
 
-use vize_carton::{Box, Vec};
+use vize_s0::{Box, Vec};
 
 use crate::errors::ErrorCode;
 use crate::{

--- a/crates/vize_atelier_core/src/lane/traverse.rs
+++ b/crates/vize_atelier_core/src/lane/traverse.rs
@@ -5,7 +5,7 @@ use crate::{
     ElementNode, ElementType, ExpressionNode, ForNode, IfBranchNode, PropNode, RuntimeHelper,
     TemplateChildNode,
 };
-use vize_carton::{ensure_sufficient_stack, profile};
+use vize_s0::{ensure_sufficient_stack, profile};
 
 use super::element::{transform_element, transform_interpolation};
 use super::structural::{
@@ -82,7 +82,7 @@ pub fn traverse_children<'a>(ctx: &mut TransformContext<'a>, parent: ParentNode<
 /// call depth here follows template nesting depth. The guard moves the descent
 /// onto a fresh stack before the thread stack runs out, because a stack overflow
 /// aborts the process instead of producing a diagnostic
-/// (`vize_carton::recursion`).
+/// (`vize_s0::recursion`).
 pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChildNode<'a>) {
     crate::walk_probe::record_visit(crate::walk_probe::WalkStage::Transform);
     ensure_sufficient_stack(|| traverse_node_guarded(ctx, node));
@@ -195,8 +195,7 @@ fn traverse_node_guarded<'a>(ctx: &mut TransformContext<'a>, node: &mut Template
                     let source = match &for_node.source {
                         ExpressionNode::Simple(exp) => exp.content,
                         ExpressionNode::Compound(c) => {
-                            compound_source =
-                                vize_carton::String::new(c.loc.span.slice(ctx.source));
+                            compound_source = vize_s0::String::new(c.loc.span.slice(ctx.source));
                             compound_source.as_str()
                         }
                     };
@@ -295,7 +294,7 @@ fn traverse_node_guarded<'a>(ctx: &mut TransformContext<'a>, node: &mut Template
                 let source = match &for_node.source {
                     ExpressionNode::Simple(exp) => exp.content,
                     ExpressionNode::Compound(c) => {
-                        compound_source = vize_carton::String::new(c.loc.span.slice(ctx.source));
+                        compound_source = vize_s0::String::new(c.loc.span.slice(ctx.source));
                         compound_source.as_str()
                     }
                 };

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   333 |               584 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   339 |               578 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -89,7 +89,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if.rs	16	s0	S0	s
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if/branch.rs	10	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_if/props.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/expr_parse_probe.rs	22	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/context.rs	3	s0	S0	stage	vize_s0	preferred	4
@@ -101,13 +101,13 @@ compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/element/tests.rs	7	
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/extensions.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/options.rs	1	s0	S0	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/patterned_template.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/patterned_template.rs	3	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural_keys.rs	3	s0	S0	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/structural/tests.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/tests.rs	7	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lane/traverse.rs	8	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	source	crates/vize_atelier_core/src/lane/traverse.rs	8	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	4

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -117,6 +117,7 @@ const laneContextModule = path.join(
   "lane",
   "context.rs",
 );
+const laneModule = path.join(repoRoot, "crates", "vize_atelier_core", "src", "lane.rs");
 const laneElementModule = path.join(
   repoRoot,
   "crates",
@@ -132,6 +133,30 @@ const laneExtensionsModule = path.join(
   "src",
   "lane",
   "extensions.rs",
+);
+const lanePatternedTemplateModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "lane",
+  "patterned_template.rs",
+);
+const laneStructuralModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "lane",
+  "structural.rs",
+);
+const laneTraverseModule = path.join(
+  repoRoot,
+  "crates",
+  "vize_atelier_core",
+  "src",
+  "lane",
+  "traverse.rs",
 );
 const sourceMapModule = path.join(
   repoRoot,
@@ -286,8 +311,12 @@ test("Atelier core migrated compiler slices import S0 storage through the stage 
     laneOptionsModule,
     laneStructuralKeysModule,
     laneContextModule,
+    laneModule,
     laneElementModule,
     laneExtensionsModule,
+    lanePatternedTemplateModule,
+    laneStructuralModule,
+    laneTraverseModule,
     sourceMapModule,
     helpersModule,
     ...rustFiles(slotsRoot),

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -52,14 +52,12 @@ void test("consumer migration scan classifies stage physical names separately fr
   assert.equal(s0.label, "S0");
   assert.equal(surfaceNameKind(s0, "vize_s0"), "preferred");
   assert.equal(surfaceNameKind(s0, "vize_carton"), "compat");
-
   const stageSurfaces = SURFACES.filter((surface) => surface.group === "stage");
   assert.deepEqual(
     stageSurfaces.map((surface) => surface.label),
     ["Davinci", "S0", "S1", "S2", "S1->S2"],
   );
   assert.ok(stageSurfaces.every((surface) => !surface.label.includes("/")));
-
   const rawOxc = SURFACES.find((surface) => surface.id === "raw_oxc");
   assert.ok(rawOxc);
   assert.equal(surfaceNameKind(rawOxc, "oxc_ast"), "raw");
@@ -67,14 +65,12 @@ void test("consumer migration scan classifies stage physical names separately fr
 
 void test("consumer migration rows preserve surface totals when split by matched name", () => {
   const scan = scanConsumerMigrationSurfaces();
-
   for (const consumer of scan.consumers) {
     assert.equal(
       consumer.groupCounts.stage,
       consumer.nameKindCounts.preferred + consumer.nameKindCounts.compat,
       `${consumer.id} stage totals must equal preferred plus compat names`,
     );
-
     for (const row of consumer.fileRows) {
       for (const surface of SURFACES) {
         assert.equal(
@@ -284,6 +280,10 @@ void test("Atelier core lane element imports S0 through the preferred physical n
     ["crates/vize_atelier_core/src/lane/element/directive_expressions.rs", "source", 1],
     ["crates/vize_atelier_core/src/lane/element/tests.rs", "test", 1],
     ["crates/vize_atelier_core/src/lane/extensions.rs", "source", 1],
+    ["crates/vize_atelier_core/src/lane.rs", "source", 1],
+    ["crates/vize_atelier_core/src/lane/patterned_template.rs", "source", 1],
+    ["crates/vize_atelier_core/src/lane/structural.rs", "source", 1],
+    ["crates/vize_atelier_core/src/lane/traverse.rs", "source", 3],
   ];
   for (const [relPath, mode, sites] of expectedRows) {
     expectCompilerS0PreferredRow(compiler, relPath, mode, sites);


### PR DESCRIPTION
## Summary
- import the remaining Atelier core lane source modules through the physical `vize_s0` name
- update the generated Davinci consumer migration surface ledger
- extend tooling guards so the migrated lane source files stay on the preferred S0 name

Closes #5098

## Tests
- `node tools/davinci/consumer-migration-surfaces.mjs --write`
- `git diff --check`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --lib`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check --locked -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.mjs`
- `vp run --workspace-root source:lengths`
- `vp run --workspace-root check:ci`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --all-targets --all-features`

## Notes
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy --locked -p vize_atelier_core --all-targets --all-features -- -D warnings -D clippy::wildcard_imports` currently fails on existing unrelated test-only lints in files outside this PR's diff.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790432102&installation_model_id=422833&pr_number=5099&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5099&signature=eb53fe025111a5fcaabf8db1a00a307b2e9a556690e8b352bc59b4522a6a8fdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal compiler components to use the preferred S0 integration.
  * Expanded migration coverage for lane-related compiler modules.

* **Tests**
  * Added checks to prevent outdated integration references in lane modules.
  * Updated surface classification and alias validation checks.

* **Documentation**
  * Updated migration tracking metrics to reflect the latest naming transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->