### PR TITLE
refactor(canon): import component options index guard through S0 alias

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/component_options_index_signature.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/component_options_index_signature.rs
@@ -8,6 +8,7 @@
 //! generated options object cannot simply always declare one.
 
 use crate::sfc_typecheck::{SfcTypeCheckOptions, type_check_sfc};
+use vize_s0::String;
 
 const OPTIONS_TYPE_HEAD: &str = "type __VizeVueComponentOptions = {\n";
 const INDEX_SIGNATURE: &str = "  [key: string]: any;\n";
@@ -36,7 +37,7 @@ defineExpose({ pick });
 </template>
 "#;
 
-fn virtual_ts(source: &str) -> vize_carton::String {
+fn virtual_ts(source: &str) -> String {
     type_check_sfc(
         source,
         &SfcTypeCheckOptions::new("Child.vue").with_virtual_ts(),
@@ -47,7 +48,7 @@ fn virtual_ts(source: &str) -> vize_carton::String {
 
 /// The emitted `__VizeVueComponentOptions` opening, up to and including its
 /// first declared member.
-fn options_type_prologue(virtual_ts: &str) -> vize_carton::String {
+fn options_type_prologue(virtual_ts: &str) -> String {
     let start = virtual_ts
         .find(OPTIONS_TYPE_HEAD)
         .expect("generated module must declare __VizeVueComponentOptions");
@@ -56,7 +57,7 @@ fn options_type_prologue(virtual_ts: &str) -> vize_carton::String {
         .find(FIRST_DECLARED_MEMBER)
         .expect("__VizeVueComponentOptions must declare `name`")
         + FIRST_DECLARED_MEMBER.len();
-    vize_carton::String::from(&rest[..end])
+    String::from(&rest[..end])
 }
 
 #[test]

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -47,7 +47,7 @@ observational guard for planning only. It does not change rollout state.
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           917 |                   420 |               497 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
-| Typechecker                |           882 |                   210 |               672 |             396 |     187 |             806 |      659 |           466 |           659 |
+| Typechecker                |           880 |                   211 |               669 |             396 |     187 |             806 |      657 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
 | LSP                        |           271 |                   271 |                 0 |             115 |      44 |             325 |      105 |           166 |           388 |
@@ -134,7 +134,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         882 |             502 |      380 |
+| S0               |         880 |             502 |      378 |
 | old AST/parser   |         160 |              35 |      125 |
 | Croquis analysis |         236 |             118 |      118 |
 | raw OXC          |         187 |             151 |       36 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1576,7 +1576,7 @@ typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/no_unused/define_emits_unused.rs	111	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/options_api_required_props.rs	173	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/package_exports_types.rs	7	s0	S0	stage	vize_carton	compat	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/component_options_index_signature.rs	39	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/component_options_index_signature.rs	11	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/css_side_effect_import.rs	19	s0	S0	stage	vize_carton	compat	2
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/diagnostic_normalization.rs	1	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_anchors.rs	11	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs
+++ b/tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs
@@ -11,6 +11,11 @@ const recentIssueRows = [
   ["crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_anchors.rs", "test", 1],
   ["crates/vize_canon/src/batch/type_checker/tests/recent_issues/directive_values.rs", "test", 1],
   [
+    "crates/vize_canon/src/batch/type_checker/tests/recent_issues/component_options_index_signature.rs",
+    "test",
+    1,
+  ],
+  [
     "crates/vize_canon/src/batch/type_checker/tests/recent_issues/diagnostic_normalization.rs",
     "test",
     1,


### PR DESCRIPTION
## Summary
- Move component_options_index_signature.rs to the vize_s0 physical stage alias.
- Add it to the Canon recent-issue alias guard.
- Regenerate Davinci consumer migration surfaces.

## Inventory movement
- Typechecker preferred stage names: 210 -> 211
- Typechecker compat code names: 672 -> 669
- Typechecker S0 lexical sites: 882 -> 880

## Verification
- cargo fmt --all -- --check
- git diff --check
- node tools/davinci/consumer-migration-surfaces.mjs --check
- node --test tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-atelier-core-internal-test-stage-alias.test.mjs
- vp install --frozen-lockfile --prefer-offline
- node_modules/.bin/tsgo --version
- CORSA_PATH="$PWD/node_modules/.bin/tsgo" VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib batch::type_checker::tests::recent_issues::component_options_index_signature --features native,legacy -- --nocapture
- CORSA_PATH="$PWD/node_modules/.bin/tsgo" VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib batch::type_checker::tests::recent_issues --features native,legacy -- --nocapture
- cargo check -p vize_canon --all-targets --features native,legacy
- cargo clippy -p vize_canon --lib --features native,legacy -- -D warnings -D clippy::wildcard_imports
- vp run --workspace-root source:lengths --check --base-ref origin/main --max-lines 350 --limit 50
- vp run --workspace-root check:ci

Closes #5157

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790486258&installation_model_id=422833&pr_number=5158&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5158&signature=561d83b7f474006af38192ddc5bf99eddc44e31cca3d93aafb7de235c82fcac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for component option index signatures to verify preferred API naming and prevent legacy references.
  * Updated recent-issue validation fixtures to include the new compatibility check.

* **Documentation**
  * Updated the consumer migration inventory with refreshed Typechecker usage counts across source, compatibility, and test areas.

* **Maintenance**
  * Standardized test helper string handling without changing test behavior or assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->