### PR TITLE
refactor(patina): port no-boolean-attr-value to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -14,6 +14,7 @@ mod jsx_interactive_supports_focus;
 mod jsx_media_has_caption;
 mod jsx_mouse_events_have_key_events;
 mod jsx_no_aria_hidden_on_focusable;
+mod jsx_no_boolean_attr_value;
 mod jsx_no_consecutive_br;
 mod jsx_no_dupe_style_properties;
 mod jsx_no_duplicate_class;

--- a/crates/vize_patina/src/linter/tests/jsx_no_boolean_attr_value.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_boolean_attr_value.rs
@@ -1,0 +1,214 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::vue::NoBooleanAttrValue;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn no_boolean_attr_value_fires_on_jsx_and_tsx_lowered_markup() {
+    let linter = linter_with(Box::new(NoBooleanAttrValue));
+    let source = r#"const A = () => <input disabled="disabled" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["vue/no-boolean-attr-value"],
+        "JSX explicit boolean attr value must flag through the lowered markup pass: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+
+    let diag = &result.diagnostics[0];
+    let attr = r#"disabled="disabled""#;
+    let attr_start = source.find(attr).unwrap() as u32;
+    assert_eq!(diag.start, attr_start);
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        attr,
+        "range must cover the authored JSX attribute"
+    );
+    assert_eq!(diag.severity, Severity::Warning);
+    assert_eq!(
+        diag.help.as_deref(),
+        Some(r#"Remove the value. Use just disabled instead of disabled="..."."#)
+    );
+    assert_eq!(diag.fix.as_ref().map(|_| "some"), None);
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <input disabled="disabled" />;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["vue/no-boolean-attr-value"],
+        "TSX explicit boolean attr value must also flag through the lowered markup pass"
+    );
+}
+
+#[test]
+fn no_boolean_attr_value_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(NoBooleanAttrValue));
+    for source in [
+        r#"const A = () => <input disabled />;"#,
+        r#"const A = () => <input disabled={isDisabled} />;"#,
+        r#"const A = () => <input {...props} />;"#,
+        r#"const A = () => <input type="text" />;"#,
+        r#"const A = () => <input declare="declare" webkitdirectory="webkitdirectory" />;"#,
+        r#"const A = () => <td nowrap="nowrap" />;"#,
+        r#"const A = () => <my-button disabled="disabled" />;"#,
+        r#"const A = () => <MyButton disabled="disabled" />;"#,
+        r#"const A = () => <INPUT disabled="disabled" />;"#,
+        r#"const A = () => <Forms.input disabled="disabled" />;"#,
+        r#"const A = () => <input DISABLED="disabled" />;"#,
+        r#"const A = () => <input autoFocus="autoFocus" />;"#,
+        r#"const A = () => <svg:input disabled="disabled" />;"#,
+        r#"const A = () => <svg:circle hidden="hidden" />;"#,
+        r#"const A = () => <input html:disabled="disabled" />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+
+    for source in [
+        r#"const A = () => <input disabled="disabled" />;"#,
+        r#"const A = () => <input disabled="" />;"#,
+        r#"const A = () => <button disabled="true">Click</button>;"#,
+        r#"const A = () => <svg hidden="hidden" />;"#,
+        r#"const A = () => <div>{cond && <input disabled="disabled" />}</div>;"#,
+        r#"const A = () => <ul>{items.map(() => <input disabled="disabled" />)}</ul>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 1,
+            "must keep warning for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+}
+
+#[test]
+fn no_boolean_attr_value_reports_multiple_attrs_in_source_order() {
+    let linter = linter_with(Box::new(NoBooleanAttrValue));
+    let source = r#"const A = () => <input disabled="disabled" required="required" checked />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["vue/no-boolean-attr-value", "vue/no-boolean-attr-value"]
+    );
+    assert_eq!(result.warning_count, 2);
+    assert_eq!(result.error_count, 0);
+
+    let slices: Vec<&str> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| &source[diagnostic.start as usize..diagnostic.end as usize])
+        .collect();
+    assert_eq!(
+        slices,
+        vec![r#"disabled="disabled""#, r#"required="required""#]
+    );
+    let fix_states: Vec<&str> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            if diagnostic.fix.is_some() {
+                "some"
+            } else {
+                "none"
+            }
+        })
+        .collect();
+    assert_eq!(fix_states, vec!["none", "none"]);
+}
+
+#[test]
+fn migrated_no_boolean_attr_value_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(NoBooleanAttrValue));
+    let result = linter.lint_jsx(
+        r#"const A = () => <input disabled="disabled" />;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated no-boolean-attr-value rule must report once: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn no_boolean_attr_value_sfc_offsets_template_diagnostics() {
+    let source = r#"<script setup lang="ts">
+const disabled = true;
+</script>
+
+<template>
+  <input disabled="disabled" />
+</template>
+"#;
+    let linter = linter_with(Box::new(NoBooleanAttrValue));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["vue/no-boolean-attr-value"],
+        "SFC template boolean attr value must report once: {:?}",
+        result.diagnostics
+    );
+
+    let diag = &result.diagnostics[0];
+    let attr = r#"disabled="disabled""#;
+    let attr_start = source.find(attr).unwrap() as u32;
+    assert_eq!(
+        diag.start, attr_start,
+        "SFC diagnostic must be offset into file coordinates"
+    );
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        attr,
+        "range must cover the boolean attribute in the full SFC"
+    );
+}
+
+#[test]
+fn no_boolean_attr_value_sfc_does_not_lint_script_tsx() {
+    let source = r#"<script setup lang="tsx">
+const A = () => <input disabled="disabled" />;
+</script>
+"#;
+    let linter = linter_with(Box::new(NoBooleanAttrValue));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        result.warning_count, 0,
+        "SFC no-boolean-attr-value must not inspect JSX inside script blocks: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -17,6 +17,7 @@ mod media_has_caption_tests;
 mod mouse_events_have_key_events_tests;
 mod no_aria_hidden_on_focusable_jsx_tests;
 mod no_aria_hidden_on_focusable_tests;
+mod no_boolean_attr_value_tests;
 mod no_consecutive_br_tests;
 mod no_dupe_style_properties_tests;
 mod no_duplicate_class_tests;

--- a/crates/vize_patina/src/markup/tests/no_boolean_attr_value_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_boolean_attr_value_tests.rs
@@ -1,0 +1,264 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::vue::NoBooleanAttrValue;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn no_boolean_attr_value_template_boundaries() {
+    let rule = NoBooleanAttrValue;
+    for (source, expected, label) in [
+        (
+            r#"<input disabled />"#,
+            0,
+            "valueless boolean attr is already shorthand",
+        ),
+        (
+            r#"<input checked />"#,
+            0,
+            "another valueless boolean attr is clean",
+        ),
+        (
+            r#"<input type="text" />"#,
+            0,
+            "non-boolean static attrs stay clean",
+        ),
+        (
+            r#"<input declare="declare" webkitdirectory="webkitdirectory" />"#,
+            0,
+            "attributes outside the Patina local boolean list stay clean",
+        ),
+        (
+            r#"<td nowrap="nowrap"></td>"#,
+            0,
+            "legacy boolean attrs omitted from this rule stay clean",
+        ),
+        (
+            r#"<input :disabled="isDisabled" />"#,
+            0,
+            "bound shorthand is dynamic and outside this rule",
+        ),
+        (
+            r#"<input v-bind:disabled="isDisabled" />"#,
+            0,
+            "long-form dynamic binding stays clean",
+        ),
+        (
+            r#"<input v-bind="{ disabled: true }" />"#,
+            0,
+            "object v-bind has no static attr argument",
+        ),
+        (
+            r#"<my-button disabled="disabled" />"#,
+            0,
+            "unknown lowercase custom tag is not native",
+        ),
+        (
+            r#"<MyButton hidden="hidden" />"#,
+            0,
+            "components stay skipped",
+        ),
+        (
+            r#"<input DISABLED="disabled" />"#,
+            0,
+            "attribute names remain exact",
+        ),
+        (
+            r#"<INPUT disabled="disabled" />"#,
+            0,
+            "native tag names remain exact for legacy HTML lookup",
+        ),
+        (
+            r#"<input disabled="disabled" />"#,
+            1,
+            "explicit boolean attr value warns",
+        ),
+        (
+            r#"<input disabled="" />"#,
+            1,
+            "empty explicit value still warns",
+        ),
+        (
+            r#"<button disabled="true">Click</button>"#,
+            1,
+            "arbitrary explicit value warns",
+        ),
+        (
+            r#"<input disabled="disabled" required="required" />"#,
+            2,
+            "each explicit boolean attr reports",
+        ),
+        (
+            r#"<div hidden="hidden">text</div>"#,
+            1,
+            "global boolean attrs on native tags report",
+        ),
+        (
+            r#"<svg hidden="hidden"></svg>"#,
+            1,
+            "global boolean attrs on native SVG tags report",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn no_boolean_attr_value_jsx_top_level_direct_matches_lowered() {
+    let rule = NoBooleanAttrValue;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <input disabled />;"#,
+            0,
+            "valueless boolean attr is clean",
+        ),
+        (
+            r#"const A = () => <input disabled="disabled" />;"#,
+            1,
+            "static explicit boolean attr value warns",
+        ),
+        (
+            r#"const A = () => <input disabled="" />;"#,
+            1,
+            "empty static explicit value warns",
+        ),
+        (
+            r#"const A = () => <button disabled="true">Click</button>;"#,
+            1,
+            "arbitrary string value warns",
+        ),
+        (
+            r#"const A = () => <input disabled="disabled" required="required" />;"#,
+            2,
+            "multiple boolean attrs report independently",
+        ),
+        (
+            r#"const A = () => <input type="text" />;"#,
+            0,
+            "non-boolean static attrs stay clean",
+        ),
+        (
+            r#"const A = () => <input declare="declare" webkitdirectory="webkitdirectory" />;"#,
+            0,
+            "attributes outside the Patina local boolean list stay clean",
+        ),
+        (
+            r#"const A = () => <td nowrap="nowrap" />;"#,
+            0,
+            "legacy boolean attrs omitted from this rule stay clean",
+        ),
+        (
+            r#"const A = () => <input disabled={isDisabled} />;"#,
+            0,
+            "dynamic expression-valued JSX attr is outside this rule",
+        ),
+        (
+            r#"const A = () => <input {...props} />;"#,
+            0,
+            "spread attributes do not expose a static boolean value",
+        ),
+        (
+            r#"const A = () => <my-button disabled="disabled" />;"#,
+            0,
+            "unknown lowercase custom tag is not native",
+        ),
+        (
+            r#"const A = () => <MyButton disabled="disabled" />;"#,
+            0,
+            "capitalized components stay skipped",
+        ),
+        (
+            r#"const A = () => <INPUT disabled="disabled" />;"#,
+            0,
+            "uppercase intrinsic spelling is a component in JSX",
+        ),
+        (
+            r#"const A = () => <Forms.input disabled="disabled" />;"#,
+            0,
+            "member components stay skipped even with native local name",
+        ),
+        (
+            r#"const A = () => <input DISABLED="disabled" />;"#,
+            0,
+            "attribute names remain exact",
+        ),
+        (
+            r#"const A = () => <input autoFocus="autoFocus" />;"#,
+            0,
+            "camelCase JSX attr names stay outside the lowercase legacy list",
+        ),
+        (
+            r#"const A = () => <svg hidden="hidden" />;"#,
+            1,
+            "global boolean attrs on native SVG tags report",
+        ),
+        (
+            r#"const A = () => <svg:input disabled="disabled" />;"#,
+            0,
+            "namespaced intrinsic local tag keeps the lowered fallback boundary",
+        ),
+        (
+            r#"const A = () => <svg:circle hidden="hidden" />;"#,
+            0,
+            "namespaced SVG tags stay outside the lowered fallback boundary",
+        ),
+        (
+            r#"const A = () => <input html:disabled="disabled" />;"#,
+            0,
+            "namespaced JSX attributes stay ignored",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(direct, expected, "JSX direct case failed: {label}");
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "JSX direct and lowered fallback diverged for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs
@@ -26,9 +26,10 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBinding, MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use crate::rules::html::helpers::BOOLEAN_ATTRIBUTES;
-use vize_relief::{ElementNode, PropNode};
+use vize_relief::ElementNode;
 use vize_s0::is_native_tag;
 
 static META: RuleMeta = RuleMeta {
@@ -42,34 +43,69 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct NoBooleanAttrValue;
 
+impl NoBooleanAttrValue {
+    fn check_binding(ctx: &mut LintContext<'_>, binding: &MarkupBinding<'_>) {
+        if binding.kind() != MarkupBindingKind::Attribute {
+            return;
+        }
+        let Some(value) = binding.static_value() else {
+            return;
+        };
+
+        let Some(name) = BOOLEAN_ATTRIBUTES
+            .iter()
+            .copied()
+            .find(|name| binding.is_static_unqualified_arg_exact(name))
+        else {
+            return;
+        };
+
+        let message = ctx.t_fmt(
+            "vue/no-boolean-attr-value.message",
+            &[("attr", name), ("value", value)],
+        );
+        let help = ctx.t_fmt("vue/no-boolean-attr-value.help", &[("attr", name)]);
+        ctx.warn_at_with_help(message, binding.range(), help);
+    }
+
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        let tag = element.tag();
+        if element.is_component() || !element.is_unqualified_tag_exact(tag) || !is_native_tag(tag) {
+            return;
+        }
+
+        element.walk_bindings(&mut |binding| Self::check_binding(ctx, &binding));
+    }
+}
+
+impl MarkupRule for NoBooleanAttrValue {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        Self::check_element(ctx.lint(), element);
+    }
+}
+
 impl Rule for NoBooleanAttrValue {
     fn meta(&self) -> &'static RuleMeta {
         &META
     }
 
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn jsx_needs_lowering(&self) -> bool {
+        // The legacy JSX fallback descends into expression containers before
+        // projecting nested elements. Keep this rule on the lowered markup path
+        // until the direct JSX document visitor has equivalent coverage.
+        true
+    }
+
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if !is_native_tag(element.tag) {
-            return;
-        }
-
-        for prop in &element.props {
-            if let PropNode::Attribute(attr) = prop {
-                let name = attr.name;
-                if !BOOLEAN_ATTRIBUTES.contains(&name) {
-                    continue;
-                }
-
-                if let Some(value) = &attr.value {
-                    // Has an explicit value — warn
-                    let message = ctx.t_fmt(
-                        "vue/no-boolean-attr-value.message",
-                        &[("attr", name), ("value", value.content)],
-                    );
-                    let help = ctx.t_fmt("vue/no-boolean-attr-value.help", &[("attr", name)]);
-                    ctx.warn_with_help(message, &attr.loc, help);
-                }
-            }
-        }
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           321 |                   321 |                 0 |             282 |     262 |             671 |      194 |           361 |           518 |
+| Linter                     |           322 |                   322 |                 0 |             283 |     265 |             671 |      199 |           362 |           520 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         321 |             224 |       97 |
-| old AST/parser   |         240 |             209 |       31 |
+| S0               |         322 |             224 |       98 |
+| old AST/parser   |         241 |             209 |       32 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         262 |             200 |       62 |
+| raw OXC          |         265 |             200 |       65 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:39`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:40`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 57 omitted.
+Additional test/dev rows are in the TSV: 58 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,9 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	39	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	39	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	39	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	40	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	40	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	40	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1017,6 +1017,9 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_foc
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_jsx_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_boolean_attr_value_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_boolean_attr_value_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_boolean_attr_value_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_consecutive_br_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_consecutive_br_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_dupe_style_properties_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
@@ -1128,8 +1131,8 @@ linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/html_button_ha
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/html_self_closing.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/multi_word_component_names.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_array_index_key.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	2
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	31	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	32	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_empty_component_block.rs	40	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_inline_style.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 29, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 30, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 118, `ir` 23, `ir-lowered` 6, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (29 = 29 `markup-facade` rules)
+- JSX lanes: `fallback` 117, `ir` 23, `ir-lowered` 7, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (30 = 30 `markup-facade` rules)
 - classification: neutral-core-candidate **87** · vue-dialect-bound **136** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -204,7 +204,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `vue/mustache-interpolation-spacing`            | template-family | `vue/mustache_interpolation_spacing.rs`                | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-array-index-key`                        | template-family | `opinionated/vue/no_array_index_key.rs`                | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-bare-strings-in-template`               | template-family | `vue/no_bare_strings_in_template.rs`                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
-| `vue/no-boolean-attr-value`                     | template-family | `opinionated/vue/no_boolean_attr_value.rs`             | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `vue/no-boolean-attr-value`                     | template-family | `opinionated/vue/no_boolean_attr_value.rs`             | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `vue/no-child-content`                          | template-family | `vue/no_child_content.rs`                              | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-deprecated-filter`                      | template-family | `vue/no_deprecated_filter.rs`                          | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-deprecated-functional-template`         | template-family | `vue/no_deprecated_functional_template.rs`             | sfc-source                     | yes (sfc-hooks)                  | no (no JSX-reachable hooks) | —                                                                                                   | container-bound        |


### PR DESCRIPTION
## Summary
- port `vue/no-boolean-attr-value` to the Patina markup facade
- preserve legacy-compatible template, JSX, TSX, and SFC behavior
- keep JSX/TSX on the lowered markup lane to preserve nested expression-container coverage
- add focused regression coverage for boolean-attribute boundaries and diagnostic stability
- update Davinci rule parity and consumer migration inventories

## Rollout
This PR does not roll out migrated implementations by default. Any rollout of existing behavior remains gated on maintainer decision.

Closes #5307

## Validation
- [x] `git diff --check`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p vize_patina --lib no_boolean_attr_value --locked`
- [x] `cargo test -p vize_patina --lib jsx_no_boolean_attr_value --locked`
- [x] `cargo test -q -p vize_patina --locked`
- [x] `cargo check -q -p vize_patina --all-targets --locked`
- [x] `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- [x] `node tools/davinci/rule-parity.mjs --check`
- [x] `node tools/davinci/consumer-migration-surfaces.mjs --check`
- [x] `node tools/davinci/sourcelocation-inventory.mjs --check`
- [x] `node tools/davinci/croquis-consumers.mjs --check`
- [x] `node tools/davinci/matrix-gen.mjs --check`
- [x] `node tools/davinci/assertion-lint.mjs`
- [x] `node --test tests/tooling/davinci-assertion-lint.test.ts`
- [x] `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- [x] `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- [x] `VIZE_TEST_REQUIRE_TSGO=1 cargo test -q --workspace --locked`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5308"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790639686&installation_model_id=422833&pr_number=5308&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5308&signature=a8e4c8748033106c763d68c17e164a35df17c3b13a558faae1bccf1c6a645710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->