### PR TITLE
refactor(patina): port require-datetime rule to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -19,6 +19,7 @@ mod jsx_no_duplicate_dt;
 mod jsx_no_i_for_icon;
 mod jsx_no_redundant_roles;
 mod jsx_no_role_presentation_on_focusable;
+mod jsx_require_datetime;
 mod jsx_streaming;
 mod no_mutating_props;
 mod no_top_level_ref;

--- a/crates/vize_patina/src/linter/tests/jsx_require_datetime.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_require_datetime.rs
@@ -1,0 +1,116 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::html::RequireDatetime;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn require_datetime_runs_over_lowered_markup_ir_once() {
+    let linter = linter_with(Box::new(RequireDatetime));
+    let source = r#"const A = () => <time>Christmas</time>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["html/require-datetime"],
+        "migrated require-datetime must report once via lowered markup IR: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+
+    let diag = &result.diagnostics[0];
+    let start = source.find("<time>").unwrap() as u32;
+    assert_eq!(diag.severity, Severity::Warning);
+    assert!(diag.help.is_some(), "diagnostic should carry help text");
+    assert!(diag.fix.is_none(), "require-datetime is not auto-fixable");
+    assert_eq!(diag.start, start);
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        "<time>Christmas</time>",
+        "range must cover the authored JSX <time>"
+    );
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <time>Christmas</time>;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["html/require-datetime"],
+        "TSX keeps the same lowered markup IR behavior"
+    );
+}
+
+#[test]
+fn require_datetime_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(RequireDatetime));
+    for source in [
+        r#"const A = () => <time datetime="2024-12-25">Christmas</time>;"#,
+        r#"const A = () => <time datetime={date}>Christmas</time>;"#,
+        r#"const A = () => <time v-bind:datetime={date}>Christmas</time>;"#,
+        r#"const A = () => <time>2024-12-25</time>;"#,
+        r#"const A = () => <time><>{'2024-12-25'}</></time>;"#,
+        r#"const A = () => <time>{formattedDate}</time>;"#,
+        r#"const A = () => <time>last {unit}</time>;"#,
+        r#"const A = () => <Time>Christmas</Time>;"#,
+        r#"const A = () => <Foo.time>Christmas</Foo.time>;"#,
+        r#"const A = () => <time-clock>Christmas</time-clock>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn require_datetime_reports_each_invalid_time_without_fallback_double_run() {
+    let linter = linter_with(Box::new(RequireDatetime));
+    let source =
+        r#"const A = () => <><time {...attrs}>Christmas</time><time>last Tuesday</time></>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["html/require-datetime", "html/require-datetime"],
+        "each invalid time reports once through the migrated lane: {:?}",
+        result.diagnostics
+    );
+
+    let ranges: Vec<&str> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| &source[diagnostic.start as usize..diagnostic.end as usize])
+        .collect();
+    assert_eq!(
+        ranges,
+        vec![
+            "<time {...attrs}>Christmas</time>",
+            "<time>last Tuesday</time>"
+        ],
+        "diagnostics should preserve source order and authored element ranges"
+    );
+
+    for diagnostic in &result.diagnostics {
+        assert_eq!(diagnostic.severity, Severity::Warning);
+        assert!(diagnostic.help.is_some());
+        assert!(diagnostic.fix.is_none());
+    }
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -23,6 +23,7 @@ mod no_i_for_icon_tests;
 mod no_redundant_roles_tests;
 mod no_role_presentation_on_focusable_jsx_tests;
 mod no_role_presentation_on_focusable_tests;
+mod require_datetime_tests;
 
 #[cfg(test)]
 mod markup_ir_tests {

--- a/crates/vize_patina/src/markup/tests/require_datetime_tests.rs
+++ b/crates/vize_patina/src/markup/tests/require_datetime_tests.rs
@@ -1,0 +1,250 @@
+use crate::context::LintContext;
+use crate::diagnostic::{LintDiagnostic, Severity};
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::html::RequireDatetime;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> Vec<LintDiagnostic> {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().to_vec()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> Vec<LintDiagnostic> {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut diagnostics = Vec::new();
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        diagnostics.extend_from_slice(lint.diagnostics());
+    }
+    diagnostics
+}
+
+fn diagnostic_ranges(diagnostics: &[LintDiagnostic]) -> Vec<(u32, u32)> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| (diagnostic.start, diagnostic.end))
+        .collect()
+}
+
+#[test]
+fn require_datetime_template_attr_and_text_boundaries() {
+    let rule = RequireDatetime;
+    for (source, expected, label) in [
+        (
+            r#"<time datetime="2024-12-25">Christmas</time>"#,
+            0,
+            "static datetime attribute",
+        ),
+        (
+            r#"<time :datetime="date">Christmas</time>"#,
+            0,
+            "v-bind datetime attribute",
+        ),
+        (
+            r#"<time v-bind:datetime="date">Christmas</time>"#,
+            0,
+            "longhand v-bind datetime attribute",
+        ),
+        (
+            r#"<time :[datetime]="date">Christmas</time>"#,
+            0,
+            "dynamic arg content still matches legacy simple expression",
+        ),
+        (
+            r#"<time v-bind="attrs">Christmas</time>"#,
+            1,
+            "argument-less v-bind does not prove datetime exists",
+        ),
+        (
+            r#"<time DATETIME="2024-12-25">Christmas</time>"#,
+            1,
+            "attribute matching is case-sensitive",
+        ),
+        (r#"<time>2024-12-25</time>"#, 0, "valid date text"),
+        (r#"<time>2024-12-25T10:30</time>"#, 0, "valid datetime text"),
+        (r#"<time>PT1H30M</time>"#, 0, "valid duration text"),
+        (
+            r#"<time>last Tuesday</time>"#,
+            1,
+            "human-readable text requires datetime",
+        ),
+        (r#"<time></time>"#, 1, "empty text requires datetime"),
+        (
+            r#"<time> </time>"#,
+            1,
+            "whitespace-only text requires datetime",
+        ),
+        (
+            r#"<time>{{ formattedDate }}</time>"#,
+            0,
+            "direct interpolation is dynamic content",
+        ),
+        (
+            r#"<time>last {{ unit }}</time>"#,
+            0,
+            "mixed direct text and interpolation is dynamic content",
+        ),
+        (
+            r#"<time><span>2024-12-25</span></time>"#,
+            1,
+            "nested text is ignored by the legacy direct text scan",
+        ),
+        (
+            r#"<time>2024<span>x</span>-12-25</time>"#,
+            0,
+            "direct text concatenates around ignored nested element text",
+        ),
+        (
+            r#"<Time>Christmas</Time>"#,
+            0,
+            "component-like uppercase tag is not lowercase time",
+        ),
+        (
+            r#"<time-clock>Christmas</time-clock>"#,
+            0,
+            "custom element tag is not lowercase time",
+        ),
+    ] {
+        let diagnostics = run_over_template(&rule, source);
+        assert_eq!(
+            diagnostics.len(),
+            expected,
+            "template boundary changed for {label}: {diagnostics:?}"
+        );
+    }
+}
+
+#[test]
+fn require_datetime_template_reports_on_time_element() {
+    let rule = RequireDatetime;
+    let source = r#"<section><time>Christmas</time></section>"#;
+    let diagnostics = run_over_template(&rule, source);
+    assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+
+    let start = source.find("<time>").unwrap() as u32;
+    assert_eq!(
+        diagnostic_ranges(&diagnostics),
+        vec![(start, start + "<time>".len() as u32)]
+    );
+    assert_eq!(diagnostics[0].rule_name, "html/require-datetime");
+    assert_eq!(diagnostics[0].severity, Severity::Warning);
+    assert!(
+        diagnostics[0].help.is_some(),
+        "diagnostic should carry help text: {:?}",
+        diagnostics[0]
+    );
+    assert!(
+        diagnostics[0].fix.is_none(),
+        "require-datetime is not auto-fixable: {:?}",
+        diagnostics[0]
+    );
+}
+
+#[test]
+fn require_datetime_jsx_lowered_attr_and_text_boundaries() {
+    let rule = RequireDatetime;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <time datetime="2024-12-25">Christmas</time>;"#,
+            0,
+            "static datetime attribute",
+        ),
+        (
+            r#"const A = () => <time datetime={date}>Christmas</time>;"#,
+            0,
+            "dynamic datetime attribute",
+        ),
+        (
+            r#"const A = () => <time v-bind:datetime={date}>Christmas</time>;"#,
+            0,
+            "JSX directive spelling lowers to v-bind datetime",
+        ),
+        (
+            r#"const A = () => <time {...attrs}>Christmas</time>;"#,
+            1,
+            "spread attributes do not prove datetime exists",
+        ),
+        (
+            r#"const A = () => <time dateTime="2024-12-25">Christmas</time>;"#,
+            1,
+            "camel-cased dateTime does not match legacy lowercase datetime",
+        ),
+        (
+            r#"const A = () => <time html:datetime="2024-12-25">Christmas</time>;"#,
+            1,
+            "namespaced datetime attribute does not match lowercase datetime",
+        ),
+        (
+            r#"const A = () => <time>{'2024-12-25'}</time>;"#,
+            0,
+            "static string expression lowers to text",
+        ),
+        (
+            r#"const A = () => <time>{'Christmas'}</time>;"#,
+            1,
+            "invalid static string expression lowers to text",
+        ),
+        (
+            r#"const A = () => <time>{formattedDate}</time>;"#,
+            0,
+            "expression child lowers to interpolation",
+        ),
+        (
+            r#"const A = () => <time>last {unit}</time>;"#,
+            0,
+            "mixed JSX text and expression is dynamic content",
+        ),
+        (
+            r#"const A = () => <time><span>2024-12-25</span></time>;"#,
+            1,
+            "nested text is ignored by the legacy direct text scan",
+        ),
+        (
+            r#"const A = () => <time><>{'Christmas'}</></time>;"#,
+            1,
+            "plain fragments are transparent through JSX lowering",
+        ),
+        (
+            r#"const A = () => <time><>{'2024-12-25'}</></time>;"#,
+            0,
+            "plain fragments preserve valid lowered text",
+        ),
+        (
+            r#"const A = () => <Time>Christmas</Time>;"#,
+            0,
+            "component tag is not lowercase time",
+        ),
+        (
+            r#"const A = () => <Foo.time>Christmas</Foo.time>;"#,
+            0,
+            "member component tag is not lowercase time",
+        ),
+        (
+            r#"const A = () => <time-clock>Christmas</time-clock>;"#,
+            0,
+            "custom element tag is not lowercase time",
+        ),
+    ] {
+        let diagnostics = run_over_jsx_lowered(&rule, source);
+        assert_eq!(
+            diagnostics.len(),
+            expected,
+            "lowered JSX boundary changed for {label}: {diagnostics:?}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/html/require_datetime.rs
+++ b/crates/vize_patina/src/rules/html/require_datetime.rs
@@ -24,8 +24,9 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBindingKind, MarkupContext, MarkupElement, MarkupNode, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, PropNode, TemplateChildNode};
+use vize_relief::ElementNode;
 
 use super::helpers::is_valid_datetime;
 use vize_s0::String;
@@ -41,52 +42,28 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct RequireDatetime;
 
-impl Rule for RequireDatetime {
-    fn meta(&self) -> &'static RuleMeta {
-        &META
-    }
-
-    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if element.tag != "time" {
+impl RequireDatetime {
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        if !element.is_unqualified_tag_exact("time") {
             return;
         }
 
-        // Check if datetime attribute exists (static or dynamic)
-        let has_datetime = element.props.iter().any(|prop| match prop {
-            PropNode::Attribute(attr) => attr.name == "datetime",
-            PropNode::Directive(dir) => {
-                dir.name == "bind"
-                    && dir.arg.as_ref().is_some_and(|arg| {
-                        if let vize_relief::ExpressionNode::Simple(s) = arg {
-                            s.content == "datetime"
-                        } else {
-                            false
-                        }
-                    })
-            }
-        });
-
-        if has_datetime {
+        if Self::has_datetime_binding(element) {
             return;
         }
 
-        // Check if text content is a valid datetime
         let mut text_content = String::default();
         let mut has_dynamic_content = false;
-
-        for child in &element.children {
-            match child {
-                TemplateChildNode::Text(text) => {
-                    text_content.push_str(text.content);
-                }
-                TemplateChildNode::Interpolation(_) => {
-                    has_dynamic_content = true;
-                }
-                _ => {}
+        element.walk_children(&mut |child| match child {
+            MarkupNode::Text(text) => {
+                text_content.push_str(text.content());
             }
-        }
+            MarkupNode::Interpolation(_) => {
+                has_dynamic_content = true;
+            }
+            _ => {}
+        });
 
-        // If there's dynamic content, we can't validate
         if has_dynamic_content {
             return;
         }
@@ -94,8 +71,54 @@ impl Rule for RequireDatetime {
         if !is_valid_datetime(&text_content) {
             let message = ctx.t("html/require-datetime.message");
             let help = ctx.t("html/require-datetime.help");
-            ctx.warn_with_help(message, &element.loc, help);
+            ctx.warn_at_with_help(message, element.range(), help);
         }
+    }
+
+    fn has_datetime_binding(element: &MarkupElement<'_>) -> bool {
+        let mut has_datetime = false;
+        element.walk_bindings(&mut |binding| {
+            if has_datetime {
+                return;
+            }
+
+            if matches!(
+                binding.kind(),
+                MarkupBindingKind::Attribute | MarkupBindingKind::Bind
+            ) && binding.is_unqualified_arg_exact("datetime")
+            {
+                has_datetime = true;
+            }
+        });
+        has_datetime
+    }
+}
+
+impl MarkupRule for RequireDatetime {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        Self::check_element(ctx.lint(), element);
+    }
+}
+
+impl Rule for RequireDatetime {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn jsx_needs_lowering(&self) -> bool {
+        true
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           317 |                   317 |                 0 |             279 |     253 |             672 |      177 |           357 |           510 |
+| Linter                     |           318 |                   318 |                 0 |             279 |     253 |             671 |      179 |           358 |           512 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,8 +99,8 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         317 |             224 |       93 |
-| old AST/parser   |         237 |             210 |       27 |
+| S0               |         318 |             224 |       94 |
+| old AST/parser   |         237 |             209 |       28 |
 | Croquis analysis |          42 |              38 |        4 |
 | raw OXC          |         253 |             200 |       53 |
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:35`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:36`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 53 omitted.
+Additional test/dev rows are in the TSV: 54 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,9 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	35	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	35	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	35	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	36	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	36	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	36	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1031,6 +1031,8 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_jsx_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/require_datetime_tests.rs	7	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/require_datetime_tests.rs	7	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/output.rs	20	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/output/agent.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/output/html.rs	6	s0	S0	stage	vize_s0	preferred	1
@@ -1089,8 +1091,8 @@ linter	Linter	source	crates/vize_patina/src/rules/html/no_consecutive_br.rs	28	o
 linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	36	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/html/no_duplicate_dt.rs	36	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/html/no_empty_palpable_content.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/html/require_datetime.rs	28	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/html/require_datetime.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	2
+linter	Linter	source	crates/vize_patina/src/rules/html/require_datetime.rs	29	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/html/require_datetime.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/musea.rs	31	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/musea.rs	31	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/musea/prefer_design_tokens.rs	26	s0	S0	stage	vize_s0	preferred	3

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,10 +34,10 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 25, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 26, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 122, `ir` 21, `ir-lowered` 4, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (25 = 25 `markup-facade` rules)
-- classification: neutral-core-candidate **86** · vue-dialect-bound **137** · container-bound **22** (0 overridden)
+- JSX lanes: `fallback` 121, `ir` 21, `ir-lowered` 5, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (26 = 26 `markup-facade` rules)
+- classification: neutral-core-candidate **87** · vue-dialect-bound **136** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
 ## Full table
@@ -103,7 +103,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `html/no-duplicate-class`                       | template-family | `opinionated/html/no_duplicate_class.rs`               | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `html/no-duplicate-dt`                          | template-family | `html/no_duplicate_dt.rs`                              | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `html/no-empty-palpable-content`                | template-family | `html/no_empty_palpable_content.rs`                    | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
-| `html/require-datetime`                         | template-family | `html/require_datetime.rs`                             | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
+| `html/require-datetime`                         | template-family | `html/require_datetime.rs`                             | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `musea/no-empty-variant`                        | musea           | `musea/no_empty_variant.rs`                            | musea-blocks                   | no                               | no                          | —                                                                                                   | container-bound        |
 | `musea/prefer-design-tokens`                    | musea           | `musea/prefer_design_tokens.rs`                        | musea-blocks                   | no                               | no                          | —                                                                                                   | container-bound        |
 | `musea/require-component`                       | musea           | `musea/require_component.rs`                           | musea-blocks                   | no                               | no                          | direct 1: `script_parser::parse_script_setup`                                                       | container-bound        |


### PR DESCRIPTION
## Summary
- Move html/require-datetime onto the Davinci MarkupRule facade while keeping the legacy Rule visitor entry point.
- Route JSX through lowered markup IR to preserve string-expression, interpolation, fragment, and range behavior.
- Add template and public JSX regressions for attributes, dynamic bindings, exact-case matching, spread attributes, direct text, nested text, dynamic content, metadata, and double-run prevention.
- Update Davinci rule parity and consumer migration surface inventories.

Closes #5289

## Verification
- cargo fmt --all -- --check
- cargo test -p vize_patina require_datetime --locked
- cargo check -q -p vize_patina --all-targets --locked
- cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports
- cargo test -q -p vize_patina --locked
- node tools/davinci/rule-parity.mjs --check
- node tools/davinci/consumer-migration-surfaces.mjs --check
- node tools/davinci/sourcelocation-inventory.mjs --check
- node tools/davinci/matrix-gen.mjs --check
- node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs
- node tools/davinci/assertion-lint.mjs
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790626949&installation_model_id=422833&pr_number=5290&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5290&signature=fddf0d6d1a5ced6f912d48963212117d7ef6671261586f71924b741a3d8d7357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->