### PR TITLE
test(content-mapper): pin transform wire DTO shape

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_protocol_tests.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use serde_json::Value;
+
 use super::super::protocol::protocol_semantic_links;
 use super::{
     CONTENT_MAPPER_SPAN_FEATURE_BITS, CONTENT_MAPPER_SPAN_FEATURES_ALL,
@@ -75,6 +77,15 @@ fn transform_declares_its_virtual_extension_on_every_response() {
     )
     .expect("transform");
     assert_eq!(valid.extension, CONTENT_MAPPER_VIRTUAL_EXTENSION);
+    let valid_json = serde_json::to_value(&valid).expect("valid transform json");
+    let valid_object = assert_serialized_transform_uses_protocol_v1_header(&valid_json);
+    let mappings = valid_object["mappings"].as_array().expect("mappings array");
+    assert!(!mappings.is_empty());
+    assert!(mappings.iter().all(|mapping| {
+        mapping
+            .as_array()
+            .is_some_and(|tuple| tuple.len() == 6 && tuple.iter().all(Value::is_number))
+    }));
 
     // The unparseable-SFC fallback is still a successful transform response, so it
     // must declare an extension too.
@@ -85,6 +96,41 @@ fn transform_declares_its_virtual_extension_on_every_response() {
     .expect("fallback transform");
     assert!(!fallback.diagnostics.is_empty());
     assert_eq!(fallback.extension, CONTENT_MAPPER_VIRTUAL_EXTENSION);
+    let fallback_json = serde_json::to_value(&fallback).expect("fallback transform json");
+    let fallback_object = assert_serialized_transform_uses_protocol_v1_header(&fallback_json);
+    assert!(
+        fallback_object["text"]
+            .as_str()
+            .is_some_and(|text| text.contains("__vize_component"))
+    );
+    assert!(
+        fallback_object["mappings"]
+            .as_array()
+            .is_some_and(Vec::is_empty)
+    );
+    let diagnostic = fallback_object["diagnostics"]
+        .as_array()
+        .and_then(|diagnostics| diagnostics.first())
+        .and_then(Value::as_object)
+        .expect("fallback diagnostic object");
+    for key in ["messageText", "start", "length", "code"] {
+        assert!(diagnostic.contains_key(key), "{diagnostic:#?}");
+    }
+}
+
+fn assert_serialized_transform_uses_protocol_v1_header(
+    value: &Value,
+) -> &serde_json::Map<String, Value> {
+    let object = value.as_object().expect("transform object");
+    assert_eq!(
+        object["extension"].as_str(),
+        Some(CONTENT_MAPPER_VIRTUAL_EXTENSION)
+    );
+    assert!(
+        !object.contains_key("scriptKind"),
+        "content-mapper protocol v1 uses extension, not the retired scriptKind field: {value:#}"
+    );
+    object
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- pin the serialized content-mapper transform response to the protocol v1 wire shape
- cover normal SFC transforms and parser-fallback responses
- guard against reviving the retired `scriptKind` response key

Closes #5186.

## Verification

- `cargo test -p vize_canon content_mapper::tests::protocol -- --nocapture`
- `cargo test -p vize content_mapper -- --nocapture`
- `cargo +1.95.0 fmt --all -- --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/content-mapper-package-contract.test.ts tests/tooling/content-mapper-manifest.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5187"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790514168&installation_model_id=422833&pr_number=5187&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5187&signature=dd78d45dd1d03262a7292f266ae800ab4f52ac55a046d1b2595596cda3d3078b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded validation for content-mapping protocol responses.
  - Added coverage for valid transformations, fallback behavior, generated fallback text, and diagnostic information.
  - Verified protocol headers and mapping formats, including rejection of obsolete metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->