### PR TITLE
test(tooling): guard TypeScript 7 user guidance

### DIFF
--- a/docs/content/fr/guide/content-mapper.md
+++ b/docs/content/fr/guide/content-mapper.md
@@ -54,8 +54,8 @@ tsgo --runExternalCode --noEmit -p tsconfig.json
 ```
 
 Dans VS Code, l'extension Vize enregistre automatiquement la prise en charge de `.vue` auprès de
-l'extension TypeScript native preview dans les espaces de travail approuvés — le même mapper
-alimente alors l'éditeur.
+l'hôte content-mapper TypeScript 7 dans les espaces de travail approuvés — le même mapper alimente
+alors l'éditeur.
 
 ## Options
 
@@ -125,8 +125,8 @@ Codes de diagnostic signalés sous la source `vize` :
 
 ## Limitations
 
-- Nécessite un `tsgo` compilé depuis la main de `typescript-go` tant qu'une version du native
-  preview n'inclut pas l'API.
+- Nécessite un `tsgo` compilé depuis la main de `typescript-go` tant qu'une version de TypeScript 7
+  n'inclut pas l'API.
 - Les declaration maps pour les entrées mappées attendent
   [microsoft/typescript-go#4860](https://github.com/microsoft/typescript-go/issues/4860).
 - `vize check` reste le chemin de vérification de types pris en charge en production tant que

--- a/docs/content/guide/content-mapper.md
+++ b/docs/content/guide/content-mapper.md
@@ -49,8 +49,8 @@ Running external mapper processes requires explicit opt-in:
 tsgo --runExternalCode --noEmit -p tsconfig.json
 ```
 
-In VS Code, the Vize extension registers `.vue` support with the TypeScript native preview
-extension automatically in trusted workspaces — the same mapper then powers the editor.
+In VS Code, the Vize extension registers `.vue` support with the TypeScript 7
+content-mapper host automatically in trusted workspaces — the same mapper then powers the editor.
 
 ## Options
 
@@ -119,7 +119,7 @@ Diagnostic codes reported under the `vize` source:
 
 ## Limitations
 
-- Requires a `tsgo` built from `typescript-go` main until a native preview release ships the API.
+- Requires a `tsgo` built from `typescript-go` main until a TypeScript 7 release ships the API.
 - Declaration maps for mapped inputs await
   [microsoft/typescript-go#4860](https://github.com/microsoft/typescript-go/issues/4860).
 - `vize check` remains the supported production typecheck path while the upstream API is in

--- a/docs/content/ja/guide/content-mapper.md
+++ b/docs/content/ja/guide/content-mapper.md
@@ -52,8 +52,8 @@ vp install -D vize
 tsgo --runExternalCode --noEmit -p tsconfig.json
 ```
 
-VS Code では、信頼されたワークスペースであれば Vize 拡張機能が TypeScript native preview
-拡張機能に `.vue` サポートを自動登録し、同じマッパーがエディターでも動作します。
+VS Code では、信頼されたワークスペースであれば Vize 拡張機能が TypeScript 7
+content-mapper ホストに `.vue` サポートを自動登録し、同じマッパーがエディターでも動作します。
 
 ## オプション
 
@@ -122,7 +122,7 @@ TypeScript と組み込み JSX の両方が正しくパースできる `.tsx` �
 
 ## 制限事項
 
-- native preview のリリースに API が含まれるまで、`typescript-go` の main からビルドした
+- TypeScript 7 のリリースに API が含まれるまで、`typescript-go` の main からビルドした
   `tsgo` が必要です。
 - マップされた入力の declaration map は
   [microsoft/typescript-go#4860](https://github.com/microsoft/typescript-go/issues/4860) 待ちです。

--- a/docs/content/pt-BR/guide/content-mapper.md
+++ b/docs/content/pt-BR/guide/content-mapper.md
@@ -53,8 +53,8 @@ Executar processos de mapper externos exige opt-in explícito:
 tsgo --runExternalCode --noEmit -p tsconfig.json
 ```
 
-No VS Code, a extensão do Vize registra o suporte a `.vue` na extensão do TypeScript native
-preview automaticamente em workspaces confiáveis — o mesmo mapper passa a alimentar o editor.
+No VS Code, a extensão do Vize registra o suporte a `.vue` no host content-mapper do TypeScript 7
+automaticamente em workspaces confiáveis — o mesmo mapper passa a alimentar o editor.
 
 ## Opções
 
@@ -123,8 +123,8 @@ Códigos de diagnóstico reportados sob a fonte `vize`:
 
 ## Limitações
 
-- Requer um `tsgo` compilado da main do `typescript-go` até que um release do native preview
-  inclua a API.
+- Requer um `tsgo` compilado da main do `typescript-go` até que um release do TypeScript 7 inclua a
+  API.
 - Declaration maps para entradas mapeadas aguardam
   [microsoft/typescript-go#4860](https://github.com/microsoft/typescript-go/issues/4860).
 - `vize check` continua sendo o caminho de verificação de tipos suportado em produção enquanto a

--- a/docs/content/zh-CN/guide/content-mapper.md
+++ b/docs/content/zh-CN/guide/content-mapper.md
@@ -51,8 +51,8 @@ vp install -D vize
 tsgo --runExternalCode --noEmit -p tsconfig.json
 ```
 
-在 VS Code 中,受信任的工作区里 Vize 扩展会自动向 TypeScript native preview 扩展注册
-`.vue` 支持,同一个映射器也随之驱动编辑器。
+在 VS Code 中,受信任的工作区里 Vize 扩展会自动向 TypeScript 7 content-mapper
+宿主注册 `.vue` 支持,同一个映射器也随之驱动编辑器。
 
 ## 选项
 
@@ -117,7 +117,7 @@ Vize 使用上游合并的 Content Mapper 协议 v1:UTF-8 位置编码、按项�
 
 ## 限制
 
-- 在 native preview 发布包含该 API 之前,需要从 `typescript-go` main 构建的 `tsgo`。
+- 在 TypeScript 7 发布包含该 API 之前,需要从 `typescript-go` main 构建的 `tsgo`。
 - 映射输入的 declaration map 依赖
   [microsoft/typescript-go#4860](https://github.com/microsoft/typescript-go/issues/4860)。
 - 在上游 API 处于预览期间,生产环境的类型检查方式仍以 `vize check` 为受支持路径。

--- a/npm/cli/README.md
+++ b/npm/cli/README.md
@@ -223,10 +223,10 @@ materializing a parallel `.vue.ts` project.
 tsgo --runExternalCode --noEmit -p tsconfig.json
 ```
 
-Content Mappers are merged on the `typescript-go` main branch but are not in a released TypeScript
-native preview yet. Use a `tsgo` built from main while evaluating them, keep `--runExternalCode`
-explicit, and keep `vize check` as the supported typecheck path until a native preview release
-ships the protocol. Vize negotiates protocol v1 with UTF-8 mappings, resolves its mapper options
+Content Mappers are merged on the `typescript-go` main branch but are not in released TypeScript 7
+platform packages yet. Use a `tsgo` built from main while evaluating them, keep `--runExternalCode`
+explicit, and keep `vize check` as the supported typecheck path until a TypeScript 7 release ships
+the protocol. Vize negotiates protocol v1 with UTF-8 mappings, resolves its mapper options
 and its declared `noUnusedLocals` compiler-option dependency per project through the
 `openProject`/`closeProject` lifecycle (invalid options surface as `optionDiagnostics` in the
 tsconfig), maps `<!-- @vue-expect-error -->` and `<!-- @vue-ignore -->` template comments onto

--- a/tests/tooling/package-manifests-corsa-runtime.test.ts
+++ b/tests/tooling/package-manifests-corsa-runtime.test.ts
@@ -15,6 +15,15 @@ const TYPESCRIPT_PLATFORM_PACKAGES = [
   "@typescript/typescript-win32-x64",
 ];
 
+const USER_GUIDANCE_FILES = [
+  "docs/content/guide/content-mapper.md",
+  "docs/content/fr/guide/content-mapper.md",
+  "docs/content/ja/guide/content-mapper.md",
+  "docs/content/pt-BR/guide/content-mapper.md",
+  "docs/content/zh-CN/guide/content-mapper.md",
+  "npm/cli/README.md",
+];
+
 test("Corsa runtime is declared for vize check users", () => {
   const packageJson = JSON.parse(
     fs.readFileSync(path.join(root, "npm/cli/package.json"), "utf-8"),
@@ -85,5 +94,13 @@ test("workspace tooling installs the stable TypeScript 7 native runtime", () => 
     for (const name of TYPESCRIPT_PLATFORM_PACKAGES) {
       assert.equal(packageJson.optionalDependencies?.[name], version, relative);
     }
+  }
+});
+
+test("published user guidance does not mention the retired native preview runtime", () => {
+  for (const relative of USER_GUIDANCE_FILES) {
+    const contents = fs.readFileSync(path.join(root, relative), "utf-8");
+    assert.doesNotMatch(contents, /@typescript\/native-preview/u, relative);
+    assert.doesNotMatch(contents, /\bnative[- ]preview\b/iu, relative);
   }
 });


### PR DESCRIPTION
## Summary

- replace remaining user-facing native preview phrasing in content-mapper docs and the CLI README with TypeScript 7/platform-package wording
- add a tooling regression that scans published guidance for retired native-preview runtime references
- keep legacy runtime resolver compatibility untouched

Closes #5235

## Tests

- node --test tests/tooling/package-manifests-corsa-runtime.test.ts
- vp check --no-error-on-unmatched-pattern docs/content/guide/content-mapper.md docs/content/fr/guide/content-mapper.md docs/content/ja/guide/content-mapper.md docs/content/pt-BR/guide/content-mapper.md docs/content/zh-CN/guide/content-mapper.md npm/cli/README.md tests/tooling/package-manifests-corsa-runtime.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790598855&installation_model_id=422833&pr_number=5236&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5236&signature=602148866e3f4b9be3cace7bdc7c9d1126612b445efc306acf0f0ee8fa9e71c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Content Mapper setup and limitation guidance to reference the TypeScript 7 content-mapper host and API availability.
  * Applied terminology updates across English, French, Japanese, Portuguese, and Chinese documentation, plus the CLI README.

* **Tests**
  * Added checks to ensure user guidance no longer references the retired native preview package or terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->