### PR TITLE
refactor(atelier): import legacy steps through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/steps/legacy.rs
+++ b/crates/vize_atelier_core/src/steps/legacy.rs
@@ -43,7 +43,7 @@
 //! dialect (its call site is guarded by `supports_v2_event_sugar`).
 
 use vize_armature::legacy::LegacyDialectCapabilities;
-use vize_carton::{Allocator, Box, String, Vec, ensure_sufficient_stack};
+use vize_s0::{Allocator, Box, String, Vec, ensure_sufficient_stack};
 
 use crate::{
     DirectiveNode, ElementNode, ExpressionNode, PropNode, RootNode, SimpleExpressionNode,

--- a/crates/vize_atelier_core/src/steps/legacy/tests.rs
+++ b/crates/vize_atelier_core/src/steps/legacy/tests.rs
@@ -11,12 +11,12 @@ mod legacy_desugar_tests {
     use crate::parser::parse;
     use crate::{SimpleExpressionNode, SourceLocation};
     use vize_armature::legacy::{LegacyDialectCapabilities, LegacyVueVersion};
-    use vize_carton::Vec as ArenaVec;
-    use vize_carton::config::VueVersion;
+    use vize_s0::Vec as ArenaVec;
+    use vize_s0::config::VueVersion;
 
     /// Full lane (parse -> transform -> codegen) under a given dialect.
     fn compile(src: &str, dialect: VueVersion) -> std::string::String {
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let (mut root, errs) = parse(&allocator, src);
         assert!(errs.is_empty(), "parse errors: {errs:?}");
         let opts = TransformOptions {
@@ -53,7 +53,7 @@ mod legacy_desugar_tests {
 
     #[test]
     fn sync_modifier_desugars_to_bind_plus_update_listener() {
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let source = r#"<Comp :foo.sync="bar" />"#;
         let (mut root, errs) = parse(&allocator, source);
         assert!(errs.is_empty());
@@ -87,7 +87,7 @@ mod legacy_desugar_tests {
 
     #[test]
     fn sync_modifier_preserves_other_modifiers() {
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         // `.sync` alongside another modifier: only `sync` is stripped.
         let (mut root, _) = parse(&allocator, r#"<Comp :foo.sync.camel="bar" />"#);
         desugar_legacy_template(&allocator, &mut root, v2_caps());
@@ -102,7 +102,7 @@ mod legacy_desugar_tests {
 
     #[test]
     fn template_slot_scope_desugars_to_v_slot() {
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let source = r#"<Comp><template slot="header" slot-scope="props">x</template></Comp>"#;
         let (mut root, _) = parse(&allocator, source);
         desugar_legacy_template(&allocator, &mut root, v2_caps());
@@ -139,7 +139,7 @@ mod legacy_desugar_tests {
 
     #[test]
     fn scope_alias_desugars_to_default_v_slot() {
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         // `scope` (2.1 alias) with no `slot=` => default slot.
         let source = r#"<Comp><template scope="props">x</template></Comp>"#;
         let (mut root, _) = parse(&allocator, source);
@@ -163,7 +163,7 @@ mod legacy_desugar_tests {
 
     #[test]
     fn vue3_dialect_is_a_noop() {
-        let allocator = vize_carton::Allocator::new();
+        let allocator = vize_s0::Allocator::new();
         let (mut root, _) = parse(
             &allocator,
             r#"<Comp :foo.sync="bar"><template slot-scope="props">x</template></Comp>"#,

--- a/crates/vize_atelier_core/src/steps/legacy_filters.rs
+++ b/crates/vize_atelier_core/src/steps/legacy_filters.rs
@@ -20,7 +20,7 @@
 //! literals, or `()[]{}` nesting are not filter separators, and `||` is the
 //! logical-OR operator, never a filter.
 
-use vize_carton::String;
+use vize_s0::String;
 
 use super::expression::is_simple_identifier;
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   367 |               550 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   377 |               540 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -167,10 +167,10 @@ compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/hoist_static.rs	16
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/hoist_static/props.rs	3	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/hoist_static/static_type.rs	10	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/hoist_static/tests.rs	5	s0	S0	stage	vize_s0	preferred	3
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy_filters.rs	23	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy.rs	45	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy_filters.rs	23	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy.rs	45	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy.rs	45	old_ast	old AST/parser	old	vize_armature	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/legacy/tests.rs	13	s0	S0	stage	vize_carton	compat	8
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/legacy/tests.rs	13	s0	S0	stage	vize_s0	preferred	8
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/legacy/tests.rs	13	old_ast	old AST/parser	old	vize_armature	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/text.rs	5	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_bind.rs	5	s0	S0	stage	vize_carton	compat	2

--- a/tests/tooling/davinci-atelier-core-legacy-stage-alias.test.mjs
+++ b/tests/tooling/davinci-atelier-core-legacy-stage-alias.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { scanConsumerMigrationSurfaces } from "../../tools/davinci/lib/consumer-migration-scan.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const legacyRows = [
+  ["crates/vize_atelier_core/src/steps/legacy.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/legacy_filters.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/legacy/tests.rs", "test", 8],
+];
+
+function compiler() {
+  const scan = scanConsumerMigrationSurfaces();
+  const consumer = scan.consumers.find((candidate) => candidate.id === "compiler");
+  assert.ok(consumer);
+  return consumer;
+}
+
+void test("Atelier core legacy steps import S0 through the preferred name", () => {
+  const rows = compiler().fileRows;
+
+  for (const [relPath, mode, sites] of legacyRows) {
+    const row = rows.find((candidate) => candidate.relPath === relPath && candidate.mode === mode);
+    assert.ok(row, `${relPath} (${mode})`);
+    assert.equal(row.surfaceCounts.s0, sites, relPath);
+    assert.equal(row.surfaceNameCounts.s0.vize_s0, sites, relPath);
+    assert.equal(row.surfaceNameCounts.s0.vize_carton ?? 0, 0, relPath);
+
+    const source = fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+    assert.doesNotMatch(source, /\bvize_carton\b/u, relPath);
+  }
+
+  const compatRows = rows
+    .filter((row) => row.relPath.startsWith("crates/vize_atelier_core/src/steps/legacy"))
+    .filter((row) => (row.surfaceNameCounts.s0.vize_carton ?? 0) > 0)
+    .map((row) => `${row.relPath}:${row.mode}`);
+  assert.deepEqual(compatRows, []);
+});


### PR DESCRIPTION
## Summary

- move legacy-step S0 references from `vize_carton` to `vize_s0`
- refresh the Davinci consumer-migration ledger for the 10 moved S0 sites
- add a focused tooling guard for the legacy-step migration rows

Closes #5106

## Non-goals

- no rollout change
- no removal of the remaining crate-level compatibility alias
- no behavior change to compiler output or Vue 2 legacy sugar handling

## Local validation

- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `git diff --check`
- `rg -n '\bvize_carton\b' crates/vize_atelier_core/src/steps/legacy.rs crates/vize_atelier_core/src/steps/legacy_filters.rs crates/vize_atelier_core/src/steps/legacy/tests.rs` (no output)
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/davinci-atelier-core-legacy-stage-alias.test.mjs tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check --locked -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy --locked -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features legacy steps::legacy -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features legacy legacy -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features legacy`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --test davinci_s2_transform -- --nocapture`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.mjs`
- `vp install --frozen-lockfile --prefer-offline`
- `vp run --workspace-root source:lengths`
- `vp run --workspace-root check:ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790444584&installation_model_id=422833&pr_number=5107&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5107&signature=5cc13a49b494994a7bc5832dd10e8d6d3ef1bd19ab4df41088a29b3d3cf55c52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Migrated legacy Atelier components and tests to use the S0 allocator and string types.
  - Reduced remaining compatibility references while preserving existing behavior.

- **Tests**
  - Added regression coverage to ensure legacy sources use the updated S0 imports and contain no outdated compatibility references.

- **Documentation**
  - Updated compiler migration metrics to reflect the latest stage-name adoption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->