### PR TITLE
refactor(canon): import v-for source callbacks through S0 alias

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/v_for_source_callbacks.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/v_for_source_callbacks.rs
@@ -1,6 +1,7 @@
 //! Diagnostics inside v-for source expressions must map back to authored bytes (#3756).
 
 use super::super::{create_project_case, resolve_test_tsgo_binary, snapshot_project_diagnostics};
+use vize_s0::String;
 
 #[test]
 fn v_for_source_callbacks_report_implicit_any_at_the_authored_parameter() {
@@ -29,9 +30,9 @@ const items: any = []
         // vue-tsc 3.3.4 with TypeScript 6.0.3, on the byte-identical fixture:
         // src/App.vue(6,36): error TS7006: Parameter 'value' implicitly has an 'any' type.
         Some(vec![(
-            vize_carton::String::from("src/App.vue"),
+            String::from("src/App.vue"),
             Some(7006),
-            vize_carton::String::from("6:36:error Parameter 'value' implicitly has an 'any' type."),
+            String::from("6:36:error Parameter 'value' implicitly has an 'any' type."),
         )]),
     );
 }
@@ -71,9 +72,9 @@ const items: any = []
     assert_eq!(
         snapshot,
         Some(vec![(
-            vize_carton::String::from("src/App.vue"),
+            String::from("src/App.vue"),
             Some(7006),
-            vize_carton::String::from("7:38:error Parameter 'value' implicitly has an 'any' type."),
+            String::from("7:38:error Parameter 'value' implicitly has an 'any' type."),
         )]),
     );
 }

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -47,7 +47,7 @@ observational guard for planning only. It does not change rollout state.
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           917 |                   420 |               497 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
-| Typechecker                |           885 |                   208 |               677 |             396 |     187 |             806 |      662 |           466 |           659 |
+| Typechecker                |           882 |                   209 |               673 |             396 |     187 |             806 |      659 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
 | LSP                        |           271 |                   271 |                 0 |             115 |      44 |             325 |      105 |           166 |           388 |
@@ -134,7 +134,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         885 |             502 |      383 |
+| S0               |         882 |             502 |      380 |
 | old AST/parser   |         160 |              35 |      125 |
 | Croquis analysis |         236 |             118 |      118 |
 | raw OXC          |         187 |             151 |       36 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1600,7 +1600,7 @@ typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/template_key_expressions/dialect_baselines.rs	12	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/ts_extension_substitution.rs	4	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/unmapped_template_fallback.rs	7	s0	S0	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/v_for_source_callbacks.rs	32	s0	S0	stage	vize_carton	compat	4
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/v_for_source_callbacks.rs	4	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/wide_props_type_complexity.rs	17	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/tsgo.rs	39	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/batch/virtual_project.rs	21	s0	S0	stage	vize_carton	compat	1

--- a/tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs
+++ b/tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs
@@ -87,6 +87,11 @@ const recentIssueRows = [
     1,
   ],
   [
+    "crates/vize_canon/src/batch/type_checker/tests/recent_issues/v_for_source_callbacks.rs",
+    "test",
+    1,
+  ],
+  [
     "crates/vize_canon/src/batch/type_checker/tests/recent_issues/global_component_callbacks.rs",
     "test",
     8,


### PR DESCRIPTION
## Summary
- import the v-for source callback recent issue test's S0 string type through `vize_s0::String`
- add the migrated file to the Davinci recent-issues S0 alias guard
- regenerate `davinci-road/plan/consumer-migration-surfaces.*` so the Typechecker inventory moves from compat to preferred naming

## Inventory movement
- `v_for_source_callbacks.rs`: `vize_carton` compat 4 -> `vize_s0` preferred 1
- Typechecker stage/Davinci: 885 -> 882
- Typechecker preferred: 208 -> 209
- Typechecker compat: 677 -> 673

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-atelier-core-internal-test-stage-alias.test.mjs`
- `vp install --frozen-lockfile --prefer-offline` (exited 0; known `musea-vrt` bin warnings)
- `node_modules/.bin/tsgo --version` -> `Version 7.0.0-dev.20260603.1`
- `CORSA_PATH="/private/tmp/vize-canon-v-for-source-callbacks-s0-alias/node_modules/.bin/tsgo" VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib batch::type_checker::tests::recent_issues::v_for_source_callbacks --features native,legacy -- --nocapture`
- `CORSA_PATH="/private/tmp/vize-canon-v-for-source-callbacks-s0-alias/node_modules/.bin/tsgo" VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib batch::type_checker::tests::recent_issues --features native,legacy -- --nocapture`
- `cargo check -p vize_canon --all-targets --features native,legacy`
- `cargo clippy -p vize_canon --lib --features native,legacy -- -D warnings -D clippy::wildcard_imports`
- `vp run --workspace-root source:lengths --check --base-ref origin/main --max-lines 350 --limit 50`
- `vp run --workspace-root check:ci`

Closes #5153

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790483417&installation_model_id=422833&pr_number=5154&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5154&signature=788a78e0811c0bb063bd32c17a561cb1df559fa82568c3465f6e6084b92dda36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated diagnostic expectations to reflect the current string representation while preserving the existing TypeScript error details.
  * Added coverage for a recent issue involving callback handling in `v-for` source expressions.
  * Refined test-stage alias validation for more accurate issue tracking.

* **Documentation**
  * Updated the consumer migration inventory to reflect current type-checker surface totals and compatibility coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->