### PR TITLE
refactor(patina): port presentation role focus rule to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -14,6 +14,7 @@ mod jsx_no_aria_hidden_on_focusable;
 mod jsx_no_consecutive_br;
 mod jsx_no_i_for_icon;
 mod jsx_no_redundant_roles;
+mod jsx_no_role_presentation_on_focusable;
 mod jsx_streaming;
 mod no_mutating_props;
 mod no_top_level_ref;

--- a/crates/vize_patina/src/linter/tests/jsx_no_role_presentation_on_focusable.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_role_presentation_on_focusable.rs
@@ -1,0 +1,140 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::NoRolePresentationOnFocusable;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn no_role_presentation_on_focusable_fires_on_jsx_and_tsx_ir() {
+    let linter = linter_with(Box::new(NoRolePresentationOnFocusable));
+    let source = r#"const A = () => <button role="presentation" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        result.error_count, 1,
+        "JSX focusable element with presentation role must flag through IR: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 0);
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/no-role-presentation-on-focusable"]
+    );
+
+    let diag = &result.diagnostics[0];
+    let element = r#"<button role="presentation" />"#;
+    let button_start = source.find(element).unwrap() as u32;
+    assert_eq!(
+        diag.start, button_start,
+        "range must start at the written JSX element"
+    );
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        element,
+        "range must cover the authored JSX element"
+    );
+    assert_eq!(diag.severity, Severity::Error);
+    assert!(diag.help.is_some(), "diagnostic should keep rule help");
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <a href="/" role="presentation">Home</a>;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(tsx.error_count, 1);
+    assert_eq!(tsx.warning_count, 0);
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["a11y/no-role-presentation-on-focusable"],
+        "TSX anchors with href must also flag through IR"
+    );
+}
+
+#[test]
+fn no_role_presentation_on_focusable_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(NoRolePresentationOnFocusable));
+    for source in [
+        r#"const A = () => <div role="presentation" />;"#,
+        r#"const A = () => <a role="presentation">decorative</a>;"#,
+        r#"const A = () => <button role="button" />;"#,
+        r#"const A = () => <button role="Presentation" />;"#,
+        r#"const A = () => <button role="presentation " />;"#,
+        r#"const A = () => <button role="presentation button" />;"#,
+        r#"const A = () => <button ROLE="presentation" />;"#,
+        r#"const A = () => <button role={role} />;"#,
+        r#"const A = () => <button role={"presentation"} />;"#,
+        r#"const A = () => <button role />;"#,
+        r#"const A = () => <button role role="presentation" />;"#,
+        r#"const A = () => <button role="button" role="presentation" />;"#,
+        r#"const A = () => <a {...props} role="presentation">Home</a>;"#,
+        r#"const A = () => <div tabIndex="0" role="presentation" />;"#,
+        r#"const A = () => <div contentEditable="true" role="presentation" />;"#,
+        r#"const A = () => <Button role="presentation" />;"#,
+        r#"const A = () => <Forms.button role="presentation" />;"#,
+        r#"const A = () => <ui:button role="presentation" />;"#,
+        r#"const A = () => <button a11y:role="presentation" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.error_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.warning_count, 0, "must not warn for {source}");
+    }
+
+    for source in [
+        r#"const A = () => <button role="presentation" />;"#,
+        r#"const A = () => <button role="none" />;"#,
+        r#"const A = () => <button role="presentation" role="button" />;"#,
+        r#"const A = () => <input role="none" />;"#,
+        r#"const A = () => <area href="/map" role="presentation" />;"#,
+        r#"const A = () => <a href="/" role="presentation">Home</a>;"#,
+        r#"const A = () => <a href={url} role="presentation">Home</a>;"#,
+        r#"const A = () => <div tabindex="0" role="presentation" />;"#,
+        r#"const A = () => <div tabindex="x" role="presentation" />;"#,
+        r#"const A = () => <div tabindex="" role="presentation" />;"#,
+        r#"const A = () => <div contenteditable="true" role="presentation" />;"#,
+        r#"const A = () => <div contenteditable="" role="presentation" />;"#,
+        r#"const A = () => <div contenteditable="plaintext-only" role="presentation" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.error_count, 1,
+            "must keep error for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.warning_count, 0, "must not warn for {source}");
+    }
+}
+
+#[test]
+fn migrated_no_role_presentation_on_focusable_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(NoRolePresentationOnFocusable));
+    let result = linter.lint_jsx(
+        r#"const A = () => <button role="presentation" />;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated no-role-presentation-on-focusable rule must report once: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 1);
+    assert_eq!(result.warning_count, 0);
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -15,6 +15,8 @@ mod no_aria_hidden_on_focusable_tests;
 mod no_consecutive_br_tests;
 mod no_i_for_icon_tests;
 mod no_redundant_roles_tests;
+mod no_role_presentation_on_focusable_jsx_tests;
+mod no_role_presentation_on_focusable_tests;
 
 #[cfg(test)]
 mod markup_ir_tests {

--- a/crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_jsx_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_jsx_tests.rs
@@ -1,0 +1,200 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::NoRolePresentationOnFocusable;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn no_role_presentation_on_focusable_jsx_direct_matches_lowered() {
+    let rule = NoRolePresentationOnFocusable;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <button role="presentation" />;"#,
+            1,
+            "native button presentation",
+        ),
+        (
+            r#"const A = () => <input role="none" />;"#,
+            1,
+            "native input none",
+        ),
+        (
+            r#"const A = () => <button role="button" />;"#,
+            0,
+            "non-presentation role",
+        ),
+        (
+            r#"const A = () => <button role="Presentation" />;"#,
+            0,
+            "role value is exact",
+        ),
+        (
+            r#"const A = () => <button role="presentation " />;"#,
+            0,
+            "role value is not trimmed",
+        ),
+        (
+            r#"const A = () => <button role="presentation button" />;"#,
+            0,
+            "role value is not tokenized",
+        ),
+        (
+            r#"const A = () => <button ROLE="presentation" />;"#,
+            0,
+            "case-sensitive role attr",
+        ),
+        (
+            r#"const A = () => <button role={role} />;"#,
+            0,
+            "dynamic role",
+        ),
+        (
+            r#"const A = () => <button role={"presentation"} />;"#,
+            0,
+            "dynamic string role",
+        ),
+        (r#"const A = () => <button role />;"#, 0, "valueless role"),
+        (
+            r#"const A = () => <button role role="presentation" />;"#,
+            0,
+            "first duplicate role wins",
+        ),
+        (
+            r#"const A = () => <button role="presentation" role="button" />;"#,
+            1,
+            "first presentation duplicate controls",
+        ),
+        (
+            r#"const A = () => <button role="button" role="presentation" />;"#,
+            0,
+            "later duplicate role does not override first value",
+        ),
+        (
+            r#"const A = () => <a role="presentation">decorative</a>;"#,
+            0,
+            "anchor without href",
+        ),
+        (
+            r#"const A = () => <a href="/" role="presentation">Home</a>;"#,
+            1,
+            "anchor with static href",
+        ),
+        (
+            r#"const A = () => <a href={url} role="presentation">Home</a>;"#,
+            1,
+            "anchor with dynamic href value",
+        ),
+        (
+            r#"const A = () => <a {...props} role="presentation">Home</a>;"#,
+            0,
+            "spread href is not inspected by the legacy helper",
+        ),
+        (
+            r#"const A = () => <a ns:href={url} role="presentation">Home</a>;"#,
+            0,
+            "namespaced href stays ignored",
+        ),
+        (
+            r#"const A = () => <div tabindex="0" role="presentation">Focusable</div>;"#,
+            1,
+            "lowercase tabindex",
+        ),
+        (
+            r#"const A = () => <div tabindex="" role="presentation">Focusable</div>;"#,
+            1,
+            "empty tabindex",
+        ),
+        (
+            r#"const A = () => <div tabindex="x" role="presentation">Focusable</div>;"#,
+            1,
+            "non-numeric tabindex",
+        ),
+        (
+            r#"const A = () => <div tabIndex="0" role="presentation">Focusable</div>;"#,
+            0,
+            "camel-case tabIndex is outside the legacy exact helper",
+        ),
+        (
+            r#"const A = () => <div contenteditable="true" role="presentation">Edit</div>;"#,
+            1,
+            "contenteditable true",
+        ),
+        (
+            r#"const A = () => <div contenteditable="" role="presentation">Edit</div>;"#,
+            1,
+            "empty contenteditable",
+        ),
+        (
+            r#"const A = () => <div contenteditable="plaintext-only" role="presentation">Edit</div>;"#,
+            1,
+            "plaintext-only contenteditable",
+        ),
+        (
+            r#"const A = () => <div contenteditable="FALSE" role="presentation">Edit</div>;"#,
+            1,
+            "contenteditable value is exact",
+        ),
+        (
+            r#"const A = () => <div contentEditable="true" role="presentation">Edit</div>;"#,
+            0,
+            "camel-case contentEditable is outside the legacy exact helper",
+        ),
+        (
+            r#"const A = () => <Button role="presentation" />;"#,
+            0,
+            "components stay skipped",
+        ),
+        (
+            r#"const A = () => <Forms.button role="presentation" />;"#,
+            0,
+            "member JSX tags stay outside unqualified native tags",
+        ),
+        (
+            r#"const A = () => <ui:button role="presentation" />;"#,
+            0,
+            "namespaced JSX tags stay outside unqualified native tags",
+        ),
+        (
+            r#"const A = () => <button a11y:role="presentation" />;"#,
+            0,
+            "namespaced role is outside exact unqualified attributes",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(direct, expected, "JSX direct case failed: {label}");
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "JSX direct and lowered fallback diverged for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_tests.rs
@@ -1,0 +1,206 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::NoRolePresentationOnFocusable;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn no_role_presentation_on_focusable_template() {
+    let rule = NoRolePresentationOnFocusable;
+    for (source, expected, label) in [
+        (r#"<div role="presentation"></div>"#, 0, "non-focusable div"),
+        (
+            r#"<a role="presentation">decorative</a>"#,
+            0,
+            "anchor without href",
+        ),
+        (
+            r#"<a href="/" role="presentation">Home</a>"#,
+            1,
+            "anchor with static href",
+        ),
+        (
+            r#"<a :href="url" role="presentation">Home</a>"#,
+            1,
+            "anchor with static-arg bound href",
+        ),
+        (
+            r#"<a :[href]="url" role="presentation">Home</a>"#,
+            0,
+            "anchor with dynamic href argument",
+        ),
+        (
+            r#"<area href="/map" role="presentation" />"#,
+            1,
+            "area with static href",
+        ),
+        (
+            r#"<button role="presentation">Click</button>"#,
+            1,
+            "native button presentation",
+        ),
+        (
+            r#"<input role="none" type="text" />"#,
+            1,
+            "native input none",
+        ),
+        (
+            r#"<button role="button">Click</button>"#,
+            0,
+            "non-presentation role",
+        ),
+        (
+            r#"<button role="Presentation">Click</button>"#,
+            0,
+            "role value is exact",
+        ),
+        (
+            r#"<button role="presentation ">Click</button>"#,
+            0,
+            "role value is not trimmed",
+        ),
+        (
+            r#"<button role="presentation button">Click</button>"#,
+            0,
+            "role value is not tokenized",
+        ),
+        (
+            r#"<button ROLE="presentation">Click</button>"#,
+            0,
+            "role attribute name is exact",
+        ),
+        (
+            r#"<button :role="'presentation'">Click</button>"#,
+            0,
+            "bound role stays dynamic",
+        ),
+        (
+            r#"<button role>Click</button>"#,
+            0,
+            "valueless role stays clean",
+        ),
+        (
+            r#"<button role role="presentation">Click</button>"#,
+            0,
+            "first valueless duplicate role masks later values",
+        ),
+        (
+            r#"<button role="presentation" role="button">Click</button>"#,
+            1,
+            "first presentation duplicate controls",
+        ),
+        (
+            r#"<button role="none" role="button">Click</button>"#,
+            1,
+            "first none duplicate controls",
+        ),
+        (
+            r#"<button role="button" role="presentation">Click</button>"#,
+            0,
+            "later duplicate role does not override first value",
+        ),
+        (
+            r#"<div tabindex="0" role="presentation">Focusable</div>"#,
+            1,
+            "tabindex zero",
+        ),
+        (
+            r#"<div :tabindex="0" role="presentation">Focusable</div>"#,
+            0,
+            "bound tabindex stays outside the legacy static-value helper",
+        ),
+        (
+            r#"<div tabindex="" role="presentation">Focusable</div>"#,
+            1,
+            "empty tabindex remains focusable",
+        ),
+        (
+            r#"<div tabindex="x" role="presentation">Focusable</div>"#,
+            1,
+            "non-numeric tabindex remains focusable",
+        ),
+        (
+            r#"<div tabindex="-1" role="presentation">Programmatic</div>"#,
+            0,
+            "negative tabindex",
+        ),
+        (
+            r#"<div tabindex tabindex="0" role="presentation">Maybe focusable</div>"#,
+            0,
+            "first valueless duplicate tabindex masks later values",
+        ),
+        (
+            r#"<div contenteditable="true" role="presentation">Edit</div>"#,
+            1,
+            "contenteditable true",
+        ),
+        (
+            r#"<div contenteditable="" role="presentation">Edit</div>"#,
+            1,
+            "empty contenteditable remains focusable",
+        ),
+        (
+            r#"<div contenteditable="plaintext-only" role="presentation">Edit</div>"#,
+            1,
+            "plaintext-only contenteditable remains focusable",
+        ),
+        (
+            r#"<div contenteditable="FALSE" role="presentation">Edit</div>"#,
+            1,
+            "contenteditable value is exact",
+        ),
+        (
+            r#"<div contenteditable="false" role="presentation">Edit</div>"#,
+            0,
+            "contenteditable false",
+        ),
+        (
+            r#"<div :contenteditable="true" role="presentation">Edit</div>"#,
+            0,
+            "bound contenteditable stays outside the legacy static-value helper",
+        ),
+        (
+            r#"<div contenteditable="false" contenteditable="true" role="presentation">Edit</div>"#,
+            0,
+            "later duplicate contenteditable does not override first value",
+        ),
+        (
+            r#"<audio role="presentation"></audio>"#,
+            0,
+            "audio is not focusable in the legacy helper",
+        ),
+        (
+            r#"<video role="presentation"></video>"#,
+            0,
+            "video is not focusable in the legacy helper",
+        ),
+        (
+            r#"<details role="presentation"></details>"#,
+            0,
+            "details is not focusable in the legacy helper",
+        ),
+        (
+            r#"<MyButton role="presentation">Click</MyButton>"#,
+            0,
+            "components stay skipped",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template case failed: {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/a11y/no_role_presentation_on_focusable.rs
+++ b/crates/vize_patina/src/rules/a11y/no_role_presentation_on_focusable.rs
@@ -10,10 +10,11 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, ElementType};
+use vize_relief::ElementNode;
 
-use super::helpers;
+use super::markup_helpers;
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/no-role-presentation-on-focusable",
@@ -27,26 +28,46 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct NoRolePresentationOnFocusable;
 
+impl NoRolePresentationOnFocusable {
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        if element.is_component() {
+            return;
+        }
+
+        if let Some(role) = markup_helpers::get_static_markup_attribute_value(element, "role")
+            && matches!(role, "presentation" | "none")
+            && markup_helpers::is_focusable_markup_element(element)
+        {
+            ctx.error_at_with_help(
+                ctx.t("a11y/no-role-presentation-on-focusable.message"),
+                element.range(),
+                ctx.t("a11y/no-role-presentation-on-focusable.help"),
+            );
+        }
+    }
+}
+
+impl MarkupRule for NoRolePresentationOnFocusable {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        Self::check_element(ctx.lint(), element);
+    }
+}
+
 impl Rule for NoRolePresentationOnFocusable {
     fn meta(&self) -> &'static RuleMeta {
         &META
     }
 
-    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if element.tag_type == ElementType::Component {
-            return;
-        }
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
 
-        if let Some(role) = helpers::get_static_attribute_value(element, "role")
-            && (role == "presentation" || role == "none")
-            && helpers::is_focusable_element(element)
-        {
-            ctx.error_with_help(
-                ctx.t("a11y/no-role-presentation-on-focusable.message"),
-                &element.loc,
-                ctx.t("a11y/no-role-presentation-on-focusable.help"),
-            );
-        }
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           309 |                   309 |                 0 |             275 |     241 |             673 |      152 |           349 |           497 |
+| Linter                     |           311 |                   311 |                 0 |             276 |     244 |             673 |      158 |           351 |           500 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         309 |             224 |       85 |
-| old AST/parser   |         233 |             211 |       22 |
+| S0               |         311 |             224 |       87 |
+| old AST/parser   |         234 |             211 |       23 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         241 |             200 |       41 |
+| raw OXC          |         244 |             200 |       44 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:27`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:29`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 45 omitted.
+Additional test/dev rows are in the TSV: 47 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,9 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	27	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	27	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	27	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	29	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	29	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	29	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1014,6 +1014,10 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.r
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_redundant_roles_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_redundant_roles_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_redundant_roles_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_jsx_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_jsx_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/output.rs	20	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/output/agent.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/output/html.rs	6	s0	S0	stage	vize_s0	preferred	1
@@ -1051,7 +1055,7 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/no_redundant_roles.rs	26	
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_refer_to_non_existent_id.rs	31	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/a11y/no_role_presentation_on_focusable.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/a11y/no_role_presentation_on_focusable.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/no_static_element_interactions.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/role_has_required_aria_props.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/tabindex_no_positive.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 20, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 21, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 127, `ir` 17, `ir-lowered` 3, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (20 = 20 `markup-facade` rules)
+- JSX lanes: `fallback` 126, `ir` 18, `ir-lowered` 3, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (21 = 21 `markup-facade` rules)
 - classification: neutral-core-candidate **85** · vue-dialect-bound **138** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -70,7 +70,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/no-i-for-icon`                            | template-family | `a11y/no_i_for_icon.rs`                                | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-redundant-roles`                       | template-family | `a11y/no_redundant_roles.rs`                           | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-refer-to-non-existent-id`              | template-family | `a11y/no_refer_to_non_existent_id.rs`                  | template-ast                   | yes (template-visitor)           | yes (fallback)              | direct 2: `croquis::ElementIdKind`; ctx 1                                                           | neutral-core-candidate |
-| `a11y/no-role-presentation-on-focusable`        | template-family | `a11y/no_role_presentation_on_focusable.rs`            | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `a11y/no-role-presentation-on-focusable`        | template-family | `a11y/no_role_presentation_on_focusable.rs`            | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-static-element-interactions`           | template-family | `a11y/no_static_element_interactions.rs`               | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/placeholder-label-option`                 | template-family | `opinionated/a11y/placeholder_label_option.rs`         | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `a11y/role-has-required-aria-props`             | template-family | `a11y/role_has_required_aria_props.rs`                 | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |


### PR DESCRIPTION
## Summary
- port `a11y/no-role-presentation-on-focusable` to `MarkupRule` on the direct JSX IR lane
- reuse the exact/unqualified markup focusability helper shared with no-aria-hidden
- add template, JSX parity, and `lint_jsx` e2e regressions; refresh Davinci matrices

Closes #5268

## Verification
- `cargo test -p vize_patina no_role_presentation_on_focusable --locked`
- `cargo test -q -p vize_patina --locked`
- `cargo check -q -p vize_patina --all-targets --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `node tools/davinci/assertion-lint.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check HEAD && git diff --check --cached`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790617177&installation_model_id=422833&pr_number=5269&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5269&signature=4ad21ad32752fba459ed96bb0bc906dea2ca82985cfe9d6768c69e876fea875b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->