### PR TITLE
test(ui): run toolchain gates in package check

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -276,7 +276,7 @@
     "pretest": "vp pack && pnpm check:size && pnpm check:tree-shaking",
     "test": "vp test run",
     "check:catalog": "vp test run src/family-catalog.test.ts",
-    "check": "vp check src scripts vite.config.ts tsconfig.typecheck.json && vue-tsc --noEmit -p tsconfig.typecheck.json",
+    "check": "pnpm lint:sfc && vp check src scripts vite.config.ts tsconfig.typecheck.json && vue-tsc --noEmit -p tsconfig.typecheck.json",
     "check:fix": "vp check --fix src scripts vite.config.ts tsconfig.typecheck.json",
     "check:size": "node scripts/check-size.mjs",
     "check:tree-shaking": "node scripts/check-tree-shaking.mjs",

--- a/npm/ui/core/src/toolchain-testbed.behavior.md
+++ b/npm/ui/core/src/toolchain-testbed.behavior.md
@@ -1,0 +1,11 @@
+# Toolchain testbed behavior contract
+
+Normative state × input → outcome table for the UI source corpus used by
+Atelier, Patina, Glyph, and Canon. Every row is proven by the named test in
+`src/toolchain-testbed.test.ts` or by the package `check` script itself.
+
+| #   | State          | Input                  | Outcome                                                              | Proven by                                                        |
+| --- | -------------- | ---------------------- | -------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| T1  | package script | `pnpm check`           | SFC lint and DOM/SSR/Vapor renderer compilation run before typecheck | `package check keeps the UI source corpus on the toolchain gate` |
+| T2  | renderer gate  | authored Vue SFC files | DOM, SSR, and Vapor lanes compile every source fixture               | `pnpm lint:sfc`                                                  |
+| T3  | linter gate    | authored Vue SFC files | opinionated SFC authoring rules run on every source fixture          | `pnpm lint:sfc`                                                  |

--- a/npm/ui/core/src/toolchain-testbed.test.ts
+++ b/npm/ui/core/src/toolchain-testbed.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { test } from "vite-plus/test";
+
+test("package check keeps the UI source corpus on the toolchain gate", async () => {
+  const manifest = JSON.parse(await readFile(path.resolve("package.json"), "utf8")) as {
+    readonly scripts: Readonly<Record<string, string>>;
+  };
+
+  assert.equal(
+    manifest.scripts["lint:sfc"],
+    "vp exec node scripts/lint-sfc.ts src && vp exec node scripts/check-renderers.ts src",
+  );
+  assert.match(manifest.scripts.check, /^pnpm lint:sfc && /);
+  assert.match(manifest.scripts.check, /vue-tsc --noEmit -p tsconfig\.typecheck\.json/);
+});
+
+test("renderer conformance script owns the DOM, SSR, and Vapor lanes", async () => {
+  const checkRendererSource = await readFile(path.resolve("scripts/check-renderers.ts"), "utf8");
+
+  assert.ok(checkRendererSource.includes('name: "dom"'));
+  assert.ok(checkRendererSource.includes('name: "ssr"'));
+  assert.ok(checkRendererSource.includes('name: "vapor"'));
+  assert.ok(checkRendererSource.includes("compileSfc"));
+  assert.ok(checkRendererSource.includes("sourceFiles.length + inlineFixtures.length"));
+});


### PR DESCRIPTION
## Summary
- run the UI SFC lint and DOM/SSR/Vapor renderer conformance gate from the package `check` script
- add a toolchain testbed behavior contract for the UI source corpus
- pin package script wiring so SFC lint and renderer conformance do not drift out of CI

Refs #4899

## Tests
- `vp install --frozen-lockfile --prefer-offline`
- `pnpm -C npm/ui/core lint:sfc`
- `pnpm -C npm/ui/core exec vp test run src/toolchain-testbed.test.ts`
- `pnpm -C npm/ui/core check`
- `pnpm -C npm/ui/core test`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790612291&installation_model_id=422833&pr_number=5256&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5256&signature=2421f86a0844a49a2d29a192b1b40b9b04203d0ba955673f69615f10024a7e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->