### PR TITLE
refactor(patina): port no-consecutive-br to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -10,6 +10,7 @@ mod jsx_deprecated_attr;
 mod jsx_fallback;
 mod jsx_media_has_caption;
 mod jsx_mouse_events_have_key_events;
+mod jsx_no_consecutive_br;
 mod jsx_no_i_for_icon;
 mod jsx_no_redundant_roles;
 mod jsx_streaming;

--- a/crates/vize_patina/src/linter/tests/jsx_no_consecutive_br.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_consecutive_br.rs
@@ -1,0 +1,119 @@
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::html::NoConsecutiveBr;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn no_consecutive_br_runs_over_lowered_markup_ir_once() {
+    let source = "const A = () => <p>line<br /><br />more</p>;";
+    let linter = linter_with(Box::new(NoConsecutiveBr));
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["html/no-consecutive-br"],
+        "migrated no-consecutive-br must report once via lowered markup IR: {:?}",
+        result.diagnostics
+    );
+
+    let diag = &result.diagnostics[0];
+    let second_br = source.rfind("<br").unwrap() as u32;
+    assert_eq!(
+        diag.start, second_br,
+        "range must start at the second JSX <br>"
+    );
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        "<br />",
+        "range must cover exactly the authored JSX <br />"
+    );
+
+    let tsx = linter.lint_jsx(
+        "const A = (): JSX.Element => <p>line<br /><br />more</p>;",
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["html/no-consecutive-br"],
+        "TSX keeps the same lowered markup IR behavior"
+    );
+}
+
+#[test]
+fn no_consecutive_br_preserves_lowered_jsx_boundaries() {
+    let linter = linter_with(Box::new(NoConsecutiveBr));
+    for source in [
+        "const A = () => <p>line<br />line</p>;",
+        "const A = () => <p>line<br />{'x'}<br />more</p>;",
+        "const A = () => <p>line<br />{spacer}<br />more</p>;",
+        "const A = () => <p><br />{cond && <br />}<br /></p>;",
+        "const A = () => <><br /><br /></>;",
+        "const A = () => <Box><br /><br /></Box>;",
+        "const A = () => <p>line<BR /><BR />more</p>;",
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+
+    for source in [
+        "const A = () => <p>line<br />{' '}<br />more</p>;",
+        "const A = () => <p>line<br />{/* spacer */}<br />more</p>;",
+        "const A = () => <p><><br /><br /></></p>;",
+        "const A = () => <p>{cond && <><br /><br /></>}</p>;",
+        "const A = () => <p>{items.map((item) => <><br /><br /></>)}</p>;",
+        "const A = () => <Box><p><br /><br /></p></Box>;",
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            diagnostic_rules(&result),
+            vec!["html/no-consecutive-br"],
+            "must keep one lowered warning for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn no_consecutive_br_keeps_parent_state_isolated() {
+    let linter = linter_with(Box::new(NoConsecutiveBr));
+    let source = "const A = () => <p><br /><br /></p>;\nconst B = () => <p><br /><br /></p>;";
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["html/no-consecutive-br", "html/no-consecutive-br"],
+        "each native parent reports independently: {:?}",
+        result.diagnostics
+    );
+
+    let starts: Vec<u32> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.start)
+        .collect();
+    let expected: Vec<u32> = source
+        .match_indices("<br")
+        .enumerate()
+        .filter_map(|(index, (offset, _))| (index % 2 == 1).then_some(offset as u32))
+        .collect();
+    assert_eq!(starts, expected, "diagnostics must point at second <br>s");
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -10,6 +10,7 @@
 mod deprecated_attr_tests;
 mod media_has_caption_tests;
 mod mouse_events_have_key_events_tests;
+mod no_consecutive_br_tests;
 mod no_i_for_icon_tests;
 mod no_redundant_roles_tests;
 

--- a/crates/vize_patina/src/markup/tests/no_consecutive_br_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_consecutive_br_tests.rs
@@ -1,0 +1,199 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::html::NoConsecutiveBr;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+#[test]
+fn no_consecutive_br_template_child_sequence() {
+    let rule = NoConsecutiveBr;
+    for (source, expected, label) in [
+        (r#"<p>line<br>line</p>"#, 0, "single br"),
+        (r#"<p>line<br><br>more</p>"#, 1, "adjacent br"),
+        (r#"<p>line<br> <br>more</p>"#, 1, "whitespace text"),
+        (r#"<p>line<br><!-- spacer --><br>more</p>"#, 1, "comment"),
+        (
+            r#"<p>line<br>{{ spacer }}<br>more</p>"#,
+            0,
+            "interpolation resets",
+        ),
+        (
+            r#"<p>line<br><span></span><br>more</p>"#,
+            0,
+            "element resets",
+        ),
+        (
+            r#"<p>line<br><template><br></template><br>more</p>"#,
+            0,
+            "template element resets",
+        ),
+        (
+            r#"<section><template><br><br></template></section>"#,
+            1,
+            "inner template element scans its own children",
+        ),
+        (r#"<p>line<br><br><br>more</p>"#, 2, "three brs"),
+        (r#"<p>line<BR><BR>more</p>"#, 0, "case-sensitive tag"),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn no_consecutive_br_template_parent_boundaries() {
+    let rule = NoConsecutiveBr;
+    for (source, expected, label) in [
+        (r#"<br><br>"#, 0, "root siblings have no legacy parent"),
+        (
+            r#"<MyText><br><br></MyText>"#,
+            0,
+            "component parent is skipped",
+        ),
+        (
+            r#"<MyText><p><br><br></p></MyText>"#,
+            1,
+            "native descendant inside component still reports",
+        ),
+        (
+            r#"<p><br><br></p><p><br><br></p>"#,
+            2,
+            "separate parents do not share state",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template parent boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn no_consecutive_br_jsx_lowered_child_sequence() {
+    let rule = NoConsecutiveBr;
+    for (source, expected, label) in [
+        ("const A = () => <p>line<br />line</p>;", 0, "single br"),
+        (
+            "const A = () => <p>line<br /><br />more</p>;",
+            1,
+            "adjacent br",
+        ),
+        (
+            "const A = () => <p>line<br />{' '}<br />more</p>;",
+            1,
+            "explicit space text",
+        ),
+        (
+            "const A = () => <p>line<br />{'x'}<br />more</p>;",
+            0,
+            "significant string text resets",
+        ),
+        (
+            "const A = () => <p>line<br />{spacer}<br />more</p>;",
+            0,
+            "expression interpolation resets",
+        ),
+        (
+            "const A = () => <p>line<br />{/* spacer */}<br />more</p>;",
+            1,
+            "JSX comments stay transparent through lowering",
+        ),
+        (
+            "const A = () => <p><><br /><br /></></p>;",
+            1,
+            "nested fragment children are spliced into parent",
+        ),
+        (
+            "const A = () => <p><br />{cond && <br />}<br /></p>;",
+            0,
+            "control-flow child resets the parent sequence",
+        ),
+        (
+            "const A = () => <p>{cond && <><br /><br /></>}</p>;",
+            1,
+            "fragment inside control-flow reports inside its branch",
+        ),
+        (
+            "const A = () => <p>{items.map((item) => <><br /><br /></>)}</p>;",
+            1,
+            "fragment inside list reports inside its branch",
+        ),
+        (
+            "const A = () => <p>line<BR /><BR />more</p>;",
+            0,
+            "uppercase JSX intrinsic is not legacy lowercase br",
+        ),
+    ] {
+        assert_eq!(
+            run_over_jsx_lowered(&rule, source),
+            expected,
+            "lowered JSX boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn no_consecutive_br_jsx_lowered_parent_boundaries() {
+    let rule = NoConsecutiveBr;
+    for (source, expected, label) in [
+        (
+            "const A = () => <><br /><br /></>;",
+            0,
+            "top-level fragment children have no legacy parent",
+        ),
+        (
+            "const A = () => <Box><br /><br /></Box>;",
+            0,
+            "component parent is skipped",
+        ),
+        (
+            "const A = () => <Box><p><br /><br /></p></Box>;",
+            1,
+            "native descendant inside component still reports",
+        ),
+        (
+            "const A = () => <p><br /><br /></p>;\nconst B = () => <p><br /><br /></p>;",
+            2,
+            "separate render roots do not share state",
+        ),
+    ] {
+        assert_eq!(
+            run_over_jsx_lowered(&rule, source),
+            expected,
+            "lowered JSX parent boundary changed for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/html/no_consecutive_br.rs
+++ b/crates/vize_patina/src/rules/html/no_consecutive_br.rs
@@ -23,6 +23,7 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupContext, MarkupElement, MarkupNode, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::{ElementNode, ElementType, TemplateChildNode};
 
@@ -37,9 +38,57 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct NoConsecutiveBr;
 
+impl NoConsecutiveBr {
+    fn check_markup_children<'a>(ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        if element.is_component() {
+            return;
+        }
+
+        let mut last_br_seen = false;
+
+        element.walk_children(&mut |child| match child {
+            MarkupNode::Element(child) if child.is_unqualified_tag_exact("br") => {
+                if last_br_seen {
+                    let message = ctx.lint().t("html/no-consecutive-br.message");
+                    let help = ctx.lint().t("html/no-consecutive-br.help");
+                    ctx.lint().warn_at_with_help(message, child.range(), help);
+                }
+                last_br_seen = true;
+            }
+            MarkupNode::Text(text) => {
+                if text.is_significant() {
+                    last_br_seen = false;
+                }
+            }
+            MarkupNode::Comment(_) => {}
+            _ => {
+                last_br_seen = false;
+            }
+        });
+    }
+}
+
+impl MarkupRule for NoConsecutiveBr {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        Self::check_markup_children(ctx, element);
+    }
+}
+
 impl Rule for NoConsecutiveBr {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn jsx_needs_lowering(&self) -> bool {
+        true
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           306 |                   306 |                 0 |             273 |     238 |             673 |      144 |           346 |           491 |
+| Linter                     |           307 |                   307 |                 0 |             274 |     238 |             673 |      146 |           347 |           493 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,8 +99,8 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         306 |             224 |       82 |
-| old AST/parser   |         231 |             211 |       20 |
+| S0               |         307 |             224 |       83 |
+| old AST/parser   |         232 |             211 |       21 |
 | Croquis analysis |          42 |              38 |        4 |
 | raw OXC          |         238 |             200 |       38 |
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:24`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:25`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 42 omitted.
+Additional test/dev rows are in the TSV: 43 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,9 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	24	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	24	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	24	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	25	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	25	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	25	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1002,6 +1002,8 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/media_has_caption_tes
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/media_has_caption_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_consecutive_br_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_consecutive_br_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1062,7 +1064,7 @@ linter	Linter	source	crates/vize_patina/src/rules/html/deprecated_element.rs	29	
 linter	Linter	source	crates/vize_patina/src/rules/html/helpers.rs	3	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/id_duplication.rs	31	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/html/id_duplication.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/html/no_consecutive_br.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/html/no_consecutive_br.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	35	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	35	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/no_empty_palpable_content.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 18, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 19, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 129, `ir` 16, `ir-lowered` 2, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (18 = 18 `markup-facade` rules)
+- JSX lanes: `fallback` 128, `ir` 16, `ir-lowered` 3, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (19 = 19 `markup-facade` rules)
 - classification: neutral-core-candidate **85** · vue-dialect-bound **138** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -98,7 +98,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `html/deprecated-attr`                          | template-family | `html/deprecated_attr.rs`                              | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `html/deprecated-element`                       | template-family | `html/deprecated_element.rs`                           | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `html/id-duplication`                           | template-family | `html/id_duplication.rs`                               | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
-| `html/no-consecutive-br`                        | template-family | `html/no_consecutive_br.rs`                            | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `html/no-consecutive-br`                        | template-family | `html/no_consecutive_br.rs`                            | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `html/no-dupe-style-properties`                 | template-family | `opinionated/html/no_dupe_style_properties.rs`         | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `html/no-duplicate-class`                       | template-family | `opinionated/html/no_duplicate_class.rs`               | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `html/no-duplicate-dt`                          | template-family | `html/no_duplicate_dt.rs`                              | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |


### PR DESCRIPTION
Fixes #5262

## Summary

- add a Davinci MarkupRule path for html/no-consecutive-br while keeping the legacy template visitor
- route JSX through lowered markup IR with jsx_needs_lowering() to preserve fragment, text, interpolation, and parent-boundary behavior
- add focused Vue/JSX/TSX regressions and refresh Davinci migration matrices

## Local Validation

- cargo test -p vize_patina --locked
- cargo check -p vize_patina --all-targets --locked
- cargo clippy -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- node tools/davinci/rule-parity.mjs --check
- node tools/davinci/consumer-migration-surfaces.mjs --check
- node --test tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs
- node tools/davinci/assertion-lint.mjs
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790614133&installation_model_id=422833&pr_number=5263&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5263&signature=fa986b3d14f746fcfd8cda3e56616453ff6a55f3988c3ec6fcff01b63e4a3164"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->