### PR TITLE
refactor(patina): port interactive focus rule to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -8,6 +8,7 @@ mod directives;
 mod jsx;
 mod jsx_deprecated_attr;
 mod jsx_fallback;
+mod jsx_interactive_supports_focus;
 mod jsx_media_has_caption;
 mod jsx_mouse_events_have_key_events;
 mod jsx_no_aria_hidden_on_focusable;

--- a/crates/vize_patina/src/linter/tests/jsx_interactive_supports_focus.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_interactive_supports_focus.rs
@@ -1,0 +1,143 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::InteractiveSupportsFocus;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn interactive_supports_focus_fires_on_jsx_and_tsx_ir() {
+    let linter = linter_with(Box::new(InteractiveSupportsFocus));
+    let source = r#"const A = () => <div role="button" onClick={handle}>Click</div>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        result.warning_count, 1,
+        "JSX element with interactive role must flag through IR: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/interactive-supports-focus"]
+    );
+
+    let diag = &result.diagnostics[0];
+    let element = r#"<div role="button" onClick={handle}>Click</div>"#;
+    let element_start = source.find(element).unwrap() as u32;
+    assert_eq!(
+        diag.start, element_start,
+        "range must start at the written JSX element"
+    );
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        element,
+        "range must cover the authored JSX element"
+    );
+    assert_eq!(diag.severity, Severity::Warning);
+    assert!(diag.help.is_some(), "diagnostic should keep rule help");
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <span role="link">Home</span>;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(tsx.warning_count, 1);
+    assert_eq!(tsx.error_count, 0);
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["a11y/interactive-supports-focus"],
+        "TSX spans with interactive roles must also flag through IR"
+    );
+}
+
+#[test]
+fn interactive_supports_focus_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(InteractiveSupportsFocus));
+    for source in [
+        r#"const A = () => <div role="presentation" />;"#,
+        r#"const A = () => <div role="Button" />;"#,
+        r#"const A = () => <div role="button " />;"#,
+        r#"const A = () => <div role="button link" />;"#,
+        r#"const A = () => <div ROLE="button" />;"#,
+        r#"const A = () => <div role={role} />;"#,
+        r#"const A = () => <div role={"button"} />;"#,
+        r#"const A = () => <div role />;"#,
+        r#"const A = () => <div role role="button" />;"#,
+        r#"const A = () => <div role="presentation" role="button" />;"#,
+        r#"const A = () => <div role="button" tabindex="0" />;"#,
+        r#"const A = () => <div role="button" tabindex="" />;"#,
+        r#"const A = () => <div role="button" tabindex="x" />;"#,
+        r#"const A = () => <div role="button" contenteditable="true" />;"#,
+        r#"const A = () => <div role="button" contenteditable="" />;"#,
+        r#"const A = () => <div role="button" contenteditable="plaintext-only" />;"#,
+        r#"const A = () => <button role="link" />;"#,
+        r#"const A = () => <a role="button">Decorative link</a>;"#,
+        r#"const A = () => <details role="button" />;"#,
+        r#"const A = () => <audio role="button" />;"#,
+        r#"const A = () => <video role="button" />;"#,
+        r#"const A = () => <area href="/map" role="button" />;"#,
+        r#"const A = () => <area href={map} role="button" />;"#,
+        r#"const A = () => <Button role="button" />;"#,
+        r#"const A = () => <Forms.button role="button" />;"#,
+        r#"const A = () => <div a11y:role="button" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+
+    for source in [
+        r#"const A = () => <div role="button" />;"#,
+        r#"const A = () => <span role="link" />;"#,
+        r#"const A = () => <div role="button" role="presentation" />;"#,
+        r#"const A = () => <div role="button" tabindex="-1" />;"#,
+        r#"const A = () => <div role="button" tabIndex="0" />;"#,
+        r#"const A = () => <div role="button" contentEditable="true" />;"#,
+        r#"const A = () => <area role="button" />;"#,
+        r#"const A = () => <area ns:href={map} role="button" />;"#,
+        r#"const A = () => <ui:button role="button" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 1,
+            "must keep warning for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+}
+
+#[test]
+fn migrated_interactive_supports_focus_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(InteractiveSupportsFocus));
+    let result = linter.lint_jsx(
+        r#"const A = () => <div role="button" onClick={handle}>Click</div>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated interactive-supports-focus rule must report once: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -8,6 +8,8 @@
 // test files) so the Davinci assertion lint, which only scans inline
 // `#[cfg(test)] mod` bodies under `src/`, keeps covering these tests.
 mod deprecated_attr_tests;
+mod interactive_supports_focus_jsx_tests;
+mod interactive_supports_focus_tests;
 mod media_has_caption_tests;
 mod mouse_events_have_key_events_tests;
 mod no_aria_hidden_on_focusable_jsx_tests;

--- a/crates/vize_patina/src/markup/tests/interactive_supports_focus_jsx_tests.rs
+++ b/crates/vize_patina/src/markup/tests/interactive_supports_focus_jsx_tests.rs
@@ -1,0 +1,229 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::InteractiveSupportsFocus;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn interactive_supports_focus_jsx_direct_matches_lowered() {
+    let rule = InteractiveSupportsFocus;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <div role="button" onClick={handle}>Click</div>;"#,
+            1,
+            "div button role without focus",
+        ),
+        (
+            r#"const A = () => <span role="link">Link</span>;"#,
+            1,
+            "span link role without focus",
+        ),
+        (
+            r#"const A = () => <div role="button" tabindex="0">Click</div>;"#,
+            0,
+            "lowercase tabindex",
+        ),
+        (
+            r#"const A = () => <div role="button" tabindex="">Click</div>;"#,
+            0,
+            "empty tabindex",
+        ),
+        (
+            r#"const A = () => <div role="button" tabindex="x">Click</div>;"#,
+            0,
+            "non-numeric tabindex",
+        ),
+        (
+            r#"const A = () => <div role="button" tabindex="-1">Click</div>;"#,
+            1,
+            "negative tabindex",
+        ),
+        (
+            r#"const A = () => <div role="button" tabIndex="0">Click</div>;"#,
+            1,
+            "camel-case tabIndex is outside the legacy exact helper",
+        ),
+        (
+            r#"const A = () => <div role="button" contenteditable="true">Click</div>;"#,
+            0,
+            "contenteditable true",
+        ),
+        (
+            r#"const A = () => <div role="button" contenteditable="">Click</div>;"#,
+            0,
+            "empty contenteditable",
+        ),
+        (
+            r#"const A = () => <div role="button" contenteditable="plaintext-only">Click</div>;"#,
+            0,
+            "plaintext-only contenteditable",
+        ),
+        (
+            r#"const A = () => <div role="button" contenteditable="FALSE">Click</div>;"#,
+            0,
+            "contenteditable value is exact",
+        ),
+        (
+            r#"const A = () => <div role="button" contentEditable="true">Click</div>;"#,
+            1,
+            "camel-case contentEditable is outside the legacy exact helper",
+        ),
+        (
+            r#"const A = () => <area role="button" />;"#,
+            1,
+            "area without href",
+        ),
+        (
+            r#"const A = () => <area href="/map" role="button" />;"#,
+            0,
+            "area with static href",
+        ),
+        (
+            r#"const A = () => <area href={map} role="button" />;"#,
+            0,
+            "area with dynamic href value",
+        ),
+        (
+            r#"const A = () => <area ns:href={map} role="button" />;"#,
+            1,
+            "namespaced href stays ignored",
+        ),
+        (
+            r#"const A = () => <button role="link">Click</button>;"#,
+            0,
+            "native button",
+        ),
+        (
+            r#"const A = () => <a role="button">Decorative link</a>;"#,
+            0,
+            "anchor is natively interactive even without href",
+        ),
+        (
+            r#"const A = () => <details role="button" />;"#,
+            0,
+            "details is natively interactive in the legacy helper",
+        ),
+        (
+            r#"const A = () => <audio role="button" />;"#,
+            0,
+            "audio is natively interactive in the legacy helper",
+        ),
+        (
+            r#"const A = () => <video role="button" />;"#,
+            0,
+            "video is natively interactive in the legacy helper",
+        ),
+        (
+            r#"const A = () => <div role="presentation">Content</div>;"#,
+            0,
+            "non-interactive role",
+        ),
+        (
+            r#"const A = () => <div role="Button">Click</div>;"#,
+            0,
+            "role value is exact",
+        ),
+        (
+            r#"const A = () => <div role="button ">Click</div>;"#,
+            0,
+            "role value is not trimmed",
+        ),
+        (
+            r#"const A = () => <div role="button link">Click</div>;"#,
+            0,
+            "role value is not tokenized",
+        ),
+        (
+            r#"const A = () => <div ROLE="button">Click</div>;"#,
+            0,
+            "case-sensitive role attr",
+        ),
+        (
+            r#"const A = () => <div role={role}>Click</div>;"#,
+            0,
+            "dynamic role",
+        ),
+        (
+            r#"const A = () => <div role={"button"}>Click</div>;"#,
+            0,
+            "dynamic string role",
+        ),
+        (
+            r#"const A = () => <div role>Click</div>;"#,
+            0,
+            "valueless role",
+        ),
+        (
+            r#"const A = () => <div role role="button">Click</div>;"#,
+            0,
+            "first valueless duplicate role masks later values",
+        ),
+        (
+            r#"const A = () => <div role="button" role="presentation">Click</div>;"#,
+            1,
+            "first interactive duplicate controls",
+        ),
+        (
+            r#"const A = () => <div role="presentation" role="button">Click</div>;"#,
+            0,
+            "later duplicate role does not override first value",
+        ),
+        (
+            r#"const A = () => <Button role="button" />;"#,
+            0,
+            "components stay skipped",
+        ),
+        (
+            r#"const A = () => <Forms.button role="button" />;"#,
+            0,
+            "member JSX tags stay outside unqualified native tags",
+        ),
+        (
+            r#"const A = () => <ui:button role="button" />;"#,
+            1,
+            "namespaced JSX tags stay outside unqualified native tags",
+        ),
+        (
+            r#"const A = () => <div a11y:role="button" />;"#,
+            0,
+            "namespaced role is outside exact unqualified attributes",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(direct, expected, "JSX direct case failed: {label}");
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "JSX direct and lowered fallback diverged for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/markup/tests/interactive_supports_focus_tests.rs
+++ b/crates/vize_patina/src/markup/tests/interactive_supports_focus_tests.rs
@@ -1,0 +1,197 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::InteractiveSupportsFocus;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn interactive_supports_focus_template() {
+    let rule = InteractiveSupportsFocus;
+    for (source, expected, label) in [
+        (
+            r#"<div role="button" @click="handle">Click</div>"#,
+            1,
+            "div button role without focus",
+        ),
+        (
+            r#"<span role="link">Link</span>"#,
+            1,
+            "span link role without focus",
+        ),
+        (
+            r#"<div role="button" tabindex="0" @click="handle">Click</div>"#,
+            0,
+            "tabindex zero",
+        ),
+        (
+            r#"<div role="button" tabindex="">Click</div>"#,
+            0,
+            "empty tabindex remains focusable",
+        ),
+        (
+            r#"<div role="button" tabindex="x">Click</div>"#,
+            0,
+            "non-numeric tabindex remains focusable",
+        ),
+        (
+            r#"<div role="button" tabindex="-1">Click</div>"#,
+            1,
+            "negative tabindex is not focusable",
+        ),
+        (
+            r#"<div role="button" tabindex tabindex="0">Click</div>"#,
+            1,
+            "first valueless duplicate tabindex masks later values",
+        ),
+        (
+            r#"<div role="button" :tabindex="0">Click</div>"#,
+            1,
+            "bound tabindex stays outside the legacy static-value helper",
+        ),
+        (
+            r#"<div role="button" contenteditable="true">Click</div>"#,
+            0,
+            "contenteditable true",
+        ),
+        (
+            r#"<div role="button" contenteditable="">Click</div>"#,
+            0,
+            "empty contenteditable remains focusable",
+        ),
+        (
+            r#"<div role="button" contenteditable="plaintext-only">Click</div>"#,
+            0,
+            "plaintext-only contenteditable remains focusable",
+        ),
+        (
+            r#"<div role="button" contenteditable="FALSE">Click</div>"#,
+            0,
+            "contenteditable value is exact",
+        ),
+        (
+            r#"<div role="button" contenteditable="false">Click</div>"#,
+            1,
+            "contenteditable false",
+        ),
+        (
+            r#"<div role="button" :contenteditable="true">Click</div>"#,
+            1,
+            "bound contenteditable stays outside the legacy static-value helper",
+        ),
+        (
+            r#"<div role="button" contenteditable="false" contenteditable="true">Click</div>"#,
+            1,
+            "later duplicate contenteditable does not override first value",
+        ),
+        (
+            r#"<area role="button" />"#,
+            1,
+            "area is focusable only with href",
+        ),
+        (
+            r#"<area href="/map" role="button" />"#,
+            0,
+            "area with static href",
+        ),
+        (
+            r#"<area :href="map" role="button" />"#,
+            0,
+            "area with static-arg bound href",
+        ),
+        (
+            r#"<area :[href]="map" role="button" />"#,
+            1,
+            "area with dynamic href argument",
+        ),
+        (r#"<button role="link">Click</button>"#, 0, "native button"),
+        (
+            r#"<a role="button">Decorative link</a>"#,
+            0,
+            "anchor is natively interactive even without href",
+        ),
+        (
+            r#"<details role="button"></details>"#,
+            0,
+            "details is natively interactive in the legacy helper",
+        ),
+        (
+            r#"<audio role="button"></audio>"#,
+            0,
+            "audio is natively interactive in the legacy helper",
+        ),
+        (
+            r#"<video role="button"></video>"#,
+            0,
+            "video is natively interactive in the legacy helper",
+        ),
+        (
+            r#"<div role="presentation">Content</div>"#,
+            0,
+            "non-interactive role",
+        ),
+        (
+            r#"<div role="Button">Click</div>"#,
+            0,
+            "role value is exact",
+        ),
+        (
+            r#"<div role="button ">Click</div>"#,
+            0,
+            "role value is not trimmed",
+        ),
+        (
+            r#"<div role="button link">Click</div>"#,
+            0,
+            "role value is not tokenized",
+        ),
+        (
+            r#"<div ROLE="button">Click</div>"#,
+            0,
+            "role attribute name is exact",
+        ),
+        (
+            r#"<div :role="'button'">Click</div>"#,
+            0,
+            "bound role stays dynamic",
+        ),
+        (r#"<div role>Click</div>"#, 0, "valueless role stays clean"),
+        (
+            r#"<div role role="button">Click</div>"#,
+            0,
+            "first valueless duplicate role masks later values",
+        ),
+        (
+            r#"<div role="button" role="presentation">Click</div>"#,
+            1,
+            "first interactive duplicate controls",
+        ),
+        (
+            r#"<div role="presentation" role="button">Click</div>"#,
+            0,
+            "later duplicate role does not override first value",
+        ),
+        (
+            r#"<MyButton role="button">Click</MyButton>"#,
+            0,
+            "components stay skipped",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template case failed: {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/a11y/helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/helpers.rs
@@ -73,51 +73,6 @@ pub fn is_interactive_role(role: &str) -> bool {
     )
 }
 
-/// Check if an element is focusable (natively or via tabindex)
-pub fn is_focusable_element(element: &ElementNode) -> bool {
-    let tag = element.tag;
-
-    if matches!(tag, "a" | "area") && has_named_prop(element, "href") {
-        return true;
-    }
-
-    // Natively focusable elements
-    if matches!(tag, "button" | "input" | "select" | "textarea" | "summary") {
-        return true;
-    }
-
-    // Check for tabindex attribute
-    if let Some(tabindex) = get_static_attribute_value(element, "tabindex") {
-        if let Ok(val) = tabindex.parse::<i32>() {
-            return val >= 0;
-        }
-        // Non-numeric tabindex is still focusable
-        return true;
-    }
-
-    // Check for contenteditable
-    if let Some(val) = get_static_attribute_value(element, "contenteditable")
-        && val != "false"
-    {
-        return true;
-    }
-
-    false
-}
-
-pub(super) fn has_named_prop(element: &ElementNode, name: &str) -> bool {
-    element.props.iter().any(|prop| match prop {
-        PropNode::Attribute(attr) => attr.name == name,
-        PropNode::Directive(dir) if dir.name == "bind" => {
-            matches!(
-                dir.arg.as_ref(),
-                Some(ExpressionNode::Simple(arg)) if arg.is_static && arg.content == name
-            )
-        }
-        _ => false,
-    })
-}
-
 /// Get the static (non-dynamic) value of an attribute on an element.
 /// Returns None if the attribute is not found or is dynamically bound.
 pub fn get_static_attribute_value<'a>(element: &'a ElementNode, name: &str) -> Option<&'a str> {

--- a/crates/vize_patina/src/rules/a11y/interactive_supports_focus.rs
+++ b/crates/vize_patina/src/rules/a11y/interactive_supports_focus.rs
@@ -20,12 +20,11 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, ElementType};
+use vize_relief::ElementNode;
 
-use super::helpers::{
-    get_static_attribute_value, is_focusable_element, is_interactive_element, is_interactive_role,
-};
+use super::{helpers::is_interactive_role, markup_helpers};
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/interactive-supports-focus",
@@ -39,23 +38,19 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct InteractiveSupportsFocus;
 
-impl Rule for InteractiveSupportsFocus {
-    fn meta(&self) -> &'static RuleMeta {
-        &META
-    }
-
-    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if element.tag_type == ElementType::Component {
+impl InteractiveSupportsFocus {
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        if element.is_component() {
             return;
         }
 
         // Skip natively interactive elements - they're already focusable
-        if is_interactive_element(element.tag) {
+        if markup_helpers::is_interactive_markup_element(element) {
             return;
         }
 
         // Check if element has an interactive role
-        let role = match get_static_attribute_value(element, "role") {
+        let role = match markup_helpers::get_static_markup_attribute_value(element, "role") {
             Some(r) => r,
             None => return,
         };
@@ -66,13 +61,37 @@ impl Rule for InteractiveSupportsFocus {
 
         // Element has interactive role but is not natively interactive
         // Check if it's focusable
-        if !is_focusable_element(element) {
-            ctx.warn_with_help(
+        if !markup_helpers::is_focusable_markup_element(element) {
+            ctx.warn_at_with_help(
                 ctx.t_fmt("a11y/interactive-supports-focus.message", &[("role", role)]),
-                &element.loc,
+                element.range(),
                 ctx.t("a11y/interactive-supports-focus.help"),
             );
         }
+    }
+}
+
+impl MarkupRule for InteractiveSupportsFocus {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        Self::check_element(ctx.lint(), element);
+    }
+}
+
+impl Rule for InteractiveSupportsFocus {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
 

--- a/crates/vize_patina/src/rules/a11y/markup_helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/markup_helpers.rs
@@ -2,6 +2,19 @@
 
 use crate::markup::{MarkupBindingKind, MarkupElement};
 
+/// Check if a markup facade element is natively interactive.
+pub fn is_interactive_markup_element(element: &MarkupElement<'_>) -> bool {
+    element.is_unqualified_tag_exact("a")
+        || element.is_unqualified_tag_exact("button")
+        || element.is_unqualified_tag_exact("input")
+        || element.is_unqualified_tag_exact("select")
+        || element.is_unqualified_tag_exact("textarea")
+        || element.is_unqualified_tag_exact("details")
+        || element.is_unqualified_tag_exact("summary")
+        || element.is_unqualified_tag_exact("video")
+        || element.is_unqualified_tag_exact("audio")
+}
+
 /// Check if a markup facade element is focusable (natively or via tabindex).
 pub fn is_focusable_markup_element(element: &MarkupElement<'_>) -> bool {
     if (element.is_unqualified_tag_exact("a") || element.is_unqualified_tag_exact("area"))

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           311 |                   311 |                 0 |             276 |     244 |             673 |      158 |           351 |           500 |
+| Linter                     |           313 |                   313 |                 0 |             277 |     247 |             673 |      164 |           353 |           503 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         311 |             224 |       87 |
-| old AST/parser   |         234 |             211 |       23 |
+| S0               |         313 |             224 |       89 |
+| old AST/parser   |         235 |             211 |       24 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         244 |             200 |       44 |
+| raw OXC          |         247 |             200 |       47 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:29`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:31`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 47 omitted.
+Additional test/dev rows are in the TSV: 49 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,12 +991,16 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	29	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	29	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	29	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	31	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	31	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	31	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/interactive_supports_focus_jsx_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/interactive_supports_focus_jsx_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/interactive_supports_focus_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/interactive_supports_focus_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/media_has_caption_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/media_has_caption_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/media_has_caption_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1042,7 +1046,7 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	s0	S0	stage	
 linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/iframe_has_title.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/a11y/img_alt.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	4
-linter	Linter	source	crates/vize_patina/src/rules/a11y/interactive_supports_focus.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/a11y/interactive_supports_focus.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/label_has_for.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/media_has_caption.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/mouse_events_have_key_events.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 21, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 22, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 126, `ir` 18, `ir-lowered` 3, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (21 = 21 `markup-facade` rules)
+- JSX lanes: `fallback` 125, `ir` 19, `ir-lowered` 3, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (22 = 22 `markup-facade` rules)
 - classification: neutral-core-candidate **85** · vue-dialect-bound **138** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -58,7 +58,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/heading-levels`                           | template-family | `opinionated/a11y/heading_levels.rs`                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `a11y/iframe-has-title`                         | template-family | `a11y/iframe_has_title.rs`                             | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/img-alt`                                  | template-family | `a11y/img_alt.rs`                                      | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |
-| `a11y/interactive-supports-focus`               | template-family | `a11y/interactive_supports_focus.rs`                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `a11y/interactive-supports-focus`               | template-family | `a11y/interactive_supports_focus.rs`                   | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/label-has-for`                            | template-family | `a11y/label_has_for.rs`                                | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/landmark-roles`                           | template-family | `opinionated/a11y/landmark_roles.rs`                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/media-has-caption`                        | template-family | `a11y/media_has_caption.rs`                            | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |


### PR DESCRIPTION
## Summary

- migrate `a11y/interactive-supports-focus` onto the shared Markup facade
- preserve legacy exact role, focusability, native-interactive, duplicate-attribute, component, and JSX namespace boundaries with regressions
- regenerate Davinci rule-parity and consumer migration surface inventories

Closes #5276

## Validation

- `cargo test -p vize_patina interactive_supports_focus --locked`
- `cargo test -q -p vize_patina --locked`
- `cargo check -q -p vize_patina --all-targets --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `node tools/davinci/assertion-lint.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check HEAD && git diff --check --cached`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790620481&installation_model_id=422833&pr_number=5277&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5277&signature=eb5da6b7a5d613d093f1b6b98eab95f58e157bda0eb1af21dd87a1bef042203f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accessibility check for interactive elements, including support for JSX and Vue markup.
  * More accurately recognizes focusability through native controls, links, `tabindex`, and `contenteditable`.
  * Prevents duplicate warnings and handles dynamic, namespaced, and duplicate attributes more consistently.

* **Documentation**
  * Updated rule coverage and migration documentation to reflect the improved accessibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->