### PR TITLE
test(tooling): exempt package manifests from source length ratchet

### DIFF
--- a/tests/tooling/source-file-lengths.test.ts
+++ b/tests/tooling/source-file-lengths.test.ts
@@ -193,6 +193,38 @@ test("source length script accepts unchanged over-limit files", () => {
   assert.match(result.stdout, /No new or grown files exceed 350 lines/);
 });
 
+test("source length script ignores package manifests", () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "vize-source-lengths-package-"));
+  const packagePath = path.join(cwd, "package.json");
+  const nestedPackagePath = path.join(cwd, "packages", "ui", "package.json");
+  fs.mkdirSync(path.dirname(nestedPackagePath), { recursive: true });
+  runGit(cwd, ["init", "-q"]);
+  writeLines(packagePath, 351);
+  writeLines(nestedPackagePath, 351);
+  runGit(cwd, ["add", "package.json", "packages/ui/package.json"]);
+  runGit(cwd, [
+    "-c",
+    "user.name=Vize",
+    "-c",
+    "user.email=vize@example.com",
+    "commit",
+    "-qm",
+    "base",
+  ]);
+  const baseRef = runGit(cwd, ["rev-parse", "HEAD"]);
+
+  writeLines(packagePath, 352);
+  writeLines(nestedPackagePath, 352);
+  const result = runMoonScript(
+    "source_file_lengths",
+    ["--check", "--base-ref", baseRef, "--max-lines", "350", "--limit", "5"],
+    { cwd },
+  );
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
+  assert.match(result.stdout, /No new or grown files exceed 350 lines/);
+});
+
 test("source length script compares renamed over-limit files to their base path", () => {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "vize-source-lengths-rename-"));
   const filePath = path.join(cwd, "large.ts");

--- a/tools/moon/cmd/source_file_lengths/main.mbt
+++ b/tools/moon/cmd/source_file_lengths/main.mbt
@@ -62,7 +62,7 @@ fn is_excluded_path(path : String) -> Bool {
   (path.has_prefix("bench/results/") ||
   path == "npm/cli/schemas/vize.config.schema.json" ||
   path == "npm/cli/src/types/generated.ts" || path == "davinci-road/plan/croquis-consumption.md" || path == "davinci-road/plan/corpus-coverage.md" ||
-  path == "editors/vscode/package.json" || path == ".github/workflows/release.yml") ||
+  (path == "package.json" || path.has_suffix("/package.json")) || path == ".github/workflows/release.yml") ||
   path.has_prefix("docs/content/ja/") || path.has_prefix("docs/content/zh-CN/") ||
   path.has_prefix("docs/content/pt-BR/") || path.has_prefix("docs/content/fr/") ||
   path.contains(".min.") ||


### PR DESCRIPTION
## Summary
- exclude root and nested package.json manifests from the source length ratchet
- add a regression test covering root and nested package manifests that grow beyond the generic source limit

## Verification
- vp install --frozen-lockfile --prefer-offline
- vp check tools/moon/cmd/source_file_lengths/main.mbt tests/tooling/source-file-lengths.test.ts
- git diff --check
- vp exec node --test tests/tooling/source-file-lengths.test.ts (blocked locally by the existing local MoonBit lexscan/toolchain mismatch; Actions setup-moonbit is the source of truth for this test)

Refs #4907

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790625337&installation_model_id=422833&pr_number=5288&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5288&signature=61b477748f6cd0d1e43d2df60fbdd23c8707b950aefe9873547c50708665a410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Source-file length checks now ignore `package.json` files in the repository root and nested directories.
  * Prevents large package metadata files from incorrectly triggering length-limit violations.

* **Tests**
  * Added regression coverage confirming package files are excluded regardless of their location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->