### PR TITLE
fix(patina): avoid drop_non_drop in Davinci markup bench

### DIFF
--- a/crates/vize_patina/benches/davinci_markup.rs
+++ b/crates/vize_patina/benches/davinci_markup.rs
@@ -36,21 +36,22 @@ fn davinci_markup(criterion: &mut Criterion) {
         let allocator = Allocator::new();
         let mut lint = LintContext::new(&allocator, ONE_ROOT, "bench.jsx");
         let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
-        let mut markup_ctx = MarkupContext::new(&mut lint, &document);
-        let visited = window.measure(|| {
-            let mut visited = 0u32;
-            for rule in registry.rules() {
-                if rule.jsx_needs_lowering() {
-                    continue;
+        let visited = {
+            let mut markup_ctx = MarkupContext::new(&mut lint, &document);
+            window.measure(|| {
+                let mut visited = 0u32;
+                for rule in registry.rules() {
+                    if rule.jsx_needs_lowering() {
+                        continue;
+                    }
+                    if let Some(markup_rule) = rule.as_markup_rule() {
+                        document.visit_with(markup_rule, &mut markup_ctx);
+                        visited += 1;
+                    }
                 }
-                if let Some(markup_rule) = rule.as_markup_rule() {
-                    document.visit_with(markup_rule, &mut markup_ctx);
-                    visited += 1;
-                }
-            }
-            visited
-        });
-        drop(markup_ctx);
+                visited
+            })
+        };
         assert!(visited > 0, "the direct-IR pass must drive markup rules");
         assert_eq!(
             lint.warning_count() + lint.error_count(),


### PR DESCRIPTION
## Summary
- replace the explicit MarkupContext drop in the Davinci markup bench with a lexical scope
- keep the mutable LintContext borrow ending before diagnostic assertions without changing benchmark behavior

Closes #5246

## Validation
- cargo fmt --all -- --check
- cargo clippy -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790608845&installation_model_id=422833&pr_number=5247&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5247&signature=f557943d21619e90e6917167d3e4cd3285f1769f0ed427e1364fc234689f2160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated benchmark resource handling to use automatic scope-based cleanup.
  * No user-facing functionality or exported APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->