### PR TITLE
refactor(atelier): import directive steps through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/steps/text.rs
+++ b/crates/vize_atelier_core/src/steps/text.rs
@@ -2,7 +2,7 @@
 //!
 //! Transforms text nodes and interpolation nodes.
 
-use vize_carton::{String, Vec};
+use vize_s0::{String, Vec};
 
 use crate::lane::TransformContext;
 use crate::{ExpressionNode, RuntimeHelper, TemplateChildNode};

--- a/crates/vize_atelier_core/src/steps/v_bind.rs
+++ b/crates/vize_atelier_core/src/steps/v_bind.rs
@@ -2,7 +2,7 @@
 //!
 //! Transforms v-bind (: shorthand) directives for dynamic props.
 
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::lane::TransformContext;
 use crate::{DirectiveNode, ExpressionNode, RuntimeHelper};
@@ -83,8 +83,8 @@ pub fn is_dynamic_binding(dir: &DirectiveNode<'_>) -> bool {
     }
 }
 
-// Re-export camelize from vize_carton
-pub use vize_carton::camelize;
+// Re-export camelize from S0.
+pub use vize_s0::camelize;
 
 #[cfg(test)]
 mod tests {

--- a/crates/vize_atelier_core/src/steps/v_for.rs
+++ b/crates/vize_atelier_core/src/steps/v_for.rs
@@ -2,7 +2,7 @@
 //!
 //! Transforms elements with v-for directive into ForNode.
 
-use vize_carton::{Allocator, Box};
+use vize_s0::{Allocator, Box};
 
 use crate::lane::TransformContext;
 use crate::{
@@ -273,7 +273,7 @@ mod tests {
     };
     use crate::TemplateChildNode;
     use crate::parser::parse;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     fn parse_for<'a>(allocator: &'a Allocator, content: &'a str) -> ForParseResult<'a> {
         parse_for_expression(allocator, content, &SourceLocation::STUB)

--- a/crates/vize_atelier_core/src/steps/v_if.rs
+++ b/crates/vize_atelier_core/src/steps/v_if.rs
@@ -66,7 +66,7 @@ mod tests {
     use super::{has_v_else, has_v_else_if, has_v_if};
     use crate::TemplateChildNode;
     use crate::parser::parse;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn test_has_v_if() {

--- a/crates/vize_atelier_core/src/steps/v_memo.rs
+++ b/crates/vize_atelier_core/src/steps/v_memo.rs
@@ -2,8 +2,8 @@
 //!
 //! Transforms v-memo directives for memoized rendering.
 
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 use crate::lane::TransformContext;
 use crate::{ElementNode, ExpressionNode, PropNode, RuntimeHelper};
@@ -98,7 +98,7 @@ mod tests {
     use super::{get_memo_deps, has_v_memo};
     use crate::TemplateChildNode;
     use crate::parser::parse;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn test_has_v_memo() {

--- a/crates/vize_atelier_core/src/steps/v_model.rs
+++ b/crates/vize_atelier_core/src/steps/v_model.rs
@@ -5,7 +5,7 @@
 use oxc_ast::ast::Expression;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{Box, String, Vec};
+use vize_s0::{Box, String, Vec};
 
 use crate::lane::TransformContext;
 use crate::{
@@ -291,7 +291,7 @@ pub fn get_model_event_prop(el: &ElementNode<'_>) -> (&'static str, &'static str
 mod tests {
     use super::{SimpleExpressionNode, Vec, parse_model_modifiers, supports_v_model};
     use crate::SourceLocation;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn test_parse_modifiers() {

--- a/crates/vize_atelier_core/src/steps/v_on.rs
+++ b/crates/vize_atelier_core/src/steps/v_on.rs
@@ -2,7 +2,7 @@
 //!
 //! Transforms v-on (@ shorthand) directives for event handling.
 
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::lane::TransformContext;
 use crate::{DirectiveNode, ExpressionNode, SimpleExpressionNode};
@@ -93,8 +93,8 @@ pub fn is_dynamic_event(dir: &DirectiveNode<'_>) -> bool {
     }
 }
 
-// Use utilities from vize_carton
-use vize_carton::{camelize, capitalize};
+// Use utilities from S0.
+use vize_s0::{camelize, capitalize};
 
 /// Create on-event name from event name
 /// Converts kebab-case to camelCase (e.g., "select-koma" -> "onSelectKoma")
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn test_camelize() {
-        // Using vize_carton::camelize (re-exported in this module)
+        // Using S0 camelize (re-exported in this module).
         assert_eq!(camelize("select-koma").as_str(), "selectKoma");
         assert_eq!(camelize("update-value").as_str(), "updateValue");
         assert_eq!(camelize("my-custom-event").as_str(), "myCustomEvent");

--- a/crates/vize_atelier_core/src/steps/v_once.rs
+++ b/crates/vize_atelier_core/src/steps/v_once.rs
@@ -4,8 +4,8 @@
 
 use crate::lane::TransformContext;
 use crate::{ElementNode, PropNode, RuntimeHelper};
-use vize_carton::String;
-use vize_carton::ToCompactString;
+use vize_s0::String;
+use vize_s0::ToCompactString;
 
 /// Check if element has v-once directive
 pub fn has_v_once(el: &ElementNode<'_>) -> bool {
@@ -56,7 +56,7 @@ mod tests {
     use super::has_v_once;
     use crate::TemplateChildNode;
     use crate::parser::parse;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn test_has_v_once() {

--- a/crates/vize_atelier_core/src/steps/v_slot.rs
+++ b/crates/vize_atelier_core/src/steps/v_slot.rs
@@ -2,7 +2,7 @@
 //!
 //! Transforms v-slot (# shorthand) directives for slot content.
 
-use vize_carton::{String, ensure_sufficient_stack};
+use vize_s0::{String, ensure_sufficient_stack};
 
 use crate::lane::TransformContext;
 use crate::{
@@ -105,7 +105,7 @@ fn has_implicit_child(child: &TemplateChildNode<'_>) -> bool {
 }
 
 /// Guarded: `v-if`/`v-for` nodes nest, so this descends once per nesting level
-/// and its depth is bounded by the input (`vize_carton::recursion`).
+/// and its depth is bounded by the input (`vize_s0::recursion`).
 fn any_implicit_child(children: &[TemplateChildNode<'_>]) -> bool {
     ensure_sufficient_stack(|| children.iter().any(has_implicit_child))
 }

--- a/crates/vize_atelier_core/src/steps/v_slot/params.rs
+++ b/crates/vize_atelier_core/src/steps/v_slot/params.rs
@@ -3,7 +3,7 @@
 use oxc_ast::ast::BindingPattern;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::{SmallVec, String};
+use vize_s0::{SmallVec, String};
 
 use crate::steps::expression::expression_is_safe_to_parse;
 

--- a/crates/vize_atelier_core/src/steps/v_slot/tests.rs
+++ b/crates/vize_atelier_core/src/steps/v_slot/tests.rs
@@ -5,7 +5,7 @@ use crate::lane::traverse::traverse_children;
 use crate::lane::{ParentNode, TransformContext};
 use crate::options::TransformOptions;
 use crate::parser::parse;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 fn transform_errors(source: &str) -> std::vec::Vec<CompilerError> {
     let allocator = Allocator::new();

--- a/crates/vize_atelier_core/src/steps/v_slot/validate.rs
+++ b/crates/vize_atelier_core/src/steps/v_slot/validate.rs
@@ -1,6 +1,6 @@
 //! `v-slot` placement and slot-template structure validation.
 
-use vize_carton::{String, is_builtin_directive};
+use vize_s0::{String, is_builtin_directive};
 
 use super::{
     find_v_slot, get_slot_name, has_implicit_child, has_structural_slot_directive,

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   377 |               540 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   397 |               520 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -172,26 +172,26 @@ compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy.rs	45	s0	S0	s
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/legacy.rs	45	old_ast	old AST/parser	old	vize_armature	legacy	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/legacy/tests.rs	13	s0	S0	stage	vize_s0	preferred	8
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/legacy/tests.rs	13	old_ast	old AST/parser	old	vize_armature	legacy	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/text.rs	5	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_bind.rs	5	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_for.rs	5	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_for.rs	276	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_if.rs	69	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_memo.rs	5	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_memo.rs	101	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_model.rs	5	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/text.rs	5	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_bind.rs	5	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_for.rs	5	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_for.rs	276	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_if.rs	69	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_memo.rs	5	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_memo.rs	101	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_model.rs	5	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_model.rs	5	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_model.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_model.rs	294	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_on.rs	5	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_once.rs	7	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_once.rs	59	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot.rs	5	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/params.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_model.rs	294	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_on.rs	5	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_once.rs	7	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_once.rs	59	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot.rs	5	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/params.rs	3	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/params.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	2
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/params.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_slot/tests.rs	8	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/validate.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_slot/tests.rs	8	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/validate.rs	3	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/test_macros.rs	17	s0	S0	stage	vize_carton	compat	12
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/conditional_named_slots.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform_vue2.rs	24	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-atelier-core-directive-stage-alias.test.mjs
+++ b/tests/tooling/davinci-atelier-core-directive-stage-alias.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { scanConsumerMigrationSurfaces } from "../../tools/davinci/lib/consumer-migration-scan.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const directiveRows = [
+  ["crates/vize_atelier_core/src/steps/text.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/v_bind.rs", "source", 2],
+  ["crates/vize_atelier_core/src/steps/v_for.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/v_for.rs", "test", 1],
+  ["crates/vize_atelier_core/src/steps/v_if.rs", "test", 1],
+  ["crates/vize_atelier_core/src/steps/v_memo.rs", "source", 2],
+  ["crates/vize_atelier_core/src/steps/v_memo.rs", "test", 1],
+  ["crates/vize_atelier_core/src/steps/v_model.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/v_model.rs", "test", 1],
+  ["crates/vize_atelier_core/src/steps/v_on.rs", "source", 2],
+  ["crates/vize_atelier_core/src/steps/v_once.rs", "source", 2],
+  ["crates/vize_atelier_core/src/steps/v_once.rs", "test", 1],
+  ["crates/vize_atelier_core/src/steps/v_slot.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/v_slot/params.rs", "source", 1],
+  ["crates/vize_atelier_core/src/steps/v_slot/tests.rs", "test", 1],
+  ["crates/vize_atelier_core/src/steps/v_slot/validate.rs", "source", 1],
+];
+
+function compiler() {
+  const scan = scanConsumerMigrationSurfaces();
+  const consumer = scan.consumers.find((candidate) => candidate.id === "compiler");
+  assert.ok(consumer);
+  return consumer;
+}
+
+void test("Atelier core directive steps import S0 through the preferred name", () => {
+  const rows = compiler().fileRows;
+
+  for (const [relPath, mode, sites] of directiveRows) {
+    const row = rows.find((candidate) => candidate.relPath === relPath && candidate.mode === mode);
+    assert.ok(row, `${relPath} (${mode})`);
+    assert.equal(row.surfaceCounts.s0, sites, relPath);
+    assert.equal(row.surfaceNameCounts.s0.vize_s0, sites, relPath);
+    assert.equal(row.surfaceNameCounts.s0.vize_carton ?? 0, 0, relPath);
+
+    const source = fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+    assert.doesNotMatch(source, /\bvize_carton\b/u, relPath);
+  }
+
+  const migratedPaths = new Set(directiveRows.map(([relPath]) => relPath));
+  const compatRows = rows
+    .filter((row) => migratedPaths.has(row.relPath))
+    .filter((row) => (row.surfaceNameCounts.s0.vize_carton ?? 0) > 0)
+    .map((row) => `${row.relPath}:${row.mode}`);
+  assert.deepEqual(compatRows, []);
+});


### PR DESCRIPTION
## Summary

- move atelier core directive/text step modules from the S0 compat code-name import (`vize_carton`) to the preferred physical import (`vize_s0`)
- add a Davinci tooling guard that keeps this step slice on the preferred S0 name
- regenerate the consumer migration ledger (`Compiler` preferred stage names 377 -> 397, compat code names 540 -> 520)

Fixes #5108

## Testing

- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/davinci-atelier-core-directive-stage-alias.test.mjs tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts`
- `git diff --check`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check --locked -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check --locked -p vize_atelier_core --all-targets --all-features`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy --locked -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features legacy`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features davinci-differential --test davinci_s2_transform_corpus -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --test davinci_s2_transform -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 -- --nocapture`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.mjs`
- `vp install --frozen-lockfile --prefer-offline`
- `vp run --workspace-root source:lengths`
- `vp run --workspace-root check:ci`

## Note

`cargo clippy --locked -p vize_atelier_core --all-targets --all-features -- -D warnings -D clippy::wildcard_imports` still trips pre-existing lint debt in unrelated test files (`chunks_exact`, disallowed `format!`/`String`, and `field_reassign_with_default`); this PR does not touch those files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790446985&installation_model_id=422833&pr_number=5109&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5109&signature=dcc886b0abd8ca05c24f3a79f85512e3707d197e1499b9abda7c666a76e9677b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated directive processing components to use the current shared runtime interfaces.
  * Completed migration of directive-related code away from legacy compatibility names.

* **Documentation**
  * Updated migration tracking to reflect the increased number of preferred stage names.

* **Tests**
  * Added coverage verifying migrated directive stages use preferred names and contain no remaining legacy references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->