### PR TITLE
refactor(patina): port heading-levels to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -8,6 +8,7 @@ mod directives;
 mod jsx;
 mod jsx_deprecated_attr;
 mod jsx_fallback;
+mod jsx_heading_levels;
 mod jsx_iframe_has_title;
 mod jsx_interactive_supports_focus;
 mod jsx_media_has_caption;

--- a/crates/vize_patina/src/linter/tests/jsx_heading_levels.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_heading_levels.rs
@@ -1,0 +1,153 @@
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::HeadingLevels;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn heading_levels_runs_over_lowered_markup_ir_once() {
+    let source = "const A = () => <><h1>Title</h1><h3>Sub</h3></>;";
+    let linter = linter_with(Box::new(HeadingLevels));
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/heading-levels"],
+        "migrated heading-levels must report once via lowered markup IR: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+
+    let diag = &result.diagnostics[0];
+    let h3_start = source.find("<h3").unwrap() as u32;
+    assert_eq!(
+        diag.start, h3_start,
+        "range must start at the skipped JSX heading"
+    );
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        "<h3>Sub</h3>",
+        "range must cover exactly the authored JSX heading"
+    );
+
+    let tsx = linter.lint_jsx(
+        "const A = (): JSX.Element => <><h1>Title</h1><h3>Sub</h3></>;",
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["a11y/heading-levels"],
+        "TSX keeps the same lowered markup IR behavior"
+    );
+}
+
+#[test]
+fn heading_levels_reports_each_skip_after_the_first() {
+    let source = "const A = () => <><h1>T</h1><h3>S</h3><h6>D</h6></>;";
+    let linter = linter_with(Box::new(HeadingLevels));
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/heading-levels", "a11y/heading-levels"],
+        "each heading jump after the first must still report: {:?}",
+        result.diagnostics
+    );
+
+    let starts: Vec<u32> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.start)
+        .collect();
+    assert_eq!(
+        starts,
+        vec![
+            source.find("<h3").unwrap() as u32,
+            source.find("<h6").unwrap() as u32,
+        ]
+    );
+}
+
+#[test]
+fn heading_levels_preserves_lowered_jsx_root_boundaries() {
+    let linter = linter_with(Box::new(HeadingLevels));
+    for source in [
+        "const A = () => <h1>Title</h1>;\nconst B = () => <h3>Sub</h3>;",
+        "const A = () => <><H1>Title</H1><H3>Sub</H3></>;",
+        "const A = () => <><h1>Title</h1><svg:h3>Sub</svg:h3></>;",
+        "const A = () => <><h1>Title</h1><Headings.h3>Sub</Headings.h3></>;",
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0);
+    }
+}
+
+#[test]
+fn heading_levels_sfc_offsets_template_diagnostics() {
+    let source = r#"<script setup lang="ts">
+const title = "Title";
+</script>
+
+<template>
+  <h1>{{ title }}</h1>
+  <h3>Sub</h3>
+</template>
+"#;
+    let linter = linter_with(Box::new(HeadingLevels));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/heading-levels"],
+        "SFC template heading skip must report once: {:?}",
+        result.diagnostics
+    );
+
+    let diag = &result.diagnostics[0];
+    let h3_start = source.find("<h3").unwrap() as u32;
+    assert_eq!(
+        diag.start, h3_start,
+        "SFC diagnostic must be offset into file coordinates"
+    );
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        "<h3>",
+        "range must cover the skipped template heading start tag in the full SFC"
+    );
+}
+
+#[test]
+fn heading_levels_sfc_does_not_lint_script_tsx() {
+    let source = r#"<script setup lang="tsx">
+const A = () => <><h1>Title</h1><h3>Sub</h3></>;
+</script>
+"#;
+    let linter = linter_with(Box::new(HeadingLevels));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        result.warning_count, 0,
+        "SFC heading-levels must not inspect JSX inside script blocks: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -8,6 +8,7 @@
 // test files) so the Davinci assertion lint, which only scans inline
 // `#[cfg(test)] mod` bodies under `src/`, keeps covering these tests.
 mod deprecated_attr_tests;
+mod heading_levels_tests;
 mod iframe_has_title_jsx_tests;
 mod iframe_has_title_tests;
 mod interactive_supports_focus_jsx_tests;

--- a/crates/vize_patina/src/markup/tests/heading_levels_tests.rs
+++ b/crates/vize_patina/src/markup/tests/heading_levels_tests.rs
@@ -1,0 +1,174 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::HeadingLevels;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn heading_levels_template_sequence_contract() {
+    let rule = HeadingLevels;
+    for (source, expected, label) in [
+        (
+            r#"<h1>Title</h1><h2>Section</h2><h3>Sub</h3>"#,
+            0,
+            "sequential headings",
+        ),
+        (
+            r#"<h2>Section A</h2><h2>Section B</h2>"#,
+            0,
+            "same heading level",
+        ),
+        (
+            r#"<h1>Title</h1><h2>Section</h2><h3>Sub</h3><h2>Back</h2>"#,
+            0,
+            "heading decrease",
+        ),
+        (r#"<h3>Only heading</h3>"#, 0, "single heading"),
+        (r#"<div>content</div>"#, 0, "no headings"),
+        (r#"<h1>Title</h1><h3>Subsection</h3>"#, 1, "h1 to h3 skip"),
+        (r#"<h1>T</h1><h3>S</h3><h6>D</h6>"#, 2, "multiple skips"),
+        (
+            r#"<h1>Title</h1><section><h3>Subsection</h3></section>"#,
+            1,
+            "nested heading stays in document order",
+        ),
+        (
+            r#"<h1>Title</h1><template><h3>Subsection</h3></template>"#,
+            1,
+            "template wrapper descendants participate",
+        ),
+        (
+            r#"<template v-if="ok"><h1>Title</h1></template><template v-else><h3>Subsection</h3></template>"#,
+            1,
+            "v-if branches preserve source-order traversal",
+        ),
+        (
+            r#"<template v-for="item in items"><h1>Title</h1><h3>Subsection</h3></template>"#,
+            1,
+            "v-for children preserve source-order traversal",
+        ),
+        (
+            r#"<H1>Title</H1><H3>Subsection</H3>"#,
+            0,
+            "uppercase component-like tags are ignored",
+        ),
+        (
+            r#"<h1>Title</h1><svg:h3>Subsection</svg:h3>"#,
+            0,
+            "qualified tag names are ignored",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template case changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn heading_levels_jsx_single_root_projection_matches_lowered() {
+    let rule = HeadingLevels;
+    for (source, expected, label) in [
+        (
+            "const A = () => <><h1>Title</h1><h2>Section</h2><h3>Sub</h3></>;",
+            0,
+            "sequential fragment headings",
+        ),
+        (
+            "const A = () => <><h1>Title</h1><h3>Subsection</h3></>;",
+            1,
+            "h1 to h3 skip",
+        ),
+        (
+            "const A = () => <section><h1>Title</h1><div><h3>Sub</h3></div></section>;",
+            1,
+            "nested heading in one root",
+        ),
+        (
+            "const A = () => <><h1>T</h1><h3>S</h3><h6>D</h6></>;",
+            2,
+            "multiple skips",
+        ),
+        (
+            "const A = () => <><H1>Title</H1><H3>Subsection</H3></>;",
+            0,
+            "component-like tags ignored",
+        ),
+        (
+            "const A = () => <><h1>Title</h1><svg:h3>Subsection</svg:h3></>;",
+            0,
+            "qualified tag ignored",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(
+            direct, expected,
+            "direct JSX projection changed for {label}"
+        );
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "direct JSX projection diverged from lowered JSX for {label}"
+        );
+    }
+}
+
+#[test]
+fn heading_levels_lowered_jsx_keeps_render_roots_isolated() {
+    let rule = HeadingLevels;
+    let separate_roots = "const A = () => <h1>Title</h1>;\nconst B = () => <h3>Sub</h3>;";
+    assert_eq!(
+        run_over_jsx_lowered(&rule, separate_roots),
+        0,
+        "legacy JSX fallback scoped heading state per lowered render root"
+    );
+
+    let each_root_has_skip = "const A = () => <><h1>Title</h1><h3>Sub</h3></>;\nconst B = () => <><h2>A</h2><h4>B</h4></>;";
+    assert_eq!(
+        run_over_jsx_lowered(&rule, each_root_has_skip),
+        2,
+        "each render root reports its own heading skip"
+    );
+}

--- a/crates/vize_patina/src/rules/html/helpers.rs
+++ b/crates/vize_patina/src/rules/html/helpers.rs
@@ -153,27 +153,3 @@ pub fn is_valid_datetime(s: &str) -> bool {
     s.chars()
         .all(|c| c.is_ascii_digit() || "-:TtZz+. W".contains(c))
 }
-
-/// Walk all elements in the template tree, calling a visitor function on each.
-pub fn walk_elements<'a, F>(children: &[TemplateChildNode<'a>], visitor: &mut F)
-where
-    F: FnMut(&ElementNode<'a>),
-{
-    for child in children {
-        match child {
-            TemplateChildNode::Element(el) => {
-                visitor(el);
-                walk_elements(&el.children, visitor);
-            }
-            TemplateChildNode::If(if_node) => {
-                for branch in if_node.branches.iter() {
-                    walk_elements(&branch.children, visitor);
-                }
-            }
-            TemplateChildNode::For(for_node) => {
-                walk_elements(&for_node.children, visitor);
-            }
-            _ => {}
-        }
-    }
-}

--- a/crates/vize_patina/src/rules/opinionated/a11y/heading_levels.rs
+++ b/crates/vize_patina/src/rules/opinionated/a11y/heading_levels.rs
@@ -26,9 +26,10 @@
 #![allow(clippy::disallowed_macros)]
 
 use crate::context::LintContext;
-use crate::diagnostic::Severity;
+use crate::diagnostic::{LintDiagnostic, Severity};
+use crate::ir::{ByteRange, TemplateSyntax};
+use crate::markup::{MarkupContext, MarkupDocument, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use crate::rules::html::helpers::walk_elements;
 use vize_relief::RootNode;
 
 static META: RuleMeta = RuleMeta {
@@ -44,42 +45,42 @@ pub struct HeadingLevels;
 
 struct HeadingInfo {
     level: u8,
-    start: u32,
-    end: u32,
+    range: ByteRange,
 }
 
-fn heading_level(tag: &str) -> Option<u8> {
-    match tag {
-        "h1" => Some(1),
-        "h2" => Some(2),
-        "h3" => Some(3),
-        "h4" => Some(4),
-        "h5" => Some(5),
-        "h6" => Some(6),
-        _ => None,
+fn heading_level(element: &MarkupElement<'_>) -> Option<u8> {
+    if element.is_unqualified_tag_exact("h1") {
+        Some(1)
+    } else if element.is_unqualified_tag_exact("h2") {
+        Some(2)
+    } else if element.is_unqualified_tag_exact("h3") {
+        Some(3)
+    } else if element.is_unqualified_tag_exact("h4") {
+        Some(4)
+    } else if element.is_unqualified_tag_exact("h5") {
+        Some(5)
+    } else if element.is_unqualified_tag_exact("h6") {
+        Some(6)
+    } else {
+        None
     }
 }
 
-impl Rule for HeadingLevels {
-    fn meta(&self) -> &'static RuleMeta {
-        &META
-    }
-
-    fn run_on_template<'a>(&self, ctx: &mut LintContext<'a>, root: &RootNode<'a>) {
+impl HeadingLevels {
+    fn check_document(ctx: &mut LintContext<'_>, document: &MarkupDocument<'_>) {
         let mut headings: Vec<HeadingInfo> = Vec::new();
 
-        walk_elements(&root.children, &mut |element| {
-            if let Some(level) = heading_level(element.tag) {
+        document.walk_elements(&mut |element| {
+            if let Some(level) = heading_level(&element) {
                 headings.push(HeadingInfo {
                     level,
-                    start: element.loc.span.start,
-                    end: element.loc.span.end,
+                    range: element.range(),
                 });
             }
         });
 
         // Sort by document order (source offset)
-        headings.sort_by_key(|h| h.start);
+        headings.sort_by_key(|h| h.range.start);
 
         let mut prev_level: u8 = 0;
         for heading in &headings {
@@ -92,17 +93,48 @@ impl Rule for HeadingLevels {
                     ],
                 );
                 let help = ctx.t("a11y/heading-levels.help");
-                let diag = crate::diagnostic::LintDiagnostic::warn(
+                let diag = LintDiagnostic::warn(
                     META.name,
                     message,
-                    heading.start,
-                    heading.end,
+                    heading.range.start,
+                    heading.range.end,
                 )
                 .with_help(help.into_owned());
                 ctx.report(diag);
             }
             prev_level = heading.level;
         }
+    }
+}
+
+impl MarkupRule for HeadingLevels {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_document(&self, ctx: &mut MarkupContext<'_, '_>, document: &MarkupDocument) {
+        Self::check_document(ctx.lint(), document);
+    }
+}
+
+impl Rule for HeadingLevels {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn jsx_needs_lowering(&self) -> bool {
+        // Heading state is scoped to each lowered render root, matching the
+        // legacy fallback. The direct OXC document covers the whole program.
+        true
+    }
+
+    fn run_on_template<'a>(&self, ctx: &mut LintContext<'a>, root: &RootNode<'a>) {
+        let document = MarkupDocument::new(root, TemplateSyntax::Vue);
+        Self::check_document(ctx, &document);
     }
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           319 |                   319 |                 0 |             280 |     256 |             671 |      184 |           359 |           514 |
+| Linter                     |           320 |                   320 |                 0 |             281 |     259 |             671 |      189 |           360 |           516 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         319 |             224 |       95 |
-| old AST/parser   |         238 |             209 |       29 |
+| S0               |         320 |             224 |       96 |
+| old AST/parser   |         239 |             209 |       30 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         256 |             200 |       56 |
+| raw OXC          |         259 |             200 |       59 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:37`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:38`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 55 omitted.
+Additional test/dev rows are in the TSV: 56 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,12 +991,15 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	37	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	37	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	37	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	38	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	38	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	38	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/heading_levels_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/heading_levels_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/heading_levels_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/iframe_has_title_jsx_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/iframe_has_title_jsx_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/iframe_has_title_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
@@ -1102,7 +1105,7 @@ linter	Linter	source	crates/vize_patina/src/rules/musea/prefer_design_tokens.rs	
 linter	Linter	source	crates/vize_patina/src/rules/musea/require_component.rs	62	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/musea/require_title.rs	83	croquis	Croquis analysis	old	vize_croquis	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/musea/unique_variant_names.rs	5	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/heading_levels.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/heading_levels.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/placeholder_label_option.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 27, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 28, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 120, `ir` 22, `ir-lowered` 5, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (27 = 27 `markup-facade` rules)
+- JSX lanes: `fallback` 119, `ir` 22, `ir-lowered` 6, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (28 = 28 `markup-facade` rules)
 - classification: neutral-core-candidate **87** · vue-dialect-bound **136** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -55,7 +55,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/click-events-have-key-events`             | template-family | `a11y/click_events_have_key_events.rs`                 | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/form-control-has-label`                   | template-family | `a11y/form_control_has_label.rs`                       | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/heading-has-content`                      | template-family | `a11y/heading_has_content.rs`                          | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
-| `a11y/heading-levels`                           | template-family | `opinionated/a11y/heading_levels.rs`                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `a11y/heading-levels`                           | template-family | `opinionated/a11y/heading_levels.rs`                   | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `a11y/iframe-has-title`                         | template-family | `a11y/iframe_has_title.rs`                             | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/img-alt`                                  | template-family | `a11y/img_alt.rs`                                      | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |
 | `a11y/interactive-supports-focus`               | template-family | `a11y/interactive_supports_focus.rs`                   | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |

--- a/davinci-road/plan/sourcelocation-inventory.md
+++ b/davinci-road/plan/sourcelocation-inventory.md
@@ -28,7 +28,7 @@ any read — or any deleted carrier — comes back.
 - Reads of `span.start` / `span.end` are **not** inventoried: they are
   the surviving offset representation — the pre-migration
   `start.offset` / `end.offset` reads moved to them verbatim
-  (301 loc-shaped span-read sites across
+  (299 loc-shaped span-read sites across
   8 crates at generation time).
 - `#[cfg(test)]` code inside `src/` is included and reported in the
   "in test code" column: a site counts as test code when its file is a test


### PR DESCRIPTION
## Summary

- Port `a11y/heading-levels` onto the shared `MarkupRule` facade while preserving the existing SFC `run_on_template` entry point.
- Keep JSX on the lowered markup lane because heading sequence state must stay scoped to each render root.
- Add focused markup and `lint_jsx` regressions for ordering, ranges, TSX, multiple skips, casing/qualified tags, and render-root isolation.
- Refresh Davinci rule-parity, consumer migration surface, and SourceLocation inventories.

Closes #5296.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p vize_patina --lib heading_levels --locked`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `node tools/davinci/assertion-lint.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `cargo check -q -p vize_patina --all-targets --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `cargo test -q -p vize_patina --locked`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790630309&installation_model_id=422833&pr_number=5297&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5297&signature=6cb944de5521937350e1324664deb1623493b4cb177acbd50ba48293292bd1f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved heading-level accessibility checks across Vue templates and JSX/TSX.
  * Correctly reports skipped heading levels, including multiple independent render roots.
  * Ignores component-like, namespaced, and member-expression tags when evaluating heading order.

* **Tests**
  * Added comprehensive coverage for valid sequences, skipped levels, nesting, and parser consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->