### PR TITLE
refactor(patina): port no-aria-hidden focus rule to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -10,6 +10,7 @@ mod jsx_deprecated_attr;
 mod jsx_fallback;
 mod jsx_media_has_caption;
 mod jsx_mouse_events_have_key_events;
+mod jsx_no_aria_hidden_on_focusable;
 mod jsx_no_consecutive_br;
 mod jsx_no_i_for_icon;
 mod jsx_no_redundant_roles;

--- a/crates/vize_patina/src/linter/tests/jsx_no_aria_hidden_on_focusable.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_aria_hidden_on_focusable.rs
@@ -1,0 +1,129 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::NoAriaHiddenOnFocusable;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn no_aria_hidden_on_focusable_fires_on_jsx_and_tsx_ir() {
+    let linter = linter_with(Box::new(NoAriaHiddenOnFocusable));
+    let source = r#"const A = () => <button aria-hidden="true" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        result.error_count, 1,
+        "JSX focusable element with aria-hidden must flag through IR: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 0);
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/no-aria-hidden-on-focusable"]
+    );
+
+    let diag = &result.diagnostics[0];
+    let element = r#"<button aria-hidden="true" />"#;
+    let button_start = source.find(element).unwrap() as u32;
+    assert_eq!(
+        diag.start, button_start,
+        "range must start at the written JSX element"
+    );
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        element,
+        "range must cover the authored JSX element"
+    );
+    assert_eq!(diag.severity, Severity::Error);
+    assert!(diag.help.is_some(), "diagnostic should keep rule help");
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <a href="/" aria-hidden="true">Home</a>;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["a11y/no-aria-hidden-on-focusable"],
+        "TSX anchors with href must also flag through IR"
+    );
+}
+
+#[test]
+fn no_aria_hidden_on_focusable_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(NoAriaHiddenOnFocusable));
+    for source in [
+        r#"const A = () => <div aria-hidden="true" />;"#,
+        r#"const A = () => <a aria-hidden="true">decorative</a>;"#,
+        r#"const A = () => <button aria-hidden="false" />;"#,
+        r#"const A = () => <button aria-hidden={true} />;"#,
+        r#"const A = () => <button aria-hidden />;"#,
+        r#"const A = () => <button aria-hidden aria-hidden="true" />;"#,
+        r#"const A = () => <button ARIA-HIDDEN="true" />;"#,
+        r#"const A = () => <button ariaHidden="true" />;"#,
+        r#"const A = () => <button a11y:aria-hidden="true" />;"#,
+        r#"const A = () => <a {...props} aria-hidden="true">Home</a>;"#,
+        r#"const A = () => <div tabIndex="0" aria-hidden="true" />;"#,
+        r#"const A = () => <div contentEditable="true" aria-hidden="true" />;"#,
+        r#"const A = () => <Button aria-hidden="true" />;"#,
+        r#"const A = () => <Forms.button aria-hidden="true" />;"#,
+        r#"const A = () => <ui:button aria-hidden="true" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.error_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.warning_count, 0, "must not warn for {source}");
+    }
+
+    for source in [
+        r#"const A = () => <button aria-hidden="true" />;"#,
+        r#"const A = () => <input aria-hidden="true" />;"#,
+        r#"const A = () => <area href="/map" aria-hidden="true" />;"#,
+        r#"const A = () => <a href="/" aria-hidden="true">Home</a>;"#,
+        r#"const A = () => <a href={url} aria-hidden="true">Home</a>;"#,
+        r#"const A = () => <div tabindex="0" aria-hidden="true" />;"#,
+        r#"const A = () => <div tabindex="x" aria-hidden="true" />;"#,
+        r#"const A = () => <div contenteditable="true" aria-hidden="true" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.error_count, 1,
+            "must keep error for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.warning_count, 0, "must not warn for {source}");
+    }
+}
+
+#[test]
+fn migrated_no_aria_hidden_on_focusable_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(NoAriaHiddenOnFocusable));
+    let result = linter.lint_jsx(
+        r#"const A = () => <button aria-hidden="true" />;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated no-aria-hidden-on-focusable rule must report once: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 1);
+    assert_eq!(result.warning_count, 0);
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -10,6 +10,8 @@
 mod deprecated_attr_tests;
 mod media_has_caption_tests;
 mod mouse_events_have_key_events_tests;
+mod no_aria_hidden_on_focusable_jsx_tests;
+mod no_aria_hidden_on_focusable_tests;
 mod no_consecutive_br_tests;
 mod no_i_for_icon_tests;
 mod no_redundant_roles_tests;

--- a/crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_jsx_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_jsx_tests.rs
@@ -1,0 +1,164 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::NoAriaHiddenOnFocusable;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn no_aria_hidden_on_focusable_jsx_direct_matches_lowered() {
+    let rule = NoAriaHiddenOnFocusable;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <button aria-hidden="true" />;"#,
+            1,
+            "native button",
+        ),
+        (
+            r#"const A = () => <button aria-hidden="false" />;"#,
+            0,
+            "aria-hidden false",
+        ),
+        (
+            r#"const A = () => <button aria-hidden={true} />;"#,
+            0,
+            "dynamic aria-hidden",
+        ),
+        (
+            r#"const A = () => <button aria-hidden={"true"} />;"#,
+            0,
+            "dynamic string aria-hidden",
+        ),
+        (
+            r#"const A = () => <button aria-hidden />;"#,
+            0,
+            "valueless aria-hidden",
+        ),
+        (
+            r#"const A = () => <button aria-hidden aria-hidden="true" />;"#,
+            0,
+            "first duplicate aria-hidden wins",
+        ),
+        (
+            r#"const A = () => <button ARIA-HIDDEN="true" />;"#,
+            0,
+            "case-sensitive aria-hidden attr",
+        ),
+        (
+            r#"const A = () => <a aria-hidden="true">decorative</a>;"#,
+            0,
+            "anchor without href",
+        ),
+        (
+            r#"const A = () => <a href="/" aria-hidden="true">Home</a>;"#,
+            1,
+            "anchor with static href",
+        ),
+        (
+            r#"const A = () => <a href={url} aria-hidden="true">Home</a>;"#,
+            1,
+            "anchor with dynamic href value",
+        ),
+        (
+            r#"const A = () => <a {...props} aria-hidden="true">Home</a>;"#,
+            0,
+            "spread href is not inspected by the legacy helper",
+        ),
+        (
+            r#"const A = () => <a ns:href={url} aria-hidden="true">Home</a>;"#,
+            0,
+            "namespaced href stays ignored",
+        ),
+        (
+            r#"const A = () => <div tabindex="0" aria-hidden="true">Focusable</div>;"#,
+            1,
+            "lowercase tabindex",
+        ),
+        (
+            r#"const A = () => <div tabindex="" aria-hidden="true">Focusable</div>;"#,
+            1,
+            "empty tabindex",
+        ),
+        (
+            r#"const A = () => <div tabIndex="0" aria-hidden="true">Focusable</div>;"#,
+            0,
+            "camel-case tabIndex is outside the legacy exact helper",
+        ),
+        (
+            r#"const A = () => <div contenteditable="true" aria-hidden="true">Edit</div>;"#,
+            1,
+            "contenteditable true",
+        ),
+        (
+            r#"const A = () => <div contenteditable="" aria-hidden="true">Edit</div>;"#,
+            1,
+            "empty contenteditable",
+        ),
+        (
+            r#"const A = () => <div contentEditable="true" aria-hidden="true">Edit</div>;"#,
+            0,
+            "camel-case contentEditable is outside the legacy exact helper",
+        ),
+        (
+            r#"const A = () => <Button aria-hidden="true" />;"#,
+            0,
+            "components stay skipped",
+        ),
+        (
+            r#"const A = () => <Forms.button aria-hidden="true" />;"#,
+            0,
+            "member JSX tags stay outside unqualified native tags",
+        ),
+        (
+            r#"const A = () => <ui:button aria-hidden="true" />;"#,
+            0,
+            "namespaced JSX tags stay outside unqualified native tags",
+        ),
+        (
+            r#"const A = () => <button ariaHidden="true" />;"#,
+            0,
+            "camel-case ariaHidden is outside the legacy exact helper",
+        ),
+        (
+            r#"const A = () => <button a11y:aria-hidden="true" />;"#,
+            0,
+            "namespaced aria-hidden is outside exact unqualified attributes",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(direct, expected, "JSX direct case failed: {label}");
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "JSX direct and lowered fallback diverged for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_tests.rs
@@ -1,0 +1,217 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::NoAriaHiddenOnFocusable;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn no_aria_hidden_on_focusable_template() {
+    let rule = NoAriaHiddenOnFocusable;
+    for (source, expected, label) in [
+        (r#"<div aria-hidden="true"></div>"#, 0, "non-focusable div"),
+        (
+            r#"<a aria-hidden="true">decorative</a>"#,
+            0,
+            "anchor without href",
+        ),
+        (
+            r#"<a href="/" aria-hidden="true">Home</a>"#,
+            1,
+            "anchor with static href",
+        ),
+        (
+            r#"<a :href="url" aria-hidden="true">Home</a>"#,
+            1,
+            "anchor with static-arg bound href",
+        ),
+        (
+            r#"<a :[href]="url" aria-hidden="true">Home</a>"#,
+            0,
+            "anchor with dynamic href argument",
+        ),
+        (
+            r#"<area href="/map" aria-hidden="true" />"#,
+            1,
+            "area with static href",
+        ),
+        (
+            r#"<button aria-hidden="true">Click</button>"#,
+            1,
+            "native button",
+        ),
+        (r#"<input aria-hidden="true" />"#, 1, "native input"),
+        (
+            r#"<button aria-hidden="false">Click</button>"#,
+            0,
+            "aria-hidden false",
+        ),
+        (
+            r#"<button aria-hidden="">Click</button>"#,
+            0,
+            "empty aria-hidden value",
+        ),
+        (
+            r#"<button aria-hidden="True">Click</button>"#,
+            0,
+            "aria-hidden value is exact",
+        ),
+        (
+            r#"<button :aria-hidden="true">Click</button>"#,
+            0,
+            "bound aria-hidden boolean stays dynamic",
+        ),
+        (
+            r#"<button :aria-hidden="'true'">Click</button>"#,
+            0,
+            "bound aria-hidden stays dynamic",
+        ),
+        (
+            r#"<button ARIA-HIDDEN="true">Click</button>"#,
+            0,
+            "aria-hidden attribute name is exact",
+        ),
+        (
+            r#"<button aria-hidden>Click</button>"#,
+            0,
+            "valueless aria-hidden stays clean",
+        ),
+        (
+            r#"<button aria-hidden aria-hidden="true">Click</button>"#,
+            0,
+            "first valueless duplicate aria-hidden masks later values",
+        ),
+        (
+            r#"<button aria-hidden="true" aria-hidden="false">Click</button>"#,
+            1,
+            "first true duplicate aria-hidden controls",
+        ),
+        (
+            r#"<button aria-hidden="false" aria-hidden="true">Click</button>"#,
+            0,
+            "later duplicate aria-hidden does not override first value",
+        ),
+        (
+            r#"<div tabindex="0" aria-hidden="true">Focusable</div>"#,
+            1,
+            "tabindex zero",
+        ),
+        (
+            r#"<div :tabindex="0" aria-hidden="true">Focusable</div>"#,
+            0,
+            "bound tabindex stays outside the legacy static-value helper",
+        ),
+        (
+            r#"<div tabindex="" aria-hidden="true">Focusable</div>"#,
+            1,
+            "empty tabindex remains focusable",
+        ),
+        (
+            r#"<div tabindex="-1" aria-hidden="true">Programmatic</div>"#,
+            0,
+            "negative tabindex",
+        ),
+        (
+            r#"<div tabindex="x" aria-hidden="true">Focusable</div>"#,
+            1,
+            "non-numeric tabindex remains focusable",
+        ),
+        (
+            r#"<div tabindex aria-hidden="true">Maybe focusable</div>"#,
+            0,
+            "valueless tabindex matches legacy static-value helper",
+        ),
+        (
+            r#"<div tabindex tabindex="0" aria-hidden="true">Maybe focusable</div>"#,
+            0,
+            "first valueless duplicate tabindex masks later values",
+        ),
+        (
+            r#"<div contenteditable="true" aria-hidden="true">Edit</div>"#,
+            1,
+            "contenteditable true",
+        ),
+        (
+            r#"<div contenteditable="" aria-hidden="true">Edit</div>"#,
+            1,
+            "empty contenteditable remains focusable",
+        ),
+        (
+            r#"<div contenteditable="plaintext-only" aria-hidden="true">Edit</div>"#,
+            1,
+            "plaintext-only contenteditable remains focusable",
+        ),
+        (
+            r#"<div contenteditable="FALSE" aria-hidden="true">Edit</div>"#,
+            1,
+            "contenteditable value is exact",
+        ),
+        (
+            r#"<div contenteditable="false" aria-hidden="true">Edit</div>"#,
+            0,
+            "contenteditable false",
+        ),
+        (
+            r#"<div :contenteditable="true" aria-hidden="true">Edit</div>"#,
+            0,
+            "bound contenteditable stays outside the legacy static-value helper",
+        ),
+        (
+            r#"<div contenteditable="false" contenteditable="true" aria-hidden="true">Edit</div>"#,
+            0,
+            "later duplicate contenteditable does not override first value",
+        ),
+        (
+            r#"<select aria-hidden="true"></select>"#,
+            1,
+            "native select",
+        ),
+        (
+            r#"<textarea aria-hidden="true"></textarea>"#,
+            1,
+            "native textarea",
+        ),
+        (
+            r#"<summary aria-hidden="true">Summary</summary>"#,
+            1,
+            "native summary",
+        ),
+        (
+            r#"<audio aria-hidden="true"></audio>"#,
+            0,
+            "audio is not focusable in the legacy helper",
+        ),
+        (
+            r#"<video aria-hidden="true"></video>"#,
+            0,
+            "video is not focusable in the legacy helper",
+        ),
+        (
+            r#"<details aria-hidden="true"></details>"#,
+            0,
+            "details is not focusable in the legacy helper",
+        ),
+        (
+            r#"<MyButton aria-hidden="true">Click</MyButton>"#,
+            0,
+            "components stay skipped",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template case failed: {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/a11y.rs
+++ b/crates/vize_patina/src/rules/a11y.rs
@@ -19,6 +19,7 @@ mod iframe_has_title;
 mod img_alt;
 mod interactive_supports_focus;
 mod label_has_for;
+pub(crate) mod markup_helpers;
 mod media_has_caption;
 mod mouse_events_have_key_events;
 mod no_access_key;

--- a/crates/vize_patina/src/rules/a11y/markup_helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/markup_helpers.rs
@@ -1,0 +1,72 @@
+//! Markup facade helpers shared by accessibility rules.
+
+use crate::markup::{MarkupBindingKind, MarkupElement};
+
+/// Check if a markup facade element is focusable (natively or via tabindex).
+pub fn is_focusable_markup_element(element: &MarkupElement<'_>) -> bool {
+    if (element.is_unqualified_tag_exact("a") || element.is_unqualified_tag_exact("area"))
+        && has_named_markup_prop(element, "href")
+    {
+        return true;
+    }
+
+    if element.is_unqualified_tag_exact("button")
+        || element.is_unqualified_tag_exact("input")
+        || element.is_unqualified_tag_exact("select")
+        || element.is_unqualified_tag_exact("textarea")
+        || element.is_unqualified_tag_exact("summary")
+    {
+        return true;
+    }
+
+    if let Some(tabindex) = get_static_markup_attribute_value(element, "tabindex") {
+        if let Ok(val) = tabindex.parse::<i32>() {
+            return val >= 0;
+        }
+        return true;
+    }
+
+    if let Some(val) = get_static_markup_attribute_value(element, "contenteditable")
+        && val != "false"
+    {
+        return true;
+    }
+
+    false
+}
+
+fn has_named_markup_prop(element: &MarkupElement<'_>, name: &str) -> bool {
+    let mut found = false;
+    element.walk_bindings(&mut |binding| {
+        if matches!(
+            binding.kind(),
+            MarkupBindingKind::Attribute | MarkupBindingKind::Bind
+        ) && binding.is_static_unqualified_arg_exact(name)
+        {
+            found = true;
+        }
+    });
+    found
+}
+
+/// Get the first static markup attribute value for an exact unqualified name.
+///
+/// Like `get_static_attribute_value`, a valueless first match returns `None`
+/// without considering later duplicate attributes.
+pub fn get_static_markup_attribute_value<'a>(
+    element: &MarkupElement<'a>,
+    name: &str,
+) -> Option<&'a str> {
+    let mut seen = false;
+    let mut value = None;
+    element.walk_bindings(&mut |binding| {
+        if !seen
+            && binding.kind() == MarkupBindingKind::Attribute
+            && binding.is_unqualified_arg_exact(name)
+        {
+            seen = true;
+            value = binding.static_value();
+        }
+    });
+    value
+}

--- a/crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs
@@ -10,10 +10,11 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, ElementType};
+use vize_relief::ElementNode;
 
-use super::helpers;
+use super::markup_helpers;
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/no-aria-hidden-on-focusable",
@@ -27,26 +28,47 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct NoAriaHiddenOnFocusable;
 
+impl NoAriaHiddenOnFocusable {
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        if element.is_component() {
+            return;
+        }
+
+        if let Some(value) =
+            markup_helpers::get_static_markup_attribute_value(element, "aria-hidden")
+            && value == "true"
+            && markup_helpers::is_focusable_markup_element(element)
+        {
+            ctx.error_at_with_help(
+                ctx.t("a11y/no-aria-hidden-on-focusable.message"),
+                element.range(),
+                ctx.t("a11y/no-aria-hidden-on-focusable.help"),
+            );
+        }
+    }
+}
+
+impl MarkupRule for NoAriaHiddenOnFocusable {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        Self::check_element(ctx.lint(), element);
+    }
+}
+
 impl Rule for NoAriaHiddenOnFocusable {
     fn meta(&self) -> &'static RuleMeta {
         &META
     }
 
-    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if element.tag_type == ElementType::Component {
-            return;
-        }
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
 
-        if let Some(value) = helpers::get_static_attribute_value(element, "aria-hidden")
-            && value == "true"
-            && helpers::is_focusable_element(element)
-        {
-            ctx.error_with_help(
-                ctx.t("a11y/no-aria-hidden-on-focusable.message"),
-                &element.loc,
-                ctx.t("a11y/no-aria-hidden-on-focusable.help"),
-            );
-        }
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           307 |                   307 |                 0 |             274 |     238 |             673 |      146 |           347 |           493 |
+| Linter                     |           309 |                   309 |                 0 |             275 |     241 |             673 |      152 |           349 |           497 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         307 |             224 |       83 |
-| old AST/parser   |         232 |             211 |       21 |
+| S0               |         309 |             224 |       85 |
+| old AST/parser   |         233 |             211 |       22 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         238 |             200 |       38 |
+| raw OXC          |         241 |             200 |       41 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:25`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:27`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 43 omitted.
+Additional test/dev rows are in the TSV: 45 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,9 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	25	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	25	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	25	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	27	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	27	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	27	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1002,6 +1002,10 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/media_has_caption_tes
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/media_has_caption_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/mouse_events_have_key_events_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_jsx_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_jsx_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_consecutive_br_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_consecutive_br_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
@@ -1039,7 +1043,7 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/label_has_for.rs	25	old_a
 linter	Linter	source	crates/vize_patina/src/rules/a11y/media_has_caption.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/mouse_events_have_key_events.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_access_key.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_autofocus.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_distracting_elements.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_i_for_icon.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -26,17 +26,17 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 ## File accounting
 
-- `.rs` files under `crates/vize_patina/src/rules/**`: **359**
+- `.rs` files under `crates/vize_patina/src/rules/**`: **360**
 - rule-defining files (exactly one `static META` each): **245** → **245 rules**
-- non-rule files: **114** — 27 module organizers (a `<name>.rs` with a `<name>/` directory beside it), 4 `*_tests.rs` companions, 83 helper/data files (rule submodules, shared tables, private utilities)
+- non-rule files: **115** — 27 module organizers (a `<name>.rs` with a `<name>/` directory beside it), 4 `*_tests.rs` companions, 84 helper/data files (rule submodules, shared tables, private utilities)
 
 ## Summary
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 19, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 20, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 128, `ir` 16, `ir-lowered` 3, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (19 = 19 `markup-facade` rules)
+- JSX lanes: `fallback` 127, `ir` 17, `ir-lowered` 3, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (20 = 20 `markup-facade` rules)
 - classification: neutral-core-candidate **85** · vue-dialect-bound **138** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -64,7 +64,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/media-has-caption`                        | template-family | `a11y/media_has_caption.rs`                            | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/mouse-events-have-key-events`             | template-family | `a11y/mouse_events_have_key_events.rs`                 | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-access-key`                            | template-family | `a11y/no_access_key.rs`                                | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |
-| `a11y/no-aria-hidden-on-focusable`              | template-family | `a11y/no_aria_hidden_on_focusable.rs`                  | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `a11y/no-aria-hidden-on-focusable`              | template-family | `a11y/no_aria_hidden_on_focusable.rs`                  | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-autofocus`                             | template-family | `a11y/no_autofocus.rs`                                 | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |
 | `a11y/no-distracting-elements`                  | template-family | `a11y/no_distracting_elements.rs`                      | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-i-for-icon`                            | template-family | `a11y/no_i_for_icon.rs`                                | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |


### PR DESCRIPTION
## Summary
- port `a11y/no-aria-hidden-on-focusable` to `MarkupRule` on the direct JSX IR lane
- add exact/unqualified markup a11y focusability helpers for reuse by follow-up focus rules
- add template, JSX parity, and `lint_jsx` e2e regressions; refresh Davinci matrices

Closes #5265

## Verification
- `cargo test -p vize_patina no_aria_hidden_on_focusable --locked`
- `cargo test -q -p vize_patina --locked`
- `cargo check -q -p vize_patina --all-targets --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `node tools/davinci/assertion-lint.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check HEAD && git diff --check --cached`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5266"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790615838&installation_model_id=422833&pr_number=5266&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5266&signature=88239be95b89eaae1cedb3d9f911788de91cfaf1aa57faf72049665ff67f91f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->