### PR TITLE
refactor(patina): port placeholder-label-option to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -21,6 +21,7 @@ mod jsx_no_duplicate_dt;
 mod jsx_no_i_for_icon;
 mod jsx_no_redundant_roles;
 mod jsx_no_role_presentation_on_focusable;
+mod jsx_placeholder_label_option;
 mod jsx_require_datetime;
 mod jsx_streaming;
 mod no_mutating_props;

--- a/crates/vize_patina/src/linter/tests/jsx_placeholder_label_option.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_placeholder_label_option.rs
@@ -1,0 +1,171 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::PlaceholderLabelOption;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn placeholder_label_option_fires_on_jsx_and_tsx_ir() {
+    let linter = linter_with(Box::new(PlaceholderLabelOption));
+    let source = r#"const A = () => <select><option value="">Choose</option></select>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/placeholder-label-option"],
+        "JSX placeholder option must flag through the IR pass: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+
+    let diag = &result.diagnostics[0];
+    let option = r#"<option value="">Choose</option>"#;
+    let option_start = source.find(option).unwrap() as u32;
+    assert_eq!(diag.start, option_start);
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        option,
+        "range must cover the authored JSX option element"
+    );
+    assert_eq!(diag.severity, Severity::Warning);
+    assert!(diag.help.is_some(), "diagnostic should keep rule help");
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <select><option value="">Choose</option></select>;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["a11y/placeholder-label-option"],
+        "TSX placeholder option must also flag through the IR pass"
+    );
+}
+
+#[test]
+fn placeholder_label_option_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(PlaceholderLabelOption));
+    for source in [
+        r#"const A = () => <select><option value="" disabled>Choose</option></select>;"#,
+        r#"const A = () => <select><option value="" hidden>Choose</option></select>;"#,
+        r#"const A = () => <select><option>Choose</option></select>;"#,
+        r#"const A = () => <select><option value={""}>Choose</option></select>;"#,
+        r#"const A = () => <Select><option value="">Choose</option></Select>;"#,
+        r#"const A = () => <Forms.select><option value="">Choose</option></Forms.select>;"#,
+        r#"const A = () => <svg:select><option value="">Choose</option></svg:select>;"#,
+        r#"const A = () => <select><Option value="">Choose</Option></select>;"#,
+        r#"const A = () => <select><svg:option value="">Choose</svg:option></select>;"#,
+        r#"const A = () => <select><span><option value="">Nested</option></span></select>;"#,
+        r#"const A = () => <select><option VALUE="">Choose</option></select>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+
+    for source in [
+        r#"const A = () => <select><option value>Choose</option></select>;"#,
+        r#"const A = () => <select><option value="">Choose</option></select>;"#,
+        r#"const A = () => <select><option value="" disabled={true}>Choose</option></select>;"#,
+        r#"const A = () => <select><option value="" DISABLED>Choose</option></select>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 1,
+            "must keep warning for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+}
+
+#[test]
+fn migrated_placeholder_label_option_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(PlaceholderLabelOption));
+    let result = linter.lint_jsx(
+        r#"const A = () => <select><option value="">Choose</option></select>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated placeholder-label-option rule must report once: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn placeholder_label_option_sfc_offsets_template_diagnostics() {
+    let source = r#"<script setup lang="ts">
+const choices = ["A"];
+</script>
+
+<template>
+  <select>
+    <option value="">Choose</option>
+    <option value="a">A</option>
+  </select>
+</template>
+"#;
+    let linter = linter_with(Box::new(PlaceholderLabelOption));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/placeholder-label-option"],
+        "SFC template placeholder option must report once: {:?}",
+        result.diagnostics
+    );
+
+    let diag = &result.diagnostics[0];
+    let option = r#"<option value="">"#;
+    let option_start = source.find(option).unwrap() as u32;
+    assert_eq!(
+        diag.start, option_start,
+        "SFC diagnostic must be offset into file coordinates"
+    );
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        option,
+        "range must cover the placeholder option in the full SFC"
+    );
+}
+
+#[test]
+fn placeholder_label_option_sfc_does_not_lint_script_tsx() {
+    let source = r#"<script setup lang="tsx">
+const A = () => <select><option value="">Choose</option></select>;
+</script>
+"#;
+    let linter = linter_with(Box::new(PlaceholderLabelOption));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        result.warning_count, 0,
+        "SFC placeholder-label-option must not inspect JSX inside script blocks: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -25,6 +25,7 @@ mod no_i_for_icon_tests;
 mod no_redundant_roles_tests;
 mod no_role_presentation_on_focusable_jsx_tests;
 mod no_role_presentation_on_focusable_tests;
+mod placeholder_label_option_tests;
 mod require_datetime_tests;
 
 #[cfg(test)]

--- a/crates/vize_patina/src/markup/tests/placeholder_label_option_tests.rs
+++ b/crates/vize_patina/src/markup/tests/placeholder_label_option_tests.rs
@@ -1,0 +1,204 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::PlaceholderLabelOption;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn placeholder_label_option_template_boundaries() {
+    let rule = PlaceholderLabelOption;
+    for (source, expected, label) in [
+        (
+            r#"<select><option value="">Choose</option><option value="a">A</option></select>"#,
+            1,
+            "first empty-valued option requires disabled or hidden",
+        ),
+        (
+            r#"<select><option value>Choose</option><option value="a">A</option></select>"#,
+            1,
+            "valueless value attribute is a placeholder",
+        ),
+        (
+            r#"<select><option value="" disabled>Choose</option></select>"#,
+            0,
+            "disabled placeholder is valid",
+        ),
+        (
+            r#"<select><option value="" hidden>Choose</option></select>"#,
+            0,
+            "hidden placeholder is valid",
+        ),
+        (
+            r#"<select><option>Choose</option><option value="a">A</option></select>"#,
+            0,
+            "missing value attribute stays outside the legacy placeholder check",
+        ),
+        (
+            r#"<select><option :value="choice">Choose</option></select>"#,
+            0,
+            "dynamic value does not prove a static placeholder",
+        ),
+        (
+            r#"<select><option value="" :disabled="disabled">Choose</option></select>"#,
+            1,
+            "bound disabled does not satisfy the static disabled check",
+        ),
+        (
+            r#"<select><option VALUE="">Choose</option></select>"#,
+            0,
+            "value attribute name remains exact",
+        ),
+        (
+            r#"<select><option value="" DISABLED>Choose</option></select>"#,
+            1,
+            "disabled attribute name remains exact",
+        ),
+        (
+            r#"<SELECT><option value="">Choose</option></SELECT>"#,
+            0,
+            "select tag name remains exact",
+        ),
+        (
+            r#"<select><OPTION value="">Choose</OPTION></select>"#,
+            0,
+            "option tag name remains exact",
+        ),
+        (
+            r#"<select><span></span><option value="">Choose</option></select>"#,
+            1,
+            "first direct option is found after non-option children",
+        ),
+        (
+            r#"<select><span><option value="">Nested</option></span></select>"#,
+            0,
+            "nested option is not a direct child",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn placeholder_label_option_jsx_direct_matches_lowered() {
+    let rule = PlaceholderLabelOption;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <select><option value="">Choose</option><option value="a">A</option></select>;"#,
+            1,
+            "first empty-valued option requires disabled or hidden",
+        ),
+        (
+            r#"const A = () => <select><option value>Choose</option></select>;"#,
+            1,
+            "valueless value attribute is a placeholder",
+        ),
+        (
+            r#"const A = () => <select><option value="" disabled>Choose</option></select>;"#,
+            0,
+            "disabled placeholder is valid",
+        ),
+        (
+            r#"const A = () => <select><option value="" hidden>Choose</option></select>;"#,
+            0,
+            "hidden placeholder is valid",
+        ),
+        (
+            r#"const A = () => <select><option value="" disabled={disabled}>Choose</option></select>;"#,
+            1,
+            "bound disabled does not satisfy the static disabled check",
+        ),
+        (
+            r#"const A = () => <select><option value={""}>Choose</option></select>;"#,
+            0,
+            "dynamic value expression does not prove a static placeholder",
+        ),
+        (
+            r#"const A = () => <select><option>Choose</option></select>;"#,
+            0,
+            "missing value attribute stays outside the legacy placeholder check",
+        ),
+        (
+            r#"const A = () => <Select><option value="">Choose</option></Select>;"#,
+            0,
+            "capitalized select is a component",
+        ),
+        (
+            r#"const A = () => <Forms.select><option value="">Choose</option></Forms.select>;"#,
+            0,
+            "member select is not an unqualified select tag",
+        ),
+        (
+            r#"const A = () => <svg:select><option value="">Choose</option></svg:select>;"#,
+            0,
+            "namespaced select is not an unqualified select tag",
+        ),
+        (
+            r#"const A = () => <select><Option value="">Choose</Option></select>;"#,
+            0,
+            "capitalized option is a component",
+        ),
+        (
+            r#"const A = () => <select><svg:option value="">Choose</svg:option></select>;"#,
+            0,
+            "namespaced option is not an unqualified option tag",
+        ),
+        (
+            r#"const A = () => <select><><option value="">Choose</option></></select>;"#,
+            1,
+            "JSX fragments under select are transparent like the lowering fallback",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(direct, expected, "JSX direct case failed: {label}");
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "JSX direct and lowered fallback diverged for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/opinionated/a11y/placeholder_label_option.rs
+++ b/crates/vize_patina/src/rules/opinionated/a11y/placeholder_label_option.rs
@@ -29,8 +29,9 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBindingKind, MarkupContext, MarkupElement, MarkupNode, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, ElementType, PropNode, TemplateChildNode};
+use vize_relief::ElementNode;
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/placeholder-label-option",
@@ -43,58 +44,106 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct PlaceholderLabelOption;
 
+impl PlaceholderLabelOption {
+    fn first_option_child<'a>(
+        element: &MarkupElement<'a>,
+        transparent_fragments: bool,
+    ) -> Option<MarkupElement<'a>> {
+        let mut first_option = None;
+        element.walk_children(&mut |child| {
+            if first_option.is_none()
+                && let MarkupNode::Element(element) = child
+                && element.is_unqualified_tag_exact("option")
+            {
+                first_option = Some(element);
+            }
+            if first_option.is_none()
+                && transparent_fragments
+                && let MarkupNode::Element(element) = child
+                && element.tag().is_empty()
+            {
+                first_option = Self::first_option_child(&element, transparent_fragments);
+            }
+        });
+        first_option
+    }
+
+    fn has_empty_static_attribute(element: &MarkupElement<'_>, name: &str) -> bool {
+        let mut found = false;
+        element.walk_bindings(&mut |binding| {
+            if binding.kind() == MarkupBindingKind::Attribute
+                && binding.is_unqualified_arg_exact(name)
+                && binding.static_value().is_none_or(str::is_empty)
+            {
+                found = true;
+            }
+        });
+        found
+    }
+
+    fn has_exact_static_attribute(element: &MarkupElement<'_>, name: &str) -> bool {
+        let mut found = false;
+        element.walk_bindings(&mut |binding| {
+            if binding.kind() == MarkupBindingKind::Attribute
+                && binding.is_unqualified_arg_exact(name)
+            {
+                found = true;
+            }
+        });
+        found
+    }
+
+    fn check_element(
+        ctx: &mut LintContext<'_>,
+        element: &MarkupElement<'_>,
+        transparent_fragments: bool,
+    ) {
+        if element.is_component() || !element.is_unqualified_tag_exact("select") {
+            return;
+        }
+
+        let Some(option) = Self::first_option_child(element, transparent_fragments) else {
+            return;
+        };
+
+        if !Self::has_empty_static_attribute(&option, "value") {
+            return;
+        }
+
+        if Self::has_exact_static_attribute(&option, "disabled")
+            || Self::has_exact_static_attribute(&option, "hidden")
+        {
+            return;
+        }
+
+        let message = ctx.t("a11y/placeholder-label-option.message");
+        let help = ctx.t("a11y/placeholder-label-option.help");
+        ctx.warn_at_with_help(message, option.range(), help);
+    }
+}
+
+impl MarkupRule for PlaceholderLabelOption {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        let transparent_fragments = ctx.is_jsx();
+        Self::check_element(ctx.lint(), element, transparent_fragments);
+    }
+}
+
 impl Rule for PlaceholderLabelOption {
     fn meta(&self) -> &'static RuleMeta {
         &META
     }
 
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if element.tag_type == ElementType::Component || element.tag != "select" {
-            return;
-        }
-
-        // Find first <option> child
-        let first_option = element.children.iter().find_map(|child| {
-            if let TemplateChildNode::Element(el) = child
-                && el.tag == "option"
-            {
-                return Some(el.as_ref());
-            }
-            None
-        });
-
-        let Some(option) = first_option else {
-            return;
-        };
-
-        // Check if it's a placeholder (value="" or no value attribute)
-        let is_placeholder = option.props.iter().any(|prop| {
-            if let PropNode::Attribute(attr) = prop
-                && attr.name == "value"
-            {
-                return attr.value.as_ref().is_none_or(|v| v.content.is_empty());
-            }
-            false
-        });
-
-        if !is_placeholder {
-            return;
-        }
-
-        // Check if disabled or hidden
-        let has_disabled_or_hidden = option.props.iter().any(|prop| {
-            if let PropNode::Attribute(attr) = prop {
-                attr.name == "disabled" || attr.name == "hidden"
-            } else {
-                false
-            }
-        });
-
-        if !has_disabled_or_hidden {
-            let message = ctx.t("a11y/placeholder-label-option.message");
-            let help = ctx.t("a11y/placeholder-label-option.help");
-            ctx.warn_with_help(message, &option.loc, help);
-        }
+        Self::check_element(ctx, &MarkupElement::new(element), false);
     }
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           320 |                   320 |                 0 |             281 |     259 |             671 |      189 |           360 |           516 |
+| Linter                     |           321 |                   321 |                 0 |             282 |     262 |             671 |      194 |           361 |           518 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         320 |             224 |       96 |
-| old AST/parser   |         239 |             209 |       30 |
+| S0               |         321 |             224 |       97 |
+| old AST/parser   |         240 |             209 |       31 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         259 |             200 |       59 |
+| raw OXC          |         262 |             200 |       62 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:38`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:39`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 56 omitted.
+Additional test/dev rows are in the TSV: 57 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,9 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	38	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	38	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	38	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	39	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	39	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	39	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1037,6 +1037,9 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_jsx_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/placeholder_label_option_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/placeholder_label_option_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/placeholder_label_option_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/require_datetime_tests.rs	7	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/require_datetime_tests.rs	7	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/output.rs	20	s0	S0	stage	vize_s0	preferred	1
@@ -1108,7 +1111,7 @@ linter	Linter	source	crates/vize_patina/src/rules/musea/unique_variant_names.rs	
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/heading_levels.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/placeholder_label_option.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/placeholder_label_option.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/use_list.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	32	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 28, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 29, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 119, `ir` 22, `ir-lowered` 6, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (28 = 28 `markup-facade` rules)
+- JSX lanes: `fallback` 118, `ir` 23, `ir-lowered` 6, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (29 = 29 `markup-facade` rules)
 - classification: neutral-core-candidate **87** · vue-dialect-bound **136** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -72,7 +72,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/no-refer-to-non-existent-id`              | template-family | `a11y/no_refer_to_non_existent_id.rs`                  | template-ast                   | yes (template-visitor)           | yes (fallback)              | direct 2: `croquis::ElementIdKind`; ctx 1                                                           | neutral-core-candidate |
 | `a11y/no-role-presentation-on-focusable`        | template-family | `a11y/no_role_presentation_on_focusable.rs`            | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/no-static-element-interactions`           | template-family | `a11y/no_static_element_interactions.rs`               | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
-| `a11y/placeholder-label-option`                 | template-family | `opinionated/a11y/placeholder_label_option.rs`         | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `a11y/placeholder-label-option`                 | template-family | `opinionated/a11y/placeholder_label_option.rs`         | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/role-has-required-aria-props`             | template-family | `a11y/role_has_required_aria_props.rs`                 | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/tabindex-no-positive`                     | template-family | `a11y/tabindex_no_positive.rs`                         | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/use-list`                                 | template-family | `opinionated/a11y/use_list.rs`                         | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |


### PR DESCRIPTION
## Summary
- port `placeholder-label-option` to the s1 markup facade while preserving legacy JSX/template behavior
- add direct markup and linter regression coverage for JSX, TSX, SFC offsets, fragments, static attributes, and script isolation
- refresh Davinci parity and consumer migration surface plans

Closes #5300

## Tests
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `cargo test -p vize_patina --lib placeholder_label_option --locked`
- `cargo test -p vize_patina --lib jsx_placeholder_label_option --locked`
- `cargo check -q -p vize_patina --all-targets --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `cargo test -q --workspace --locked`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790633731&installation_model_id=422833&pr_number=5301&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5301&signature=700b3ec2e196d45ba40700b9a94ac2e791b204ce5f045bc37a13b24f4452472e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the accessibility rule for placeholder `<option>` elements across Vue, JSX, and TSX.
  - Diagnostics now consistently identify invalid placeholder options and provide accurate source locations.

- **Bug Fixes**
  - Correctly handles disabled, hidden, nested, dynamic, and namespaced option cases.
  - Prevents duplicate diagnostics and excludes unsupported JSX contexts.

- **Tests**
  - Added comprehensive coverage across supported markup formats and parsing paths.

- **Documentation**
  - Updated rule parity and migration tracking documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->