### PR TITLE
refactor(patina): port no-i-for-icon to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -7,6 +7,7 @@ mod css;
 mod directives;
 mod jsx;
 mod jsx_fallback;
+mod jsx_no_i_for_icon;
 mod jsx_streaming;
 mod no_mutating_props;
 mod no_top_level_ref;

--- a/crates/vize_patina/src/linter/tests/jsx_no_i_for_icon.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_i_for_icon.rs
@@ -1,0 +1,81 @@
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::NoIForIcon;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn no_i_for_icon_fires_on_jsx_and_tsx_ir() {
+    let linter = linter_with(Box::new(NoIForIcon));
+    let source = "const A = () => <i class=\"fas fa-home\" />;";
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        result.warning_count, 1,
+        "<i class=\"fas ...\"> must flag through the IR pass: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(diagnostic_rules(&result), vec!["a11y/no-i-for-icon"]);
+
+    let diag = &result.diagnostics[0];
+    let i_start = source.find("<i").unwrap() as u32;
+    assert_eq!(diag.start, i_start, "range must start at the <i> tag");
+
+    let tsx = linter.lint_jsx(
+        "const A = (): JSX.Element => <i class=\"fas fa-home\" />;",
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["a11y/no-i-for-icon"],
+        "TSX <i class=\"fas ...\"> must also flag through the IR pass"
+    );
+}
+
+#[test]
+fn no_i_for_icon_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(NoIForIcon));
+    for source in [
+        "const A = () => <i className=\"fas fa-home\" />;",
+        "const A = () => <i class={iconClass} />;",
+        "const A = () => <i class={'fas fa-home'} />;",
+        "const A = () => <i {...props} />;",
+        "const A = () => <Icons.i class=\"fas fa-home\" />;",
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn migrated_no_i_for_icon_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(NoIForIcon));
+    let result = linter.lint_jsx(
+        r#"const A = () => <i class="fas fa-home"/>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated no-i-for-icon rule must report once: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/vize_patina/src/markup.rs
+++ b/crates/vize_patina/src/markup.rs
@@ -61,8 +61,7 @@ use vize_relief::{
     AttributeNode, DirectiveNode, ElementNode, ElementType, ExpressionNode, ForNode, IfNode,
     PropNode, RootNode, SourceLocation, TemplateChildNode, TextNode,
 };
-use vize_s0::String;
-use vize_s0::profile;
+use vize_s0::{String, profile};
 
 /// High-level classification for a markup element.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1646,5 +1645,6 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
     }
 }
 
+mod exact;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_patina/src/markup/exact.rs
+++ b/crates/vize_patina/src/markup/exact.rs
@@ -1,0 +1,62 @@
+use super::{
+    MarkupBinding, MarkupBindingInner, MarkupBindingKind, MarkupElement, MarkupElementInner,
+    jsx_attribute_arg_name, jsx_attribute_binding_kind, jsx_attribute_ref, jsx_element_ref,
+    relief_directive_kind,
+};
+use oxc_ast::ast::{JSXAttributeName, JSXElementName};
+use vize_relief::ExpressionNode;
+
+impl<'a> MarkupElement<'a> {
+    /// Check whether this element is an unqualified tag with an exact name.
+    ///
+    /// This deliberately does not match JSX member or namespaced tags, even when
+    /// their local/property name equals `expected`.
+    pub fn is_unqualified_tag_exact(&self, expected: &str) -> bool {
+        match self.inner {
+            MarkupElementInner::Relief(node) => node.tag == expected,
+            MarkupElementInner::JsxElement { node, .. } => {
+                match &jsx_element_ref(node).opening_element.name {
+                    JSXElementName::Identifier(identifier) => identifier.name.as_str() == expected,
+                    JSXElementName::IdentifierReference(reference) => {
+                        reference.name.as_str() == expected
+                    }
+                    JSXElementName::NamespacedName(_)
+                    | JSXElementName::MemberExpression(_)
+                    | JSXElementName::ThisExpression(_) => false,
+                }
+            }
+            MarkupElementInner::JsxFragment { .. } => false,
+        }
+    }
+}
+
+impl<'a> MarkupBinding<'a> {
+    /// Whether this binding is an unqualified prop/attribute with an exact name.
+    ///
+    /// Unlike [`Self::arg_name_eq`], this is case-sensitive and does not collapse
+    /// JSX namespace attributes such as `foo:class` into their local name.
+    pub fn is_unqualified_arg_exact(&self, expected: &str) -> bool {
+        match self.inner {
+            MarkupBindingInner::ReliefAttribute(node) => node.name == expected,
+            MarkupBindingInner::ReliefDirective(node) => match relief_directive_kind(node) {
+                MarkupBindingKind::Custom => node.name == expected,
+                _ => match node.arg.as_ref() {
+                    Some(ExpressionNode::Simple(simple)) => simple.content == expected,
+                    _ => false,
+                },
+            },
+            MarkupBindingInner::Jsx { node, .. } => {
+                let attr = jsx_attribute_ref(node);
+                match &attr.name {
+                    JSXAttributeName::Identifier(identifier) => {
+                        match jsx_attribute_binding_kind(attr) {
+                            MarkupBindingKind::On => jsx_attribute_arg_name(attr) == Some(expected),
+                            _ => identifier.name.as_str() == expected,
+                        }
+                    }
+                    JSXAttributeName::NamespacedName(_) => false,
+                }
+            }
+        }
+    }
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -7,6 +7,8 @@
 // Wrapped in an inline `#[cfg(test)] mod` (the repo convention for split
 // test files) so the Davinci assertion lint, which only scans inline
 // `#[cfg(test)] mod` bodies under `src/`, keeps covering these tests.
+mod no_i_for_icon_tests;
+
 #[cfg(test)]
 mod markup_ir_tests {
     use crate::context::LintContext;

--- a/crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs
@@ -1,0 +1,85 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::NoIForIcon;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn no_i_for_icon_template() {
+    let rule = NoIForIcon;
+    assert_eq!(
+        run_over_template(&rule, r#"<i class="fas fa-home"></i>"#),
+        1,
+        "template <i> with a static icon class must warn through the IR"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<i :class="'fas fa-home'"></i>"#),
+        0,
+        "template dynamic :class stays outside the legacy rule"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<i class="emphasis" class="fas fa-home"></i>"#),
+        0,
+        "only the first static class attribute participates"
+    );
+}
+
+#[test]
+fn no_i_for_icon_jsx_oxc() {
+    let rule = NoIForIcon;
+    assert_eq!(
+        run_over_jsx_oxc(&rule, "const I = () => <i class=\"fas fa-home\" />;"),
+        1,
+        "JSX <i> with a static icon class must warn through the OXC IR path"
+    );
+    assert_eq!(
+        run_over_jsx_oxc(&rule, "const I = () => <i className=\"fas fa-home\" />;"),
+        0,
+        "className is not the legacy Vue/JSX class spelling for this rule"
+    );
+    assert_eq!(
+        run_over_jsx_oxc(&rule, "const I = () => <i class={iconClass} />;"),
+        0,
+        "dynamic class={{…}} stays outside the legacy rule"
+    );
+    assert_eq!(
+        run_over_jsx_oxc(&rule, "const I = () => <Icons.i class=\"fas fa-home\" />;"),
+        0,
+        "JSX member components with local property `i` are not intrinsic <i>"
+    );
+    assert_eq!(
+        run_over_jsx_oxc(&rule, "const I = () => <svg:i class=\"fas fa-home\" />;"),
+        0,
+        "JSX namespaced tags are not unqualified intrinsic <i> elements"
+    );
+    assert_eq!(
+        run_over_jsx_oxc(&rule, "const I = () => <i icon:class=\"fas fa-home\" />;"),
+        0,
+        "JSX namespaced attributes are not unqualified static class attributes"
+    );
+}

--- a/crates/vize_patina/src/rules/a11y/no_i_for_icon.rs
+++ b/crates/vize_patina/src/rules/a11y/no_i_for_icon.rs
@@ -27,6 +27,7 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use crate::rules::a11y::helpers::get_static_attribute_value;
 use vize_relief::ElementNode;
@@ -41,6 +42,23 @@ static META: RuleMeta = RuleMeta {
 
 #[derive(Default)]
 pub struct NoIForIcon;
+
+impl NoIForIcon {
+    fn first_static_class_value<'a>(element: &MarkupElement<'a>) -> Option<&'a str> {
+        let mut found_class = false;
+        let mut class_value = None;
+        element.walk_bindings(&mut |binding| {
+            if !found_class
+                && binding.kind() == MarkupBindingKind::Attribute
+                && binding.is_unqualified_arg_exact("class")
+            {
+                found_class = true;
+                class_value = binding.static_value();
+            }
+        });
+        class_value
+    }
+}
 
 /// Check if a CSS class token indicates an icon framework usage
 fn is_icon_class(class: &str) -> bool {
@@ -84,9 +102,44 @@ fn is_icon_class(class: &str) -> bool {
     false
 }
 
+/// Markup-IR entry point for `a11y/no-i-for-icon`.
+///
+/// Mirrors the legacy template visitor exactly: only an unqualified lowercase
+/// `<i>` tag with the first static, unqualified `class` attribute containing an
+/// icon-looking token is reported. Dynamic `:class`/`class={...}`,
+/// `className`, and JSX member or namespaced tags stay outside this rule.
+impl MarkupRule for NoIForIcon {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        if !element.is_unqualified_tag_exact("i") {
+            return;
+        }
+
+        let Some(class_value) = Self::first_static_class_value(element) else {
+            return;
+        };
+
+        let has_icon_class = class_value.split_whitespace().any(is_icon_class);
+        if !has_icon_class {
+            return;
+        }
+
+        let message = ctx.lint().t("a11y/no-i-for-icon.message");
+        let help = ctx.lint().t("a11y/no-i-for-icon.help");
+        ctx.lint().warn_at_with_help(message, element.range(), help);
+    }
+}
+
 impl Rule for NoIForIcon {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
@@ -152,6 +205,33 @@ mod tests {
     fn test_valid_i_with_dynamic_class() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<i :class="iconClass"></i>"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_i_with_bound_literal_class() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<i :class="'fas fa-home'"></i>"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_case_mismatched_i_or_class() {
+        let linter = create_linter();
+        let uppercase_tag = linter.lint_template(r#"<I class="fas fa-home"></I>"#, "test.vue");
+        assert_eq!(uppercase_tag.warning_count, 0);
+
+        let uppercase_class = linter.lint_template(r#"<i Class="fas fa-home"></i>"#, "test.vue");
+        assert_eq!(uppercase_class.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_uses_first_static_class_only() {
+        let linter = create_linter();
+        let result = linter.lint_template_rules_only(
+            r#"<i class="emphasis" class="fas fa-home"></i>"#,
+            "test.vue",
+        );
         assert_eq!(result.warning_count, 0);
     }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           302 |                   302 |                 0 |             268 |     225 |             673 |      122 |           340 |           480 |
+| Linter                     |           302 |                   302 |                 0 |             270 |     229 |             674 |      127 |           342 |           483 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         302 |             225 |       77 |
-| old AST/parser   |         226 |             211 |       15 |
+| S0               |         302 |             224 |       78 |
+| old AST/parser   |         228 |             212 |       16 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         225 |             199 |       26 |
+| raw OXC          |         229 |             200 |       29 |
 
 #### Top source and manifest files
 
@@ -110,11 +110,11 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 | ----------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/linter/engine.rs:25`                                        | source   | S0 5<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |    13 |
 | `crates/vize_patina/Cargo.toml:13`                                                  | manifest | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 6 |    10 |
-| `crates/vize_patina/src/markup.rs:49`                                               | source   | S0 2<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |    10 |
 | `crates/vize_patina/src/rules/script/no_ref_as_operand.rs:29`                       | source   | S0 1<br>raw OXC 9                                           |    10 |
+| `crates/vize_patina/src/markup.rs:49`                                               | source   | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |     9 |
 | `crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs:46` | source   | S0 2<br>old AST/parser 4<br>Croquis analysis 3              |     9 |
 
-Additional source/manifest rows are in the TSV: 306 omitted.
+Additional source/manifest rows are in the TSV: 307 omitted.
 
 #### Top test/dev files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 306 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:18`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:20`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 37 omitted.
+Additional test/dev rows are in the TSV: 38 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -983,15 +983,20 @@ linter	Linter	test/dev	crates/vize_patina/src/linter/tests.rs	3	s0	S0	stage	vize
 linter	Linter	test/dev	crates/vize_patina/src/linter/tests/jsx_streaming.rs	13	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/linter/tests/nuxt.rs	2	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/linter/tests/recovered_parse_analysis.rs	11	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/markup.rs	49	s0	S0	stage	vize_s0	preferred	2
+linter	Linter	source	crates/vize_patina/src/markup.rs	49	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	18	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	18	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	18	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	20	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	20	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	20	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/output.rs	20	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/output/agent.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/output/html.rs	6	s0	S0	stage	vize_s0	preferred	1
@@ -1024,7 +1029,7 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/no_access_key.rs	15	old_a
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_autofocus.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_distracting_elements.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/a11y/no_i_for_icon.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/a11y/no_i_for_icon.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_redundant_roles.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 13, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 14, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 134, `ir` 12, `ir-lowered` 1, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (13 = 13 `markup-facade` rules)
+- JSX lanes: `fallback` 133, `ir` 13, `ir-lowered` 1, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (14 = 14 `markup-facade` rules)
 - classification: neutral-core-candidate **85** · vue-dialect-bound **138** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -67,7 +67,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/no-aria-hidden-on-focusable`              | template-family | `a11y/no_aria_hidden_on_focusable.rs`                  | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-autofocus`                             | template-family | `a11y/no_autofocus.rs`                                 | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |
 | `a11y/no-distracting-elements`                  | template-family | `a11y/no_distracting_elements.rs`                      | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
-| `a11y/no-i-for-icon`                            | template-family | `a11y/no_i_for_icon.rs`                                | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `a11y/no-i-for-icon`                            | template-family | `a11y/no_i_for_icon.rs`                                | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-redundant-roles`                       | template-family | `a11y/no_redundant_roles.rs`                           | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-refer-to-non-existent-id`              | template-family | `a11y/no_refer_to_non_existent_id.rs`                  | template-ast                   | yes (template-visitor)           | yes (fallback)              | direct 2: `croquis::ElementIdKind`; ctx 1                                                           | neutral-core-candidate |
 | `a11y/no-role-presentation-on-focusable`        | template-family | `a11y/no_role_presentation_on_focusable.rs`            | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |


### PR DESCRIPTION
## Summary
- port `a11y/no-i-for-icon` onto the Patina markup facade for JSX/TSX IR linting
- add exact unqualified tag/arg helpers so `className`, dynamic `class={...}`, JSX members, and namespaces keep legacy boundaries
- split new facade helpers and regressions into small files so existing over-limit source files do not grow
- update Davinci rule parity and consumer migration surface generated inventory

Closes #5239.

## Verification
- `cargo test -p vize_patina rules::a11y::no_i_for_icon --locked`
- `cargo test -p vize_patina markup::tests --locked`
- `cargo test -p vize_patina linter::tests::jsx --locked`
- `SOURCE_LENGTH_BASE_REF=58ccb6d8753e06e28ab3f7bde7d37f929fee5146 node --test tests/tooling/source-file-lengths.test.ts`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-matrices.test.ts`
- `cargo check -p vize_patina --all-targets --locked`
- `cargo fmt --all -- --check`
- `git diff --check`
- `vp check --no-error-on-unmatched-pattern crates/vize_patina/src/markup.rs crates/vize_patina/src/markup/exact.rs crates/vize_patina/src/markup/tests.rs crates/vize_patina/src/markup/no_i_for_icon_tests.rs crates/vize_patina/src/rules/a11y/no_i_for_icon.rs crates/vize_patina/src/linter/tests.rs crates/vize_patina/src/linter/tests/jsx.rs crates/vize_patina/src/linter/tests/jsx_no_i_for_icon.rs davinci-road/plan/rule-parity.md davinci-road/plan/consumer-migration-surfaces.md davinci-road/plan/consumer-migration-surfaces.tsv tests/tooling/davinci-matrices.test.ts tests/tooling/source-file-lengths.test.ts tools/davinci/rule-parity.mjs tools/davinci/consumer-migration-surfaces.mjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the accessibility rule that detects icon usage through `<i>` elements.
  - The rule now works consistently across template, JSX, and TSX code.
  - Added precise matching to avoid false positives for namespaced, member, dynamic, or differently cased elements and attributes.

- **Bug Fixes**
  - Prevented duplicate diagnostics when the same issue is processed through multiple analysis paths.

- **Tests**
  - Added coverage for static, dynamic, bound, and edge-case icon class patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->