### PR TITLE
feat(ui): add source registry CLI foundation

### DIFF
--- a/npm/ui/core/scripts/source-registry.ts
+++ b/npm/ui/core/scripts/source-registry.ts
@@ -47,12 +47,13 @@ type CliRecord =
       readonly family: UiSourceFamilyManifest;
     };
 
-const usage = `Usage:
+const usage = `Usage (repository checkout only; not a published @vizejs/ui package bin):
+  cd npm/ui/core
   node scripts/source-registry.ts list [--format json|jsonl]
   node scripts/source-registry.ts search <query> [--format json|jsonl]
   node scripts/source-registry.ts info <name-or-alias> [--format json|jsonl]
 
-Commands are read-only. Source install, update, diff, cache, and rollback commands are tracked by issue #4896 but are not implemented in this foundation slice.
+This CLI imports package source files from the checkout. Commands are read-only. Source install, update, diff, cache, package-consumer bin, and rollback commands are tracked by issue #4896 but are not implemented in this foundation slice.
 `;
 
 const mutatingCommands = new Set([

--- a/npm/ui/core/scripts/source-registry.ts
+++ b/npm/ui/core/scripts/source-registry.ts
@@ -1,0 +1,263 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import {
+  UI_SOURCE_REGISTRY_SCHEMA_VERSION,
+  createUiSourceRegistryManifest,
+  getUiSourceFamilyInfo,
+  listUiSourceFamilies,
+  searchUiSourceFamilies,
+  type UiSourceFamilyManifest,
+  type UiSourceFamilySummary,
+  type UiSourceRegistryOutputFormat,
+  type UiSourceSearchResult,
+} from "../src/source-registry.ts";
+
+interface WritableOutput {
+  write(chunk: string): void;
+}
+
+interface CliIo {
+  readonly stdout: WritableOutput;
+  readonly stderr: WritableOutput;
+}
+
+interface ParsedArgs {
+  readonly format: UiSourceRegistryOutputFormat;
+  readonly help: boolean;
+  readonly positional: readonly string[];
+  readonly error: string | null;
+}
+
+type CliRecord =
+  | {
+      readonly schemaVersion: typeof UI_SOURCE_REGISTRY_SCHEMA_VERSION;
+      readonly command: "list";
+      readonly family: UiSourceFamilySummary;
+    }
+  | {
+      readonly schemaVersion: typeof UI_SOURCE_REGISTRY_SCHEMA_VERSION;
+      readonly command: "search";
+      readonly query: string;
+      readonly match: UiSourceSearchResult;
+    }
+  | {
+      readonly schemaVersion: typeof UI_SOURCE_REGISTRY_SCHEMA_VERSION;
+      readonly command: "info";
+      readonly family: UiSourceFamilyManifest;
+    };
+
+const usage = `Usage:
+  node scripts/source-registry.ts list [--format json|jsonl]
+  node scripts/source-registry.ts search <query> [--format json|jsonl]
+  node scripts/source-registry.ts info <name-or-alias> [--format json|jsonl]
+
+Commands are read-only. Source install, update, diff, cache, and rollback commands are tracked by issue #4896 but are not implemented in this foundation slice.
+`;
+
+const mutatingCommands = new Set([
+  "init",
+  "add",
+  "add-many",
+  "remove",
+  "diff",
+  "update",
+  "doctor",
+  "audit",
+]);
+
+function parseFormat(value: string): UiSourceRegistryOutputFormat | null {
+  return value === "json" || value === "jsonl" ? value : null;
+}
+
+function parseArgs(args: readonly string[]): ParsedArgs {
+  let format: UiSourceRegistryOutputFormat = "json";
+  let help = false;
+  const positional: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg == null) continue;
+
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+      continue;
+    }
+
+    if (arg === "--json") {
+      format = "json";
+      continue;
+    }
+
+    if (arg === "--jsonl") {
+      format = "jsonl";
+      continue;
+    }
+
+    if (arg === "--format") {
+      const value = args[index + 1];
+      if (value == null) {
+        return { format, help, positional, error: "--format requires json or jsonl" };
+      }
+
+      const parsedFormat = parseFormat(value);
+      if (parsedFormat == null) {
+        return { format, help, positional, error: `Unsupported output format "${value}"` };
+      }
+
+      format = parsedFormat;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith("--format=")) {
+      const parsedFormat = parseFormat(arg.slice("--format=".length));
+      if (parsedFormat == null) {
+        return { format, help, positional, error: `Unsupported output format "${arg}"` };
+      }
+
+      format = parsedFormat;
+      continue;
+    }
+
+    if (arg.startsWith("-")) {
+      return { format, help, positional, error: `Unsupported option "${arg}"` };
+    }
+
+    positional.push(arg);
+  }
+
+  return { format, help, positional, error: null };
+}
+
+function writeJson(output: WritableOutput, value: unknown): void {
+  output.write(`${JSON.stringify(value, null, 2)}\n`);
+}
+
+function writeJsonl(output: WritableOutput, records: readonly CliRecord[]): void {
+  for (const record of records) output.write(`${JSON.stringify(record)}\n`);
+}
+
+function writeError(io: CliIo, message: string): number {
+  io.stderr.write(`${message}\n\n${usage}`);
+  return 1;
+}
+
+function queryFromArgs(args: readonly string[]): string {
+  return args.join(" ").trim();
+}
+
+export function runUiSourceRegistryCli(
+  args: readonly string[],
+  io: CliIo = { stdout: process.stdout, stderr: process.stderr },
+): number {
+  const parsed = parseArgs(args);
+  if (parsed.help) {
+    io.stdout.write(usage);
+    return 0;
+  }
+
+  if (parsed.error != null) return writeError(io, parsed.error);
+
+  const command = parsed.positional[0];
+  if (command == null) {
+    io.stdout.write(usage);
+    return 0;
+  }
+
+  if (mutatingCommands.has(command)) {
+    return writeError(
+      io,
+      `Command "${command}" is read-only in this foundation slice; install workflows remain tracked by issue #4896.`,
+    );
+  }
+
+  const manifest = createUiSourceRegistryManifest();
+
+  if (command === "list") {
+    if (parsed.positional.length !== 1) {
+      return writeError(io, "The list command does not accept a query");
+    }
+
+    const families = listUiSourceFamilies(manifest);
+    if (parsed.format === "jsonl") {
+      writeJsonl(
+        io.stdout,
+        families.map((family) => ({
+          schemaVersion: UI_SOURCE_REGISTRY_SCHEMA_VERSION,
+          command,
+          family,
+        })),
+      );
+    } else {
+      writeJson(io.stdout, {
+        schemaVersion: UI_SOURCE_REGISTRY_SCHEMA_VERSION,
+        command,
+        familyCount: families.length,
+        families,
+      });
+    }
+    return 0;
+  }
+
+  if (command === "search") {
+    const query = queryFromArgs(parsed.positional.slice(1));
+    if (query.length === 0) return writeError(io, "The search command requires a query");
+
+    const matches = searchUiSourceFamilies(query, manifest);
+    if (parsed.format === "jsonl") {
+      writeJsonl(
+        io.stdout,
+        matches.map((match) => ({
+          schemaVersion: UI_SOURCE_REGISTRY_SCHEMA_VERSION,
+          command,
+          query,
+          match,
+        })),
+      );
+    } else {
+      writeJson(io.stdout, {
+        schemaVersion: UI_SOURCE_REGISTRY_SCHEMA_VERSION,
+        command,
+        query,
+        matchCount: matches.length,
+        matches,
+      });
+    }
+    return 0;
+  }
+
+  if (command === "info") {
+    const target = queryFromArgs(parsed.positional.slice(1));
+    if (target.length === 0) return writeError(io, "The info command requires a family name");
+
+    const family = getUiSourceFamilyInfo(target, manifest);
+    if (family == null) return writeError(io, `Unknown UI source family "${target}"`);
+
+    if (parsed.format === "jsonl") {
+      writeJsonl(io.stdout, [
+        {
+          schemaVersion: UI_SOURCE_REGISTRY_SCHEMA_VERSION,
+          command,
+          family,
+        },
+      ]);
+    } else {
+      writeJson(io.stdout, {
+        schemaVersion: UI_SOURCE_REGISTRY_SCHEMA_VERSION,
+        command,
+        family,
+      });
+    }
+    return 0;
+  }
+
+  return writeError(io, `Unsupported command "${command}"`);
+}
+
+const isMain =
+  process.argv[1] != null && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url;
+
+if (isMain) {
+  process.exitCode = runUiSourceRegistryCli(process.argv.slice(2));
+}

--- a/npm/ui/core/src/source-registry.behavior.md
+++ b/npm/ui/core/src/source-registry.behavior.md
@@ -1,0 +1,24 @@
+# Source Registry Behavior
+
+The source registry is the read-only manifest surface for future source-owned
+install workflows tracked by issue #4896. It projects the existing
+`uiFamilyCatalog` into deterministic JSON so tooling can discover the source
+files, behavior contract, tests, type tests, dependencies, and bundle evidence
+for each UI family without reading package exports.
+
+| Command                | Output                                                     | Contract                                                                                                               |
+| ---------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `list`                 | JSON or JSONL family summaries in canonical catalog order. | Does not inspect user projects, write files, or resolve remote packages.                                               |
+| `search <query>`       | JSON or JSONL matches with the fields that matched.        | Searches names, titles, aliases, upstream coverage, source paths, and quality gates with deterministic token matching. |
+| `info <name-or-alias>` | JSON or JSONL full family manifest.                        | Resolves canonical names, package subpaths, titles, and exact aliases before returning source-owned artifacts.         |
+
+## Non-goals
+
+- It does not implement `init`, `add`, `add-many`, `remove`, `diff`, `update`,
+  `doctor`, or `audit`.
+- It does not create an offline cache, signed index, transaction journal,
+  rollback path, or three-way update.
+- It does not expose a new public package subpath.
+
+Future mutating commands must keep dry-run and machine-readable output as a
+first-class contract before writing user files.

--- a/npm/ui/core/src/source-registry.behavior.md
+++ b/npm/ui/core/src/source-registry.behavior.md
@@ -1,7 +1,7 @@
 # Source Registry Behavior
 
-The source registry is the read-only manifest surface for future source-owned
-install workflows tracked by issue #4896. It projects the existing
+The source registry is the repository-only, read-only manifest surface for
+future source-owned install workflows tracked by issue #4896. It projects the existing
 `uiFamilyCatalog` into deterministic JSON so tooling can discover the source
 files, behavior contract, tests, type tests, dependencies, and bundle evidence
 for each UI family without reading package exports.
@@ -19,6 +19,8 @@ for each UI family without reading package exports.
 - It does not create an offline cache, signed index, transaction journal,
   rollback path, or three-way update.
 - It does not expose a new public package subpath.
+- It does not publish a package bin or support execution from an installed
+  `@vizejs/ui` consumer project.
 
 Future mutating commands must keep dry-run and machine-readable output as a
 first-class contract before writing user files.

--- a/npm/ui/core/src/source-registry.test.ts
+++ b/npm/ui/core/src/source-registry.test.ts
@@ -1,0 +1,228 @@
+import assert from "node:assert/strict";
+import { readFile, stat } from "node:fs/promises";
+import path from "node:path";
+
+import { test } from "vite-plus/test";
+
+import { runUiSourceRegistryCli } from "../scripts/source-registry.ts";
+import { UI_FAMILY_CATALOG_SCHEMA_VERSION, uiFamilyCatalog } from "./family-catalog.ts";
+import {
+  UI_SOURCE_REGISTRY_PACKAGE_NAME,
+  UI_SOURCE_REGISTRY_SCHEMA_VERSION,
+  UI_SOURCE_REGISTRY_SOURCE_ROOT,
+  createUiSourceRegistryManifest,
+  getUiSourceFamilyInfo,
+  listUiSourceFamilies,
+  searchUiSourceFamilies,
+  type UiSourceFamilyManifest,
+  type UiSourceFamilySummary,
+  type UiSourceSearchResult,
+} from "./source-registry.ts";
+
+interface ListJsonOutput {
+  readonly schemaVersion: number;
+  readonly command: "list";
+  readonly familyCount: number;
+  readonly families: readonly UiSourceFamilySummary[];
+}
+
+interface SearchJsonOutput {
+  readonly schemaVersion: number;
+  readonly command: "search";
+  readonly query: string;
+  readonly matchCount: number;
+  readonly matches: readonly UiSourceSearchResult[];
+}
+
+interface InfoJsonOutput {
+  readonly schemaVersion: number;
+  readonly command: "info";
+  readonly family: UiSourceFamilyManifest;
+}
+
+interface CapturedCli {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+function runCli(args: readonly string[]): CapturedCli {
+  let stdout = "";
+  let stderr = "";
+  const exitCode = runUiSourceRegistryCli(args, {
+    stdout: {
+      write(chunk) {
+        stdout += chunk;
+      },
+    },
+    stderr: {
+      write(chunk) {
+        stderr += chunk;
+      },
+    },
+  });
+
+  return { exitCode, stdout, stderr };
+}
+
+function parseJson<Output>(source: string): Output {
+  return JSON.parse(source) as Output;
+}
+
+test("projects the family catalog into a deterministic source-owned registry manifest", () => {
+  const manifest = createUiSourceRegistryManifest();
+  const manifestAgain = createUiSourceRegistryManifest();
+
+  assert.equal(manifest.schemaVersion, UI_SOURCE_REGISTRY_SCHEMA_VERSION);
+  assert.equal(manifest.catalogSchemaVersion, UI_FAMILY_CATALOG_SCHEMA_VERSION);
+  assert.equal(manifest.registryKind, "source-owned");
+  assert.equal(manifest.packageName, UI_SOURCE_REGISTRY_PACKAGE_NAME);
+  assert.equal(manifest.sourceRoot, UI_SOURCE_REGISTRY_SOURCE_ROOT);
+  assert.equal(JSON.stringify(manifest), JSON.stringify(manifestAgain));
+
+  assert.deepEqual(
+    manifest.families.map((family) => family.name),
+    uiFamilyCatalog.map((entry) => entry.canonicalName),
+  );
+  assert.deepEqual(
+    listUiSourceFamilies(manifest).map((family) => family.name),
+    manifest.families.map((family) => family.name),
+  );
+});
+
+test("manifest entries stay source-installable and drift-sensitive", async () => {
+  const manifest = createUiSourceRegistryManifest();
+  const familyNames = new Set(manifest.families.map((family) => family.name));
+
+  for (const family of manifest.families) {
+    assert.equal(family.packageName, UI_SOURCE_REGISTRY_PACKAGE_NAME);
+    assert.equal(
+      family.source.sourceFiles.includes(family.source.entryFile),
+      true,
+      `${family.name} source files must include its entry file`,
+    );
+    assert.equal(
+      family.kind,
+      family.source.sourceFiles.some((file) => file.endsWith(".vue")) ? "component" : "foundation",
+    );
+    assert.equal(
+      new Set(family.source.sourceFiles).size,
+      family.source.sourceFiles.length,
+      `${family.name} source files must not contain duplicates`,
+    );
+    assert.equal(
+      new Set(family.dependencies).size,
+      family.dependencies.length,
+      `${family.name} dependencies must not contain duplicates`,
+    );
+    assert.ok(family.bundleBudget, `${family.name} must expose its enforced bundle budget`);
+
+    for (const dependency of family.dependencies) {
+      assert.ok(familyNames.has(dependency), `${family.name} has unknown dependency ${dependency}`);
+      assert.notEqual(dependency, family.name, `${family.name} must not depend on itself`);
+    }
+
+    const sourcePaths = [
+      ...family.source.sourceFiles,
+      family.source.behaviorContract,
+      ...family.source.tests,
+      ...family.source.typeTests,
+    ];
+    await Promise.all(sourcePaths.map((file) => stat(path.resolve(file))));
+  }
+});
+
+test("search and info resolve source families by names, aliases, and coverage", () => {
+  const manifest = createUiSourceRegistryManifest();
+
+  assert.equal(getUiSourceFamilyInfo("action-button", manifest)?.name, "button");
+  assert.equal(getUiSourceFamilyInfo("./checkbox", manifest)?.name, "checkbox");
+  assert.equal(getUiSourceFamilyInfo("Live Region", manifest)?.name, "live-region");
+  assert.equal(getUiSourceFamilyInfo("missing-family", manifest), undefined);
+
+  const roving = searchUiSourceFamilies("roving focus", manifest);
+  assert.deepEqual(
+    roving.map((match) => match.family.name),
+    ["composite-navigation"],
+  );
+  assert.deepEqual(roving[0]?.matchedFields, ["alias", "upstreamCoverage"]);
+
+  const ariaLive = searchUiSourceFamilies("aria live", manifest);
+  assert.ok(ariaLive.some((match) => match.family.name === "live-region"));
+  assert.ok(ariaLive.some((match) => match.matchedFields.includes("upstreamCoverage")));
+});
+
+test("documents the read-only command contract", async () => {
+  const behavior = await readFile(path.resolve("src/source-registry.behavior.md"), "utf8");
+
+  assert.match(behavior, /^\| Command\s+\| Output\s+\| Contract\s+\|$/m);
+  assert.match(behavior, /read-only manifest surface/);
+  assert.match(behavior, /It does not implement `init`, `add`, `add-many`/);
+  assert.match(behavior, /It does not expose a new public package subpath/);
+});
+
+test("CLI emits deterministic machine-readable list, search, and info output", () => {
+  const listOutput = runCli(["list", "--format", "json"]);
+  const shorthandListOutput = runCli(["list", "--json"]);
+  assert.equal(listOutput.exitCode, 0);
+  assert.equal(shorthandListOutput.exitCode, 0);
+  assert.equal(listOutput.stdout, shorthandListOutput.stdout);
+  assert.equal(listOutput.stderr, "");
+
+  const listed = parseJson<ListJsonOutput>(listOutput.stdout);
+  assert.equal(listed.schemaVersion, UI_SOURCE_REGISTRY_SCHEMA_VERSION);
+  assert.equal(listed.command, "list");
+  assert.equal(listed.familyCount, uiFamilyCatalog.length);
+  assert.deepEqual(
+    listed.families.map((family) => family.name),
+    uiFamilyCatalog.map((entry) => entry.canonicalName),
+  );
+
+  const searchOutput = runCli(["search", "roving", "focus"]);
+  assert.equal(searchOutput.exitCode, 0);
+  assert.equal(searchOutput.stderr, "");
+  const search = parseJson<SearchJsonOutput>(searchOutput.stdout);
+  assert.equal(search.schemaVersion, UI_SOURCE_REGISTRY_SCHEMA_VERSION);
+  assert.equal(search.command, "search");
+  assert.equal(search.query, "roving focus");
+  assert.equal(search.matchCount, 1);
+  assert.equal(search.matches[0]?.family.name, "composite-navigation");
+  assert.deepEqual(search.matches[0]?.matchedFields, ["alias", "upstreamCoverage"]);
+
+  const infoOutput = runCli(["info", "./button"]);
+  assert.equal(infoOutput.exitCode, 0);
+  assert.equal(infoOutput.stderr, "");
+  const info = parseJson<InfoJsonOutput>(infoOutput.stdout);
+  assert.equal(info.schemaVersion, UI_SOURCE_REGISTRY_SCHEMA_VERSION);
+  assert.equal(info.command, "info");
+  assert.equal(info.family.name, "button");
+  assert.equal(info.family.source.entryFile, "src/button.ts");
+});
+
+test("CLI jsonl output is one schema-versioned record per result", () => {
+  const output = runCli(["search", "safe", "triangle", "--jsonl"]);
+  assert.equal(output.exitCode, 0);
+  assert.equal(output.stderr, "");
+  const lines = output.stdout.trim().split("\n");
+  const records = lines.map((line) => parseJson<{ readonly schemaVersion: number }>(line));
+
+  assert.ok(lines.length > 0);
+  assert.ok(records.every((record) => record.schemaVersion === UI_SOURCE_REGISTRY_SCHEMA_VERSION));
+  assert.ok(lines.every((line) => !line.includes("\n")));
+
+  const infoOutput = runCli(["info", "action-button", "--format=jsonl"]);
+  assert.equal(infoOutput.exitCode, 0);
+  assert.equal(infoOutput.stderr, "");
+  const infoLines = infoOutput.stdout.trim().split("\n");
+  assert.equal(infoLines.length, 1);
+  assert.equal(parseJson<InfoJsonOutput>(infoLines[0] ?? "").family.name, "button");
+});
+
+test("CLI rejects mutating issue-4896 commands in this foundation slice", () => {
+  const output = runCli(["add", "button"]);
+
+  assert.equal(output.exitCode, 1);
+  assert.equal(output.stdout, "");
+  assert.match(output.stderr, /read-only in this foundation slice/);
+  assert.match(output.stderr, /issue #4896/);
+});

--- a/npm/ui/core/src/source-registry.test.ts
+++ b/npm/ui/core/src/source-registry.test.ts
@@ -159,9 +159,16 @@ test("documents the read-only command contract", async () => {
   assert.match(behavior, /read-only manifest surface/);
   assert.match(behavior, /It does not implement `init`, `add`, `add-many`/);
   assert.match(behavior, /It does not expose a new public package subpath/);
+  assert.match(behavior, /does not publish a package bin/);
 });
 
 test("CLI emits deterministic machine-readable list, search, and info output", () => {
+  const helpOutput = runCli(["--help"]);
+  assert.equal(helpOutput.exitCode, 0);
+  assert.match(helpOutput.stdout, /repository checkout only/);
+  assert.match(helpOutput.stdout, /not a published @vizejs\/ui package bin/);
+  assert.match(helpOutput.stdout, /imports package source files from the checkout/);
+
   const listOutput = runCli(["list", "--format", "json"]);
   const shorthandListOutput = runCli(["list", "--json"]);
   assert.equal(listOutput.exitCode, 0);

--- a/npm/ui/core/src/source-registry.ts
+++ b/npm/ui/core/src/source-registry.ts
@@ -1,0 +1,268 @@
+import { uiFamilyCatalog } from "./family-catalog.ts";
+import {
+  UI_FAMILY_CATALOG_SCHEMA_VERSION,
+  type UiFamilyCatalogEntry,
+  type UiFamilyMaturity,
+  type UiFamilyQualityGate,
+} from "./family-catalog-types.ts";
+
+export const UI_SOURCE_REGISTRY_SCHEMA_VERSION = 1;
+export const UI_SOURCE_REGISTRY_PACKAGE_NAME = "@vizejs/ui";
+export const UI_SOURCE_REGISTRY_SOURCE_ROOT = "npm/ui/core";
+
+export type UiSourceRegistryKind = "source-owned";
+export type UiSourceFamilyKind = "component" | "foundation";
+export type UiSourceRegistryOutputFormat = "json" | "jsonl";
+export type UiSourceRendererFixture = NonNullable<UiFamilyCatalogEntry["rendererFixture"]>;
+
+export interface UiSourceBundleBudgetManifest {
+  readonly exportName: string;
+  readonly retainedSignature: string;
+  readonly allowedRetainedFamilies: readonly string[];
+  readonly maximumJavaScriptGzipBytes: number;
+  readonly maximumCssGzipBytes: number;
+}
+
+export interface UiSourceFamilySourceManifest {
+  readonly entryFile: UiFamilyCatalogEntry["entryFile"];
+  readonly sourceFiles: readonly `src/${string}`[];
+  readonly behaviorContract: UiFamilyCatalogEntry["behaviorContract"];
+  readonly tests: readonly `src/${string}.test.ts`[];
+  readonly typeTests: readonly `src/${string}.types.test-d.ts`[];
+  readonly rendererFixture: UiSourceRendererFixture | null;
+}
+
+export interface UiSourceFamilyManifest {
+  readonly name: string;
+  readonly title: string;
+  readonly kind: UiSourceFamilyKind;
+  readonly packageName: typeof UI_SOURCE_REGISTRY_PACKAGE_NAME;
+  readonly packageSubpath: UiFamilyCatalogEntry["packageSubpath"];
+  readonly source: UiSourceFamilySourceManifest;
+  readonly dependencies: readonly string[];
+  readonly aliases: readonly string[];
+  readonly upstreamCoverage: readonly string[];
+  readonly qualityGates: readonly UiFamilyQualityGate[];
+  readonly bundleBudget: UiSourceBundleBudgetManifest | null;
+  readonly maturity: UiFamilyMaturity;
+  readonly owner: string;
+}
+
+export interface UiSourceFamilySummary {
+  readonly name: string;
+  readonly title: string;
+  readonly kind: UiSourceFamilyKind;
+  readonly packageSubpath: UiFamilyCatalogEntry["packageSubpath"];
+  readonly entryFile: UiFamilyCatalogEntry["entryFile"];
+  readonly sourceFileCount: number;
+  readonly testFileCount: number;
+  readonly typeTestFileCount: number;
+  readonly dependencies: readonly string[];
+  readonly maturity: UiFamilyMaturity;
+}
+
+export interface UiSourceRegistryManifest {
+  readonly schemaVersion: typeof UI_SOURCE_REGISTRY_SCHEMA_VERSION;
+  readonly catalogSchemaVersion: typeof UI_FAMILY_CATALOG_SCHEMA_VERSION;
+  readonly registryKind: UiSourceRegistryKind;
+  readonly packageName: typeof UI_SOURCE_REGISTRY_PACKAGE_NAME;
+  readonly sourceRoot: typeof UI_SOURCE_REGISTRY_SOURCE_ROOT;
+  readonly families: readonly UiSourceFamilyManifest[];
+}
+
+export type UiSourceSearchField =
+  | "name"
+  | "title"
+  | "alias"
+  | "upstreamCoverage"
+  | "source"
+  | "qualityGate";
+
+export interface UiSourceSearchResult {
+  readonly family: UiSourceFamilySummary;
+  readonly matchedFields: readonly UiSourceSearchField[];
+}
+
+const searchFields = [
+  "name",
+  "title",
+  "alias",
+  "upstreamCoverage",
+  "source",
+  "qualityGate",
+] as const satisfies readonly UiSourceSearchField[];
+
+function copyStrings<Value extends string>(values: readonly Value[]): readonly Value[] {
+  return [...values];
+}
+
+function getFamilyKind(entry: UiFamilyCatalogEntry): UiSourceFamilyKind {
+  return entry.sourceFiles.some((file) => file.endsWith(".vue")) ? "component" : "foundation";
+}
+
+function createBundleBudgetManifest(
+  entry: UiFamilyCatalogEntry,
+): UiSourceBundleBudgetManifest | null {
+  if (entry.bundleBudget == null) return null;
+
+  return {
+    exportName: entry.bundleBudget.exportName,
+    retainedSignature: entry.bundleBudget.retainedSignature,
+    allowedRetainedFamilies: copyStrings(entry.bundleBudget.allowedRetainedFamilies ?? []),
+    maximumJavaScriptGzipBytes: entry.bundleBudget.maximumJavaScriptGzipBytes,
+    maximumCssGzipBytes: entry.bundleBudget.maximumCssGzipBytes,
+  };
+}
+
+function createFamilyManifest(entry: UiFamilyCatalogEntry): UiSourceFamilyManifest {
+  return {
+    name: entry.canonicalName,
+    title: entry.title,
+    kind: getFamilyKind(entry),
+    packageName: UI_SOURCE_REGISTRY_PACKAGE_NAME,
+    packageSubpath: entry.packageSubpath,
+    source: {
+      entryFile: entry.entryFile,
+      sourceFiles: copyStrings(entry.sourceFiles),
+      behaviorContract: entry.behaviorContract,
+      tests: copyStrings(entry.tests),
+      typeTests: copyStrings(entry.typeTests ?? []),
+      rendererFixture: entry.rendererFixture ?? null,
+    },
+    dependencies: copyStrings(entry.dependencies),
+    aliases: copyStrings(entry.aliases),
+    upstreamCoverage: copyStrings(entry.upstreamCoverage),
+    qualityGates: copyStrings(entry.qualityGates),
+    bundleBudget: createBundleBudgetManifest(entry),
+    maturity: entry.maturity,
+    owner: entry.owner,
+  };
+}
+
+export function createUiSourceRegistryManifest(): UiSourceRegistryManifest {
+  return {
+    schemaVersion: UI_SOURCE_REGISTRY_SCHEMA_VERSION,
+    catalogSchemaVersion: UI_FAMILY_CATALOG_SCHEMA_VERSION,
+    registryKind: "source-owned",
+    packageName: UI_SOURCE_REGISTRY_PACKAGE_NAME,
+    sourceRoot: UI_SOURCE_REGISTRY_SOURCE_ROOT,
+    families: uiFamilyCatalog.map(createFamilyManifest),
+  };
+}
+
+export function summarizeUiSourceFamily(family: UiSourceFamilyManifest): UiSourceFamilySummary {
+  return {
+    name: family.name,
+    title: family.title,
+    kind: family.kind,
+    packageSubpath: family.packageSubpath,
+    entryFile: family.source.entryFile,
+    sourceFileCount: family.source.sourceFiles.length,
+    testFileCount: family.source.tests.length,
+    typeTestFileCount: family.source.typeTests.length,
+    dependencies: copyStrings(family.dependencies),
+    maturity: family.maturity,
+  };
+}
+
+export function listUiSourceFamilies(
+  manifest: UiSourceRegistryManifest = createUiSourceRegistryManifest(),
+): readonly UiSourceFamilySummary[] {
+  return manifest.families.map(summarizeUiSourceFamily);
+}
+
+function normalizeSearchValue(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function searchTokens(query: string): readonly string[] {
+  const normalized = normalizeSearchValue(query);
+  return normalized.length === 0 ? [] : normalized.split(/\s+/);
+}
+
+function matchesTokens(value: string, tokens: readonly string[]): boolean {
+  if (tokens.length === 0) return false;
+
+  const normalized = normalizeSearchValue(value);
+  return tokens.every((token) => normalized.includes(token));
+}
+
+function packageSubpathName(family: UiSourceFamilyManifest): string {
+  return family.packageSubpath === "." ? "." : family.packageSubpath.slice(2);
+}
+
+function sourceSearchValues(family: UiSourceFamilyManifest): readonly string[] {
+  const rendererFixture =
+    family.source.rendererFixture == null ? [] : [family.source.rendererFixture];
+
+  return [
+    family.source.entryFile,
+    ...family.source.sourceFiles,
+    family.source.behaviorContract,
+    ...family.source.tests,
+    ...family.source.typeTests,
+    ...rendererFixture,
+  ];
+}
+
+function fieldSearchValues(
+  family: UiSourceFamilyManifest,
+  field: UiSourceSearchField,
+): readonly string[] {
+  switch (field) {
+    case "name":
+      return [family.name, family.packageSubpath, packageSubpathName(family)];
+    case "title":
+      return [family.title];
+    case "alias":
+      return family.aliases;
+    case "upstreamCoverage":
+      return family.upstreamCoverage;
+    case "source":
+      return sourceSearchValues(family);
+    case "qualityGate":
+      return family.qualityGates;
+  }
+}
+
+export function searchUiSourceFamilies(
+  query: string,
+  manifest: UiSourceRegistryManifest = createUiSourceRegistryManifest(),
+): readonly UiSourceSearchResult[] {
+  const tokens = searchTokens(query);
+  if (tokens.length === 0) return [];
+
+  return manifest.families.flatMap((family): readonly UiSourceSearchResult[] => {
+    const matchedFields = searchFields.filter((field) =>
+      fieldSearchValues(family, field).some((value) => matchesTokens(value, tokens)),
+    );
+
+    return matchedFields.length === 0
+      ? []
+      : [{ family: summarizeUiSourceFamily(family), matchedFields }];
+  });
+}
+
+export function getUiSourceFamilyInfo(
+  nameOrAlias: string,
+  manifest: UiSourceRegistryManifest = createUiSourceRegistryManifest(),
+): UiSourceFamilyManifest | undefined {
+  const raw = nameOrAlias.trim();
+  if (raw.length === 0) return undefined;
+
+  const normalized = normalizeSearchValue(raw);
+  const exact = manifest.families.find(
+    (family) =>
+      raw === family.name || raw === family.packageSubpath || raw === packageSubpathName(family),
+  );
+  if (exact != null) return exact;
+
+  return manifest.families.find(
+    (family) =>
+      normalizeSearchValue(family.title) === normalized ||
+      family.aliases.some((alias) => normalizeSearchValue(alias) === normalized),
+  );
+}

--- a/npm/ui/core/src/source-registry.types.test-d.ts
+++ b/npm/ui/core/src/source-registry.types.test-d.ts
@@ -1,0 +1,47 @@
+/** Compile-only assertions for the source-owned registry contract. */
+
+import {
+  UI_SOURCE_REGISTRY_PACKAGE_NAME,
+  UI_SOURCE_REGISTRY_SCHEMA_VERSION,
+  createUiSourceRegistryManifest,
+  getUiSourceFamilyInfo,
+  type UiSourceFamilyManifest,
+  type UiSourceRegistryManifest,
+  type UiSourceRegistryOutputFormat,
+} from "./source-registry.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+export const manifest = createUiSourceRegistryManifest();
+export const button = getUiSourceFamilyInfo("button", manifest);
+
+type _ManifestSchemaVersionIsLiteral = Expect<
+  Equal<typeof manifest.schemaVersion, typeof UI_SOURCE_REGISTRY_SCHEMA_VERSION>
+>;
+type _ManifestPackageNameIsLiteral = Expect<
+  Equal<typeof manifest.packageName, typeof UI_SOURCE_REGISTRY_PACKAGE_NAME>
+>;
+type _ManifestShapeIsClosed = Expect<Equal<typeof manifest, UiSourceRegistryManifest>>;
+type _InfoMayMiss = Expect<Equal<typeof button, UiSourceFamilyManifest | undefined>>;
+type _OutputFormatsAreMachineReadable = Expect<
+  Equal<UiSourceRegistryOutputFormat, "json" | "jsonl">
+>;
+
+if (button != null) {
+  const sourceFiles: readonly `src/${string}`[] = button.source.sourceFiles;
+  const behavior: `src/${string}.behavior.md` = button.source.behaviorContract;
+  const rendererFixture: `${string}Consumer.vue` | `${string}.vue` | null =
+    button.source.rendererFixture;
+  void sourceFiles;
+  void behavior;
+  void rendererFixture;
+
+  // @ts-expect-error manifest families are immutable to callers.
+  button.name = "checkbox";
+  // @ts-expect-error source files are immutable to callers.
+  button.source.sourceFiles.push("src/checkbox.ts");
+}


### PR DESCRIPTION
## Summary

- add a read-only @vizejs/ui source registry manifest helper derived from uiFamilyCatalog
- add a source-registry CLI for list/search/info JSON and JSONL output
- document that install/update/cache/rollback remain out of scope for this #4896 slice

## Tests

- vp install --frozen-lockfile --prefer-offline
- PATH=/private/tmp/pnpm12-wrapper:$PATH pnpm check
- PATH=/private/tmp/pnpm12-wrapper:$PATH pnpm test
- vp test run src/source-registry.test.ts
- node scripts/source-registry.ts list --format=json
- node scripts/source-registry.ts info action-button --format=jsonl

Refs #4896

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790613938&installation_model_id=422833&pr_number=5260&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5260&signature=17adea164aa668f495f7cc449246c15c65a201a326e487d91860ac969a5fb6a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only UI source registry with commands to list, search, and view source details.
  * Added machine-readable JSON and JSONL output formats.
  * Supports lookup by family name, alias, and related metadata.

* **Documentation**
  * Documented registry behavior, output contracts, and read-only scope.

* **Bug Fixes**
  * Invalid commands, options, and missing arguments now return usage guidance instead of proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->