### PR TITLE
refactor(canon): import diagnostic normalization guard through S0 alias

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/diagnostic_normalization.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/diagnostic_normalization.rs
@@ -1,4 +1,6 @@
-type DiagnosticSnapshot = Vec<(vize_carton::String, Option<u32>, vize_carton::String)>;
+use vize_s0::String;
+
+type DiagnosticSnapshot = Vec<(String, Option<u32>, String)>;
 
 /// Normalize TypeScript's target-side parameter labels in function assignment
 /// diagnostics while keeping the authored parameter, code, anchor, and type
@@ -22,7 +24,7 @@ pub(super) fn normalize_target_parameter_names(
 /// Replace only the generated side of `Types of parameters ...` diagnostic
 /// rows. TypeScript may report that side as a tuple label, callback parameter,
 /// or rest parameter name without changing the assignability behavior.
-fn normalize_target_parameter_name(message: &str) -> vize_carton::String {
+fn normalize_target_parameter_name(message: &str) -> String {
     let marker = "Types of parameters '";
     let separator = "' and '";
     let suffix = "' are incompatible.";
@@ -46,9 +48,9 @@ fn normalize_target_parameter_name(message: &str) -> vize_carton::String {
     }
 
     if normalized.is_empty() {
-        vize_carton::String::from(message)
+        String::from(message)
     } else {
         normalized.push_str(rest);
-        vize_carton::String::from(normalized)
+        String::from(normalized)
     }
 }

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -47,7 +47,7 @@ observational guard for planning only. It does not change rollout state.
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           917 |                   420 |               497 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
-| Typechecker                |           889 |                   207 |               682 |             396 |     187 |             806 |      666 |           466 |           659 |
+| Typechecker                |           885 |                   208 |               677 |             396 |     187 |             806 |      662 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
 | LSP                        |           271 |                   271 |                 0 |             115 |      44 |             325 |      105 |           166 |           388 |
@@ -134,7 +134,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         889 |             502 |      387 |
+| S0               |         885 |             502 |      383 |
 | old AST/parser   |         160 |              35 |      125 |
 | Croquis analysis |         236 |             118 |      118 |
 | raw OXC          |         187 |             151 |       36 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1578,7 +1578,7 @@ typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/package_exports_types.rs	7	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/component_options_index_signature.rs	39	s0	S0	stage	vize_carton	compat	3
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/css_side_effect_import.rs	19	s0	S0	stage	vize_carton	compat	2
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/diagnostic_normalization.rs	1	s0	S0	stage	vize_carton	compat	5
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/diagnostic_normalization.rs	1	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_anchors.rs	11	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_values.rs	9	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/exact_optional_props.rs	17	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs
+++ b/tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs
@@ -11,6 +11,11 @@ const recentIssueRows = [
   ["crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_anchors.rs", "test", 1],
   ["crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_values.rs", "test", 1],
   [
+    "crates/vize_canon/src/batch/type_checker/tests/recent_issues/diagnostic_normalization.rs",
+    "test",
+    1,
+  ],
+  [
     "crates/vize_canon/src/batch/type_checker/tests/recent_issues/external_slot_payloads.rs",
     "test",
     1,


### PR DESCRIPTION
## Summary

- migrate the `diagnostic_normalization` recent-issues helper from `vize_carton` to the preferred `vize_s0` alias
- add the helper to the Canon recent-issues S0 alias guard
- regenerate the Davinci consumer migration surface inventory so the row moves from compat `vize_carton` to preferred `vize_s0`

Closes #5151

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `vp install --frozen-lockfile --prefer-offline`
- `node_modules/.bin/tsgo --version` -> `Version 7.0.0-dev.20260603.1`
- `node --test tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-atelier-core-internal-test-stage-alias.test.mjs`
- `CORSA_PATH="$PWD/node_modules/.bin/tsgo" VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib batch::type_checker::tests::recent_issues::template_handler_ts7006 --features native,legacy -- --nocapture`
- `CORSA_PATH="$PWD/node_modules/.bin/tsgo" VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib batch::type_checker::tests::recent_issues --features native,legacy -- --nocapture`
- `cargo check -p vize_canon --all-targets --features native,legacy`
- `cargo clippy -p vize_canon --lib --features native,legacy -- -D warnings -D clippy::wildcard_imports`
- `vp run --workspace-root source:lengths --check --base-ref origin/main --max-lines 350 --limit 50`
- `vp run --workspace-root check:ci`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790482027&installation_model_id=422833&pr_number=5152&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5152&signature=df692245faaf6d69710cbb05fc32fb45c2989f3f2a9bf33de91d9763b2873620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in diagnostic data handling without changing normalization behavior.
  * Updated typechecker surface tracking to reflect the current inventory accurately.

* **Tests**
  * Expanded coverage for recent diagnostic issue files and preferred S0 import usage.

* **Documentation**
  * Refreshed consumer inventory counts to keep reported metrics aligned with the current codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->