### PR TITLE
feat(ui): add locale display and collation helpers

### DIFF
--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 125_300],
+  ["index.mjs", 126_000],
   ["alert.mjs", 1_050],
   ["announcer.mjs", 4_100],
   ["aspect-ratio.mjs", 1_500],
@@ -42,7 +42,7 @@ const budgets = new Map([
   ["history.mjs", 3_400],
   ["hover.mjs", 2_200],
   ["live-region.mjs", 2_400],
-  ["locale.mjs", 2_100],
+  ["locale.mjs", 3_000],
   ["long-press.mjs", 8_175],
   ["measure.mjs", 2_400],
   // Styled entries statically import the shared dist/style.css, so their

--- a/npm/ui/core/src/family-catalog-overlays.ts
+++ b/npm/ui/core/src/family-catalog-overlays.ts
@@ -71,7 +71,12 @@ export const overlayFamilyCatalog = [
     title: "Locale and Direction",
     packageSubpath: "./locale",
     entryFile: "src/locale.ts",
-    sourceFiles: ["src/locale-provider.vue", "src/locale.ts", "src/locale-runtime.ts"],
+    sourceFiles: [
+      "src/locale-provider.vue",
+      "src/locale.ts",
+      "src/locale-runtime.ts",
+      "src/locale-text.ts",
+    ],
     behaviorContract: "src/locale.behavior.md",
     tests: ["src/locale.test.ts", "src/locale-ssr.test.ts"],
     typeTests: ["src/locale.types.test-d.ts"],

--- a/npm/ui/core/src/locale-runtime.ts
+++ b/npm/ui/core/src/locale-runtime.ts
@@ -21,8 +21,29 @@ export type LocaleListFormatterOptions = Intl.ListFormatOptions;
 /** Relative-time formatter options resolved against the active locale. */
 export type LocaleRelativeTimeFormatterOptions = Intl.RelativeTimeFormatOptions;
 
+/** Collator options resolved against the active locale. */
+export type LocaleCollatorOptions = Intl.CollatorOptions;
+
+/** Display-name kinds supported by `Intl.DisplayNames`. */
+export type LocaleDisplayNamesType =
+  | "language"
+  | "region"
+  | "script"
+  | "currency"
+  | "calendar"
+  | "dateTimeField";
+
+/** Display-name formatter options resolved against the active locale. */
+export type LocaleDisplayNamesOptions = Omit<Intl.DisplayNamesOptions, "type"> & {
+  /** Code kind to localize. */
+  readonly type: LocaleDisplayNamesType;
+};
+
 /** Static, ref, or getter-backed formatter options. */
 export type LocaleFormatterOptionsInput<Options> = MaybeRefOrGetter<Options | undefined>;
+
+/** Static, ref, or getter-backed display-name options. */
+export type LocaleDisplayNamesOptionsInput = MaybeRefOrGetter<LocaleDisplayNamesOptions>;
 
 /** Locale and direction published by LocaleProvider. */
 export interface LocaleValue {
@@ -32,6 +53,10 @@ export interface LocaleValue {
 
 const fallbackLocaleValue = "en-US";
 const setupDiagnostic = "VIZE_UI_LOCALE_SETUP";
+const defaultSearchCollatorOptions = Object.freeze({
+  sensitivity: "base",
+  usage: "search",
+} satisfies LocaleCollatorOptions);
 
 /** Typed locale context for application and component subtrees. */
 export const localeContext = createContext<LocaleValue>("Locale");
@@ -106,6 +131,27 @@ export function resolveRelativeTimeFormatter(
   return new Intl.RelativeTimeFormat(resolveLocale(locale), options);
 }
 
+/** Create a display-name formatter. */
+export function resolveDisplayNames(
+  locale: string,
+  options: LocaleDisplayNamesOptions,
+): Intl.DisplayNames {
+  return new Intl.DisplayNames(resolveLocale(locale), options);
+}
+
+/** Create a collator. */
+export function resolveCollator(locale: string, options?: LocaleCollatorOptions): Intl.Collator {
+  return new Intl.Collator(resolveLocale(locale), options);
+}
+
+/** Create a search collator with stable typeahead defaults. */
+export function resolveSearchCollator(
+  locale: string,
+  options?: LocaleCollatorOptions,
+): Intl.Collator {
+  return resolveCollator(locale, { ...defaultSearchCollatorOptions, ...options });
+}
+
 /** Read the nearest locale, or the document/SSR fallback. */
 export function useLocale(): ComputedRef<string> {
   if (!getCurrentInstance()) {
@@ -154,4 +200,28 @@ export function useRelativeTimeFormatter(
 ): ComputedRef<Intl.RelativeTimeFormat> {
   const locale = useLocale();
   return computed(() => resolveRelativeTimeFormatter(locale.value, toValue(options)));
+}
+
+/** Read the nearest locale and memoize a display-name formatter. */
+export function useDisplayNames(
+  options: LocaleDisplayNamesOptionsInput,
+): ComputedRef<Intl.DisplayNames> {
+  const locale = useLocale();
+  return computed(() => resolveDisplayNames(locale.value, toValue(options)));
+}
+
+/** Read the nearest locale and memoize a collator. */
+export function useCollator(
+  options?: LocaleFormatterOptionsInput<LocaleCollatorOptions>,
+): ComputedRef<Intl.Collator> {
+  const locale = useLocale();
+  return computed(() => resolveCollator(locale.value, toValue(options)));
+}
+
+/** Read the nearest locale and memoize a search collator. */
+export function useSearchCollator(
+  options?: LocaleFormatterOptionsInput<LocaleCollatorOptions>,
+): ComputedRef<Intl.Collator> {
+  const locale = useLocale();
+  return computed(() => resolveSearchCollator(locale.value, toValue(options)));
 }

--- a/npm/ui/core/src/locale-ssr.test.ts
+++ b/npm/ui/core/src/locale-ssr.test.ts
@@ -4,7 +4,7 @@ import { test } from "vite-plus/test";
 import { createSSRApp, defineComponent, h } from "vue";
 import { renderToString } from "vue/server-renderer";
 
-import { useNumberFormatter } from "./locale.ts";
+import { useDisplayNames, useNumberFormatter, useSearchCollator } from "./locale.ts";
 import LocaleProvider from "./locale-provider.vue";
 
 const SsrProbe = defineComponent({
@@ -37,6 +37,24 @@ test("uses the SSR fallback locale for formatters without a provider", async () 
 
   const output = await renderToString(createSSRApp(Probe));
   assert.match(output, />en-US</);
+});
+
+test("uses the SSR fallback locale for display names and search collators", async () => {
+  const Probe = defineComponent({
+    name: "LocaleSearchSsrProbe",
+    setup() {
+      const displayNames = useDisplayNames({ type: "region" });
+      const collator = useSearchCollator();
+      return () =>
+        h(
+          "span",
+          `${displayNames.value.resolvedOptions().locale}:${collator.value.resolvedOptions().usage}`,
+        );
+    },
+  });
+
+  const output = await renderToString(createSSRApp(Probe));
+  assert.match(output, />en-US:search</);
 });
 
 test("normalizes invalid provider locales during SSR", async () => {

--- a/npm/ui/core/src/locale-text.ts
+++ b/npm/ui/core/src/locale-text.ts
@@ -1,0 +1,91 @@
+/** Match policy for locale-aware text comparisons. */
+export type LocaleTextMatchMode = "prefix" | "exact" | "contains";
+
+/** Options for locale-aware normalized text matching. */
+export interface LocaleTextMatchOptions {
+  /**
+   * Locale-aware comparator used after NFC and whitespace normalization.
+   *
+   * Use a search collator with `sensitivity: "base"` for typeahead and
+   * command-palette matching.
+   */
+  readonly collator: Intl.Collator;
+
+  /**
+   * Match the whole value, a leading segment, or any segment.
+   *
+   * @default "prefix"
+   */
+  readonly match?: LocaleTextMatchMode;
+}
+
+/**
+ * Normalize authored, extracted, or searched text without applying a locale.
+ *
+ * Unicode is normalized to NFC and every whitespace run becomes one ASCII
+ * space. Locale-sensitive equality remains the responsibility of a collator.
+ */
+export function normalizeLocaleText(value: string): string {
+  return value.normalize("NFC").trim().replace(/\s+/gu, " ");
+}
+
+/** Whether a candidate text starts with a query under locale-aware comparison. */
+export function localeTextStartsWith(
+  candidate: string,
+  query: string,
+  collator: Intl.Collator,
+): boolean {
+  const normalizedCandidate = normalizeLocaleText(candidate);
+  const normalizedQuery = normalizeLocaleText(query);
+  let codeUnitLength = 0;
+  for (const character of normalizedCandidate) {
+    codeUnitLength += character.length;
+    if (collator.compare(normalizedCandidate.slice(0, codeUnitLength), normalizedQuery) === 0) {
+      return true;
+    }
+  }
+  return normalizedQuery.length === 0;
+}
+
+/** Whether a candidate text contains a query under locale-aware comparison. */
+export function localeTextContains(
+  candidate: string,
+  query: string,
+  collator: Intl.Collator,
+): boolean {
+  const normalizedCandidate = normalizeLocaleText(candidate);
+  const normalizedQuery = normalizeLocaleText(query);
+  if (normalizedQuery.length === 0) return true;
+
+  for (const start of codeUnitOffsets(normalizedCandidate)) {
+    if (localeTextStartsWith(normalizedCandidate.slice(start), normalizedQuery, collator)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Match normalized text with a locale-aware comparator. */
+export function localeTextMatches(
+  candidate: string,
+  query: string,
+  options: LocaleTextMatchOptions,
+): boolean {
+  const match = options.match ?? "prefix";
+  if (match === "exact") {
+    return (
+      options.collator.compare(normalizeLocaleText(candidate), normalizeLocaleText(query)) === 0
+    );
+  }
+  if (match === "contains") return localeTextContains(candidate, query, options.collator);
+  return localeTextStartsWith(candidate, query, options.collator);
+}
+
+function* codeUnitOffsets(value: string): Generator<number> {
+  let offset = 0;
+  yield offset;
+  for (const character of value) {
+    offset += character.length;
+    if (offset < value.length) yield offset;
+  }
+}

--- a/npm/ui/core/src/locale.behavior.md
+++ b/npm/ui/core/src/locale.behavior.md
@@ -5,18 +5,21 @@ Every row is proven by the named test in `src/locale.test.ts` or
 `src/locale-ssr.test.ts`; compile-only assertions live in
 `src/locale.types.test-d.ts`.
 
-| #   | State         | Input                               | Outcome                                                   | Proven by                                                              |
-| --- | ------------- | ----------------------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------- |
-| I1  | provider      | default props                       | `lang=en-US` and `dir=ltr`                                | `provides default locale and direction`                                |
-| I2  | provider      | `locale` and `direction=rtl`        | subtree lang/dir and slot props update                    | `publishes an explicit rtl locale`                                     |
-| I3  | provider      | `direction=auto` with RTL tag       | resolved direction is `rtl` when the engine can tell      | `resolves auto direction from the locale`                              |
-| I4  | locale helper | invalid or lower-case locale tags   | canonical locale or `en-US` fallback is used              | `canonicalizes invalid locale tags before formatter construction`      |
-| I5  | provider      | formatter composables with options  | number, date, list, and relative-time use provider locale | `resolves formatters from the provider locale and explicit options`    |
-| I6  | provider      | locale or formatter options change  | formatter composables update without stale Intl objects   | `updates formatter composables when provider locale or options change` |
-| I7  | provider      | invalid locale tag                  | context, markup, direction, and formatters fall back      | `normalizes invalid provider locales before publishing context`        |
-| I8  | no provider   | `useLocale` / `useDirection`        | document or SSR fallbacks are used                        | `falls back without a provider`                                        |
-| I9  | outside setup | composable call                     | stable setup diagnostic is thrown                         | `rejects composable use outside setup`                                 |
-| I10 | SSR           | identical trees                     | byte-identical lang and dir                               | SSR test                                                               |
-| I11 | SSR           | formatter without provider          | `en-US` fallback locale is used                           | SSR formatter test                                                     |
-| I12 | SSR           | invalid provider locale             | fallback lang and direction are rendered                  | SSR invalid-locale test                                                |
-| I13 | public types  | invalid direction or formatter opts | compilation rejects misuse                                | `src/locale.types.test-d.ts`                                           |
+| #   | State         | Input                                      | Outcome                                                    | Proven by                                                                  |
+| --- | ------------- | ------------------------------------------ | ---------------------------------------------------------- | -------------------------------------------------------------------------- |
+| I1  | provider      | default props                              | `lang=en-US` and `dir=ltr`                                 | `provides default locale and direction`                                    |
+| I2  | provider      | `locale` and `direction=rtl`               | subtree lang/dir and slot props update                     | `publishes an explicit rtl locale`                                         |
+| I3  | provider      | `direction=auto` with RTL tag              | resolved direction is `rtl` when the engine can tell       | `resolves auto direction from the locale`                                  |
+| I4  | locale helper | invalid or lower-case locale tags          | canonical locale or `en-US` fallback is used               | `canonicalizes invalid locale tags before formatter construction`          |
+| I5  | provider      | formatter composables with options         | number, date, list, and relative-time use provider locale  | `resolves formatters from the provider locale and explicit options`        |
+| I6  | provider      | display-name and search-collator helpers   | localized code names and accent-insensitive search compare | `resolves display names and search collators from the provider locale`     |
+| I7  | locale helper | decomposed Unicode and whitespace          | text is NFC-normalized before exact, prefix, or contains   | `matches normalized locale text with exact, prefix, and contains policies` |
+| I8  | provider      | locale or formatter options change         | formatter composables update without stale Intl objects    | `updates formatter composables when provider locale or options change`     |
+| I9  | provider      | invalid locale tag                         | context, markup, direction, and formatters fall back       | `normalizes invalid provider locales before publishing context`            |
+| I10 | no provider   | `useLocale` / `useDirection`               | document or SSR fallbacks are used                         | `falls back without a provider`                                            |
+| I11 | outside setup | composable call                            | stable setup diagnostic is thrown                          | `rejects composable use outside setup`                                     |
+| I12 | SSR           | identical trees                            | byte-identical lang and dir                                | SSR test                                                                   |
+| I13 | SSR           | formatter without provider                 | `en-US` fallback locale is used                            | SSR formatter test                                                         |
+| I14 | SSR           | display names and search collator fallback | `en-US` formatter locale and search usage are used         | SSR display/search test                                                    |
+| I15 | SSR           | invalid provider locale                    | fallback lang and direction are rendered                   | SSR invalid-locale test                                                    |
+| I16 | public types  | invalid direction or formatter/search opts | compilation rejects misuse                                 | `src/locale.types.test-d.ts`                                               |

--- a/npm/ui/core/src/locale.test.ts
+++ b/npm/ui/core/src/locale.test.ts
@@ -5,15 +5,22 @@ import { defineComponent, h, nextTick, ref } from "vue";
 
 import { mountInteraction } from "./testing/mount.ts";
 import {
+  localeTextMatches,
+  normalizeLocaleText,
   resolveDirection,
+  resolveDisplayNames,
   resolveLocale,
   resolveNumberFormatter,
+  resolveSearchCollator,
+  useCollator,
   useDateTimeFormatter,
   useDirection,
+  useDisplayNames,
   useListFormatter,
   useLocale,
   useNumberFormatter,
   useRelativeTimeFormatter,
+  useSearchCollator,
 } from "./locale.ts";
 import LocaleProvider from "./locale-provider.vue";
 
@@ -55,6 +62,10 @@ test("canonicalizes invalid locale tags before formatter construction", () => {
   assert.equal(resolveLocale(" ja-jp "), "ja-JP");
   assert.equal(resolveLocale("not a locale"), "en-US");
   assert.equal(resolveNumberFormatter("not a locale").resolvedOptions().locale, "en-US");
+  assert.equal(
+    resolveDisplayNames("not a locale", { type: "region" }).resolvedOptions().locale,
+    "en-US",
+  );
 });
 
 test("resolves formatters from the provider locale and explicit options", () => {
@@ -133,6 +144,104 @@ test("resolves formatters from the provider locale and explicit options", () => 
     [snapshot?.number, snapshot?.date, snapshot?.list, snapshot?.relativeTime].join("|"),
   );
   handle.unmount();
+});
+
+test("resolves display names and search collators from the provider locale", () => {
+  let snapshot:
+    | {
+        readonly displayName: string | undefined;
+        readonly displayLocale: string;
+        readonly searchLocale: string;
+        readonly searchUsage: string;
+        readonly accentInsensitive: boolean;
+      }
+    | undefined;
+
+  const Probe = defineComponent({
+    name: "LocaleDisplayAndSearchProbe",
+    setup() {
+      const displayNames = useDisplayNames({ style: "long", type: "region" });
+      const searchCollator = useSearchCollator();
+      return () => {
+        snapshot = {
+          displayName: displayNames.value.of("US"),
+          displayLocale: displayNames.value.resolvedOptions().locale,
+          searchLocale: searchCollator.value.resolvedOptions().locale,
+          searchUsage: searchCollator.value.resolvedOptions().usage,
+          accentInsensitive:
+            localeTextMatches("Cafe\u0301 noir", "cafe", {
+              collator: searchCollator.value,
+            }) &&
+            localeTextMatches("Cafe\u0301 noir", "noir", {
+              collator: searchCollator.value,
+              match: "contains",
+            }),
+        };
+        return h("span", snapshot.displayName);
+      };
+    },
+  });
+
+  const handle = mountInteraction(
+    defineComponent({
+      name: "LocaleDisplayAndSearchHost",
+      setup() {
+        return () => h(LocaleProvider, { locale: "fr-FR" }, { default: () => h(Probe) });
+      },
+    }),
+  );
+
+  const expectedDisplayNames = new Intl.DisplayNames("fr-FR", {
+    style: "long",
+    type: "region",
+  });
+  const expectedDisplayName = expectedDisplayNames.of("US");
+  const expectedSearch = new Intl.Collator("fr-FR", {
+    sensitivity: "base",
+    usage: "search",
+  });
+  assert.deepEqual(snapshot, {
+    displayName: expectedDisplayName,
+    displayLocale: expectedDisplayNames.resolvedOptions().locale,
+    searchLocale: expectedSearch.resolvedOptions().locale,
+    searchUsage: "search",
+    accentInsensitive: true,
+  });
+  assert.equal(handle.root().textContent, expectedDisplayName);
+  handle.unmount();
+});
+
+test("matches normalized locale text with exact, prefix, and contains policies", () => {
+  const collator = resolveSearchCollator("en-US");
+
+  assert.equal(normalizeLocaleText("  Cafe\u0301\nnoir  "), "Café noir");
+  assert.equal(
+    localeTextMatches("  Cafe\u0301\nnoir  ", "café", {
+      collator,
+    }),
+    true,
+  );
+  assert.equal(
+    localeTextMatches("  Cafe\u0301\nnoir  ", "noir", {
+      collator,
+      match: "contains",
+    }),
+    true,
+  );
+  assert.equal(
+    localeTextMatches("  Cafe\u0301\nnoir  ", "Café noir", {
+      collator,
+      match: "exact",
+    }),
+    true,
+  );
+  assert.equal(
+    localeTextMatches("  Cafe\u0301\nnoir  ", "noir", {
+      collator,
+      match: "prefix",
+    }),
+    false,
+  );
 });
 
 test("updates formatter composables when provider locale or options change", async () => {
@@ -225,4 +334,7 @@ test("rejects composable use outside setup", () => {
   assert.throws(() => useDateTimeFormatter(), /VIZE_UI_LOCALE_SETUP/);
   assert.throws(() => useListFormatter(), /VIZE_UI_LOCALE_SETUP/);
   assert.throws(() => useRelativeTimeFormatter(), /VIZE_UI_LOCALE_SETUP/);
+  assert.throws(() => useDisplayNames({ type: "region" }), /VIZE_UI_LOCALE_SETUP/);
+  assert.throws(() => useCollator(), /VIZE_UI_LOCALE_SETUP/);
+  assert.throws(() => useSearchCollator(), /VIZE_UI_LOCALE_SETUP/);
 });

--- a/npm/ui/core/src/locale.ts
+++ b/npm/ui/core/src/locale.ts
@@ -1,19 +1,29 @@
 export {
+  resolveCollator,
   localeContext,
   resolveDateTimeFormatter,
   resolveDirection,
+  resolveDisplayNames,
   resolveListFormatter,
   resolveLocale,
   resolveNumberFormatter,
   resolveRelativeTimeFormatter,
+  resolveSearchCollator,
+  useCollator,
   useDateTimeFormatter,
   useDirection,
+  useDisplayNames,
   useListFormatter,
   useLocale,
   useNumberFormatter,
   useRelativeTimeFormatter,
+  useSearchCollator,
   type DirectionPreference,
+  type LocaleCollatorOptions,
   type LocaleDateTimeFormatterOptions,
+  type LocaleDisplayNamesOptions,
+  type LocaleDisplayNamesOptionsInput,
+  type LocaleDisplayNamesType,
   type LocaleFormatterOptionsInput,
   type LocaleListFormatterOptions,
   type LocaleNumberFormatterOptions,
@@ -21,6 +31,15 @@ export {
   type LocaleValue,
   type TextDirection,
 } from "./locale-runtime.ts";
+
+export {
+  localeTextContains,
+  localeTextMatches,
+  localeTextStartsWith,
+  normalizeLocaleText,
+  type LocaleTextMatchMode,
+  type LocaleTextMatchOptions,
+} from "./locale-text.ts";
 
 /** Locale and direction provider for a document subtree. */
 export { default as LocaleProvider } from "./locale-provider.vue";

--- a/npm/ui/core/src/locale.types.test-d.ts
+++ b/npm/ui/core/src/locale.types.test-d.ts
@@ -3,25 +3,39 @@
 import type { ComputedRef } from "vue";
 
 import {
+  localeTextMatches,
+  normalizeLocaleText,
+  resolveCollator,
   resolveDateTimeFormatter,
   resolveDirection,
+  resolveDisplayNames,
   resolveListFormatter,
   resolveLocale,
   resolveNumberFormatter,
   resolveRelativeTimeFormatter,
+  resolveSearchCollator,
+  type LocaleCollatorOptions,
   type LocaleDateTimeFormatterOptions,
+  type LocaleDisplayNamesOptions,
+  type LocaleDisplayNamesOptionsInput,
+  type LocaleDisplayNamesType,
   type LocaleFormatterOptionsInput,
   type LocaleListFormatterOptions,
   type LocaleNumberFormatterOptions,
   type LocaleRelativeTimeFormatterOptions,
+  type LocaleTextMatchMode,
+  type LocaleTextMatchOptions,
   type DirectionPreference,
   type TextDirection,
+  useCollator,
   useDateTimeFormatter,
   useDirection,
+  useDisplayNames,
   useListFormatter,
   useLocale,
   useNumberFormatter,
   useRelativeTimeFormatter,
+  useSearchCollator,
 } from "./locale.ts";
 
 type Equal<Left, Right> =
@@ -55,6 +69,17 @@ export const relativeTimeOptions = {
   numeric: "auto",
   style: "narrow",
 } satisfies LocaleRelativeTimeFormatterOptions;
+export const displayNamesType: LocaleDisplayNamesType = "region";
+export const displayNamesOptions = {
+  style: "short",
+  type: displayNamesType,
+} satisfies LocaleDisplayNamesOptions;
+export const displayNamesOptionsInput = (() =>
+  displayNamesOptions) satisfies LocaleDisplayNamesOptionsInput;
+export const collatorOptions = {
+  sensitivity: "base",
+  usage: "search",
+} satisfies LocaleCollatorOptions;
 export const numberFormatter: Intl.NumberFormat = resolveNumberFormatter("ja-JP", numberOptions);
 export const reactiveNumberFormatter: ComputedRef<Intl.NumberFormat> = useNumberFormatter(
   () => numberOptions,
@@ -76,6 +101,25 @@ export const relativeTimeFormatter: Intl.RelativeTimeFormat = resolveRelativeTim
 );
 export const reactiveRelativeTimeFormatter: ComputedRef<Intl.RelativeTimeFormat> =
   useRelativeTimeFormatter(() => relativeTimeOptions);
+export const displayNamesFormatter: Intl.DisplayNames = resolveDisplayNames(
+  "ja-JP",
+  displayNamesOptions,
+);
+export const reactiveDisplayNames: ComputedRef<Intl.DisplayNames> =
+  useDisplayNames(displayNamesOptions);
+export const collator: Intl.Collator = resolveCollator("ja-JP", collatorOptions);
+export const searchCollator: Intl.Collator = resolveSearchCollator("ja-JP");
+export const reactiveCollator: ComputedRef<Intl.Collator> = useCollator(() => collatorOptions);
+export const reactiveSearchCollator: ComputedRef<Intl.Collator> = useSearchCollator();
+export const normalizedText: string = normalizeLocaleText("  Cafe\u0301\nnoir  ");
+export const textMatchMode: LocaleTextMatchMode = "contains";
+export const textMatchOptions = {
+  collator: searchCollator,
+  match: textMatchMode,
+} satisfies LocaleTextMatchOptions;
+export const textMatches: boolean = localeTextMatches("Café noir", "cafe", {
+  collator: searchCollator,
+});
 
 type _LocaleIsComputedString = Expect<Equal<ReturnType<typeof useLocale>, ComputedRef<string>>>;
 type _DirectionIsComputed = Expect<
@@ -93,6 +137,15 @@ type _ListFormatterIsComputed = Expect<
 type _RelativeTimeFormatterIsComputed = Expect<
   Equal<ReturnType<typeof useRelativeTimeFormatter>, ComputedRef<Intl.RelativeTimeFormat>>
 >;
+type _DisplayNamesIsComputed = Expect<
+  Equal<ReturnType<typeof useDisplayNames>, ComputedRef<Intl.DisplayNames>>
+>;
+type _CollatorIsComputed = Expect<
+  Equal<ReturnType<typeof useCollator>, ComputedRef<Intl.Collator>>
+>;
+type _SearchCollatorIsComputed = Expect<
+  Equal<ReturnType<typeof useSearchCollator>, ComputedRef<Intl.Collator>>
+>;
 
 // @ts-expect-error auto is a preference, not a resolved direction.
 export const unresolved: TextDirection = "auto";
@@ -104,3 +157,11 @@ resolveDateTimeFormatter("en-US", { dateStyle: "tiny" });
 resolveListFormatter("en-US", { type: "sentence" });
 // @ts-expect-error relative-time numeric policy is a closed union.
 resolveRelativeTimeFormatter("en-US", { numeric: "sometimes" });
+// @ts-expect-error display-name type is required.
+resolveDisplayNames("en-US", {});
+// @ts-expect-error display-name types are closed unions.
+resolveDisplayNames("en-US", { type: "continent" });
+// @ts-expect-error collator usage is a closed union.
+resolveCollator("en-US", { usage: "lookup" });
+// @ts-expect-error text match modes are closed unions.
+localeTextMatches("Alpha", "a", { collator: searchCollator, match: "fuzzy" });


### PR DESCRIPTION
Refs #4889.

## Summary
- add display-name and collator composables to the locale provider runtime
- add public collation-aware text matching helpers for exact, prefix, and contains matching
- document and catalog the new locale surface while keeping collection standalone for subpath size

## Tests
- vp check src scripts vite.config.ts tsconfig.typecheck.json
- vp test run src/locale.test.ts src/locale-ssr.test.ts src/locale.types.test-d.ts src/collection.test.ts src/family-catalog.test.ts src/runtime-conformance.test.ts
- ./node_modules/.bin/vue-tsc --noEmit -p tsconfig.typecheck.json
- vp exec node scripts/lint-sfc.ts src
- vp exec node scripts/check-renderers.ts src
- vp pack
- node scripts/check-size.mjs
- node scripts/check-tree-shaking.mjs
- vp test run
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790634056&installation_model_id=422833&pr_number=5302&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5302&signature=716f3b4498b067b36011fc93bdcc07cfced2959fb90e3e05d1ce01eb8152524c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added locale-aware display names and collator support for sorting and searching.
  - Added text-matching utilities with exact, prefix, and contains modes.
  - Improved Unicode normalization and accent-insensitive matching for localized text.
- **Bug Fixes**
  - Added reliable server-side rendering fallbacks for display names and search behavior.
  - Improved handling of invalid locale and formatter options.
- **Performance**
  - Updated size budgets to accommodate the expanded locale functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->