### PR TITLE
fix(canon): resolve TypeScript 7 tsc wrappers

### DIFF
--- a/crates/vize/tests/lsp_cli.rs
+++ b/crates/vize/tests/lsp_cli.rs
@@ -57,7 +57,7 @@ fn lsp_exit_notification_terminates_process_while_stdin_stays_open() {
 fn lsp_corsa_smoke_publishes_diagnostics_and_hover() {
     let workspace_root = workspace_root();
     let Some(corsa_path) = discover_corsa_in_ancestors(workspace_root) else {
-        eprintln!("skipping LSP Corsa smoke: @typescript/native-preview runtime is unavailable");
+        eprintln!("skipping LSP Corsa smoke: TypeScript 7 Corsa runtime is unavailable");
         return;
     };
     let project = create_lsp_project(workspace_root, &corsa_path);

--- a/crates/vize/tests/support/corsa_path.rs
+++ b/crates/vize/tests/support/corsa_path.rs
@@ -1,107 +1,20 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
-use vize_s0::cstr;
+use vize_s0::corsa_resolver::discover_corsa_in_ancestors;
 
 pub(crate) fn resolve(workspace_root: &Path) -> Option<String> {
     if let Some(path) = std::env::var_os("CORSA_PATH").filter(|path| Path::new(path).is_file()) {
         return Some(path.to_string_lossy().into_owned());
     }
 
-    let sibling_cache = workspace_root.parent()?.join("corsa-bind/.cache/tsgo");
-    if sibling_cache.exists() {
-        return Some(sibling_cache.display().to_string());
-    }
-
-    if let Some(native_tsgo) = resolve_workspace_native_tsgo(workspace_root) {
-        return Some(native_tsgo.display().to_string());
-    }
-
-    for candidate in [
-        workspace_root.join("node_modules/.bin/tsgo"),
-        workspace_root.join("examples/vite-musea/node_modules/.bin/tsgo"),
+    for start in [
+        workspace_root.to_path_buf(),
+        workspace_root.join("examples").join("vite-musea"),
     ] {
-        if candidate.exists() {
-            return Some(candidate.display().to_string());
+        if let Some(path) = discover_corsa_in_ancestors(&start).filter(|path| path.is_file()) {
+            return Some(path.display().to_string());
         }
     }
 
     None
-}
-
-fn resolve_workspace_native_tsgo(workspace_root: &Path) -> Option<PathBuf> {
-    let platform_suffix = native_preview_platform_suffix();
-    let package_name = cstr!("@typescript/native-preview-{platform_suffix}");
-
-    let pnpm_root = workspace_root.join("node_modules/.pnpm");
-    if let Ok(entries) = std::fs::read_dir(&pnpm_root) {
-        for entry in entries.flatten() {
-            let name = entry.file_name();
-            let name = name.to_string_lossy();
-            if !name.starts_with(cstr!("@typescript+native-preview-{platform_suffix}@").as_str()) {
-                continue;
-            }
-
-            if let Some(path) = first_existing_tsgo_binary(
-                entry
-                    .path()
-                    .join("node_modules")
-                    .join("@typescript")
-                    .join(package_name.as_str())
-                    .join("lib"),
-            ) {
-                return Some(path);
-            }
-        }
-    }
-
-    first_existing_tsgo_binary(
-        workspace_root
-            .join("node_modules")
-            .join("@typescript")
-            .join(package_name.as_str())
-            .join("lib"),
-    )
-}
-
-fn first_existing_tsgo_binary(lib_dir: PathBuf) -> Option<PathBuf> {
-    for executable in test_corsa_executable_names() {
-        let candidate = lib_dir.join(executable);
-        if candidate.exists() {
-            return Some(candidate);
-        }
-    }
-
-    None
-}
-
-fn test_corsa_executable_names() -> &'static [&'static str] {
-    if cfg!(windows) {
-        &["tsgo.exe", "tsgo", "corsa.exe", "corsa"]
-    } else {
-        &["tsgo", "corsa"]
-    }
-}
-
-fn native_preview_platform_suffix() -> &'static str {
-    if cfg!(target_os = "macos") {
-        if cfg!(target_arch = "aarch64") {
-            "darwin-arm64"
-        } else {
-            "darwin-x64"
-        }
-    } else if cfg!(target_os = "linux") {
-        if cfg!(target_arch = "aarch64") {
-            "linux-arm64"
-        } else {
-            "linux-x64"
-        }
-    } else if cfg!(target_os = "windows") {
-        if cfg!(target_arch = "aarch64") {
-            "win32-arm64"
-        } else {
-            "win32-x64"
-        }
-    } else {
-        ""
-    }
 }

--- a/crates/vize_carton/src/corsa_resolver.rs
+++ b/crates/vize_carton/src/corsa_resolver.rs
@@ -12,24 +12,10 @@
 //!    `CORSA_EXECUTABLE`, `TSGO_PATH`, `TSGO_EXECUTABLE`. The first one set
 //!    wins; its value must point at an existing file.
 //! 3. Project discovery: an ancestor walk from the project root (and the
-//!    current directory) probing, per directory:
-//!    - `<dir>/.cache/{corsa,tsgo}[.exe]`
-//!    - developer-checkout paths (`<dir>/ref/typescript-go/...` and the
-//!      sibling `../corsa-bind` checkout) — only when dev paths are enabled,
-//!      see below
-//!    - Node-style resolution of `typescript@7` and its
-//!      `@typescript/typescript-*` platform package
-//!    - the `typescript@7` runtime shipped under `node_modules/vize`
-//!    - legacy Node-style resolution of `@typescript/native-preview/package.json`,
-//!      reading its platform `optionalDependencies` entry
-//!    - the legacy platform package / meta package under `node_modules/@typescript`
-//!    - the pnpm virtual store (`node_modules/.pnpm`) as a legacy fallback
-//!
-//!      Every native-binary probe accepts both `{corsa,tsgo}` and
-//!      `{corsa,tsgo}.exe` — npm's Windows platform packages ship
-//!      `lib/tsgo.exe`.
-//!    - `node_modules/.bin` wrappers (used only when no native binary is
-//!      found anywhere in the walk)
+//!    current directory) probing project caches, dev-checkout paths, stable
+//!    `typescript@7` platform packages, the bundled `node_modules/vize`
+//!    runtime, legacy `@typescript/native-preview` layouts, pnpm store
+//!    fallbacks, and finally local `node_modules/.bin` wrappers.
 //! 4. Common global install locations under `$HOME` plus `npm root -g`.
 //! 5. A `PATH` lookup for `corsa` then `tsgo`.
 //!
@@ -408,10 +394,7 @@ fn find_vize_owned_stable_typescript_native(node_modules: &Path, suffix: &str) -
     find_stable_typescript_native(&node_modules.join("vize").join("node_modules"), suffix)
 }
 
-/// Resolve the platform binary the way Node would: read
-/// `typescript/package.json`, require a stable TypeScript 7+ package, pick the
-/// platform entry from its `optionalDependencies`, and walk `node_modules`
-/// directories upward from the (symlink-resolved) meta package directory.
+/// Resolve the TypeScript 7 platform binary through its package manifest.
 fn resolve_typescript_platform_package(node_modules: &Path, suffix: &str) -> Option<PathBuf> {
     let package_dir = node_modules.join("typescript");
     let manifest = std::fs::read_to_string(package_dir.join("package.json")).ok()?;
@@ -452,10 +435,7 @@ fn package_major_at_least(manifest: &serde_json::Value, minimum: u64) -> bool {
         .is_some_and(|major| major >= minimum)
 }
 
-/// Resolve the platform binary the way Node would: read
-/// `@typescript/native-preview/package.json`, pick the platform entry from its
-/// `optionalDependencies`, and walk `node_modules` directories upward from the
-/// (symlink-resolved) meta package directory.
+/// Resolve the legacy native-preview platform binary through its manifest.
 fn resolve_native_preview_platform_package(node_modules: &Path, suffix: &str) -> Option<PathBuf> {
     let package_dir = node_modules.join("@typescript").join("native-preview");
     let manifest = std::fs::read_to_string(package_dir.join("package.json")).ok()?;
@@ -554,6 +534,17 @@ fn find_node_modules_wrapper(dir: &Path) -> Option<PathBuf> {
         }
     }
 
+    if typescript_package_major_at_least(&node_modules, 7) {
+        for candidate in [
+            node_modules.join(".bin").join("tsc"),
+            node_modules.join("typescript").join("bin").join("tsc"),
+        ] {
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+
     for executable in CORSA_EXECUTABLE_NAMES {
         let candidate = node_modules
             .join("@typescript")
@@ -566,6 +557,13 @@ fn find_node_modules_wrapper(dir: &Path) -> Option<PathBuf> {
     }
 
     None
+}
+
+fn typescript_package_major_at_least(node_modules: &Path, minimum: u64) -> bool {
+    std::fs::read_to_string(node_modules.join("typescript").join("package.json"))
+        .ok()
+        .and_then(|manifest| serde_json::from_str::<serde_json::Value>(&manifest).ok())
+        .is_some_and(|manifest| package_major_at_least(&manifest, minimum))
 }
 
 fn find_in_home_locations() -> Option<PathBuf> {

--- a/crates/vize_carton/src/corsa_resolver/tests/package_runtime.rs
+++ b/crates/vize_carton/src/corsa_resolver/tests/package_runtime.rs
@@ -1,5 +1,5 @@
 use super::super::{discover_in_walk, platform_suffix};
-use super::write_file;
+use super::{write_file, write_typescript_manifest};
 use std::fs;
 use tempfile::TempDir;
 
@@ -175,6 +175,45 @@ fn scrapes_pnpm_store_when_typescript_platform_package_is_not_linked() {
     let resolved = discover_in_walk(&[root], false);
 
     assert_eq!(resolved, Some(store_binary));
+}
+
+#[test]
+fn falls_back_to_typescript_seven_bin_wrapper_when_platform_package_missing() {
+    let suffix = platform_suffix();
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().join("project");
+    let node_modules = root.join("node_modules");
+    let wrapper = node_modules.join(".bin").join("tsc");
+
+    write_typescript_manifest(
+        &node_modules.join("typescript").join("package.json"),
+        suffix,
+        "7.0.2",
+    );
+    write_file(&wrapper);
+
+    let resolved = discover_in_walk(&[root], false);
+
+    assert_eq!(resolved, Some(wrapper));
+}
+
+#[test]
+fn ignores_typescript_six_bin_wrapper() {
+    let suffix = platform_suffix();
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path().join("project");
+    let node_modules = root.join("node_modules");
+
+    write_typescript_manifest(
+        &node_modules.join("typescript").join("package.json"),
+        suffix,
+        "6.0.3",
+    );
+    write_file(&node_modules.join(".bin").join("tsc"));
+
+    let resolved = discover_in_walk(&[root], false);
+
+    assert_eq!(resolved, None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add guarded fallback discovery for project-local `typescript@7` `tsc` wrappers
- keep TypeScript 6 `tsc` ignored so JS TypeScript installs do not masquerade as Corsa runtimes
- share the CLI test Corsa resolver with production discovery so TS7 platform packages and legacy native-preview paths stay consistent

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p vize_carton corsa_resolver -- --nocapture`
- `cargo test -p vize --test lsp_cli lsp_corsa_smoke_publishes_diagnostics_and_hover -- --nocapture`
- `cargo test -p vize --test check_cli check_json_reports_empty_result_when_no_files_match -- --nocapture`
- `cargo clippy -p vize_carton --lib -- -D warnings`
- `vp run --workspace-root source:lengths --check --base-ref origin/main --max-lines 350 --limit 10`
- `node --test tests/tooling/package-manifests-corsa-runtime.test.ts`

## Notes
- `cargo clippy -p vize_carton --tests -- -D warnings` still fails on existing unrelated test lint (`config/loader/tests.rs` dead_code/disallowed_macros and `clone_in.rs` needless_borrow).
- A 15s smoke of `npx --yes vize@0.387.0 check --format json --quiet --no-config` in the reported aimCMS-front project produced no early `corsa not found` or native-preview requirement before being intentionally terminated.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790531303&installation_model_id=422833&pr_number=5195&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5195&signature=c9419d67f5fc3087759720462eccece09566b1ca4a67f89da4621215abfe0909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Corsa executable discovery through configured paths and workspace ancestor directories.
  * Added support for TypeScript 7 `tsc` wrappers when resolving the runtime.
  * Prevented TypeScript 6 wrappers from being selected in TypeScript 7 environments.
  * Updated LSP smoke-test messaging to reference the TypeScript 7 Corsa runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->