### PR TITLE
refactor(canon): import exact optional props guard through S0 alias

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/exact_optional_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/exact_optional_props.rs
@@ -14,7 +14,7 @@
 
 use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
 use std::path::Path;
-use vize_carton::String;
+use vize_s0::{String, cstr};
 
 const CHILD: &str = r#"<script setup lang="ts">
 defineProps<{ label?: string }>()
@@ -31,7 +31,7 @@ fn write_tsconfig(project_root: &Path, exact_optional: bool) {
     };
     std::fs::write(
         project_root.join("tsconfig.json"),
-        vize_carton::cstr!(
+        cstr!(
             r#"{{
   "compilerOptions": {{
     "strict": true,{exact}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -47,7 +47,7 @@ observational guard for planning only. It does not change rollout state.
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           917 |                   420 |               497 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
-| Typechecker                |           890 |                   206 |               684 |             396 |     187 |             806 |      667 |           466 |           659 |
+| Typechecker                |           889 |                   207 |               682 |             396 |     187 |             806 |      666 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
 | LSP                        |           271 |                   271 |                 0 |             115 |      44 |             325 |      105 |           166 |           388 |
@@ -134,7 +134,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         890 |             502 |      388 |
+| S0               |         889 |             502 |      387 |
 | old AST/parser   |         160 |              35 |      125 |
 | Croquis analysis |         236 |             118 |      118 |
 | raw OXC          |         187 |             151 |       36 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1581,7 +1581,7 @@ typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/diagnostic_normalization.rs	1	s0	S0	stage	vize_carton	compat	5
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_anchors.rs	11	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_values.rs	9	s0	S0	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/exact_optional_props.rs	17	s0	S0	stage	vize_carton	compat	2
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/exact_optional_props.rs	17	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/external_slot_payloads.rs	11	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/fallthrough_unknown_attrs.rs	14	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/generic_emit_guard.rs	6	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs
+++ b/tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs
@@ -16,6 +16,11 @@ const recentIssueRows = [
     1,
   ],
   [
+    "crates/vize_canon/src/batch/type_checker/tests/recent_issues/exact_optional_props.rs",
+    "test",
+    1,
+  ],
+  [
     "crates/vize_canon/src/batch/type_checker/tests/recent_issues/fallthrough_unknown_attrs.rs",
     "test",
     1,


### PR DESCRIPTION
## Summary

- migrate the `exactOptionalPropertyTypes` recent-issue guard from `vize_carton` to the preferred `vize_s0` alias
- add the file to the Canon recent-issues S0 alias guard
- regenerate the Davinci consumer migration surface inventory

Closes #5149

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `vp install --frozen-lockfile --prefer-offline`
- `node_modules/.bin/tsgo --version` -> `Version 7.0.0-dev.20260603.1`
- `node --test tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-atelier-core-internal-test-stage-alias.test.mjs`
- `CORSA_PATH="$PWD/node_modules/.bin/tsgo" VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib batch::type_checker::tests::recent_issues::exact_optional_props --features native,legacy -- --nocapture`
- `CORSA_PATH="$PWD/node_modules/.bin/tsgo" VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib batch::type_checker::tests::recent_issues --features native,legacy -- --nocapture`
- `cargo check -p vize_canon --all-targets --features native,legacy`
- `cargo clippy -p vize_canon --lib --features native,legacy -- -D warnings -D clippy::wildcard_imports`
- `vp run --workspace-root source:lengths --check --base-ref origin/main --max-lines 350 --limit 50`
- `vp run --workspace-root check:ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790480622&installation_model_id=422833&pr_number=5150&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5150&signature=d84e011ca94ba7457f5f64009e9c6ffd3c4006af53c33b8503cc2d6120dc1119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the exact optional properties recent-issue scenario.
  * Updated the test expectations to verify the preferred S0 import name and test-mode usage.

* **Documentation**
  * Updated consumer migration tracking to reflect the latest Typechecker and S0 surface counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->