### PR TITLE
fix(ricalco): emit dynamic v-on modifiers

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dynamic_von_keys.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dynamic_von_keys.rs
@@ -1,6 +1,6 @@
-//! P2-11 dynamic `v-on` key witness: modifier-free computed event keys
-//! compare byte-for-byte against the shipped DOM lane, while modifiers,
-//! non-JS event names and slot-outlet named events stay typed refusals.
+//! P2-11 dynamic `v-on` key witness: computed event keys and modifiers
+//! compare byte-for-byte against the shipped DOM lane, while non-JS event
+//! names and slot-outlet named events stay typed refusals.
 
 #![allow(
     clippy::disallowed_macros,
@@ -25,6 +25,18 @@ const BATTERY: &[(&str, &str)] = &[
     (
         "native_dynamic_inline",
         r#"<button @[event]="handler($event)"></button>"#,
+    ),
+    (
+        "native_dynamic_stop",
+        r#"<button @[event].stop="handler"></button>"#,
+    ),
+    (
+        "native_dynamic_enter_stop",
+        r#"<button @[event].enter.stop="handler"></button>"#,
+    ),
+    (
+        "native_dynamic_option_modifiers",
+        r#"<button @[event].once.capture.passive="handler"></button>"#,
     ),
     ("component_dynamic", r#"<Foo @[event]="handler" />"#),
     (
@@ -66,11 +78,6 @@ const BATTERY: &[(&str, &str)] = &[
 ];
 
 const REFUSALS: &[(&str, &str, support::ExpectedRefusal)] = &[
-    (
-        "dynamic_event_with_modifier",
-        r#"<button @[event].stop="handler"></button>"#,
-        support::ExpectedRefusal::Unsupported(Reason::DynamicOnHasModifiers),
-    ),
     (
         "dynamic_event_name_not_js",
         r#"<button @[event.]="handler"></button>"#,

--- a/crates/vize_ricalco/src/emit.rs
+++ b/crates/vize_ricalco/src/emit.rs
@@ -39,8 +39,8 @@
 //! (static refs, dynamic `:ref`, and `ref_for` in `v-for`), and **Vue 2
 //! `.native` event sugar** (accepted and stripped like the shipped lane),
 //! **static+dynamic `style` merge** (`[{"color":"red"}, s]`), and
-//! **modifier-free dynamic `v-on` keys** (`@[event]` through
-//! `toHandlerKey`), plus native-element **`v-once`** cache wrappers,
+//! **dynamic `v-on` keys** (`@[event]` through `toHandlerKey`,
+//! including event/key modifiers), plus native-element **`v-once`** cache wrappers,
 //! while SFC style-block carriers (`vue.css-bind` facts) stay DOM-inert.
 //! Static-name `v-bind` modifiers (`.camel`, `.prop`, `.attr`, plus the
 //! dot shorthand) and dynamic-argument `v-bind` keys / modifiers are

--- a/crates/vize_ricalco/src/emit/on.rs
+++ b/crates/vize_ricalco/src/emit/on.rs
@@ -1,5 +1,5 @@
 //! Static-name `ui.on` (`@click` / `v-on:click`), dynamic-name `ui.on`
-//! (`@[event]`), including static-name event / key / option modifiers
+//! (`@[event]`), including event / key / option modifiers
 //! (`withModifiers` / `withKeys`, `onClickOnce`, …).
 //! Object `v-on` lives in [`super::merge`].
 
@@ -13,15 +13,10 @@ use super::EmitError;
 use super::UnsupportedReason as Reason;
 use super::buf::Buf;
 
-// A reviewed inventory of 179 natural modified `v-on` attributes currently
-// uses up to two entries in each of the three classifier buckets. The checked
-// inventory in `tests/tooling/davinci-v-on-storage.test.ts` selects this inline
-// capacity; it is not a syntax limit. Authored directives remain unbounded and
-// spill without changing order or output. On 64-bit targets this trades 48
-// bytes of transient stack space (`Classified`: 120 rather than three 24-byte
-// `Vec`s) for inline storage. The `ricalco_emit_von_two_per_bucket` allocation
-// budget in `davinci-road/plan/budgets.toml`, measured by
-// `crates/vize_ricalco/benches/davinci_storage.rs`, owns the allocation proof.
+// The checked modifier inventory in `tests/tooling/davinci-v-on-storage.test.ts`
+// selects two inline entries per classifier bucket. Authored directives remain
+// unbounded and spill without changing order or output; the allocation budget in
+// `davinci-road/plan/budgets.toml` owns the measured proof.
 const OPTION_INLINE_CAP: usize = 2;
 const EVENT_INLINE_CAP: usize = 2;
 const KEY_INLINE_CAP: usize = 2;
@@ -30,7 +25,7 @@ type OptionModifiers<'a> = SmallVec<[&'a str; OPTION_INLINE_CAP]>;
 type EventModifiers<'a> = SmallVec<[&'a str; EVENT_INLINE_CAP]>;
 type KeyModifiers<'a> = SmallVec<[&'a str; KEY_INLINE_CAP]>;
 
-struct Classified<'a> {
+pub(super) struct Classified<'a> {
     options: OptionModifiers<'a>,
     event: EventModifiers<'a>,
     keys: KeyModifiers<'a>,
@@ -119,7 +114,7 @@ pub(super) fn needs_hydration(key: &str, on: &OnOp<'_>) -> bool {
 
 pub(super) fn forces_inline_on(on: &OnOp<'_>) -> bool {
     if super::on_dynamic::is_dynamic_on_name(on) {
-        return false;
+        return super::on_dynamic::forces_inline(on);
     }
     classify(on).is_ok_and(|classified| {
         has_native_modifier(on) || !classified.event.is_empty() || !classified.keys.is_empty()
@@ -155,7 +150,7 @@ pub(super) fn emit_on_value(cx: &mut EmitCx<'_>, on: &OnOp<'_>) -> Result<(), Em
     emit_wrapped_handler(cx, on, &classified)
 }
 
-fn emit_wrapped_handler(
+pub(super) fn emit_wrapped_handler(
     cx: &mut EmitCx<'_>,
     on: &OnOp<'_>,
     classified: &Classified<'_>,
@@ -227,11 +222,28 @@ fn classify<'a>(on: &'a OnOp<'a>) -> Result<Classified<'a>, EmitError> {
     Ok(classify_modifiers(name, on.modifiers.iter().copied()))
 }
 
+pub(super) fn classify_dynamic_modifiers<'a>(
+    modifiers: impl IntoIterator<Item = &'a str>,
+) -> Classified<'a> {
+    classify_modifier_buckets(false, false, modifiers)
+}
+
 fn classify_modifiers<'a>(
     name: &str,
     modifiers: impl IntoIterator<Item = &'a str>,
 ) -> Classified<'a> {
-    let keyboard = matches!(name, "keydown" | "keyup" | "keypress");
+    classify_modifier_buckets(
+        matches!(name, "keydown" | "keyup" | "keypress"),
+        true,
+        modifiers,
+    )
+}
+
+fn classify_modifier_buckets<'a>(
+    keyboard: bool,
+    keep_options: bool,
+    modifiers: impl IntoIterator<Item = &'a str>,
+) -> Classified<'a> {
     let mut options = OptionModifiers::new();
     let mut event = EventModifiers::new();
     let mut keys = KeyModifiers::new();
@@ -241,7 +253,8 @@ fn classify_modifiers<'a>(
             // lane before handler wrapping, and does not affect the event
             // key. Keep the authored modifier accepted but inert here.
             "native" => {}
-            "capture" | "once" | "passive" => options.push(modifier),
+            "capture" | "once" | "passive" if keep_options => options.push(modifier),
+            "capture" | "once" | "passive" => {}
             "left" | "right" if keyboard => keys.push(modifier),
             "stop" | "prevent" | "self" | "ctrl" | "shift" | "alt" | "meta" | "middle"
             | "exact" | "left" | "right" => event.push(modifier),

--- a/crates/vize_ricalco/src/emit/on_dynamic.rs
+++ b/crates/vize_ricalco/src/emit/on_dynamic.rs
@@ -1,4 +1,4 @@
-//! Modifier-free dynamic-name `ui.on` (`@[event]`) emission.
+//! Dynamic-name `ui.on` (`@[event]`) emission.
 
 use vize_s2::expr::{ExprRef, JsExpr};
 use vize_s2::op::{DynamicName, OnOp};
@@ -13,12 +13,6 @@ pub(super) fn is_dynamic_on_name(on: &OnOp<'_>) -> bool {
 
 pub(super) fn admit(on: &OnOp<'_>) -> Result<(), EmitError> {
     dynamic_name(on)?;
-    if !on.modifiers.is_empty() {
-        return Err(EmitError::unsupported_at(
-            Reason::DynamicOnHasModifiers,
-            on.span,
-        ));
-    }
     match on.handler {
         None | Some(ExprRef::Js(_)) => Ok(()),
         Some(expr) => Err(EmitError::unsupported_at(
@@ -30,12 +24,6 @@ pub(super) fn admit(on: &OnOp<'_>) -> Result<(), EmitError> {
 
 pub(super) fn emit_pair(cx: &mut EmitCx<'_>, on: &OnOp<'_>) -> Result<(), EmitError> {
     let js = dynamic_name(on)?;
-    if !on.modifiers.is_empty() {
-        return Err(EmitError::unsupported_at(
-            Reason::DynamicOnHasModifiers,
-            on.span,
-        ));
-    }
     cx.buf.use_to_handler_key();
     cx.buf.push("[");
     cx.buf.push(Buf::to_handler_key_alias());
@@ -46,26 +34,14 @@ pub(super) fn emit_pair(cx: &mut EmitCx<'_>, on: &OnOp<'_>) -> Result<(), EmitEr
 }
 
 pub(super) fn emit_value(cx: &mut EmitCx<'_>, on: &OnOp<'_>) -> Result<(), EmitError> {
-    if !on.modifiers.is_empty() {
-        return Err(EmitError::unsupported_at(
-            Reason::DynamicOnHasModifiers,
-            on.span,
-        ));
-    }
-    match on.handler {
-        Some(ExprRef::Js(js)) => {
-            super::on::emit_handler(cx, js);
-            Ok(())
-        }
-        None => {
-            cx.buf.push("() => {}");
-            Ok(())
-        }
-        Some(expr) => Err(EmitError::unsupported_at(
-            Reason::OnHandlerNotJs,
-            expr.span(),
-        )),
-    }
+    let classified = super::on::classify_dynamic_modifiers(on.modifiers.iter().copied());
+    super::on::emit_wrapped_handler(cx, on, &classified)
+}
+
+pub(super) fn forces_inline(on: &OnOp<'_>) -> bool {
+    on.modifiers
+        .iter()
+        .any(|modifier| !matches!(*modifier, "capture" | "once" | "passive"))
 }
 
 fn dynamic_name<'a>(on: &'a OnOp<'a>) -> Result<&'a JsExpr<'a>, EmitError> {

--- a/crates/vize_ricalco/tests/emit_dynamic_on_keys.rs
+++ b/crates/vize_ricalco/tests/emit_dynamic_on_keys.rs
@@ -1,4 +1,4 @@
-//! Modifier-free dynamic-name `ui.on` emit pins (`@[event]`).
+//! Dynamic-name `ui.on` emit pins (`@[event]`).
 
 #![allow(
     clippy::disallowed_macros,
@@ -83,10 +83,45 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
-fn a_dynamic_event_name_with_modifiers_is_unsupported_this_installment() {
+fn a_dynamic_event_name_with_event_modifiers_wraps_with_modifiers() {
     assert_eq!(
-        refused(r#"<button @[event].stop="handler"></button>"#).reason(),
-        Some(Reason::DynamicOnHasModifiers)
+        assembled(r#"<button @[event].stop.prevent="handler"></button>"#),
+        "\
+const { withModifiers: _withModifiers, toHandlerKey: _toHandlerKey, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"button\", {
+    [_toHandlerKey(_ctx.event)]: _withModifiers(handler, [\"stop\",\"prevent\"])
+  }, null, 16 /* FULL_PROPS */))
+}"
+    );
+}
+
+#[test]
+fn a_dynamic_event_name_with_key_modifiers_nests_keys_outside_modifiers() {
+    assert_eq!(
+        assembled(r#"<button @[event].enter.stop="handler"></button>"#),
+        "\
+const { withKeys: _withKeys, withModifiers: _withModifiers, toHandlerKey: _toHandlerKey, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"button\", {
+    [_toHandlerKey(_ctx.event)]: _withKeys(_withModifiers(handler, [\"stop\"]), [\"enter\"])
+  }, null, 16 /* FULL_PROPS */))
+}"
+    );
+}
+
+#[test]
+fn a_dynamic_event_name_with_option_modifiers_keeps_the_computed_key() {
+    assert_eq!(
+        assembled(r#"<button @[event].once.capture.passive="handler"></button>"#),
+        "\
+const { toHandlerKey: _toHandlerKey, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"button\", { [_toHandlerKey(_ctx.event)]: handler }, null, 16 /* FULL_PROPS */))
+}"
     );
 }
 

--- a/crates/vize_ricalco/tests/emit_unsupported_catalogue.rs
+++ b/crates/vize_ricalco/tests/emit_unsupported_catalogue.rs
@@ -16,7 +16,6 @@ const SOURCE: &[Reason] = &[
     Reason::CustomDirectiveExprNotJs,
     Reason::DuplicateClassBinding,
     Reason::DuplicateStyleBinding,
-    Reason::DynamicOnHasModifiers,
     Reason::ForSourceNotJs,
     Reason::IfConditionNotJs,
     Reason::ModelArgumentNotJs,
@@ -58,7 +57,10 @@ const GUARD_ONLY: &[Reason] = &[
     Reason::WalkIdOverflow,
 ];
 
-const RETIRED: &[Reason] = &[Reason::CreateSlotsMissingSlotTemplate];
+const RETIRED: &[Reason] = &[
+    Reason::CreateSlotsMissingSlotTemplate,
+    Reason::DynamicOnHasModifiers,
+];
 
 #[test]
 fn reason_catalogue_is_fully_accounted_for() {

--- a/crates/vize_ricalco/tests/emit_unsupported_census.rs
+++ b/crates/vize_ricalco/tests/emit_unsupported_census.rs
@@ -121,12 +121,6 @@ const SOURCE_CASES: &[Case] = &[
         Reason::OnNameNotJs,
     ),
     case(
-        "dynamic_on_mod",
-        r#"<div @[event].stop="handler"></div>"#,
-        VUE3,
-        Reason::DynamicOnHasModifiers,
-    ),
-    case(
         "slot_template_extra_binding",
         r#"<Foo><template #header v-pin>x</template></Foo>"#,
         VUE3,
@@ -203,7 +197,6 @@ fn committed_fixture_refusal_census_is_pinned() {
             ("custom_directive_expr_not_js", 1),
             ("duplicate_class_binding", 1),
             ("duplicate_style_binding", 1),
-            ("dynamic_on_has_modifiers", 1),
             ("for_source_not_js", 1),
             ("if_condition_not_js", 1),
             ("model_argument_not_js", 1),


### PR DESCRIPTION
## Summary

- Emit dynamic `v-on` modifier handlers from S2 with the same `withModifiers` / `withKeys` wrapper path used by static `v-on`.
- Keep dynamic event prop keys on `toHandlerKey(...)` and preserve shipped-lane option modifier behavior for dynamic names.
- Retire `dynamic_on_has_modifiers` from the source refusal census once the source-valid case is emitted.

Closes #5189.

## Change Class

- [ ] Parser or AST
- [x] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

P2-11 DOM backend on S2. The byte-for-byte oracle is the existing shipped DOM lane via `vize_atelier_dom::compile_template`; this PR only expands the S2 strangler path and does not switch production rollout.

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [x] Fuzzing target or crash-reproducer coverage considered
- [x] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

Commands run:

- `cargo fmt --all -- --check`
- `cargo test -p vize_ricalco --test emit_dynamic_on_keys -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_dynamic_von_keys -- --nocapture`
- `cargo test -p vize_ricalco --test emit_unsupported_catalogue --test emit_unsupported_census -- --nocapture`
- `cargo test -p vize_ricalco --test emit_on -- --nocapture`
- `cargo test -p vize_ricalco on::tests -- --nocapture`
- `cargo clippy -p vize_ricalco --all-targets -- -D warnings -D clippy::wildcard_imports`
- `node tools/davinci/assertion-lint.mjs`
- `node --test tests/tooling/davinci-matrices.test.ts`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-assertion-lint.test.ts`
- `moon run -q --target native tools/moon/cmd/source_file_lengths -- --check --base-ref origin/main --max-lines 350 --limit 50`
- `git diff --check`

## Risk

Low to medium. The changed path is still the S2 DOM strangler lane, not the shipped compiler path. The main compatibility risk is exact modifier classification for dynamic event names, covered by new hardcoded emit pins plus the atelier differential suite against the shipped DOM lane. No production rollout switch is included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790518618&installation_model_id=422833&pr_number=5190&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5190&signature=0af04c9bbe15a4c0e1f8396ba9e7c7f2408e7c866269198ff36c4811ffdbc2e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for event and key modifiers on dynamically named event handlers.
  * Dynamic events now support modifiers such as `.stop`, `.enter`, `.once`, `.capture`, and `.passive`.
  * Modifier combinations work with computed event names while preserving expected event behavior.

* **Bug Fixes**
  * Dynamic event handlers with modifiers are now emitted and executed instead of being rejected.

* **Tests**
  * Added coverage for dynamic event modifiers and their generated output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->