### PR TITLE
feat(ui): add native alert primitive

### DIFF
--- a/npm/ui/core/package.json
+++ b/npm/ui/core/package.json
@@ -34,6 +34,11 @@
       "import": "./dist/index.mjs",
       "default": "./dist/index.mjs"
     },
+    "./alert": {
+      "types": "./dist/alert.d.mts",
+      "import": "./dist/alert.mjs",
+      "default": "./dist/alert.mjs"
+    },
     "./announcer": {
       "types": "./dist/announcer.d.mts",
       "import": "./dist/announcer.mjs",

--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,8 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 115_800],
+  ["index.mjs", 116_100],
+  ["alert.mjs", 1_050],
   ["announcer.mjs", 4_100],
   ["button.mjs", 1_600],
   ["link.mjs", 3_150],

--- a/npm/ui/core/src/alert-types.ts
+++ b/npm/ui/core/src/alert-types.ts
@@ -1,0 +1,31 @@
+import type { ShallowRef } from "vue";
+
+/** ARIA live-region roles accepted by the Alert primitive. */
+export type AlertRole = "alert" | "status";
+
+/** Consumer styling variants exposed only through data attributes and slot state. */
+export type AlertVariant = "danger" | "info" | "success" | "warning";
+
+/** Visibility state exposed to data attributes and slot consumers. */
+export type AlertState = "closed" | "open";
+
+/** State exposed to the default slot for external chrome and dismissal composition. */
+export interface AlertSlotState {
+  /** Whether the alert is currently visible and announceable. */
+  readonly open: boolean;
+
+  /** ARIA role used by the alert root. */
+  readonly role: AlertRole;
+
+  /** Visibility state mirrored to `data-state`. */
+  readonly state: AlertState;
+
+  /** Styling variant mirrored to `data-variant`. */
+  readonly variant: AlertVariant;
+}
+
+/** Methods and state exposed by the alert component instance. */
+export interface AlertExpose {
+  /** Rendered alert root for composition with application-owned effects. */
+  readonly element: Readonly<ShallowRef<HTMLDivElement | null>>;
+}

--- a/npm/ui/core/src/alert.behavior.md
+++ b/npm/ui/core/src/alert.behavior.md
@@ -1,0 +1,20 @@
+# Alert behavior contract
+
+Normative state x input -> outcome table for `alert.vue` (`@vizejs/ui/alert`).
+Every row is proven by the named mounted-DOM test in `src/alert.test.ts`,
+runtime conformance in `src/runtime-conformance.test.ts`, or compile-only
+assertions in `src/alert.types.test-d.ts`; a row without a passing test is a
+contract violation.
+
+| #   | State         | Input                | Outcome                                                                                                                | Proven by                                                                               |
+| --- | ------------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| A1  | open, alert   | render               | native `<div role="alert">`, assertive live region, atomic announcements, accessible labelling, and `data-state`       | `renders an assertive alert with labelling, description, variant, and open state`       |
+| A2  | open, status  | render               | `role="status"` switches to polite live-region semantics and preserves consumer-owned atomic policy                    | `switches to a polite status region without forcing atomic announcements`               |
+| A3  | closed        | render / Tab         | the root remains mounted for hydration stability, carries `hidden`, mirrors `data-state="closed"`, and is not tabbable | `closed alerts stay mounted but are hidden from user agents`                            |
+| A4  | any           | slot / exposed state | slot consumers receive the live role, variant, visibility state, and boolean; exposed `element` is the rendered root   | `exposes slot state for application-owned chrome and dismissal`                         |
+| A5  | SSR/hydration | isolated requests    | server markup is byte-identical per request and hydrates without replacing the root                                    | `renders stable, accessible markup across isolated SSR requests`; hydration conformance |
+| A6  | public types  | invalid role/variant | compilation rejects unsupported live-region roles and variants                                                         | `src/alert.types.test-d.ts`                                                             |
+
+The primitive intentionally ships no built-in dismiss button or CSS. Dismissal
+chrome is application-owned in this slice and can consume slot state while the
+subpath remains tree-shakable with zero packaged CSS.

--- a/npm/ui/core/src/alert.test.ts
+++ b/npm/ui/core/src/alert.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+
+import { test } from "vite-plus/test";
+
+import Alert from "./alert.vue";
+import type { AlertSlotState } from "./alert.ts";
+import { mountInteraction } from "./testing/mount.ts";
+
+test("renders an assertive alert with labelling, description, variant, and open state", () => {
+  const handle = mountInteraction(Alert, {
+    props: {
+      id: "release-alert",
+      variant: "warning",
+      ariaLabel: "Release warning",
+      ariaDescribedby: "release-help",
+    },
+    slots: { default: "Deployment is delayed" },
+  });
+  const alert = handle.getByRole("alert", { name: "Release warning" });
+
+  assert.equal(alert.tagName, "DIV");
+  assert.equal(alert.id, "release-alert");
+  assert.equal(alert.getAttribute("aria-live"), "assertive");
+  assert.equal(alert.getAttribute("aria-atomic"), "true");
+  assert.equal(alert.getAttribute("aria-describedby"), "release-help");
+  assert.equal(alert.getAttribute("data-vize-ui"), "alert");
+  assert.equal(alert.getAttribute("data-state"), "open");
+  assert.equal(alert.getAttribute("data-variant"), "warning");
+  assert.equal(alert.hasAttribute("hidden"), false);
+  assert.equal(alert.textContent, "Deployment is delayed");
+  handle.unmount();
+});
+
+test("switches to a polite status region without forcing atomic announcements", () => {
+  const labelled = document.createElement("span");
+  labelled.id = "sync-label";
+  labelled.textContent = "Sync status";
+  document.body.append(labelled);
+  const handle = mountInteraction(Alert, {
+    props: {
+      role: "status",
+      variant: "success",
+      atomic: false,
+      ariaLabelledby: "sync-label",
+    },
+    slots: { default: "All files saved" },
+  });
+  const status = handle.getByRole("status", { name: "Sync status" });
+
+  assert.equal(status.getAttribute("aria-live"), "polite");
+  assert.equal(status.getAttribute("aria-atomic"), "false");
+  assert.equal(status.getAttribute("aria-labelledby"), "sync-label");
+  assert.equal(status.getAttribute("data-state"), "open");
+  assert.equal(status.getAttribute("data-variant"), "success");
+  handle.unmount();
+  labelled.remove();
+});
+
+test("closed alerts stay mounted but are hidden from user agents", async () => {
+  const handle = mountInteraction(Alert, {
+    props: { open: false, ariaLabel: "Offline", variant: "danger" },
+    slots: { default: "Connection lost" },
+  });
+  const root = handle.root();
+
+  assert.equal(root.getAttribute("role"), "alert");
+  assert.equal(root.getAttribute("hidden"), "");
+  assert.equal(root.getAttribute("data-state"), "closed");
+  assert.equal(root.getAttribute("data-variant"), "danger");
+  assert.ok((await handle.tab()) === null, "a non-interactive alert must not join tab order");
+  handle.unmount();
+});
+
+test("exposes slot state for application-owned chrome and dismissal", async () => {
+  const handle = mountInteraction(Alert, {
+    props: { role: "status", variant: "info", open: true },
+    slots: {
+      default: (state: AlertSlotState) =>
+        `${state.role}:${state.variant}:${state.state}:${state.open}`,
+    },
+  });
+
+  assert.equal(handle.root().textContent, "status:info:open:true");
+  await handle.wrapper.setProps({ open: false, variant: "success" });
+  assert.equal(handle.root().textContent, "status:success:closed:false");
+  assert.ok(
+    handle.exposes<{ element: HTMLDivElement | null }>().element === handle.root(),
+    "the exposed element must be the rendered alert root",
+  );
+  handle.unmount();
+});

--- a/npm/ui/core/src/alert.ts
+++ b/npm/ui/core/src/alert.ts
@@ -1,0 +1,9 @@
+/** Accessible, unstyled alert and status live-region container. */
+export { default as Alert } from "./alert.vue";
+export type {
+  AlertExpose,
+  AlertRole,
+  AlertSlotState,
+  AlertState,
+  AlertVariant,
+} from "./alert-types.ts";

--- a/npm/ui/core/src/alert.types.test-d.ts
+++ b/npm/ui/core/src/alert.types.test-d.ts
@@ -1,0 +1,36 @@
+/** Compile-only assertions for the public alert contract. */
+
+import type { ShallowRef } from "vue";
+
+import type { AlertExpose, AlertRole, AlertSlotState, AlertState, AlertVariant } from "./alert.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+export const roles: readonly AlertRole[] = ["alert", "status"];
+export const variants: readonly AlertVariant[] = ["danger", "info", "success", "warning"];
+
+type _StateIsLiteral = Expect<Equal<AlertState, "closed" | "open">>;
+type _ElementIsTemplateRef = Expect<
+  Equal<AlertExpose["element"], Readonly<ShallowRef<HTMLDivElement | null>>>
+>;
+type _SlotStateIsLiteral = Expect<
+  Equal<
+    AlertSlotState,
+    {
+      readonly open: boolean;
+      readonly role: AlertRole;
+      readonly state: AlertState;
+      readonly variant: AlertVariant;
+    }
+  >
+>;
+
+// @ts-expect-error log is not an Alert live-region role.
+export const invalidRole: AlertRole = "log";
+
+// @ts-expect-error neutral is not a shipped Alert variant.
+export const invalidVariant: AlertVariant = "neutral";

--- a/npm/ui/core/src/alert.vue
+++ b/npm/ui/core/src/alert.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { computed, useTemplateRef } from "vue";
+
+import type {
+  AlertExpose,
+  AlertRole,
+  AlertSlotState,
+  AlertState,
+  AlertVariant,
+} from "./alert-types.ts";
+
+const {
+  id = undefined,
+  role = "alert",
+  variant = "info",
+  open = true,
+  atomic = true,
+  ariaLabel = undefined,
+  ariaLabelledby = undefined,
+  ariaDescribedby = undefined,
+} = defineProps<{
+  /**
+   * Consumer-owned root id for labels, descriptions, or anchors.
+   *
+   * @default undefined
+   */
+  readonly id?: string;
+
+  /**
+   * Live-region role: `alert` is assertive, `status` is polite.
+   *
+   * @default "alert"
+   */
+  readonly role?: AlertRole;
+
+  /**
+   * Styling variant mirrored to `data-variant`; no CSS is emitted.
+   *
+   * @default "info"
+   */
+  readonly variant?: AlertVariant;
+
+  /**
+   * Whether the alert is visible and announceable.
+   *
+   * @default true
+   */
+  readonly open?: boolean;
+
+  /**
+   * Whether assistive technology should present the whole region on updates.
+   *
+   * @default true
+   */
+  readonly atomic?: boolean;
+
+  /**
+   * Accessible name when no visible label or `aria-labelledby` supplies one.
+   *
+   * @default undefined
+   */
+  readonly ariaLabel?: string;
+
+  /**
+   * Space-separated ids that label the alert.
+   *
+   * @default undefined
+   */
+  readonly ariaLabelledby?: string;
+
+  /**
+   * Space-separated ids that describe the alert.
+   *
+   * @default undefined
+   */
+  readonly ariaDescribedby?: string;
+}>();
+
+defineSlots<{
+  /** Renders alert content with current role, variant, and visibility state. */
+  default(props: AlertSlotState): unknown;
+}>();
+
+const element = useTemplateRef<HTMLDivElement>("element");
+const live = computed(() => (role === "alert" ? "assertive" : "polite"));
+const state = computed<AlertState>(() => (open ? "open" : "closed"));
+
+const exposed = {
+  element,
+} satisfies AlertExpose;
+
+defineExpose(exposed);
+</script>
+
+<template>
+  <div
+    :id
+    ref="element"
+    :role
+    :hidden="open ? undefined : true"
+    :aria-label="ariaLabel"
+    :aria-labelledby="ariaLabelledby"
+    :aria-describedby="ariaDescribedby"
+    :aria-live="live"
+    :aria-atomic="atomic ? 'true' : 'false'"
+    data-vize-ui="alert"
+    :data-state="state"
+    :data-variant="variant"
+  >
+    <slot :open :role :state="state" :variant />
+  </div>
+</template>
+
+<style scoped>
+/* Headless by design. Native CSS remains entirely consumer-owned. */
+</style>

--- a/npm/ui/core/src/family-catalog-feedback.ts
+++ b/npm/ui/core/src/family-catalog-feedback.ts
@@ -1,0 +1,31 @@
+import {
+  catalogOwner,
+  componentQualityGates,
+  type UiFamilyCatalogEntry,
+} from "./family-catalog-types.ts";
+
+export const feedbackFamilyCatalog = [
+  {
+    canonicalName: "alert",
+    title: "Alert",
+    packageSubpath: "./alert",
+    entryFile: "src/alert.ts",
+    sourceFiles: ["src/alert.vue", "src/alert.ts", "src/alert-types.ts"],
+    behaviorContract: "src/alert.behavior.md",
+    tests: ["src/alert.test.ts"],
+    typeTests: ["src/alert.types.test-d.ts"],
+    rendererFixture: "alert.vue",
+    qualityGates: componentQualityGates,
+    bundleBudget: {
+      exportName: "Alert",
+      retainedSignature: "data-vize-ui[\\s\\S]{0,16}alert",
+      maximumJavaScriptGzipBytes: 750,
+      maximumCssGzipBytes: 0,
+    },
+    aliases: ["inline alert", "status alert", "callout primitive"],
+    upstreamCoverage: ["WAI-ARIA alert role", "WAI-ARIA status role", "shadcn/ui Alert"],
+    dependencies: [],
+    maturity: "stable",
+    owner: catalogOwner,
+  },
+] as const satisfies readonly UiFamilyCatalogEntry[];

--- a/npm/ui/core/src/family-catalog.ts
+++ b/npm/ui/core/src/family-catalog.ts
@@ -1,4 +1,5 @@
 import { basicFamilyCatalog } from "./family-catalog-basics.ts";
+import { feedbackFamilyCatalog } from "./family-catalog-feedback.ts";
 import { focusFamilyCatalog } from "./family-catalog-focus.ts";
 import { foundationFamilyCatalog } from "./family-catalog-foundations.ts";
 import { interactionFamilyCatalog } from "./family-catalog-interactions.ts";
@@ -15,6 +16,7 @@ export {
 
 const allFamilyCatalogEntries = [
   ...basicFamilyCatalog,
+  ...feedbackFamilyCatalog,
   ...foundationFamilyCatalog,
   ...focusFamilyCatalog,
   ...interactionFamilyCatalog,

--- a/npm/ui/core/src/index.ts
+++ b/npm/ui/core/src/index.ts
@@ -7,6 +7,7 @@ export * from "./field-wiring.ts";
 // so the layer contract is established before any layered rule;
 // src/theme-stylesheet.test.ts pins the shipped order.
 export * from "./theme.ts";
+export * from "./alert.ts";
 export * from "./announcer.ts";
 export * from "./checkbox.ts";
 export * from "./collection.ts";

--- a/npm/ui/core/src/runtime-conformance-alert-fixtures.ts
+++ b/npm/ui/core/src/runtime-conformance-alert-fixtures.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+
+import { h } from "vue";
+
+import Alert from "./alert.vue";
+import type { RuntimeFixture } from "./runtime-conformance-fixtures.ts";
+
+export const alertRuntimeFixture: RuntimeFixture = {
+  name: "alert",
+  sourceFile: "alert.vue",
+  render: () =>
+    h(
+      Alert,
+      {
+        ariaDescribedby: "network-help",
+        ariaLabel: "Network warning",
+        id: "network-alert",
+        variant: "warning",
+      },
+      {
+        default: () => h("p", { id: "network-help" }, "Connection lost"),
+      },
+    ),
+  assertServerMarkup(html) {
+    assert.match(html, /^<div/);
+    assert.match(html, /id="network-alert"/);
+    assert.match(html, /role="alert"/);
+    assert.match(html, /aria-live="assertive"/);
+    assert.match(html, /aria-atomic="true"/);
+    assert.match(html, /data-vize-ui="alert"/);
+    assert.match(html, /data-state="open"/);
+    assert.match(html, /data-variant="warning"/);
+    assert.match(html, /Connection lost/);
+  },
+  assertHydratedDom(host) {
+    const alert = host.querySelector('[data-vize-ui="alert"]');
+    assert.ok(alert instanceof HTMLDivElement);
+    assert.equal(alert.getAttribute("role"), "alert");
+    assert.equal(alert.getAttribute("aria-live"), "assertive");
+    assert.equal(alert.getAttribute("data-state"), "open");
+    assert.equal(alert.getAttribute("data-variant"), "warning");
+  },
+};

--- a/npm/ui/core/src/runtime-conformance-fixtures.ts
+++ b/npm/ui/core/src/runtime-conformance-fixtures.ts
@@ -9,6 +9,7 @@ import { useDeterministicId } from "./deterministic-id.ts";
 import ErrorSummary from "./error-summary.vue";
 import LinkAnchor from "./link-anchor.vue";
 import PrimitiveElement from "./primitive-element.vue";
+import { alertRuntimeFixture } from "./runtime-conformance-alert-fixtures.ts";
 import { switchRuntimeFixture } from "./runtime-conformance-switch-fixtures.ts";
 import SearchField from "./search-field.vue";
 import TextInput from "./text-input.vue";
@@ -38,6 +39,7 @@ const DeterministicIdProbe = defineComponent({
 });
 
 export const controlRuntimeFixtures: readonly RuntimeFixture[] = [
+  alertRuntimeFixture,
   {
     name: "button",
     sourceFile: "action-button.vue",

--- a/npm/ui/core/src/sfc-lint.test.ts
+++ b/npm/ui/core/src/sfc-lint.test.ts
@@ -19,6 +19,7 @@ test("discovers every SFC with the opinionated Vize contract", async () => {
     results.map((result) => result.filename),
     [
       "src/action-button.vue",
+      "src/alert.vue",
       "src/announcer-provider.vue",
       "src/checkbox-control.vue",
       "src/deterministic-id-provider.vue",
@@ -44,6 +45,7 @@ test("discovers every SFC with the opinionated Vize contract", async () => {
     requests,
     [
       "action-button.vue",
+      "alert.vue",
       "announcer-provider.vue",
       "checkbox-control.vue",
       "deterministic-id-provider.vue",

--- a/npm/ui/core/vite.config.ts
+++ b/npm/ui/core/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
       index: "src/index.ts",
       theme: "src/theme.ts",
       "theme-scope": "src/theme-scope.ts",
+      alert: "src/alert.ts",
       announcer: "src/announcer.ts",
       button: "src/button.ts",
       link: "src/link.ts",


### PR DESCRIPTION
## Summary
- add a headless native Alert primitive with severity, live-region, ARIA, and slot state contracts
- register the alert entry in package exports, catalog metadata, renderer/runtime fixtures, type tests, size budgets, and tree-shaking checks

Refs #4906

## Verification
- vp exec node scripts/lint-sfc.ts src
- vp exec node scripts/check-renderers.ts src
- vp check src scripts vite.config.ts tsconfig.typecheck.json
- ./node_modules/.bin/vue-tsc --noEmit -p tsconfig.typecheck.json
- vp pack
- vp test run (120 files / 705 tests)
- node scripts/check-size.mjs
- node scripts/check-tree-shaking.mjs
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790623019&installation_model_id=422833&pr_number=5281&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5281&signature=8ace33d2aa542ceefdfb480b8d3a6774107e444812c25285e8a63ac139896a67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->