### PR TITLE
refactor(patina): port no-duplicate-dt rule to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -15,6 +15,7 @@ mod jsx_mouse_events_have_key_events;
 mod jsx_no_aria_hidden_on_focusable;
 mod jsx_no_consecutive_br;
 mod jsx_no_duplicate_class;
+mod jsx_no_duplicate_dt;
 mod jsx_no_i_for_icon;
 mod jsx_no_redundant_roles;
 mod jsx_no_role_presentation_on_focusable;

--- a/crates/vize_patina/src/linter/tests/jsx_no_duplicate_dt.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_duplicate_dt.rs
@@ -1,0 +1,139 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::html::NoDuplicateDt;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn no_duplicate_dt_runs_over_lowered_markup_ir_once() {
+    let linter = linter_with(Box::new(NoDuplicateDt));
+    let source = r#"const A = () => <dl><dt>A</dt><dd>def 1</dd><dt>A</dt></dl>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["html/no-duplicate-dt"],
+        "migrated no-duplicate-dt must report once via lowered markup IR: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+
+    let diag = &result.diagnostics[0];
+    let duplicate_start = source.rfind("<dt>").unwrap() as u32;
+    assert_eq!(diag.severity, Severity::Warning);
+    assert!(diag.help.is_some(), "diagnostic should carry help text");
+    assert!(diag.fix.is_none(), "no-duplicate-dt is not auto-fixable");
+    assert!(
+        diag.message.contains("A"),
+        "diagnostic message should name the duplicate term: {diag:?}"
+    );
+    assert_eq!(diag.start, duplicate_start);
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        "<dt>A</dt>",
+        "range must cover the duplicate authored JSX <dt>"
+    );
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <dl><dt>A</dt><dt>A</dt></dl>;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["html/no-duplicate-dt"],
+        "TSX keeps the same lowered markup IR behavior"
+    );
+}
+
+#[test]
+fn no_duplicate_dt_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(NoDuplicateDt));
+    for source in [
+        r#"const A = () => <dl><dt>A</dt><dt>B</dt></dl>;"#,
+        r#"const A = () => <div><dt>A</dt><dt>A</dt></div>;"#,
+        r#"const A = () => <dl><div><dt>A</dt></div><dt>A</dt></dl>;"#,
+        r#"const A = () => <dl>{cond && <dt>A</dt>}<dt>A</dt></dl>;"#,
+        r#"const A = () => <dl>{items.map(() => <dt>A</dt>)}<dt>A</dt></dl>;"#,
+        r#"const A = () => <dl><dt>A{'!'}</dt><dt>A</dt></dl>;"#,
+        r#"const A = () => <Dl><dt>A</dt><dt>A</dt></Dl>;"#,
+        r#"const A = () => <DL><dt>A</dt><dt>A</dt></DL>;"#,
+        r#"const A = () => <dl><DT>A</DT><dt>A</dt></dl>;"#,
+        r#"const A = () => <svg:dl><dt>A</dt><dt>A</dt></svg:dl>;"#,
+        r#"const A = () => <dl><svg:dt>A</svg:dt><dt>A</dt></dl>;"#,
+        r#"const A = () => <Lists.dl><dt>A</dt><dt>A</dt></Lists.dl>;"#,
+        r#"const A = () => <dl><Terms.dt>A</Terms.dt><dt>A</dt></dl>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn no_duplicate_dt_reports_repeated_terms_without_fallback_double_run() {
+    let linter = linter_with(Box::new(NoDuplicateDt));
+    let source = r#"const A = () => <dl><dt>X</dt><dt>X</dt><dt>X</dt></dl>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["html/no-duplicate-dt", "html/no-duplicate-dt"],
+        "each repeated term after the first reports once: {:?}",
+        result.diagnostics
+    );
+
+    let expected_starts: Vec<u32> = source
+        .match_indices("<dt>X</dt>")
+        .skip(1)
+        .map(|(offset, _)| offset as u32)
+        .collect();
+    let actual_starts: Vec<u32> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.start)
+        .collect();
+    assert_eq!(actual_starts, expected_starts);
+
+    for diagnostic in &result.diagnostics {
+        assert_eq!(
+            &source[diagnostic.start as usize..diagnostic.end as usize],
+            "<dt>X</dt>"
+        );
+    }
+}
+
+#[test]
+fn no_duplicate_dt_keeps_lowered_jsx_fragment_text_behavior() {
+    let linter = linter_with(Box::new(NoDuplicateDt));
+
+    for source in [
+        r#"const A = () => <dl><dt>{'A'}</dt><dt>A</dt></dl>;"#,
+        r#"const A = () => <dl><><dt>A</dt><dt>A</dt></></dl>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            diagnostic_rules(&result),
+            vec!["html/no-duplicate-dt"],
+            "lowered JSX fallback boundary changed for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -18,6 +18,7 @@ mod no_aria_hidden_on_focusable_jsx_tests;
 mod no_aria_hidden_on_focusable_tests;
 mod no_consecutive_br_tests;
 mod no_duplicate_class_tests;
+mod no_duplicate_dt_tests;
 mod no_i_for_icon_tests;
 mod no_redundant_roles_tests;
 mod no_role_presentation_on_focusable_jsx_tests;

--- a/crates/vize_patina/src/markup/tests/no_duplicate_dt_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_duplicate_dt_tests.rs
@@ -1,0 +1,252 @@
+use crate::context::LintContext;
+use crate::diagnostic::LintDiagnostic;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::html::NoDuplicateDt;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> Vec<LintDiagnostic> {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().to_vec()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> Vec<LintDiagnostic> {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut diagnostics = Vec::new();
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        diagnostics.extend_from_slice(lint.diagnostics());
+    }
+    diagnostics
+}
+
+fn diagnostic_ranges(diagnostics: &[LintDiagnostic]) -> Vec<(u32, u32)> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.start, diagnostic.end))
+        .collect()
+}
+
+#[test]
+fn no_duplicate_dt_template_direct_child_terms() {
+    let rule = NoDuplicateDt;
+    for (source, expected, label) in [
+        (
+            r#"<dl><dt>A</dt><dd>def A</dd><dt>B</dt><dd>def B</dd></dl>"#,
+            0,
+            "unique terms",
+        ),
+        (
+            r#"<dl><dt>A</dt><dd>def 1</dd><dt>A</dt><dd>def 2</dd></dl>"#,
+            1,
+            "one duplicate term",
+        ),
+        (
+            r#"<dl><dt>X</dt><dd>1</dd><dt>X</dt><dd>2</dd><dt>X</dt><dd>3</dd></dl>"#,
+            2,
+            "every repeated term after the first reports",
+        ),
+        (
+            r#"<dl><dt>  A  </dt><dt>A</dt></dl>"#,
+            1,
+            "term text is trimmed before comparison",
+        ),
+        (
+            r#"<dl><dt>A</dt><dt>A </dt><dt> A</dt></dl>"#,
+            2,
+            "trimmed repeats after the first each report",
+        ),
+        (
+            r#"<dl><dt>A{{ suffix }}</dt><dt>A</dt></dl>"#,
+            1,
+            "only direct text nodes form the term",
+        ),
+        (
+            r#"<dl><dt><span>A</span></dt><dt>A</dt><dt>A</dt></dl>"#,
+            1,
+            "nested text is ignored before duplicate comparison",
+        ),
+        (
+            r#"<dl><dt> </dt><dt></dt><dt>A</dt></dl>"#,
+            0,
+            "empty normalized terms are ignored",
+        ),
+        (
+            r#"<dl><dt>A</dt><dt>a</dt></dl>"#,
+            0,
+            "term comparison is case-sensitive",
+        ),
+        (
+            r#"<dl><dt>A B</dt><dt>A  B</dt></dl>"#,
+            1,
+            "parser-normalized inner whitespace participates in comparison",
+        ),
+        (
+            r#"<dl><div><dt>A</dt></div><dt>A</dt></dl>"#,
+            0,
+            "nested dt elements are not dl direct children",
+        ),
+        (
+            r#"<MyDl><dt>A</dt><dt>A</dt></MyDl>"#,
+            0,
+            "component parents are skipped",
+        ),
+        (
+            r#"<MyDl><dl><dt>A</dt><dt>A</dt></dl></MyDl>"#,
+            1,
+            "native dl descendants under components still run",
+        ),
+        (
+            r#"<DL><dt>A</dt><dt>A</dt></DL>"#,
+            0,
+            "dl tag names are case-sensitive",
+        ),
+        (
+            r#"<dl><DT>A</DT><dt>A</dt></dl>"#,
+            0,
+            "dt tag names are case-sensitive",
+        ),
+        (
+            r#"<dl><dt>A</dt><dt>A</dt></dl><dl><dt>A</dt><dt>A</dt></dl>"#,
+            2,
+            "separate dl elements do not share state",
+        ),
+    ] {
+        let diagnostics = run_over_template(&rule, source);
+        assert_eq!(
+            diagnostics.len(),
+            expected,
+            "template boundary changed for {label}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn no_duplicate_dt_template_reports_on_duplicate_dt_element() {
+    let rule = NoDuplicateDt;
+    let source = r#"<dl><dt>A</dt><dd>def 1</dd><dt>A</dt><dd>def 2</dd></dl>"#;
+    let diagnostics = run_over_template(&rule, source);
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+
+    let duplicate_start = source.rfind("<dt>").unwrap() as u32;
+    assert_eq!(
+        diagnostic_ranges(&diagnostics),
+        vec![(duplicate_start, duplicate_start + "<dt>".len() as u32)]
+    );
+}
+
+#[test]
+fn no_duplicate_dt_template_reports_multi_term_duplicates_in_order() {
+    let rule = NoDuplicateDt;
+    let source = r#"<dl><dt>A</dt><dt>B</dt><dt>A</dt><dt>B</dt></dl>"#;
+    let diagnostics = run_over_template(&rule, source);
+    assert_eq!(diagnostics.len(), 2, "{diagnostics:?}");
+
+    let expected: Vec<(u32, u32)> = source
+        .match_indices("<dt>")
+        .skip(2)
+        .map(|(offset, term)| {
+            let start = offset as u32;
+            (start, start + term.len() as u32)
+        })
+        .collect();
+    assert_eq!(diagnostic_ranges(&diagnostics), expected);
+    assert!(
+        diagnostics[0].message.contains("A"),
+        "first duplicate message should name term A: {:?}",
+        diagnostics[0]
+    );
+    assert!(
+        diagnostics[1].message.contains("B"),
+        "second duplicate message should name term B: {:?}",
+        diagnostics[1]
+    );
+}
+
+#[test]
+fn no_duplicate_dt_jsx_lowered_matches_legacy_fallback_boundaries() {
+    let rule = NoDuplicateDt;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <dl><dt>A</dt><dd>def 1</dd><dt>A</dt></dl>;"#,
+            1,
+            "one duplicate term",
+        ),
+        (
+            r#"const A = () => <dl><dt>{'A'}</dt><dt>A</dt></dl>;"#,
+            1,
+            "static string expression text still follows JSX lowering",
+        ),
+        (
+            r#"const A = () => <dl><dt>A{'!'}</dt><dt>A</dt></dl>;"#,
+            0,
+            "JSX string children around expression content follow lowering",
+        ),
+        (
+            r#"const A = () => <dl><><dt>A</dt><dt>A</dt></></dl>;"#,
+            1,
+            "plain fragments are transparent through JSX lowering",
+        ),
+        (
+            r#"const A = () => <dl>{cond && <dt>A</dt>}<dt>A</dt></dl>;"#,
+            0,
+            "conditional dt is not a direct dl child in the legacy fallback",
+        ),
+        (
+            r#"const A = () => <dl>{items.map(() => <dt>A</dt>)}<dt>A</dt></dl>;"#,
+            0,
+            "mapped dt is not a direct dl child in the legacy fallback",
+        ),
+        (
+            r#"const A = () => <Dl><dt>A</dt><dt>A</dt></Dl>;"#,
+            0,
+            "component parents are skipped",
+        ),
+        (
+            r#"const A = () => <dl><DT>A</DT><dt>A</dt></dl>;"#,
+            0,
+            "uppercase DT stays outside exact lowercase dt matching",
+        ),
+        (
+            r#"const A = () => <svg:dl><dt>A</dt><dt>A</dt></svg:dl>;"#,
+            0,
+            "namespaced dl stays outside exact lowercase dl matching",
+        ),
+        (
+            r#"const A = () => <dl><svg:dt>A</svg:dt><dt>A</dt></dl>;"#,
+            0,
+            "namespaced dt stays outside exact lowercase dt matching",
+        ),
+        (
+            r#"const A = () => <Lists.dl><dt>A</dt><dt>A</dt></Lists.dl>;"#,
+            0,
+            "member dl stays outside exact lowercase dl matching",
+        ),
+        (
+            r#"const A = () => <dl><Terms.dt>A</Terms.dt><dt>A</dt></dl>;"#,
+            0,
+            "member dt stays outside exact lowercase dt matching",
+        ),
+    ] {
+        let diagnostics = run_over_jsx_lowered(&rule, source);
+        assert_eq!(
+            diagnostics.len(),
+            expected,
+            "lowered JSX boundary changed for {label}: {diagnostics:?}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/html/no_duplicate_dt.rs
+++ b/crates/vize_patina/src/rules/html/no_duplicate_dt.rs
@@ -31,8 +31,9 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupContext, MarkupElement, MarkupNode, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, ElementType, TemplateChildNode};
+use vize_relief::ElementNode;
 use vize_s0::FxHashMap;
 use vize_s0::String;
 use vize_s0::ToCompactString;
@@ -48,53 +49,67 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct NoDuplicateDt;
 
-impl Rule for NoDuplicateDt {
-    fn meta(&self) -> &'static RuleMeta {
-        &META
-    }
-
-    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if element.tag_type == ElementType::Component || element.tag != "dl" {
+impl NoDuplicateDt {
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        if element.is_component() || !element.is_unqualified_tag_exact("dl") {
             return;
         }
 
         let mut seen: FxHashMap<String, u32> = FxHashMap::default();
 
-        for child in &element.children {
-            if let TemplateChildNode::Element(el) = child
-                && el.tag == "dt"
+        element.walk_children(&mut |child| {
+            if let MarkupNode::Element(el) = child
+                && el.is_unqualified_tag_exact("dt")
             {
-                let text = get_text_content(el);
+                let text = el.direct_text_content();
                 let normalized = text.trim().to_compact_string();
                 if normalized.is_empty() {
-                    continue;
+                    return;
                 }
 
                 if let std::collections::hash_map::Entry::Vacant(entry) =
                     seen.entry(normalized.clone())
                 {
-                    entry.insert(el.loc.span.start);
+                    entry.insert(el.range().start);
                 } else {
                     let message = ctx.t_fmt(
                         "html/no-duplicate-dt.message",
                         &[("term", normalized.as_str())],
                     );
                     let help = ctx.t("html/no-duplicate-dt.help");
-                    ctx.warn_with_help(message, &el.loc, help);
+                    ctx.warn_at_with_help(message, el.range(), help);
                 }
             }
-        }
+        });
     }
 }
 
-fn get_text_content(element: &ElementNode) -> String {
-    let mut text = String::default();
-    for child in &element.children {
-        if let TemplateChildNode::Text(t) = child {
-            text.push_str(t.content);
-        }
+impl MarkupRule for NoDuplicateDt {
+    fn name(&self) -> &'static str {
+        META.name
     }
-    text
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        Self::check_element(ctx.lint(), element);
+    }
+}
+
+impl Rule for NoDuplicateDt {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn jsx_needs_lowering(&self) -> bool {
+        true
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        Self::check_element(ctx, &MarkupElement::new(element));
+    }
 }
 
 #[cfg(test)]

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           316 |                   316 |                 0 |             278 |     253 |             672 |      175 |           356 |           508 |
+| Linter                     |           317 |                   317 |                 0 |             279 |     253 |             672 |      177 |           357 |           510 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,8 +99,8 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         316 |             224 |       92 |
-| old AST/parser   |         236 |             210 |       26 |
+| S0               |         317 |             224 |       93 |
+| old AST/parser   |         237 |             210 |       27 |
 | Croquis analysis |          42 |              38 |        4 |
 | raw OXC          |         253 |             200 |       53 |
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:34`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:35`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 52 omitted.
+Additional test/dev rows are in the TSV: 53 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,9 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	34	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	34	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	34	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	35	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	35	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	35	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1019,6 +1019,8 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_consecutive_br_tes
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_class_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_class_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_class_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_dt_tests.rs	7	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_dt_tests.rs	7	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1084,8 +1086,8 @@ linter	Linter	source	crates/vize_patina/src/rules/html/helpers.rs	3	old_ast	old 
 linter	Linter	source	crates/vize_patina/src/rules/html/id_duplication.rs	31	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/html/id_duplication.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/no_consecutive_br.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	35	s0	S0	stage	vize_s0	preferred	3
-linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	35	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	36	s0	S0	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	36	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/no_empty_palpable_content.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/require_datetime.rs	28	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/html/require_datetime.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	2

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 24, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 25, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 123, `ir` 21, `ir-lowered` 3, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (24 = 24 `markup-facade` rules)
+- JSX lanes: `fallback` 122, `ir` 21, `ir-lowered` 4, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (25 = 25 `markup-facade` rules)
 - classification: neutral-core-candidate **86** · vue-dialect-bound **137** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -101,7 +101,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `html/no-consecutive-br`                        | template-family | `html/no_consecutive_br.rs`                            | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `html/no-dupe-style-properties`                 | template-family | `opinionated/html/no_dupe_style_properties.rs`         | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `html/no-duplicate-class`                       | template-family | `opinionated/html/no_duplicate_class.rs`               | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
-| `html/no-duplicate-dt`                          | template-family | `html/no_duplicate_dt.rs`                              | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `html/no-duplicate-dt`                          | template-family | `html/no_duplicate_dt.rs`                              | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `html/no-empty-palpable-content`                | template-family | `html/no_empty_palpable_content.rs`                    | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `html/require-datetime`                         | template-family | `html/require_datetime.rs`                             | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `musea/no-empty-variant`                        | musea           | `musea/no_empty_variant.rs`                            | musea-blocks                   | no                               | no                          | —                                                                                                   | container-bound        |

--- a/davinci-road/plan/sourcelocation-inventory.md
+++ b/davinci-road/plan/sourcelocation-inventory.md
@@ -28,7 +28,7 @@ any read — or any deleted carrier — comes back.
 - Reads of `span.start` / `span.end` are **not** inventoried: they are
   the surviving offset representation — the pre-migration
   `start.offset` / `end.offset` reads moved to them verbatim
-  (302 loc-shaped span-read sites across
+  (301 loc-shaped span-read sites across
   8 crates at generation time).
 - `#[cfg(test)]` code inside `src/` is included and reported in the
   "in test code" column: a site counts as test code when its file is a test


### PR DESCRIPTION
## Summary

- Port `html/no-duplicate-dt` to the Davinci markup facade.
- Keep JSX on the lowered markup lane to preserve legacy fallback text/fragment behavior.
- Add strict Vue template and JSX regressions for direct-child matching, text normalization, ranges, component/case boundaries, and fallback double-run prevention.
- Regenerate Davinci rule parity, consumer surface, and SourceLocation inventories.

Closes #5286

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p vize_patina no_duplicate_dt --locked`
- `cargo check -q -p vize_patina --all-targets --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `cargo test -q -p vize_patina --locked`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `node tools/davinci/assertion-lint.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check HEAD`
- `git diff --cached --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790624992&installation_model_id=422833&pr_number=5287&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5287&signature=efe7b021f8cb083358575c9560b9b126643e52c5bf51c75f31892e305d8cbf2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->