### PR TITLE
refactor(davinci): rename compact-storage bench ids to s1_to_s2

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -376,7 +376,7 @@ jobs:
       - name: Davinci no_std stage-library portability lanes (TS-24)
         run: cargo build -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 && cargo build -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 --no-default-features
       - name: Davinci compact-storage allocation gate
-        run: cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && node tools/davinci/bench-compare.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket --bench patina_jsx_markup_one_root
+        run: cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && node tools/davinci/bench-compare.mjs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root
       - name: Upload Davinci compact-storage bench reports
         if: ${{ always() }}
         uses: ./.github/actions/upload-davinci-compact-storage-bench-reports

--- a/crates/vize_s1_to_s2/benches/davinci_storage.rs
+++ b/crates/vize_s1_to_s2/benches/davinci_storage.rs
@@ -21,7 +21,7 @@ const VON_TWO_PER_BUCKET: &str =
 // v-on-storage-synthetic:end
 
 fn davinci_storage(criterion: &mut Criterion) {
-    let vfor_id = cstr!("ricalco_lower_vfor_three_aliases");
+    let vfor_id = cstr!("s1_to_s2_lower_vfor_three_aliases");
     bench_stage_with_metrics(
         criterion,
         &vfor_id,
@@ -40,7 +40,7 @@ fn davinci_storage(criterion: &mut Criterion) {
         },
     );
 
-    let von_id = cstr!("ricalco_emit_von_two_per_bucket");
+    let von_id = cstr!("s1_to_s2_emit_von_two_per_bucket");
     bench_stage_with_metrics(
         criterion,
         &von_id,

--- a/davinci-road/plan/budgets.toml
+++ b/davinci-road/plan/budgets.toml
@@ -186,8 +186,8 @@ davinci_pipeline_no_observer = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0
 # within one day, PRs #4857/#4877), so the deterministic alloc and
 # per-platform peak gates carry these probes until a reference-runner
 # recording methodology lands.
-ricalco_lower_vfor_three_aliases = { wall_p50_ns = 0, allocs = 10, rss_peak_bytes = 0, wall_tolerance = 0.10 }
-ricalco_emit_von_two_per_bucket = { wall_p50_ns = 0, allocs = 18, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+s1_to_s2_lower_vfor_three_aliases = { wall_p50_ns = 0, allocs = 10, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+s1_to_s2_emit_von_two_per_bucket = { wall_p50_ns = 0, allocs = 18, rss_peak_bytes = 0, wall_tolerance = 0.10 }
 
 # Patina direct-IR JSX markup probe. The measured window is the per-rule
 # `visit_with` loop over a one-root, diagnostic-free JSX module; root
@@ -200,8 +200,8 @@ patina_jsx_markup_one_root = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0, 
 # the value deterministic on one platform, but allocator requests can differ
 # across target operating systems. Every gated platform is therefore explicit;
 # an unknown report platform or a missing platform entry fails closed.
-ricalco_lower_vfor_three_aliases = { linux = 1254, macos = 1246 }
-ricalco_emit_von_two_per_bucket = { linux = 648, macos = 648 }
+s1_to_s2_lower_vfor_three_aliases = { linux = 1254, macos = 1246 }
+s1_to_s2_emit_von_two_per_bucket = { linux = 648, macos = 648 }
 
 [mutation]
 # cargo-mutants minimum scores per crate (P0-12). score = caught / viable,

--- a/tests/tooling/davinci-bench-platform.test.ts
+++ b/tests/tooling/davinci-bench-platform.test.ts
@@ -14,7 +14,7 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const comparePath = path.join(repoRoot, "tools", "davinci", "bench-compare.mjs");
-const benchId = "ricalco_lower_vfor_three_aliases";
+const benchId = "s1_to_s2_lower_vfor_three_aliases";
 
 function budgetText(peaks: string): string {
   return (
@@ -80,7 +80,7 @@ test("an unknown report platform fails closed", () => {
   assert.equal(result.status, 1, result.stdout);
   assert.match(
     result.stdout,
-    /FAIL ricalco_lower_vfor_three_aliases alloc_bytes_peak platform freebsd has no exact budget \(registered: linux, macos\)/u,
+    /FAIL s1_to_s2_lower_vfor_three_aliases alloc_bytes_peak platform freebsd has no exact budget \(registered: linux, macos\)/u,
   );
 });
 

--- a/tests/tooling/davinci-budgets.test.ts
+++ b/tests/tooling/davinci-budgets.test.ts
@@ -32,8 +32,8 @@ const budgets = parseTomlLite(budgetsText) as {
 };
 
 const COMPACT_STORAGE_STAGE_WINDOWS = new Set([
-  "ricalco_lower_vfor_three_aliases",
-  "ricalco_emit_von_two_per_bucket",
+  "s1_to_s2_lower_vfor_three_aliases",
+  "s1_to_s2_emit_von_two_per_bucket",
 ]);
 
 // --- bench-id enumeration from the bench sources -------------------------
@@ -207,8 +207,8 @@ test("every bench entry is one single-line inline table", () => {
 
 test("compact-storage peaks are exact per-platform allocation budgets", () => {
   assert.deepEqual(budgets.allocation_peak, {
-    ricalco_lower_vfor_three_aliases: { linux: 1254, macos: 1246 },
-    ricalco_emit_von_two_per_bucket: { linux: 648, macos: 648 },
+    s1_to_s2_lower_vfor_three_aliases: { linux: 1254, macos: 1246 },
+    s1_to_s2_emit_von_two_per_bucket: { linux: 648, macos: 648 },
   });
   for (const [id, peaks] of Object.entries(budgets.allocation_peak)) {
     assert.ok(id in budgets.bench, `${id} must also have a [bench] budget`);
@@ -230,8 +230,8 @@ test("compact-storage probes stay wall-report-only with exact alloc gates", () =
   // wall_p50_ns = 0 seed. The deterministic alloc and per-platform peak gates
   // still fail closed.
   const expected = {
-    ricalco_lower_vfor_three_aliases: { allocs: 10, allocBytesPeakLinux: 1254 },
-    ricalco_emit_von_two_per_bucket: { allocs: 18, allocBytesPeakLinux: 648 },
+    s1_to_s2_lower_vfor_three_aliases: { allocs: 10, allocBytesPeakLinux: 1254 },
+    s1_to_s2_emit_von_two_per_bucket: { allocs: 18, allocBytesPeakLinux: 648 },
   };
   for (const [id, row] of Object.entries(expected)) {
     const reportPath = path.join(repoRoot, "bench", "results", "davinci", "baseline", `${id}.json`);

--- a/tests/tooling/davinci-portability-lane.test.ts
+++ b/tests/tooling/davinci-portability-lane.test.ts
@@ -61,7 +61,7 @@ test("TS-24: the wasm32-wasip2 lanes ride the required clippy-and-test job", () 
   assert.doesNotMatch(job, /cargo build[^\n]*-p (?:vize_s0|vize_carton)[^\n]*wasm32-wasip2/);
   assert.match(
     job,
-    /cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && node tools\/davinci\/bench-compare\.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket --bench patina_jsx_markup_one_root/u,
+    /cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && node tools\/davinci\/bench-compare\.mjs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root/u,
   );
 });
 

--- a/tests/tooling/github-workflows-davinci-bench.test.ts
+++ b/tests/tooling/github-workflows-davinci-bench.test.ts
@@ -42,7 +42,7 @@ test("check workflow uploads Davinci compact-storage bench reports", () => {
   );
   assert.match(
     steps[gateIndex].run ?? "",
-    /node tools\/davinci\/bench-compare\.mjs --bench ricalco_lower_vfor_three_aliases --bench ricalco_emit_von_two_per_bucket --bench patina_jsx_markup_one_root/,
+    /node tools\/davinci\/bench-compare\.mjs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root/,
   );
   assert.deepEqual(steps[gateIndex + 1], {
     name: "Upload Davinci compact-storage bench reports",


### PR DESCRIPTION
## Summary

- rename Davinci compact-storage benchmark IDs from `ricalco_*` to `s1_to_s2_*`
- update allocation budgets, workflow gate args, and tests to pin the physical layer spelling

Closes #5230

## Validation

- `node --test tests/tooling/davinci-budgets.test.ts tests/tooling/davinci-bench-platform.test.ts tests/tooling/davinci-portability-lane.test.ts tests/tooling/github-workflows-davinci-bench.test.ts`
- `cargo bench --locked -p vize_s1_to_s2 --bench davinci_storage -- --quick`
- `node tools/davinci/bench-compare.mjs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --locked -p vize_s1_to_s2 --all-targets -- -D warnings -D clippy::wildcard_imports`
- `cargo test --locked -p vize_s1_to_s2`
- `vp check --no-error-on-unmatched-pattern $(git diff --name-only --diff-filter=ACMRT origin/main --)`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790593843&installation_model_id=422833&pr_number=5231&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5231&signature=c7fc909491b7749f873d1a615f428b0a2cc5bdb98faade413dcf1d867729ce02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated benchmark validation and portability checks to use the current `s1_to_s2_*` benchmark names.
  * Preserved existing budget values, tolerances, measurements, and failure handling.

* **Chores**
  * Synchronized benchmark registrations, comparison workflows, budget definitions, and test expectations with the renamed identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->