### PR TITLE
fix(ui): make search clear slot optional

### DIFF
--- a/npm/ui/core/src/search-field-types.ts
+++ b/npm/ui/core/src/search-field-types.ts
@@ -94,7 +94,7 @@ export interface SearchFieldClearSlotState {
 /** Slots accepted by the SearchField component. */
 export interface SearchFieldSlots {
   /** Renders the default clear button contents with current availability state. */
-  clear(props: SearchFieldClearSlotState): unknown;
+  clear?(props: SearchFieldClearSlotState): unknown;
 }
 
 /** Emits declared by the SearchField component. */

--- a/npm/ui/core/src/search-field.types.test-d.ts
+++ b/npm/ui/core/src/search-field.types.test-d.ts
@@ -1,5 +1,7 @@
 /** Compile-only assertions for the public search field contract. */
 
+import { h } from "vue";
+
 import type {
   SearchFieldAriaInvalid,
   SearchFieldClearSlotState,
@@ -7,7 +9,9 @@ import type {
   SearchFieldEnterKeyHint,
   SearchFieldExpose,
   SearchFieldInputMode,
+  SearchFieldSlots,
 } from "./search-field.ts";
+import { SearchField } from "./search-field.ts";
 
 type Equal<Left, Right> =
   (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
@@ -44,6 +48,12 @@ search.clear();
 search.reset();
 search.focus();
 search.select();
+h(SearchField, { ariaLabel: "Search", defaultValue: "query", showClear: "always" });
+
+export const slotlessSlots: SearchFieldSlots = {};
+export const clearSlots: SearchFieldSlots = {
+  clear: (state) => (state.empty ? "Empty" : "Clear"),
+};
 
 // @ts-expect-error search values are strings.
 search.setValue(1);

--- a/npm/ui/core/src/search-field.vue
+++ b/npm/ui/core/src/search-field.vue
@@ -72,7 +72,7 @@ const {
 
 defineSlots<{
   /** Replaces the default clear button contents with availability state. */
-  clear(props: SearchFieldClearSlotState): unknown;
+  clear?(props: SearchFieldClearSlotState): unknown;
 }>();
 
 const emit = defineEmits<{


### PR DESCRIPTION
## Summary
- make the SearchField clear slot optional in the SFC and public slot contract
- add consumer type fixtures for slotless SearchField usage and empty slot maps

## Verification
- vp exec node scripts/lint-sfc.ts src && vp exec node scripts/check-renderers.ts src
- vp check src scripts vite.config.ts tsconfig.typecheck.json
- ./node_modules/.bin/vue-tsc --noEmit -p tsconfig.typecheck.json
- vp pack
- vp test run
- node scripts/check-size.mjs
- node scripts/check-tree-shaking.mjs
- git diff --check

Follow-up for #5271
Refs #4901

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790619670&installation_model_id=422833&pr_number=5274&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5274&signature=11088eeb237e349d0cdb1df02da159a3f35b8c4c3af19cc0679d1985cf568169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->