### PR TITLE
test(ui): add story testbed inventory harness

### DIFF
--- a/npm/ui/core/src/story-testbed.behavior.md
+++ b/npm/ui/core/src/story-testbed.behavior.md
@@ -1,0 +1,13 @@
+# Story testbed behavior contract
+
+Normative contract for the issue #4898 story harness inventory. The harness is
+source-local: it derives coverage from `src/family-catalog.ts`, keeps pending
+Musea/browser/VRT work explicit, and lets future family PRs flip individual
+artifacts to ready when the colocated files are added.
+
+| #   | State             | Input                         | Outcome                                                                                                      | Proven by                                                            |
+| --- | ----------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| S1  | family catalog    | stable public family          | one deterministic story-testbed entry is emitted in canonical order                                          | `publishes a deterministic story-testbed inventory for each family`  |
+| S2  | Musea surface     | catalogued family name        | planned story path is `src/<family>.art.vue` and remains colocated                                           | `publishes a deterministic story-testbed inventory for each family`  |
+| S3  | matrix controls   | story-testbed entry           | states, slots, parts, presets, RTL, reduced-motion, and forced-colors are required                           | `publishes a deterministic story-testbed inventory for each family`  |
+| S4  | existing evidence | package source file inventory | supporting behavior tests must exist; planned Musea/VTU/browser/VRT files must stay pending until registered | `audits planned artifacts and supporting tests against source files` |

--- a/npm/ui/core/src/story-testbed.test.ts
+++ b/npm/ui/core/src/story-testbed.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { test } from "vite-plus/test";
+
+import { uiFamilyCatalog } from "./family-catalog.ts";
+import {
+  auditUiStoryTestbedInventory,
+  formatUiStoryTestbedViolations,
+  UI_STORY_TESTBED_SCHEMA_VERSION,
+  uiStoryMatrixDimensions,
+  uiStoryTestbedInventory,
+  uiStoryTestbedSurfaces,
+  uiStoryTestbedViewports,
+} from "./story-testbed.ts";
+import { themePresets } from "./theme-constants.ts";
+
+async function collectSourceFiles(
+  directory: string,
+  relativeDirectory = "src",
+): Promise<ReadonlySet<string>> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry): Promise<readonly string[]> => {
+      const entryPath = path.join(directory, entry.name);
+      const relativePath = path.posix.join(relativeDirectory, entry.name);
+      if (entry.isDirectory()) return [...(await collectSourceFiles(entryPath, relativePath))];
+      return entry.isFile() ? [relativePath] : [];
+    }),
+  );
+
+  return new Set(files.flat().sort((left, right) => left.localeCompare(right)));
+}
+
+test("publishes a deterministic story-testbed inventory for each family", () => {
+  assert.equal(UI_STORY_TESTBED_SCHEMA_VERSION, 1);
+  assert.equal(uiStoryTestbedInventory.length, uiFamilyCatalog.length);
+
+  const catalogNames = uiFamilyCatalog.map((entry) => entry.canonicalName);
+  const inventoryNames = uiStoryTestbedInventory.map((entry) => entry.canonicalName);
+  assert.deepEqual(inventoryNames, catalogNames);
+
+  const catalogByName = new Map(uiFamilyCatalog.map((entry) => [entry.canonicalName, entry]));
+  for (const entry of uiStoryTestbedInventory) {
+    const catalogEntry = catalogByName.get(entry.canonicalName);
+    assert.ok(catalogEntry, `${entry.canonicalName} must exist in the family catalog`);
+
+    assert.equal(entry.title, catalogEntry.title);
+    assert.equal(entry.packageSubpath, catalogEntry.packageSubpath);
+    assert.equal(entry.storyFile, `src/${entry.canonicalName}.art.vue`);
+    assert.equal(entry.vueTestFile, `src/${entry.canonicalName}.vue.test.ts`);
+    assert.equal(entry.browserTestFile, `src/${entry.canonicalName}.browser.spec.ts`);
+    assert.equal(entry.vrtTestFile, `src/${entry.canonicalName}.vrt.spec.ts`);
+    assert.deepEqual(entry.supportingTestFiles, catalogEntry.tests);
+    assert.deepEqual(entry.matrixDimensions, uiStoryMatrixDimensions);
+    assert.deepEqual(entry.presets, themePresets);
+    assert.deepEqual(entry.viewports, uiStoryTestbedViewports);
+
+    for (const targetFile of entry.targetFiles) {
+      assert.ok(
+        catalogEntry.sourceFiles.includes(targetFile) || targetFile === catalogEntry.entryFile,
+        `${entry.canonicalName} target ${targetFile} must come from the family catalog`,
+      );
+      assert.equal(
+        path.posix.dirname(targetFile),
+        path.posix.dirname(entry.storyFile),
+        `${entry.canonicalName} story must stay colocated with its target files`,
+      );
+    }
+
+    const artifactsBySurface = new Map(
+      entry.artifacts.map((artifact) => [artifact.surface, artifact]),
+    );
+    assert.deepEqual([...artifactsBySurface.keys()], uiStoryTestbedSurfaces);
+    assert.equal(artifactsBySurface.get("musea-story")?.status, "planned");
+    assert.equal(artifactsBySurface.get("vue-test-utils")?.status, "planned");
+    assert.equal(artifactsBySurface.get("vitest-browser")?.status, "planned");
+    assert.equal(artifactsBySurface.get("playwright-vrt")?.status, "planned");
+  }
+});
+
+test("audits planned artifacts and supporting tests against source files", async () => {
+  const existingFiles = await collectSourceFiles(path.resolve("src"));
+  const violations = auditUiStoryTestbedInventory(uiStoryTestbedInventory, { existingFiles });
+
+  assert.equal(formatUiStoryTestbedViolations(violations), "");
+  assert.deepEqual(violations, []);
+
+  const plannedArtifacts = uiStoryTestbedInventory.flatMap((entry) =>
+    entry.artifacts.filter((artifact) => artifact.status === "planned"),
+  );
+  const supportingTestFiles = uiStoryTestbedInventory.flatMap((entry) => entry.supportingTestFiles);
+  assert.equal(plannedArtifacts.length, uiFamilyCatalog.length * 4);
+  assert.ok(supportingTestFiles.length >= uiFamilyCatalog.length);
+});
+
+test("behavior contract documents the issue 4898 harness gates", async () => {
+  const behavior = await readFile(path.resolve("src/story-testbed.behavior.md"), "utf8");
+
+  assert.match(behavior, /S1.+family catalog.+stable public family/);
+  assert.match(behavior, /S2.+Musea surface.+src\/<family>\.art\.vue/);
+  assert.match(
+    behavior,
+    /S3.+states, slots, parts, presets, RTL, reduced-motion, and forced-colors/,
+  );
+  assert.match(behavior, /S4.+supporting behavior tests must exist/);
+});

--- a/npm/ui/core/src/story-testbed.ts
+++ b/npm/ui/core/src/story-testbed.ts
@@ -1,0 +1,350 @@
+import { uiFamilyCatalog, type UiFamilyCatalogEntry } from "./family-catalog.ts";
+import { themePresets } from "./theme-constants.ts";
+import type { ThemePresetName } from "./theme-types.ts";
+
+export const UI_STORY_TESTBED_SCHEMA_VERSION = 1;
+
+export const uiStoryTestbedSurfaces = [
+  "musea-story",
+  "vue-test-utils",
+  "vitest-browser",
+  "playwright-vrt",
+] as const;
+
+export type UiStoryTestbedSurface = (typeof uiStoryTestbedSurfaces)[number];
+
+export type UiStoryTestbedArtifactStatus = "planned" | "ready";
+
+export const uiStoryMatrixDimensions = [
+  "states",
+  "slots",
+  "parts",
+  "presets",
+  "rtl",
+  "reduced-motion",
+  "forced-colors",
+] as const;
+
+export type UiStoryMatrixDimension = (typeof uiStoryMatrixDimensions)[number];
+
+export interface UiStoryTestbedViewport {
+  /** Stable name shared by Musea and Playwright snapshots. */
+  readonly name: "desktop" | "mobile";
+
+  /** CSS pixel viewport width. */
+  readonly width: number;
+
+  /** CSS pixel viewport height. */
+  readonly height: number;
+
+  /** Device scale factor used for visual regression snapshots. */
+  readonly deviceScaleFactor: number;
+}
+
+export const uiStoryTestbedViewports: readonly UiStoryTestbedViewport[] = [
+  { name: "desktop", width: 1280, height: 900, deviceScaleFactor: 1 },
+  { name: "mobile", width: 390, height: 844, deviceScaleFactor: 2 },
+] as const;
+
+export interface UiStoryTestbedArtifact {
+  /** Harness lane owned by this artifact. */
+  readonly surface: UiStoryTestbedSurface;
+
+  /** Whether the concrete file is already present or explicitly planned. */
+  readonly status: UiStoryTestbedArtifactStatus;
+
+  /** Source-local file paths that prove or will prove the surface. */
+  readonly files: readonly `src/${string}`[];
+}
+
+export interface UiStoryTestbedEntry {
+  /** Stable machine name copied from the public family catalog. */
+  readonly canonicalName: string;
+
+  /** Human-readable family title copied from the public family catalog. */
+  readonly title: string;
+
+  /** Package subpath this story-testbed entry covers. */
+  readonly packageSubpath: UiFamilyCatalogEntry["packageSubpath"];
+
+  /** Primary authored component or composable files that the story drives. */
+  readonly targetFiles: readonly `src/${string}`[];
+
+  /** Colocated Musea art file expected for this public family. */
+  readonly storyFile: `src/${string}.art.vue`;
+
+  /** Colocated Vue Test Utils story harness spec expected for this public family. */
+  readonly vueTestFile: `src/${string}.vue.test.ts`;
+
+  /** Colocated Vitest browser-mode spec expected for this public family. */
+  readonly browserTestFile: `src/${string}.browser.spec.ts`;
+
+  /** Colocated Playwright visual-regression spec expected for this public family. */
+  readonly vrtTestFile: `src/${string}.vrt.spec.ts`;
+
+  /** Existing catalogued behavior tests that keep the family observable today. */
+  readonly supportingTestFiles: readonly `src/${string}.test.ts`[];
+
+  /** Required state/control dimensions for future Musea variants. */
+  readonly matrixDimensions: readonly UiStoryMatrixDimension[];
+
+  /** Package theme presets that every visual story matrix must exercise. */
+  readonly presets: readonly ThemePresetName[];
+
+  /** Shared viewport set used by browser and VRT lanes. */
+  readonly viewports: readonly UiStoryTestbedViewport[];
+
+  /** Current concrete or planned evidence for the issue #4898 lanes. */
+  readonly artifacts: readonly UiStoryTestbedArtifact[];
+}
+
+export type UiStoryTestbedViolationCode =
+  | "duplicate-family"
+  | "duplicate-surface"
+  | "missing-surface"
+  | "missing-matrix-dimension"
+  | "missing-preset"
+  | "misplaced-story-file"
+  | "misplaced-vue-test-file"
+  | "misplaced-browser-test-file"
+  | "misplaced-vrt-test-file"
+  | "supporting-test-missing"
+  | "ready-artifact-missing"
+  | "planned-artifact-present";
+
+export interface UiStoryTestbedViolation {
+  readonly code: UiStoryTestbedViolationCode;
+  readonly family: string;
+  readonly message: string;
+}
+
+export interface UiStoryTestbedAuditOptions {
+  /**
+   * Source-root file inventory, relative to the package root. When provided,
+   * the audit checks ready/planned status against concrete files.
+   *
+   * @default undefined
+   */
+  readonly existingFiles?: ReadonlySet<string>;
+}
+
+function storyFileFor(canonicalName: string): `src/${string}.art.vue` {
+  return `src/${canonicalName}.art.vue`;
+}
+
+function vueTestFileFor(canonicalName: string): `src/${string}.vue.test.ts` {
+  return `src/${canonicalName}.vue.test.ts`;
+}
+
+function browserTestFileFor(canonicalName: string): `src/${string}.browser.spec.ts` {
+  return `src/${canonicalName}.browser.spec.ts`;
+}
+
+function vrtTestFileFor(canonicalName: string): `src/${string}.vrt.spec.ts` {
+  return `src/${canonicalName}.vrt.spec.ts`;
+}
+
+function isVueSourceFile(file: `src/${string}`): file is `src/${string}.vue` {
+  return file.endsWith(".vue");
+}
+
+function testbedTargetsFor(entry: UiFamilyCatalogEntry): readonly `src/${string}`[] {
+  const componentTargets = entry.sourceFiles.filter(isVueSourceFile);
+  return componentTargets.length > 0 ? componentTargets : [entry.entryFile];
+}
+
+function createStoryTestbedEntry(entry: UiFamilyCatalogEntry): UiStoryTestbedEntry {
+  const storyFile = storyFileFor(entry.canonicalName);
+  const vueTestFile = vueTestFileFor(entry.canonicalName);
+  const browserTestFile = browserTestFileFor(entry.canonicalName);
+  const vrtTestFile = vrtTestFileFor(entry.canonicalName);
+
+  return {
+    canonicalName: entry.canonicalName,
+    title: entry.title,
+    packageSubpath: entry.packageSubpath,
+    targetFiles: testbedTargetsFor(entry),
+    storyFile,
+    vueTestFile,
+    browserTestFile,
+    vrtTestFile,
+    supportingTestFiles: entry.tests,
+    matrixDimensions: uiStoryMatrixDimensions,
+    presets: themePresets,
+    viewports: uiStoryTestbedViewports,
+    artifacts: [
+      { surface: "musea-story", status: "planned", files: [storyFile] },
+      { surface: "vue-test-utils", status: "planned", files: [vueTestFile] },
+      { surface: "vitest-browser", status: "planned", files: [browserTestFile] },
+      { surface: "playwright-vrt", status: "planned", files: [vrtTestFile] },
+    ],
+  };
+}
+
+export const uiStoryTestbedInventory: readonly UiStoryTestbedEntry[] =
+  uiFamilyCatalog.map(createStoryTestbedEntry);
+
+export function auditUiStoryTestbedInventory(
+  inventory: readonly UiStoryTestbedEntry[] = uiStoryTestbedInventory,
+  options: UiStoryTestbedAuditOptions = {},
+): readonly UiStoryTestbedViolation[] {
+  const violations: UiStoryTestbedViolation[] = [];
+  const seenFamilies = new Set<string>();
+
+  for (const entry of inventory) {
+    if (seenFamilies.has(entry.canonicalName)) {
+      violations.push({
+        code: "duplicate-family",
+        family: entry.canonicalName,
+        message: "family appears more than once in the story-testbed inventory",
+      });
+    }
+    seenFamilies.add(entry.canonicalName);
+
+    if (entry.storyFile !== storyFileFor(entry.canonicalName)) {
+      violations.push({
+        code: "misplaced-story-file",
+        family: entry.canonicalName,
+        message: `expected ${storyFileFor(entry.canonicalName)}, got ${entry.storyFile}`,
+      });
+    }
+
+    if (entry.vueTestFile !== vueTestFileFor(entry.canonicalName)) {
+      violations.push({
+        code: "misplaced-vue-test-file",
+        family: entry.canonicalName,
+        message: `expected ${vueTestFileFor(entry.canonicalName)}, got ${entry.vueTestFile}`,
+      });
+    }
+
+    if (entry.browserTestFile !== browserTestFileFor(entry.canonicalName)) {
+      violations.push({
+        code: "misplaced-browser-test-file",
+        family: entry.canonicalName,
+        message: `expected ${browserTestFileFor(entry.canonicalName)}, got ${entry.browserTestFile}`,
+      });
+    }
+
+    if (entry.vrtTestFile !== vrtTestFileFor(entry.canonicalName)) {
+      violations.push({
+        code: "misplaced-vrt-test-file",
+        family: entry.canonicalName,
+        message: `expected ${vrtTestFileFor(entry.canonicalName)}, got ${entry.vrtTestFile}`,
+      });
+    }
+
+    pushMissingValues(
+      violations,
+      entry,
+      "missing-matrix-dimension",
+      uiStoryMatrixDimensions,
+      entry.matrixDimensions,
+      "matrix dimension",
+    );
+    pushMissingValues(
+      violations,
+      entry,
+      "missing-preset",
+      themePresets,
+      entry.presets,
+      "theme preset",
+    );
+    auditArtifacts(violations, entry, options.existingFiles);
+    auditSupportingTests(violations, entry, options.existingFiles);
+  }
+
+  return violations;
+}
+
+export function formatUiStoryTestbedViolations(
+  violations: readonly UiStoryTestbedViolation[],
+): string {
+  return violations
+    .map((violation) => `${violation.code}: ${violation.family}: ${violation.message}`)
+    .join("\n");
+}
+
+function pushMissingValues<Value extends string>(
+  violations: UiStoryTestbedViolation[],
+  entry: UiStoryTestbedEntry,
+  code: Extract<
+    UiStoryTestbedViolationCode,
+    "missing-matrix-dimension" | "missing-preset" | "missing-surface"
+  >,
+  required: readonly Value[],
+  actual: readonly Value[],
+  label: string,
+): void {
+  const actualSet = new Set(actual);
+  for (const value of required) {
+    if (actualSet.has(value)) continue;
+    violations.push({
+      code,
+      family: entry.canonicalName,
+      message: `missing ${label} ${value}`,
+    });
+  }
+}
+
+function auditSupportingTests(
+  violations: UiStoryTestbedViolation[],
+  entry: UiStoryTestbedEntry,
+  existingFiles: ReadonlySet<string> | undefined,
+): void {
+  if (!existingFiles) return;
+  for (const file of entry.supportingTestFiles) {
+    if (existingFiles.has(file)) continue;
+    violations.push({
+      code: "supporting-test-missing",
+      family: entry.canonicalName,
+      message: `catalogued behavior test ${file} does not exist`,
+    });
+  }
+}
+
+function auditArtifacts(
+  violations: UiStoryTestbedViolation[],
+  entry: UiStoryTestbedEntry,
+  existingFiles: ReadonlySet<string> | undefined,
+): void {
+  const surfaces = entry.artifacts.map((artifact) => artifact.surface);
+  pushMissingValues(
+    violations,
+    entry,
+    "missing-surface",
+    uiStoryTestbedSurfaces,
+    surfaces,
+    "surface",
+  );
+
+  const seenSurfaces = new Set<UiStoryTestbedSurface>();
+  for (const artifact of entry.artifacts) {
+    if (seenSurfaces.has(artifact.surface)) {
+      violations.push({
+        code: "duplicate-surface",
+        family: entry.canonicalName,
+        message: `surface ${artifact.surface} appears more than once`,
+      });
+    }
+    seenSurfaces.add(artifact.surface);
+
+    if (!existingFiles) continue;
+    for (const file of artifact.files) {
+      const exists = existingFiles.has(file);
+      if (artifact.status === "ready" && !exists) {
+        violations.push({
+          code: "ready-artifact-missing",
+          family: entry.canonicalName,
+          message: `${artifact.surface} marks ${file} ready but the file does not exist`,
+        });
+      }
+      if (artifact.status === "planned" && exists) {
+        violations.push({
+          code: "planned-artifact-present",
+          family: entry.canonicalName,
+          message: `${artifact.surface} file ${file} exists but is still marked planned`,
+        });
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a source-local story-testbed behavior contract for #4898
- derive an internal inventory from the UI family catalog for Musea, Vue Test Utils, Vitest browser, and Playwright VRT planned artifacts
- audit supporting behavior tests plus deterministic planned story/testbed paths across the current public UI families

## Verification
- node /Users/ubugeeei/.cache/node/corepack/v1/pnpm/12.1.0/bin/pnpm.mjs install --frozen-lockfile --prefer-offline
- vp fmt --write src scripts vite.config.ts
- vp test run src/story-testbed.test.ts
- vp exec node scripts/lint-sfc.ts src && vp exec node scripts/check-renderers.ts src && vp check src scripts vite.config.ts tsconfig.typecheck.json && vp exec vue-tsc --noEmit -p tsconfig.typecheck.json
- vp pack && node scripts/check-size.mjs && node scripts/check-tree-shaking.mjs && vp test run

Refs #4898

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790613883&installation_model_id=422833&pr_number=5259&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5259&signature=459cdb8d4c94a97a365eef6045de98589cbb681b8df777353667f600e3cb6c7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a UI story-testbed inventory covering component families, story locations, supported test surfaces, matrix dimensions, presets, and viewports.
  * Added auditing and reporting for missing files, incomplete coverage, invalid placements, and artifact readiness.
  * Documented the story-testbed behavior contract, including deterministic inventory generation and evidence requirements.

* **Tests**
  * Added comprehensive validation for inventory alignment, file colocation, matrix configuration, source auditing, and supporting test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->