### PR TITLE
refactor(patina): port no-redundant-roles to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -9,6 +9,7 @@ mod jsx;
 mod jsx_fallback;
 mod jsx_mouse_events_have_key_events;
 mod jsx_no_i_for_icon;
+mod jsx_no_redundant_roles;
 mod jsx_streaming;
 mod no_mutating_props;
 mod no_top_level_ref;

--- a/crates/vize_patina/src/linter/tests/jsx_no_redundant_roles.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_redundant_roles.rs
@@ -1,0 +1,89 @@
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::NoRedundantRoles;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn no_redundant_roles_fires_on_jsx_and_tsx_ir() {
+    let linter = linter_with(Box::new(NoRedundantRoles));
+    let source = r#"const A = () => <nav role="navigation" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        result.warning_count, 1,
+        "JSX nav/navigation must flag through the IR pass: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(diagnostic_rules(&result), vec!["a11y/no-redundant-roles"]);
+
+    let diag = &result.diagnostics[0];
+    let nav_start = source.find("<nav").unwrap() as u32;
+    assert_eq!(diag.start, nav_start, "range must start at the <nav> tag");
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <button role="button" />;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["a11y/no-redundant-roles"],
+        "TSX button/button must also flag through the IR pass"
+    );
+}
+
+#[test]
+fn no_redundant_roles_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(NoRedundantRoles));
+    for source in [
+        r#"const A = () => <div role="navigation" />;"#,
+        r#"const A = () => <nav role={role} />;"#,
+        r#"const A = () => <button role={"button"} />;"#,
+        r#"const A = () => <button role />;"#,
+        r#"const A = () => <button Role="button" />;"#,
+        r#"const A = () => <button role="Button" />;"#,
+        r#"const A = () => <button role="button " />;"#,
+        r#"const A = () => <button role="button checkbox" />;"#,
+        r#"const A = () => <a href={url} role="link" />;"#,
+        r#"const A = () => <Nav role="navigation" />;"#,
+        r#"const A = () => <input type={type} role="checkbox" />;"#,
+        r#"const A = () => <svg:button role="button" />;"#,
+        r#"const A = () => <Forms.button role="button" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn migrated_no_redundant_roles_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(NoRedundantRoles));
+    let result = linter.lint_jsx(
+        r#"const A = () => <main role="main" />;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated no-redundant-roles rule must report once: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -9,6 +9,7 @@
 // `#[cfg(test)] mod` bodies under `src/`, keeps covering these tests.
 mod mouse_events_have_key_events_tests;
 mod no_i_for_icon_tests;
+mod no_redundant_roles_tests;
 
 #[cfg(test)]
 mod markup_ir_tests {

--- a/crates/vize_patina/src/markup/tests/no_redundant_roles_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_redundant_roles_tests.rs
@@ -1,0 +1,230 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::NoRedundantRoles;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn no_redundant_roles_template() {
+    let rule = NoRedundantRoles;
+    assert_eq!(
+        run_over_template(&rule, r#"<nav role="navigation">Navigation</nav>"#),
+        1,
+        "template nav/navigation must warn through markup IR"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<div role="navigation">Navigation</div>"#),
+        0,
+        "non-implicit roles stay clean"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<a href="/" role="link">Home</a>"#),
+        1,
+        "static href gives anchors their implicit link role"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<a :href="url" role="link">Home</a>"#),
+        0,
+        "bound href stays outside the legacy implicit-role probe"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<img alt="" role="presentation" />"#),
+        1,
+        "empty static alt maps img to presentation"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<input type="checkbox" role="checkbox" />"#),
+        1,
+        "static input type controls the implicit input role"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<nav :role="'navigation'">Navigation</nav>"#),
+        0,
+        "bound role values remain ignored"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<button ROLE="button">Click</button>"#),
+        0,
+        "role attribute names remain exact and case-sensitive"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<button role="Button">Click</button>"#),
+        0,
+        "role values remain exact and case-sensitive"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<button role="button ">Click</button>"#),
+        0,
+        "role values are not trimmed"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<button role="button checkbox">Click</button>"#),
+        0,
+        "role values are not tokenized"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<MyNav role="navigation">Navigation</MyNav>"#),
+        0,
+        "components stay skipped"
+    );
+    assert_eq!(
+        run_over_template(
+            &rule,
+            r#"<nav role class="x" role="navigation">Navigation</nav>"#
+        ),
+        0,
+        "a valueless first role attribute masks later duplicates like the legacy helper"
+    );
+    assert_eq!(
+        run_over_template(
+            &rule,
+            r#"<button role="button" role="switch">Click</button>"#
+        ),
+        1,
+        "the first static role attribute controls duplicate-role behavior"
+    );
+    assert_eq!(
+        run_over_template(
+            &rule,
+            r#"<button role="switch" role="button">Click</button>"#
+        ),
+        0,
+        "later duplicate role attributes do not override the first one"
+    );
+}
+
+#[test]
+fn no_redundant_roles_jsx_direct_matches_lowered_boundaries() {
+    let rule = NoRedundantRoles;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <nav role="navigation" />;"#,
+            1,
+            "nav/navigation",
+        ),
+        (
+            r#"const A = () => <div role="navigation" />;"#,
+            0,
+            "div/navigation",
+        ),
+        (
+            r#"const A = () => <a href="/" role="link" />;"#,
+            1,
+            "static href anchor",
+        ),
+        (
+            r#"const A = () => <a href={url} role="link" />;"#,
+            0,
+            "dynamic href anchor",
+        ),
+        (
+            r#"const A = () => <img alt="" role="presentation" />;"#,
+            1,
+            "empty alt img",
+        ),
+        (
+            r#"const A = () => <input type="checkbox" role="checkbox" />;"#,
+            1,
+            "typed input",
+        ),
+        (r#"const A = () => <nav role={role} />;"#, 0, "dynamic role"),
+        (r#"const A = () => <button role />;"#, 0, "valueless role"),
+        (
+            r#"const A = () => <button Role="button" />;"#,
+            0,
+            "case-sensitive role attribute",
+        ),
+        (
+            r#"const A = () => <button role="Button" />;"#,
+            0,
+            "case-sensitive role value",
+        ),
+        (
+            r#"const A = () => <button role="button " />;"#,
+            0,
+            "untrimmed role value",
+        ),
+        (
+            r#"const A = () => <button role="button checkbox" />;"#,
+            0,
+            "untokenized role value",
+        ),
+        (
+            r#"const A = () => <button role="button" role="switch" />;"#,
+            1,
+            "first duplicate role wins",
+        ),
+        (
+            r#"const A = () => <button role="switch" role="button" />;"#,
+            0,
+            "later duplicate roles stay ignored",
+        ),
+        (
+            r#"const A = () => <svg:button role="button" />;"#,
+            0,
+            "namespaced JSX tag",
+        ),
+        (
+            r#"const A = () => <Forms.button role="button" />;"#,
+            0,
+            "member JSX component",
+        ),
+        (
+            r#"const A = () => <MyNav role="navigation" />;"#,
+            0,
+            "component",
+        ),
+    ] {
+        assert_eq!(
+            run_over_jsx_lowered(&rule, source),
+            expected,
+            "lowered JSX boundary changed for {label}"
+        );
+        assert_eq!(
+            run_over_jsx_oxc(&rule, source),
+            expected,
+            "direct JSX IR must match the lowered boundary for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/a11y/helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/helpers.rs
@@ -238,16 +238,23 @@ pub const ARIA_UNSUPPORTED_ELEMENTS: &[&str] = &["meta", "html", "script", "styl
 
 /// Mapping of elements to their implicit ARIA roles
 pub fn get_implicit_role(tag: &str, element: &ElementNode) -> Option<&'static str> {
+    get_implicit_role_by_attr(tag, |name| get_static_attribute_value(element, name))
+}
+
+pub(super) fn get_implicit_role_by_attr<'a>(
+    tag: &str,
+    mut static_attribute_value: impl FnMut(&str) -> Option<&'a str>,
+) -> Option<&'static str> {
     match tag {
         "a" => {
-            if get_static_attribute_value(element, "href").is_some() {
+            if static_attribute_value("href").is_some() {
                 Some("link")
             } else {
                 None
             }
         }
         "area" => {
-            if get_static_attribute_value(element, "href").is_some() {
+            if static_attribute_value("href").is_some() {
                 Some("link")
             } else {
                 None
@@ -267,14 +274,14 @@ pub fn get_implicit_role(tag: &str, element: &ElementNode) -> Option<&'static st
         "header" => Some("banner"),
         "hr" => Some("separator"),
         "img" => {
-            let alt = get_static_attribute_value(element, "alt");
+            let alt = static_attribute_value("alt");
             match alt {
                 Some("") => Some("presentation"),
                 _ => Some("img"),
             }
         }
         "input" => {
-            let input_type = get_static_attribute_value(element, "type").unwrap_or("text");
+            let input_type = static_attribute_value("type").unwrap_or("text");
             match input_type {
                 "button" | "image" | "reset" | "submit" => Some("button"),
                 "checkbox" => Some("checkbox"),

--- a/crates/vize_patina/src/rules/a11y/no_redundant_roles.rs
+++ b/crates/vize_patina/src/rules/a11y/no_redundant_roles.rs
@@ -21,10 +21,11 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::{ElementNode, ElementType};
 
-use super::helpers::{get_implicit_role, get_static_attribute_value};
+use super::helpers::{get_implicit_role, get_implicit_role_by_attr, get_static_attribute_value};
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/no-redundant-roles",
@@ -38,9 +39,81 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct NoRedundantRoles;
 
+impl NoRedundantRoles {
+    fn first_static_attribute_value<'a>(
+        element: &MarkupElement<'a>,
+        name: &str,
+    ) -> Option<&'a str> {
+        let mut found = false;
+        let mut value = None;
+        element.walk_bindings(&mut |binding| {
+            if !found
+                && binding.kind() == MarkupBindingKind::Attribute
+                && binding.is_static_unqualified_arg_exact(name)
+            {
+                found = true;
+                value = binding.static_value();
+            }
+        });
+        value
+    }
+
+    fn markup_implicit_role<'a>(element: &MarkupElement<'a>) -> Option<&'static str> {
+        let tag = element.tag();
+        if !element.is_unqualified_tag_exact(tag) {
+            return None;
+        }
+
+        get_implicit_role_by_attr(tag, |name| {
+            Self::first_static_attribute_value(element, name)
+        })
+    }
+}
+
+/// Markup-IR entry point for `a11y/no-redundant-roles`.
+///
+/// The role table mirrors the legacy `ElementNode` helper, including its
+/// static-attribute-only `href` / `type` / `alt` probes and first-attribute
+/// behavior. Exact unqualified tag / attribute checks keep direct JSX/TSX
+/// projection inside the same visible boundary the old lowering fallback had.
+impl MarkupRule for NoRedundantRoles {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        if element.is_component() {
+            return;
+        }
+
+        let Some(role_value) = Self::first_static_attribute_value(element, "role") else {
+            return;
+        };
+
+        let Some(implicit) = Self::markup_implicit_role(element) else {
+            return;
+        };
+
+        if implicit != role_value {
+            return;
+        }
+
+        let message = ctx.lint().t_fmt(
+            "a11y/no-redundant-roles.message",
+            &[("tag", element.tag()), ("role", role_value)],
+        );
+        let help = ctx.lint().t("a11y/no-redundant-roles.help");
+        ctx.lint().warn_at_with_help(message, element.range(), help);
+    }
+}
+
 impl Rule for NoRedundantRoles {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           303 |                   303 |                 0 |             271 |     229 |             674 |      129 |           343 |           485 |
+| Linter                     |           304 |                   304 |                 0 |             272 |     232 |             674 |      134 |           344 |           487 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         303 |             224 |       79 |
-| old AST/parser   |         229 |             212 |       17 |
+| S0               |         304 |             224 |       80 |
+| old AST/parser   |         230 |             212 |       18 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         229 |             200 |       29 |
+| raw OXC          |         232 |             200 |       32 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:21`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:22`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 39 omitted.
+Additional test/dev rows are in the TSV: 40 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,14 +991,17 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	21	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	21	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	21	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	22	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	22	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	22	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_redundant_roles_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_redundant_roles_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_redundant_roles_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/output.rs	20	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/output/agent.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/output/html.rs	6	s0	S0	stage	vize_s0	preferred	1
@@ -1032,7 +1035,7 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusab
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_autofocus.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_distracting_elements.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_i_for_icon.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/a11y/no_redundant_roles.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/a11y/no_redundant_roles.rs	26	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	croquis	Croquis analysis	old	vize_croquis	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 15, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 16, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 132, `ir` 13, `ir-lowered` 2, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (15 = 15 `markup-facade` rules)
+- JSX lanes: `fallback` 131, `ir` 14, `ir-lowered` 2, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (16 = 16 `markup-facade` rules)
 - classification: neutral-core-candidate **85** · vue-dialect-bound **138** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -68,7 +68,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/no-autofocus`                             | template-family | `a11y/no_autofocus.rs`                                 | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |
 | `a11y/no-distracting-elements`                  | template-family | `a11y/no_distracting_elements.rs`                      | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-i-for-icon`                            | template-family | `a11y/no_i_for_icon.rs`                                | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
-| `a11y/no-redundant-roles`                       | template-family | `a11y/no_redundant_roles.rs`                           | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `a11y/no-redundant-roles`                       | template-family | `a11y/no_redundant_roles.rs`                           | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-refer-to-non-existent-id`              | template-family | `a11y/no_refer_to_non_existent_id.rs`                  | template-ast                   | yes (template-visitor)           | yes (fallback)              | direct 2: `croquis::ElementIdKind`; ctx 1                                                           | neutral-core-candidate |
 | `a11y/no-role-presentation-on-focusable`        | template-family | `a11y/no_role_presentation_on_focusable.rs`            | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-static-element-interactions`           | template-family | `a11y/no_static_element_interactions.rs`               | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |


### PR DESCRIPTION
## Summary

- port `a11y/no-redundant-roles` to the shared Patina markup facade for direct JSX/TSX IR dispatch
- share the implicit-role table between the legacy `ElementNode` helper and the markup implementation
- add Vue template, direct JSX IR, lowered JSX boundary, and public `Linter::lint_jsx` regression coverage
- regenerate Davinci rule-parity and consumer migration inventories

Closes #5244

## Verification

- `cargo test -p vize_patina --lib no_redundant_roles --locked`
- `cargo test -p vize_patina linter::tests::jsx --locked`
- `cargo test -p vize_patina markup::tests --locked`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo check -p vize_patina --all-targets --locked`
- `cargo clippy -p vize_patina -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-matrices.test.ts`
- `node tools/davinci/assertion-lint.mjs`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790606630&installation_model_id=422833&pr_number=5245&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5245&signature=f29f36883b98a8f302d3eea7082d535b155650f255770fb24ece7912fddf00ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility linting to consistently detect redundant ARIA roles across JSX, TSX, and Vue templates.
  * Preserved correct behavior for dynamic attributes, custom components, namespaced elements, and other edge cases.
  * Prevented duplicate diagnostics when the same issue is processed through multiple paths.

* **Documentation**
  * Updated rule coverage and migration tracking to reflect the expanded support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->