### PR TITLE
refactor(patina): port mouse-events a11y rule to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -7,6 +7,7 @@ mod css;
 mod directives;
 mod jsx;
 mod jsx_fallback;
+mod jsx_mouse_events_have_key_events;
 mod jsx_no_i_for_icon;
 mod jsx_streaming;
 mod no_mutating_props;

--- a/crates/vize_patina/src/linter/tests/jsx_mouse_events_have_key_events.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_mouse_events_have_key_events.rs
@@ -1,0 +1,128 @@
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::MouseEventsHaveKeyEvents;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn mouse_events_preserves_standard_jsx_clean_boundary() {
+    let linter = linter_with(Box::new(MouseEventsHaveKeyEvents));
+    for source in [
+        "const A = () => <div onMouseEnter={show} />;",
+        "const A = () => <div onMouseLeave={hide} />;",
+        "const A = () => <div onMouseEnterCapture={show} />;",
+        "const A = () => <div onMouseLeaveCapture={hide} />;",
+        "const A = () => <Tooltip onMouseenterCapture={show} />;",
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn mouse_events_runs_over_lowered_markup_ir_once() {
+    let source = "const A = () => <div onMouseenterCapture={show} />;";
+    let linter = linter_with(Box::new(MouseEventsHaveKeyEvents));
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/mouse-events-have-key-events"],
+        "migrated mouse event rule must report once via lowered markup IR: {:?}",
+        result.diagnostics
+    );
+
+    let diag = &result.diagnostics[0];
+    let div_start = source.find("<div").unwrap() as u32;
+    assert_eq!(diag.start, div_start, "range must start at the JSX tag");
+
+    let tsx = linter.lint_jsx(
+        "const A = (): JSX.Element => <div onMouseenterCapture={show} />;",
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["a11y/mouse-events-have-key-events"],
+        "TSX keeps the same lowered markup IR behavior"
+    );
+}
+
+#[test]
+fn mouse_events_jsx_lowering_keeps_legacy_companion_mapping() {
+    let linter = linter_with(Box::new(MouseEventsHaveKeyEvents));
+    let directive = linter.lint_jsx(
+        "const A = () => <div v-on:mouseenter={show} />;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&directive),
+        vec!["a11y/mouse-events-have-key-events"],
+        "JSX v-on directive spelling keeps the old fallback warning"
+    );
+
+    let jsx_focus = linter.lint_jsx(
+        "const A = () => <div v-on:mouseenter={show} onFocus={show} />;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&jsx_focus),
+        vec!["a11y/mouse-events-have-key-events"],
+        "standard JSX onFocus does not satisfy legacy v-on:focus"
+    );
+
+    let directive_pair = linter.lint_jsx(
+        "const A = () => <div v-on:mouseenter={show} v-on:focus={show} />;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        directive_pair.warning_count, 0,
+        "v-on:focus companion produced by legacy lowering must stay clean: {:?}",
+        directive_pair.diagnostics
+    );
+
+    let paired = linter.lint_jsx(
+        "const A = () => <div onMouseenterCapture={show} onFocusCapture={show} />;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        paired.warning_count, 0,
+        "focus companion produced by legacy lowering must stay clean: {:?}",
+        paired.diagnostics
+    );
+
+    let both_missing = linter.lint_jsx(
+        "const A = () => <div onMouseenterCapture={show} onMouseleaveCapture={hide} />;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&both_missing),
+        vec![
+            "a11y/mouse-events-have-key-events",
+            "a11y/mouse-events-have-key-events"
+        ],
+        "missing focus and blur still produce both diagnostics"
+    );
+}

--- a/crates/vize_patina/src/markup/exact.rs
+++ b/crates/vize_patina/src/markup/exact.rs
@@ -59,4 +59,36 @@ impl<'a> MarkupBinding<'a> {
             }
         }
     }
+
+    /// Whether this binding has a static, unqualified prop/directive argument
+    /// with an exact name.
+    ///
+    /// Vue dynamic directive arguments such as `@[click]` are not static and
+    /// must not match legacy event rules that only saw `arg.is_static`.
+    pub fn is_static_unqualified_arg_exact(&self, expected: &str) -> bool {
+        match self.inner {
+            MarkupBindingInner::ReliefAttribute(node) => node.name == expected,
+            MarkupBindingInner::ReliefDirective(node) => match relief_directive_kind(node) {
+                MarkupBindingKind::Custom => node.name == expected,
+                _ => match node.arg.as_ref() {
+                    Some(ExpressionNode::Simple(simple)) if simple.is_static => {
+                        simple.content == expected
+                    }
+                    _ => false,
+                },
+            },
+            MarkupBindingInner::Jsx { node, .. } => {
+                let attr = jsx_attribute_ref(node);
+                match &attr.name {
+                    JSXAttributeName::Identifier(identifier) => {
+                        match jsx_attribute_binding_kind(attr) {
+                            MarkupBindingKind::On => jsx_attribute_arg_name(attr) == Some(expected),
+                            _ => identifier.name.as_str() == expected,
+                        }
+                    }
+                    JSXAttributeName::NamespacedName(_) => false,
+                }
+            }
+        }
+    }
 }

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -7,6 +7,7 @@
 // Wrapped in an inline `#[cfg(test)] mod` (the repo convention for split
 // test files) so the Davinci assertion lint, which only scans inline
 // `#[cfg(test)] mod` bodies under `src/`, keeps covering these tests.
+mod mouse_events_have_key_events_tests;
 mod no_i_for_icon_tests;
 
 #[cfg(test)]

--- a/crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs
+++ b/crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs
@@ -1,0 +1,144 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::MouseEventsHaveKeyEvents;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+#[test]
+fn mouse_events_template() {
+    let rule = MouseEventsHaveKeyEvents;
+    assert_eq!(
+        run_over_template(&rule, r#"<div @mouseenter="show"></div>"#),
+        1,
+        "template mouseenter without focus must warn through markup IR"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<div @mouseover="show" @focus="show"></div>"#),
+        0,
+        "template mouseover paired with focus is clean"
+    );
+    assert_eq!(
+        run_over_template(
+            &rule,
+            r#"<div @mouseenter="show" @mouseleave="hide"></div>"#
+        ),
+        2,
+        "missing focus and blur produce the two legacy diagnostics"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<div @mouseenter="show" @mouseover="show"></div>"#),
+        1,
+        "enter-group mouse events report once per element"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<div @mouseleave="hide" @mouseout="hide"></div>"#),
+        1,
+        "leave-group mouse events report once per element"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<div @[mouseenter]="show"></div>"#),
+        0,
+        "dynamic mouse event arguments stay outside the legacy rule"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<div @mouseenter="show" @[focus]="show"></div>"#),
+        1,
+        "dynamic focus arguments do not satisfy the static companion event"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<div @mouseEnter="show" @focus="show"></div>"#),
+        0,
+        "event arguments remain exact and case-sensitive"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<div @mouseenter="show" @Focus="show"></div>"#),
+        1,
+        "companion event arguments remain exact and case-sensitive"
+    );
+}
+
+#[test]
+fn mouse_events_jsx_lowered() {
+    let rule = MouseEventsHaveKeyEvents;
+    assert_eq!(
+        run_over_jsx_lowered(&rule, "const A = () => <div onMouseEnter={show} />;"),
+        0,
+        "standard JSX onMouseEnter stays clean, matching the old fallback"
+    );
+    assert_eq!(
+        run_over_jsx_lowered(&rule, "const A = () => <div onMouseEnterCapture={show} />;"),
+        0,
+        "standard JSX event suffix casing stays clean"
+    );
+    assert_eq!(
+        run_over_jsx_lowered(&rule, "const A = () => <div onMouseenterCapture={show} />;"),
+        1,
+        "legacy JSX lowering maps this casing to mouseenter"
+    );
+    assert_eq!(
+        run_over_jsx_lowered(&rule, "const A = () => <div v-on:mouseenter={show} />;"),
+        1,
+        "JSX Vue directive spelling keeps the legacy fallback warning"
+    );
+    assert_eq!(
+        run_over_jsx_lowered(
+            &rule,
+            "const A = () => <div v-on:mouseenter={show} onFocus={show} />;"
+        ),
+        1,
+        "standard JSX onFocus does not satisfy a legacy v-on:focus companion"
+    );
+    assert_eq!(
+        run_over_jsx_lowered(
+            &rule,
+            "const A = () => <div v-on:mouseenter={show} v-on:focus={show} />;"
+        ),
+        0,
+        "JSX Vue directive spelling can provide the focus companion"
+    );
+    assert_eq!(
+        run_over_jsx_lowered(
+            &rule,
+            "const A = () => <div onMouseenterCapture={show} onFocusCapture={show} />;"
+        ),
+        0,
+        "legacy JSX lowering also maps onFocusCapture to the companion focus event"
+    );
+    assert_eq!(
+        run_over_jsx_lowered(
+            &rule,
+            "const A = () => <Tooltip onMouseenterCapture={show} />;"
+        ),
+        0,
+        "JSX components stay skipped"
+    );
+}

--- a/crates/vize_patina/src/rules/a11y/mouse_events_have_key_events.rs
+++ b/crates/vize_patina/src/rules/a11y/mouse_events_have_key_events.rs
@@ -20,6 +20,7 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::{ElementNode, ElementType};
 
@@ -37,9 +38,63 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct MouseEventsHaveKeyEvents;
 
+impl MouseEventsHaveKeyEvents {
+    fn has_static_event_handler(element: &MarkupElement<'_>, event_name: &str) -> bool {
+        let mut found = false;
+        element.walk_bindings(&mut |binding| {
+            if binding.kind() == MarkupBindingKind::On
+                && binding.is_static_unqualified_arg_exact(event_name)
+            {
+                found = true;
+            }
+        });
+        found
+    }
+}
+
+impl MarkupRule for MouseEventsHaveKeyEvents {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        if element.is_component() {
+            return;
+        }
+
+        let has_mouse_enter = Self::has_static_event_handler(element, "mouseenter")
+            || Self::has_static_event_handler(element, "mouseover");
+        if has_mouse_enter && !Self::has_static_event_handler(element, "focus") {
+            let message = ctx
+                .lint()
+                .t("a11y/mouse-events-have-key-events.message_enter");
+            let help = ctx.lint().t("a11y/mouse-events-have-key-events.help");
+            ctx.lint().warn_at_with_help(message, element.range(), help);
+        }
+
+        let has_mouse_leave = Self::has_static_event_handler(element, "mouseleave")
+            || Self::has_static_event_handler(element, "mouseout");
+        if has_mouse_leave && !Self::has_static_event_handler(element, "blur") {
+            let message = ctx
+                .lint()
+                .t("a11y/mouse-events-have-key-events.message_leave");
+            let help = ctx.lint().t("a11y/mouse-events-have-key-events.help");
+            ctx.lint().warn_at_with_help(message, element.range(), help);
+        }
+    }
+}
+
 impl Rule for MouseEventsHaveKeyEvents {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn jsx_needs_lowering(&self) -> bool {
+        true
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           302 |                   302 |                 0 |             270 |     229 |             674 |      127 |           342 |           483 |
+| Linter                     |           303 |                   303 |                 0 |             271 |     229 |             674 |      129 |           343 |           485 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,8 +99,8 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         302 |             224 |       78 |
-| old AST/parser   |         228 |             212 |       16 |
+| S0               |         303 |             224 |       79 |
+| old AST/parser   |         229 |             212 |       17 |
 | Croquis analysis |          42 |              38 |        4 |
 | raw OXC          |         229 |             200 |       29 |
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:20`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:21`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 38 omitted.
+Additional test/dev rows are in the TSV: 39 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,11 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	20	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	20	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	20	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	21	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	21	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	21	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1024,7 +1026,7 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/img_alt.rs	14	old_ast	old
 linter	Linter	source	crates/vize_patina/src/rules/a11y/interactive_supports_focus.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/label_has_for.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/media_has_caption.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	2
-linter	Linter	source	crates/vize_patina/src/rules/a11y/mouse_events_have_key_events.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/a11y/mouse_events_have_key_events.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_access_key.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_autofocus.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 14, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 15, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 133, `ir` 13, `ir-lowered` 1, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (14 = 14 `markup-facade` rules)
+- JSX lanes: `fallback` 132, `ir` 13, `ir-lowered` 2, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (15 = 15 `markup-facade` rules)
 - classification: neutral-core-candidate **85** · vue-dialect-bound **138** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -62,7 +62,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/label-has-for`                            | template-family | `a11y/label_has_for.rs`                                | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/landmark-roles`                           | template-family | `opinionated/a11y/landmark_roles.rs`                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/media-has-caption`                        | template-family | `a11y/media_has_caption.rs`                            | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
-| `a11y/mouse-events-have-key-events`             | template-family | `a11y/mouse_events_have_key_events.rs`                 | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `a11y/mouse-events-have-key-events`             | template-family | `a11y/mouse_events_have_key_events.rs`                 | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-access-key`                            | template-family | `a11y/no_access_key.rs`                                | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |
 | `a11y/no-aria-hidden-on-focusable`              | template-family | `a11y/no_aria_hidden_on_focusable.rs`                  | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-autofocus`                             | template-family | `a11y/no_autofocus.rs`                                 | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |


### PR DESCRIPTION
## Summary

- Port `a11y/mouse-events-have-key-events` to the shared `MarkupRule` facade.
- Preserve legacy JSX behavior by routing the migrated rule over lowered Markup IR instead of direct OXC IR.
- Add Markup and JSX/TSX regression coverage for exact static event args, dynamic-arg clean cases, companion mapping, grouped diagnostics, and single-report dispatch.
- Regenerate Davinci rule parity and consumer migration surfaces.

Closes #5242

## Verification

- `cargo test -p vize_patina markup::tests::mouse_events_have_key_events_tests --locked`
- `cargo test -p vize_patina linter::tests::jsx_mouse_events_have_key_events --locked`
- `cargo test -p vize_patina rules::a11y::mouse_events_have_key_events --locked`
- `cargo test -p vize_patina --lib mouse_events_have_key_events --locked`
- `cargo test -p vize_patina linter::tests::jsx --locked`
- `cargo test -p vize_patina markup::tests --locked`
- `cargo check -p vize_patina --all-targets --locked`
- `cargo clippy -p vize_patina -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `node --test tests/tooling/davinci-module-layout.test.ts`
- `node --test tests/tooling/davinci-matrices.test.ts`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node tools/davinci/assertion-lint.mjs`
- `git diff --check`
- `/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules/.bin/vp check --no-error-on-unmatched-pattern ...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790604974&installation_model_id=422833&pr_number=5243&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5243&signature=626969212ed198804d21e75916e66a5f427011630797ccb808904c0002ef3c79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->