### PR TITLE
feat(tools): add Rust Script command surface

### DIFF
--- a/.github/actions/app-e2e-row/action.yml
+++ b/.github/actions/app-e2e-row/action.yml
@@ -33,6 +33,12 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup Rust
+      id: rust-toolchain
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+    - uses: ./.github/actions/setup-rust-script
+
     - name: Validate and hydrate planned fixtures
       shell: bash
       env:
@@ -47,7 +53,7 @@ runs:
         PLANNED_ARTIFACT_STEM: ${{ inputs.artifact-stem }}
       run: |
         set -euo pipefail
-        planner=(node tools/github/app-e2e-plan.mjs --profile "$PLAN_PROFILE" --suite "$PLAN_SUITE" --shard "$PLAN_SHARD")
+        planner=(rust-script tools/commands/ci/github/app-e2e-plan.rs --profile "$PLAN_PROFILE" --suite "$PLAN_SUITE" --shard "$PLAN_SHARD")
         test "$("${planner[@]}" --field task)" = "$PLANNED_TASK"
         test "$("${planner[@]}" --field timeout)" = "$PLANNED_TIMEOUT"
         test "$("${planner[@]}" --field needs-playwright)" = "$PLANNED_BROWSER"
@@ -60,10 +66,6 @@ runs:
           exit 1
         fi
         git submodule update --init --recursive --depth 1 -- "${fixture_paths[@]}"
-
-    - name: Setup Rust
-      id: rust-toolchain
-      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
     - name: Setup Wild linker
       uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0

--- a/.github/actions/package-editor-extensions/action.yml
+++ b/.github/actions/package-editor-extensions/action.yml
@@ -19,6 +19,8 @@ runs:
         key: editor-extensions
         cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
 
+    - uses: ./.github/actions/setup-rust-script
+
     - name: Install JS dependencies
       shell: bash
       env:

--- a/.github/actions/setup-rust-script/action.yml
+++ b/.github/actions/setup-rust-script/action.yml
@@ -1,0 +1,16 @@
+name: Setup Rust Script
+description: Install the pinned rust-script runner used by tools/commands
+
+runs:
+  using: composite
+  steps:
+    - name: Install rust-script
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v rust-script >/dev/null 2>&1; then
+          rust-script --version
+          exit 0
+        fi
+        cargo install rust-script --version 0.34.0 --locked
+        rust-script --version

--- a/.github/actions/vscode-host-smoke/action.yml
+++ b/.github/actions/vscode-host-smoke/action.yml
@@ -26,6 +26,8 @@ runs:
         key: editor-host-smoke
         cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
 
+    - uses: ./.github/actions/setup-rust-script
+
     - name: Hydrate pinned create-vue fixture
       shell: bash
       run: |
@@ -92,7 +94,7 @@ runs:
         set -euo pipefail
         mkdir -p "${XDG_CONFIG_HOME}/helix"
         cp editors/helix/languages.toml "${XDG_CONFIG_HOME}/helix/languages.toml"
-        node tools/helix-vize/assert-helix-health.mjs "${RUNNER_TEMP}/helix/hx"
+        rust-script tools/commands/editors/helix/assert-helix-health.rs "${RUNNER_TEMP}/helix/hx"
 
     - name: Stabilize Ubuntu package archive
       uses: ./.github/actions/setup-ubuntu-archive

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -96,13 +96,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-      - name: Resolve SemVer change marker
-        env:
-          GITHUB_TOKEN: ${{ github.event_name == 'push' && github.token || '' }}
-        run: node tools/github/semver-change-marker.mjs "$RUNNER_TEMP/semver-change-marker.txt"
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           toolchain: 1.95.0
+      - uses: ./.github/actions/setup-rust-script
+      - name: Resolve SemVer change marker
+        env:
+          GITHUB_TOKEN: ${{ github.event_name == 'push' && github.token || '' }}
+        run: rust-script tools/commands/ci/github/semver-change-marker.rs "$RUNNER_TEMP/semver-change-marker.txt"
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
           wild-version: "0.9.0"
@@ -227,7 +228,6 @@ jobs:
           key: vue-parity
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
       - uses: ./.github/actions/check-vue-parity
-
   test-scripts:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     # Restoration of the original setup after the trim in #519 broke
@@ -256,6 +256,7 @@ jobs:
         with:
           key: test-scripts
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+      - uses: ./.github/actions/setup-rust-script
       - name: Hydrate CLI diagnostic fixture and install JS dependencies
         run: git submodule update --init --force --depth 1 -- tests/_fixtures/_git/ant-design-vue tests/_fixtures/_git/create-vue && vp install --frozen-lockfile --prefer-offline
       - name: Build vize CLI
@@ -264,21 +265,18 @@ jobs:
         run: sudo install -m 0755 target/ci/vize /usr/local/bin/vize
       - name: Test release scripts
         run: vp run --workspace-root test:scripts
-
   editor-extensions:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/package-editor-extensions
-
   editor-host-smoke:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/vscode-host-smoke
-
   build-js-packages:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
@@ -371,12 +369,13 @@ jobs:
         with:
           key: clippy-test
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+      - uses: ./.github/actions/setup-rust-script
       - name: Clippy
-        run: cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports && cargo clippy -p vize_maestro --tests -- -D warnings && bash tools/github/check-maestro-feature-contract.sh
+        run: cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports && cargo clippy -p vize_maestro --tests -- -D warnings && rust-script tools/commands/ci/github/check-maestro-feature-contract.rs
       - name: Davinci no_std stage-library portability lanes (TS-24)
         run: cargo build -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 && cargo build -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 --no-default-features
       - name: Davinci compact-storage allocation gate
-        run: cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && node tools/davinci/bench-compare.mjs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root
+        run: cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && rust-script tools/commands/davinci/bench-compare.rs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root
       - name: Upload Davinci compact-storage bench reports
         if: ${{ always() }}
         uses: ./.github/actions/upload-davinci-compact-storage-bench-reports
@@ -385,7 +384,6 @@ jobs:
       - name: Test
         env: { VIZE_TEST_REQUIRE_TSGO: "1" }
         run: cargo test --workspace && cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus -- --nocapture && cargo test -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli && cargo test -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 && cargo test -p vize_vitrine --no-default-features --features wasm
-
   coverage:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30
@@ -648,6 +646,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - name: Collect test inventory
         run: node bench/test-inventory.mjs --json test-inventory.json --markdown "$GITHUB_STEP_SUMMARY"
       - name: Upload test inventory
@@ -659,7 +659,7 @@ jobs:
       # Runs last so the inventory is collected and uploaded either way.
       - name: Require every needed job to succeed
         env: { NEEDS_JSON: "${{ toJSON(needs) }}" }
-        run: node tools/github/require-needs-success.mjs
+        run: rust-script tools/commands/ci/github/require-needs-success.rs
 
   test-report-comment:
     name: test-report-comment

--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -58,6 +58,8 @@ on:
       - "tools/npm/prepare-publish-manifest.mjs"
       - "tools/npm/smoke-release-install.mjs"
       - "tools/npm/smoke-release-runtime.mjs"
+      - "tools/commands/release/npm/**"
+      - "tools/rust/**"
       - "tests/_fixtures/davinci-ts40-projection/**"
       - "tests/tooling/davinci-ts40-projection.test.ts"
       - "tests/tooling/support/davinci-ts40-projection.ts"
@@ -118,6 +120,8 @@ on:
       - "tools/npm/prepare-publish-manifest.mjs"
       - "tools/npm/smoke-release-install.mjs"
       - "tools/npm/smoke-release-runtime.mjs"
+      - "tools/commands/release/npm/**"
+      - "tools/rust/**"
       - "tests/_fixtures/davinci-ts40-projection/**"
       - "tests/tooling/davinci-ts40-projection.test.ts"
       - "tests/tooling/support/davinci-ts40-projection.ts"
@@ -170,6 +174,7 @@ jobs:
         with:
           key: content-mapper-conformance
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+      - uses: ./.github/actions/setup-rust-script
       - name: Setup Vite Plus
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -210,7 +215,7 @@ jobs:
         env:
           VIZE_TEST_CONTENT_MAPPER_TSGO: ${{ runner.temp }}/tsgo
         run: |
-          node tools/npm/smoke-release-install.mjs --prepare-manifests --content-mapper-checks \
+          rust-script tools/commands/release/npm/smoke-release-install.rs --prepare-manifests --content-mapper-checks \
             npm/native npm/native/npm/* \
             npm/cli
       - name: Run standard project and declaration conformance

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -98,6 +98,8 @@ jobs:
               - 'tests/snapshots/build/__snapshots__/generic-*.snap'
               - 'tests/tooling/cli-lint-contract.test.ts'
               - 'tools/github/app-e2e-*.mjs'
+              - 'tools/commands/ci/github/app-e2e-*.rs'
+              - 'tools/rust/**'
               - 'tools/moon/**'
               - 'tools/vite-plus/**'
               - 'tsconfig.json'
@@ -109,6 +111,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
+      - if: steps.changes.outputs.readiness == 'true'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
+        if: steps.changes.outputs.readiness == 'true'
       - name: Verify readiness merge SHA
         if: steps.changes.outputs.readiness == 'true'
         env:
@@ -120,16 +126,12 @@ jobs:
       - name: Plan readiness rows
         if: steps.changes.outputs.readiness == 'true'
         id: plan
-        run: |
-          echo "matrix=$(node tools/github/app-e2e-plan.mjs --profile readiness)" >> "$GITHUB_OUTPUT"
-          echo "count=$(node tools/github/app-e2e-plan.mjs --profile readiness --field count)" >> "$GITHUB_OUTPUT"
+        run: echo "matrix=$(rust-script tools/commands/ci/github/app-e2e-plan.rs --profile readiness)" >> "$GITHUB_OUTPUT" && echo "count=$(rust-script tools/commands/ci/github/app-e2e-plan.rs --profile readiness --field count)" >> "$GITHUB_OUTPUT"
       - name: Write readiness plan evidence
         if: steps.changes.outputs.readiness == 'true'
         env:
           E2E_SOURCE_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          mkdir -p target/app-e2e-plan
-          node tools/github/app-e2e-plan.mjs --profile readiness --field evidence > target/app-e2e-plan/readiness.json
+        run: mkdir -p target/app-e2e-plan && rust-script tools/commands/ci/github/app-e2e-plan.rs --profile readiness --field evidence > target/app-e2e-plan/readiness.json
       - name: Upload readiness plan evidence
         if: steps.changes.outputs.readiness == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -137,7 +139,6 @@ jobs:
           name: app-e2e-plan-readiness-${{ github.run_id }}-${{ github.run_attempt }}
           path: target/app-e2e-plan/readiness.json
           if-no-files-found: error
-
   app-readiness-producer:
     name: app-readiness (${{ matrix.shard }})
     needs: app-readiness-plan
@@ -179,13 +180,15 @@ jobs:
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - name: Aggregate app readiness
         env:
           RUN_REQUIRED: ${{ needs.app-readiness-plan.outputs.run }}
           PLAN_RESULT: ${{ needs.app-readiness-plan.result }}
           PRODUCER_RESULT: ${{ needs.app-readiness-producer.result }}
           PLANNED_COUNT: ${{ needs.app-readiness-plan.outputs.count }}
-        run: node tools/github/app-e2e-aggregate.mjs readiness all "$RUN_REQUIRED" "$PLAN_RESULT" "$PRODUCER_RESULT" "$PLANNED_COUNT"
+        run: rust-script tools/commands/ci/github/app-e2e-aggregate.rs readiness all "$RUN_REQUIRED" "$PLAN_RESULT" "$PRODUCER_RESULT" "$PLANNED_COUNT"
 
   testbox:
     name: Testbox
@@ -273,6 +276,8 @@ jobs:
         with:
           ref: ${{ env.E2E_TARGET_SHA }}
           persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - name: Verify full App E2E SHA
         env:
           EXPECTED_SHA: ${{ env.E2E_TARGET_SHA }}
@@ -281,16 +286,11 @@ jobs:
         id: plan
         env:
           REQUESTED_SUITE: ${{ github.event_name == 'workflow_dispatch' && inputs.suite || 'all' }}
-        run: |
-          echo "suite=$REQUESTED_SUITE" >> "$GITHUB_OUTPUT"
-          echo "matrix=$(node tools/github/app-e2e-plan.mjs --profile full --suite "$REQUESTED_SUITE")" >> "$GITHUB_OUTPUT"
-          echo "count=$(node tools/github/app-e2e-plan.mjs --profile full --suite "$REQUESTED_SUITE" --field count)" >> "$GITHUB_OUTPUT"
+        run: echo "suite=$REQUESTED_SUITE" >> "$GITHUB_OUTPUT" && echo "matrix=$(rust-script tools/commands/ci/github/app-e2e-plan.rs --profile full --suite "$REQUESTED_SUITE")" >> "$GITHUB_OUTPUT" && echo "count=$(rust-script tools/commands/ci/github/app-e2e-plan.rs --profile full --suite "$REQUESTED_SUITE" --field count)" >> "$GITHUB_OUTPUT"
       - name: Write full plan evidence
         env:
           REQUESTED_SUITE: ${{ github.event_name == 'workflow_dispatch' && inputs.suite || 'all' }}
-        run: |
-          mkdir -p target/app-e2e-plan
-          node tools/github/app-e2e-plan.mjs --profile full --suite "$REQUESTED_SUITE" --field evidence > target/app-e2e-plan/full.json
+        run: mkdir -p target/app-e2e-plan && rust-script tools/commands/ci/github/app-e2e-plan.rs --profile full --suite "$REQUESTED_SUITE" --field evidence > target/app-e2e-plan/full.json
       - name: Upload full plan evidence
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -338,10 +338,12 @@ jobs:
         with:
           ref: ${{ env.E2E_TARGET_SHA }}
           persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - name: Aggregate full App E2E
         env:
           PLAN_RESULT: ${{ needs.app-e2e-plan.result }}
           PRODUCER_RESULT: ${{ needs.app-e2e-producer.result }}
           PLANNED_COUNT: ${{ needs.app-e2e-plan.outputs.count }}
           PLANNED_SUITE: ${{ needs.app-e2e-plan.outputs.suite }}
-        run: node tools/github/app-e2e-aggregate.mjs full "$PLANNED_SUITE" true "$PLAN_RESULT" "$PRODUCER_RESULT" "$PLANNED_COUNT"
+        run: rust-script tools/commands/ci/github/app-e2e-aggregate.rs full "$PLANNED_SUITE" true "$PLAN_RESULT" "$PRODUCER_RESULT" "$PLANNED_COUNT"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,6 +40,8 @@ on:
       - "crates/vize_s1/**"
       - "tests/fuzz/**"
       - "tools/fuzz/**"
+      - "tools/commands/ci/fuzz/**"
+      - "tools/rust/**"
       - ".github/workflows/fuzz.yml"
 
 run-name: Fuzz ${{ github.event_name == 'workflow_dispatch' && (inputs.mode == 'replay' && 'replay' || format('{0}s', inputs.max-total-time)) || github.event_name }} @ ${{ github.sha }}
@@ -129,6 +131,8 @@ jobs:
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
           target-path: tests/fuzz/target
 
+      - uses: ./.github/actions/setup-rust-script
+
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked --version "^0.13"
 
@@ -141,7 +145,7 @@ jobs:
           node-version-file: ".node-version"
 
       - name: Seed fuzz corpus from repository fixtures
-        run: node tools/fuzz/seed_corpus.mjs
+        run: rust-script tools/commands/ci/fuzz/seed_corpus.rs
 
       - name: Restore grown corpus cache
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -230,4 +234,4 @@ jobs:
           FUZZ_EVENT_NAME: ${{ github.event_name }}
           FUZZ_OUTCOME: ${{ steps.fuzz.outcome || 'skipped' }}
           FUZZ_TARGET: ${{ matrix.target }}
-        run: node tools/fuzz/enforce-result.mjs "$FUZZ_EVENT_NAME" "$FUZZ_TARGET" "$FUZZ_OUTCOME"
+        run: rust-script tools/commands/ci/fuzz/enforce-result.rs "$FUZZ_EVENT_NAME" "$FUZZ_TARGET" "$FUZZ_OUTCOME"

--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -81,6 +81,7 @@ jobs:
         with:
           shared-key: native-smoke-${{ matrix.target }}
           cache-workspace-crates: "true"
+      - uses: ./.github/actions/setup-rust-script
       - name: Install native package dependencies
         run: vp install --frozen-lockfile --prefer-offline --filter './npm/native...'
       - name: Build CLI
@@ -97,12 +98,12 @@ jobs:
         run: vp run --filter './npm/native' build:ci
       - name: Verify GNU native glibc compatibility
         if: runner.os == 'Linux' && endsWith(matrix.target, '-gnu')
-        run: node tools/github/verify-glibc-symbols.mjs --max 2.36 npm/native/*.linux-*-gnu.node
+        run: rust-script tools/commands/ci/github/verify-glibc-symbols.rs --max 2.36 npm/native/*.linux-*-gnu.node
       - name: Smoke @vizejs/native
         run: node -e "const native = require('./npm/native'); if (typeof native.compileSfc !== 'function') throw new Error('compileSfc missing')"
       - name: Package-install smoke for host native package
         if: runner.os == 'Linux'
-        run: node tools/npm/smoke-release-install.mjs --prepare-manifests npm/native
+        run: rust-script tools/commands/release/npm/smoke-release-install.rs --prepare-manifests npm/native
 
   fresh-install-smoke:
     name: Fresh install smoke (${{ matrix.platform.target }}, Node ${{ matrix.node-version }})
@@ -176,6 +177,7 @@ jobs:
         with:
           shared-key: fresh-install-smoke-${{ matrix.platform.target }}
           cache-workspace-crates: "true"
+      - uses: ./.github/actions/setup-rust-script
       - name: Install package dependencies
         shell: bash
         run: |
@@ -221,6 +223,6 @@ jobs:
       - name: Fresh install and runtime smoke published tarballs
         shell: bash
         run: |
-          node tools/npm/smoke-release-install.mjs --prepare-manifests --runtime-checks \
+          rust-script tools/commands/release/npm/smoke-release-install.rs --prepare-manifests --runtime-checks \
             npm/native npm/native/npm/* \
             npm/cli npm/builder/vite

--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -92,6 +92,9 @@ jobs:
           node-version-file: ".node-version"
           cache: true
           run-install: false
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
 
       - name: Enable package manager shims
         run: corepack enable
@@ -100,7 +103,7 @@ jobs:
         shell: bash
         run: |
           mapfile -t fixture_paths < <(
-            node tools/fixtures/tool-matrix-report.mjs \
+            rust-script tools/commands/fixtures/tool-matrix-report.rs \
               --list-fixture-paths \
               --shard-index "$FIXTURE_SHARD_INDEX" \
               --shard-count "$FIXTURE_SHARD_COUNT"
@@ -118,7 +121,7 @@ jobs:
         if: ${{ !cancelled() }}
         continue-on-error: true
         run: |
-          node tools/fixtures/typecheck-dependency-prepare.mjs \
+          rust-script tools/commands/fixtures/typecheck-dependency-prepare.rs \
             --output-dir "$FIXTURE_REPORT_DIR" \
             --shard-index "$FIXTURE_SHARD_INDEX" \
             --shard-count "$FIXTURE_SHARD_COUNT" \
@@ -131,13 +134,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          node tools/fixtures/glyph-corpus-waiver-audit.mjs \
+          rust-script tools/commands/fixtures/glyph-corpus-waiver-audit.rs \
             --output "$FIXTURE_REPORT_DIR/glyph-waiver-issues.json"
 
       - uses: ./.github/actions/setup-moonbit
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Setup Wild linker
         uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
@@ -162,7 +162,7 @@ jobs:
         env:
           CORE_TOOLS_TIMEOUT_MS: ${{ inputs.core_tools_timeout_ms || '2400000' }}
         run: |
-          node tools/fixtures/tool-matrix-report.mjs \
+          rust-script tools/commands/fixtures/tool-matrix-report.rs \
             --shard-index "$FIXTURE_SHARD_INDEX" \
             --shard-count "$FIXTURE_SHARD_COUNT" \
             --vize-bin target/ci/vize \
@@ -193,7 +193,7 @@ jobs:
         env:
           LINT_DIVERGENCE_MODE: ${{ inputs.lint_divergence_mode || 'enforce' }}
         run: |
-          node tools/fixtures/lint-divergence-report.mjs \
+          rust-script tools/commands/fixtures/lint-divergence-report.rs \
             --shard-index "$FIXTURE_SHARD_INDEX" \
             --shard-count "$FIXTURE_SHARD_COUNT" \
             --measure-coverage-gap \
@@ -257,7 +257,7 @@ jobs:
         env:
           BUDGET_MODE: ${{ inputs.typecheck_divergence_mode || 'enforce' }}
         run: |
-          node tools/fixtures/typecheck-divergence-report.mjs \
+          rust-script tools/commands/fixtures/typecheck-divergence-report.rs \
             --report-dir "$FIXTURE_REPORT_DIR" \
             --shard-index "$FIXTURE_SHARD_INDEX" \
             --shard-count "$FIXTURE_SHARD_COUNT" \
@@ -304,7 +304,7 @@ jobs:
           if [[ "$TYPECHECK_DIVERGENCE_MODE" == "record-only" && "$typecheck_divergence_verdict" == "failure" ]]; then
             typecheck_divergence_verdict=success
           fi
-          node tools/fixtures/real-project-surface-verdict.mjs \
+          rust-script tools/commands/fixtures/real-project-surface-verdict.rs \
             --output "$FIXTURE_REPORT_DIR/surface-verdict.json" \
             --surface "waiver-audit=$VIZE_WAIVER_AUDIT_OUTCOME" \
             --surface "typecheck-dependencies=$typecheck_dependencies_verdict" \
@@ -318,7 +318,7 @@ jobs:
       - name: Publish shard summary
         if: ${{ always() }}
         shell: bash
-        run: bash tools/github/publish-real-project-shard-summary.sh
+        run: rust-script tools/commands/ci/github/publish-real-project-shard-summary.rs
 
       - name: Upload shard report
         if: ${{ always() }}

--- a/.github/workflows/release-npm-bootstrap.yml
+++ b/.github/workflows/release-npm-bootstrap.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Checkout bootstrap controls from main
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with: { fetch-depth: 0, persist-credentials: false }
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - name: Validate first-publish request
         id: preflight
         env:
@@ -33,7 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           RELEASE_RUN_ID: ${{ github.event.client_payload.release_run_id }}
           RELEASE_TAG_NAME: ${{ github.event.client_payload.tag_name }}
-        run: node tools/github/npm-bootstrap-preflight.mjs preflight
+        run: rust-script tools/commands/ci/github/npm-bootstrap-preflight.rs preflight
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -62,14 +65,14 @@ jobs:
           EXPECTED_PACKAGE_NAME: ${{ steps.preflight.outputs.package_name }}
           EXPECTED_PACKAGE_VERSION: ${{ steps.preflight.outputs.version }}
         run: |
-          node tools/github/npm-bootstrap-preflight.mjs artifact
-          node tools/npm/smoke-release-install.mjs --prepare-manifests "$BOOTSTRAP_ARTIFACT_PATH"
+          rust-script tools/commands/ci/github/npm-bootstrap-preflight.rs artifact
+          rust-script tools/commands/release/npm/smoke-release-install.rs --prepare-manifests "$BOOTSTRAP_ARTIFACT_PATH"
       - name: Confirm package is still unpublished
         env:
           BOOTSTRAP_PACKAGE_PATH: ${{ steps.preflight.outputs.package_path }}
           RELEASE_RUN_ID: ${{ steps.preflight.outputs.release_run_id }}
           RELEASE_TAG_NAME: ${{ github.event.client_payload.tag_name }}
-        run: node tools/github/npm-bootstrap-preflight.mjs registry-recheck
+        run: rust-script tools/commands/ci/github/npm-bootstrap-preflight.rs registry-recheck
       - name: Pack deterministic npm CLI first-publish handoff
         id: handoff
         env:
@@ -81,7 +84,7 @@ jobs:
           RELEASE_RUN_ID: ${{ steps.preflight.outputs.release_run_id }}
           RELEASE_TAG_NAME: ${{ github.event.client_payload.tag_name }}
           RELEASE_TAG_SHA: ${{ steps.preflight.outputs.tag_sha }}
-        run: node tools/github/npm-bootstrap-handoff.mjs
+        run: rust-script tools/commands/ci/github/npm-bootstrap-handoff.rs
       - name: Upload npm CLI first-publish handoff
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -30,10 +30,15 @@ jobs:
         with:
           node-version-file: ".node-version"
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: ./.github/actions/setup-rust-script
+
       - name: Verify immutable tag, metadata, required gates, and release blockers
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: node tools/github/release-preflight.mjs
+        run: rust-script tools/commands/ci/github/release-preflight.rs
 
   validate-crates:
     name: Validate crates.io publish plan

--- a/.github/workflows/release-tag-rollback.yml
+++ b/.github/workflows/release-tag-rollback.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with: { fetch-depth: 0, fetch-tags: true }
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - name: Delete unchanged unpublished tag
         env: { GITHUB_TOKEN: "${{ github.token }}" }
-        run: node tools/github/release-tag-rollback.mjs
+        run: rust-script tools/commands/ci/github/release-tag-rollback.rs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,12 @@ jobs:
       native_matrix: ${{ steps.platforms.outputs.native_matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - name: Select release platforms
         id: platforms
-        run: node tools/github/release-platforms.mjs github-output "${{ github.ref_name }}"
+        run: rust-script tools/commands/ci/github/release-platforms.rs github-output "${{ github.ref_name }}"
   build-cli:
     name: Build CLI - ${{ matrix.settings.target }}
     needs: plan-release-platforms
@@ -68,6 +71,7 @@ jobs:
           targets: ${{ matrix.settings.target }}
       - name: Install Rust target
         run: rustup target add ${{ matrix.settings.target }}
+      - uses: ./.github/actions/setup-rust-script
       - name: Setup Wild linker (Linux)
         if: runner.os == 'Linux' && !endsWith(matrix.settings.target, '-musl')
         uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
@@ -84,7 +88,7 @@ jobs:
         uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2
       - name: Configure Zig linker (Linux musl CLI)
         if: endsWith(matrix.settings.target, '-musl')
-        run: bash tools/github/configure-zig-musl-linkers.sh
+        run: rust-script tools/commands/ci/github/configure-zig-musl-linkers.rs
       - name: Mount Rust sticky disks (Linux)
         if: runner.os == 'Linux'
         uses: ./.github/actions/setup-rust-sticky-cache
@@ -112,7 +116,7 @@ jobs:
       - name: Create archive (Unix)
         if: runner.os != 'Windows'
         shell: bash
-        run: if [[ "${{ matrix.settings.target }}" == *-musl ]]; then bash tools/github/verify-musl-cli-binary.sh "${{ matrix.settings.target }}"; fi; moon run --target native tools/moon/cmd/github/create_cli_archive -- ${{ matrix.settings.target }} ${{ matrix.settings.archive }} vize
+        run: if [[ "${{ matrix.settings.target }}" == *-musl ]]; then rust-script tools/commands/ci/github/verify-musl-cli-binary.rs "${{ matrix.settings.target }}"; fi; moon run --target native tools/moon/cmd/github/create_cli_archive -- ${{ matrix.settings.target }} ${{ matrix.settings.archive }} vize
       - name: Create archive (Windows)
         if: runner.os == 'Windows'
         shell: bash
@@ -140,6 +144,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: ./.github/actions/setup-rust-sticky-cache
         with: { key: release-tools, cache-key-suffix: "${{ runner.os }}-${{ runner.arch }}" }
+      - uses: ./.github/actions/setup-rust-script
       # upload-artifact only fails when NO path matches, so every path it uploads needs a task here.
       - name: Package editor extensions
         run: |
@@ -351,6 +356,7 @@ jobs:
         with:
           key: release-wasm
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+      - uses: ./.github/actions/setup-rust-script
       - name: Cache WASM package build
         id: cache-wasm
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
@@ -369,7 +375,7 @@ jobs:
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
       - name: Smoke @vizejs/wasm package
-        run: node tools/npm/smoke-wasm-package.mjs npm/wasm
+        run: rust-script tools/commands/release/npm/smoke-wasm-package.rs npm/wasm
       - name: Upload WASM package artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -421,6 +427,7 @@ jobs:
           shared-key: release-native-${{ matrix.settings.target }}
           cache-workspace-crates: "true"
           save-if: "false"
+      - uses: ./.github/actions/setup-rust-script
       - name: Tune Windows release profile
         if: runner.os == 'Windows'
         shell: bash
@@ -435,7 +442,7 @@ jobs:
         run: moon run --target native tools/moon/cmd/github/clean_node_binaries -- npm/native npm/fresco-native
       - name: Build vize-native
         shell: bash
-        run: moon run --target native tools/moon/cmd/github/build_napi_package -- npm/native ../../crates/vize_vitrine/Cargo.toml vize_vitrine ${{ matrix.settings.target }} ${{ matrix.settings.cross_compile == true && '--cross-compile' || '' }} && if [[ "$RUNNER_OS" == Linux && "${{ matrix.settings.target }}" == *-gnu ]]; then node tools/github/verify-glibc-symbols.mjs --max 2.36 npm/native/*.linux-*-gnu.node; fi
+        run: moon run --target native tools/moon/cmd/github/build_napi_package -- npm/native ../../crates/vize_vitrine/Cargo.toml vize_vitrine ${{ matrix.settings.target }} ${{ matrix.settings.cross_compile == true && '--cross-compile' || '' }} && if [[ "$RUNNER_OS" == Linux && "${{ matrix.settings.target }}" == *-gnu ]]; then rust-script tools/commands/ci/github/verify-glibc-symbols.rs --max 2.36 npm/native/*.linux-*-gnu.node; fi
       - name: Collect vize-native artifact
         shell: bash
         run: moon run --target native tools/moon/cmd/github/collect_native_artifacts -- npm/native .artifacts/vize-native vize-native
@@ -448,7 +455,7 @@ jobs:
           compression-level: 0
       - name: Build fresco-native
         shell: bash
-        run: moon run --target native tools/moon/cmd/github/build_napi_package -- npm/fresco-native ../../crates/vize_fresco/Cargo.toml vize_fresco ${{ matrix.settings.target }} ${{ matrix.settings.cross_compile == true && '--cross-compile' || '' }} && if [[ "$RUNNER_OS" == Linux && "${{ matrix.settings.target }}" == *-gnu ]]; then node tools/github/verify-glibc-symbols.mjs --max 2.36 npm/fresco-native/*.linux-*-gnu.node; fi
+        run: moon run --target native tools/moon/cmd/github/build_napi_package -- npm/fresco-native ../../crates/vize_fresco/Cargo.toml vize_fresco ${{ matrix.settings.target }} ${{ matrix.settings.cross_compile == true && '--cross-compile' || '' }} && if [[ "$RUNNER_OS" == Linux && "${{ matrix.settings.target }}" == *-gnu ]]; then rust-script tools/commands/ci/github/verify-glibc-symbols.rs --max 2.36 npm/fresco-native/*.linux-*-gnu.node; fi
       - name: Collect fresco-native artifact
         shell: bash
         run: moon run --target native tools/moon/cmd/github/collect_native_artifacts -- npm/fresco-native .artifacts/fresco-native fresco-native
@@ -469,6 +476,9 @@ jobs:
       - name: Setup runtime package managers
         uses: ./.github/actions/setup-runtime-package-managers
         with: { node-version-file: ".node-version" }
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - uses: ./.github/actions/setup-moonbit
       - name: Install native package tooling dependencies
         run: vp install --frozen-lockfile --prefer-offline --filter './npm/native...' --filter './npm/fresco-native...'
@@ -521,7 +531,7 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { pattern: fresco-bindings-*, path: npm/fresco-native/artifacts }
       - name: Apply slow platform release cadence
-        run: node tools/github/release-platforms.mjs apply-cadence "${{ github.ref_name }}" npm/native/package.json npm/oxint/package.json
+        run: rust-script tools/commands/ci/github/release-platforms.rs apply-cadence "${{ github.ref_name }}" npm/native/package.json npm/oxint/package.json
       - name: Prepare native package tarballs
         working-directory: npm/native
         run: |
@@ -534,7 +544,7 @@ jobs:
           moon run --target native tools/moon/cmd/github/collect_native_artifacts -- npm/fresco-native/artifacts npm/fresco-native fresco-native
       - name: Smoke install release package tarballs
         run: |
-          node tools/npm/smoke-release-install.mjs --prepare-manifests --runtime-checks \
+          rust-script tools/commands/release/npm/smoke-release-install.rs --prepare-manifests --runtime-checks \
             npm/native npm/native/npm/* \
             npm/fresco-native \
             npm/cli \
@@ -573,6 +583,9 @@ jobs:
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", cache: true, run-install: false }
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - uses: ./.github/actions/setup-moonbit
       - name: Install dependencies
         run: vp install --frozen-lockfile --prefer-offline --filter './npm/native...'
@@ -582,7 +595,7 @@ jobs:
           pattern: bindings-*
           path: npm/native/artifacts
       - name: Apply slow platform release cadence
-        run: node tools/github/release-platforms.mjs apply-cadence "${{ github.ref_name }}" npm/native/package.json
+        run: rust-script tools/commands/ci/github/release-platforms.rs apply-cadence "${{ github.ref_name }}" npm/native/package.json
       - name: Create npm platform directories
         working-directory: npm/native
         run: vp exec napi create-npm-dirs
@@ -595,7 +608,7 @@ jobs:
       - name: List packages
         run: ls -R npm/native/npm/
       - name: Smoke install native package tarballs
-        run: node tools/npm/smoke-release-install.mjs --prepare-manifests --runtime-checks npm/native npm/native/npm/*
+        run: rust-script tools/commands/release/npm/smoke-release-install.rs --prepare-manifests --runtime-checks npm/native npm/native/npm/*
       - name: Publish platform packages
         run: moon run --target native tools/moon/cmd/publish_npm_package_dirs -- npm/native/npm --provenance
       - name: Publish
@@ -612,6 +625,9 @@ jobs:
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", cache: true, run-install: false }
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - uses: ./.github/actions/setup-moonbit
       - name: Install dependencies
         run: vp install --frozen-lockfile --prefer-offline --filter './npm/fresco-native...'
@@ -625,7 +641,7 @@ jobs:
       - name: Stage bundled native binaries
         run: moon run --target native tools/moon/cmd/github/collect_native_artifacts -- npm/fresco-native/artifacts npm/fresco-native fresco-native
       - name: Smoke install Fresco native package tarball
-        run: node tools/npm/smoke-release-install.mjs --prepare-manifests npm/fresco-native
+        run: rust-script tools/commands/release/npm/smoke-release-install.rs --prepare-manifests npm/fresco-native
       - name: Publish
         run: moon run --target native tools/moon/cmd/publish_npm_package -- npm/fresco-native --provenance
 
@@ -643,13 +659,16 @@ jobs:
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: true }
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - name: Download prebuilt WASM package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with: { name: release-package-vize-wasm, path: npm/wasm }
       - name: Smoke @vizejs/wasm package
-        run: node tools/npm/smoke-wasm-package.mjs npm/wasm
+        run: rust-script tools/commands/release/npm/smoke-wasm-package.rs npm/wasm
       - name: Smoke install WASM package tarball
-        run: node tools/npm/smoke-release-install.mjs npm/wasm
+        run: rust-script tools/commands/release/npm/smoke-release-install.rs npm/wasm
       - name: Publish @vizejs/wasm
         run: moon run --target native tools/moon/cmd/publish_npm_package -- npm/wasm --provenance
   release-npm-vite-plugin:
@@ -672,6 +691,9 @@ jobs:
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - uses: ./.github/actions/setup-moonbit
       - name: Download prebuilt packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -698,6 +720,9 @@ jobs:
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with: { node-version-file: ".node-version", run-install: false }
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - uses: ./.github/actions/setup-moonbit
       - name: Download prebuilt packages
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -705,7 +730,7 @@ jobs:
       - name: Inject native binding package versions
         run: moon run --target native tools/moon/cmd/inject_native_optional_deps -- npm/oxint/package.json npm/native/package.json --print
       - name: Apply slow platform release cadence
-        run: node tools/github/release-platforms.mjs apply-cadence "${{ github.ref_name }}" npm/oxint/package.json
+        run: rust-script tools/commands/ci/github/release-platforms.rs apply-cadence "${{ github.ref_name }}" npm/oxint/package.json
       - name: Publish oxlint-plugin-vize
         run: moon run --target native tools/moon/cmd/publish_npm_package -- npm/oxint --provenance
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -23,8 +23,8 @@
     "check": "tsc --noEmit && vp check src vite.config.ts",
     "check:fix": "vp check --fix src vite.config.ts && tsc --noEmit",
     "fmt": "vp fmt --write src vite.config.ts",
-    "package": "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && vsce package --no-dependencies --out dist/vize.vsix && node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
-    "test:host": "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && node test/run-extension-host.mjs",
+    "package": "rust-script ../../tools/commands/editors/vscode/sync-typescript-plugin.rs stage && vsce package --no-dependencies --out dist/vize.vsix && rust-script ../../tools/commands/editors/vscode/sync-typescript-plugin.rs inject dist/vize.vsix",
+    "test:host": "rust-script ../../tools/commands/editors/vscode/sync-typescript-plugin.rs stage && node test/run-extension-host.mjs",
     "publish": "npm run package && vsce publish --packagePath dist/vize.vsix",
     "publish:pre": "npm run package && vsce publish --pre-release --packagePath dist/vize.vsix"
   },

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -77,6 +77,8 @@ const REQUIRED_TRIGGER_PATHS = [
   "tools/npm/prepare-publish-manifest.mjs",
   "tools/npm/smoke-release-install.mjs",
   "tools/npm/smoke-release-runtime.mjs",
+  "tools/commands/release/npm/**",
+  "tools/rust/**",
   "tests/_fixtures/davinci-ts40-projection/**",
   "tests/tooling/davinci-ts40-projection.test.ts",
   "tests/tooling/support/davinci-ts40-projection.ts",
@@ -197,7 +199,7 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
   assert.match(job, /cp "\$binary" "npm\/\$target\/"/);
   assert.match(
     job,
-    /VIZE_TEST_CONTENT_MAPPER_TSGO: \$\{\{ runner\.temp \}\}\/tsgo[\s\S]*smoke-release-install\.mjs --prepare-manifests --content-mapper-checks[\s\S]*npm\/native npm\/native\/npm\/\*[\s\S]*npm\/cli/,
+    /VIZE_TEST_CONTENT_MAPPER_TSGO: \$\{\{ runner\.temp \}\}\/tsgo[\s\S]*smoke-release-install\.rs --prepare-manifests --content-mapper-checks[\s\S]*npm\/native npm\/native\/npm\/\*[\s\S]*npm\/cli/,
   );
   const packageRouteSteps = steps.flatMap((step, index) =>
     PACKAGE_ROUTE_COMMANDS.every((command) => step.run?.includes(command)) ? [index] : [],

--- a/tests/tooling/davinci-portability-lane.test.ts
+++ b/tests/tooling/davinci-portability-lane.test.ts
@@ -61,7 +61,7 @@ test("TS-24: the wasm32-wasip2 lanes ride the required clippy-and-test job", () 
   assert.doesNotMatch(job, /cargo build[^\n]*-p (?:vize_s0|vize_carton)[^\n]*wasm32-wasip2/);
   assert.match(
     job,
-    /cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && node tools\/davinci\/bench-compare\.mjs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root/u,
+    /cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && rust-script tools\/commands\/davinci\/bench-compare\.rs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root/u,
   );
 });
 

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -84,6 +84,8 @@ test("PR readiness plans six isolated rows behind one stable aggregator", () => 
     "tests/app/dev/{misskey,nuxt-ui}.spec.ts",
     "tests/app/dev/{misskey-hmr,nuxt-ui-dev-server,nuxt-ui-hmr,source-restore}.ts",
     "tools/github/app-e2e-*.mjs",
+    "tools/commands/ci/github/app-e2e-*.rs",
+    "tools/rust/**",
   ]) {
     assert.match(filters, new RegExp(path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
@@ -130,7 +132,7 @@ test("PR readiness plans six isolated rows behind one stable aggregator", () => 
   assert.match(aggregate.if ?? "", /always\(\)/);
   assert.match(
     namedStep(aggregate, "Aggregate app readiness").run ?? "",
-    /app-e2e-aggregate\.mjs readiness all/,
+    /app-e2e-aggregate\.rs readiness all/,
   );
   assert.equal(
     Object.values(jobs).filter((job) => job.name === "app-readiness").length,
@@ -176,7 +178,7 @@ test("full App E2E uses a planner, isolated matrix producers, and stable release
   assert.match(aggregate.if ?? "", /always\(\)/);
   assert.match(
     namedStep(aggregate, "Aggregate full App E2E").run ?? "",
-    /app-e2e-aggregate\.mjs full/,
+    /app-e2e-aggregate\.rs full/,
   );
   assert.equal(Object.values(jobs).filter((job) => job.name === "app-e2e").length, 1);
 });
@@ -243,7 +245,7 @@ test("shared row action validates the plan and never parallelizes fixture proces
     { steps: action.runs?.steps },
     "Validate and hydrate planned fixtures",
   );
-  assert.match(hydration.run ?? "", /app-e2e-plan\.mjs/);
+  assert.match(hydration.run ?? "", /app-e2e-plan\.rs/);
   assert.match(hydration.run ?? "", /mapfile -t fixture_paths/);
   assert.match(
     hydration.run ?? "",

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -373,38 +373,3 @@ test("zed-vize registers art-vue as a first-party language", () => {
   assert.match(injections, /style_element/);
   assert.match(injections, /template_element/);
 });
-
-test("CI packages editor extension artifacts", () => {
-  const packageAction = readText(".github/actions/package-editor-extensions/action.yml");
-  const buildTasks = readText("tools/vite-plus/tasks/build.ts");
-  const taskCommands = readText("tools/vite-plus/task-commands.ts");
-  const testTasks = readText("tools/vite-plus/tasks/test-benchmark.ts");
-  assert.match(packageAction, /package:editor-extensions/);
-  assert.match(buildTasks, /package:vscode-extension[\s\S]*assert-vsix-package\.mjs/);
-  assert.match(buildTasks, /package:editor-extensions[\s\S]*assert-vsix-package\.mjs/);
-  assert.match(
-    taskCommands,
-    /run-package-bin\.mjs vite-plus vp --version >\/dev\/null 2>&1[\s\S]*corepack pnpm install --ignore-workspace --lockfile-dir \. --no-lockfile --prefer-offline --ignore-scripts/,
-  );
-  assert.match(testTasks, /test:vscode-extension:vsix[\s\S]*assert-vsix-package\.mjs/);
-  assert.match(testTasks, /test:vscode-extension:host[\s\S]*pnpm run test:host/);
-  assert.match(testTasks, /test:vscode-extension:host-real[\s\S]*run-extension-host-real\.mjs/);
-  assert.match(buildTasks, /package:zed-extension[\s\S]*assert-zed-package\.mjs/);
-  assert.match(testTasks, /test:zed-extension:package[\s\S]*package:zed-extension/);
-  assert.match(testTasks, /test:zed-extension:unit[\s\S]*cargo test/);
-  assert.match(buildTasks, /package:editor-extensions[\s\S]*test:zed-extension:unit/);
-  assert.match(buildTasks, /package:nvim-extension[\s\S]*assert-nvim-package\.mjs/);
-  assert.match(buildTasks, /package:editor-extensions[\s\S]*package:nvim-extension/);
-  assert.match(testTasks, /test:nvim-extension:headless[\s\S]*nvim --headless/);
-  assert.match(testTasks, /test:nvim-extension:package[\s\S]*package:nvim-extension/);
-  assert.match(buildTasks, /package:vim-extension[\s\S]*assert-vim-package\.mjs/);
-  assert.match(buildTasks, /package:editor-extensions[\s\S]*package:vim-extension/);
-  assert.match(testTasks, /test:vim-extension:headless[\s\S]*vim -Nu NONE/);
-  assert.match(testTasks, /test:vim-extension:package[\s\S]*package:vim-extension/);
-  assert.match(buildTasks, /package:helix-extension[\s\S]*assert-helix-package\.mjs/);
-  assert.match(buildTasks, /package:editor-extensions[\s\S]*package:helix-extension/);
-  assert.match(testTasks, /test:helix-extension:package[\s\S]*package:helix-extension/);
-  assert.match(buildTasks, /package:emacs-extension[\s\S]*assert-emacs-package\.mjs/);
-  assert.match(buildTasks, /package:editor-extensions[\s\S]*package:emacs-extension/);
-  assert.match(testTasks, /test:emacs-extension:package[\s\S]*package:emacs-extension/);
-});

--- a/tests/tooling/editor-package-tasks.test.ts
+++ b/tests/tooling/editor-package-tasks.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { readRepoFile } from "./support/github-workflows.ts";
+
+test("CI packages editor extension artifacts through Rust Script wrappers", () => {
+  const packageAction = readRepoFile(
+    ".github",
+    "actions",
+    "package-editor-extensions",
+    "action.yml",
+  );
+  const buildTasks = readRepoFile("tools", "vite-plus", "tasks", "build.ts");
+  const taskCommands = readRepoFile("tools", "vite-plus", "task-commands.ts");
+  const testTasks = readRepoFile("tools", "vite-plus", "tasks", "test-benchmark.ts");
+  const vscodePackage =
+    /const assertVscodePackage = rustToolFromVscodeExtension\(\s*"editors\/vscode\/assert-vsix-package"/;
+
+  assert.match(packageAction, /package:editor-extensions/);
+  assert.match(
+    taskCommands,
+    /if \$\{vscodeExtensionPackageBin\("vite-plus", "vp"\)\} --version >\/dev\/null 2>&1[\s\S]*corepack pnpm install --ignore-workspace --lockfile-dir \. --no-lockfile --prefer-offline --ignore-scripts/,
+  );
+  for (const contents of [buildTasks, testTasks]) {
+    assert.match(contents, vscodePackage);
+  }
+  assert.match(buildTasks, /package:vscode-extension[\s\S]*assertVscodePackage/);
+  assert.match(buildTasks, /package:editor-extensions[\s\S]*assertVscodePackage/);
+  assert.match(testTasks, /test:vscode-extension:vsix[\s\S]*assertVscodePackage/);
+  assert.match(testTasks, /test:vscode-extension:host[\s\S]*pnpm run test:host/);
+  assert.match(testTasks, /test:vscode-extension:host-real[\s\S]*run-extension-host-real\.mjs/);
+
+  for (const [task, wrapper] of [
+    ["zed", "editors/zed/assert-zed-package"],
+    ["nvim", "editors/neovim/assert-nvim-package"],
+    ["vim", "editors/vim/assert-vim-package"],
+    ["helix", "editors/helix/assert-helix-package"],
+    ["emacs", "editors/emacs/assert-emacs-package"],
+  ] as const) {
+    const escapedWrapper = wrapper.replaceAll("/", "\\/");
+    assert.match(
+      buildTasks,
+      new RegExp(`package:${task}-extension[\\s\\S]*rustTool\\("${escapedWrapper}`),
+    );
+    assert.match(
+      buildTasks,
+      new RegExp(`package:editor-extensions[\\s\\S]*package:${task}-extension`),
+    );
+    assert.match(
+      testTasks,
+      new RegExp(`test:${task}-extension:package[\\s\\S]*package:${task}-extension`),
+    );
+  }
+
+  assert.match(testTasks, /test:zed-extension:unit[\s\S]*cargo test/);
+  assert.match(testTasks, /test:nvim-extension:headless[\s\S]*nvim --headless/);
+  assert.match(testTasks, /test:vim-extension:headless[\s\S]*vim -Nu NONE/);
+});

--- a/tests/tooling/editor-real-server-e2e.test.ts
+++ b/tests/tooling/editor-real-server-e2e.test.ts
@@ -78,17 +78,17 @@ function runVimPackageGuard(omit: string[] = []): { status: number; output: stri
   }
 }
 
-test("the Neovim real-server scenario has a task that runs its Node launcher", () => {
+test("the Neovim real-server scenario has a task that runs its Rust Script launcher", () => {
   assert.equal(
     taskCommand("test:nvim-extension:real-server"),
-    "node tools/nvim-vize/run-real-server.mjs",
+    "'rust-script' 'tools/commands/editors/neovim/run-real-server.rs'",
   );
 });
 
-test("the Vim real-server scenario has a task that runs its Node launcher", () => {
+test("the Vim real-server scenario has a task that runs its Rust Script launcher", () => {
   assert.equal(
     taskCommand("test:vim-extension:real-server"),
-    "node tools/vim-vize/run-real-server.mjs",
+    "'rust-script' 'tools/commands/editors/vim/run-real-server.rs'",
   );
 });
 

--- a/tests/tooling/editor-real-server-helix-e2e.test.ts
+++ b/tests/tooling/editor-real-server-helix-e2e.test.ts
@@ -8,10 +8,10 @@ function taskCommand(name: string): string {
   return (testAndBenchmarkTasks[name] as { command: string }).command;
 }
 
-test("the Helix real-server scenario has a task that runs its Node launcher", () => {
+test("the Helix real-server scenario has a task that runs its Rust Script launcher", () => {
   assert.equal(
     taskCommand("test:helix-extension:real-server"),
-    "node tools/helix-vize/run-real-server.mjs",
+    "'rust-script' 'tools/commands/editors/helix/run-real-server.rs'",
   );
 });
 
@@ -35,7 +35,7 @@ test("CI checks the package with a pinned official Helix before the server scena
   assert.match(health, /XDG_CONFIG_HOME: \$\{\{ runner\.temp \}\}\/helix-config/);
   assert.match(health, /HELIX_RUNTIME: \$\{\{ runner\.temp \}\}\/helix\/runtime/);
   assert.match(health, /VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/);
-  assert.match(health, /node tools\/helix-vize\/assert-helix-health\.mjs/);
+  assert.match(health, /rust-script tools\/commands\/editors\/helix\/assert-helix-health\.rs/);
 
   const scenario = action.slice(scenarioAt);
   assert.match(scenario, /VIZE_SERVER_PATH: \$\{\{ github\.workspace \}\}\/target\/ci\/vize/);

--- a/tests/tooling/editor-real-server-zed-e2e.test.ts
+++ b/tests/tooling/editor-real-server-zed-e2e.test.ts
@@ -8,10 +8,10 @@ function taskCommand(name: string): string {
   return (testAndBenchmarkTasks[name] as { command: string }).command;
 }
 
-test("the Zed real-server scenario has a task that runs its Node launcher", () => {
+test("the Zed real-server scenario has a task that runs its Rust Script launcher", () => {
   assert.equal(
     taskCommand("test:zed-extension:real-server"),
-    "node tools/zed-vize/run-real-server.mjs",
+    "'rust-script' 'tools/commands/editors/zed/run-real-server.rs'",
   );
 });
 

--- a/tests/tooling/fuzz-setup.test.ts
+++ b/tests/tooling/fuzz-setup.test.ts
@@ -135,7 +135,7 @@ test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () 
     FUZZ_MODE: "${{ inputs.mode || 'campaign' }}",
   });
   const enforceStep = fuzzJob.steps.find((step) => step.id === "enforce");
-  assert.match(enforceStep?.run ?? "", /tools\/fuzz\/enforce-result\.mjs/);
+  assert.match(enforceStep?.run ?? "", /tools\/commands\/ci\/fuzz\/enforce-result\.rs/);
   assert.deepEqual(enforceStep?.env, {
     FUZZ_EVENT_NAME: "${{ github.event_name }}",
     FUZZ_OUTCOME: "${{ steps.fuzz.outcome || 'skipped' }}",

--- a/tests/tooling/github-workflows-check-gate.test.ts
+++ b/tests/tooling/github-workflows-check-gate.test.ts
@@ -265,6 +265,8 @@ test("test-report collects the inventory before it enforces the gate", () => {
     })),
     [
       { name: null, uses: "actions/checkout", run: null, env: null },
+      { name: null, uses: "dtolnay/rust-toolchain", run: null, env: null },
+      { name: null, uses: "./.github/actions/setup-rust-script", run: null, env: null },
       {
         name: "Collect test inventory",
         uses: null,
@@ -275,7 +277,7 @@ test("test-report collects the inventory before it enforces the gate", () => {
       {
         name: "Require every needed job to succeed",
         uses: null,
-        run: "node tools/github/require-needs-success.mjs",
+        run: "rust-script tools/commands/ci/github/require-needs-success.rs",
         env: { NEEDS_JSON: "${{ toJSON(needs) }}" },
       },
     ],

--- a/tests/tooling/github-workflows-davinci-bench.test.ts
+++ b/tests/tooling/github-workflows-davinci-bench.test.ts
@@ -42,7 +42,7 @@ test("check workflow uploads Davinci compact-storage bench reports", () => {
   );
   assert.match(
     steps[gateIndex].run ?? "",
-    /node tools\/davinci\/bench-compare\.mjs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root/,
+    /rust-script tools\/commands\/davinci\/bench-compare\.rs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root/,
   );
   assert.deepEqual(steps[gateIndex + 1], {
     name: "Upload Davinci compact-storage bench reports",

--- a/tests/tooling/github-workflows-npm-bootstrap.test.ts
+++ b/tests/tooling/github-workflows-npm-bootstrap.test.ts
@@ -65,7 +65,10 @@ test("npm bootstrap validates an exact tag before building with existing release
 
   const steps = job.steps ?? [];
   const preflight = steps.find((step) => step.id === "preflight");
-  assert.equal(preflight?.run, "node tools/github/npm-bootstrap-preflight.mjs preflight");
+  assert.equal(
+    preflight?.run,
+    "rust-script tools/commands/ci/github/npm-bootstrap-preflight.rs preflight",
+  );
   assert.equal(
     preflight?.env?.BOOTSTRAP_PACKAGE_PATH,
     "${{ github.event.client_payload.package_path }}",
@@ -93,11 +96,14 @@ test("npm bootstrap validates an exact tag before building with existing release
   const smoke = steps.find(
     (step) => step.name === "Validate and smoke the exact Release package artifact",
   );
-  assert.match(smoke?.run ?? "", /npm-bootstrap-preflight\.mjs artifact/);
-  assert.match(smoke?.run ?? "", /smoke-release-install\.mjs --prepare-manifests/);
+  assert.match(smoke?.run ?? "", /npm-bootstrap-preflight\.rs artifact/);
+  assert.match(smoke?.run ?? "", /smoke-release-install\.rs --prepare-manifests/);
 
   const recheck = steps.find((step) => step.name === "Confirm package is still unpublished");
-  assert.equal(recheck?.run, "node tools/github/npm-bootstrap-preflight.mjs registry-recheck");
+  assert.equal(
+    recheck?.run,
+    "rust-script tools/commands/ci/github/npm-bootstrap-preflight.rs registry-recheck",
+  );
 
   const requiredOrder = [preflight, install, testPackage, download, smoke, recheck];
   assert.ok(requiredOrder.every((step) => step != null));
@@ -118,7 +124,7 @@ test("npm bootstrap creates a credential-free deterministic CLI handoff", () => 
   );
   assert.ok(pack);
   assert.equal(pack.id, "handoff");
-  assert.equal(pack.run, "node tools/github/npm-bootstrap-handoff.mjs");
+  assert.equal(pack.run, "rust-script tools/commands/ci/github/npm-bootstrap-handoff.rs");
   assert.equal(pack.env?.BOOTSTRAP_ARTIFACT_PATH, "bootstrap-package");
   assert.equal(pack.env?.BOOTSTRAP_HANDOFF_PATH, "npm-cli-first-publish");
   assert.equal(pack.env?.EXPECTED_PACKAGE_NAME, "${{ steps.preflight.outputs.package_name }}");

--- a/tests/tooling/github-workflows-release-build.test.ts
+++ b/tests/tooling/github-workflows-release-build.test.ts
@@ -34,7 +34,7 @@ test("release workflow plans slow platform cadence before building", () => {
   const buildCliJob = workflowJobBody(workflow, "build-cli");
   const buildNativeJob = workflowJobBody(workflow, "build-native-all");
 
-  assert.match(planJob, /node tools\/github\/release-platforms\.mjs github-output/);
+  assert.match(planJob, /release-platforms\.rs github-output/);
   assert.match(buildCliJob, /needs:\s*plan-release-platforms/);
   assert.match(
     buildCliJob,
@@ -45,7 +45,7 @@ test("release workflow plans slow platform cadence before building", () => {
     buildNativeJob,
     /settings:\s*\$\{\{\s*fromJSON\(needs\.plan-release-platforms\.outputs\.native_matrix\)\s*\}\}/,
   );
-  assert.match(workflow, /release-platforms\.mjs apply-cadence/);
+  assert.match(workflow, /release-platforms\.rs apply-cadence/);
 });
 
 test("release workflow jobs cap runtime with explicit timeouts", () => {
@@ -97,10 +97,7 @@ test("release workflow smoke installs npm tarballs before publishing", () => {
   assert.match(smokeJob, /name:\s*Apply slow platform release cadence/);
   assert.match(smokeJob, /name:\s*Prepare native package tarballs/);
   assert.match(smokeJob, /name:\s*Prepare Fresco native package tarball/);
-  assert.match(
-    smokeJob,
-    /node tools\/npm\/smoke-release-install\.mjs --prepare-manifests --runtime-checks/,
-  );
+  assert.match(smokeJob, /smoke-release-install\.rs --prepare-manifests --runtime-checks/);
 
   for (const packageDir of [
     "npm/native",
@@ -156,7 +153,7 @@ test("release workflow smoke installs npm tarballs before publishing", () => {
     assert.notEqual(publishIndex, -1, `${jobName} is missing ${publishStep}`);
     assert.ok(smokeIndex < publishIndex, `${jobName} must smoke install before publishing`);
     if (jobName === "release-npm-native") {
-      assert.match(job, /smoke-release-install\.mjs --prepare-manifests --runtime-checks/);
+      assert.match(job, /smoke-release-install\.rs --prepare-manifests --runtime-checks/);
     }
   }
 });
@@ -259,11 +256,11 @@ test("release workflow inspects musl CLI binaries while archiving", () => {
   assert.ok(buildIndex < archiveIndex, "the musl binary check must inspect the built CLI binary");
   assert.match(
     buildCliJob,
-    /Create archive \(Unix\)[\s\S]*if \[\[ "\$\{\{ matrix\.settings\.target \}\}" == \*-musl \]\]; then bash tools\/github\/verify-musl-cli-binary\.sh/,
+    /Create archive \(Unix\)[\s\S]*if \[\[ "\$\{\{ matrix\.settings\.target \}\}" == \*-musl \]\]; then rust-script tools\/commands\/ci\/github\/verify-musl-cli-binary\.rs/,
   );
   assert.match(
     buildCliJob,
-    /verify-musl-cli-binary\.sh[\s\S]*tools\/moon\/cmd\/github\/create_cli_archive/,
+    /verify-musl-cli-binary\.rs[\s\S]*tools\/moon\/cmd\/github\/create_cli_archive/,
   );
   assert.match(verifier, /readelf -l "\$binary"[\s\S]*Requesting program interpreter/);
   assert.match(verifier, /strings "\$binary" \| grep -Eq 'GLIBC_\[0-9\]'/);
@@ -307,7 +304,7 @@ test("release workflow configures Zig linkers for Linux musl CLI archives", () =
     buildCliJob,
     /Setup Wild linker \(Linux\)[\s\S]*if:\s*runner\.os == 'Linux' && !endsWith\(matrix\.settings\.target, '-musl'\)/,
   );
-  assert.match(buildCliJob, /bash tools\/github\/configure-zig-musl-linkers\.sh/);
+  assert.match(buildCliJob, /configure-zig-musl-linkers\.rs/);
   assert.match(zigLinkerScript, /CARGO_TARGET_%s_LINKER=rust-lld/);
   assert.match(zigLinkerScript, /write_cc X86_64_UNKNOWN_LINUX_MUSL x86_64-linux-musl/);
   assert.match(zigLinkerScript, /write_cc AARCH64_UNKNOWN_LINUX_MUSL aarch64-linux-musl/);

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -231,7 +231,10 @@ test("release workflow smokes the wasm package wrapper before publishing", () =>
   assert.notEqual(smoke, -1);
   assert.notEqual(publish, -1);
   assert.ok(setupNode < download && download < smoke && smoke < publish);
-  assert.match(publishJob, /node tools\/npm\/smoke-wasm-package\.mjs npm\/wasm/);
+  assert.match(
+    publishJob,
+    /rust-script tools\/commands\/release\/npm\/smoke-wasm-package\.rs npm\/wasm/,
+  );
 });
 
 test("release workflow creates GitHub Releases only after registry publishing succeeds", () => {

--- a/tests/tooling/github-workflows-release-smoke.test.ts
+++ b/tests/tooling/github-workflows-release-smoke.test.ts
@@ -36,9 +36,9 @@ test("smoke job downloads every packed artifact directory it smoke-installs", ()
   const smokeJob = jobs["smoke-release-packages"];
   assert.ok(smokeJob, "missing smoke-release-packages job");
   const smokeRun = (smokeJob.steps ?? []).find((step) =>
-    step.run?.includes("smoke-release-install.mjs"),
+    step.run?.includes("smoke-release-install.rs"),
   )?.run;
-  assert.ok(smokeRun, "smoke-release-packages must run smoke-release-install.mjs");
+  assert.ok(smokeRun, "smoke-release-packages must run smoke-release-install.rs");
   const smokedDirectories = smokeRun
     .replace(/\\\n/g, " ")
     .split(/\s+/)
@@ -82,13 +82,13 @@ test("wasm release job installs workspace dependencies before root smoke scripts
     (step) => step.uses?.includes("voidzero-dev/setup-vp@") && step.with?.["run-install"] === true,
   );
   const smokeIndex = steps.findIndex((step) =>
-    step.run?.includes("node tools/npm/smoke-release-install.mjs npm/wasm"),
+    step.run?.includes("rust-script tools/commands/release/npm/smoke-release-install.rs npm/wasm"),
   );
 
   assert.notEqual(setupIndex, -1, "release-npm-wasm setup-vp must install root dependencies");
   assert.notEqual(smokeIndex, -1, "release-npm-wasm must smoke install the WASM tarball");
   assert.ok(
     setupIndex < smokeIndex,
-    "release-npm-wasm must install root dependencies before smoke-release-install.mjs imports semver",
+    "release-npm-wasm must install root dependencies before smoke-release-install.rs imports semver",
   );
 });

--- a/tests/tooling/github-workflows-semver.test.ts
+++ b/tests/tooling/github-workflows-semver.test.ts
@@ -17,7 +17,7 @@ test("push SemVer checks preserve pull-request markers after squash merge", () =
   );
   assert.match(
     job,
-    /node tools\/github\/semver-change-marker\.mjs "\$RUNNER_TEMP\/semver-change-marker\.txt"/,
+    /rust-script tools\/commands\/ci\/github\/semver-change-marker\.rs "\$RUNNER_TEMP\/semver-change-marker\.txt"/,
   );
   assert.match(job, /SEMVER_CHANGE_MARKER="\$\(cat "\$RUNNER_TEMP\/semver-change-marker\.txt"\)"/);
   assert.doesNotMatch(job, /git log -1 --format=%B/);

--- a/tests/tooling/github-workflows-setup.test.ts
+++ b/tests/tooling/github-workflows-setup.test.ts
@@ -205,9 +205,9 @@ test("native smoke workflow covers host platforms before release tags", () => {
   }
   assert.match(job, /cargo build --profile ci -p vize/);
   assert.match(job, /vp run --filter '\.\/npm\/native' build:ci/);
-  assert.match(job, /verify-glibc-symbols\.mjs --max 2\.36 npm\/native\/\*\.linux-\*-gnu\.node/);
+  assert.match(job, /verify-glibc-symbols\.rs --max 2\.36 npm\/native\/\*\.linux-\*-gnu\.node/);
   assert.match(job, /require\('\.\/npm\/native'\)/);
-  assert.match(job, /smoke-release-install\.mjs --prepare-manifests npm\/native/);
+  assert.match(job, /smoke-release-install\.rs --prepare-manifests npm\/native/);
 });
 
 test("native smoke workflow fresh-installs runtime tarballs across supported targets", () => {
@@ -231,7 +231,7 @@ test("native smoke workflow fresh-installs runtime tarballs across supported tar
   assert.match(job, /vp exec napi pre-publish -t npm --no-gh-release --skip-optional-publish/);
   assert.match(
     job,
-    /smoke-release-install\.mjs --prepare-manifests --runtime-checks[\s\S]*npm\/native npm\/native\/npm\/\*[\s\S]*npm\/cli npm\/builder\/vite/,
+    /smoke-release-install\.rs --prepare-manifests --runtime-checks[\s\S]*npm\/native npm\/native\/npm\/\*[\s\S]*npm\/cli npm\/builder\/vite/,
   );
 });
 

--- a/tests/tooling/glibc-symbols.test.ts
+++ b/tests/tooling/glibc-symbols.test.ts
@@ -48,6 +48,6 @@ test("glibc verifier accepts binaries at the Debian bookworm ceiling", () => {
 test("release workflow gates GNU native binaries against the Debian bookworm glibc ceiling", () => {
   assert.match(
     workflowJobBody(readRepoFile(".github", "workflows", "release.yml"), "build-native-all"),
-    /verify-glibc-symbols\.mjs --max 2\.36 npm\/native\/\*\.linux-\*-gnu\.node[\s\S]*verify-glibc-symbols\.mjs --max 2\.36 npm\/fresco-native\/\*\.linux-\*-gnu\.node/,
+    /verify-glibc-symbols\.rs --max 2\.36 npm\/native\/\*\.linux-\*-gnu\.node[\s\S]*verify-glibc-symbols\.rs --max 2\.36 npm\/fresco-native\/\*\.linux-\*-gnu\.node/,
   );
 });

--- a/tests/tooling/maestro-feature-contract.test.ts
+++ b/tests/tooling/maestro-feature-contract.test.ts
@@ -6,11 +6,19 @@ import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
 test("check workflow enforces the Maestro non-native feature contract", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
   const script = readRepoFile("tools", "github", "check-maestro-feature-contract.sh");
+  const wrapper = readRepoFile(
+    "tools",
+    "commands",
+    "ci",
+    "github",
+    "check-maestro-feature-contract.rs",
+  );
 
   assert.match(
     workflowJobBody(workflow, "clippy-and-test"),
-    /bash tools\/github\/check-maestro-feature-contract\.sh/,
+    /rust-script tools\/commands\/ci\/github\/check-maestro-feature-contract\.rs/,
   );
+  assert.match(wrapper, /"tools\/github\/check-maestro-feature-contract\.sh"/);
   assert.match(script, /export RUSTFLAGS="-D warnings"/);
   assert.match(script, /cargo check -p vize_maestro --no-default-features\s*$/m);
   assert.match(

--- a/tests/tooling/real-project-matrix-summary.test.ts
+++ b/tests/tooling/real-project-matrix-summary.test.ts
@@ -5,7 +5,7 @@ import {
   findStep,
   readShardSummaryScript,
   realProjectMatrixSteps,
-  shardSummaryScriptPath,
+  shardSummaryCommandPath,
 } from "./support/real-project-matrix-workflow.ts";
 
 test("real-project workflow gates every measured surface on one verdict", () => {
@@ -34,7 +34,7 @@ test("real-project workflow gates every measured surface on one verdict", () => 
     VIZE_TYPECHECK_DIVERGENCE_OUTCOME: "${{ steps.typecheck_divergence.outcome }}",
   });
   for (const pattern of [
-    /real-project-surface-verdict\.mjs/,
+    /real-project-surface-verdict\.rs/,
     /surface-verdict\.json/,
     /core_tools_verdict="\$VIZE_CORE_TOOLS_OUTCOME"/,
     /\[\[ "\$CORE_TOOLS_MODE" == "record-only"/,
@@ -71,7 +71,7 @@ test("real-project workflow publishes and uploads the shard evidence it produced
   assert.ok(steps.indexOf(summary) < steps.indexOf(upload));
   assert.equal(summary.if, "${{ always() }}");
   assert.equal(summary.shell, "bash");
-  assert.equal(summary.run, `bash ${shardSummaryScriptPath}`);
+  assert.equal(summary.run, `rust-script ${shardSummaryCommandPath}`);
   assert.equal(upload.if, "${{ always() }}");
   assert.match(upload.uses ?? "", /^actions\/upload-artifact@[0-9a-f]{40}$/);
   assert.deepEqual(upload.with, {

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -139,7 +139,7 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
       dependencyIndex < waiverAuditIndex &&
       waiverAuditIndex < runIndex,
   );
-  assert.match(dependency.run ?? "", /tools\/fixtures\/typecheck-dependency-prepare\.mjs/);
+  assert.match(dependency.run ?? "", /tools\/commands\/fixtures\/typecheck-dependency-prepare\.rs/);
   assert.match(dependency.run ?? "", /--output-dir "\$FIXTURE_REPORT_DIR"/);
   assert.match(dependency.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
   assert.match(dependency.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);
@@ -160,9 +160,9 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.equal(waiverAudit.if, "${{ !cancelled() }}");
   assert.equal(waiverAudit["continue-on-error"], true);
   assert.deepEqual(waiverAudit.env, { GITHUB_TOKEN: "${{ github.token }}" });
-  assert.match(waiverAudit.run ?? "", /glyph-corpus-waiver-audit\.mjs/);
+  assert.match(waiverAudit.run ?? "", /glyph-corpus-waiver-audit\.rs/);
   assert.match(waiverAudit.run ?? "", /glyph-waiver-issues\.json/);
-  assert.match(run.run ?? "", /tools\/fixtures\/tool-matrix-report\.mjs/);
+  assert.match(run.run ?? "", /tools\/commands\/fixtures\/tool-matrix-report\.rs/);
   assert.match(run.run ?? "", /--vize-bin target\/ci\/vize/);
   assert.match(run.run ?? "", /--timeout-ms "\$CORE_TOOLS_TIMEOUT_MS"/);
   assert.match(run.run ?? "", /--output-dir "\$FIXTURE_REPORT_DIR"/);
@@ -198,7 +198,7 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
     "the hydrated fixture corpus must be measured against the lint baseline",
   );
   for (const pattern of [
-    /tools\/fixtures\/lint-divergence-report\.mjs/,
+    /tools\/commands\/fixtures\/lint-divergence-report\.rs/,
     /--shard-index "\$FIXTURE_SHARD_INDEX"/,
     /--shard-count "\$FIXTURE_SHARD_COUNT"/,
     /--measure-coverage-gap/,
@@ -253,7 +253,7 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
     /\[\[ ! -s "\$FIXTURE_REPORT_DIR\/glyph-pug-semantics\.json" \]\][\s\S]*?glyph_exit_code=1/,
   );
   assert.ok(runIndex < divergenceIndex);
-  assert.match(divergence.run ?? "", /tools\/fixtures\/typecheck-divergence-report\.mjs/);
+  assert.match(divergence.run ?? "", /tools\/commands\/fixtures\/typecheck-divergence-report\.rs/);
   assert.match(divergence.run ?? "", /--report-dir "\$FIXTURE_REPORT_DIR"/);
   assert.match(divergence.run ?? "", /--shard-index "\$FIXTURE_SHARD_INDEX"/);
   assert.match(divergence.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);

--- a/tests/tooling/release-preflight-workflow.test.ts
+++ b/tests/tooling/release-preflight-workflow.test.ts
@@ -51,7 +51,7 @@ test("reusable release preflight verifies evidence and crate plans without regis
   assert.equal(verifyCheckout.with?.["fetch-depth"], 0);
   assert.equal(verifyCheckout.with?.["persist-credentials"], false);
   const verification = verify.steps?.find((step) => step.run != null);
-  assert.equal(verification?.run, "node tools/github/release-preflight.mjs");
+  assert.equal(verification?.run, "rust-script tools/commands/ci/github/release-preflight.rs");
   assert.equal(verification?.env?.GITHUB_TOKEN, "${{ github.token }}");
 
   const crateValidation = workflow.jobs?.["validate-crates"];

--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -177,7 +177,7 @@ test("the smoke only passes init flags the guide documents", () => {
   }
 });
 
-/** Arguments of every `smoke-release-install.mjs` step in a workflow. */
+/** Arguments of every `smoke-release-install.rs` step in a workflow. */
 function smokeInstallInvocations(workflow: string): string[][] {
   const parsed = parse(readRepoFile(".github", "workflows", workflow)) as {
     jobs?: Record<string, { steps?: Array<{ run?: string }> }>;
@@ -185,11 +185,11 @@ function smokeInstallInvocations(workflow: string): string[][] {
   const invocations: string[][] = [];
   for (const job of Object.values(parsed.jobs ?? {})) {
     for (const step of job.steps ?? []) {
-      if (!step.run?.includes("smoke-release-install.mjs")) continue;
+      if (!step.run?.includes("smoke-release-install.rs")) continue;
       invocations.push(step.run.replace(/\\\n/gu, " ").trim().split(/\s+/u));
     }
   }
-  assert.ok(invocations.length > 0, `${workflow} runs no smoke-release-install.mjs step`);
+  assert.ok(invocations.length > 0, `${workflow} runs no smoke-release-install.rs step`);
   return invocations;
 }
 
@@ -278,7 +278,7 @@ function assertRuntimeSmokePackageManagers(workflow: string, jobName: string) {
   const steps = workflowSteps(workflow, jobName);
   const setupIndex = steps.findIndex((step) => step.uses === RUNTIME_PACKAGE_MANAGER_ACTION);
   const runtimeSmokeIndex = steps.findIndex((step) =>
-    step.run?.includes("smoke-release-install.mjs --prepare-manifests --runtime-checks"),
+    step.run?.includes("smoke-release-install.rs --prepare-manifests --runtime-checks"),
   );
   assert.notEqual(setupIndex, -1, `${workflow} ${jobName} must install runtime managers`);
   assert.notEqual(runtimeSmokeIndex, -1, `${workflow} ${jobName} must run runtime package smoke`);

--- a/tests/tooling/release-tag-rollback.test.ts
+++ b/tests/tooling/release-tag-rollback.test.ts
@@ -216,7 +216,7 @@ test("release calls a credential-minimal hosted rollback workflow after prefligh
   assert.equal(rollback["timeout-minutes"], 5);
   assert.deepEqual(rollback.permissions, { contents: "write" });
   assert.doesNotMatch(JSON.stringify(rollback), /environment|id-token|secrets\./);
-  assert.match(JSON.stringify(rollback), /release-tag-rollback\.mjs/);
+  assert.match(JSON.stringify(rollback), /release-tag-rollback\.rs/);
 });
 
 test("release stabilizes apt before installing ARM64 cross-compilation tools", () => {

--- a/tests/tooling/rust-script-tools.test.ts
+++ b/tests/tooling/rust-script-tools.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const explicitEntrypoints = [
+  "tools/fixtures/glyph-corpus-waiver-audit.mjs",
+  "tools/fixtures/patina-rule-map.mjs",
+  "tools/fixtures/real-project-surface-verdict.mjs",
+  "tools/github/release-platforms.mjs",
+  "tools/github/require-needs-success.mjs",
+  "tools/github/semver-change-marker.mjs",
+];
+
+test("tool command surface is Rust Script first", () => {
+  const source = readRepoFile("tools/rust/verify-layout.rs");
+  assert.match(source, /rust-script tools: verified/);
+  assert.match(source, /tools\/commands/);
+
+  const wrappers = collectFiles(path.join(root, "tools", "commands")).filter((file) =>
+    file.endsWith(".rs"),
+  );
+  assert.ok(wrappers.length > 0, "expected Rust Script command wrappers");
+
+  for (const wrapper of wrappers) {
+    const relative = path.relative(root, wrapper);
+    const text = fs.readFileSync(wrapper, "utf8");
+    assert.match(text, /^#!\/usr\/bin\/env rust-script\n/, relative);
+    assert.match(text, /legacy_command::run\(/, relative);
+    assert.doesNotMatch(relative, /-vize\//, "editor command buckets use product-neutral names");
+  }
+});
+
+test("legacy tool entrypoints are covered by Rust Script wrappers", () => {
+  const expected = legacyEntrypoints()
+    .map((legacy) => rustCommandPath(legacy))
+    .sort();
+  const wrappers = collectFiles(path.join(root, "tools", "commands"))
+    .filter((file) => file.endsWith(".rs"))
+    .map((file) => path.relative(root, file).split(path.sep).join("/"))
+    .sort();
+
+  assert.deepEqual(wrappers, expected);
+});
+
+function legacyEntrypoints(): string[] {
+  return collectFiles(path.join(root, "tools"))
+    .filter((file) => {
+      const relative = path.relative(root, file).split(path.sep).join("/");
+      if (relative.startsWith("tools/commands/")) return false;
+      if (relative.startsWith("tools/rust/")) return false;
+      if (relative.startsWith("tools/moon/.mooncakes/")) return false;
+      if (!/\.(?:mjs|js|ts|sh)$/.test(relative)) return false;
+      return (
+        fs.readFileSync(file, "utf8").startsWith("#!") || explicitEntrypoints.includes(relative)
+      );
+    })
+    .map((file) => path.relative(root, file).split(path.sep).join("/"))
+    .sort();
+}
+
+function rustCommandPath(legacy: string): string {
+  const buckets: Record<string, string> = {
+    "ai-fix-agent.mjs": "agents",
+    davinci: "davinci",
+    "editor-e2e": "editors/e2e",
+    "emacs-vize": "editors/emacs",
+    fixtures: "fixtures",
+    fuzz: "ci/fuzz",
+    github: "ci/github",
+    "helix-vize": "editors/helix",
+    npm: "release/npm",
+    "nvim-vize": "editors/neovim",
+    release: "release",
+    "vim-vize": "editors/vim",
+    "vscode-vize": "editors/vscode",
+    "zed-vize": "editors/zed",
+  };
+  const parts = legacy.slice("tools/".length).split("/");
+  const file = parts.pop();
+  assert.ok(file);
+  const stem = file.replace(/\.(?:mjs|js|ts|sh)$/, "");
+  const bucket = buckets[parts[0] ?? file];
+  assert.ok(bucket, `missing Rust Script bucket for ${legacy}`);
+  return `tools/commands/${bucket}/${stem}.rs`;
+}
+
+function collectFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const absolute = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectFiles(absolute));
+    } else if (entry.isFile()) {
+      files.push(absolute);
+    }
+  }
+  return files;
+}
+
+function readRepoFile(filePath: string): string {
+  return fs.readFileSync(path.join(root, filePath), "utf8");
+}

--- a/tests/tooling/support/real-project-matrix-workflow.ts
+++ b/tests/tooling/support/real-project-matrix-workflow.ts
@@ -34,6 +34,8 @@ export type RealProjectMatrixWorkflow = {
   permissions?: Record<string, string>;
 };
 
+export const shardSummaryCommandPath =
+  "tools/commands/ci/github/publish-real-project-shard-summary.rs";
 export const shardSummaryScriptPath = "tools/github/publish-real-project-shard-summary.sh";
 
 export function readRealProjectMatrixWorkflow(): RealProjectMatrixWorkflow {

--- a/tests/tooling/vscode-packaged-host-smoke.test.ts
+++ b/tests/tooling/vscode-packaged-host-smoke.test.ts
@@ -160,12 +160,16 @@ test("packaged host strips Node-only options from the VS Code app environment", 
 test("real host task packages and statically validates the same VSIX that it runs", () => {
   const { command } = taskShape(testAndBenchmarkTasks["test:vscode-extension:host-real"]);
 
-  const packageAt = command.indexOf("vsce package --no-dependencies --out dist/vize.vsix");
+  const packageAt = command.indexOf("../../tools/commands/editors/vscode/run-package-bin.rs");
+  const vsceAt = command.indexOf("@vscode/vsce");
+  const packageArgsAt = command.indexOf("package --no-dependencies --out dist/vize.vsix");
   const staticAssertAt = command.indexOf(
-    "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
+    "../../tools/commands/editors/vscode/assert-vsix-package.rs",
   );
   const hostAt = command.indexOf("node test/run-extension-host-real.mjs");
   assert.ok(packageAt >= 0, "real host smoke must build the production VSIX");
+  assert.ok(vsceAt > packageAt, "real host smoke must package with the VS Code CLI");
+  assert.ok(packageArgsAt > vsceAt, "real host smoke must pass production VSIX package args");
   assert.ok(staticAssertAt > packageAt, "the packaged VSIX must retain its static allowlist check");
   assert.ok(hostAt > staticAssertAt, "the validated VSIX must run in the real host");
 });

--- a/tests/tooling/vscode-typescript-vue-plugin.test.ts
+++ b/tests/tooling/vscode-typescript-vue-plugin.test.ts
@@ -48,22 +48,28 @@ test("VS Code extension installs the guarded TypeScript Vue plugin", () => {
   assert.equal(manifest.scripts?.watch, "vp pack --watch");
   assert.equal(
     manifest.scripts?.package,
-    "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && vsce package --no-dependencies --out dist/vize.vsix && node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix",
+    "rust-script ../../tools/commands/editors/vscode/sync-typescript-plugin.rs stage && vsce package --no-dependencies --out dist/vize.vsix && rust-script ../../tools/commands/editors/vscode/sync-typescript-plugin.rs inject dist/vize.vsix",
   );
   assert.equal(
     manifest.scripts?.["test:host"],
-    "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage && node test/run-extension-host.mjs",
+    "rust-script ../../tools/commands/editors/vscode/sync-typescript-plugin.rs stage && node test/run-extension-host.mjs",
   );
 
-  assert.match(readFile("tools/vite-plus/tasks/build.ts"), /sync-typescript-plugin\.mjs stage/);
-  assert.match(readFile("tools/vite-plus/tasks/build.ts"), /sync-typescript-plugin\.mjs inject/);
   assert.match(
-    readFile("tools/vite-plus/tasks/test-benchmark.ts"),
-    /sync-typescript-plugin\.mjs stage/,
+    readFile("tools/vite-plus/tasks/build.ts"),
+    /rustToolFromVscodeExtension\(\s*"editors\/vscode\/sync-typescript-plugin"/,
+  );
+  assert.match(
+    readFile("tools/vite-plus/tasks/build.ts"),
+    /rustToolFromVscodeExtension\(\s*"editors\/vscode\/assert-vsix-package"/,
   );
   assert.match(
     readFile("tools/vite-plus/tasks/test-benchmark.ts"),
-    /sync-typescript-plugin\.mjs inject/,
+    /rustToolFromVscodeExtension\(\s*"editors\/vscode\/sync-typescript-plugin"/,
+  );
+  assert.match(
+    readFile("tools/vite-plus/tasks/test-benchmark.ts"),
+    /rustToolFromVscodeExtension\(\s*"editors\/vscode\/assert-vsix-package"/,
   );
 
   assert.match(readFile("editors/vscode/.vscodeignore"), /^typescript-vue-plugin\/$/m);

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,23 @@
+# Tools
+
+`tools/commands` is the canonical command surface for repository automation.
+Every file there is a Rust Script entrypoint and can be run with `rust-script`.
+
+The older JavaScript and shell files remain as compatibility implementation
+modules while the command surface migrates. They are still imported by tooling
+tests, but new CI/package invocations should call the Rust Script command path.
+
+## Layout
+
+- `tools/commands/agents`: agent-facing local automation.
+- `tools/commands/ci`: GitHub Actions, fuzz, and hosted verification helpers.
+- `tools/commands/davinci`: Davinci roadmap, matrix, corpus, and budget commands.
+- `tools/commands/editors`: editor extension packaging and real-server checks.
+- `tools/commands/fixtures`: real-project and generated fixture orchestration.
+- `tools/commands/release`: release, npm, and changelog commands.
+- `tools/rust`: shared Rust Script support and layout verification.
+- `tools/moon`: MoonBit command packages that are still built with `moon run`.
+
+Run `rust-script tools/rust/verify-layout.rs` after adding or removing tool
+entrypoints. It verifies that every legacy command entrypoint has a matching
+Rust Script wrapper and that wrappers point at the expected runtime.

--- a/tools/commands/agents/ai-fix-agent.rs
+++ b/tools/commands/agents/ai-fix-agent.rs
@@ -1,0 +1,12 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(legacy_command::Runtime::Node, "tools/ai-fix-agent.mjs")
+}

--- a/tools/commands/ci/fuzz/enforce-result.rs
+++ b/tools/commands/ci/fuzz/enforce-result.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/fuzz/enforce-result.mjs",
+    )
+}

--- a/tools/commands/ci/fuzz/seed_corpus.rs
+++ b/tools/commands/ci/fuzz/seed_corpus.rs
@@ -1,0 +1,12 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(legacy_command::Runtime::Node, "tools/fuzz/seed_corpus.mjs")
+}

--- a/tools/commands/ci/github/app-e2e-aggregate.rs
+++ b/tools/commands/ci/github/app-e2e-aggregate.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/github/app-e2e-aggregate.mjs",
+    )
+}

--- a/tools/commands/ci/github/app-e2e-plan.rs
+++ b/tools/commands/ci/github/app-e2e-plan.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/github/app-e2e-plan.mjs",
+    )
+}

--- a/tools/commands/ci/github/check-maestro-feature-contract.rs
+++ b/tools/commands/ci/github/check-maestro-feature-contract.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Bash,
+        "tools/github/check-maestro-feature-contract.sh",
+    )
+}

--- a/tools/commands/ci/github/configure-zig-musl-linkers.rs
+++ b/tools/commands/ci/github/configure-zig-musl-linkers.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Bash,
+        "tools/github/configure-zig-musl-linkers.sh",
+    )
+}

--- a/tools/commands/ci/github/npm-bootstrap-handoff.rs
+++ b/tools/commands/ci/github/npm-bootstrap-handoff.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/github/npm-bootstrap-handoff.mjs",
+    )
+}

--- a/tools/commands/ci/github/npm-bootstrap-preflight.rs
+++ b/tools/commands/ci/github/npm-bootstrap-preflight.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/github/npm-bootstrap-preflight.mjs",
+    )
+}

--- a/tools/commands/ci/github/publish-real-project-shard-summary.rs
+++ b/tools/commands/ci/github/publish-real-project-shard-summary.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Bash,
+        "tools/github/publish-real-project-shard-summary.sh",
+    )
+}

--- a/tools/commands/ci/github/release-local-guard.rs
+++ b/tools/commands/ci/github/release-local-guard.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/github/release-local-guard.mjs",
+    )
+}

--- a/tools/commands/ci/github/release-platforms.rs
+++ b/tools/commands/ci/github/release-platforms.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/github/release-platforms.mjs",
+    )
+}

--- a/tools/commands/ci/github/release-preflight.rs
+++ b/tools/commands/ci/github/release-preflight.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/github/release-preflight.mjs",
+    )
+}

--- a/tools/commands/ci/github/release-tag-rollback.rs
+++ b/tools/commands/ci/github/release-tag-rollback.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/github/release-tag-rollback.mjs",
+    )
+}

--- a/tools/commands/ci/github/require-needs-success.rs
+++ b/tools/commands/ci/github/require-needs-success.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/github/require-needs-success.mjs",
+    )
+}

--- a/tools/commands/ci/github/semver-change-marker.rs
+++ b/tools/commands/ci/github/semver-change-marker.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/github/semver-change-marker.mjs",
+    )
+}

--- a/tools/commands/ci/github/verify-glibc-symbols.rs
+++ b/tools/commands/ci/github/verify-glibc-symbols.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/github/verify-glibc-symbols.mjs",
+    )
+}

--- a/tools/commands/ci/github/verify-musl-cli-binary.rs
+++ b/tools/commands/ci/github/verify-musl-cli-binary.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Bash,
+        "tools/github/verify-musl-cli-binary.sh",
+    )
+}

--- a/tools/commands/davinci/assertion-lint.rs
+++ b/tools/commands/davinci/assertion-lint.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/davinci/assertion-lint.mjs",
+    )
+}

--- a/tools/commands/davinci/bench-compare.rs
+++ b/tools/commands/davinci/bench-compare.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/davinci/bench-compare.mjs",
+    )
+}

--- a/tools/commands/davinci/consumer-migration-surfaces.rs
+++ b/tools/commands/davinci/consumer-migration-surfaces.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/davinci/consumer-migration-surfaces.mjs",
+    )
+}

--- a/tools/commands/davinci/corpus-baseline.rs
+++ b/tools/commands/davinci/corpus-baseline.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/davinci/corpus-baseline.mjs",
+    )
+}

--- a/tools/commands/davinci/corpus-coverage.rs
+++ b/tools/commands/davinci/corpus-coverage.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/davinci/corpus-coverage.mjs",
+    )
+}

--- a/tools/commands/davinci/corpus-diff.rs
+++ b/tools/commands/davinci/corpus-diff.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/davinci/corpus-diff.mjs",
+    )
+}

--- a/tools/commands/davinci/croquis-consumers.rs
+++ b/tools/commands/davinci/croquis-consumers.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/davinci/croquis-consumers.mjs",
+    )
+}

--- a/tools/commands/davinci/matrix-gen.rs
+++ b/tools/commands/davinci/matrix-gen.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/davinci/matrix-gen.mjs",
+    )
+}

--- a/tools/commands/davinci/rule-parity.rs
+++ b/tools/commands/davinci/rule-parity.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/davinci/rule-parity.mjs",
+    )
+}

--- a/tools/commands/davinci/seed-defects.rs
+++ b/tools/commands/davinci/seed-defects.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/davinci/seed-defects.mjs",
+    )
+}

--- a/tools/commands/davinci/sourcelocation-inventory.rs
+++ b/tools/commands/davinci/sourcelocation-inventory.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/davinci/sourcelocation-inventory.mjs",
+    )
+}

--- a/tools/commands/davinci/suppression-telemetry.rs
+++ b/tools/commands/davinci/suppression-telemetry.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/davinci/suppression-telemetry.mjs",
+    )
+}

--- a/tools/commands/editors/e2e/real-vue-workspace.rs
+++ b/tools/commands/editors/e2e/real-vue-workspace.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/editor-e2e/real-vue-workspace.mjs",
+    )
+}

--- a/tools/commands/editors/emacs/assert-emacs-package.rs
+++ b/tools/commands/editors/emacs/assert-emacs-package.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/emacs-vize/assert-emacs-package.mjs",
+    )
+}

--- a/tools/commands/editors/helix/assert-helix-health.rs
+++ b/tools/commands/editors/helix/assert-helix-health.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/helix-vize/assert-helix-health.mjs",
+    )
+}

--- a/tools/commands/editors/helix/assert-helix-package.rs
+++ b/tools/commands/editors/helix/assert-helix-package.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/helix-vize/assert-helix-package.mjs",
+    )
+}

--- a/tools/commands/editors/helix/run-real-server.rs
+++ b/tools/commands/editors/helix/run-real-server.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/helix-vize/run-real-server.mjs",
+    )
+}

--- a/tools/commands/editors/neovim/assert-nvim-package.rs
+++ b/tools/commands/editors/neovim/assert-nvim-package.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/nvim-vize/assert-nvim-package.mjs",
+    )
+}

--- a/tools/commands/editors/neovim/run-real-server.rs
+++ b/tools/commands/editors/neovim/run-real-server.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/nvim-vize/run-real-server.mjs",
+    )
+}

--- a/tools/commands/editors/vim/assert-vim-package.rs
+++ b/tools/commands/editors/vim/assert-vim-package.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/vim-vize/assert-vim-package.mjs",
+    )
+}

--- a/tools/commands/editors/vim/run-real-server.rs
+++ b/tools/commands/editors/vim/run-real-server.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/vim-vize/run-real-server.mjs",
+    )
+}

--- a/tools/commands/editors/vscode/assert-vsix-package.rs
+++ b/tools/commands/editors/vscode/assert-vsix-package.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/vscode-vize/assert-vsix-package.mjs",
+    )
+}

--- a/tools/commands/editors/vscode/run-package-bin.rs
+++ b/tools/commands/editors/vscode/run-package-bin.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/vscode-vize/run-package-bin.mjs",
+    )
+}

--- a/tools/commands/editors/vscode/sync-typescript-plugin.rs
+++ b/tools/commands/editors/vscode/sync-typescript-plugin.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/vscode-vize/sync-typescript-plugin.mjs",
+    )
+}

--- a/tools/commands/editors/zed/assert-zed-package.rs
+++ b/tools/commands/editors/zed/assert-zed-package.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/zed-vize/assert-zed-package.mjs",
+    )
+}

--- a/tools/commands/editors/zed/run-real-server.rs
+++ b/tools/commands/editors/zed/run-real-server.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/zed-vize/run-real-server.mjs",
+    )
+}

--- a/tools/commands/fixtures/compiler-diff-report.rs
+++ b/tools/commands/fixtures/compiler-diff-report.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/fixtures/compiler-diff-report.mjs",
+    )
+}

--- a/tools/commands/fixtures/fixture-compatibility-report.rs
+++ b/tools/commands/fixtures/fixture-compatibility-report.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/fixtures/fixture-compatibility-report.mjs",
+    )
+}

--- a/tools/commands/fixtures/glyph-corpus-waiver-audit.rs
+++ b/tools/commands/fixtures/glyph-corpus-waiver-audit.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/fixtures/glyph-corpus-waiver-audit.mjs",
+    )
+}

--- a/tools/commands/fixtures/lint-divergence-report.rs
+++ b/tools/commands/fixtures/lint-divergence-report.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/fixtures/lint-divergence-report.mjs",
+    )
+}

--- a/tools/commands/fixtures/patina-rule-map.rs
+++ b/tools/commands/fixtures/patina-rule-map.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/fixtures/patina-rule-map.mjs",
+    )
+}

--- a/tools/commands/fixtures/real-project-surface-verdict.rs
+++ b/tools/commands/fixtures/real-project-surface-verdict.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/fixtures/real-project-surface-verdict.mjs",
+    )
+}

--- a/tools/commands/fixtures/toml-to-pkl.rs
+++ b/tools/commands/fixtures/toml-to-pkl.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/fixtures/toml-to-pkl.mjs",
+    )
+}

--- a/tools/commands/fixtures/tool-matrix-report.rs
+++ b/tools/commands/fixtures/tool-matrix-report.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/fixtures/tool-matrix-report.mjs",
+    )
+}

--- a/tools/commands/fixtures/typecheck-dependency-prepare.rs
+++ b/tools/commands/fixtures/typecheck-dependency-prepare.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/fixtures/typecheck-dependency-prepare.mjs",
+    )
+}

--- a/tools/commands/fixtures/typecheck-divergence-report.rs
+++ b/tools/commands/fixtures/typecheck-divergence-report.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/fixtures/typecheck-divergence-report.mjs",
+    )
+}

--- a/tools/commands/release/npm/smoke-release-install.rs
+++ b/tools/commands/release/npm/smoke-release-install.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/npm/smoke-release-install.mjs",
+    )
+}

--- a/tools/commands/release/npm/smoke-wasm-package.rs
+++ b/tools/commands/release/npm/smoke-wasm-package.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/npm/smoke-wasm-package.mjs",
+    )
+}

--- a/tools/commands/release/regenerate-changelog.rs
+++ b/tools/commands/release/regenerate-changelog.rs
@@ -1,0 +1,15 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+#[path = "../../rust/legacy_command.rs"]
+mod legacy_command;
+
+fn main() -> std::process::ExitCode {
+    legacy_command::run(
+        legacy_command::Runtime::Node,
+        "tools/release/regenerate-changelog.mjs",
+    )
+}

--- a/tools/rust/legacy_command.rs
+++ b/tools/rust/legacy_command.rs
@@ -1,0 +1,127 @@
+use std::{
+    env,
+    ffi::OsStr,
+    path::{Path, PathBuf},
+    process::{Command, ExitCode},
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
+pub enum Runtime {
+    Bash,
+    Node,
+}
+
+impl Runtime {
+    fn executable(self) -> &'static str {
+        match self {
+            Self::Bash => "bash",
+            Self::Node => "node",
+        }
+    }
+}
+
+pub fn run(runtime: Runtime, legacy_tool: &str) -> ExitCode {
+    run_with_args(runtime, legacy_tool, env::args_os().skip(1))
+}
+
+fn run_with_args<I, S>(runtime: Runtime, legacy_tool: &str, args: I) -> ExitCode
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    match run_inner(runtime, legacy_tool, args) {
+        Ok(code) => ExitCode::from(code),
+        Err(message) => {
+            eprintln!("{message}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn run_inner<I, S>(runtime: Runtime, legacy_tool: &str, args: I) -> Result<u8, String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let root = repo_root()?;
+    let tool_path = validate_legacy_tool(&root, legacy_tool)?;
+    let status = Command::new(runtime.executable())
+        .arg(tool_path)
+        .args(args)
+        .status()
+        .map_err(|error| {
+            format!(
+                "failed to run {} for {legacy_tool}: {error}",
+                runtime.executable()
+            )
+        })?;
+
+    Ok(status.code().unwrap_or(1).clamp(0, 255) as u8)
+}
+
+fn repo_root() -> Result<PathBuf, String> {
+    if let Some(root) = env::var_os("VIZE_REPO_ROOT") {
+        let root = PathBuf::from(root);
+        if is_repo_root(&root) {
+            return Ok(root);
+        }
+        return Err(format!(
+            "VIZE_REPO_ROOT={} is not a Vize repository root",
+            root.display()
+        ));
+    }
+
+    let current =
+        env::current_dir().map_err(|error| format!("cannot read current dir: {error}"))?;
+    for dir in current.ancestors() {
+        if is_repo_root(dir) {
+            return Ok(dir.to_path_buf());
+        }
+    }
+
+    Err(format!(
+        "cannot find Vize repository root from {}; run the command inside the repository or set VIZE_REPO_ROOT",
+        current.display()
+    ))
+}
+
+fn is_repo_root(dir: &Path) -> bool {
+    dir.join("Cargo.toml").is_file() && dir.join("pnpm-workspace.yaml").is_file()
+}
+
+fn validate_legacy_tool(root: &Path, legacy_tool: &str) -> Result<PathBuf, String> {
+    let relative = Path::new(legacy_tool);
+    if relative.is_absolute() {
+        return Err(format!(
+            "legacy tool path must be repository-relative: {legacy_tool}"
+        ));
+    }
+    if !relative.starts_with("tools") {
+        return Err(format!(
+            "legacy tool path must live under tools/: {legacy_tool}"
+        ));
+    }
+    if relative
+        .components()
+        .any(|component| component.as_os_str() == "..")
+    {
+        return Err(format!(
+            "legacy tool path cannot contain '..': {legacy_tool}"
+        ));
+    }
+    if legacy_tool.contains("tools/moon/.mooncakes/") {
+        return Err(format!(
+            "legacy tool path cannot target vendored MoonBit cache: {legacy_tool}"
+        ));
+    }
+
+    let tool_path = root.join(relative);
+    if !tool_path.is_file() {
+        return Err(format!(
+            "legacy tool does not exist: {}",
+            tool_path.display()
+        ));
+    }
+    Ok(tool_path)
+}

--- a/tools/rust/verify-layout.rs
+++ b/tools/rust/verify-layout.rs
@@ -1,0 +1,254 @@
+#!/usr/bin/env rust-script
+//! ```cargo
+//! [package]
+//! edition = "2024"
+//! ```
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env, fs, io,
+    path::{Path, PathBuf},
+    process::ExitCode,
+};
+
+const EXPLICIT_ENTRYPOINTS: &[&str] = &[
+    "tools/fixtures/glyph-corpus-waiver-audit.mjs",
+    "tools/fixtures/patina-rule-map.mjs",
+    "tools/fixtures/real-project-surface-verdict.mjs",
+    "tools/github/release-platforms.mjs",
+    "tools/github/require-needs-success.mjs",
+    "tools/github/semver-change-marker.mjs",
+];
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum Runtime {
+    Bash,
+    Node,
+}
+
+impl Runtime {
+    fn wrapper_token(self) -> &'static str {
+        match self {
+            Self::Bash => "Runtime::Bash",
+            Self::Node => "Runtime::Node",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct Entrypoint {
+    command: String,
+    legacy: String,
+    runtime: Runtime,
+}
+
+fn main() -> ExitCode {
+    match verify() {
+        Ok(count) => {
+            println!("rust-script tools: verified {count} command wrappers");
+            ExitCode::SUCCESS
+        }
+        Err(errors) => {
+            for error in errors {
+                eprintln!("rust-script tools: {error}");
+            }
+            ExitCode::from(1)
+        }
+    }
+}
+
+fn verify() -> Result<usize, Vec<String>> {
+    let root = repo_root().map_err(|error| vec![error])?;
+    let tools = root.join("tools");
+    let entrypoints =
+        collect_entrypoints(&root, &tools).map_err(|error| vec![error.to_string()])?;
+    let mut errors = Vec::new();
+    let mut expected_commands = BTreeSet::new();
+
+    for entrypoint in &entrypoints {
+        expected_commands.insert(entrypoint.command.clone());
+        let path = root.join(&entrypoint.command);
+        let source = match fs::read_to_string(&path) {
+            Ok(source) => source,
+            Err(error) => {
+                errors.push(format!("missing wrapper {}: {error}", entrypoint.command));
+                continue;
+            }
+        };
+        if !source.starts_with("#!/usr/bin/env rust-script\n") {
+            errors.push(format!(
+                "{} must start with a rust-script shebang",
+                entrypoint.command
+            ));
+        }
+        if !source.contains("legacy_command::run(") {
+            errors.push(format!(
+                "{} must call the shared legacy runner",
+                entrypoint.command
+            ));
+        }
+        if !source.contains(entrypoint.runtime.wrapper_token()) {
+            errors.push(format!(
+                "{} must use {}",
+                entrypoint.command,
+                entrypoint.runtime.wrapper_token()
+            ));
+        }
+        if !source.contains(&format!("\"{}\"", entrypoint.legacy)) {
+            errors.push(format!(
+                "{} must point at {}",
+                entrypoint.command, entrypoint.legacy
+            ));
+        }
+    }
+
+    for command in collect_command_wrappers(&root, &root.join("tools/commands"))
+        .map_err(|error| vec![error.to_string()])?
+    {
+        if !expected_commands.contains(&command) {
+            errors.push(format!("{command} has no matching legacy entrypoint"));
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(entrypoints.len())
+    } else {
+        Err(errors)
+    }
+}
+
+fn collect_entrypoints(root: &Path, tools: &Path) -> io::Result<Vec<Entrypoint>> {
+    let mut files = Vec::new();
+    visit_files(tools, &mut files)?;
+    let mut entrypoints = Vec::new();
+
+    for file in files {
+        let legacy = normalize_relative(root, &file);
+        if skip_path(&legacy) {
+            continue;
+        }
+        let Some(runtime) = runtime_for(&file) else {
+            continue;
+        };
+        if !has_shebang(&file)? && !EXPLICIT_ENTRYPOINTS.contains(&legacy.as_str()) {
+            continue;
+        }
+        let command = command_path(&legacy)
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        entrypoints.push(Entrypoint {
+            command,
+            legacy,
+            runtime,
+        });
+    }
+
+    entrypoints.sort();
+    Ok(entrypoints)
+}
+
+fn collect_command_wrappers(root: &Path, commands: &Path) -> io::Result<Vec<String>> {
+    let mut files = Vec::new();
+    visit_files(commands, &mut files)?;
+    let mut wrappers = files
+        .into_iter()
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("rs"))
+        .map(|path| normalize_relative(root, &path))
+        .collect::<Vec<_>>();
+    wrappers.sort();
+    Ok(wrappers)
+}
+
+fn visit_files(dir: &Path, files: &mut Vec<PathBuf>) -> io::Result<()> {
+    if !dir.exists() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            visit_files(&path, files)?;
+        } else if path.is_file() {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn skip_path(path: &str) -> bool {
+    path.starts_with("tools/commands/")
+        || path.starts_with("tools/rust/")
+        || path.starts_with("tools/moon/.mooncakes/")
+}
+
+fn runtime_for(path: &Path) -> Option<Runtime> {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("js" | "mjs" | "ts") => Some(Runtime::Node),
+        Some("sh") => Some(Runtime::Bash),
+        _ => None,
+    }
+}
+
+fn has_shebang(path: &Path) -> io::Result<bool> {
+    let source = fs::read_to_string(path)?;
+    Ok(source.starts_with("#!"))
+}
+
+fn command_path(legacy: &str) -> Result<String, String> {
+    let legacy = legacy.strip_prefix("tools/").expect("tool path");
+    let mut parts = legacy.split('/').collect::<Vec<_>>();
+    let file = parts.pop().expect("file name");
+    let stem = file
+        .strip_suffix(".mjs")
+        .or_else(|| file.strip_suffix(".js"))
+        .or_else(|| file.strip_suffix(".ts"))
+        .or_else(|| file.strip_suffix(".sh"))
+        .unwrap_or(file);
+
+    let mut buckets = BTreeMap::from([
+        ("ai-fix-agent.mjs", vec!["agents"]),
+        ("davinci", vec!["davinci"]),
+        ("editor-e2e", vec!["editors", "e2e"]),
+        ("emacs-vize", vec!["editors", "emacs"]),
+        ("fixtures", vec!["fixtures"]),
+        ("fuzz", vec!["ci", "fuzz"]),
+        ("github", vec!["ci", "github"]),
+        ("helix-vize", vec!["editors", "helix"]),
+        ("npm", vec!["release", "npm"]),
+        ("nvim-vize", vec!["editors", "neovim"]),
+        ("release", vec!["release"]),
+        ("vim-vize", vec!["editors", "vim"]),
+        ("vscode-vize", vec!["editors", "vscode"]),
+        ("zed-vize", vec!["editors", "zed"]),
+    ]);
+    let first = parts.first().copied().unwrap_or(file);
+    let mut command_parts = buckets
+        .remove(first)
+        .ok_or_else(|| format!("missing canonical command bucket for tools/{legacy}"))?;
+    command_parts.push(stem);
+    Ok(format!("tools/commands/{}.rs", command_parts.join("/")))
+}
+
+fn repo_root() -> Result<PathBuf, String> {
+    let current =
+        env::current_dir().map_err(|error| format!("cannot read current dir: {error}"))?;
+    for dir in current.ancestors() {
+        if dir.join("Cargo.toml").is_file() && dir.join("pnpm-workspace.yaml").is_file() {
+            return Ok(dir.to_path_buf());
+        }
+    }
+    Err(format!(
+        "cannot find repository root from {}",
+        current.display()
+    ))
+}
+
+fn normalize(path: &Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn normalize_relative(root: &Path, path: &Path) -> String {
+    normalize(path.strip_prefix(root).unwrap_or(path))
+}

--- a/tools/vite-plus/task-commands.ts
+++ b/tools/vite-plus/task-commands.ts
@@ -1,11 +1,23 @@
 import { existsSync } from "node:fs";
 
 import type { PackagePath } from "./task-types.ts";
-import { shellCommand } from "./task-shell.ts";
+import { shellCommand, shellQuote } from "./task-shell.ts";
 
 export const localVp = "./node_modules/.bin/vp";
-export const vscodeExtensionPackageBin = (packageName: string, binName: string) =>
-  `node ../../tools/vscode-vize/run-package-bin.mjs ${packageName} ${binName}`;
+
+const rustScript = (scriptPath: string, args: readonly string[]) =>
+  ["rust-script", scriptPath, ...args].map(shellQuote).join(" ");
+
+export const vscodeExtensionPackageBin = (
+  packageName: string,
+  binName: string,
+  ...args: string[]
+) =>
+  rustScript("../../tools/commands/editors/vscode/run-package-bin.rs", [
+    packageName,
+    binName,
+    ...args,
+  ]);
 
 /**
  * Runs a command after changing into a package directory.
@@ -25,7 +37,7 @@ export const runPackageScriptDirectly = (taskName: string, packages: readonly Pa
  */
 export const installVscodeExtensionDependencies = runInDirectory(
   "editors/vscode",
-  "if node ../../tools/vscode-vize/run-package-bin.mjs vite-plus vp --version >/dev/null 2>&1; then exit 0; fi && corepack pnpm install --ignore-workspace --lockfile-dir . --no-lockfile --prefer-offline --ignore-scripts",
+  `if ${vscodeExtensionPackageBin("vite-plus", "vp")} --version >/dev/null 2>&1; then exit 0; fi && corepack pnpm install --ignore-workspace --lockfile-dir . --no-lockfile --prefer-offline --ignore-scripts`,
 );
 
 /**
@@ -64,6 +76,12 @@ export const runInPackages = (
 
 export const runTask = (taskName: string) => `vp run --workspace-root ${taskName}`;
 export const runTasks = (...taskNames: string[]) => taskNames.map(runTask).join(" && ");
+
+export const rustTool = (command: string, ...args: string[]) =>
+  rustScript(`tools/commands/${command}.rs`, args);
+
+export const rustToolFromVscodeExtension = (command: string, ...args: string[]) =>
+  rustScript(`../../tools/commands/${command}.rs`, args);
 
 const workspaceMoonHome = ".cache/moonbit";
 const workspaceMoonBin = `${workspaceMoonHome}/bin/moon`;

--- a/tools/vite-plus/task-helpers.ts
+++ b/tools/vite-plus/task-helpers.ts
@@ -9,6 +9,8 @@ export {
   runInPackages,
   runInVscodeExtension,
   runPackageScriptDirectly,
+  rustTool,
+  rustToolFromVscodeExtension,
   runTask,
   runTasks,
   vscodeExtensionPackageBin,

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -6,6 +6,8 @@ import {
   runInPackages,
   runInVscodeExtension,
   runPackageScriptDirectly,
+  rustTool,
+  rustToolFromVscodeExtension,
   runTask,
   runTasks,
   task,
@@ -13,9 +15,19 @@ import {
 } from "../task-helpers.ts";
 import { inTestbox } from "./testbox.ts";
 
-const stageVscodeTypeScriptPlugin = "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage";
-const injectVscodeTypeScriptPlugin =
-  "node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix";
+const stageVscodeTypeScriptPlugin = rustToolFromVscodeExtension(
+  "editors/vscode/sync-typescript-plugin",
+  "stage",
+);
+const injectVscodeTypeScriptPlugin = rustToolFromVscodeExtension(
+  "editors/vscode/sync-typescript-plugin",
+  "inject",
+  "dist/vize.vsix",
+);
+const assertVscodePackage = rustToolFromVscodeExtension(
+  "editors/vscode/assert-vsix-package",
+  "dist/vize.vsix",
+);
 const packageVscodeExtension = [
   stageVscodeTypeScriptPlugin,
   `${vscodeExtensionPackageBin("@vscode/vsce", "vsce")} package --no-dependencies --out dist/vize.vsix`,
@@ -74,35 +86,32 @@ export const buildTasks = defineTasks({
   ),
   "build:editor-extensions": noCacheTask(runTasks("build:vscode-extension", "check:zed-extension")),
   "package:vscode-extension": noCacheTask(
-    runInVscodeExtension(
-      packageVscodeExtension,
-      "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
-    ),
+    runInVscodeExtension(packageVscodeExtension, assertVscodePackage),
   ),
   "check:zed-extension": task("cargo check --manifest-path editors/zed/Cargo.toml", {
     input: ["editors/zed/**"],
   }),
   "package:zed-extension": noCacheTask(
-    "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar --exclude 'zed/target' -czf zed-vize-extension.tar.gz -C editors zed && node tools/zed-vize/assert-zed-package.mjs zed-vize-extension.tar.gz",
+    `COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar --exclude 'zed/target' -czf zed-vize-extension.tar.gz -C editors zed && ${rustTool("editors/zed/assert-zed-package", "zed-vize-extension.tar.gz")}`,
   ),
   "package:nvim-extension": noCacheTask(
-    "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf nvim-vize-extension.tar.gz -C editors nvim && node tools/nvim-vize/assert-nvim-package.mjs nvim-vize-extension.tar.gz",
+    `COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf nvim-vize-extension.tar.gz -C editors nvim && ${rustTool("editors/neovim/assert-nvim-package", "nvim-vize-extension.tar.gz")}`,
   ),
   "package:vim-extension": noCacheTask(
-    "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf vim-vize-extension.tar.gz -C editors vim && node tools/vim-vize/assert-vim-package.mjs vim-vize-extension.tar.gz",
+    `COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf vim-vize-extension.tar.gz -C editors vim && ${rustTool("editors/vim/assert-vim-package", "vim-vize-extension.tar.gz")}`,
   ),
   "package:helix-extension": noCacheTask(
-    "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf helix-vize-extension.tar.gz -C editors helix && node tools/helix-vize/assert-helix-package.mjs helix-vize-extension.tar.gz",
+    `COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf helix-vize-extension.tar.gz -C editors helix && ${rustTool("editors/helix/assert-helix-package", "helix-vize-extension.tar.gz")}`,
   ),
   "package:emacs-extension": noCacheTask(
-    "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf emacs-vize-extension.tar.gz -C editors emacs && node tools/emacs-vize/assert-emacs-package.mjs emacs-vize-extension.tar.gz",
+    `COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf emacs-vize-extension.tar.gz -C editors emacs && ${rustTool("editors/emacs/assert-emacs-package", "emacs-vize-extension.tar.gz")}`,
   ),
   "package:editor-extensions": noCacheTask(
     `${runInVscodeExtension(
       `${vscodeExtensionPackageBin("typescript", "tsc")} --noEmit`,
       `${vscodeExtensionPackageBin("vite-plus", "vp")} check src vite.config.ts`,
       packageVscodeExtension,
-      "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
+      assertVscodePackage,
     )} && ${runTask("check:zed-extension")} && ${runTask(
       "test:zed-extension:unit",
     )} && ${runTask("package:zed-extension")} && ${runTask(

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -5,6 +5,8 @@ import {
   noCacheTask,
   runInPackages,
   runInVscodeExtension,
+  rustTool,
+  rustToolFromVscodeExtension,
   runTask,
   runTasks,
   task,
@@ -12,9 +14,19 @@ import {
 } from "../task-helpers.ts";
 import { inTestbox } from "./testbox.ts";
 
-const stageVscodeTypeScriptPlugin = "node ../../tools/vscode-vize/sync-typescript-plugin.mjs stage";
-const injectVscodeTypeScriptPlugin =
-  "node ../../tools/vscode-vize/sync-typescript-plugin.mjs inject dist/vize.vsix";
+const stageVscodeTypeScriptPlugin = rustToolFromVscodeExtension(
+  "editors/vscode/sync-typescript-plugin",
+  "stage",
+);
+const injectVscodeTypeScriptPlugin = rustToolFromVscodeExtension(
+  "editors/vscode/sync-typescript-plugin",
+  "inject",
+  "dist/vize.vsix",
+);
+const assertVscodePackage = rustToolFromVscodeExtension(
+  "editors/vscode/assert-vsix-package",
+  "dist/vize.vsix",
+);
 const packageVscodeExtension = [
   stageVscodeTypeScriptPlugin,
   `${vscodeExtensionPackageBin("@vscode/vsce", "vsce")} package --no-dependencies --out dist/vize.vsix`,
@@ -102,13 +114,10 @@ export const testAndBenchmarkTasks = defineTasks({
   // dev profile (~1m20s). Building once in the CI profile saves both legs.
   "test:js": noCacheTask(`${runTask("build:native:test")} && ${jsPackageTestCommand}`),
   "test:scripts": noCacheTask(
-    `${runTask("build:native:test")} && VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.ts tests/tooling/*.test.mjs`,
+    `${runTask("build:native:test")} && rust-script tools/rust/verify-layout.rs && VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/*.test.ts tests/tooling/*.test.mjs`,
   ),
   "test:vscode-extension:vsix": noCacheTask(
-    runInVscodeExtension(
-      packageVscodeExtension,
-      "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
-    ),
+    runInVscodeExtension(packageVscodeExtension, assertVscodePackage),
   ),
   "test:vscode-extension:host": noCacheTask(
     runInVscodeExtension(
@@ -120,7 +129,7 @@ export const testAndBenchmarkTasks = defineTasks({
   "test:vscode-extension:host-real": noCacheTask(
     runInVscodeExtension(
       packageVscodeExtension,
-      "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
+      assertVscodePackage,
       "node test/run-extension-host-real.mjs",
     ),
   ),
@@ -128,7 +137,7 @@ export const testAndBenchmarkTasks = defineTasks({
   "test:zed-extension:unit": task("cargo test --manifest-path editors/zed/Cargo.toml", {
     input: ["editors/zed/**"],
   }),
-  "test:zed-extension:real-server": noCacheTask("node tools/zed-vize/run-real-server.mjs"),
+  "test:zed-extension:real-server": noCacheTask(rustTool("editors/zed/run-real-server")),
   "test:nvim-extension:headless": noCacheTask(
     "nvim --headless -u NONE --noplugin '+set runtimepath^=editors/nvim' '+luafile editors/nvim/test/vize_spec.lua' '+qa' && VIZE_TEST_ART_VUE_NATIVE_PARSER=1 nvim --headless -u NONE --noplugin '+set runtimepath^=editors/nvim' '+luafile editors/nvim/test/vize_spec.lua' '+qa'",
   ),
@@ -136,14 +145,14 @@ export const testAndBenchmarkTasks = defineTasks({
   // The headless Neovim end-to-end scenario against a real `vize lsp` (#3457).
   // It needs a built server binary, so CI runs it in the same job that builds
   // one for the VS Code host smoke.
-  "test:nvim-extension:real-server": noCacheTask("node tools/nvim-vize/run-real-server.mjs"),
+  "test:nvim-extension:real-server": noCacheTask(rustTool("editors/neovim/run-real-server")),
   "test:vim-extension:headless": noCacheTask(
     "vim -Nu NONE -n -es -S editors/vim/test/vize_spec.vim",
   ),
-  "test:vim-extension:real-server": noCacheTask("node tools/vim-vize/run-real-server.mjs"),
+  "test:vim-extension:real-server": noCacheTask(rustTool("editors/vim/run-real-server")),
   "test:vim-extension:package": noCacheTask("vp run --workspace-root package:vim-extension"),
   "test:helix-extension:package": noCacheTask("vp run --workspace-root package:helix-extension"),
-  "test:helix-extension:real-server": noCacheTask("node tools/helix-vize/run-real-server.mjs"),
+  "test:helix-extension:real-server": noCacheTask(rustTool("editors/helix/run-real-server")),
   "test:emacs-extension:headless": noCacheTask(
     "emacs -Q --batch -l ert -l editors/emacs/test/vize-test.el -f ert-run-tests-batch-and-exit",
   ),


### PR DESCRIPTION
## Summary
- add a canonical Rust Script command surface under `tools/commands`, with shared Rust runner validation and a fail-closed layout verifier
- reorganize tool entrypoints into agents, ci, davinci, editors, fixtures, and release buckets while keeping existing implementation modules importable
- route GitHub Actions, Vite+ tasks, and VS Code package scripts through the Rust Script entrypoints

## Verification
- `vp install --frozen-lockfile --prefer-offline`
- `vp check --fix`
- `rustfmt tools/rust/*.rs $(find tools/commands -name '*.rs' -type f | sort)`
- `rust-script tools/rust/verify-layout.rs` (57 command wrappers)
- `rust-script tools/commands/ci/fuzz/enforce-result.rs pull_request sfc_parse success`
- affected 155-test workflow/task/tooling suite with `node --test`
- `git diff --check`
- source-length ratchet line counts checked against the current base
- `vp run --workspace-root test:scripts` was attempted locally; the full local sweep is still blocked by the local MoonBit toolchain issue outside this change, while CI runs it in the pinned workflow environment