### PR TITLE
fix(canon): materialize TS7 Vue overlay diagnostics

### DIFF
--- a/crates/vize_canon/src/lsp_client/diagnostics.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::file_uri::file_uri_to_path;
 use corsa::{CorsaError, runtime::block_on};
-use lsp_types::{Diagnostic, DocumentDiagnosticReport, DocumentDiagnosticReportResult};
+use lsp_types::Diagnostic;
 use std::time::Duration;
 use vize_s0::{FxHashMap, String, cstr};
 
@@ -15,6 +15,9 @@ type EditorLspDiagnosticDocuments = FxHashMap<String, String>;
 type EditorLspDiagnosticPairs = Vec<(String, String)>;
 const LSP_DIAGNOSTICS_BATCH_CHUNK_SIZE: usize = 128;
 const LSP_DIAGNOSTICS_BATCH_TRANSIENT_RETRIES: usize = 1;
+
+mod lsp_report;
+mod virtual_overlay_diagnostics;
 
 impl CorsaProjectClient {
     /// Get cached diagnostics for a URI.
@@ -36,6 +39,11 @@ impl CorsaProjectClient {
         &mut self,
         uris: &[String],
     ) -> Result<Vec<(String, Vec<LspDiagnostic>)>, String> {
+        virtual_overlay_diagnostics::ensure_materialized_project(
+            self,
+            uris.iter().map(|uri| uri.as_str()),
+        )?;
+
         if self.has_materialized_documents(uris)
             && let Some(results) = self.request_diagnostics_batch_via_materialized_files(uris)?
         {
@@ -64,6 +72,8 @@ impl CorsaProjectClient {
         &mut self,
         uri: &str,
     ) -> Result<DiagnosticFetch, String> {
+        virtual_overlay_diagnostics::ensure_materialized_project(self, std::iter::once(uri))?;
+
         if self.supports_file_diagnostics_api()
             && self.can_use_api_for_uri(uri)
             && let Some(fetch) = self.request_diagnostics_full_via_file_api(uri)?
@@ -354,7 +364,7 @@ impl CorsaProjectClient {
         };
         let diagnostics = diagnostics
             .into_iter()
-            .map(lsp_diagnostic_to_native)
+            .map(lsp_report::lsp_diagnostic_to_native)
             .collect::<Vec<_>>();
         Ok(Some(self.store_file_diagnostics(uri, diagnostics)))
     }
@@ -436,7 +446,7 @@ impl CorsaProjectClient {
                 }
             };
 
-            let diagnostics = self.remap_diagnostics(extract_lsp_report_diagnostics(report));
+            let diagnostics = self.remap_diagnostics(lsp_report::extract_diagnostics(report));
             self.diagnostics
                 .insert(external_uri.clone(), diagnostics.clone());
             results.push((external_uri.clone(), convert_diagnostics(&diagnostics)));
@@ -468,8 +478,8 @@ impl CorsaProjectClient {
                 .get(document_uri.as_str())
                 .cloned()
                 .or_else(|| self.document_texts.get(uri.as_str()).cloned())
-                .or_else(|| read_file_uri(document_uri.as_str()))
-                .or_else(|| read_file_uri(uri.as_str()))
+                .or_else(|| lsp_report::read_file_uri(document_uri.as_str()))
+                .or_else(|| lsp_report::read_file_uri(uri.as_str()))
                 .ok_or_else(|| cstr!("Failed to load document text for {uri}"))?;
             documents.entry(document_uri.clone()).or_insert(text);
             pairs.push((uri.clone(), document_uri));
@@ -509,67 +519,6 @@ fn diagnostics_api_is_unsupported(error: &str) -> bool {
 
 fn diagnostics_api_error_is_unsupported(error: &impl std::fmt::Display) -> bool {
     diagnostics_api_is_unsupported(cstr!("{error}").as_str())
-}
-
-fn extract_lsp_report_diagnostics(report: DocumentDiagnosticReportResult) -> Vec<Diagnostic> {
-    match report {
-        DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(report)) => {
-            report.full_document_diagnostic_report.items
-        }
-        DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Unchanged(_)) => {
-            Vec::new()
-        }
-        DocumentDiagnosticReportResult::Partial(_) => Vec::new(),
-    }
-}
-
-fn lsp_diagnostic_to_native(diagnostic: LspDiagnostic) -> Diagnostic {
-    Diagnostic {
-        range: lsp_types::Range::new(
-            lsp_types::Position::new(
-                diagnostic.range.start.line,
-                diagnostic.range.start.character,
-            ),
-            lsp_types::Position::new(diagnostic.range.end.line, diagnostic.range.end.character),
-        ),
-        severity: diagnostic.severity.and_then(lsp_severity_from_i32),
-        code: diagnostic.code.map(json_code_to_lsp_code),
-        code_description: None,
-        source: diagnostic.source.map(|source| source.into()),
-        message: diagnostic.message.into(),
-        related_information: None,
-        tags: None,
-        data: None,
-    }
-}
-
-fn lsp_severity_from_i32(severity: i32) -> Option<lsp_types::DiagnosticSeverity> {
-    match severity {
-        1 => Some(lsp_types::DiagnosticSeverity::ERROR),
-        2 => Some(lsp_types::DiagnosticSeverity::WARNING),
-        3 => Some(lsp_types::DiagnosticSeverity::INFORMATION),
-        4 => Some(lsp_types::DiagnosticSeverity::HINT),
-        _ => None,
-    }
-}
-
-fn json_code_to_lsp_code(code: serde_json::Value) -> lsp_types::NumberOrString {
-    match code {
-        serde_json::Value::Number(number) => {
-            if let Some(value) = number.as_i64() {
-                lsp_types::NumberOrString::Number(value as i32)
-            } else {
-                lsp_types::NumberOrString::String(cstr!("{number}").into())
-            }
-        }
-        serde_json::Value::String(string) => lsp_types::NumberOrString::String(string),
-        other => lsp_types::NumberOrString::String(cstr!("{other}").into()),
-    }
-}
-
-fn read_file_uri(uri: &str) -> Option<String> {
-    let path = file_uri_to_path(uri)?;
-    std::fs::read_to_string(path).ok().map(Into::into)
 }
 
 #[cfg(test)]

--- a/crates/vize_canon/src/lsp_client/diagnostics/lsp_report.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics/lsp_report.rs
@@ -1,0 +1,67 @@
+use crate::{file_uri::file_uri_to_path, lsp_client::LspDiagnostic};
+use lsp_types::{
+    Diagnostic, DiagnosticSeverity, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
+    NumberOrString, Position, Range,
+};
+use vize_s0::{String, cstr};
+
+pub(super) fn extract_diagnostics(report: DocumentDiagnosticReportResult) -> Vec<Diagnostic> {
+    match report {
+        DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Full(report)) => {
+            report.full_document_diagnostic_report.items
+        }
+        DocumentDiagnosticReportResult::Report(DocumentDiagnosticReport::Unchanged(_)) => {
+            Vec::new()
+        }
+        DocumentDiagnosticReportResult::Partial(_) => Vec::new(),
+    }
+}
+
+pub(super) fn lsp_diagnostic_to_native(diagnostic: LspDiagnostic) -> Diagnostic {
+    Diagnostic {
+        range: Range::new(
+            Position::new(
+                diagnostic.range.start.line,
+                diagnostic.range.start.character,
+            ),
+            Position::new(diagnostic.range.end.line, diagnostic.range.end.character),
+        ),
+        severity: diagnostic.severity.and_then(lsp_severity_from_i32),
+        code: diagnostic.code.map(json_code_to_lsp_code),
+        code_description: None,
+        source: diagnostic.source.map(|source| source.into()),
+        message: diagnostic.message.into(),
+        related_information: None,
+        tags: None,
+        data: None,
+    }
+}
+
+pub(super) fn read_file_uri(uri: &str) -> Option<String> {
+    let path = file_uri_to_path(uri)?;
+    std::fs::read_to_string(path).ok().map(Into::into)
+}
+
+fn lsp_severity_from_i32(severity: i32) -> Option<DiagnosticSeverity> {
+    match severity {
+        1 => Some(DiagnosticSeverity::ERROR),
+        2 => Some(DiagnosticSeverity::WARNING),
+        3 => Some(DiagnosticSeverity::INFORMATION),
+        4 => Some(DiagnosticSeverity::HINT),
+        _ => None,
+    }
+}
+
+fn json_code_to_lsp_code(code: serde_json::Value) -> NumberOrString {
+    match code {
+        serde_json::Value::Number(number) => {
+            if let Some(value) = number.as_i64() {
+                NumberOrString::Number(value as i32)
+            } else {
+                NumberOrString::String(cstr!("{number}").into())
+            }
+        }
+        serde_json::Value::String(string) => NumberOrString::String(string),
+        other => NumberOrString::String(cstr!("{other}").into()),
+    }
+}

--- a/crates/vize_canon/src/lsp_client/diagnostics/tests.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics/tests.rs
@@ -1,5 +1,8 @@
 use super::{CorsaError, corsa_diagnostics_error_is_unsupported, diagnostics_api_is_unsupported};
-use crate::lsp_client::lsp_transport_error_is_transient;
+use crate::{
+    file_uri::path_to_file_uri, lsp_client::CorsaProjectClient,
+    lsp_client::lsp_transport_error_is_transient,
+};
 
 // Regression: a missing diagnostics scope on the corsa `ProjectSession`
 // must be detected through the typed `CorsaError::Unsupported` variant
@@ -43,4 +46,49 @@ fn recognizes_transient_lsp_transport_errors() {
     assert!(!lsp_transport_error_is_transient(
         "TypeScript semantic diagnostics are unavailable"
     ));
+}
+
+#[test]
+fn virtual_vue_overlay_diagnostics_force_materialized_project_config() {
+    let project = tempfile::tempdir().unwrap();
+    let project_root = project.path().join("workspace");
+    let src = project_root.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(project_root.join("tsconfig.json"), "{}").unwrap();
+    std::fs::write(src.join("App.vue"), "<template><div /></template>").unwrap();
+
+    let virtual_uri = path_to_file_uri(&src.join("App.vue.ts"));
+    let mut client = CorsaProjectClient::empty_for_test(project_root);
+    client
+        .document_texts
+        .insert(virtual_uri.clone(), "export {};".into());
+
+    assert!(
+        super::virtual_overlay_diagnostics::needs_materialized_project_config(
+            &client,
+            &virtual_uri
+        )
+    );
+
+    let authored_uri = path_to_file_uri(&src.join("App.vue"));
+    client
+        .document_texts
+        .insert(authored_uri.clone(), "<template><div /></template>".into());
+    assert!(
+        !super::virtual_overlay_diagnostics::needs_materialized_project_config(
+            &client,
+            &authored_uri
+        )
+    );
+
+    let missing_backing_uri = path_to_file_uri(&src.join("Missing.vue.ts"));
+    client
+        .document_texts
+        .insert(missing_backing_uri.clone(), "export {};".into());
+    assert!(
+        !super::virtual_overlay_diagnostics::needs_materialized_project_config(
+            &client,
+            &missing_backing_uri
+        )
+    );
 }

--- a/crates/vize_canon/src/lsp_client/diagnostics/virtual_overlay_diagnostics.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics/virtual_overlay_diagnostics.rs
@@ -1,0 +1,26 @@
+use super::CorsaProjectClient;
+use crate::{file_uri::file_uri_to_path, lsp_client::virtual_overlay};
+
+pub(super) fn ensure_materialized_project<'a>(
+    client: &mut CorsaProjectClient,
+    uris: impl IntoIterator<Item = &'a str>,
+) -> Result<(), String> {
+    if client.has_project_session()
+        && !client.materialized_project_session
+        && uris
+            .into_iter()
+            .any(|uri| needs_materialized_project_config(client, uri))
+    {
+        client.activate_materialized_project_session()?;
+    }
+    Ok(())
+}
+
+pub(super) fn needs_materialized_project_config(client: &CorsaProjectClient, uri: &str) -> bool {
+    client.document_texts.contains_key(uri)
+        && file_uri_to_path(uri).is_some_and(|path| {
+            path.starts_with(&client.project_root)
+                && !path.exists()
+                && virtual_overlay::target_exists(&path)
+        })
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -47,7 +47,7 @@ observational guard for planning only. It does not change rollout state.
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           928 |                   431 |               497 |             139 |     371 |             952 |      486 |           483 |           591 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
-| Typechecker                |           878 |                   226 |               652 |             396 |     187 |             806 |      655 |           466 |           660 |
+| Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           662 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
 | LSP                        |           271 |                   271 |                 0 |             115 |      44 |             325 |      105 |           166 |           388 |
@@ -134,7 +134,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         878 |             502 |      376 |
+| S0               |         879 |             503 |      376 |
 | old AST/parser   |         160 |              35 |      125 |
 | Croquis analysis |         236 |             118 |      118 |
 | raw OXC          |         187 |             151 |       36 |
@@ -149,7 +149,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 | `crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/cache.rs:7` | source   | S0 10                                                       |    10 |
 | `crates/vize_canon/src/virtual_ts/expressions/statements.rs:15`                | source   | S0 6<br>Croquis analysis 3                                  |     9 |
 
-Additional source/manifest rows are in the TSV: 308 omitted.
+Additional source/manifest rows are in the TSV: 309 omitted.
 
 #### Top test/dev files
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1763,6 +1763,7 @@ typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/bootstrap.rs	13	
 typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/diagnostics_api.rs	6	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/diagnostics_lsp.rs	12	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/diagnostics.rs	11	s0	S0	stage	vize_s0	preferred	1
+typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/diagnostics/lsp_report.rs	6	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp.rs	30	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/client.rs	7	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize_canon/src/lsp_client/editor_lsp/file_rename.rs	5	s0	S0	stage	vize_s0	preferred	1


### PR DESCRIPTION
## Summary
- switch diagnostics for missing-on-disk Vue virtual overlays to the materialized Corsa project before querying diagnostics APIs
- keep the user tsconfig untouched while using the existing overlay tsconfig that enables TS7 .ts-extension imports
- add a unit regression for the materialization predicate

Closes #5218

## Verification
- cargo fmt --all -- --check
- cargo test -p vize_canon lsp_client::diagnostics::tests::virtual_vue_overlay_diagnostics_force_materialized_project_config
- cargo test -p vize --test check_server_cli -- --nocapture
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790583114&installation_model_id=422833&pr_number=5219&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5219&signature=48a2fa27fa9fb39d9cacaff4aae5d1d70352c046fc7ec0a261daab222ca69a25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for virtual files whose corresponding project files are missing.
  * Ensured project configuration is available before returning diagnostics for affected virtual overlays.
  * Preserved existing behavior for authored files and overlays without backing files.
  * Improved handling and normalization of diagnostics returned by language services.

* **Tests**
  * Added coverage for diagnostics involving virtual Vue files and project configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->