### PR TITLE
fix(ricalco): emit object v-bind modifiers

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_bind_modifiers.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_bind_modifiers.rs
@@ -25,6 +25,13 @@ const BATTERY: &[(&str, &str)] = &[
         "merge_props_prop",
         r#"<div v-bind="bag" :value.prop="value"></div>"#,
     ),
+    ("object_prop", r#"<div v-bind.prop="bag"></div>"#),
+    ("object_attr", r#"<div v-bind.attr="bag"></div>"#),
+    ("object_camel", r#"<div v-bind.camel="bag"></div>"#),
+    (
+        "merge_object_prop",
+        r#"<div id="x" v-bind.prop="bag"></div>"#,
+    ),
     ("v_if_attr", r#"<div v-if="ok" :value.attr="value"></div>"#),
     (
         "v_for_camel",

--- a/crates/vize_ricalco/src/emit/merge.rs
+++ b/crates/vize_ricalco/src/emit/merge.rs
@@ -30,12 +30,6 @@ pub(super) fn has_object_spread(bindings: &[BindingOp<'_>]) -> bool {
 }
 
 pub(super) fn admit_object(bind: &BindOp<'_>) -> Result<(), EmitError> {
-    if !bind.modifiers.is_empty() {
-        return Err(EmitError::unsupported_at(
-            Reason::ObjectBindHasModifiers,
-            bind.span,
-        ));
-    }
     js_value(bind).map(|_| ())
 }
 

--- a/crates/vize_ricalco/tests/emit_merge.rs
+++ b/crates/vize_ricalco/tests/emit_merge.rs
@@ -10,7 +10,7 @@
 mod support;
 
 use support::with_transformed;
-use vize_ricalco::{EmitError, UnsupportedReason as Reason, emit_dom};
+use vize_ricalco::emit_dom;
 
 fn assembled(source: &str) -> String {
     with_transformed(source, |lowered, _folio, facts, _budget| {
@@ -18,12 +18,6 @@ fn assembled(source: &str) -> String {
             .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
             .assembled()
             .to_string()
-    })
-}
-
-fn refused(source: &str) -> EmitError {
-    with_transformed(source, |lowered, _, facts, _| {
-        emit_dom(lowered, facts).expect_err("expected Unsupported")
     })
 }
 
@@ -244,10 +238,14 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
-fn an_object_bind_with_modifiers_is_unsupported_this_installment() {
+fn object_bind_modifiers_preserve_the_spread_expression() {
     assert_eq!(
-        refused(r#"<div v-bind.prop="obj"></div>"#).reason(),
-        Some(Reason::ObjectBindHasModifiers)
+        assembled(r#"<div v-bind.prop="obj"></div>"#),
+        assembled(r#"<div v-bind="obj"></div>"#)
+    );
+    assert_eq!(
+        assembled(r#"<div id="x" v-bind.attr.camel="obj"></div>"#),
+        assembled(r#"<div id="x" v-bind="obj"></div>"#)
     );
 }
 

--- a/crates/vize_ricalco/tests/emit_unsupported_catalogue.rs
+++ b/crates/vize_ricalco/tests/emit_unsupported_catalogue.rs
@@ -21,7 +21,6 @@ const SOURCE: &[Reason] = &[
     Reason::IfConditionNotJs,
     Reason::MemoExpressionNotJs,
     Reason::ModelArgumentNotJs,
-    Reason::ObjectBindHasModifiers,
     Reason::ObjectOnHandlerNotJs,
     Reason::ObjectOnHasModifiers,
     Reason::OnHandlerNotJs,
@@ -64,6 +63,7 @@ const GUARD_ONLY: &[Reason] = &[
 const RETIRED: &[Reason] = &[
     Reason::CreateSlotsMissingSlotTemplate,
     Reason::DynamicOnHasModifiers,
+    Reason::ObjectBindHasModifiers,
 ];
 
 #[test]

--- a/crates/vize_ricalco/tests/emit_unsupported_census.rs
+++ b/crates/vize_ricalco/tests/emit_unsupported_census.rs
@@ -109,12 +109,6 @@ const SOURCE_CASES: &[Case] = &[
         Reason::ModelArgumentNotJs,
     ),
     case(
-        "object_bind_mod",
-        r#"<div v-bind.prop="obj"></div>"#,
-        VUE3,
-        Reason::ObjectBindHasModifiers,
-    ),
-    case(
         "object_on_bad_handler",
         r#"<div v-on="handlers."></div>"#,
         VUE3,
@@ -220,7 +214,6 @@ fn committed_fixture_refusal_census_is_pinned() {
             ("if_condition_not_js", 1),
             ("memo_expression_not_js", 1),
             ("model_argument_not_js", 1),
-            ("object_bind_has_modifiers", 1),
             ("object_on_handler_not_js", 1),
             ("object_on_has_modifiers", 1),
             ("on_handler_not_js", 1),


### PR DESCRIPTION
## Summary
- allow S2 DOM emission for object `v-bind` spreads that carry `.prop`, `.attr`, or `.camel` modifiers
- keep the spread expression byte-compatible with the shipped DOM lane and retire the old refusal bucket from the source census
- add S2-vs-shipped DOM parity cases for lone and merged object `v-bind` modifiers

## Tests
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p vize_ricalco`
- `cargo test -p vize_atelier_dom`
- `cargo test -p vize_atelier_core --test davinci_s2_transform`
- `node --test tests/tooling/davinci-*.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `vp check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790567525&installation_model_id=422833&pr_number=5208&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5208&signature=f653ebd6af21ca66f328922f4572fccc36e9628927d3666cbb452b6dfc52203b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Object-form `v-bind` now supports `.prop`, `.attr`, and `.camel` modifiers.
  * Modifier usage can be combined with existing attributes while preserving spread behavior.

* **Bug Fixes**
  * Prevented valid object bindings with modifiers from being incorrectly rejected.
  * Updated output handling to preserve expected DOM rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->