### PR TITLE
fix(cli): require TypeScript 7 for bundled check runtime

### DIFF
--- a/npm/cli/src/corsa-runtime.ts
+++ b/npm/cli/src/corsa-runtime.ts
@@ -47,6 +47,7 @@ export function resolveBundledCorsaRuntime(options: RuntimeResolutionOptions = {
       const platformManifest = readManifest(platformManifestPath);
       if (
         platformManifest.name !== platformPackage ||
+        !isTypeScriptSevenOrNewer(platformManifest.version) ||
         !matchesDeclaredVersion(platformManifest.version, declaredBundledPlatformVersion)
       ) {
         return null;

--- a/npm/cli/tests/corsa-runtime.test.ts
+++ b/npm/cli/tests/corsa-runtime.test.ts
@@ -123,6 +123,27 @@ test("missing bundled runtime leaves existing discovery untouched", () => {
   }
 });
 
+test("old bundled TypeScript platform runtime leaves existing discovery untouched", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-cli-corsa-old-runtime-"));
+  try {
+    const packageRoot = path.join(root, "node_modules", "vize");
+    const platformPackage = `@typescript/typescript-${process.platform}-${process.arch}`;
+    writeTypeScriptRuntime(packageRoot, platformPackage, "6.0.3", oldRuntimeSource);
+    writeJson(path.join(packageRoot, "package.json"), {
+      name: "vize",
+      optionalDependencies: { [platformPackage]: "6.0.3" },
+      type: "module",
+    });
+    const environment = {};
+
+    assert.equal(resolveBundledCorsaRuntime({ packageRoot }), null);
+    assert.equal(configureBundledCorsaRuntime(environment, { packageRoot }), null);
+    assert.deepEqual(environment, {});
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});
+
 test("missing platform executable falls back without mutating the environment", () => {
   const fixture = createRuntimeFixture();
   try {


### PR DESCRIPTION
Closes #5272

## Summary
- require bundled @typescript/typescript-* platform runtimes to report TypeScript 7 or newer before setting CORSA_PATH
- add a CLI regression proving a bundled TypeScript 6 platform runtime is ignored without mutating discovery state

## Verification
- cargo fmt --all -- --check
- pnpm --filter vize check
- pnpm --filter vize test
- node --test tests/tooling/release-smoke-install.test.ts tests/tooling/package-manifests-corsa-runtime.test.ts
- cargo test -p vize_canon --locked corsa_not_found
- cargo test -p vize_carton --locked corsa_resolver
- npx vize check in /Users/nishimura/Code/gitlab.com/mates-pay/app/aim/aimCMS-front reaches TypeScript 7 Corsa diagnostics instead of native-preview guidance

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790618947&installation_model_id=422833&pr_number=5273&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5273&signature=4650770969acbd711073764ae38bef8c9b75461ea9d833e72db71415ed2b660a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->