### PR TITLE
fix(ricalco): elide inert slot-template bindings

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
@@ -38,6 +38,14 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<Foo><template #header id="x">x</template></Foo>"#,
     ),
     (
+        "named_header_v_once",
+        r#"<Foo><template #header v-once>x</template></Foo>"#,
+    ),
+    (
+        "named_header_v_memo",
+        r#"<Foo><template #header v-memo="[ok]">x</template></Foo>"#,
+    ),
+    (
         "hyphenated_slot",
         "<Foo><template #foo-bar>x</template></Foo>",
     ),
@@ -49,10 +57,18 @@ const BATTERY: &[(&str, &str)] = &[
     ("ws_named", "<Foo><template #header>  </template></Foo>"),
     ("component_v_slot_header", "<Foo v-slot:header>title</Foo>"),
     ("component_v_slot", "<Foo v-slot>title</Foo>"),
+    (
+        "component_v_slot_empty_params",
+        r#"<Foo v-slot="">title</Foo>"#,
+    ),
     ("component_hash_header", "<Foo #header>title</Foo>"),
     (
         "dynamic_slot_name",
         r#"<Foo><template #[name]>x</template></Foo>"#,
+    ),
+    (
+        "named_slot_empty_params",
+        r#"<Foo><template #header="">x</template></Foo>"#,
     ),
     (
         "scoped_ident",
@@ -67,12 +83,32 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<Foo><template #header v-if="ok">x</template></Foo>"#,
     ),
     (
+        "create_slots_if_v_once",
+        r#"<Foo><template #header v-if="ok" v-once>x</template></Foo>"#,
+    ),
+    (
+        "create_slots_if_v_memo",
+        r#"<Foo><template #header v-if="ok" v-memo="[ok]">x</template></Foo>"#,
+    ),
+    (
+        "create_slots_empty_params",
+        r#"<Foo><template #header="" v-if="ok">x</template></Foo>"#,
+    ),
+    (
         "create_slots_if_extra_attr",
         r#"<Foo><template #header id="x" v-if="ok">x</template></Foo>"#,
     ),
     (
         "create_slots_for",
         r#"<Foo><template v-for="i in n" #header>x</template></Foo>"#,
+    ),
+    (
+        "create_slots_for_v_once",
+        r#"<Foo><template v-for="i in n" #header v-once>x</template></Foo>"#,
+    ),
+    (
+        "create_slots_for_v_memo",
+        r#"<Foo><template v-for="i in n" #header v-memo="[i]">x</template></Foo>"#,
     ),
     (
         "create_slots_for_extra_attr",

--- a/crates/vize_ricalco/src/emit/slots.rs
+++ b/crates/vize_ricalco/src/emit/slots.rs
@@ -83,11 +83,12 @@ fn walk_admit(region: &Region<'_>) -> Result<(), EmitError> {
         match op {
             Op::Text(_) | Op::Interpolation(_) => {}
             Op::Element(element) if is_slot_template(element) => {
-                if element
-                    .bindings
-                    .iter()
-                    .any(|binding| !matches!(binding, BindingOp::SlotContent(_)))
-                {
+                if element.bindings.iter().any(|binding| {
+                    !matches!(
+                        binding,
+                        BindingOp::SlotContent(_) | BindingOp::VueOnce(_) | BindingOp::VueMemo(_)
+                    )
+                }) {
                     return Err(EmitError::unsupported_at(
                         Reason::SlotDefaultShape,
                         element.span,

--- a/crates/vize_ricalco/tests/emit_create_slots.rs
+++ b/crates/vize_ricalco/tests/emit_create_slots.rs
@@ -59,6 +59,19 @@ fn static_attrs_on_conditional_slot_templates_are_elided() {
 }
 
 #[test]
+fn inert_builtin_bindings_on_conditional_slot_templates_are_elided() {
+    let plain = assembled(r#"<Foo><template #header v-if="ok">x</template></Foo>"#);
+    assert_eq!(
+        assembled(r#"<Foo><template #header v-if="ok" v-once>x</template></Foo>"#),
+        plain
+    );
+    assert_eq!(
+        assembled(r#"<Foo><template #header v-if="ok" v-memo="[ok]">x</template></Foo>"#),
+        plain
+    );
+}
+
+#[test]
 fn a_v_for_named_template_uses_render_list() {
     assert_eq!(
         assembled(r#"<Foo><template v-for="i in n" #header>x</template></Foo>"#),
@@ -87,6 +100,19 @@ fn static_attrs_on_looped_slot_templates_are_elided() {
     assert_eq!(
         assembled(r#"<Foo><template v-for="i in n" #header id="x">x</template></Foo>"#),
         assembled(r#"<Foo><template v-for="i in n" #header>x</template></Foo>"#)
+    );
+}
+
+#[test]
+fn inert_builtin_bindings_on_looped_slot_templates_are_elided() {
+    let plain = assembled(r#"<Foo><template v-for="i in n" #header>x</template></Foo>"#);
+    assert_eq!(
+        assembled(r#"<Foo><template v-for="i in n" #header v-once>x</template></Foo>"#),
+        plain
+    );
+    assert_eq!(
+        assembled(r#"<Foo><template v-for="i in n" #header v-memo="[i]">x</template></Foo>"#),
+        plain
     );
 }
 

--- a/crates/vize_ricalco/tests/emit_slots.rs
+++ b/crates/vize_ricalco/tests/emit_slots.rs
@@ -162,6 +162,19 @@ fn static_attrs_on_named_slot_templates_are_elided() {
 }
 
 #[test]
+fn inert_builtin_bindings_on_named_slot_templates_are_elided() {
+    let plain = assembled(r#"<Foo><template #header>x</template></Foo>"#);
+    assert_eq!(
+        assembled(r#"<Foo><template #header v-once>x</template></Foo>"#),
+        plain
+    );
+    assert_eq!(
+        assembled(r#"<Foo><template #header v-memo="[ok]">x</template></Foo>"#),
+        plain
+    );
+}
+
+#[test]
 fn a_bare_template_default_slot_child_is_hoisted() {
     assert_eq!(
         assembled("<Foo><template>x</template></Foo>"),

--- a/crates/vize_ricalco/tests/emit_unsupported_census.rs
+++ b/crates/vize_ricalco/tests/emit_unsupported_census.rs
@@ -128,7 +128,7 @@ const SOURCE_CASES: &[Case] = &[
     ),
     case(
         "slot_template_extra_binding",
-        r#"<Foo><template #header v-once>x</template></Foo>"#,
+        r#"<Foo><template #header v-pin>x</template></Foo>"#,
         VUE3,
         Reason::SlotDefaultShape,
     ),


### PR DESCRIPTION
## Summary

- elide inert `v-once` and `v-memo` bindings on authored slot-template carriers in the S2 DOM emitter
- add byte-for-byte S2-vs-shipped DOM coverage for plain, conditional, and looped slot templates plus empty slot-props positions
- keep `SlotDefaultShape` source-covered with a truly unsupported extra directive case

Closes #5177.

## Verification

- cargo +1.95.0 test -p vize_ricalco --test emit_slots --test emit_create_slots --test emit_unsupported_census --test emit_unsupported_catalogue -- --quiet
- cargo +1.95.0 test -p vize_atelier_dom --test davinci_s2_slots -- --quiet
- cargo +1.95.0 fmt --all
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790501760&installation_model_id=422833&pr_number=5178&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5178&signature=1a430fe2cbbeb9db8f959ab48928e2ee2762e5047b7d367b1aaa70d948dcf6bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of `v-once` and `v-memo` on named, conditional, and looped slot templates.
  * These inert directives are now omitted from generated output instead of causing slot processing errors.
  * Unsupported additional slot bindings continue to be rejected appropriately.

* **Tests**
  * Added coverage for named slots, conditional slots, looped slots, component-root slots, and empty slot parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->