### PR TITLE
refactor(atelier): import expression steps through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/steps/expression.rs
+++ b/crates/vize_atelier_core/src/steps/expression.rs
@@ -15,7 +15,7 @@ mod typescript;
 
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{Allocator, Box, String};
+use vize_s0::{Allocator, Box, String};
 
 use crate::{ConstantType, ExpressionNode, SimpleExpressionNode, lane::TransformContext};
 

--- a/crates/vize_atelier_core/src/steps/expression/collector.rs
+++ b/crates/vize_atelier_core/src/steps/expression/collector.rs
@@ -13,8 +13,8 @@ use oxc_ast_visit::{
     },
 };
 use oxc_syntax::scope::ScopeFlags;
-use vize_carton::FxHashSet;
-use vize_carton::String;
+use vize_s0::FxHashSet;
+use vize_s0::String;
 
 use vize_croquis::builtins::is_global_allowed;
 

--- a/crates/vize_atelier_core/src/steps/expression/inline_handler.rs
+++ b/crates/vize_atelier_core/src/steps/expression/inline_handler.rs
@@ -3,7 +3,7 @@
 //! Transforms inline event handler expressions (e.g., `@click="count++"`)
 //! by prefixing identifiers and wrapping in arrow functions when needed.
 
-use vize_carton::{Box, String};
+use vize_s0::{Box, String};
 
 use crate::{ConstantType, ExpressionNode, SimpleExpressionNode, lane::TransformContext};
 
@@ -204,7 +204,7 @@ mod tests {
         lane::TransformContext,
         options::{BindingMetadata, BindingType, TransformOptions},
     };
-    use vize_carton::{Allocator, Box, FxHashMap};
+    use vize_s0::{Allocator, Box, FxHashMap};
 
     fn test_context<'a>(allocator: &'a Allocator, source: &'a str) -> TransformContext<'a> {
         let mut bindings = FxHashMap::default();

--- a/crates/vize_atelier_core/src/steps/expression/nesting.rs
+++ b/crates/vize_atelier_core/src/steps/expression/nesting.rs
@@ -1,5 +1,5 @@
 //! Re-export shim: the expression nesting guard lives in
-//! [`vize_carton::expression_guard`] since Davinci P1-5, so the armature
+//! [`vize_s0::expression_guard`] since Davinci P1-5, so the armature
 //! retained-expression parse site shares the exact guard these transform and
 //! codegen entry points use. Import paths through this module are preserved.
 //! Since P1-9 the transform rewrite runs these scans only on its legacy
@@ -7,13 +7,13 @@
 //! at the armature parse over the same bytes, so the AST-driven path skips
 //! them.
 
-pub use vize_carton::expression_guard::{
+pub use vize_s0::expression_guard::{
     MAX_EXPRESSION_NESTING_DEPTH, expression_exceeds_max_depth, expression_has_balanced_delimiters,
     expression_is_safe_to_parse, expression_nesting_depth,
 };
 
 pub(crate) mod scan {
-    pub(crate) use vize_carton::expression_guard::scan::{
+    pub(crate) use vize_s0::expression_guard::scan::{
         keyword_allows_regex_after, skip_identifier, skip_line_comment, skip_number, skip_quoted,
         skip_regex,
     };

--- a/crates/vize_atelier_core/src/steps/expression/parse_checks.rs
+++ b/crates/vize_atelier_core/src/steps/expression/parse_checks.rs
@@ -3,7 +3,7 @@
 
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::String;
+use vize_s0::String;
 
 /// Returns true when `content` parses as a TypeScript expression or program.
 ///

--- a/crates/vize_atelier_core/src/steps/expression/prefix.rs
+++ b/crates/vize_atelier_core/src/steps/expression/prefix.rs
@@ -5,7 +5,7 @@
 
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 use vize_croquis::builtins::is_global_allowed;
 

--- a/crates/vize_atelier_core/src/steps/expression/reparse.rs
+++ b/crates/vize_atelier_core/src/steps/expression/reparse.rs
@@ -13,8 +13,8 @@ use oxc_ast::ast::Expression;
 use oxc_ast_visit::Visit;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::String;
 use vize_relief::JsExpression;
+use vize_s0::String;
 
 use crate::lane::TransformContext;
 

--- a/crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs
+++ b/crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs
@@ -18,9 +18,9 @@
 //! result is dual-run against the legacy wrapped re-parse and compared
 //! exactly (code bytes and helper usage); divergence panics.
 
-#[cfg(any(test, feature = "davinci-differential"))]
-use vize_carton::String;
 use vize_relief::JsExpression;
+#[cfg(any(test, feature = "davinci-differential"))]
+use vize_s0::String;
 
 use crate::lane::TransformContext;
 

--- a/crates/vize_atelier_core/src/steps/expression/rewrite.rs
+++ b/crates/vize_atelier_core/src/steps/expression/rewrite.rs
@@ -12,8 +12,8 @@
 //! `plan/phase-1.md` P1-9.
 
 use oxc_span::SourceType;
-use vize_carton::String;
 use vize_relief::JsExpression;
+use vize_s0::String;
 
 use crate::SourceLocation;
 use crate::errors::ErrorCode;

--- a/crates/vize_atelier_core/src/steps/expression/splice.rs
+++ b/crates/vize_atelier_core/src/steps/expression/splice.rs
@@ -30,7 +30,7 @@
 //!   prefix then displaced it at the same position, so an edit emits as
 //!   `prefix` then `suffix`.
 
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 /// Splice pure insertions into `original` in one forward pass.
 ///
@@ -111,7 +111,7 @@ pub(super) fn splice_replacements(
 #[cfg(test)]
 mod tests {
     use super::{splice_insertions, splice_replacements};
-    use vize_carton::{FxHashSet, String};
+    use vize_s0::{FxHashSet, String};
 
     /// The retired string-rewriting loop, kept verbatim as the test oracle:
     /// stable descending sort, then end-to-start `insert_str` with the

--- a/crates/vize_atelier_core/src/steps/expression/tests.rs
+++ b/crates/vize_atelier_core/src/steps/expression/tests.rs
@@ -14,7 +14,7 @@ mod transform_expression_tests {
         lane::TransformContext,
         options::{BindingMetadata, BindingType, TransformOptions},
     };
-    use vize_carton::{Allocator, Box, FxHashMap};
+    use vize_s0::{Allocator, Box, FxHashMap};
 
     fn test_context<'a>(allocator: &'a Allocator, source: &'a str) -> TransformContext<'a> {
         let mut bindings = FxHashMap::default();

--- a/crates/vize_atelier_core/src/steps/expression/typescript.rs
+++ b/crates/vize_atelier_core/src/steps/expression/typescript.rs
@@ -8,7 +8,7 @@ use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use oxc_transformer::{TransformOptions, Transformer};
-use vize_carton::String;
+use vize_s0::String;
 
 /// Check if expression contains TypeScript syntax that needs stripping
 pub(crate) fn needs_typescript_stripping(content: &str) -> bool {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   343 |               574 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   359 |               558 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -120,46 +120,46 @@ compiler	Compiler	test/dev	crates/vize_atelier_core/src/retained/tests.rs	20	s0	
 compiler	Compiler	source	crates/vize_atelier_core/src/runtime_helpers.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/element.rs	5	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/element.rs	307	s0	S0	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression.rs	16	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression.rs	16	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression.rs	16	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector_targets.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector.rs	6	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector.rs	6	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector.rs	6	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/collector.rs	6	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/inline_handler.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/inline_handler.rs	6	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/inline_handler.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/inline_handler.rs	207	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/nesting.rs	10	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/parse_checks.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/inline_handler.rs	207	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/nesting.rs	10	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/parse_checks.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/parse_checks.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/prefix.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/prefix.rs	6	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/prefix.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/prefix.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	13
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/prefix.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/prefix.rs	300	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	raw_oxc	raw OXC	raw	oxc_allocator	raw	2
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/reparse.rs	12	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	22	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	22	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	22	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	22	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	2
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	22	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/rewrite.rs	15	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	21	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	21	old_ast	old AST/parser	old	vize_relief	legacy	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	21	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	21	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	2
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs	21	raw_oxc	raw OXC	raw	oxc_parser	raw	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/rewrite.rs	15	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/rewrite.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/shape_checks.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/shape_checks.rs	7	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/shape_checks.rs	7	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/shape_checks.rs	7	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/splice.rs	33	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/splice.rs	114	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/tests.rs	17	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/splice.rs	33	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/splice.rs	114	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/expression/tests.rs	17	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	raw_oxc	raw OXC	raw	oxc_codegen	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	raw_oxc	raw OXC	raw	oxc_semantic	raw	1

--- a/tests/tooling/davinci-atelier-core-expression-stage-alias.test.mjs
+++ b/tests/tooling/davinci-atelier-core-expression-stage-alias.test.mjs
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { scanConsumerMigrationSurfaces } from "../../tools/davinci/lib/consumer-migration-scan.mjs";
+
+const expressionRows = [
+  ["crates/vize_atelier_core/src/steps/expression.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/expression/collector.rs", "source", 2],
+  ["crates/vize_atelier_core/src/steps/expression/inline_handler.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/expression/inline_handler.rs", "test", 1],
+  ["crates/vize_atelier_core/src/steps/expression/nesting.rs", "source", 2],
+  ["crates/vize_atelier_core/src/steps/expression/parse_checks.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/expression/prefix.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/expression/reparse.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/expression/retained_rewrite.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/expression/rewrite.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/expression/splice.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/expression/splice.rs", "test", 1],
+  ["crates/vize_atelier_core/src/steps/expression/tests.rs", "test", 1],
+  ["crates/vize_atelier_core/src/steps/expression/typescript.rs", "source", 1],
+];
+
+function compiler() {
+  const scan = scanConsumerMigrationSurfaces();
+  const consumer = scan.consumers.find((candidate) => candidate.id === "compiler");
+  assert.ok(consumer);
+  return consumer;
+}
+
+void test("Atelier core expression transform steps import S0 through the preferred name", () => {
+  const rows = compiler().fileRows;
+
+  for (const [relPath, mode, sites] of expressionRows) {
+    const row = rows.find((candidate) => candidate.relPath === relPath && candidate.mode === mode);
+    assert.ok(row, `${relPath} (${mode})`);
+    assert.equal(row.surfaceCounts.s0, sites, relPath);
+    assert.equal(row.surfaceNameCounts.s0.vize_s0, sites, relPath);
+    assert.equal(row.surfaceNameCounts.s0.vize_carton ?? 0, 0, relPath);
+  }
+
+  const compatRows = rows
+    .filter((row) => row.relPath.startsWith("crates/vize_atelier_core/src/steps/expression"))
+    .filter((row) => (row.surfaceNameCounts.s0.vize_carton ?? 0) > 0)
+    .map((row) => `${row.relPath}:${row.mode}`);
+  assert.deepEqual(compatRows, []);
+});

--- a/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
+++ b/tests/tooling/davinci-atelier-core-slots-stage-alias.test.ts
@@ -330,6 +330,8 @@ test("Atelier core migrated compiler slices import S0 storage through the stage 
     ...rustFiles(generateRoot),
     ...rustFiles(helpersRoot),
     stepsElementModule,
+    path.join(repoRoot, "crates/vize_atelier_core/src/steps/expression.rs"),
+    ...rustFiles(path.join(repoRoot, "crates/vize_atelier_core/src/steps/expression")),
     ...rustFiles(laneElementRoot),
     ...rustFiles(testRoot),
     benchPath,


### PR DESCRIPTION
Closes #5102

## Summary
- import atelier core expression transform S0 references through the preferred physical `vize_s0` alias
- refresh the Davinci consumer migration surface ledger for the compiler preferred/compat split
- add focused guards for the expression transform step surface without growing existing 350-line tooling tests past budget

## Tests
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `git diff --check`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/davinci-atelier-core-expression-stage-alias.test.mjs tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check --locked -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `vp run --workspace-root source:lengths`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy --locked -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --lib steps::expression -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.mjs`
- `vp run --workspace-root check:ci`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features legacy,davinci-differential --all-targets`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790437999&installation_model_id=422833&pr_number=5103&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5103&signature=d9b0ae7668fdacff8c5a46c68ef03e0e67499bd1c19d1c036e5da985f80436d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated expression transformation components to use the preferred S0 interfaces.
  * Reclassified affected compiler surfaces from compatibility aliases to preferred names without changing functionality.

* **Tests**
  * Added coverage confirming expression transformation files use preferred interfaces and contain no legacy imports.
  * Expanded migration checks across expression-related modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->