### PR TITLE
refactor(canon): import options API bridge guard through S0 alias

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/options_api_bridge_anchors.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/options_api_bridge_anchors.rs
@@ -18,7 +18,7 @@ use super::super::{
     BatchTypeChecker, create_project_case, relative_path, resolve_test_tsgo_binary,
 };
 use crate::batch::TypeChecker;
-use vize_carton::cstr;
+use vize_s0::{String, cstr};
 
 /// A long template above the script block, so an authored offset and the
 /// matching generated offset can never coincide by accident.
@@ -96,9 +96,7 @@ fn options_api_method_diagnostics_anchor_on_the_authored_property() {
 /// The caller already gated on the two legitimate skips (no `tsgo` binary, no
 /// installed `vue`), so a checker error past that point is a real defect and
 /// must fail the test rather than collapse into a silent pass.
-fn legacy_vue2_diagnostics(
-    project_root: &Path,
-) -> Vec<(vize_carton::String, Option<u32>, vize_carton::String)> {
+fn legacy_vue2_diagnostics(project_root: &Path) -> Vec<(String, Option<u32>, String)> {
     let mut checker = BatchTypeChecker::new(project_root).expect("batch type checker construction");
     checker.enable_legacy_vue2();
     checker.scan_project().expect("project scan");

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -47,7 +47,7 @@ observational guard for planning only. It does not change rollout state.
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           917 |                   420 |               497 |             139 |     371 |             952 |      475 |           477 |           585 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
-| Typechecker                |           880 |                   213 |               667 |             396 |     187 |             806 |      657 |           466 |           659 |
+| Typechecker                |           878 |                   214 |               664 |             396 |     187 |             806 |      655 |           466 |           659 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
 | LSP                        |           271 |                   271 |                 0 |             115 |      44 |             325 |      105 |           166 |           388 |
@@ -134,7 +134,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         880 |             502 |      378 |
+| S0               |         878 |             502 |      376 |
 | old AST/parser   |         160 |              35 |      125 |
 | Croquis analysis |         236 |             118 |      118 |
 | raw OXC          |         187 |             151 |       36 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1588,7 +1588,7 @@ typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/global_component_callbacks.rs	49	s0	S0	stage	vize_s0	preferred	8
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/global_html_fallthrough_attrs.rs	21	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/literal_union_props.rs	7	s0	S0	stage	vize_s0	preferred	1
-typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/options_api_bridge_anchors.rs	21	s0	S0	stage	vize_carton	compat	3
+typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/options_api_bridge_anchors.rs	21	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/single_required_camel_prop.rs	4	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/split_script_diagnostic_anchors.rs	8	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	test/dev	crates/vize_canon/src/batch/type_checker/tests/recent_issues/strict_route_instance_global.rs	14	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs
+++ b/tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs
@@ -52,6 +52,11 @@ const recentIssueRows = [
     1,
   ],
   [
+    "crates/vize_canon/src/batch/type_checker/tests/recent_issues/options_api_bridge_anchors.rs",
+    "test",
+    1,
+  ],
+  [
     "crates/vize_canon/src/batch/type_checker/tests/recent_issues/single_required_camel_prop.rs",
     "test",
     1,


### PR DESCRIPTION
## Summary

- Import the Options API bridge recent-issue guard through the preferred S0 alias instead of the compat `vize_carton` name.
- Regenerate the Davinci consumer migration surface inventory so the Typechecker S0 counts reflect this single test migration.
- Extend the Canon recent-issue stage-alias tooling guard to cover `options_api_bridge_anchors.rs`.

## Change Class

- [x] Virtual TypeScript and type checking
- [x] Not language-facing

## Behavior Reference

Closes #5161

## Inventory Movement

- Typechecker S0 total: `880 -> 878`
- Typechecker preferred stage names: `213 -> 214`
- Typechecker compat code names: `667 -> 664`
- Typechecker test/dev S0 sites: `657 -> 655`
- `recent_issues` compat files: `2 -> 1`

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated: `tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs` now covers `options_api_bridge_anchors.rs`.
- [x] Snapshot/baseline changes reviewed and explained: `davinci-road/plan/consumer-migration-surfaces.md` and `.tsv` only update the Typechecker S0 preferred/compat counts for this import migration.
- [x] Parity or real-world fixture coverage considered: no runtime behavior change; this is a stage-alias import cleanup for an existing recent-issue regression guard.
- [x] Performance status or PR benchmark impact considered: no production path or benchmark-sensitive code changed.

Verification:
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-canon-recent-issues-test-stage-alias.test.mjs tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-atelier-core-internal-test-stage-alias.test.mjs`
- `vp install --frozen-lockfile --prefer-offline`
- `node_modules/.bin/tsgo --version` (`7.0.0-dev.20260603.1`)
- `CORSA_PATH="$PWD/node_modules/.bin/tsgo" VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib batch::type_checker::tests::recent_issues::options_api_bridge_anchors --features native,legacy -- --nocapture`
- `CORSA_PATH="$PWD/node_modules/.bin/tsgo" VIZE_TEST_REQUIRE_TSGO=1 cargo test -p vize_canon --lib batch::type_checker::tests::recent_issues --features native,legacy -- --nocapture`
- `cargo check -p vize_canon --all-targets --features native,legacy`
- `cargo clippy -p vize_canon --lib --features native,legacy -- -D warnings -D clippy::wildcard_imports`
- `vp run --workspace-root source:lengths --check --base-ref origin/main --max-lines 350 --limit 50`
- `vp run --workspace-root check:ci`

## Risk

Low. The diff is limited to one Canon test import, the generated Davinci migration inventory, and the tooling guard that tracks preferred S0 aliases. It does not change rollout state or production typechecking behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790488969&installation_model_id=422833&pr_number=5162&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5162&signature=6fae02d78ccd7c469670cb1953a80cb2f1a5b83d9abf43fe67faba1a41e2e1fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded migration validation to cover an additional Options API diagnostic scenario.
  * Confirmed preferred naming is used consistently in the covered compatibility test.
  * Updated expected migration-surface counts to reflect the latest codebase state.

* **Documentation**
  * Refreshed Typechecker migration tracking figures, including total, preferred-name, compatibility, and test coverage counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->