### PR TITLE
fix(canon): materialize TS7 LSP fallback overlays

### DIFF
--- a/crates/vize_canon/src/lsp_client/diagnostics/tests.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics/tests.rs
@@ -1,6 +1,7 @@
 use super::{CorsaError, corsa_diagnostics_error_is_unsupported, diagnostics_api_is_unsupported};
 use crate::{
-    file_uri::path_to_file_uri, lsp_client::CorsaProjectClient,
+    file_uri::{file_uri_to_path, path_to_file_uri},
+    lsp_client::CorsaProjectClient,
     lsp_client::lsp_transport_error_is_transient,
 };
 
@@ -91,4 +92,39 @@ fn virtual_vue_overlay_diagnostics_force_materialized_project_config() {
             &missing_backing_uri
         )
     );
+}
+
+#[test]
+fn virtual_vue_overlay_diagnostics_materializes_for_lsp_fallback() {
+    let project = tempfile::tempdir().unwrap();
+    let project_root = project.path().join("workspace");
+    let src = project_root.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(project_root.join("tsconfig.json"), "{}").unwrap();
+    std::fs::write(src.join("App.vue"), "<template><div /></template>").unwrap();
+
+    let virtual_uri = path_to_file_uri(&src.join("App.vue.ts"));
+    let mut client = CorsaProjectClient::empty_for_test(project_root.clone());
+    client
+        .document_texts
+        .insert(virtual_uri.clone(), "export {};".into());
+
+    super::virtual_overlay_diagnostics::ensure_materialized_project(
+        &mut client,
+        std::iter::once(virtual_uri.as_str()),
+    )
+    .unwrap();
+
+    assert!(client.materialized_project_session);
+    let document_uri = client.session_document_uri(virtual_uri.as_str());
+    assert_ne!(document_uri, virtual_uri);
+    let document_path = file_uri_to_path(document_uri.as_str()).unwrap();
+    assert_eq!(
+        std::fs::read_to_string(document_path).unwrap(),
+        "export {};"
+    );
+
+    let generated_config = project_root.join("node_modules/.vize/corsa-overlay/tsconfig.json");
+    let config = std::fs::read_to_string(generated_config).unwrap();
+    assert!(config.contains("\"allowImportingTsExtensions\":true"));
 }

--- a/crates/vize_canon/src/lsp_client/diagnostics/virtual_overlay_diagnostics.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics/virtual_overlay_diagnostics.rs
@@ -5,22 +5,29 @@ pub(super) fn ensure_materialized_project<'a>(
     client: &mut CorsaProjectClient,
     uris: impl IntoIterator<Item = &'a str>,
 ) -> Result<(), String> {
-    if client.has_project_session()
-        && !client.materialized_project_session
-        && uris
-            .into_iter()
-            .any(|uri| needs_materialized_project_config(client, uri))
-    {
+    if client.materialized_project_session {
+        return Ok(());
+    }
+
+    let requested_virtual_overlay = uris
+        .into_iter()
+        .any(|uri| needs_materialized_project_config(client, uri));
+    let open_virtual_overlay = !requested_virtual_overlay
+        && client
+            .document_texts
+            .keys()
+            .any(|uri| open_uri_needs_materialized_project_config(uri));
+    if requested_virtual_overlay || open_virtual_overlay {
         client.activate_materialized_project_session()?;
     }
     Ok(())
 }
 
 pub(super) fn needs_materialized_project_config(client: &CorsaProjectClient, uri: &str) -> bool {
-    client.document_texts.contains_key(uri)
-        && file_uri_to_path(uri).is_some_and(|path| {
-            path.starts_with(&client.project_root)
-                && !path.exists()
-                && virtual_overlay::target_exists(&path)
-        })
+    client.document_texts.contains_key(uri) && open_uri_needs_materialized_project_config(uri)
+}
+
+fn open_uri_needs_materialized_project_config(uri: &str) -> bool {
+    file_uri_to_path(uri)
+        .is_some_and(|path| !path.exists() && virtual_overlay::target_exists(&path))
 }


### PR DESCRIPTION
## Summary

- materialize Vue virtual overlays even when TS7 diagnostics are using the editor-LSP fallback without a ProjectSession
- detect materialization needs from already-open Vue virtual overlay documents, not just the requested diagnostic URI
- add a regression that proves the no-ProjectSession path writes the materialized overlay config with allowImportingTsExtensions

## Verification

- cargo fmt --all
- cargo test -p vize_canon lsp_client::diagnostics::tests::virtual_vue_overlay_diagnostics_materializes_for_lsp_fallback
- cargo test -p vize --test check_server_cli -- --nocapture
- cargo test -p vize_canon lsp_client::diagnostics::tests
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- git diff --check
- node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/source-file-lengths.test.ts
- vp check --no-error-on-unmatched-pattern crates/vize_canon/src/lsp_client/diagnostics/tests.rs crates/vize_canon/src/lsp_client/diagnostics/virtual_overlay_diagnostics.rs

Closes #5220

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790585269&installation_model_id=422833&pr_number=5221&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5221&signature=8b6bc6cbbe4df3e1725233b2ba5c8fa0be4447567929c50ec0d822ec426b2b98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostics for virtual Vue and TypeScript overlay documents.
  - Ensured required project configuration is generated when open documents need materialized-project support.
  - Prevented unnecessary reactivation when the materialized project is already active.
  - Added support for overlay documents outside the configured project root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->