### PR TITLE
fix(ui): track textarea composition emptiness

### DIFF
--- a/npm/ui/core/src/textarea-control.vue
+++ b/npm/ui/core/src/textarea-control.vue
@@ -188,7 +188,7 @@ const emit = defineEmits<{
 const element = useTemplateRef<HTMLTextAreaElement>("element");
 const controlId = useDeterministicId({ id: () => id, hint: "textarea" });
 const composing = ref(false);
-let compositionInputValue: string | undefined;
+const composingValue = ref<string | undefined>(undefined);
 const state = useControllableState({
   value: () => modelValue,
   defaultValue: () => defaultValue,
@@ -203,10 +203,10 @@ const dataState = computed(() => {
   if (disabled) return "disabled";
   return readOnly ? "readonly" : "editable";
 });
-const dataEmpty = computed(() => (value.value.length === 0 ? "true" : "false"));
 const renderedValue = computed(() =>
-  composing.value ? (element.value?.value ?? value.value) : value.value,
+  composing.value ? (composingValue.value ?? element.value?.value ?? value.value) : value.value,
 );
+const dataEmpty = computed(() => (renderedValue.value.length === 0 ? "true" : "false"));
 
 function syncNativeValue(): void {
   if (composing.value) return;
@@ -239,7 +239,7 @@ function readTextAreaValue(event: Event): string | undefined {
 function onInput(event: Event): void {
   const next = readTextAreaValue(event);
   if (next === undefined) return;
-  if (composing.value) compositionInputValue = next;
+  if (composing.value) composingValue.value = next;
   state.set(next);
   emit("input", next, event);
   void nextTick(syncNativeValue);
@@ -255,25 +255,24 @@ function onChange(event: Event): void {
 
 function onCompositionStart(event: CompositionEvent): void {
   composing.value = true;
-  compositionInputValue = undefined;
+  composingValue.value = element.value?.value ?? value.value;
   emit("compositionStart", value.value, event);
 }
 
 function onCompositionEnd(event: CompositionEvent): void {
-  composing.value = false;
   const next = readTextAreaValue(event);
-  if (next !== undefined && next !== compositionInputValue) state.set(next);
-  compositionInputValue = undefined;
-  emit("compositionEnd", next ?? value.value, event);
+  const composed = next ?? composingValue.value;
+  composing.value = false;
+  if (composed !== undefined && composed !== composingValue.value) state.set(composed);
+  composingValue.value = undefined;
+  emit("compositionEnd", composed ?? value.value, event);
   void nextTick(syncNativeValue);
 }
 
-/** Move focus to the native textarea. */
 function focus(options?: FocusOptions): void {
   element.value?.focus(options);
 }
 
-/** Select the current native textarea text. */
 function select(): void {
   element.value?.select();
 }

--- a/npm/ui/core/src/textarea.test.ts
+++ b/npm/ui/core/src/textarea.test.ts
@@ -210,12 +210,14 @@ test("controlled textarea does not rewrite native text during IME composition", 
   await nextTick();
 
   assert.equal(textarea.value, "か\n");
+  assert.equal(textarea.getAttribute("data-empty"), "false");
   assert.equal(handle.exposes<{ composing: boolean }>().composing, true);
 
   dispatchComposition(textarea, "compositionend");
   await nextTick();
 
   assert.equal(textarea.value, "");
+  assert.equal(textarea.getAttribute("data-empty"), "true");
   assert.deepEqual(
     handle.recorded().map((emitted) => [emitted.event, emitted.payload[0]]),
     [


### PR DESCRIPTION
## Summary
- track the native textarea value reactively while IME composition is active
- derive data-empty from the composed text during composition and the committed state otherwise
- cover the controlled composition case where the parent has not accepted the update yet

## Verification
- vp exec node scripts/lint-sfc.ts src && vp exec node scripts/check-renderers.ts src
- vp check src scripts vite.config.ts tsconfig.typecheck.json
- ./node_modules/.bin/vue-tsc --noEmit -p tsconfig.typecheck.json
- vp pack
- vp test run
- node scripts/check-size.mjs
- node scripts/check-tree-shaking.mjs
- git diff --check

Refs #4901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controlled textarea behavior during IME text composition.
  * Empty-state indicators now accurately reflect composed text while typing and after composition ends.
  * Final composed values are reliably applied when composition completes.

* **Tests**
  * Added coverage for empty-state behavior during and after IME composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->