### PR TITLE
refactor(patina): port media-has-caption to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -8,6 +8,7 @@ mod directives;
 mod jsx;
 mod jsx_deprecated_attr;
 mod jsx_fallback;
+mod jsx_media_has_caption;
 mod jsx_mouse_events_have_key_events;
 mod jsx_no_i_for_icon;
 mod jsx_no_redundant_roles;

--- a/crates/vize_patina/src/linter/tests/jsx_media_has_caption.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_media_has_caption.rs
@@ -1,0 +1,105 @@
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::MediaHasCaption;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn media_has_caption_fires_on_jsx_and_tsx_ir() {
+    let linter = linter_with(Box::new(MediaHasCaption));
+    let source = r#"const A = () => <video src="movie.mp4" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        result.warning_count, 1,
+        "JSX <video> without captions must flag through the IR pass: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(diagnostic_rules(&result), vec!["a11y/media-has-caption"]);
+
+    let diag = &result.diagnostics[0];
+    let video_start = source.find("<video").unwrap() as u32;
+    assert_eq!(
+        diag.start, video_start,
+        "range must start at the written JSX element"
+    );
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <audio src="podcast.mp3" />;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["a11y/media-has-caption"],
+        "TSX <audio> without captions must also flag through the IR pass"
+    );
+}
+
+#[test]
+fn media_has_caption_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(MediaHasCaption));
+    for source in [
+        r#"const A = () => <video muted />;"#,
+        r#"const A = () => <video aria-label={label} />;"#,
+        r#"const A = () => <audio aria-labelledby={labelId} />;"#,
+        r#"const A = () => <video><track kind="captions" /></video>;"#,
+        r#"const A = () => <video><track kind="descriptions" /></video>;"#,
+        r#"const A = () => <video><><track kind="captions" /></></video>;"#,
+        r#"const A = () => <Video src="movie.mp4" />;"#,
+        r#"const A = () => <Player.Video src="movie.mp4" />;"#,
+        r#"const A = () => <svg:video><track kind="captions" /></svg:video>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+
+    for source in [
+        r#"const A = () => <video muted={true} />;"#,
+        r#"const A = () => <video><track kind={kind} /></video>;"#,
+        r#"const A = () => <video><track KIND="captions" /></video>;"#,
+        r#"const A = () => <video><track kind="Captions" /></video>;"#,
+        r#"const A = () => <video><track kind kind="captions" /></video>;"#,
+        r#"const A = () => <video><span><track kind="captions" /></span></video>;"#,
+        r#"const A = () => <video><svg:track kind="captions" /></video>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 1,
+            "must keep warning for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn migrated_media_has_caption_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(MediaHasCaption));
+    let result = linter.lint_jsx(
+        r#"const A = () => <video src="movie.mp4" />;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated media-has-caption rule must report once: {:?}",
+        result.diagnostics
+    );
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -8,6 +8,7 @@
 // test files) so the Davinci assertion lint, which only scans inline
 // `#[cfg(test)] mod` bodies under `src/`, keeps covering these tests.
 mod deprecated_attr_tests;
+mod media_has_caption_tests;
 mod mouse_events_have_key_events_tests;
 mod no_i_for_icon_tests;
 mod no_redundant_roles_tests;

--- a/crates/vize_patina/src/markup/tests/media_has_caption_tests.rs
+++ b/crates/vize_patina/src/markup/tests/media_has_caption_tests.rs
@@ -1,0 +1,256 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::MediaHasCaption;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn media_has_caption_template() {
+    let rule = MediaHasCaption;
+    assert_eq!(
+        run_over_template(&rule, r#"<video src="movie.mp4"></video>"#),
+        1,
+        "template <video> without captions must warn through markup IR"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<audio src="podcast.mp3"></audio>"#),
+        1,
+        "template <audio> without captions must warn through markup IR"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<video src="movie.mp4" muted></video>"#),
+        0,
+        "static muted attribute keeps the legacy exemption"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<video src="movie.mp4" :muted="true"></video>"#),
+        1,
+        "bound muted does not satisfy the legacy static-attribute exemption"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<video src="movie.mp4" MUTED></video>"#),
+        1,
+        "muted attribute names remain exact and case-sensitive"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<video v-bind="{ muted: true }"></video>"#),
+        1,
+        "object v-bind does not satisfy the legacy static-muted check"
+    );
+    assert_eq!(
+        run_over_template(
+            &rule,
+            r#"<video src="movie.mp4" aria-label="Movie clip"></video>"#
+        ),
+        0,
+        "static aria-label provides an accessible name"
+    );
+    assert_eq!(
+        run_over_template(
+            &rule,
+            r#"<audio src="podcast.mp3" :aria-labelledby="labelId"></audio>"#
+        ),
+        0,
+        "static-arg bound aria-labelledby provides an accessible name"
+    );
+    assert_eq!(
+        run_over_template(
+            &rule,
+            r#"<video><track kind="captions" src="captions.vtt" /></video>"#
+        ),
+        0,
+        "direct static captions track is clean"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<video><track kind="descriptions" /></video>"#),
+        0,
+        "direct static descriptions track is clean"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<video><track :kind="'captions'" /></video>"#),
+        1,
+        "bound track kind remains outside the legacy static-value check"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<video><track KIND="captions" /></video>"#),
+        1,
+        "track kind attribute names remain exact and case-sensitive"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<video><track kind="Captions" /></video>"#),
+        1,
+        "track kind values remain exact and case-sensitive"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<video><track kind kind="captions" /></video>"#),
+        1,
+        "a valueless first kind attribute masks later duplicates like the legacy helper"
+    );
+    assert_eq!(
+        run_over_template(
+            &rule,
+            r#"<video><span><track kind="captions" /></span></video>"#
+        ),
+        1,
+        "nested track does not satisfy the direct-child legacy check"
+    );
+    assert_eq!(
+        run_over_template(&rule, r#"<VideoPlayer src="movie.mp4"></VideoPlayer>"#),
+        0,
+        "components stay skipped"
+    );
+}
+
+#[test]
+fn media_has_caption_jsx_direct_matches_lowered_boundaries() {
+    let rule = MediaHasCaption;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <video src="movie.mp4" />;"#,
+            1,
+            "video without captions",
+        ),
+        (
+            r#"const A = () => <audio src="podcast.mp3" />;"#,
+            1,
+            "audio without captions",
+        ),
+        (
+            r#"const A = () => <video src="movie.mp4" muted />;"#,
+            0,
+            "boolean muted",
+        ),
+        (
+            r#"const A = () => <video src="movie.mp4" muted={true} />;"#,
+            1,
+            "dynamic muted",
+        ),
+        (
+            r#"const A = () => <video src="movie.mp4" aria-label="Movie clip" />;"#,
+            0,
+            "static aria-label",
+        ),
+        (
+            r#"const A = () => <video src="movie.mp4" aria-label={label} />;"#,
+            0,
+            "dynamic aria-label",
+        ),
+        (
+            r#"const A = () => <audio src="podcast.mp3" aria-labelledby={labelId} />;"#,
+            0,
+            "dynamic aria-labelledby",
+        ),
+        (
+            r#"const A = () => <video><track kind="captions" /></video>;"#,
+            0,
+            "captions track",
+        ),
+        (
+            r#"const A = () => <video><track kind="descriptions" /></video>;"#,
+            0,
+            "descriptions track",
+        ),
+        (
+            r#"const A = () => <video><track kind={kind} /></video>;"#,
+            1,
+            "dynamic track kind",
+        ),
+        (
+            r#"const A = () => <video><track KIND="captions" /></video>;"#,
+            1,
+            "case-sensitive track kind attr",
+        ),
+        (
+            r#"const A = () => <video><track kind="Captions" /></video>;"#,
+            1,
+            "case-sensitive track kind value",
+        ),
+        (
+            r#"const A = () => <video><track kind kind="captions" /></video>;"#,
+            1,
+            "first duplicate track kind wins",
+        ),
+        (
+            r#"const A = () => <video><span><track kind="captions" /></span></video>;"#,
+            1,
+            "nested track",
+        ),
+        (
+            r#"const A = () => <video><><track kind="captions" /></></video>;"#,
+            0,
+            "child fragments are transparent like JSX lowering",
+        ),
+        (
+            r#"const A = () => <Video src="movie.mp4" />;"#,
+            0,
+            "component",
+        ),
+        (
+            r#"const A = () => <Player.Video src="movie.mp4" />;"#,
+            0,
+            "member component",
+        ),
+        (
+            r#"const A = () => <svg:video><track kind="captions" /></svg:video>;"#,
+            0,
+            "namespaced video",
+        ),
+        (
+            r#"const A = () => <video><svg:track kind="captions" /></video>;"#,
+            1,
+            "namespaced track",
+        ),
+    ] {
+        assert_eq!(
+            run_over_jsx_lowered(&rule, source),
+            expected,
+            "lowered JSX boundary changed for {label}"
+        );
+        assert_eq!(
+            run_over_jsx_oxc(&rule, source),
+            expected,
+            "direct JSX IR must match the lowered boundary for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/a11y/media_has_caption.rs
+++ b/crates/vize_patina/src/rules/a11y/media_has_caption.rs
@@ -23,11 +23,9 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBindingKind, MarkupContext, MarkupElement, MarkupNode, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, ElementType, TemplateChildNode};
-
-use super::helpers::{get_static_attribute_value, has_named_prop};
-use vize_relief::PropNode;
+use vize_relief::ElementNode;
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/media-has-caption",
@@ -41,17 +39,120 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct MediaHasCaption;
 
-fn has_caption_track(children: &[TemplateChildNode]) -> bool {
-    for child in children {
-        if let TemplateChildNode::Element(el) = child
-            && el.tag == "track"
-            && let Some(kind) = get_static_attribute_value(el, "kind")
-            && (kind == "captions" || kind == "descriptions")
-        {
-            return true;
-        }
+impl MediaHasCaption {
+    fn has_exact_static_attribute(element: &MarkupElement<'_>, name: &str) -> bool {
+        let mut found = false;
+        element.walk_bindings(&mut |binding| {
+            if binding.kind() == MarkupBindingKind::Attribute
+                && binding.is_unqualified_arg_exact(name)
+            {
+                found = true;
+            }
+        });
+        found
     }
-    false
+
+    fn has_exact_named_prop(element: &MarkupElement<'_>, name: &str) -> bool {
+        let mut found = false;
+        element.walk_bindings(&mut |binding| {
+            if matches!(
+                binding.kind(),
+                MarkupBindingKind::Attribute | MarkupBindingKind::Bind
+            ) && binding.is_static_unqualified_arg_exact(name)
+            {
+                found = true;
+            }
+        });
+        found
+    }
+
+    fn first_exact_static_attribute_value<'a>(
+        element: &MarkupElement<'a>,
+        name: &str,
+    ) -> Option<&'a str> {
+        let mut seen = false;
+        let mut value = None;
+        element.walk_bindings(&mut |binding| {
+            if !seen
+                && binding.kind() == MarkupBindingKind::Attribute
+                && binding.is_unqualified_arg_exact(name)
+            {
+                seen = true;
+                value = binding.static_value();
+            }
+        });
+        value
+    }
+
+    fn has_caption_track(element: &MarkupElement<'_>, transparent_fragments: bool) -> bool {
+        let mut found = false;
+        element.walk_children(&mut |child| {
+            if let MarkupNode::Element(child_element) = child
+                && child_element.is_unqualified_tag_exact("track")
+                && let Some(kind) = Self::first_exact_static_attribute_value(&child_element, "kind")
+                && (kind == "captions" || kind == "descriptions")
+            {
+                found = true;
+            }
+            // JSX lowering splices fragments in child position. Preserve that
+            // boundary for direct OXC IR without changing Vue `<template>`.
+            if let MarkupNode::Element(child_element) = child
+                && transparent_fragments
+                && child_element.tag().is_empty()
+                && Self::has_caption_track(&child_element, transparent_fragments)
+            {
+                found = true;
+            }
+        });
+        found
+    }
+
+    fn check_element(
+        ctx: &mut LintContext<'_>,
+        element: &MarkupElement<'_>,
+        transparent_fragments: bool,
+    ) {
+        if element.is_component() {
+            return;
+        }
+
+        if !element.is_unqualified_tag_exact("video") && !element.is_unqualified_tag_exact("audio")
+        {
+            return;
+        }
+
+        if Self::has_exact_static_attribute(element, "muted") {
+            return;
+        }
+
+        if Self::has_exact_named_prop(element, "aria-label") {
+            return;
+        }
+
+        if Self::has_exact_named_prop(element, "aria-labelledby") {
+            return;
+        }
+
+        if Self::has_caption_track(element, transparent_fragments) {
+            return;
+        }
+
+        let tag = element.tag();
+        let message = ctx.t_fmt("a11y/media-has-caption.message", &[("tag", tag)]);
+        let help = ctx.t("a11y/media-has-caption.help");
+        ctx.warn_at_with_help(message, element.range(), help);
+    }
+}
+
+impl MarkupRule for MediaHasCaption {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        let transparent_fragments = ctx.is_jsx();
+        Self::check_element(ctx.lint(), element, transparent_fragments);
+    }
 }
 
 impl Rule for MediaHasCaption {
@@ -59,46 +160,12 @@ impl Rule for MediaHasCaption {
         &META
     }
 
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if element.tag_type == ElementType::Component {
-            return;
-        }
-
-        if element.tag != "video" && element.tag != "audio" {
-            return;
-        }
-
-        // Muted media doesn't need captions (boolean attribute - may have no value)
-        let has_muted = element.props.iter().any(|prop| {
-            if let PropNode::Attribute(attr) = prop {
-                attr.name == "muted"
-            } else {
-                false
-            }
-        });
-        if has_muted {
-            return;
-        }
-
-        // Static and bound accessible names satisfy the requirement.
-        if has_named_prop(element, "aria-label") {
-            return;
-        }
-
-        if has_named_prop(element, "aria-labelledby") {
-            return;
-        }
-
-        // Check for <track kind="captions"> child
-        if has_caption_track(&element.children) {
-            return;
-        }
-
-        ctx.warn_with_help(
-            ctx.t_fmt("a11y/media-has-caption.message", &[("tag", element.tag)]),
-            &element.loc,
-            ctx.t("a11y/media-has-caption.help"),
-        );
+        Self::check_element(ctx, &MarkupElement::new(element), false);
     }
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           305 |                   305 |                 0 |             273 |     235 |             674 |      139 |           345 |           489 |
+| Linter                     |           306 |                   306 |                 0 |             273 |     238 |             673 |      144 |           346 |           491 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         305 |             224 |       81 |
-| old AST/parser   |         231 |             212 |       19 |
+| S0               |         306 |             224 |       82 |
+| old AST/parser   |         231 |             211 |       20 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         235 |             200 |       35 |
+| raw OXC          |         238 |             200 |       38 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:23`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:24`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 41 omitted.
+Additional test/dev rows are in the TSV: 42 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,12 +991,15 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	23	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	23	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	23	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	24	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	24	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	24	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/media_has_caption_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/media_has_caption_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/media_has_caption_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
@@ -1031,7 +1034,7 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/iframe_has_title.rs	12	ol
 linter	Linter	source	crates/vize_patina/src/rules/a11y/img_alt.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	4
 linter	Linter	source	crates/vize_patina/src/rules/a11y/interactive_supports_focus.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/label_has_for.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/a11y/media_has_caption.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	2
+linter	Linter	source	crates/vize_patina/src/rules/a11y/media_has_caption.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/mouse_events_have_key_events.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_access_key.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 17, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 18, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 130, `ir` 15, `ir-lowered` 2, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (17 = 17 `markup-facade` rules)
+- JSX lanes: `fallback` 129, `ir` 16, `ir-lowered` 2, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (18 = 18 `markup-facade` rules)
 - classification: neutral-core-candidate **85** · vue-dialect-bound **138** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -61,7 +61,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/interactive-supports-focus`               | template-family | `a11y/interactive_supports_focus.rs`                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `a11y/label-has-for`                            | template-family | `a11y/label_has_for.rs`                                | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/landmark-roles`                           | template-family | `opinionated/a11y/landmark_roles.rs`                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
-| `a11y/media-has-caption`                        | template-family | `a11y/media_has_caption.rs`                            | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `a11y/media-has-caption`                        | template-family | `a11y/media_has_caption.rs`                            | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/mouse-events-have-key-events`             | template-family | `a11y/mouse_events_have_key_events.rs`                 | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-access-key`                            | template-family | `a11y/no_access_key.rs`                                | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |
 | `a11y/no-aria-hidden-on-focusable`              | template-family | `a11y/no_aria_hidden_on_focusable.rs`                  | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |


### PR DESCRIPTION
## Summary

- port `a11y/media-has-caption` onto the Davinci `MarkupRule` facade and keep the legacy `Rule` path delegating to the same check
- add template/lowered JSX/direct JSX parity tests for static-only `muted`, static/bound aria names, direct child track semantics, duplicate attr boundaries, and JSX fragment transparency
- update Davinci rule parity and consumer migration surface matrices (`markup-facade` 17 -> 18, JSX fallback 130 -> 129)

## Verification

- `cargo test -p vize_patina --locked`
- `cargo check -p vize_patina --all-targets --locked`
- `cargo clippy -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-matrices.test.ts`
- `node tools/davinci/assertion-lint.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check HEAD`

Closes #5253

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5254"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790611668&installation_model_id=422833&pr_number=5254&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5254&signature=7d6d6a4e0bb9abc7c512ffb82d2fd1e628bce5dc8e17d11d52975fa1721982b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->