### PR TITLE
chore(tooling): update pnpm to v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "@typescript/typescript-win32-arm64": "catalog:corsa-runtime",
     "@typescript/typescript-win32-x64": "catalog:corsa-runtime"
   },
-  "packageManager": "pnpm@11.21.0"
+  "packageManager": "pnpm@12.1.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.1.0
+        version: 12.1.0
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.1.0':
+    resolution: {integrity: sha512-9K+uSnTsJe9zD/YCMPiQDiwU8IiQRp+ZEE9IyVSr0Ppzfg5/xC0pwet2R320ifDIMroT3WYLkCEolV6XxtSS/g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.1.0':
+    resolution: {integrity: sha512-JcOc77W/KLg5ZZXr7q0WN8UDKirxQTuoaTkqRfMNkGyUHc/4bfNxLwjoZBilRQV6xmhJvU79ZUg++eYohzJhog==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.1.0':
+    resolution: {integrity: sha512-RVJlfI4T2l6XXA5s/Wv9HHEq4ztIq79fiZXDVHyHaKEbp+11ZM5k61z0gaGzXCEGUp5anW2Uc3UgQpmjAR+IPw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.1.0':
+    resolution: {integrity: sha512-iLEE0ykaRZ3/OBhIjwe/Zo96ac0c7pY7toyf6+jUN8gOsIIwJTS+AqSyOy+U1Zyhuuec8nJiRQ4URl60nRxTwA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.1.0':
+    resolution: {integrity: sha512-k+NUTRbz2CR9DBvGyAdtXU5HHPXytxi9MQ79uQRYNLF8nr/l1qHo++TvZ0OUuEpRxhg9B3n84Itv6MAHJR7TQQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.1.0':
+    resolution: {integrity: sha512-GTi1DEM8vwIWpgC8P+xhw3Y2Ko2V88WtKAjbNwdeJAzMpzmcBeE4f0c2QKmeKpvi8/eYarxSIvBhYkTjA1BAcQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.1.0':
+    resolution: {integrity: sha512-cK6kklZY8rs3d9gg8akGUgjDenFy65ZSAANXojs98d7Ne7gbzZYzU2joHRRilfpzCfawgG+lpPsh46a4xu55jQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.1.0':
+    resolution: {integrity: sha512-Pk7Lvq3E5PWQFRJLLnLgW2qJAphtgPYCaaODB+FZRRvKksn8IPnF8Aj+/AT4+52GmckiANTbKwCsL18naJhohw==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.1.0:
+    resolution: {integrity: sha512-2bgnbZf27IbkmBWHf5Hun2PO5h8gY7ME5Dttq4+gfOipr9RtL6zTn5Ieap0Gs8dagTSce4iMLSKIa64CKZAQNw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.1.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.1.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.1.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.1.0':
+    optional: true
+
+  pnpm@12.1.0:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.1.0
+      '@pnpm/exe.darwin-x64': 12.1.0
+      '@pnpm/exe.linux-arm64': 12.1.0
+      '@pnpm/exe.linux-arm64-musl': 12.1.0
+      '@pnpm/exe.linux-x64': 12.1.0
+      '@pnpm/exe.linux-x64-musl': 12.1.0
+      '@pnpm/exe.win32-arm64': 12.1.0
+      '@pnpm/exe.win32-x64': 12.1.0
+
+---
 lockfileVersion: '9.0'
 
 settings:

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -384,7 +384,7 @@ test("CI packages editor extension artifacts", () => {
   assert.match(buildTasks, /package:editor-extensions[\s\S]*assert-vsix-package\.mjs/);
   assert.match(
     taskCommands,
-    /pnpm install --ignore-workspace --no-lockfile --prefer-offline --ignore-scripts/,
+    /run-package-bin\.mjs vite-plus vp --version >\/dev\/null 2>&1[\s\S]*corepack pnpm install --ignore-workspace --lockfile-dir \. --no-lockfile --prefer-offline --ignore-scripts/,
   );
   assert.match(testTasks, /test:vscode-extension:vsix[\s\S]*assert-vsix-package\.mjs/);
   assert.match(testTasks, /test:vscode-extension:host[\s\S]*pnpm run test:host/);

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -262,7 +262,7 @@ test("check workflow runs JS package unit tests and production dependency audit"
   const jsPackageJob = workflowJobBody(workflow, "test-js-packages");
   const auditJob = workflowJobBody(workflow, "security-audit");
 
-  assert.equal(packageJson.packageManager, "pnpm@11.21.0");
+  assert.equal(packageJson.packageManager, "pnpm@12.1.0");
   assert.equal(packageJson.pnpm, undefined);
   assert.match(pnpmWorkspace, /^overrides:\n/m);
   assert.match(

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -583,7 +583,7 @@ test("workspace TypeScript package builds use vp pack", () => {
   const oxlintTest = "vp pack && vp test run src/file-state.test.ts && node src/test.ts";
   assert.equal(oxlintPackage.scripts?.test, `${oxlintTest} && node src/script-location.test.ts`);
   const rootTasks = fs.readFileSync(path.join(root, "tools/vite-plus/tasks/build.ts"), "utf-8");
-  assert.match(rootTasks, /pnpm exec vp pack/);
+  assert.match(rootTasks, /vscodeExtensionPackageBin\("vite-plus", "vp"\)[\s\S]*pack/);
 });
 
 test("fresco-native publishes bundled binaries directly from the root package", () => {

--- a/tools/vite-plus/task-commands.ts
+++ b/tools/vite-plus/task-commands.ts
@@ -4,6 +4,8 @@ import type { PackagePath } from "./task-types.ts";
 import { shellCommand } from "./task-shell.ts";
 
 export const localVp = "./node_modules/.bin/vp";
+export const vscodeExtensionPackageBin = (packageName: string, binName: string) =>
+  `node ../../tools/vscode-vize/run-package-bin.mjs ${packageName} ${binName}`;
 
 /**
  * Runs a command after changing into a package directory.
@@ -23,7 +25,7 @@ export const runPackageScriptDirectly = (taskName: string, packages: readonly Pa
  */
 export const installVscodeExtensionDependencies = runInDirectory(
   "editors/vscode",
-  "if [ -x node_modules/.bin/vp ]; then exit 0; fi && mkdir -p node_modules/.bin && pnpm install --ignore-workspace --no-lockfile --prefer-offline --ignore-scripts",
+  "if node ../../tools/vscode-vize/run-package-bin.mjs vite-plus vp --version >/dev/null 2>&1; then exit 0; fi && corepack pnpm install --ignore-workspace --lockfile-dir . --no-lockfile --prefer-offline --ignore-scripts",
 );
 
 /**

--- a/tools/vite-plus/task-helpers.ts
+++ b/tools/vite-plus/task-helpers.ts
@@ -11,6 +11,7 @@ export {
   runPackageScriptDirectly,
   runTask,
   runTasks,
+  vscodeExtensionPackageBin,
 } from "./task-commands.ts";
 export { noCacheTask, task } from "./task-definition.ts";
 export { shellCommand, shellQuote, withRustTaskEnvironment } from "./task-shell.ts";

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -9,6 +9,7 @@ import {
   runTask,
   runTasks,
   task,
+  vscodeExtensionPackageBin,
 } from "../task-helpers.ts";
 import { inTestbox } from "./testbox.ts";
 
@@ -17,7 +18,7 @@ const injectVscodeTypeScriptPlugin =
   "node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix";
 const packageVscodeExtension = [
   stageVscodeTypeScriptPlugin,
-  "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
+  `${vscodeExtensionPackageBin("@vscode/vsce", "vsce")} package --no-dependencies --out dist/vize.vsix`,
   injectVscodeTypeScriptPlugin,
 ].join(" && ");
 const localBuildCommand = runTasks("build:rust", "build:all");
@@ -66,7 +67,10 @@ export const buildTasks = defineTasks({
   "build:plugin": noCacheTask(runTask("build:vite-plugin")),
   "build:cli": task("cargo build --release -p vize"),
   "build:vscode-extension": noCacheTask(
-    runInVscodeExtension(stageVscodeTypeScriptPlugin, "pnpm exec vp pack"),
+    runInVscodeExtension(
+      stageVscodeTypeScriptPlugin,
+      `${vscodeExtensionPackageBin("vite-plus", "vp")} pack`,
+    ),
   ),
   "build:editor-extensions": noCacheTask(runTasks("build:vscode-extension", "check:zed-extension")),
   "package:vscode-extension": noCacheTask(
@@ -95,8 +99,8 @@ export const buildTasks = defineTasks({
   ),
   "package:editor-extensions": noCacheTask(
     `${runInVscodeExtension(
-      "pnpm exec tsc --noEmit",
-      "pnpm exec vp check src vite.config.ts",
+      `${vscodeExtensionPackageBin("typescript", "tsc")} --noEmit`,
+      `${vscodeExtensionPackageBin("vite-plus", "vp")} check src vite.config.ts`,
       packageVscodeExtension,
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
     )} && ${runTask("check:zed-extension")} && ${runTask(

--- a/tools/vite-plus/tasks/check.ts
+++ b/tools/vite-plus/tasks/check.ts
@@ -17,6 +17,7 @@ import {
   runTasks,
   shellCommand,
   task,
+  vscodeExtensionPackageBin,
 } from "../task-helpers.ts";
 import { inTestbox } from "./testbox.ts";
 
@@ -78,7 +79,10 @@ export const checkTasks = defineTasks({
   "check:fix": noCacheTask(runInPackages("check:fix", checkedPackages)),
   "check:rust": noCacheTask("cargo check --workspace"),
   "check:vscode-extension": noCacheTask(
-    runInVscodeExtension("pnpm exec tsc --noEmit", "pnpm exec vp check src vite.config.ts"),
+    runInVscodeExtension(
+      `${vscodeExtensionPackageBin("typescript", "tsc")} --noEmit`,
+      `${vscodeExtensionPackageBin("vite-plus", "vp")} check src vite.config.ts`,
+    ),
   ),
   "check:editor-extensions": noCacheTask(runTasks("check:vscode-extension", "check:zed-extension")),
   clippy: task(rustClippyCommand, { input: cacheInputs.rust }),

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -8,6 +8,7 @@ import {
   runTask,
   runTasks,
   task,
+  vscodeExtensionPackageBin,
 } from "../task-helpers.ts";
 import { inTestbox } from "./testbox.ts";
 
@@ -16,7 +17,7 @@ const injectVscodeTypeScriptPlugin =
   "node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix";
 const packageVscodeExtension = [
   stageVscodeTypeScriptPlugin,
-  "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
+  `${vscodeExtensionPackageBin("@vscode/vsce", "vsce")} package --no-dependencies --out dist/vize.vsix`,
   injectVscodeTypeScriptPlugin,
 ].join(" && ");
 const localTestCommand = runTasks(
@@ -110,7 +111,11 @@ export const testAndBenchmarkTasks = defineTasks({
     ),
   ),
   "test:vscode-extension:host": noCacheTask(
-    runInVscodeExtension(stageVscodeTypeScriptPlugin, "pnpm exec vp pack", "pnpm run test:host"),
+    runInVscodeExtension(
+      stageVscodeTypeScriptPlugin,
+      `${vscodeExtensionPackageBin("vite-plus", "vp")} pack`,
+      "pnpm run test:host",
+    ),
   ),
   "test:vscode-extension:host-real": noCacheTask(
     runInVscodeExtension(

--- a/tools/vscode-vize/run-package-bin.mjs
+++ b/tools/vscode-vize/run-package-bin.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const [packageName, binName, ...args] = process.argv.slice(2);
+
+if (packageName == null || binName == null) {
+  console.error("Usage: run-package-bin.mjs <package-name> <bin-name> [args...]");
+  process.exit(1);
+}
+
+const cwd = process.cwd();
+const nodeModules = path.join(cwd, "node_modules");
+const packageRoot = resolvePackageRoot(packageName);
+const packageJson = readJson(path.join(packageRoot, "package.json"));
+const relativeBin = resolveBinPath(packageJson, binName);
+const binPath = path.resolve(packageRoot, relativeBin);
+
+if (!fs.existsSync(binPath)) {
+  console.error(`Package bin "${binName}" for ${packageName} does not exist at ${binPath}`);
+  process.exit(1);
+}
+
+const runWithNode = process.platform === "win32" && !/\.(?:bat|cmd|exe)$/i.test(binPath);
+const command = runWithNode ? process.execPath : binPath;
+const commandArgs = runWithNode ? [binPath, ...args] : args;
+const result = spawnSync(command, commandArgs, {
+  cwd,
+  env: process.env,
+  stdio: "inherit",
+});
+
+if (result.error != null) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);
+
+function resolvePackageRoot(name) {
+  const directPackagePath = path.join(nodeModules, ...name.split("/"));
+  if (fs.existsSync(path.join(directPackagePath, "package.json"))) {
+    return directPackagePath;
+  }
+
+  const packageMapPath = path.join(nodeModules, ".package-map.json");
+  if (!fs.existsSync(packageMapPath)) {
+    console.error(`Cannot resolve ${name}: ${packageMapPath} does not exist`);
+    process.exit(1);
+  }
+
+  const packageMap = readJson(packageMapPath);
+  const packages = packageMap.packages;
+  if (packages == null || typeof packages !== "object") {
+    console.error(`Cannot resolve ${name}: ${packageMapPath} has no packages object`);
+    process.exit(1);
+  }
+
+  const expectedVersion = exactManifestVersion(name);
+  const candidates = Object.entries(packages)
+    .filter(([, entry]) => {
+      if (entry == null || typeof entry !== "object" || typeof entry.url !== "string") {
+        return false;
+      }
+      if (!normalizeSeparators(entry.url).endsWith(`/node_modules/${name}`)) {
+        return false;
+      }
+      return fs.existsSync(path.join(nodeModules, entry.url, "package.json"));
+    })
+    .sort(
+      ([left], [right]) =>
+        scorePackageId(right, name, expectedVersion) - scorePackageId(left, name, expectedVersion),
+    );
+
+  if (candidates.length === 0) {
+    console.error(`Cannot resolve ${name}: no matching package entry in ${packageMapPath}`);
+    process.exit(1);
+  }
+
+  const [, entry] = candidates[0];
+  return path.resolve(nodeModules, entry.url);
+}
+
+function exactManifestVersion(name) {
+  const manifestPath = path.join(cwd, "package.json");
+  if (!fs.existsSync(manifestPath)) {
+    return null;
+  }
+
+  const manifest = readJson(manifestPath);
+  for (const key of ["dependencies", "devDependencies", "optionalDependencies"]) {
+    const dependencies = manifest[key];
+    const value = dependencies?.[name];
+    if (typeof value === "string" && /^\d+\.\d+\.\d+(?:[-+].*)?$/.test(value)) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function scorePackageId(id, name, expectedVersion) {
+  let score = 0;
+  if (expectedVersion != null && id.startsWith(`${name}@${expectedVersion}`)) {
+    score += 2;
+  }
+  if (!id.includes("(")) {
+    score += 1;
+  }
+  return score;
+}
+
+function resolveBinPath(packageJson, name) {
+  const bin = packageJson.bin;
+  if (typeof bin === "string") {
+    return bin;
+  }
+  if (bin != null && typeof bin === "object" && typeof bin[name] === "string") {
+    return bin[name];
+  }
+
+  console.error(`Package ${packageJson.name ?? "(unknown)"} does not expose bin "${name}"`);
+  process.exit(1);
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function normalizeSeparators(value) {
+  return value.replaceAll(path.sep, "/");
+}


### PR DESCRIPTION
## Summary
- Pin the workspace package manager to pnpm 12.1.0.
- Record pnpm v12 package manager dependencies in the lockfile.
- Keep VS Code extension package-local tasks compatible with pnpm v12's package-map bin layout.

## Verification
- `COREPACK_HOME=$(mktemp -d) COREPACK_ENABLE_DOWNLOAD_PROMPT=0 vp install --frozen-lockfile --prefer-offline`
- `COREPACK_HOME=$(mktemp -d) COREPACK_ENABLE_DOWNLOAD_PROMPT=0 vp exec pnpm audit --prod --audit-level moderate`
- `COREPACK_HOME=$(mktemp -d) COREPACK_ENABLE_DOWNLOAD_PROMPT=0 vp run --workspace-root package:editor-extensions`
- `COREPACK_HOME=$(mktemp -d) COREPACK_ENABLE_DOWNLOAD_PROMPT=0 vp run --workspace-root check:ci` with the CI-pinned MoonBit toolchain
- `VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/editor-integrations.test.ts`
- `node --test tests/tooling/node-engine-matrix.test.ts tests/tooling/package-manifests.test.ts`
- `node --test tests/tooling/github-workflows-check.test.ts`
- `SOURCE_LENGTH_BASE_REF=123a077a34d8762b53feccc94db20818c37ee6b4 node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790610693&installation_model_id=422833&pr_number=5251&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5251&signature=53ce7427837260da28c5c283a7e767cd689d3faade8fdcb2efa4776e85e2dd5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project’s package manager to pnpm 12.1.0.

* **Bug Fixes**
  * Improved VS Code extension dependency installation and packaging workflows.
  * Enhanced resolution of extension tooling across supported environments, including Windows.
  * Added offline-friendly installation behavior and more reliable lockfile handling.
  * Improved error reporting when required extension tools or packages cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->