### PR TITLE
refactor(vitrine): import s0 storage through stage alias

### DIFF
--- a/crates/vize_vitrine/Cargo.toml
+++ b/crates/vize_vitrine/Cargo.toml
@@ -32,7 +32,7 @@ napi = [
 wasm = ["dep:wasm-bindgen", "dep:serde-wasm-bindgen", "dep:js-sys", "dep:web-sys", "glyph"]
 
 [dependencies]
-vize_carton = { workspace = true }
+vize_s0 = { workspace = true }
 vize_relief = { workspace = true }
 vize_atelier_core = { workspace = true }
 vize_atelier_dom = { workspace = true }

--- a/crates/vize_vitrine/src/napi/art.rs
+++ b/crates/vize_vitrine/src/napi/art.rs
@@ -13,7 +13,7 @@
 use napi::bindgen_prelude::{Error, Result, Status};
 use napi_derive::napi;
 use rayon::prelude::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 // ============================================================================
 // Art file types

--- a/crates/vize_vitrine/src/napi/jsx.rs
+++ b/crates/vize_vitrine/src/napi/jsx.rs
@@ -23,7 +23,7 @@ use napi_derive::napi;
 use vize_atelier_jsx::{
     JsxCompatMode, JsxCompileConfig, JsxLang, JsxOutputMode, compile_jsx as jsx_compile,
 };
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 /// Options for [`compile_jsx`].
 #[napi(object)]

--- a/crates/vize_vitrine/src/napi/lint.rs
+++ b/crates/vize_vitrine/src/napi/lint.rs
@@ -15,7 +15,7 @@ use napi_derive::napi;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use serde_json::{Value, json};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use vize_carton::append;
+use vize_s0::append;
 
 use super::lint_fix::{lint_file_with_optional_fix, lint_source};
 mod empty_result;
@@ -88,8 +88,8 @@ const fn severity_name(severity: vize_patina::Severity) -> &'static str {
 }
 
 fn collect_patina_rule_metadata() -> Vec<PatinaRuleMetaNapi<'static>> {
-    use vize_carton::FxHashSet;
     use vize_patina::{LintPreset, RuleRegistry, builtin_script_rules};
+    use vize_s0::FxHashSet;
 
     let template_rule_registries = [
         RuleRegistry::with_preset(LintPreset::Opinionated),
@@ -348,15 +348,15 @@ pub fn lint(patterns: Vec<String>, options: Option<LintOptionsNapi>) -> Result<L
     let quiet = opts.quiet.unwrap_or(false);
 
     // Format output
-    let mut output = vize_carton::CompactString::default();
+    let mut output = vize_s0::CompactString::default();
     if format.renders_details_when_quiet() || !quiet || total_errors > 0 || total_warnings > 0 {
         let lint_results: Vec<_> = results.iter().map(|(_, _, r)| r).cloned().collect();
         let sources: Vec<_> = results
             .iter()
             .map(|(f, s, _)| {
                 (
-                    vize_carton::CompactString::from(f.as_str()),
-                    vize_carton::CompactString::from(s.as_str()),
+                    vize_s0::CompactString::from(f.as_str()),
+                    vize_s0::CompactString::from(s.as_str()),
                 )
             })
             .collect();

--- a/crates/vize_vitrine/src/napi/lint_fix.rs
+++ b/crates/vize_vitrine/src/napi/lint_fix.rs
@@ -1,7 +1,7 @@
 //! Lint text-edit application for the native API.
 
 use std::{fs, path::Path};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 pub(super) fn lint_file_with_optional_fix(
     linter: &vize_patina::Linter,
@@ -141,8 +141,17 @@ mod tests {
 
     #[test]
     fn script_extensions_do_not_expand_directory_collection() {
-        for extension in ["js", "jsx", "mjs", "cjs", "ts", "tsx", "mts", "cts"] {
-            assert!(is_script_filename(&format!("nuxt.config.{extension}")));
+        for (filename, extension) in [
+            ("nuxt.config.js", "js"),
+            ("nuxt.config.jsx", "jsx"),
+            ("nuxt.config.mjs", "mjs"),
+            ("nuxt.config.cjs", "cjs"),
+            ("nuxt.config.ts", "ts"),
+            ("nuxt.config.tsx", "tsx"),
+            ("nuxt.config.mts", "mts"),
+            ("nuxt.config.cts", "cts"),
+        ] {
+            assert!(is_script_filename(filename));
             assert!(!is_lintable_extension(extension));
         }
     }

--- a/crates/vize_vitrine/src/napi/plugin/precompile.rs
+++ b/crates/vize_vitrine/src/napi/plugin/precompile.rs
@@ -109,7 +109,7 @@ fn into_native_entries_ref(
     entries.iter().map(Into::into).collect()
 }
 
-fn into_native_files(files: Vec<String>) -> Vec<vize_carton::String> {
+fn into_native_files(files: Vec<String>) -> Vec<vize_s0::String> {
     files.into_iter().map(Into::into).collect()
 }
 

--- a/crates/vize_vitrine/src/napi/sfc/batch.rs
+++ b/crates/vize_vitrine/src/napi/sfc/batch.rs
@@ -3,7 +3,7 @@ use napi::bindgen_prelude::{Error, Result, Status};
 use napi_derive::napi;
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use std::{fs, time::Instant};
-use vize_carton::FxHashMap;
+use vize_s0::FxHashMap;
 
 use super::{
     batch_helpers::{
@@ -132,7 +132,7 @@ fn compile_sfc_batch_inner(
         .par_iter()
         .map(|job| {
             let source_len = job.input_bytes;
-            let filename: vize_carton::CompactString = job.path.to_string_lossy().as_ref().into();
+            let filename: vize_s0::CompactString = job.path.to_string_lossy().as_ref().into();
             let parse_opts = SfcParseOptions {
                 filename: filename.clone(),
                 ..Default::default()

--- a/crates/vize_vitrine/src/napi/sfc/batch_helpers.rs
+++ b/crates/vize_vitrine/src/napi/sfc/batch_helpers.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 use vize_atelier_core::TemplateSyntaxMode;
-use vize_carton::hash::hash_str;
+use vize_s0::hash::hash_str;
 
 #[derive(Default)]
 pub(super) struct BatchStats {

--- a/crates/vize_vitrine/src/napi/sfc/batch_results.rs
+++ b/crates/vize_vitrine/src/napi/sfc/batch_results.rs
@@ -7,7 +7,7 @@ use std::{
 };
 use vize_atelier_sfc::build_sfc_source_map;
 use vize_atelier_sfc::compile_script::typescript::ensure_javascript_output;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::types::ModuleShapeNapi;
 use super::{
@@ -82,7 +82,7 @@ fn compile_sfc_batch_with_results_inner(
         .map(|file| {
             let scope_id =
                 vize_atelier_sfc::generate_bundler_scope_id(&file.path, None, false, None);
-            let filename_cs: vize_carton::CompactString = file.path.as_str().into();
+            let filename_cs: vize_s0::CompactString = file.path.as_str().into();
             let descriptor = match sfc_parse(
                 &file.source,
                 SfcParseOptions {

--- a/crates/vize_vitrine/src/napi/sfc/compile.rs
+++ b/crates/vize_vitrine/src/napi/sfc/compile.rs
@@ -2,7 +2,7 @@ use napi::{Result, Status};
 use napi_derive::napi;
 use vize_atelier_sfc::build_sfc_source_map;
 use vize_atelier_sfc::compile_script::typescript::ensure_javascript_output;
-use vize_carton::cstr;
+use vize_s0::cstr;
 
 use super::types::ModuleShapeNapi;
 use super::{
@@ -26,7 +26,7 @@ pub fn compile_sfc(
     };
 
     let opts = options.unwrap_or_default();
-    let filename: vize_carton::CompactString =
+    let filename: vize_s0::CompactString =
         opts.filename.as_deref().unwrap_or("anonymous.vue").into();
     let parse_opts = SfcParseOptions {
         filename: filename.clone(),
@@ -70,7 +70,7 @@ pub fn compile_sfc(
     let custom_elements = vize_atelier_core::options::CustomElementMatcher::from_patterns(
         crate::types::custom_element_patterns(opts.custom_elements.as_deref()),
     );
-    let external_scope_id: Option<vize_carton::CompactString> = opts
+    let external_scope_id: Option<vize_s0::CompactString> = opts
         .scope_id
         .as_ref()
         .map(|sid| sid.strip_prefix("data-v-").unwrap_or(sid).into());

--- a/crates/vize_vitrine/src/napi/template.rs
+++ b/crates/vize_vitrine/src/napi/template.rs
@@ -12,7 +12,7 @@
 
 use napi::bindgen_prelude::{Error, Result, Status};
 use napi_derive::napi;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 use crate::{CompileResult, CompilerOptions, template_syntax::resolve_template_syntax};
 use vize_atelier_core::{

--- a/crates/vize_vitrine/src/napi/tokens.rs
+++ b/crates/vize_vitrine/src/napi/tokens.rs
@@ -4,7 +4,7 @@
 use napi::bindgen_prelude::{Error, Result, Status};
 use napi_derive::napi;
 use serde::Serialize;
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 #[napi(js_name = "parseDesignTokensFromPath")]
 pub fn parse_design_tokens_from_path(tokens_path: String) -> Result<String> {
@@ -70,18 +70,18 @@ fn categories_from_json(source: &str) -> Result<Vec<vize_musea::tokens::TokenCat
     serde_json::from_str(source).map_err(|error| {
         Error::new(
             Status::InvalidArg,
-            vize_carton::cstr!("Invalid token categories: {error}"),
+            vize_s0::cstr!("Invalid token categories: {error}"),
         )
     })
 }
 
 fn token_map_from_json(
     source: &str,
-) -> Result<vize_carton::FxHashMap<vize_carton::String, vize_musea::tokens::DesignToken>> {
+) -> Result<vize_s0::FxHashMap<vize_s0::String, vize_musea::tokens::DesignToken>> {
     serde_json::from_str(source).map_err(|error| {
         Error::new(
             Status::InvalidArg,
-            vize_carton::cstr!("Invalid token map: {error}"),
+            vize_s0::cstr!("Invalid token map: {error}"),
         )
     })
 }
@@ -90,7 +90,7 @@ fn to_json(value: impl Serialize) -> Result<String> {
     serde_json::to_string(&value).map_err(|error| {
         Error::new(
             Status::GenericFailure,
-            vize_carton::cstr!("Failed to serialize token result: {error}"),
+            vize_s0::cstr!("Failed to serialize token result: {error}"),
         )
     })
 }

--- a/crates/vize_vitrine/src/napi_typecheck.rs
+++ b/crates/vize_vitrine/src/napi_typecheck.rs
@@ -85,7 +85,7 @@ pub fn type_check_napi(
     options: Option<TypeCheckOptionsNapi>,
 ) -> Result<TypeCheckResultNapi> {
     let opts = options.unwrap_or_default();
-    let filename: vize_carton::CompactString =
+    let filename: vize_s0::CompactString =
         opts.filename.as_deref().unwrap_or("anonymous.vue").into();
 
     let mut check_opts = TypeCheckOptions::new(filename);
@@ -345,7 +345,7 @@ pub fn type_check_batch_napi(
             Err(_) => return,
         };
 
-        let filename: vize_carton::CompactString = path
+        let filename: vize_s0::CompactString = path
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("anonymous.vue")

--- a/crates/vize_vitrine/src/types.rs
+++ b/crates/vize_vitrine/src/types.rs
@@ -80,7 +80,7 @@ pub struct CompilerOptions {
 /// Only the NAPI and WASM bridges consume this, so it is gated to those builds
 /// to keep default-feature builds free of dead code.
 #[cfg(any(feature = "napi", feature = "wasm"))]
-pub(crate) fn custom_element_patterns(patterns: Option<&[String]>) -> Vec<vize_carton::String> {
+pub(crate) fn custom_element_patterns(patterns: Option<&[String]>) -> Vec<vize_s0::String> {
     patterns
         .unwrap_or_default()
         .iter()

--- a/crates/vize_vitrine/src/wasm/analyze.rs
+++ b/crates/vize_vitrine/src/wasm/analyze.rs
@@ -9,7 +9,7 @@
 
 use super::source_offsets::{ScriptOffsetMapper, to_sfc_utf16_range};
 use super::to_js_value;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 use wasm_bindgen::prelude::*;
 
 /// Analyze Vue SFC for semantic information (scopes, bindings, etc.)

--- a/crates/vize_vitrine/src/wasm/compiler.rs
+++ b/crates/vize_vitrine/src/wasm/compiler.rs
@@ -6,7 +6,7 @@ pub(in crate::wasm) mod pipeline;
 
 pub use free_fns::*;
 
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 use wasm_bindgen::prelude::*;
 
 use crate::{CompilerOptions, template_syntax::resolve_template_syntax};
@@ -104,7 +104,7 @@ impl Compiler {
     /// Parse SFC (.vue file)
     #[wasm_bindgen(js_name = "parseSfc")]
     pub fn parse_sfc_method(&self, source: &str, options: JsValue) -> Result<JsValue, JsValue> {
-        let filename: vize_carton::CompactString =
+        let filename: vize_s0::CompactString =
             js_sys::Reflect::get(&options, &JsValue::from_str("filename"))
                 .ok()
                 .and_then(|v| v.as_string())
@@ -157,7 +157,7 @@ impl Compiler {
         let parsed = parse_compiler_options(&options);
         let opts = parsed.options;
 
-        let filename: vize_carton::CompactString = opts
+        let filename: vize_s0::CompactString = opts
             .filename
             .clone()
             .unwrap_or_else(|| "anonymous.vue".to_string())

--- a/crates/vize_vitrine/src/wasm/compiler/pipeline.rs
+++ b/crates/vize_vitrine/src/wasm/compiler/pipeline.rs
@@ -8,7 +8,7 @@ use vize_atelier_ssr::{SsrCompilerOptions, compile_ssr_with_custom_elements_and_
 use vize_atelier_vapor::{
     VaporCompilerOptions, compile_vapor_with_custom_elements_and_template_syntax,
 };
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 use super::compiler_codegen_options;
 use crate::wasm::ast::build_ast_json;

--- a/crates/vize_vitrine/src/wasm/cross_file.rs
+++ b/crates/vize_vitrine/src/wasm/cross_file.rs
@@ -8,7 +8,6 @@
 )]
 
 use super::{to_js_value, utf8_byte_to_utf16_offset};
-use vize_carton::Allocator;
 use vize_croquis_cf::CrossFileDiagnosticKind::{
     ArrayMutationNotTriggering, AsyncBoundaryCrossing, AsyncWithoutSuspense, BrowserApiInSsr,
     CircularDependency, CircularReactiveDependency, ClosureCapturesReactive,
@@ -28,6 +27,7 @@ use vize_croquis_cf::CrossFileDiagnosticKind::{
     UnusedFallthroughAttrs, UnusedProvide, ValueExtractionBreaksReactivity, WatchEffectWithAsync,
     WatchMutationCanBeComputed, WatcherOutsideSetup,
 };
+use vize_s0::Allocator;
 use wasm_bindgen::prelude::*;
 
 /// Analyze multiple Vue SFC files for cross-file issues
@@ -226,7 +226,7 @@ pub fn analyze_cross_file_wasm(files: JsValue, options: JsValue) -> Result<JsVal
                     |(file_id, offset, message): &(
                         vize_croquis_cf::FileId,
                         u32,
-                        vize_carton::CompactString,
+                        vize_s0::CompactString,
                     )| {
                         let file_path = file_paths
                             .get(file_id.as_u32() as usize)

--- a/crates/vize_vitrine/src/wasm/jsx.rs
+++ b/crates/vize_vitrine/src/wasm/jsx.rs
@@ -19,7 +19,7 @@ use wasm_bindgen::prelude::*;
 use vize_atelier_jsx::{
     JsxCompatMode, JsxCompileConfig, JsxLang, JsxOutputMode, compile_jsx as jsx_compile,
 };
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 use super::serde::to_json_js_value;
 

--- a/crates/vize_vitrine/src/wasm/lint.rs
+++ b/crates/vize_vitrine/src/wasm/lint.rs
@@ -102,7 +102,7 @@ fn plugin_preset_name_from_raw(preset: &'static str) -> &'static str {
     }
 }
 
-fn parse_enabled_rules(options: &JsValue) -> Option<Vec<vize_carton::CompactString>> {
+fn parse_enabled_rules(options: &JsValue) -> Option<Vec<vize_s0::CompactString>> {
     js_sys::Reflect::get(options, &JsValue::from_str("enabledRules"))
         .ok()
         .and_then(|v| {
@@ -112,7 +112,7 @@ fn parse_enabled_rules(options: &JsValue) -> Option<Vec<vize_carton::CompactStri
             js_sys::Array::from(&v)
                 .iter()
                 .map(|item| item.as_string().map(Into::into))
-                .collect::<Option<Vec<vize_carton::CompactString>>>()
+                .collect::<Option<Vec<vize_s0::CompactString>>>()
         })
 }
 
@@ -197,8 +197,8 @@ pub fn lint_template_wasm(source: &str, options: JsValue) -> Result<JsValue, JsV
 /// Lint Vue SFC file (full SFC including script)
 #[wasm_bindgen(js_name = "lintSfc")]
 pub fn lint_sfc_wasm(source: &str, options: JsValue) -> Result<JsValue, JsValue> {
-    use vize_carton::i18n::{Locale as CartonLocale, t_fmt};
     use vize_patina::{Locale, LspEmitter};
+    use vize_s0::i18n::{Locale as S0Locale, t_fmt};
 
     let filename: String = js_sys::Reflect::get(&options, &JsValue::from_str("filename"))
         .ok()
@@ -212,11 +212,11 @@ pub fn lint_sfc_wasm(source: &str, options: JsValue) -> Result<JsValue, JsValue>
         .and_then(|s| Locale::parse(&s))
         .unwrap_or_default();
 
-    // Convert to carton locale for i18n
-    let carton_locale = match locale {
-        Locale::En => CartonLocale::En,
-        Locale::Ja => CartonLocale::Ja,
-        Locale::Zh => CartonLocale::Zh,
+    // Convert to S0 locale for i18n.
+    let s0_locale = match locale {
+        Locale::En => S0Locale::En,
+        Locale::Ja => S0Locale::Ja,
+        Locale::Zh => S0Locale::Zh,
     };
 
     let linter = create_linter(locale, &options);
@@ -232,7 +232,7 @@ pub fn lint_sfc_wasm(source: &str, options: JsValue) -> Result<JsValue, JsValue>
         .map(|(d, lsp)| {
             // Format message with i18n format string
             let formatted_message = t_fmt(
-                carton_locale,
+                s0_locale,
                 "diagnostic.format",
                 &[("rule", d.rule_name), ("message", d.message.as_ref())],
             );
@@ -275,7 +275,7 @@ pub fn lint_sfc_wasm(source: &str, options: JsValue) -> Result<JsValue, JsValue>
 #[wasm_bindgen(js_name = "getLintRules")]
 #[allow(clippy::disallowed_macros)]
 pub fn get_lint_rules_wasm() -> Result<JsValue, JsValue> {
-    use vize_carton::FxHashSet;
+    use vize_s0::FxHashSet;
     let template_rule_registries = [
         RuleRegistry::with_preset(LintPreset::Opinionated),
         RuleRegistry::with_ecosystem(),

--- a/crates/vize_vitrine/src/wasm/musea.rs
+++ b/crates/vize_vitrine/src/wasm/musea.rs
@@ -8,7 +8,7 @@
 )]
 
 use super::to_js_value;
-use vize_carton::cstr;
+use vize_s0::cstr;
 use wasm_bindgen::prelude::*;
 
 /// Parse Art file (*.art.vue)
@@ -139,7 +139,7 @@ pub fn generate_art_doc_wasm(source: &str, options: JsValue) -> Result<JsValue, 
         include_metadata,
         include_toc,
         toc_threshold,
-        base_path: vize_carton::CompactString::default(),
+        base_path: vize_s0::CompactString::default(),
         title: None,
         include_timestamp: false,
     };
@@ -200,7 +200,7 @@ pub fn generate_art_catalog_wasm(
         include_metadata,
         include_toc: true,
         toc_threshold: 5,
-        base_path: vize_carton::CompactString::default(),
+        base_path: vize_s0::CompactString::default(),
         title: title.map(Into::into),
         include_timestamp: false,
     };

--- a/crates/vize_vitrine/src/wasm/sfc_types.rs
+++ b/crates/vize_vitrine/src/wasm/sfc_types.rs
@@ -125,7 +125,7 @@ pub struct SfcBlockLocationWasm {
 }
 
 fn attrs_to_wasm(
-    attrs: &vize_carton::FxHashMap<std::borrow::Cow<'_, str>, std::borrow::Cow<'_, str>>,
+    attrs: &vize_s0::FxHashMap<std::borrow::Cow<'_, str>, std::borrow::Cow<'_, str>>,
 ) -> BTreeMap<String, String> {
     attrs
         .iter()

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -260,6 +260,14 @@ test("Curator reporting utilities import S0 storage through the stage alias", ()
   });
 });
 
+test("Vitrine bindings import S0 storage through the stage alias", () => {
+  assertS0AliasConsumer({
+    packageName: "vize_vitrine",
+    label: "Vitrine bindings",
+    directory: path.join(repoRoot, "crates", "vize_vitrine"),
+  });
+});
+
 test("Maestro LSP imports S0 storage through the stage alias", () => {
   assertS0AliasConsumer({
     packageName: "vize_maestro",


### PR DESCRIPTION
## Summary

- rename `vize_vitrine`'s S0 dependency import to the workspace `vize_s0` alias
- update Vitrine Rust references and local S0 locale naming away from the historical crate name
- extend the Davinci stage dependency guard so Vitrine cannot regress back to direct `vize_carton` imports

Closes #5228

## Validation

- `node --test --test-concurrency=1 tests/tooling/davinci-stage-dependencies.test.ts`
- `cargo test -p vize_vitrine`
- `cargo test -p vize_vitrine --no-default-features --features wasm`
- `cargo clippy --locked -p vize_vitrine --all-targets -- -D warnings -D clippy::wildcard_imports`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`
- `vp check --no-error-on-unmatched-pattern $(git diff --name-only --diff-filter=ACMRT origin/main --)`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790593266&installation_model_id=422833&pr_number=5229&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5229&signature=ae416a42b44c091c777cf801b48fc39bf8b9a83da9cb6be41092d26d365eef88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Vitrine bindings to use the S0 storage layer consistently.
  * Preserved existing compilation, linting, analysis, token, and template-processing behavior across native and WebAssembly integrations.

* **Tests**
  * Added coverage verifying that Vitrine uses the expected S0 storage alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->