### PR TITLE
refactor(patina): port no-duplicate-class rule to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -14,6 +14,7 @@ mod jsx_media_has_caption;
 mod jsx_mouse_events_have_key_events;
 mod jsx_no_aria_hidden_on_focusable;
 mod jsx_no_consecutive_br;
+mod jsx_no_duplicate_class;
 mod jsx_no_i_for_icon;
 mod jsx_no_redundant_roles;
 mod jsx_no_role_presentation_on_focusable;

--- a/crates/vize_patina/src/linter/tests/jsx_no_duplicate_class.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_duplicate_class.rs
@@ -1,0 +1,95 @@
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::opinionated::html::NoDuplicateClass;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn no_duplicate_class_fires_on_jsx_and_tsx_ir() {
+    let linter = linter_with(Box::new(NoDuplicateClass));
+    let source = r#"const A = () => <div class="btn btn primary" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        result.warning_count, 1,
+        "JSX duplicate class must flag through the IR pass: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+    assert_eq!(diagnostic_rules(&result), vec!["html/no-duplicate-class"]);
+
+    let diag = &result.diagnostics[0];
+    let attr_start = source.find("class").unwrap() as u32;
+    assert_eq!(
+        diag.start, attr_start,
+        "range must start at the written JSX class attribute"
+    );
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        r#"class="btn btn primary""#
+    );
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <div class="btn btn" />;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["html/no-duplicate-class"],
+        "TSX duplicate class must also flag through the IR pass"
+    );
+}
+
+#[test]
+fn no_duplicate_class_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(NoDuplicateClass));
+    for source in [
+        r#"const A = () => <div className="btn btn" />;"#,
+        r#"const A = () => <div class />;"#,
+        r#"const A = () => <div class={'btn btn'} />;"#,
+        r#"const A = () => <div class={classes} />;"#,
+        r#"const A = () => <div {...props} />;"#,
+        r#"const A = () => <div CLASS="btn btn" />;"#,
+        r#"const A = () => <div html:class="btn btn" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn no_duplicate_class_reports_once_per_duplicate_token_not_per_backend() {
+    let linter = linter_with(Box::new(NoDuplicateClass));
+    let source = r#"const A = () => <div class="a a b b" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["html/no-duplicate-class", "html/no-duplicate-class"],
+        "a migrated no-duplicate-class rule must not double-run: {:?}",
+        result.diagnostics
+    );
+
+    let attr_start = source.find("class").unwrap() as u32;
+    let attr_end = attr_start + r#"class="a a b b""#.len() as u32;
+    for diagnostic in &result.diagnostics {
+        assert_eq!(diagnostic.start, attr_start);
+        assert_eq!(diagnostic.end, attr_end);
+    }
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -17,6 +17,7 @@ mod mouse_events_have_key_events_tests;
 mod no_aria_hidden_on_focusable_jsx_tests;
 mod no_aria_hidden_on_focusable_tests;
 mod no_consecutive_br_tests;
+mod no_duplicate_class_tests;
 mod no_i_for_icon_tests;
 mod no_redundant_roles_tests;
 mod no_role_presentation_on_focusable_jsx_tests;

--- a/crates/vize_patina/src/markup/tests/no_duplicate_class_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_duplicate_class_tests.rs
@@ -1,0 +1,221 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::opinionated::html::NoDuplicateClass;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn no_duplicate_class_template() {
+    let rule = NoDuplicateClass;
+    for (source, expected, label) in [
+        (
+            r#"<div class="btn btn primary">x</div>"#,
+            1,
+            "one duplicate token",
+        ),
+        (
+            r#"<div class="a a b b">x</div>"#,
+            2,
+            "two distinct duplicate tokens",
+        ),
+        (
+            r#"<div class="x x x">x</div>"#,
+            1,
+            "triple duplicate reports once per token",
+        ),
+        (
+            "<div class=\"a\ta\">x</div>",
+            1,
+            "ASCII whitespace tokenization is preserved",
+        ),
+        (
+            r#"<div class="a" class="a">x</div>"#,
+            0,
+            "duplicate tokens across attributes are not combined",
+        ),
+        (
+            r#"<div class="a a" class="b b">x</div>"#,
+            2,
+            "each static class attribute is checked independently",
+        ),
+        (r#"<div class>x</div>"#, 0, "valueless class is ignored"),
+        (r#"<div class="">x</div>"#, 0, "empty class is clean"),
+        (
+            r#"<div :class="['btn', 'btn']">x</div>"#,
+            0,
+            "dynamic class binding is ignored",
+        ),
+        (
+            r#"<div v-bind:class="'btn btn'">x</div>"#,
+            0,
+            "long-form dynamic class binding is ignored",
+        ),
+        (
+            r#"<div CLASS="btn btn">x</div>"#,
+            0,
+            "attribute names are case-sensitive",
+        ),
+        (
+            r#"<div class="a a" CLASS="b b">x</div>"#,
+            1,
+            "only exact lowercase class attributes participate",
+        ),
+        (
+            r#"<div class="foo Foo">x</div>"#,
+            0,
+            "class tokens are case-sensitive",
+        ),
+        (
+            r#"<div class="foo foo Foo Foo">x</div>"#,
+            2,
+            "case-distinct duplicate tokens report independently",
+        ),
+        (
+            r#"<div v-bind="{ class: 'btn btn' }">x</div>"#,
+            0,
+            "object v-bind stays dynamic and ignored",
+        ),
+        (
+            r#"<MyWidget class="btn btn">x</MyWidget>"#,
+            1,
+            "components are still inspected because the rule is attr-only",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template case failed: {label}"
+        );
+    }
+}
+
+#[test]
+fn no_duplicate_class_jsx_direct_matches_lowered_static_boundaries() {
+    let rule = NoDuplicateClass;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <div class="btn btn primary" />;"#,
+            1,
+            "one duplicate token",
+        ),
+        (
+            r#"const A = () => <div class="a a b b" />;"#,
+            2,
+            "two distinct duplicate tokens",
+        ),
+        (
+            r#"const A = () => <div class="x x x" />;"#,
+            1,
+            "triple duplicate reports once per token",
+        ),
+        (
+            r#"const A = () => <div class="a" class="a" />;"#,
+            0,
+            "duplicate tokens across attributes are not combined",
+        ),
+        (
+            r#"const A = () => <div class="a a" class="b b" />;"#,
+            2,
+            "each static class attribute is checked independently",
+        ),
+        (
+            r#"const A = () => <div class />;"#,
+            0,
+            "valueless class is ignored",
+        ),
+        (
+            r#"const A = () => <div className="btn btn" />;"#,
+            0,
+            "className is not the legacy class spelling",
+        ),
+        (
+            r#"const A = () => <div CLASS="btn btn" />;"#,
+            0,
+            "attribute names are case-sensitive",
+        ),
+        (
+            r#"const A = () => <div class={'btn btn'} />;"#,
+            0,
+            "expression-valued class is dynamic and ignored",
+        ),
+        (
+            r#"const A = () => <div class={classes} />;"#,
+            0,
+            "dynamic class is ignored",
+        ),
+        (
+            r#"const A = () => <div {...props} />;"#,
+            0,
+            "spread props are ignored",
+        ),
+        (
+            r#"const A = () => <div html:class="btn btn" />;"#,
+            0,
+            "namespaced class attributes are ignored",
+        ),
+        (
+            r#"const A = () => <Component class="btn btn" />;"#,
+            1,
+            "components are still inspected like the legacy visitor",
+        ),
+        (
+            r#"const A = () => <Icons.Div class="btn btn" />;"#,
+            1,
+            "member components are still inspected because the rule is attr-only",
+        ),
+        (
+            r#"const A = () => <svg:div class="btn btn" />;"#,
+            1,
+            "namespaced tags are still inspected because the rule is attr-only",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(direct, expected, "JSX direct case failed: {label}");
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "JSX direct and lowered fallback diverged for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/opinionated/html.rs
+++ b/crates/vize_patina/src/rules/opinionated/html.rs
@@ -3,7 +3,7 @@ mod no_duplicate_class;
 
 use crate::rule::RuleRegistry;
 use no_dupe_style_properties::NoDupeStyleProperties;
-use no_duplicate_class::NoDuplicateClass;
+pub(crate) use no_duplicate_class::NoDuplicateClass;
 
 pub(crate) fn register(registry: &mut RuleRegistry) {
     registry.register(Box::new(NoDuplicateClass));

--- a/crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs
+++ b/crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs
@@ -23,8 +23,10 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::ir::ByteRange;
+use crate::markup::{MarkupBinding, MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, PropNode};
+use vize_relief::ElementNode;
 use vize_s0::FxHashSet;
 
 static META: RuleMeta = RuleMeta {
@@ -38,33 +40,64 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct NoDuplicateClass;
 
+impl NoDuplicateClass {
+    fn check_class_value(ctx: &mut LintContext<'_>, class_value: &str, range: ByteRange) {
+        let mut seen: FxHashSet<&str> = FxHashSet::default();
+        let mut reported: FxHashSet<&str> = FxHashSet::default();
+
+        for class_name in class_value.split_ascii_whitespace() {
+            if !seen.insert(class_name) && reported.insert(class_name) {
+                let message = ctx.t_fmt("html/no-duplicate-class.message", &[("name", class_name)]);
+                let help = ctx.t("html/no-duplicate-class.help");
+                ctx.warn_at_with_help(message, range, help);
+            }
+        }
+    }
+
+    fn check_binding(ctx: &mut LintContext<'_>, binding: &MarkupBinding<'_>) {
+        if binding.kind() == MarkupBindingKind::Attribute
+            && binding.is_unqualified_arg_exact("class")
+            && let Some(class_value) = binding.static_value()
+        {
+            Self::check_class_value(ctx, class_value, binding.range());
+        }
+    }
+
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        element.walk_bindings(&mut |binding| {
+            Self::check_binding(ctx, &binding);
+        });
+    }
+}
+
+impl MarkupRule for NoDuplicateClass {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_binding<'a>(
+        &self,
+        ctx: &mut MarkupContext<'_, 'a>,
+        _element: &MarkupElement<'a>,
+        binding: &MarkupBinding<'a>,
+    ) {
+        Self::check_binding(ctx.lint(), binding);
+    }
+}
+
 impl Rule for NoDuplicateClass {
     fn meta(&self) -> &'static RuleMeta {
         &META
     }
 
-    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        for prop in &element.props {
-            if let PropNode::Attribute(attr) = prop
-                && attr.name == "class"
-                && let Some(value) = &attr.value
-            {
-                let mut seen: FxHashSet<&str> = FxHashSet::default();
-                let mut reported: FxHashSet<&str> = FxHashSet::default();
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
 
-                for cls in value.content.split_ascii_whitespace() {
-                    if !seen.insert(cls) && reported.insert(cls) {
-                        let message =
-                            ctx.t_fmt("html/no-duplicate-class.message", &[("name", cls)]);
-                        let help = ctx.t("html/no-duplicate-class.help");
-                        ctx.warn_with_help(message, &attr.loc, help);
-                    }
-                }
-            }
-        }
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::NoDuplicateClass;

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           315 |                   315 |                 0 |             277 |     250 |             672 |      170 |           355 |           506 |
+| Linter                     |           316 |                   316 |                 0 |             278 |     253 |             672 |      175 |           356 |           508 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         315 |             224 |       91 |
-| old AST/parser   |         235 |             210 |       25 |
+| S0               |         316 |             224 |       92 |
+| old AST/parser   |         236 |             210 |       26 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         250 |             200 |       50 |
+| raw OXC          |         253 |             200 |       53 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:33`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:34`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 51 omitted.
+Additional test/dev rows are in the TSV: 52 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,9 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	33	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	33	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	33	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	34	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	34	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	34	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1016,6 +1016,9 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_foc
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_consecutive_br_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_consecutive_br_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_class_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_class_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_class_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1099,8 +1102,8 @@ linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/placeholder_l
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/use_list.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	30	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	27	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	29	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/no_inline_template.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs	28	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 23, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 24, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 124, `ir` 20, `ir-lowered` 3, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (23 = 23 `markup-facade` rules)
+- JSX lanes: `fallback` 123, `ir` 21, `ir-lowered` 3, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (24 = 24 `markup-facade` rules)
 - classification: neutral-core-candidate **86** · vue-dialect-bound **137** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -100,7 +100,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `html/id-duplication`                           | template-family | `html/id_duplication.rs`                               | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `html/no-consecutive-br`                        | template-family | `html/no_consecutive_br.rs`                            | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `html/no-dupe-style-properties`                 | template-family | `opinionated/html/no_dupe_style_properties.rs`         | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
-| `html/no-duplicate-class`                       | template-family | `opinionated/html/no_duplicate_class.rs`               | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `html/no-duplicate-class`                       | template-family | `opinionated/html/no_duplicate_class.rs`               | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `html/no-duplicate-dt`                          | template-family | `html/no_duplicate_dt.rs`                              | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `html/no-empty-palpable-content`                | template-family | `html/no_empty_palpable_content.rs`                    | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `html/require-datetime`                         | template-family | `html/require_datetime.rs`                             | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |


### PR DESCRIPTION
## Summary

- port `html/no-duplicate-class` to the shared MarkupRule facade and direct JSX IR lane
- preserve legacy static-only, exact lowercase `class` behavior and full-attribute diagnostic ranges
- add Vue MarkupRule, JSX direct-vs-lowered parity, and public `Linter::lint_jsx` regressions
- update Davinci rule-parity and consumer-migration matrices

Closes #5282

## Validation

- `cargo test -p vize_patina no_duplicate_class --locked`
- `cargo fmt --all -- --check`
- `cargo check -q -p vize_patina --all-targets --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `cargo test -q -p vize_patina --locked`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `node tools/davinci/assertion-lint.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check HEAD`
- `git diff --cached --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790623365&installation_model_id=422833&pr_number=5283&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5283&signature=5a414504dab8d2ec542a03782d133afac9d47ac5e60e37eadc953be6da4da5a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->