### PR TITLE
refactor(atelier): import internal tests through s0 alias

### DIFF
--- a/crates/vize_atelier_core/src/codegen/tests.rs
+++ b/crates/vize_atelier_core/src/codegen/tests.rs
@@ -2,9 +2,8 @@
 
 use crate::compile;
 
-fn result_output(result: &super::CodegenResult) -> vize_carton::String {
-    let mut output =
-        vize_carton::String::with_capacity(result.preamble.len() + result.code.len() + 1);
+fn result_output(result: &super::CodegenResult) -> vize_s0::String {
+    let mut output = vize_s0::String::with_capacity(result.preamble.len() + result.code.len() + 1);
     output.push_str(&result.preamble);
     output.push('\n');
     output.push_str(&result.code);
@@ -45,9 +44,9 @@ fn test_codegen_component() {
 
 #[test]
 fn test_codegen_component_name_with_colon_uses_valid_identifier() {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let parser_opts = crate::ParserOptions {
-        is_native_tag: Some(vize_carton::is_native_tag),
+        is_native_tag: Some(vize_s0::is_native_tag),
         ..Default::default()
     };
     let (mut root, errors) = crate::parse_with_options(
@@ -92,16 +91,16 @@ fn test_codegen_self_component_resolve_marks_maybe_self_reference() {
 
 #[test]
 fn test_codegen_inline_setup_ref_component_prop_uses_value() {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = crate::parse(&allocator, r#"<Child :initialText="initialText" />"#);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
 
-    let mut bindings = vize_carton::FxHashMap::default();
+    let mut bindings = vize_s0::FxHashMap::default();
     bindings.insert("Child".into(), crate::BindingType::SetupConst);
     bindings.insert("initialText".into(), crate::BindingType::SetupRef);
     let binding_metadata = crate::BindingMetadata {
         bindings,
-        props_aliases: vize_carton::FxHashMap::default(),
+        props_aliases: vize_s0::FxHashMap::default(),
         is_script_setup: true,
     };
 
@@ -190,7 +189,7 @@ fn test_codegen_duplicate_attribute_keeps_first_occurrence() {
     // diagnostic is classified as recoverable so downstream
     // continues. The compile macro bails on parse errors, so this
     // test drives the lane by hand.
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = crate::parser::parse(&allocator, r#"<div id="a" id="b">x</div>"#);
     assert!(
         errors
@@ -463,7 +462,7 @@ fn test_codegen_looped_slot_key_and_index_aliases_stay_local_in_dynamic_args() {
     use crate::lane::transform;
     use crate::options::{CodegenOptions, TransformOptions};
     use crate::parser::parse;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     let allocator = Allocator::new();
     let (mut root, _) = parse(
@@ -622,7 +621,7 @@ fn test_codegen_v_for_aliases_without_parentheses_stay_local() {
     use crate::lane::transform;
     use crate::options::{CodegenOptions, TransformOptions};
     use crate::parser::parse;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     let allocator = Allocator::new();
     let (mut root, _) = parse(
@@ -670,7 +669,7 @@ fn test_codegen_v_for_scope_handlers_are_not_cached() {
     use crate::lane::transform;
     use crate::options::{CodegenOptions, TransformOptions};
     use crate::parser::parse;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     let allocator = Allocator::new();
     let (mut root, _) = parse(
@@ -705,7 +704,7 @@ fn test_codegen_merged_v_on_handlers_are_cached() {
     use crate::lane::transform;
     use crate::options::{CodegenOptions, TransformOptions};
     use crate::parser::parse;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     let allocator = Allocator::new();
     let (mut root, _) = parse(
@@ -842,7 +841,7 @@ fn test_codegen_scoped_slot_params_stay_local_in_handlers() {
     use crate::lane::transform;
     use crate::options::{CodegenOptions, TransformOptions};
     use crate::parser::parse;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     let allocator = Allocator::new();
     let (mut root, _) = parse(
@@ -908,8 +907,8 @@ fn test_codegen_escape_multiline_style_attribute() {
     assert_codegen_snapshot!(result);
 }
 
-fn compile_prefixed(source: &str) -> vize_carton::String {
-    let allocator = vize_carton::Allocator::new();
+fn compile_prefixed(source: &str) -> vize_s0::String {
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = crate::parse(&allocator, source);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
     crate::lane::transform(
@@ -1011,8 +1010,8 @@ fn test_codegen_v1_triple_mustache_is_raw_unescaped() {
     use crate::lane::transform;
     use crate::options::{CodegenOptions, ParserOptions, TransformOptions};
     use crate::parser::parse_with_options;
-    use vize_carton::Allocator;
-    use vize_carton::config::VueVersion;
+    use vize_s0::Allocator;
+    use vize_s0::config::VueVersion;
 
     let allocator = Allocator::new();
     let mut options = ParserOptions::default();
@@ -1143,7 +1142,7 @@ fn decode_mappings(mappings: &str) -> Vec<DecodedSegment> {
 /// Compile a template with `prefix_identifiers` so dynamic expressions surface
 /// as `_ctx.<name>` in the output (the interesting mapping case).
 fn compile_with_map(src: &str, filename: &str) -> super::CodegenResult {
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = crate::parser::parse(&allocator, src);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
     crate::lane::transform(
@@ -1249,7 +1248,7 @@ fn source_map_does_not_alter_generated_code() {
 
     let with_map = compile_with_map(src, "Foo.vue");
 
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = crate::parser::parse(&allocator, src);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
     crate::lane::transform(
@@ -1458,7 +1457,7 @@ fn source_map_static_attr_and_text_do_not_alter_generated_code() {
 
     let with_map = compile_with_map(src, "Foo.vue");
 
-    let allocator = vize_carton::Allocator::new();
+    let allocator = vize_s0::Allocator::new();
     let (mut root, errors) = crate::parser::parse(&allocator, src);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
     crate::lane::transform(

--- a/crates/vize_atelier_core/src/lane/structural/tests.rs
+++ b/crates/vize_atelier_core/src/lane/structural/tests.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 #[allow(clippy::disallowed_macros)]
 mod structural_transform_tests {
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     use super::super::super::traverse::traverse_children;
     use super::super::*;

--- a/crates/vize_atelier_core/src/lane/tests.rs
+++ b/crates/vize_atelier_core/src/lane/tests.rs
@@ -4,7 +4,7 @@ use super::{transform, transform_with_template_syntax_quirks};
 use crate::codegen::generate;
 use crate::options::{CodegenOptions, TransformOptions};
 use crate::parser::parse;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn test_transform_simple_element() {

--- a/crates/vize_atelier_core/src/retained/tests.rs
+++ b/crates/vize_atelier_core/src/retained/tests.rs
@@ -17,7 +17,7 @@ use crate::lane::transform;
 use crate::options::{CodegenOptions, TransformOptions};
 use crate::parser::Parser;
 use crate::retained::differential;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 const BATTERY: &str = r#"<div :style="{ zIndex: items.length + 1 }" :data-x="alpha + beta">
   {{ items.filter(item => item.id > 0).length / total }}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           917 |                   397 |               520 |             139 |     371 |             952 |      475 |           477 |           585 |
+| Compiler                   |           917 |                   420 |               497 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           890 |                   166 |               724 |             396 |     187 |             806 |      667 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -78,7 +78,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/slots/params.rs	4	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/slots/tests.rs	5	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/source_map.rs	35	s0	S0	stage	vize_s0	preferred	3
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	s0	S0	stage	vize_carton	compat	20
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	s0	S0	stage	vize_s0	preferred	20
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/codegen/tests.rs	5	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for.rs	20	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	source	crates/vize_atelier_core/src/codegen/v_for/generate.rs	34	s0	S0	stage	vize_s0	preferred	3
@@ -105,8 +105,8 @@ compiler	Compiler	source	crates/vize_atelier_core/src/lane/patterned_template.rs
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural_keys.rs	3	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/structural/tests.rs	7	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/tests.rs	7	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/structural/tests.rs	7	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/tests.rs	7	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/traverse.rs	8	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	s0	S0	stage	vize_carton	compat	1
@@ -116,7 +116,7 @@ compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	old_ast	old
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_core/src/retained/tests.rs	20	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_core/src/retained/tests.rs	20	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/runtime_helpers.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/element.rs	5	s0	S0	stage	vize_s0	preferred	3
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/element.rs	307	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-atelier-core-internal-test-stage-alias.test.mjs
+++ b/tests/tooling/davinci-atelier-core-internal-test-stage-alias.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { scanConsumerMigrationSurfaces } from "../../tools/davinci/lib/consumer-migration-scan.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const internalTestRows = [
+  ["crates/vize_atelier_core/src/codegen/tests.rs", "test", 20],
+  ["crates/vize_atelier_core/src/lane/tests.rs", "test", 1],
+  ["crates/vize_atelier_core/src/lane/structural/tests.rs", "test", 1],
+  ["crates/vize_atelier_core/src/retained/tests.rs", "test", 1],
+];
+
+function compiler() {
+  const scan = scanConsumerMigrationSurfaces();
+  const consumer = scan.consumers.find((candidate) => candidate.id === "compiler");
+  assert.ok(consumer);
+  return consumer;
+}
+
+void test("Atelier core internal tests import S0 through the preferred name", () => {
+  const rows = compiler().fileRows;
+
+  for (const [relPath, mode, sites] of internalTestRows) {
+    const row = rows.find((candidate) => candidate.relPath === relPath && candidate.mode === mode);
+    assert.ok(row, `${relPath} (${mode})`);
+    assert.equal(row.surfaceCounts.s0, sites, relPath);
+    assert.equal(row.surfaceNameCounts.s0.vize_s0, sites, relPath);
+    assert.equal(row.surfaceNameCounts.s0.vize_carton ?? 0, 0, relPath);
+
+    const source = fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+    assert.doesNotMatch(source, /\bvize_carton\b/u, relPath);
+  }
+
+  const migratedPaths = new Set(internalTestRows.map(([relPath]) => relPath));
+  const compatRows = rows
+    .filter((row) => migratedPaths.has(row.relPath))
+    .filter((row) => (row.surfaceNameCounts.s0.vize_carton ?? 0) > 0)
+    .map((row) => `${row.relPath}:${row.mode}`);
+  assert.deepEqual(compatRows, []);
+});


### PR DESCRIPTION
Fixes #5110

## Summary

- move atelier core internal test S0 imports from `vize_carton` to the preferred `vize_s0` name
- refresh the Davinci consumer migration ledger for the 23 moved test/dev S0 sites
- add a focused tooling guard for the internal test slice

## Non-goals

- no rollout change
- no removal of the remaining crate-level `vize_carton` compatibility bridge
- no `test_macros.rs` macro-body migration; exported macros need a separate `$crate`-qualified compatibility strategy
- no compiler behavior or output change

## Acceptance

- `vize_carton` is absent from the migrated codegen/lane/retained internal test files
- `davinci-road/plan/consumer-migration-surfaces.*` records the moved sites as `vize_s0` preferred
- the focused tooling test prevents this internal test slice from drifting back to the compat name
- local validation and PR CI pass before merge

## Local validation

- `git diff --check origin/main...HEAD`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `NODE_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules node --test tests/tooling/davinci-atelier-core-internal-test-stage-alias.test.mjs tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-dependencies.test.ts`
- `cargo fmt --all -- --check`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo check --locked -p vize_atelier_core --all-targets --features legacy,davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --all-targets --no-run`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features legacy`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test --locked -p vize_atelier_core --features davinci-differential --test davinci_s2_transform_corpus -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo clippy --locked -p vize_atelier_core --lib --features legacy,davinci-differential -- -D warnings -D clippy::wildcard_imports`
- `vp install --frozen-lockfile --prefer-offline`
- `vp run --workspace-root check:ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790450571&installation_model_id=422833&pr_number=5111&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5111&signature=de87d6c61f08a30342b75a33a223cbd906d437313a4dda9f502af6a483b2708c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test coverage to use the current S0-based interfaces.
  * Added validation to detect remaining legacy compatibility references and confirm migration counts.

* **Documentation**
  * Updated compiler migration metrics to reflect the latest preferred and compatibility stage-name totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->