### PR TITLE
test(tooling): add Vben authored LSP oracle

### DIFF
--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -777,6 +777,7 @@
           "tests/_fixtures/_git/vee-validate",
           "tests/_fixtures/_git/vue-draggable-plus",
           "tests/_fixtures/_git/vue-termui",
+          "tests/_fixtures/_git/vue-vben-admin",
           "tests/_fixtures/_git/vue-bits",
           "tests/_fixtures/_git/shadcn-vue"
         ]

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 7,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 15,
+    "minimumProjectCount": 16,
     "trackingIssue": 3952
   },
   "projects": [
@@ -58,6 +58,69 @@
           "sharedRepairedSecondApp": 3000,
           "warmNoopSecondApp": 1500,
           "cancellationConverge": 6000
+        }
+      },
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "packages/effects/common-ui/src/components/count-to/count-to.vue",
+          "symbol": "numMain",
+          "usageAnchor": "{{ numMain }}",
+          "declarationAnchor": "const numMain = computed(() => {",
+          "hoverContains": ["const numMain:"],
+          "renameTo": "__vizeRenamedNumMain"
+        },
+        "componentBoundary": {
+          "importerFile": "packages/effects/layouts/src/widgets/theme-toggle/theme-toggle.vue",
+          "componentFile": "packages/effects/layouts/src/widgets/theme-toggle/theme-button.vue",
+          "tagName": "ThemeButton",
+          "tagAnchor": "<ThemeButton\n          ",
+          "completionItemCount": 30,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "type", "rank": 28 },
+            { "label": "model-value", "rank": 29 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  type?: 'icon' | 'normal';\n",
+            "replacement": "  type?: 'icon' | 'normal';\n  vizeOracleProbe?: boolean;\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "packages/effects/layouts/src/widgets/theme-toggle/__VizeOracleThemeButton.vue",
+          "renamedFile": "packages/effects/layouts/src/widgets/theme-toggle/__VizeOracleRenamedThemeButton.vue",
+          "originalImportSpecifier": "./theme-button.vue",
+          "copiedImportSpecifier": "./__VizeOracleThemeButton.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedThemeButton.vue",
+          "markerInsertionAnchor": "import { VbenButton } from '@vben-core/shadcn-ui';\n\n",
+          "markerSymbol": "__vizeVbenThemeButtonMarker__"
         }
       },
       "batchCheckBudget": {

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 15,
+      "authored-lsp": 16,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tests/tooling/real-project-lsp-authored-registry.test.ts
+++ b/tests/tooling/real-project-lsp-authored-registry.test.ts
@@ -11,7 +11,7 @@ const registryPath = path.join(root, "tests", "_fixtures", "vue-ecosystem-fixtur
 
 type Registry = {
   lspAuthoredOracleGate: { minimumProjectCount: number; trackingIssue: number };
-  projects: FixtureProject[];
+  projects: Array<FixtureProject & { lspIncrementalBudget?: unknown }>;
 };
 
 test("authored LSP feature oracles are explicit and ratcheted", () => {
@@ -25,9 +25,29 @@ test("authored LSP feature oracles are explicit and ratcheted", () => {
   assert.ok(registry.lspAuthoredOracleGate.minimumProjectCount > 0);
   assert.ok(configured.length >= registry.lspAuthoredOracleGate.minimumProjectCount);
   assert.ok(
+    configured.some((project) => project.id === "vue-vben-admin"),
+    "vue-vben-admin must keep an authored LSP feature oracle",
+  );
+  assert.ok(
     configured.some((project) => project.id === "misskey"),
     "misskey must keep an authored LSP feature oracle",
   );
+
+  const budgetOwnerIds = registry.projects
+    .filter((project) => project.lspIncrementalBudget != null)
+    .map((project) => project.id);
+  assert.deepEqual(
+    budgetOwnerIds,
+    ["vue-vben-admin", "misskey"],
+    "LSP incremental-budget owners must stay explicit so authored-oracle coverage can ratchet",
+  );
+  const authoredProjectIds = new Set(configured.map((project) => project.id));
+  for (const id of budgetOwnerIds) {
+    assert.ok(
+      authoredProjectIds.has(id),
+      `${id} has an LSP incremental budget but no authored LSP feature oracle`,
+    );
+  }
 
   for (const project of configured) {
     const oracle = project.lspAuthoredOracle;

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 15, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 16, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
## Summary

- add a `vue-vben-admin` authored LSP oracle for template binding, component-boundary completion, dependency edits, and file lifecycle behavior
- ratchet authored real-project LSP coverage to 16 projects
- require every LSP incremental-budget owner to keep an authored oracle

Closes #5233
Parent: #3952

## Validation

- `node --test tests/tooling/real-project-lsp-authored-registry.test.ts`
- `FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=0 FIXTURE_REPORT_DIR=target/vize-tests/real-project-lsp-vben VIZE_LSP_BIN=/Users/nishimura/Code/github.com/ubugeeei/vize/target/debug/vize CORSA_PATH=$PWD/node_modules/@typescript/typescript-darwin-arm64/lib/tsc REAL_PROJECT_LSP_TIMEOUT_MS=600000 node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts`
- `VIZE_LSP_BIN=/Users/nishimura/Code/github.com/ubugeeei/vize/target/debug/vize CORSA_PATH=$PWD/node_modules/@typescript/typescript-darwin-arm64/lib/tsc node --test --test-concurrency=1 tests/performance/vben-lsp-incremental.test.ts`
- `node --test tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/lsp-incremental-budgets.test.ts tests/tooling/source-file-lengths.test.ts`
- `node --test tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/davinci-matrices.test.ts`
- `node --test tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts`
- `vp check --no-error-on-unmatched-pattern $(git diff --name-only --diff-filter=ACMRT origin/main --)`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790596632&installation_model_id=422833&pr_number=5234&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5234&signature=3a6bc8009a820a34ed2756142344e6103fc304da352187bcc3c25a9f3266c609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded LSP-authored feature coverage with an additional Vue ecosystem project.
  * Added validation that projects with incremental analysis budgets also provide authored feature coverage.
  * Added checks ensuring all supported projects maintain the required LSP test configuration.
  * Updated compatibility expectations to reflect the expanded fixture coverage and verify consistent test reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->