### PR TITLE
refactor(atelier): import hoist static steps through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/steps/hoist_static.rs
+++ b/crates/vize_atelier_core/src/steps/hoist_static.rs
@@ -13,7 +13,7 @@ use props::{
 pub use static_type::{StaticType, get_static_type, is_static_node};
 use static_type::{has_only_native_element_descendants, has_only_static_nested_children};
 
-use vize_carton::{Allocator, Box, String, Vec, ensure_sufficient_stack};
+use vize_s0::{Allocator, Box, String, Vec, ensure_sufficient_stack};
 
 use crate::lane::TransformContext;
 use crate::{

--- a/crates/vize_atelier_core/src/steps/hoist_static/props.rs
+++ b/crates/vize_atelier_core/src/steps/hoist_static/props.rs
@@ -1,6 +1,6 @@
 //! Static property detection and hoisting.
 
-use vize_carton::{Allocator, Box, String, ToCompactString, Vec, camelize};
+use vize_s0::{Allocator, Box, String, ToCompactString, Vec, camelize};
 
 use crate::codegen::is_constant_simple_expression;
 use crate::lane::TransformContext;
@@ -16,7 +16,7 @@ pub(super) fn create_props_expression<'a>(
     skip_is: bool,
 ) -> Option<PropsExpression<'a>> {
     let mut obj_props = Vec::new_in(&allocator);
-    let mut seen: vize_carton::FxHashSet<String> = vize_carton::FxHashSet::default();
+    let mut seen: vize_s0::FxHashSet<String> = vize_s0::FxHashSet::default();
 
     for prop in props {
         if skip_is && is_is_prop(prop) {

--- a/crates/vize_atelier_core/src/steps/hoist_static/static_type.rs
+++ b/crates/vize_atelier_core/src/steps/hoist_static/static_type.rs
@@ -2,12 +2,12 @@
 //!
 //! Every predicate here answers a question about an element *and everything
 //! under it*, so each one descends the tree once per nesting level. That makes
-//! them recursion steps in the sense of `vize_carton::recursion`: their call
+//! them recursion steps in the sense of `vize_s0::recursion`: their call
 //! depth is bounded by the input, not by the code, so each descent is wrapped in
 //! `ensure_sufficient_stack` — otherwise a deeply nested template aborts the
 //! process instead of compiling.
 
-use vize_carton::ensure_sufficient_stack;
+use vize_s0::ensure_sufficient_stack;
 
 use super::is_hoistable_static_prop;
 use crate::{ElementNode, ElementType, PropNode, TemplateChildNode};

--- a/crates/vize_atelier_core/src/steps/hoist_static/tests.rs
+++ b/crates/vize_atelier_core/src/steps/hoist_static/tests.rs
@@ -2,7 +2,7 @@ use super::static_type::{has_only_native_element_descendants, has_only_static_ne
 use super::{StaticType, get_static_type, is_static_node};
 use crate::TemplateChildNode;
 use crate::parser::parse;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn test_static_text() {
@@ -84,7 +84,7 @@ fn test_nested_with_dynamic_text_not_fully_static() {
     assert_eq!(get_static_type(&root.children[0]), StaticType::NotStatic);
 }
 
-fn compile_hoisted(src: &str) -> (vize_carton::String, vize_carton::String) {
+fn compile_hoisted(src: &str) -> (vize_s0::String, vize_s0::String) {
     let allocator = Allocator::new();
     let (mut root, _errors) = parse(&allocator, src);
     let opts = crate::options::TransformOptions {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   359 |               558 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   367 |               550 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -163,10 +163,10 @@ compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescrip
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	raw_oxc	raw OXC	raw	oxc_codegen	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/expression/typescript.rs	6	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/hoist_static.rs	16	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/hoist_static/props.rs	3	s0	S0	stage	vize_carton	compat	3
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/hoist_static/static_type.rs	10	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/hoist_static/tests.rs	5	s0	S0	stage	vize_carton	compat	3
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/hoist_static.rs	16	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/hoist_static/props.rs	3	s0	S0	stage	vize_s0	preferred	3
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/hoist_static/static_type.rs	10	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/hoist_static/tests.rs	5	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy_filters.rs	23	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy.rs	45	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy.rs	45	old_ast	old AST/parser	old	vize_armature	legacy	1

--- a/tests/tooling/davinci-atelier-core-hoist-static-stage-alias.test.mjs
+++ b/tests/tooling/davinci-atelier-core-hoist-static-stage-alias.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { scanConsumerMigrationSurfaces } from "../../tools/davinci/lib/consumer-migration-scan.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const hoistStaticRows = [
+  ["crates/vize_atelier_core/src/steps/hoist_static.rs", "test", 1],
+  ["crates/vize_atelier_core/src/steps/hoist_static/props.rs", "source", 3],
+  ["crates/vize_atelier_core/src/steps/hoist_static/static_type.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/hoist_static/tests.rs", "test", 3],
+];
+
+function compiler() {
+  const scan = scanConsumerMigrationSurfaces();
+  const consumer = scan.consumers.find((candidate) => candidate.id === "compiler");
+  assert.ok(consumer);
+  return consumer;
+}
+
+void test("Atelier core hoist static steps import S0 through the preferred name", () => {
+  const rows = compiler().fileRows;
+
+  for (const [relPath, mode, sites] of hoistStaticRows) {
+    const row = rows.find((candidate) => candidate.relPath === relPath && candidate.mode === mode);
+    assert.ok(row, `${relPath} (${mode})`);
+    assert.equal(row.surfaceCounts.s0, sites, relPath);
+    assert.equal(row.surfaceNameCounts.s0.vize_s0, sites, relPath);
+    assert.equal(row.surfaceNameCounts.s0.vize_carton ?? 0, 0, relPath);
+
+    const source = fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+    assert.doesNotMatch(source, /\bvize_carton\b/u, relPath);
+  }
+
+  const compatRows = rows
+    .filter(
+      (row) =>
+        row.relPath === "crates/vize_atelier_core/src/steps/hoist_static.rs" ||
+        row.relPath.startsWith("crates/vize_atelier_core/src/steps/hoist_static/"),
+    )
+    .filter((row) => (row.surfaceNameCounts.s0.vize_carton ?? 0) > 0)
+    .map((row) => `${row.relPath}:${row.mode}`);
+  assert.deepEqual(compatRows, []);
+});


### PR DESCRIPTION
## Summary

- move the hoist_static transform step's S0 imports from `vize_carton` to `vize_s0`
- refresh the Davinci consumer-migration ledger for the 8 moved S0 sites
- add a focused tooling guard for the hoist_static migration rows

Closes #5104

## Non-goals

- no rollout change
- no removal of the remaining crate-level compatibility alias
- no behavior change to compiler output

## Local validation

- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `git diff --check`
- `rg -n '\bvize_carton\b' crates/vize_atelier_core/src/steps/hoist_static.rs crates/vize_atelier_core/src/steps/hoist_static` (no output)
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/davinci-atelier-core-hoist-static-stage-alias.test.mjs tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check --locked -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy --locked -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --lib steps::hoist_static -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --test davinci_s2_transform -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features davinci-differential --test davinci_s2_transform_corpus -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 -- --nocapture`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.mjs`
- `vp run --workspace-root source:lengths`
- `vp run --workspace-root check:ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790441446&installation_model_id=422833&pr_number=5105&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5105&signature=22158dacad9e4f7b8b1e1d474e3658a8bb30bf8b5de65d8e9d5cfe2405dc73cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated static content processing to use the latest preferred platform interfaces.
  * Improved consistency across static hoisting and property-processing workflows.
  * Refined compiler surface classifications for clearer migration tracking.

* **Tests**
  * Added coverage to verify preferred interface usage and prevent legacy references in static hoisting components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->