### PR TITLE
refactor(atelier): import element step through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/steps/element.rs
+++ b/crates/vize_atelier_core/src/steps/element.rs
@@ -2,7 +2,7 @@
 //!
 //! Transforms element nodes and their props.
 
-use vize_carton::{String, capitalize, is_native_tag};
+use vize_s0::{String, capitalize, is_native_tag};
 
 use crate::lane::TransformContext;
 use crate::{ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper, TemplateChildNode};
@@ -114,7 +114,7 @@ pub fn build_props<'a>(
     // Dedupe by attribute name — Vue keeps the first occurrence on a
     // duplicate attribute. The parser records both nodes so linters can
     // warn about the repeat; codegen takes the first only. (#958)
-    let mut seen_attr_names: vize_carton::FxHashSet<String> = vize_carton::FxHashSet::default();
+    let mut seen_attr_names: vize_s0::FxHashSet<String> = vize_s0::FxHashSet::default();
 
     for prop in el.props.iter() {
         match prop {
@@ -304,7 +304,7 @@ mod tests {
     use crate::TemplateChildNode;
     use crate::lane::TransformContext;
     use crate::parser::parse;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn test_resolve_element_type() {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   339 |               578 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   343 |               574 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -118,8 +118,8 @@ compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/retained/tests.rs	20	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/runtime_helpers.rs	4	s0	S0	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/element.rs	5	s0	S0	stage	vize_carton	compat	3
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/element.rs	307	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/element.rs	5	s0	S0	stage	vize_s0	preferred	3
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/element.rs	307	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression.rs	16	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression.rs	16	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector_targets.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	1

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -197,6 +197,7 @@ const generateRoot = path.join(
   "generate",
 );
 const helpersRoot = path.join(repoRoot, "crates", "vize_atelier_core", "src", "codegen", "helpers");
+const stepsElementModule = path.join(repoRoot, "crates/vize_atelier_core/src/steps/element.rs");
 const laneElementRoot = path.join(
   repoRoot,
   "crates",
@@ -328,6 +329,7 @@ test("Atelier core migrated compiler slices import S0 storage through the stage 
     ...rustFiles(expressionRoot),
     ...rustFiles(generateRoot),
     ...rustFiles(helpersRoot),
+    stepsElementModule,
     ...rustFiles(laneElementRoot),
     ...rustFiles(testRoot),
     benchPath,

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -253,7 +253,7 @@ void test("Atelier core patch flag codegen imports S0 through the preferred phys
   }
 });
 
-void test("Atelier core singleton compiler slices import S0 through the preferred physical name", () => {
+void test("Atelier core singleton and element step slices import S0 through the preferred name", () => {
   const scan = scanConsumerMigrationSurfaces();
   const compiler = scan.consumers.find((consumer) => consumer.id === "compiler");
   assert.ok(compiler);
@@ -264,6 +264,8 @@ void test("Atelier core singleton compiler slices import S0 through the preferre
     ["crates/vize_atelier_core/src/lane/options.rs", "source", 1],
     ["crates/vize_atelier_core/src/lane/structural_keys.rs", "source", 1],
     ["crates/vize_atelier_core/src/lane/context.rs", "source", 4],
+    ["crates/vize_atelier_core/src/steps/element.rs", "source", 3],
+    ["crates/vize_atelier_core/src/steps/element.rs", "test", 1],
   ];
   for (const [relPath, mode, sites] of expectedRows) {
     expectCompilerS0PreferredRow(compiler, relPath, mode, sites);


### PR DESCRIPTION
Closes #5100

## Summary
- import the atelier core element step S0 surface through the preferred physical `vize_s0` alias
- refresh the Davinci consumer migration surface ledger for the preferred/compat split
- extend tooling guards so this element step stays covered by the migrated compiler slice checks

## Tests
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `git diff --check`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts`
- `cargo fmt --all -- --check`
- `vp run --workspace-root source:lengths`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --lib`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy -p vize_atelier_core --lib -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check --locked -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.mjs`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `vp run --workspace-root check:ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Migrated element processing to the updated S0 module naming.

- **Documentation**
  - Updated compiler migration tracking to reflect additional preferred stage names and fewer compatibility names.

- **Tests**
  - Expanded migration checks to cover element processing and its test utilities.
  - Updated expected migration coverage for singleton and element processing stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->