### PR TITLE
refactor(patina): port deprecated-attr to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -6,6 +6,7 @@ mod basic;
 mod css;
 mod directives;
 mod jsx;
+mod jsx_deprecated_attr;
 mod jsx_fallback;
 mod jsx_mouse_events_have_key_events;
 mod jsx_no_i_for_icon;

--- a/crates/vize_patina/src/linter/tests/jsx_deprecated_attr.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_deprecated_attr.rs
@@ -1,0 +1,92 @@
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::html::DeprecatedAttr;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn deprecated_attr_fires_on_jsx_and_tsx_ir() {
+    let linter = linter_with(Box::new(DeprecatedAttr));
+    let source = r#"const A = () => <div align="center" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        result.warning_count, 1,
+        "JSX align attr must flag through the IR pass: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(diagnostic_rules(&result), vec!["html/deprecated-attr"]);
+
+    let diag = &result.diagnostics[0];
+    let attr_start = source.find("align").unwrap() as u32;
+    assert_eq!(
+        diag.start, attr_start,
+        "range must start at the written JSX attribute"
+    );
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <table cellpadding="5" />;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["html/deprecated-attr"],
+        "TSX lowercase cellpadding must also flag through the IR pass"
+    );
+}
+
+#[test]
+fn deprecated_attr_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(DeprecatedAttr));
+    for source in [
+        r#"const A = () => <table border="1" />;"#,
+        r#"const A = () => <table cellPadding="5" />;"#,
+        r#"const A = () => <table cellpadding={5} />;"#,
+        r#"const A = () => <div ALIGN="center" />;"#,
+        r#"const A = () => <Table align="center" />;"#,
+        r#"const A = () => <div html:align="center" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+
+    let namespaced_table = r#"const A = () => <svg:table border="1" />;"#;
+    let result = linter.lint_jsx(namespaced_table, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        result.warning_count, 1,
+        "namespaced tags must keep the old lowered-tag table exception boundary"
+    );
+}
+
+#[test]
+fn migrated_deprecated_attr_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(DeprecatedAttr));
+    let result = linter.lint_jsx(
+        r#"const A = () => <body background="/bg.png" />;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated deprecated-attr rule must report once: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -7,6 +7,7 @@
 // Wrapped in an inline `#[cfg(test)] mod` (the repo convention for split
 // test files) so the Davinci assertion lint, which only scans inline
 // `#[cfg(test)] mod` bodies under `src/`, keeps covering these tests.
+mod deprecated_attr_tests;
 mod mouse_events_have_key_events_tests;
 mod no_i_for_icon_tests;
 mod no_redundant_roles_tests;

--- a/crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs
+++ b/crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs
@@ -1,0 +1,159 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::html::DeprecatedAttr;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn deprecated_attr_template() {
+    let rule = DeprecatedAttr;
+    assert_eq!(
+        run_over_template(&rule, r#"<div align="center">text</div>"#),
+        1,
+        "template static deprecated attrs must warn through markup IR"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<div align>text</div>"#),
+        1,
+        "valueless deprecated attrs remain static attrs"
+    );
+    assert_eq!(
+        run_over_template(&rule, r##"<table bgcolor="#fff" cellpadding="5"></table>"##),
+        2,
+        "every deprecated table attr reports"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<table border="1"></table>"#),
+        0,
+        "table border keeps its legacy exception"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<div :align="side">text</div>"#),
+        0,
+        "bound attributes stay outside the legacy rule"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<div v-bind:align="side">text</div>"#),
+        0,
+        "long-form v-bind attributes stay outside the legacy rule"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<div ALIGN="center">text</div>"#),
+        0,
+        "attribute names remain exact and case-sensitive"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<MyTable align="center">text</MyTable>"#),
+        0,
+        "components stay skipped"
+    );
+}
+
+#[test]
+fn deprecated_attr_jsx_direct_matches_lowered_static_boundaries() {
+    let rule = DeprecatedAttr;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <div align="center" />;"#,
+            1,
+            "static global deprecated attr",
+        ),
+        (
+            r#"const A = () => <div align />;"#,
+            1,
+            "valueless deprecated attr",
+        ),
+        (
+            r#"const A = () => <table border="1" />;"#,
+            0,
+            "table border exception",
+        ),
+        (
+            r#"const A = () => <table cellpadding="5" />;"#,
+            1,
+            "lowercase table cellpadding",
+        ),
+        (
+            r#"const A = () => <table cellPadding="5" />;"#,
+            0,
+            "JSX camelCase attrs are not legacy lowercase HTML attrs",
+        ),
+        (
+            r#"const A = () => <table cellpadding={5} />;"#,
+            0,
+            "dynamic JSX attrs stay outside the legacy rule",
+        ),
+        (
+            r#"const A = () => <div ALIGN="center" />;"#,
+            0,
+            "case-sensitive attr name",
+        ),
+        (
+            r#"const A = () => <Table align="center" />;"#,
+            0,
+            "component",
+        ),
+        (
+            r#"const A = () => <svg:table border="1" />;"#,
+            1,
+            "namespaced table does not receive the unqualified table exception",
+        ),
+        (
+            r#"const A = () => <div html:align="center" />;"#,
+            0,
+            "namespaced JSX attributes stay ignored",
+        ),
+    ] {
+        assert_eq!(
+            run_over_jsx_lowered(&rule, source),
+            expected,
+            "lowered JSX boundary changed for {label}"
+        );
+        assert_eq!(
+            run_over_jsx_oxc(&rule, source),
+            expected,
+            "direct JSX IR must match the lowered boundary for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/html/deprecated_attr.rs
+++ b/crates/vize_patina/src/rules/html/deprecated_attr.rs
@@ -23,10 +23,11 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBinding, MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::{ElementNode, ElementType, PropNode};
 
-use super::helpers::deprecated_attr_suggestion;
+use super::helpers::{deprecated_attr_suggestion, deprecated_attr_suggestion_by_tag};
 
 static META: RuleMeta = RuleMeta {
     name: "html/deprecated-attr",
@@ -39,9 +40,72 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct DeprecatedAttr;
 
+impl DeprecatedAttr {
+    fn deprecated_markup_attr<'a>(
+        element: &MarkupElement<'a>,
+        binding: &MarkupBinding<'a>,
+    ) -> Option<(&'a str, &'static str)> {
+        if binding.kind() != MarkupBindingKind::Attribute {
+            return None;
+        }
+
+        let name = binding.arg_name()?;
+        if !binding.is_static_unqualified_arg_exact(name) {
+            return None;
+        }
+
+        deprecated_attr_suggestion_by_tag(name, |expected| {
+            element.is_unqualified_tag_exact(expected)
+        })
+        .map(|suggestion| (name, suggestion))
+    }
+}
+
+/// Markup-IR entry point for `html/deprecated-attr`.
+///
+/// Mirrors the legacy template visitor exactly: only static, unqualified
+/// attributes on non-component elements are checked. Bound attributes
+/// (`:align` / `align={...}`), case-different names, and JSX namespaced props
+/// stay outside the rule; tag-specific exceptions use exact unqualified tag
+/// matching so JSX namespaced tags keep the old lowered-tag behavior.
+impl MarkupRule for DeprecatedAttr {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_binding<'a>(
+        &self,
+        ctx: &mut MarkupContext<'_, 'a>,
+        element: &MarkupElement<'a>,
+        binding: &MarkupBinding<'a>,
+    ) {
+        if element.is_component() {
+            return;
+        }
+
+        let tag = element.tag();
+        let Some((name, suggestion)) = Self::deprecated_markup_attr(element, binding) else {
+            return;
+        };
+
+        let message = ctx.lint().t_fmt(
+            "html/deprecated-attr.message",
+            &[("attr", name), ("tag", tag)],
+        );
+        let help = ctx
+            .lint()
+            .t_fmt("html/deprecated-attr.help", &[("suggestion", suggestion)]);
+        ctx.lint().warn_at_with_help(message, binding.range(), help);
+    }
+}
+
 impl Rule for DeprecatedAttr {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {

--- a/crates/vize_patina/src/rules/html/helpers.rs
+++ b/crates/vize_patina/src/rules/html/helpers.rs
@@ -36,24 +36,37 @@ pub const DEPRECATED_ELEMENTS: &[&str] = &[
 
 /// Returns a CSS replacement suggestion if the attribute is deprecated on the given element.
 pub fn deprecated_attr_suggestion(element: &str, attr: &str) -> Option<&'static str> {
-    match (element, attr) {
-        (_, "align") => Some("CSS `text-align` or `margin: auto`"),
-        (_, "bgcolor") => Some("CSS `background-color`"),
-        (_, "border") if element != "table" => Some("CSS `border`"),
-        ("body", "background") => Some("CSS `background-image`"),
-        ("body", "text") => Some("CSS `color`"),
-        ("body", "link" | "vlink" | "alink") => Some("CSS `:link`, `:visited`"),
-        ("table", "cellpadding") => Some("CSS `padding` on cells"),
-        ("table", "cellspacing") => Some("CSS `border-spacing`"),
-        ("td" | "th", "width" | "height") => Some("CSS `width`/`height`"),
-        ("td" | "th", "valign") => Some("CSS `vertical-align`"),
-        ("td" | "th", "nowrap") => Some("CSS `white-space: nowrap`"),
-        ("img", "hspace" | "vspace") => Some("CSS `margin`"),
-        ("br", "clear") => Some("CSS `clear`"),
-        ("hr", "noshade" | "size" | "width" | "color") => Some("CSS styling"),
-        ("li", "type") => Some("CSS `list-style-type`"),
-        ("ul", "type") => Some("CSS `list-style-type`"),
-        ("pre", "width") => Some("CSS `width`"),
+    deprecated_attr_suggestion_by_tag(attr, |tag| element == tag)
+}
+
+/// Returns a CSS replacement suggestion for a deprecated attribute.
+///
+/// The tag predicate lets zero-copy frontends preserve exact tag semantics
+/// without first allocating a normalized tag string. This matters for JSX
+/// namespaced tags: the legacy lowering sees `svg:table`, which is not exactly
+/// `table`, so table-only exceptions such as `border` must not accidentally
+/// apply to the local name.
+pub fn deprecated_attr_suggestion_by_tag(
+    attr: &str,
+    mut is_tag: impl FnMut(&str) -> bool,
+) -> Option<&'static str> {
+    match attr {
+        "align" => Some("CSS `text-align` or `margin: auto`"),
+        "bgcolor" => Some("CSS `background-color`"),
+        "border" if !is_tag("table") => Some("CSS `border`"),
+        "background" if is_tag("body") => Some("CSS `background-image`"),
+        "text" if is_tag("body") => Some("CSS `color`"),
+        "link" | "vlink" | "alink" if is_tag("body") => Some("CSS `:link`, `:visited`"),
+        "cellpadding" if is_tag("table") => Some("CSS `padding` on cells"),
+        "cellspacing" if is_tag("table") => Some("CSS `border-spacing`"),
+        "width" | "height" if is_tag("td") || is_tag("th") => Some("CSS `width`/`height`"),
+        "valign" if is_tag("td") || is_tag("th") => Some("CSS `vertical-align`"),
+        "nowrap" if is_tag("td") || is_tag("th") => Some("CSS `white-space: nowrap`"),
+        "hspace" | "vspace" if is_tag("img") => Some("CSS `margin`"),
+        "clear" if is_tag("br") => Some("CSS `clear`"),
+        "noshade" | "size" | "width" | "color" if is_tag("hr") => Some("CSS styling"),
+        "type" if is_tag("li") || is_tag("ul") => Some("CSS `list-style-type`"),
+        "width" if is_tag("pre") => Some("CSS `width`"),
         _ => None,
     }
 }

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           304 |                   304 |                 0 |             272 |     232 |             674 |      134 |           344 |           487 |
+| Linter                     |           305 |                   305 |                 0 |             273 |     235 |             674 |      139 |           345 |           489 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         304 |             224 |       80 |
-| old AST/parser   |         230 |             212 |       18 |
+| S0               |         305 |             224 |       81 |
+| old AST/parser   |         231 |             212 |       19 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         232 |             200 |       32 |
+| raw OXC          |         235 |             200 |       35 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:22`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:23`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 40 omitted.
+Additional test/dev rows are in the TSV: 41 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,12 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	22	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	22	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	22	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	23	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	23	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	23	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
@@ -1051,7 +1054,7 @@ linter	Linter	source	crates/vize_patina/src/rules/ecosystem/router_link_require_
 linter	Linter	source	crates/vize_patina/src/rules/ecosystem/void_link_require_href.rs	11	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/ecosystem/void_link_valid_method.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/ecosystem/vue_router_prefer_named_link.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/html/deprecated_attr.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/html/deprecated_attr.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/deprecated_element.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/helpers.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/id_duplication.rs	31	s0	S0	stage	vize_s0	preferred	3

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 16, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 17, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 131, `ir` 14, `ir-lowered` 2, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (16 = 16 `markup-facade` rules)
+- JSX lanes: `fallback` 130, `ir` 15, `ir-lowered` 2, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (17 = 17 `markup-facade` rules)
 - classification: neutral-core-candidate **85** · vue-dialect-bound **138** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -95,7 +95,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `ecosystem/vue-router-prefer-named-link`        | template-family | `ecosystem/vue_router_prefer_named_link.rs`            | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `ecosystem/vue-router-prefer-named-push`        | script          | `script/vue_router_prefer_named_push.rs`               | script-oxc                     | yes (script-blocks)              | no                          | —                                                                                                   | vue-dialect-bound      |
 | `ecosystem/vue-test-utils-no-html-snapshot`     | script          | `script/vue_test_utils_no_html_snapshot.rs`            | script-oxc                     | yes (script-blocks)              | no                          | —                                                                                                   | vue-dialect-bound      |
-| `html/deprecated-attr`                          | template-family | `html/deprecated_attr.rs`                              | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `html/deprecated-attr`                          | template-family | `html/deprecated_attr.rs`                              | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `html/deprecated-element`                       | template-family | `html/deprecated_element.rs`                           | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `html/id-duplication`                           | template-family | `html/id_duplication.rs`                               | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `html/no-consecutive-br`                        | template-family | `html/no_consecutive_br.rs`                            | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |


### PR DESCRIPTION
## Summary
- add a Davinci MarkupRule entry point for html/deprecated-attr while keeping the legacy template visitor intact
- share the deprecated-attribute suggestion table through an exact tag predicate so JSX direct IR preserves lowered fallback boundaries
- cover static/bound/case/component/namespaced JSX and template edge cases, and refresh Davinci rule parity and consumer migration matrices

Closes #5248

## Validation
- cargo test -p vize_patina --lib deprecated_attr --locked
- cargo test -p vize_patina markup::tests --locked
- cargo test -p vize_patina linter::tests::jsx --locked
- cargo check -p vize_patina --all-targets --locked
- cargo clippy -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- node tools/davinci/rule-parity.mjs --check
- node tools/davinci/consumer-migration-surfaces.mjs --check
- node --test tests/tooling/davinci-matrices.test.ts
- node tools/davinci/assertion-lint.mjs
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

No rollout change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790609809&installation_model_id=422833&pr_number=5249&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5249&signature=15d478e89951edc4c45ad5e053ace467b37ad8afa4e1a2106480b0f8eebac41b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The `html/deprecated-attr` rule now checks JSX and TSX markup in addition to existing template support.
  - Deprecated attributes are reported consistently across supported markup formats.
  - Warnings include context-appropriate suggestions for modern replacements.

- **Bug Fixes**
  - Preserved valid exceptions for dynamic, namespaced, component, and case-sensitive attributes.
  - Prevented duplicate warnings when the same markup is processed through multiple analysis paths.

- **Tests**
  - Added comprehensive coverage for Vue templates, JSX, and TSX attribute handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->