### PR TITLE
refactor(patina): port iframe title rule to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -8,6 +8,7 @@ mod directives;
 mod jsx;
 mod jsx_deprecated_attr;
 mod jsx_fallback;
+mod jsx_iframe_has_title;
 mod jsx_interactive_supports_focus;
 mod jsx_media_has_caption;
 mod jsx_mouse_events_have_key_events;

--- a/crates/vize_patina/src/linter/tests/jsx_iframe_has_title.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_iframe_has_title.rs
@@ -1,0 +1,121 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::IframeHasTitle;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn iframe_has_title_fires_on_jsx_and_tsx_ir() {
+    let linter = linter_with(Box::new(IframeHasTitle));
+    let source = r#"const A = () => <iframe src="https://example.com" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        result.warning_count, 1,
+        "JSX iframe without title must flag through IR: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+    assert_eq!(diagnostic_rules(&result), vec!["a11y/iframe-has-title"]);
+
+    let diag = &result.diagnostics[0];
+    let element = r#"<iframe src="https://example.com" />"#;
+    let iframe_start = source.find(element).unwrap() as u32;
+    assert_eq!(
+        diag.start, iframe_start,
+        "range must start at the written JSX iframe"
+    );
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        element,
+        "range must cover the authored JSX iframe element"
+    );
+    assert_eq!(diag.severity, Severity::Warning);
+    assert!(diag.help.is_some(), "diagnostic should keep rule help");
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <iframe src="https://example.com" />;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(tsx.warning_count, 1);
+    assert_eq!(tsx.error_count, 0);
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["a11y/iframe-has-title"],
+        "TSX iframe without title must also flag through IR"
+    );
+}
+
+#[test]
+fn iframe_has_title_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(IframeHasTitle));
+    for source in [
+        r#"const A = () => <iframe src="https://example.com" title="Example" />;"#,
+        r#"const A = () => <iframe src="https://example.com" title="0" />;"#,
+        r#"const A = () => <iframe src="https://example.com" title={frameTitle} />;"#,
+        r#"const A = () => <iframe src="https://example.com" title={""} />;"#,
+        r#"const A = () => <iframe src="https://example.com" title="" title="Example" />;"#,
+        r#"const A = () => <iframe src="https://example.com" title="" title={frameTitle} />;"#,
+        r#"const A = () => <Iframe src="https://example.com" />;"#,
+        r#"const A = () => <Frame.iframe src="https://example.com" />;"#,
+        r#"const A = () => <svg:iframe src="https://example.com" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+
+    for source in [
+        r#"const A = () => <iframe src="https://example.com" />;"#,
+        r#"const A = () => <iframe src="https://example.com" title />;"#,
+        r#"const A = () => <iframe src="https://example.com" title="" />;"#,
+        r#"const A = () => <iframe src="https://example.com" title="   " />;"#,
+        r#"const A = () => <iframe src="https://example.com" TITLE="Example" />;"#,
+        r#"const A = () => <iframe src="https://example.com" {...frameAttrs} />;"#,
+        r#"const A = () => <iframe src="https://example.com" ns:title="Example" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 1,
+            "must keep warning for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+}
+
+#[test]
+fn migrated_iframe_has_title_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(IframeHasTitle));
+    let result = linter.lint_jsx(
+        r#"const A = () => <iframe src="https://example.com" />;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated iframe-has-title rule must report once: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -8,6 +8,8 @@
 // test files) so the Davinci assertion lint, which only scans inline
 // `#[cfg(test)] mod` bodies under `src/`, keeps covering these tests.
 mod deprecated_attr_tests;
+mod iframe_has_title_jsx_tests;
+mod iframe_has_title_tests;
 mod interactive_supports_focus_jsx_tests;
 mod interactive_supports_focus_tests;
 mod media_has_caption_tests;

--- a/crates/vize_patina/src/markup/tests/iframe_has_title_jsx_tests.rs
+++ b/crates/vize_patina/src/markup/tests/iframe_has_title_jsx_tests.rs
@@ -1,0 +1,129 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::IframeHasTitle;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn iframe_has_title_jsx_direct_matches_lowered() {
+    let rule = IframeHasTitle;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <iframe src="https://example.com" title="Example website" />;"#,
+            0,
+            "static title",
+        ),
+        (
+            r#"const A = () => <iframe src="https://example.com" title="0" />;"#,
+            0,
+            "nonempty numeric-looking title",
+        ),
+        (
+            r#"const A = () => <iframe src="https://example.com" title={frameTitle} />;"#,
+            0,
+            "dynamic title",
+        ),
+        (
+            r#"const A = () => <iframe src="https://example.com" title={""} />;"#,
+            0,
+            "dynamic empty string title stays valid like the legacy fallback",
+        ),
+        (
+            r#"const A = () => <iframe src="https://example.com" />;"#,
+            1,
+            "missing title",
+        ),
+        (
+            r#"const A = () => <iframe src="https://example.com" title />;"#,
+            1,
+            "valueless title",
+        ),
+        (
+            r#"const A = () => <iframe src="https://example.com" title="" />;"#,
+            1,
+            "empty title",
+        ),
+        (
+            r#"const A = () => <iframe src="https://example.com" title="   " />;"#,
+            1,
+            "whitespace-only title",
+        ),
+        (
+            r#"const A = () => <iframe src="https://example.com" TITLE="Example" />;"#,
+            1,
+            "title attribute name is exact",
+        ),
+        (
+            r#"const A = () => <iframe src="https://example.com" {...frameAttrs} />;"#,
+            1,
+            "spread props do not prove title",
+        ),
+        (
+            r#"const A = () => <iframe src="https://example.com" title="" title="Example" />;"#,
+            0,
+            "later nonempty duplicate static title can satisfy the rule",
+        ),
+        (
+            r#"const A = () => <iframe src="https://example.com" title="" title={frameTitle} />;"#,
+            0,
+            "later dynamic duplicate title can satisfy the rule",
+        ),
+        (
+            r#"const A = () => <iframe src="https://example.com" ns:title="Example" />;"#,
+            1,
+            "namespaced title is not an unqualified title attribute",
+        ),
+        (
+            r#"const A = () => <Iframe src="https://example.com" />;"#,
+            0,
+            "capitalized component is not an iframe tag",
+        ),
+        (
+            r#"const A = () => <Frame.iframe src="https://example.com" />;"#,
+            0,
+            "member JSX tag is not an iframe tag",
+        ),
+        (
+            r#"const A = () => <svg:iframe src="https://example.com" />;"#,
+            0,
+            "namespaced tag is not an unqualified iframe tag",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(direct, expected, "JSX direct case failed: {label}");
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "JSX direct and lowered fallback diverged for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/markup/tests/iframe_has_title_tests.rs
+++ b/crates/vize_patina/src/markup/tests/iframe_has_title_tests.rs
@@ -1,0 +1,150 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::IframeHasTitle;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn iframe_has_title_template() {
+    let rule = IframeHasTitle;
+    for (source, expected, label) in [
+        (
+            r#"<iframe src="https://example.com" title="Example website"></iframe>"#,
+            0,
+            "static title",
+        ),
+        (
+            r#"<iframe src="https://example.com" title="0"></iframe>"#,
+            0,
+            "nonempty numeric-looking title",
+        ),
+        (
+            r#"<iframe src="https://example.com" :title="frameTitle"></iframe>"#,
+            0,
+            "bound shorthand title",
+        ),
+        (
+            r#"<iframe src="https://example.com" v-bind:title="frameTitle"></iframe>"#,
+            0,
+            "bound longhand title",
+        ),
+        (
+            r#"<iframe src="https://example.com" :title></iframe>"#,
+            0,
+            "valueless bound title matches legacy arg-only behavior",
+        ),
+        (
+            r#"<iframe src="https://example.com" :title.trim="frameTitle"></iframe>"#,
+            0,
+            "bound title modifiers keep matching legacy arg-only behavior",
+        ),
+        (
+            r#"<iframe src="https://example.com" v-bind:title=""></iframe>"#,
+            0,
+            "empty bound title expression is still a title binding",
+        ),
+        (
+            r#"<iframe src="https://example.com" :[title]="frameTitle"></iframe>"#,
+            0,
+            "dynamic argument title matches legacy simple arg content",
+        ),
+        (
+            r#"<iframe src="https://example.com" v-bind:[title]="frameTitle"></iframe>"#,
+            0,
+            "longhand dynamic argument title matches legacy simple arg content",
+        ),
+        (
+            r#"<iframe src="https://example.com"></iframe>"#,
+            1,
+            "missing title",
+        ),
+        (
+            r#"<iframe src="https://example.com" title></iframe>"#,
+            1,
+            "valueless title",
+        ),
+        (
+            r#"<iframe src="https://example.com" title=""></iframe>"#,
+            1,
+            "empty title",
+        ),
+        (
+            r#"<iframe src="https://example.com" title="   "></iframe>"#,
+            1,
+            "whitespace-only title",
+        ),
+        (
+            r#"<iframe src="https://example.com" TITLE="Example"></iframe>"#,
+            1,
+            "title attribute name is exact",
+        ),
+        (
+            r#"<iframe src="https://example.com" :Title="frameTitle"></iframe>"#,
+            1,
+            "bound title argument is exact",
+        ),
+        (
+            r#"<iframe src="https://example.com" :[foo]="frameTitle"></iframe>"#,
+            1,
+            "dynamic argument with a different simple content is ignored",
+        ),
+        (
+            r#"<iframe src="https://example.com" v-bind="frameAttrs"></iframe>"#,
+            1,
+            "object v-bind does not prove title",
+        ),
+        (
+            r#"<iframe src="https://example.com" title="" :title="frameTitle"></iframe>"#,
+            0,
+            "later bound title can satisfy the rule",
+        ),
+        (
+            r#"<iframe src="https://example.com" :title="frameTitle" title=""></iframe>"#,
+            0,
+            "earlier bound title can satisfy the rule",
+        ),
+        (
+            r#"<iframe src="https://example.com" title title="Example"></iframe>"#,
+            0,
+            "later nonempty duplicate title can satisfy the rule",
+        ),
+        (
+            r#"<iframe src="https://example.com" title="" title="Example"></iframe>"#,
+            0,
+            "later nonempty duplicate static title can satisfy the rule",
+        ),
+        (
+            r#"<iframe src="https://example.com" @title="noop"></iframe>"#,
+            1,
+            "event named title is ignored",
+        ),
+        (
+            r#"<Iframe src="https://example.com"></Iframe>"#,
+            0,
+            "capitalized component is not an iframe tag",
+        ),
+        (
+            r#"<iframe-widget src="https://example.com"></iframe-widget>"#,
+            0,
+            "custom element is not exact iframe",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template case failed: {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/a11y/iframe_has_title.rs
+++ b/crates/vize_patina/src/rules/a11y/iframe_has_title.rs
@@ -8,8 +8,9 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, PropNode};
+use vize_relief::ElementNode;
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/iframe-has-title",
@@ -23,44 +24,68 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct IframeHasTitle;
 
+impl IframeHasTitle {
+    fn has_title(element: &MarkupElement<'_>) -> bool {
+        let mut has_title = false;
+        element.walk_bindings(&mut |binding| {
+            if !binding.is_unqualified_arg_exact("title") {
+                return;
+            }
+
+            match binding.kind() {
+                MarkupBindingKind::Attribute => {
+                    if binding
+                        .static_value()
+                        .is_some_and(|value| !value.trim().is_empty())
+                    {
+                        has_title = true;
+                    }
+                }
+                MarkupBindingKind::Bind => {
+                    has_title = true;
+                }
+                MarkupBindingKind::On | MarkupBindingKind::Model | MarkupBindingKind::Custom => {}
+            }
+        });
+        has_title
+    }
+
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        if !element.is_unqualified_tag_exact("iframe") {
+            return;
+        }
+
+        if !Self::has_title(element) {
+            ctx.warn_at_with_help(
+                ctx.t("a11y/iframe-has-title.message"),
+                element.range(),
+                ctx.t("a11y/iframe-has-title.help"),
+            );
+        }
+    }
+}
+
+impl MarkupRule for IframeHasTitle {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        Self::check_element(ctx.lint(), element);
+    }
+}
+
 impl Rule for IframeHasTitle {
     fn meta(&self) -> &'static RuleMeta {
         &META
     }
 
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if element.tag != "iframe" {
-            return;
-        }
-
-        // Check for title attribute (static or dynamic)
-        let has_title = element.props.iter().any(|prop| match prop {
-            PropNode::Attribute(attr) => {
-                attr.name == "title"
-                    && attr
-                        .value
-                        .as_ref()
-                        .is_some_and(|v| !v.content.trim().is_empty())
-            }
-            PropNode::Directive(dir) => {
-                if dir.name == "bind" {
-                    matches!(
-                        &dir.arg,
-                        Some(vize_relief::ExpressionNode::Simple(s)) if s.content == "title"
-                    )
-                } else {
-                    false
-                }
-            }
-        });
-
-        if !has_title {
-            ctx.warn_with_help(
-                ctx.t("a11y/iframe-has-title.message"),
-                &element.loc,
-                ctx.t("a11y/iframe-has-title.help"),
-            );
-        }
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           313 |                   313 |                 0 |             277 |     247 |             673 |      164 |           353 |           503 |
+| Linter                     |           315 |                   315 |                 0 |             277 |     250 |             672 |      170 |           355 |           506 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         313 |             224 |       89 |
-| old AST/parser   |         235 |             211 |       24 |
+| S0               |         315 |             224 |       91 |
+| old AST/parser   |         235 |             210 |       25 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         247 |             200 |       47 |
+| raw OXC          |         250 |             200 |       50 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:31`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:33`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 49 omitted.
+Additional test/dev rows are in the TSV: 51 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,12 +991,16 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	31	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	31	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	31	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	33	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	33	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	33	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/iframe_has_title_jsx_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/iframe_has_title_jsx_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/iframe_has_title_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/iframe_has_title_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/interactive_supports_focus_jsx_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/interactive_supports_focus_jsx_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/interactive_supports_focus_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
@@ -1044,7 +1048,7 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/form_control_has_label.rs
 linter	Linter	source	crates/vize_patina/src/rules/a11y/heading_has_content.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/a11y/iframe_has_title.rs	12	old_ast	old AST/parser	old	vize_relief	legacy	2
+linter	Linter	source	crates/vize_patina/src/rules/a11y/iframe_has_title.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/img_alt.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	4
 linter	Linter	source	crates/vize_patina/src/rules/a11y/interactive_supports_focus.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/label_has_for.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,10 +34,10 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 22, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 23, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 125, `ir` 19, `ir-lowered` 3, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (22 = 22 `markup-facade` rules)
-- classification: neutral-core-candidate **85** · vue-dialect-bound **138** · container-bound **22** (0 overridden)
+- JSX lanes: `fallback` 124, `ir` 20, `ir-lowered` 3, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (23 = 23 `markup-facade` rules)
+- classification: neutral-core-candidate **86** · vue-dialect-bound **137** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
 ## Full table
@@ -56,7 +56,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/form-control-has-label`                   | template-family | `a11y/form_control_has_label.rs`                       | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/heading-has-content`                      | template-family | `a11y/heading_has_content.rs`                          | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/heading-levels`                           | template-family | `opinionated/a11y/heading_levels.rs`                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
-| `a11y/iframe-has-title`                         | template-family | `a11y/iframe_has_title.rs`                             | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
+| `a11y/iframe-has-title`                         | template-family | `a11y/iframe_has_title.rs`                             | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/img-alt`                                  | template-family | `a11y/img_alt.rs`                                      | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |
 | `a11y/interactive-supports-focus`               | template-family | `a11y/interactive_supports_focus.rs`                   | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/label-has-for`                            | template-family | `a11y/label_has_for.rs`                                | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |


### PR DESCRIPTION
## Summary

- migrate `a11y/iframe-has-title` onto the shared Markup facade
- preserve legacy exact iframe/title matching, dynamic title binding behavior, duplicate title semantics, and JSX namespace/member boundaries with regressions
- regenerate Davinci rule-parity and consumer migration surface inventories

Closes #5279

## Validation

- `cargo test -p vize_patina iframe_has_title --locked`
- `cargo test -q -p vize_patina --locked`
- `cargo check -q -p vize_patina --all-targets --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `cargo fmt --all -- --check`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `node tools/davinci/assertion-lint.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check HEAD && git diff --check --cached`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790621813&installation_model_id=422833&pr_number=5280&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5280&signature=9461ff856e39de872f149497bf60198c0eed5e359e899754fa79665a1ec48f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility linting for `<iframe>` elements across JSX, TSX, and Vue templates.
  * Valid title attributes and bindings are recognized consistently, while invalid, empty, and unsupported bindings are flagged correctly.

* **Tests**
  * Added comprehensive coverage for iframe title validation across syntax variants, parsing paths, and markup cases.

* **Documentation**
  * Updated rule parity and migration reports to reflect the improved cross-format support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->