### PR TITLE
refactor(patina): port no-dupe-style-properties to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -14,6 +14,7 @@ mod jsx_media_has_caption;
 mod jsx_mouse_events_have_key_events;
 mod jsx_no_aria_hidden_on_focusable;
 mod jsx_no_consecutive_br;
+mod jsx_no_dupe_style_properties;
 mod jsx_no_duplicate_class;
 mod jsx_no_duplicate_dt;
 mod jsx_no_i_for_icon;

--- a/crates/vize_patina/src/linter/tests/jsx_no_dupe_style_properties.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_dupe_style_properties.rs
@@ -1,0 +1,104 @@
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::opinionated::html::NoDupeStyleProperties;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn no_dupe_style_properties_fires_on_jsx_and_tsx_ir() {
+    let linter = linter_with(Box::new(NoDupeStyleProperties));
+    let source = r#"const A = () => <div style="color: red; color: blue" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        result.warning_count, 1,
+        "JSX duplicate style property must flag through the IR pass: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["html/no-dupe-style-properties"]
+    );
+
+    let diag = &result.diagnostics[0];
+    let attr_start = source.find("style").unwrap() as u32;
+    assert_eq!(
+        diag.start, attr_start,
+        "range must start at the written JSX style attribute"
+    );
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        r#"style="color: red; color: blue""#
+    );
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <div style="margin: 0; MARGIN: 1px" />;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["html/no-dupe-style-properties"],
+        "TSX duplicate style property must also flag through the IR pass"
+    );
+}
+
+#[test]
+fn no_dupe_style_properties_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(NoDupeStyleProperties));
+    for source in [
+        r#"const A = () => <div style />;"#,
+        r#"const A = () => <div style={{ color: a, color: b }} />;"#,
+        r#"const A = () => <div style={'color:red;color:blue'} />;"#,
+        r#"const A = () => <div {...props} />;"#,
+        r#"const A = () => <div STYLE="color: red; color: blue" />;"#,
+        r#"const A = () => <div html:style="color: red; color: blue" />;"#,
+        r#"const A = () => <Component style="color: red; color: blue" />;"#,
+        r#"const A = () => <Icons.Div style="color: red; color: blue" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn no_dupe_style_properties_reports_once_per_duplicate_not_per_backend() {
+    let linter = linter_with(Box::new(NoDupeStyleProperties));
+    let source =
+        r#"const A = () => <div style="color: red; color: blue; margin: 0; margin: 1px" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec![
+            "html/no-dupe-style-properties",
+            "html/no-dupe-style-properties"
+        ],
+        "a migrated no-dupe-style-properties rule must not double-run: {:?}",
+        result.diagnostics
+    );
+
+    let attr_start = source.find("style").unwrap() as u32;
+    let attr_end =
+        attr_start + r#"style="color: red; color: blue; margin: 0; margin: 1px""#.len() as u32;
+    for diagnostic in &result.diagnostics {
+        assert_eq!(diagnostic.start, attr_start);
+        assert_eq!(diagnostic.end, attr_end);
+    }
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -17,6 +17,7 @@ mod mouse_events_have_key_events_tests;
 mod no_aria_hidden_on_focusable_jsx_tests;
 mod no_aria_hidden_on_focusable_tests;
 mod no_consecutive_br_tests;
+mod no_dupe_style_properties_tests;
 mod no_duplicate_class_tests;
 mod no_duplicate_dt_tests;
 mod no_i_for_icon_tests;

--- a/crates/vize_patina/src/markup/tests/no_dupe_style_properties_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_dupe_style_properties_tests.rs
@@ -1,0 +1,216 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::opinionated::html::NoDupeStyleProperties;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn no_dupe_style_properties_template() {
+    let rule = NoDupeStyleProperties;
+    for (source, expected, label) in [
+        (
+            r#"<div style="color: red; color: blue">x</div>"#,
+            1,
+            "one duplicate declaration",
+        ),
+        (
+            r#"<div style="color: red; color: blue; color: green">x</div>"#,
+            2,
+            "triple duplicate reports each repeated declaration",
+        ),
+        (
+            r#"<div style="color: red; color: blue; margin: 0; margin: 1px">x</div>"#,
+            2,
+            "two distinct repeated properties",
+        ),
+        (
+            r#"<div style="margin: 0; MARGIN: 1px">x</div>"#,
+            1,
+            "property names are case-insensitive",
+        ),
+        (
+            r#"<div style="  color :red ;  color : blue ">x</div>"#,
+            1,
+            "property names are trimmed",
+        ),
+        (
+            r#"<div style="background: url(http://example.com/a); background: blue">x</div>"#,
+            1,
+            "colons inside values do not affect property parsing",
+        ),
+        (
+            r#"<div style="color; color: blue">x</div>"#,
+            0,
+            "declarations without a colon are ignored",
+        ),
+        (
+            r#"<div style="color: red" style="color: blue">x</div>"#,
+            0,
+            "duplicate properties across attributes are not combined",
+        ),
+        (
+            r#"<div style="color: red; color: blue" style="margin: 0; margin: 1px">x</div>"#,
+            2,
+            "each static style attribute is checked independently",
+        ),
+        (r#"<div style>x</div>"#, 0, "valueless style is ignored"),
+        (r#"<div style="">x</div>"#, 0, "empty style is clean"),
+        (
+            r#"<div :style="{ color: a, color: b }">x</div>"#,
+            0,
+            "dynamic style binding is ignored",
+        ),
+        (
+            r#"<div v-bind:style="'color:red;color:blue'">x</div>"#,
+            0,
+            "long-form dynamic style binding is ignored",
+        ),
+        (
+            r#"<div STYLE="color: red; color: blue">x</div>"#,
+            0,
+            "attribute names are case-sensitive",
+        ),
+        (
+            r#"<MyWidget style="color: red; color: blue">x</MyWidget>"#,
+            0,
+            "components stay skipped",
+        ),
+        (
+            r#"<slot style="color: red; color: blue"></slot>"#,
+            1,
+            "slot elements are not components and stay inspected",
+        ),
+        (
+            r#"<template style="color: red; color: blue"><div /></template>"#,
+            1,
+            "template elements are not components and stay inspected",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template case failed: {label}"
+        );
+    }
+}
+
+#[test]
+fn no_dupe_style_properties_jsx_direct_matches_lowered_static_boundaries() {
+    let rule = NoDupeStyleProperties;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <div style="color: red; color: blue" />;"#,
+            1,
+            "one duplicate declaration",
+        ),
+        (
+            r#"const A = () => <div style="color: red; color: blue; color: green" />;"#,
+            2,
+            "triple duplicate reports each repeated declaration",
+        ),
+        (
+            r#"const A = () => <div style="margin: 0; MARGIN: 1px" />;"#,
+            1,
+            "property names are case-insensitive",
+        ),
+        (
+            r#"const A = () => <div style="background: url(http://example.com/a); background: blue" />;"#,
+            1,
+            "colons inside values do not affect property parsing",
+        ),
+        (
+            r#"const A = () => <div style="color: red" style="color: blue" />;"#,
+            0,
+            "duplicate properties across attributes are not combined",
+        ),
+        (
+            r#"const A = () => <div style />;"#,
+            0,
+            "valueless style is ignored",
+        ),
+        (
+            r#"const A = () => <div style={{ color: a, color: b }} />;"#,
+            0,
+            "expression-valued style is dynamic and ignored",
+        ),
+        (
+            r#"const A = () => <div style={'color:red;color:blue'} />;"#,
+            0,
+            "string expression style is dynamic and ignored",
+        ),
+        (
+            r#"const A = () => <div STYLE="color: red; color: blue" />;"#,
+            0,
+            "attribute names are case-sensitive",
+        ),
+        (
+            r#"const A = () => <div html:style="color: red; color: blue" />;"#,
+            0,
+            "namespaced style attributes are ignored",
+        ),
+        (
+            r#"const A = () => <Component style="color: red; color: blue" />;"#,
+            0,
+            "components stay skipped",
+        ),
+        (
+            r#"const A = () => <Icons.Div style="color: red; color: blue" />;"#,
+            0,
+            "member components stay skipped",
+        ),
+        (
+            r#"const A = () => <svg:div style="color: red; color: blue" />;"#,
+            1,
+            "lowercase namespaced intrinsic tags stay inspected",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(direct, expected, "JSX direct case failed: {label}");
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "JSX direct and lowered fallback diverged for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/opinionated/html.rs
+++ b/crates/vize_patina/src/rules/opinionated/html.rs
@@ -2,7 +2,7 @@ mod no_dupe_style_properties;
 mod no_duplicate_class;
 
 use crate::rule::RuleRegistry;
-use no_dupe_style_properties::NoDupeStyleProperties;
+pub(crate) use no_dupe_style_properties::NoDupeStyleProperties;
 pub(crate) use no_duplicate_class::NoDuplicateClass;
 
 pub(crate) fn register(registry: &mut RuleRegistry) {

--- a/crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs
+++ b/crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs
@@ -26,9 +26,11 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::ir::ByteRange;
+use crate::markup::{MarkupBinding, MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, ElementType, PropNode};
-use vize_s0::FxHashMap;
+use vize_relief::ElementNode;
+use vize_s0::FxHashSet;
 use vize_s0::String;
 use vize_s0::ToCompactString;
 
@@ -43,53 +45,83 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct NoDupeStyleProperties;
 
+impl NoDupeStyleProperties {
+    fn check_style_value(ctx: &mut LintContext<'_>, value: &str, range: ByteRange) {
+        let mut seen: FxHashSet<String> = FxHashSet::default();
+        for declaration in value.split(';') {
+            // A declaration is `property: value`; the property name is the
+            // text before the first colon.
+            let property = match declaration.split_once(':') {
+                Some((name, _)) => name,
+                None => continue,
+            };
+            let normalized = property.trim().to_lowercase();
+            if normalized.is_empty() {
+                continue;
+            }
+            let normalized = normalized.to_compact_string();
+
+            if !seen.insert(normalized.clone()) {
+                let message = ctx.t_fmt(
+                    "html/no-dupe-style-properties.message",
+                    &[("property", normalized.as_str())],
+                );
+                let help = ctx.t("html/no-dupe-style-properties.help");
+                ctx.warn_at_with_help(message, range, help);
+            }
+        }
+    }
+
+    fn check_binding(ctx: &mut LintContext<'_>, binding: &MarkupBinding<'_>) {
+        if binding.kind() == MarkupBindingKind::Attribute
+            && binding.is_unqualified_arg_exact("style")
+            && let Some(value) = binding.static_value()
+        {
+            Self::check_style_value(ctx, value, binding.range());
+        }
+    }
+
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        if element.is_component() {
+            return;
+        }
+
+        element.walk_bindings(&mut |binding| {
+            Self::check_binding(ctx, &binding);
+        });
+    }
+}
+
+impl MarkupRule for NoDupeStyleProperties {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_binding<'a>(
+        &self,
+        ctx: &mut MarkupContext<'_, 'a>,
+        element: &MarkupElement<'a>,
+        binding: &MarkupBinding<'a>,
+    ) {
+        if element.is_component() {
+            return;
+        }
+
+        Self::check_binding(ctx.lint(), binding);
+    }
+}
+
 impl Rule for NoDupeStyleProperties {
     fn meta(&self) -> &'static RuleMeta {
         &META
     }
 
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if element.tag_type == ElementType::Component {
-            return;
-        }
-
-        for prop in &element.props {
-            // Only inspect the static `style` attribute. Dynamic `:style`
-            // bindings are directives and are skipped here.
-            let PropNode::Attribute(attr) = prop else {
-                continue;
-            };
-            if attr.name != "style" {
-                continue;
-            }
-            let Some(value) = &attr.value else {
-                continue;
-            };
-
-            let mut seen: FxHashMap<String, ()> = FxHashMap::default();
-            for declaration in value.content.split(';') {
-                // A declaration is `property: value`; the property name is the
-                // text before the first colon.
-                let property = match declaration.split_once(':') {
-                    Some((name, _)) => name,
-                    None => continue,
-                };
-                let normalized = property.trim().to_lowercase();
-                if normalized.is_empty() {
-                    continue;
-                }
-                let normalized = normalized.to_compact_string();
-
-                if seen.insert(normalized.clone(), ()).is_some() {
-                    let message = ctx.t_fmt(
-                        "html/no-dupe-style-properties.message",
-                        &[("property", normalized.as_str())],
-                    );
-                    let help = ctx.t("html/no-dupe-style-properties.help");
-                    ctx.warn_with_help(message, &attr.loc, help);
-                }
-            }
-        }
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
 
@@ -159,6 +191,26 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_duplicate_reports_attribute_range_and_normalized_property() {
+        let linter = create_linter();
+        let source = r#"<div style="margin: 0; MARGIN: 1px">x</div>"#;
+        let result = linter.lint_template(source, "test.vue");
+        assert_eq!(result.warning_count, 1);
+
+        let diagnostic = &result.diagnostics[0];
+        assert_eq!(diagnostic.rule_name, "html/no-dupe-style-properties");
+        assert_eq!(
+            diagnostic.message.as_str(),
+            "Duplicate property 'margin' in inline style"
+        );
+        assert_eq!(
+            &source[diagnostic.start as usize..diagnostic.end as usize],
+            r#"style="margin: 0; MARGIN: 1px""#,
+            "template diagnostics stay on the written style attribute"
+        );
+    }
+
+    #[test]
     fn test_invalid_duplicate_with_whitespace() {
         let linter = create_linter();
         let result = linter.lint_template(
@@ -166,6 +218,18 @@ mod tests {
             "test.vue",
         );
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_custom_property_names_keep_existing_case_folding() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r#"<div style="--Gap: 0; --gap: 1px">x</div>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+        assert_eq!(
+            result.diagnostics[0].message.as_str(),
+            "Duplicate property '--gap' in inline style"
+        );
     }
 
     #[test]

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           318 |                   318 |                 0 |             279 |     253 |             671 |      179 |           358 |           512 |
+| Linter                     |           319 |                   319 |                 0 |             280 |     256 |             671 |      184 |           359 |           514 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         318 |             224 |       94 |
-| old AST/parser   |         237 |             209 |       28 |
+| S0               |         319 |             224 |       95 |
+| old AST/parser   |         238 |             209 |       29 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         253 |             200 |       53 |
+| raw OXC          |         256 |             200 |       56 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:36`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:37`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 54 omitted.
+Additional test/dev rows are in the TSV: 55 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,9 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	36	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	36	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	36	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	37	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	37	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	37	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1016,6 +1016,9 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_foc
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_consecutive_br_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_consecutive_br_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_dupe_style_properties_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_dupe_style_properties_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_dupe_style_properties_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_class_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_class_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_class_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1104,8 +1107,8 @@ linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_role
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/placeholder_label_option.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/use_list.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	30	s0	S0	stage	vize_s0	preferred	3
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	32	s0	S0	stage	vize_s0	preferred	3
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	29	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vapor/no_inline_template.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 26, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 27, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 121, `ir` 21, `ir-lowered` 5, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (26 = 26 `markup-facade` rules)
+- JSX lanes: `fallback` 120, `ir` 22, `ir-lowered` 5, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (27 = 27 `markup-facade` rules)
 - classification: neutral-core-candidate **87** · vue-dialect-bound **136** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -99,7 +99,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `html/deprecated-element`                       | template-family | `html/deprecated_element.rs`                           | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `html/id-duplication`                           | template-family | `html/id_duplication.rs`                               | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `html/no-consecutive-br`                        | template-family | `html/no_consecutive_br.rs`                            | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
-| `html/no-dupe-style-properties`                 | template-family | `opinionated/html/no_dupe_style_properties.rs`         | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `html/no-dupe-style-properties`                 | template-family | `opinionated/html/no_dupe_style_properties.rs`         | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `html/no-duplicate-class`                       | template-family | `opinionated/html/no_duplicate_class.rs`               | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `html/no-duplicate-dt`                          | template-family | `html/no_duplicate_dt.rs`                              | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `html/no-empty-palpable-content`                | template-family | `html/no_empty_palpable_content.rs`                    | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |


### PR DESCRIPTION
## Summary
- move `html/no-dupe-style-properties` onto the Davinci markup facade while preserving the legacy Vue template path
- add cross-backend regression coverage for static style parsing, dynamic/style expression skips, component skips, duplicate counting, and diagnostic ranges
- update Davinci rule parity and consumer migration surface inventories

Closes #5292

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p vize_patina --lib no_dupe_style_properties --locked`
- `cargo test -p vize_patina --lib linter::tests::jsx_no_dupe_style_properties --locked`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `node tools/davinci/matrix-gen.mjs --check`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `node tools/davinci/assertion-lint.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo check -q -p vize_patina --all-targets --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `cargo test -q -p vize_patina --locked`
- `git diff --check HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790628707&installation_model_id=422833&pr_number=5293&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5293&signature=f6143bd59da40db17aa90d5d2adab4f680cc43dff0a1a6d40057b195e876e271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of duplicate CSS properties in JSX and TSX `style` attributes.
  * Duplicate properties are now reported consistently across JSX parsing paths.
  * Diagnostics highlight the complete affected `style` attribute and handle custom-property names case-insensitively.

* **Tests**
  * Added coverage for static, dynamic, namespaced, component, and legacy JSX style scenarios.

* **Documentation**
  * Updated rule parity and migration tracking to reflect expanded JSX support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->