### PR TITLE
refactor(atelier): remove Atelier core S0 code-name alias

### DIFF
--- a/crates/vize_atelier_core/src/lib.rs
+++ b/crates/vize_atelier_core/src/lib.rs
@@ -11,8 +11,6 @@
 //! `vize_atelier_core` provides the foundational infrastructure
 //! that all other Vize compilers build upon.
 
-extern crate vize_s0 as vize_carton;
-
 pub mod codegen;
 pub mod runtime_helpers;
 #[macro_use]

--- a/crates/vize_atelier_core/src/test_macros.rs
+++ b/crates/vize_atelier_core/src/test_macros.rs
@@ -14,7 +14,7 @@
 #[macro_export]
 macro_rules! parse_test {
     ($input:expr => { $($assertion:expr),* $(,)? }) => {{
-        let allocator = vize_carton::Allocator::new();
+        let allocator = $crate::Allocator::new();
         let (root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
         $(
@@ -34,7 +34,7 @@ macro_rules! parse_test {
 #[macro_export]
 macro_rules! assert_parse {
     ($input:expr => element($tag:expr)) => {{
-        let allocator = vize_carton::Allocator::new();
+        let allocator = $crate::Allocator::new();
         let (root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
         assert_eq!(root.children.len(), 1, "Expected 1 child");
@@ -47,7 +47,7 @@ macro_rules! assert_parse {
     }};
 
     ($input:expr => element($tag:expr, children: $count:expr)) => {{
-        let allocator = vize_carton::Allocator::new();
+        let allocator = $crate::Allocator::new();
         let (root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
         assert_eq!(root.children.len(), 1, "Expected 1 root child");
@@ -61,7 +61,7 @@ macro_rules! assert_parse {
     }};
 
     ($input:expr => element($tag:expr, props: [$($prop:tt),*])) => {{
-        let allocator = vize_carton::Allocator::new();
+        let allocator = $crate::Allocator::new();
         let (root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
         match &root.children[0] {
@@ -78,7 +78,7 @@ macro_rules! assert_parse {
     }};
 
     ($input:expr => text($content:expr)) => {{
-        let allocator = vize_carton::Allocator::new();
+        let allocator = $crate::Allocator::new();
         let (root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
         assert_eq!(root.children.len(), 1, "Expected 1 child");
@@ -91,7 +91,7 @@ macro_rules! assert_parse {
     }};
 
     ($input:expr => interpolation($content:expr)) => {{
-        let allocator = vize_carton::Allocator::new();
+        let allocator = $crate::Allocator::new();
         let (root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
         assert_eq!(root.children.len(), 1, "Expected 1 child");
@@ -109,7 +109,7 @@ macro_rules! assert_parse {
     }};
 
     ($input:expr => children($count:expr)) => {{
-        let allocator = vize_carton::Allocator::new();
+        let allocator = $crate::Allocator::new();
         let (root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
         assert_eq!(root.children.len(), $count, "Children count mismatch");
@@ -206,7 +206,7 @@ macro_rules! assert_prop {
 #[macro_export]
 macro_rules! assert_transform {
     ($input:expr => helpers: [$($helper:ident),* $(,)?]) => {{
-        let allocator = vize_carton::Allocator::new();
+        let allocator = $crate::Allocator::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
         $crate::lane::transform(&allocator, &mut root, $crate::options::TransformOptions::default(), None);
@@ -220,7 +220,7 @@ macro_rules! assert_transform {
     }};
 
     ($input:expr => components: [$($comp:expr),* $(,)?]) => {{
-        let allocator = vize_carton::Allocator::new();
+        let allocator = $crate::Allocator::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
         $crate::lane::transform(&allocator, &mut root, $crate::options::TransformOptions::default(), None);
@@ -269,7 +269,7 @@ macro_rules! get_directive {
 #[allow(clippy::disallowed_macros)]
 macro_rules! assert_codegen {
     ($input:expr => snapshot) => {{
-        let allocator = vize_carton::Allocator::new();
+        let allocator = $crate::Allocator::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
         $crate::lane::transform(
@@ -288,7 +288,7 @@ macro_rules! assert_codegen {
 #[macro_export]
 macro_rules! compile {
     ($input:expr) => {{
-        let allocator = vize_carton::Allocator::new();
+        let allocator = $crate::Allocator::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
         $crate::lane::transform(
@@ -301,7 +301,7 @@ macro_rules! compile {
     }};
 
     ($input:expr, $options:expr) => {{
-        let allocator = vize_carton::Allocator::new();
+        let allocator = $crate::Allocator::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
         $crate::lane::transform(

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           928 |                   431 |               497 |             139 |     371 |             952 |      486 |           483 |           591 |
+| Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
 | Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
@@ -61,7 +61,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          21 |               4 |       17 |
-| S0               |         852 |             491 |      361 |
+| S0               |         838 |             477 |      361 |
 | S1               |           5 |               1 |        4 |
 | S2               |          15 |               1 |       14 |
 | S1->S2           |          35 |               2 |       33 |
@@ -79,7 +79,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | `crates/vize_atelier_sfc/src/script/define_props_destructure/collector.rs:6` | source   | S0 2<br>raw OXC 15                                                                                   |    17 |
 | `crates/vize_atelier_core/src/steps/expression/prefix.rs:6`                  | source   | S0 1<br>Croquis analysis 1<br>raw OXC 14                                                             |    16 |
 
-Additional source/manifest rows are in the TSV: 309 omitted.
+Additional source/manifest rows are in the TSV: 308 omitted.
 
 #### Top test/dev files
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -108,10 +108,9 @@ compiler	Compiler	source	crates/vize_atelier_core/src/lane/structural.rs	3	old_a
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/structural/tests.rs	7	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/lane/tests.rs	7	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/lane/traverse.rs	8	s0	S0	stage	vize_s0	preferred	3
-compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	s0	S0	stage	vize_s0	preferred	2
-compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	4
-compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	14	old_ast	old AST/parser	old	vize_armature	legacy	3
+compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	33	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	4
+compiler	Compiler	source	crates/vize_atelier_core/src/lib.rs	33	old_ast	old AST/parser	old	vize_armature	legacy	3
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	old_ast	old AST/parser	old	vize_relief	legacy	1
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_core/src/retained.rs	47	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
@@ -192,7 +191,6 @@ compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/params.rs	3	r
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/params.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/src/steps/v_slot/tests.rs	8	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_core/src/steps/v_slot/validate.rs	3	s0	S0	stage	vize_s0	preferred	1
-compiler	Compiler	source	crates/vize_atelier_core/src/test_macros.rs	17	s0	S0	stage	vize_carton	compat	12
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/conditional_named_slots.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform_vue2.rs	24	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_core/tests/davinci_s2_transform.rs	119	davinci	Davinci	stage	vize_davinci	preferred	3

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -292,6 +292,22 @@ test("Atelier DOM compiler imports S0 storage through the stage alias", () => {
   });
 });
 
+test("Atelier core compiler macros import S0 storage through the stage alias", () => {
+  const manifest = readRepoFile("crates", "vize_atelier_core", "Cargo.toml");
+  assert.match(manifest, /^vize_s0 = \{ workspace = true \}$/m);
+  assert.doesNotMatch(manifest, /^vize_carton\.workspace = true$/m);
+  assertS0AliasConsumer({
+    packageName: "vize_atelier_core",
+    label: "Atelier core compiler",
+    directory: path.join(repoRoot, "crates", "vize_atelier_core", "src"),
+  });
+
+  for (const relative of ["lib.rs", "test_macros.rs"]) {
+    const source = readRepoFile("crates", "vize_atelier_core", "src", relative);
+    assert.doesNotMatch(source, /\bvize_carton\b/u, `${relative} must use vize_s0 or $crate`);
+  }
+});
+
 test("Relief AST imports S0 storage through the stage alias", () => {
   assertS0AliasConsumer({
     packageName: "vize_relief",


### PR DESCRIPTION
## Summary

- remove the internal `vize_carton` alias from Atelier core test macro plumbing
- route exported compiler test macros through the crate S0 allocator re-export via `$crate::Allocator`
- add a Davinci stage dependency guard and refresh consumer migration surfaces

Closes #5237

## Tests

- node tools/davinci/consumer-migration-surfaces.mjs --check
- node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs
- node --test tests/tooling/davinci-matrices.test.ts
- cargo test -p vize_atelier_core --locked test_macros
- cargo check -p vize_atelier_core --locked
- cargo fmt --all -- --check
- vp check --no-error-on-unmatched-pattern crates/vize_atelier_core/src/lib.rs crates/vize_atelier_core/src/test_macros.rs tests/tooling/davinci-stage-dependencies.test.ts davinci-road/plan/consumer-migration-surfaces.md davinci-road/plan/consumer-migration-surfaces.tsv
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790599789&installation_model_id=422833&pr_number=5238&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5238&signature=627e0f31abe0cac454f4b21d0a65de1ba51fb082617874a1348dc497e4337912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated Atelier compiler macros to use the standardized stage alias.
  * Removed an obsolete crate alias without changing runtime behavior.

* **Tests**
  * Added validation to prevent direct references to the legacy stage name.

* **Documentation**
  * Refreshed the consumer migration inventory with updated compiler surface counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->