### PR TITLE
fix(corsa): use JSON-RPC for TypeScript 7 runtimes

### DIFF
--- a/crates/vize_canon/src/lsp_client/session/bootstrap.rs
+++ b/crates/vize_canon/src/lsp_client/session/bootstrap.rs
@@ -7,7 +7,7 @@ use corsa::{
     api::{ApiMode, ApiSpawnConfig, CapabilitiesResponse, ProjectSession},
     runtime::block_on,
 };
-use vize_s0::{String, cstr};
+use vize_s0::{String, corsa_api_mode::uses_async_json_rpc_api, cstr};
 
 pub(in crate::lsp_client) fn spawn_project_session(
     executable: &str,
@@ -101,31 +101,9 @@ pub(super) fn should_retry_json_rpc(mode: ApiMode, error: &CorsaError) -> bool {
 }
 
 pub(super) fn api_mode_for_executable(executable: &str) -> ApiMode {
-    if is_node_wrapper_executable(Path::new(executable)) {
+    if uses_async_json_rpc_api(Path::new(executable)) {
         ApiMode::AsyncJsonRpcStdio
     } else {
         ApiMode::SyncMsgpackStdio
     }
-}
-
-fn is_node_wrapper_executable(path: &Path) -> bool {
-    if path.extension().and_then(|extension| extension.to_str()) == Some("js") {
-        return true;
-    }
-    if path
-        .parent()
-        .and_then(|parent| parent.file_name())
-        .and_then(|name| name.to_str())
-        == Some(".bin")
-    {
-        return true;
-    }
-    let Some(parent) = path.parent() else {
-        return false;
-    };
-    let Some(grandparent) = parent.parent() else {
-        return false;
-    };
-    parent.file_name().and_then(|name| name.to_str()) == Some("bin")
-        && grandparent.file_name().and_then(|name| name.to_str()) == Some("native-preview")
 }

--- a/crates/vize_canon/src/lsp_client/session/tests.rs
+++ b/crates/vize_canon/src/lsp_client/session/tests.rs
@@ -64,6 +64,21 @@ fn uses_async_json_rpc_for_native_preview_js_entrypoints() {
 }
 
 #[test]
+fn uses_async_json_rpc_for_typescript_seven_native_binaries() {
+    for executable in ["tsc", "tsc.exe"] {
+        let path = format!(
+            "/tmp/project/node_modules/@typescript/typescript-darwin-arm64/lib/{executable}"
+        );
+
+        assert_eq!(
+            api_mode_for_executable(&path),
+            ApiMode::AsyncJsonRpcStdio,
+            "{path}"
+        );
+    }
+}
+
+#[test]
 fn keeps_native_binaries_on_sync_msgpack() {
     assert_eq!(
         api_mode_for_executable("/tmp/project/corsa-bind/.cache/tsgo"),

--- a/crates/vize_carton/src/corsa_api_mode.rs
+++ b/crates/vize_carton/src/corsa_api_mode.rs
@@ -1,0 +1,87 @@
+//! Runtime transport classification shared by Corsa-backed integrations.
+
+use std::path::Path;
+
+/// Whether `path` names a TypeScript/Corsa runtime that speaks the async
+/// JSON-RPC stdio API instead of Corsa's older sync msgpack transport.
+pub fn uses_async_json_rpc_api(path: &Path) -> bool {
+    if path.extension().and_then(|extension| extension.to_str()) == Some("js") {
+        return true;
+    }
+
+    if path
+        .parent()
+        .and_then(|parent| parent.file_name())
+        .and_then(|name| name.to_str())
+        == Some(".bin")
+    {
+        return true;
+    }
+
+    is_typescript_package_runtime(path)
+}
+
+fn is_typescript_package_runtime(path: &Path) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let Some(parent_name) = parent.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if parent_name != "bin" && parent_name != "lib" {
+        return false;
+    }
+
+    let Some(package_dir) = parent.parent() else {
+        return false;
+    };
+    let Some(package_name) = package_dir.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    if package_name == "typescript" {
+        return true;
+    }
+    let Some(scope_name) = package_dir
+        .parent()
+        .and_then(|scope| scope.file_name())
+        .and_then(|name| name.to_str())
+    else {
+        return false;
+    };
+    if scope_name != "@typescript" {
+        return false;
+    }
+
+    package_name.starts_with("typescript-")
+        || package_name == "native-preview"
+        || package_name.starts_with("native-preview-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::uses_async_json_rpc_api;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn classifies_typescript_package_runtimes_as_json_rpc() {
+        for path in [
+            PathBuf::from("/workspace/node_modules/.bin/tsgo"),
+            PathBuf::from("/workspace/node_modules/typescript/bin/tsc"),
+            PathBuf::from("/workspace/node_modules/typescript/lib/tsc.js"),
+            PathBuf::from("/workspace/node_modules/@typescript/typescript-darwin-arm64/lib/tsc"),
+            PathBuf::from("/workspace/node_modules/@typescript/typescript-win32-x64/lib/tsc.exe"),
+            PathBuf::from(
+                "/workspace/node_modules/@typescript/native-preview-darwin-arm64/lib/tsgo",
+            ),
+            PathBuf::from("/workspace/node_modules/@typescript/native-preview/bin/tsgo.js"),
+        ] {
+            assert!(
+                uses_async_json_rpc_api(&path),
+                "{} should use async JSON-RPC",
+                path.display()
+            );
+        }
+
+        assert!(!uses_async_json_rpc_api(Path::new("/workspace/bin/corsa")));
+    }
+}

--- a/crates/vize_carton/src/lib.rs
+++ b/crates/vize_carton/src/lib.rs
@@ -42,6 +42,8 @@ mod vec;
 // Shared modules
 pub mod config;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod corsa_api_mode;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod corsa_resolver;
 pub mod dialect;
 pub mod directive;

--- a/crates/vize_patina/src/linter/corsa_session/session.rs
+++ b/crates/vize_patina/src/linter/corsa_session/session.rs
@@ -13,7 +13,7 @@ use corsa::{
     },
     runtime::block_on,
 };
-use vize_s0::{String, ToCompactString, profile};
+use vize_s0::{String, ToCompactString, corsa_api_mode::uses_async_json_rpc_api, profile};
 
 impl CorsaTypeAwareSession {
     pub(in crate::linter) fn new_with_corsa_path(
@@ -195,52 +195,11 @@ impl Drop for SessionRootCleanup {
 }
 
 fn api_mode_for_executable(path: &std::path::Path) -> ApiMode {
-    if path.extension().and_then(|extension| extension.to_str()) == Some("js") {
-        return ApiMode::AsyncJsonRpcStdio;
-    }
-
-    if path
-        .parent()
-        .and_then(|parent| parent.file_name())
-        .and_then(|name| name.to_str())
-        == Some(".bin")
-    {
-        return ApiMode::AsyncJsonRpcStdio;
-    }
-
-    if is_typescript_native_preview_executable(path) {
+    if uses_async_json_rpc_api(path) {
         return ApiMode::AsyncJsonRpcStdio;
     }
 
     ApiMode::SyncMsgpackStdio
-}
-
-fn is_typescript_native_preview_executable(path: &std::path::Path) -> bool {
-    let Some(parent) = path.parent() else {
-        return false;
-    };
-    let Some(parent_name) = parent.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    if parent_name != "bin" && parent_name != "lib" {
-        return false;
-    };
-
-    let Some(package_dir) = parent.parent() else {
-        return false;
-    };
-    let Some(package_name) = package_dir.file_name().and_then(|name| name.to_str()) else {
-        return false;
-    };
-    if package_name != "native-preview" && !package_name.starts_with("native-preview-") {
-        return false;
-    }
-
-    package_dir
-        .parent()
-        .and_then(|scope| scope.file_name())
-        .and_then(|name| name.to_str())
-        == Some("@typescript")
 }
 
 #[cfg(test)]

--- a/crates/vize_patina/src/linter/corsa_session/session/tests.rs
+++ b/crates/vize_patina/src/linter/corsa_session/session/tests.rs
@@ -32,6 +32,23 @@ fn uses_json_rpc_for_typescript_native_preview_binaries() {
 }
 
 #[test]
+fn uses_json_rpc_for_typescript_seven_native_binaries() {
+    let suffix = platform_suffix();
+    for executable in ["tsc", "tsc.exe"] {
+        let path = PathBuf::from(format!(
+            "/workspace/node_modules/@typescript/typescript-{suffix}/lib/{executable}"
+        ));
+
+        assert_eq!(
+            api_mode_for_executable(&path),
+            ApiMode::AsyncJsonRpcStdio,
+            "{}",
+            path.display()
+        );
+    }
+}
+
+#[test]
 fn uses_msgpack_for_generic_native_binaries() {
     assert_eq!(
         api_mode_for_executable(Path::new("/workspace/bin/corsa")),
@@ -107,6 +124,16 @@ fn test_corsa_path() -> Option<PathBuf> {
         .parent()?
         .parent()?
         .to_path_buf();
+    let stable = repo_root
+        .join("node_modules")
+        .join("@typescript")
+        .join(&*cstr!("typescript-{}", platform_suffix()))
+        .join("lib")
+        .join(&*cstr!("tsc{}", std::env::consts::EXE_SUFFIX));
+    if stable.is_file() {
+        return Some(stable);
+    }
+
     let native = repo_root
         .join("node_modules")
         .join("@typescript")


### PR DESCRIPTION
## Summary

- add a shared Corsa runtime transport classifier in vize_carton
- classify TypeScript 7 platform binaries such as @typescript/typescript-*/lib/tsc(.exe) as async JSON-RPC runtimes
- reuse that classifier from Canon LSP and Patina type-aware lint while preserving legacy native-preview and generic Corsa behavior

Closes #5179.

## Verification

- cargo +1.95.0 fmt --all -- --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo +1.95.0 test -p vize_carton corsa_api_mode::tests::classifies_typescript_package_runtimes_as_json_rpc -- --exact
- cargo +1.95.0 test -p vize_carton corsa_ -- --quiet
- cargo +1.95.0 test -p vize_patina linter::corsa_session::session::tests -- --quiet
- cargo +1.95.0 test -p vize_canon lsp_client::session::tests -- --quiet
- cargo +1.95.0 test -p vize_canon batch::error::tests -- --quiet
- cargo +1.95.0 clippy -p vize_carton -p vize_canon -p vize_patina --lib --locked -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/package-manifests-corsa-runtime.test.ts
- npx --yes --package vize@latest -- vize check --no-config --tsconfig tsconfig.node.json --format json --quiet vite.config.ts (in /Users/nishimura/Code/gitlab.com/mates-pay/app/aim/aimCMS-front)

## Notes

The reported @typescript/native-preview install guidance did not reproduce with current vize@0.387.0. Current latest already reports typescript@^7 for missing runtime guidance and declares @typescript/typescript-* optional runtime packages. This PR fixes the remaining transport-classification gap for TypeScript 7 stable native binaries.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5180"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790505902&installation_model_id=422833&pr_number=5180&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5180&signature=797b32019196097a71648e2f15e3dd826770be364ad6b9ceecbdac76a3c3bf97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing TypeScript 7 native binaries and routing them through Async JSON-RPC over stdio.
  * Unified runtime transport detection across supported Corsa-backed integrations.

* **Bug Fixes**
  * Improved API mode selection for TypeScript, JavaScript, native-preview, and related executable paths.

* **Tests**
  * Added coverage for platform-specific TypeScript 7 binaries, including Windows executables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->