### PR TITLE
refactor(patina): port use-list to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -25,6 +25,7 @@ mod jsx_no_role_presentation_on_focusable;
 mod jsx_placeholder_label_option;
 mod jsx_require_datetime;
 mod jsx_streaming;
+mod jsx_use_list;
 mod no_mutating_props;
 mod no_top_level_ref;
 mod no_unused_components;

--- a/crates/vize_patina/src/linter/tests/jsx_use_list.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_use_list.rs
@@ -1,0 +1,211 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::UseList;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+fn diagnostic_slices<'a>(source: &'a str, result: &LintResult) -> Vec<&'a str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| &source[diagnostic.start as usize..diagnostic.end as usize])
+        .collect()
+}
+
+#[test]
+fn use_list_fires_on_jsx_and_tsx_lowered_markup() {
+    let linter = linter_with(Box::new(UseList));
+    let source = r#"const A = () => <p>- Item one</p>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/use-list"],
+        "JSX bullet text must flag through the lowered markup pass: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+
+    let diag = &result.diagnostics[0];
+    let text_start = source.find("- Item one").unwrap() as u32;
+    assert_eq!(diag.start, text_start);
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        "- Item one",
+        "range must cover the authored JSX text node"
+    );
+    assert_eq!(diag.severity, Severity::Warning);
+    assert_eq!(
+        diag.help.as_deref(),
+        Some(
+            "Screen readers cannot identify bullet characters as list items. Use semantic <ul>/<ol> with <li> elements instead."
+        )
+    );
+    assert_eq!(diag.fix.as_ref().map(|_| "some"), None);
+
+    let tsx = linter.lint_jsx(
+        r#"const A = <T,>(props: { x: T }) => <section><p>• Item</p></section>;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["a11y/use-list"],
+        "TSX bullet text must also flag through the lowered markup pass"
+    );
+}
+
+#[test]
+fn use_list_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(UseList));
+    for source in [
+        r#"const A = () => <p>Normal text</p>;"#,
+        r#"const A = () => <p>-word</p>;"#,
+        r#"const A = () => <ul><li>- Item</li></ul>;"#,
+        r#"const A = () => <ol><li>* Item</li></ol>;"#,
+        r#"const A = () => <li>+ Item</li>;"#,
+        r#"const A = () => <pre>- markdown content</pre>;"#,
+        r#"const A = () => <code>- flag</code>;"#,
+        r#"const A = () => <p>{lead} - Item</p>;"#,
+        r#"const A = () => <p><span />- Item</p>;"#,
+        r#"const A = () => <Panel>- Item</Panel>;"#,
+        r#"const A = () => <Icons.Panel>- Item</Icons.Panel>;"#,
+        r#"const A = () => <ul><li><span>- Item</span></li></ul>;"#,
+        r#"const A = () => <ul>{items.map((item) => <span>- Item</span>)}</ul>;"#,
+        r#"const A = () => <pre><span>- literal</span></pre>;"#,
+        r#"const A = () => <code><span>- flag</span></code>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+
+    for source in [
+        r#"const A = () => <p>- Item</p>;"#,
+        r#"const A = () => <span>* Item</span>;"#,
+        r#"const A = () => <div>+ Item</div>;"#,
+        r#"const A = () => <p>   - Item</p>;"#,
+        r#"const A = () => <section>- Item</section>;"#,
+        r#"const A = () => <panel>- Item</panel>;"#,
+        r#"const A = () => <my-panel>- Item</my-panel>;"#,
+        r#"const A = () => <List.ul><p>- Item</p></List.ul>;"#,
+        r#"const A = () => <p>{'- Item'}</p>;"#,
+        r#"const A = () => <p>{/* comment */}- Item</p>;"#,
+        r#"const A = () => <p><>- Item</></p>;"#,
+        r#"const A = () => <p>{cond && <span>- Item</span>}</p>;"#,
+        r#"const A = () => <p>{items.map((item) => <span>* Item</span>)}</p>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 1,
+            "must keep warning for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+}
+
+#[test]
+fn use_list_reports_multiple_text_nodes_in_source_order() {
+    let linter = linter_with(Box::new(UseList));
+    let source = r#"const A = () => <div><p>- First</p><span>* Second</span></div>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/use-list", "a11y/use-list"]
+    );
+    assert_eq!(result.warning_count, 2);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        diagnostic_slices(source, &result),
+        vec!["- First", "* Second"]
+    );
+}
+
+#[test]
+fn migrated_use_list_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(UseList));
+    let result = linter.lint_jsx(
+        r#"const A = () => <p>- Item one</p>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated use-list rule must report once: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn use_list_sfc_offsets_template_diagnostics() {
+    let source = r#"<script setup lang="ts">
+const bullet = "- Item";
+</script>
+
+<template>
+  <p>- Item one</p>
+</template>
+"#;
+    let linter = linter_with(Box::new(UseList));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/use-list"],
+        "SFC template bullet text must report once: {:?}",
+        result.diagnostics
+    );
+
+    let diag = &result.diagnostics[0];
+    let text_start = source.find("- Item one").unwrap() as u32;
+    assert_eq!(
+        diag.start, text_start,
+        "SFC diagnostic must be offset into file coordinates"
+    );
+    assert_eq!(
+        &source[diag.start as usize..diag.end as usize],
+        "- Item one",
+        "range must cover the bullet text in the full SFC"
+    );
+}
+
+#[test]
+fn use_list_sfc_does_not_lint_script_tsx() {
+    let source = r#"<script setup lang="tsx">
+const A = () => <p>- Item one</p>;
+</script>
+"#;
+    let linter = linter_with(Box::new(UseList));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        result.warning_count, 0,
+        "SFC use-list must not inspect JSX inside script blocks: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -28,6 +28,7 @@ mod no_role_presentation_on_focusable_jsx_tests;
 mod no_role_presentation_on_focusable_tests;
 mod placeholder_label_option_tests;
 mod require_datetime_tests;
+mod use_list_tests;
 
 #[cfg(test)]
 mod markup_ir_tests {

--- a/crates/vize_patina/src/markup/tests/use_list_tests.rs
+++ b/crates/vize_patina/src/markup/tests/use_list_tests.rs
@@ -1,0 +1,274 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::UseList;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn use_list_template_markup_boundaries() {
+    let rule = UseList;
+    for (source, expected, label) in [
+        (r#"<p>Normal text</p>"#, 0, "normal text is clean"),
+        (
+            r#"<p>-word</p>"#,
+            0,
+            "dash without following space is clean",
+        ),
+        (r#"<p>   </p>"#, 0, "whitespace-only text is clean"),
+        (
+            r#"<ul><li>- Item</li></ul>"#,
+            0,
+            "list item context is clean",
+        ),
+        (
+            r#"<ol><li>* Item</li></ol>"#,
+            0,
+            "ordered list context is clean",
+        ),
+        (r#"<li>+ Item</li>"#, 0, "direct li context is clean"),
+        (
+            r#"<pre>- markdown content</pre>"#,
+            0,
+            "pre context is clean",
+        ),
+        (r#"<code>- flag</code>"#, 0, "code context is clean"),
+        (r#"<script>- script</script>"#, 0, "script context is clean"),
+        (r#"<style>- css</style>"#, 0, "style context is clean"),
+        (
+            r#"<p><span></span>- Item</p>"#,
+            0,
+            "first non-text child stops scanning",
+        ),
+        (
+            r#"<p><!-- comment -->- Item</p>"#,
+            0,
+            "comment before text stops scanning",
+        ),
+        (
+            r#"<p>{{ lead }} - Item</p>"#,
+            0,
+            "interpolation before text stops scanning",
+        ),
+        (r#"<MyPanel>- Item</MyPanel>"#, 0, "components are clean"),
+        (r#"<p>- Item one</p>"#, 1, "dash bullet warns"),
+        (r#"<span>* Item one</span>"#, 1, "asterisk bullet warns"),
+        (r#"<div>+ Item one</div>"#, 1, "plus bullet warns"),
+        (
+            r#"<p>   - Item one</p>"#,
+            1,
+            "leading whitespace is ignored",
+        ),
+        (r#"<section>- Item</section>"#, 1, "native section warns"),
+        (
+            r#"<my-panel>- Item</my-panel>"#,
+            1,
+            "lowercase custom element warns",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn use_list_list_context_ancestors_suppress_nested_bullets() {
+    let rule = UseList;
+    for (source, expected, label) in [
+        (
+            r#"<ul><li><span>- Item</span></li></ul>"#,
+            0,
+            "ul/li ancestor suppresses nested span",
+        ),
+        (
+            r#"<ol><li><p>* Item</p></li></ol>"#,
+            0,
+            "ol/li ancestor suppresses nested paragraph",
+        ),
+        (
+            r#"<pre><span>- literal</span></pre>"#,
+            0,
+            "pre ancestor suppresses nested literal text",
+        ),
+        (
+            r#"<code><span>- flag</span></code>"#,
+            0,
+            "code ancestor suppresses nested literal text",
+        ),
+        (
+            r#"<script><span>- text</span></script>"#,
+            0,
+            "script ancestor suppresses nested text",
+        ),
+        (
+            r#"<style><span>- text</span></style>"#,
+            0,
+            "style ancestor suppresses nested text",
+        ),
+        (
+            r#"<div><p>- Item</p></div>"#,
+            1,
+            "ordinary ancestor does not suppress bullet text",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template ancestor boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn use_list_jsx_direct_matches_lowered_for_element_boundaries() {
+    let rule = UseList;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <p>Normal text</p>;"#,
+            0,
+            "normal text is clean",
+        ),
+        (
+            r#"const A = () => <p>-word</p>;"#,
+            0,
+            "dash without following space is clean",
+        ),
+        (
+            r#"const A = () => <ul><li>- Item</li></ul>;"#,
+            0,
+            "list context is clean",
+        ),
+        (
+            r#"const A = () => <pre>- markdown content</pre>;"#,
+            0,
+            "pre context is clean",
+        ),
+        (
+            r#"const A = () => <p>{lead} - Item</p>;"#,
+            0,
+            "expression before text stops scanning",
+        ),
+        (
+            r#"const A = () => <p><span />- Item</p>;"#,
+            0,
+            "element before text stops scanning",
+        ),
+        (
+            r#"const A = () => <Panel>- Item</Panel>;"#,
+            0,
+            "capitalized component is clean",
+        ),
+        (
+            r#"const A = () => <Icons.Panel>- Item</Icons.Panel>;"#,
+            0,
+            "member component is clean",
+        ),
+        (r#"const A = () => <p>- Item</p>;"#, 1, "dash bullet warns"),
+        (
+            r#"const A = () => <span>* Item</span>;"#,
+            1,
+            "asterisk bullet warns",
+        ),
+        (
+            r#"const A = () => <div>+ Item</div>;"#,
+            1,
+            "plus bullet warns",
+        ),
+        (
+            r#"const A = () => <p><span>- Item</span></p>;"#,
+            1,
+            "nested child element text still warns",
+        ),
+        (
+            r#"const A = () => <panel>- Item</panel>;"#,
+            1,
+            "lowercase JSX intrinsic-style custom element warns",
+        ),
+        (
+            r#"const A = () => <my-panel>- Item</my-panel>;"#,
+            1,
+            "hyphenated lowercase JSX custom element warns",
+        ),
+        (
+            r#"const A = () => <List.ul><p>- Item</p></List.ul>;"#,
+            1,
+            "member property named ul is not list context",
+        ),
+    ] {
+        assert_eq!(
+            run_over_jsx_oxc(&rule, source),
+            expected,
+            "direct JSX markup boundary changed for {label}"
+        );
+        assert_eq!(
+            run_over_jsx_lowered(&rule, source),
+            expected,
+            "lowered JSX markup boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn use_list_unicode_bullet_prefixes_require_space() {
+    let rule = UseList;
+    for bullet in [
+        "\u{2022}", "\u{2023}", "\u{25E6}", "\u{2043}", "\u{2219}", "\u{25AA}", "\u{25CF}",
+    ] {
+        let invalid = format!("<p>{bullet} Item</p>");
+        assert_eq!(
+            run_over_template(&rule, &invalid),
+            1,
+            "unicode bullet with a following space must warn for {bullet:?}"
+        );
+
+        let valid = format!("<p>{bullet}Item</p>");
+        assert_eq!(
+            run_over_template(&rule, &valid),
+            0,
+            "unicode bullet without a following space must stay clean for {bullet:?}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/opinionated/a11y/use_list.rs
+++ b/crates/vize_patina/src/rules/opinionated/a11y/use_list.rs
@@ -25,8 +25,11 @@
 //! </template>
 //! ```
 
+use std::cell::Cell;
+
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupElement, MarkupNode, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::{ElementNode, ElementType, TemplateChildNode};
 
@@ -58,9 +61,108 @@ const LIST_CONTEXT_TAGS: &[&str] = &["ul", "ol", "li", "pre", "code", "script", 
 #[derive(Default)]
 pub struct UseList;
 
+impl UseList {
+    fn is_list_context_tag(tag: &str) -> bool {
+        LIST_CONTEXT_TAGS.contains(&tag)
+    }
+
+    fn is_list_context_element(element: &MarkupElement<'_>) -> bool {
+        !element.is_component()
+            && LIST_CONTEXT_TAGS
+                .iter()
+                .any(|tag| element.is_unqualified_tag_exact(tag))
+    }
+
+    fn check_markup_element(
+        ctx: &mut LintContext<'_>,
+        element: &MarkupElement<'_>,
+        has_list_context_ancestor: bool,
+    ) {
+        if element.is_component() {
+            return;
+        }
+
+        // Skip if already in list context
+        if Self::is_list_context_element(element) {
+            return;
+        }
+
+        // Skip if ancestor is list context
+        if has_list_context_ancestor {
+            return;
+        }
+
+        // Check first text child for bullet prefix
+        let mut checking_first_meaningful_child = true;
+        element.walk_children(&mut |child| {
+            if !checking_first_meaningful_child {
+                return;
+            }
+
+            match child {
+                MarkupNode::Text(text) => {
+                    let trimmed = text.content().trim_start();
+                    if BULLET_CHARS
+                        .iter()
+                        .any(|prefix| trimmed.starts_with(prefix))
+                    {
+                        let message = ctx.t("a11y/use-list.message");
+                        let help = ctx.t("a11y/use-list.help");
+                        ctx.warn_at_with_help(message, text.range(), help);
+                    }
+                    // Only check the first meaningful text node
+                    if text.is_significant() {
+                        checking_first_meaningful_child = false;
+                    }
+                }
+                _ => {
+                    checking_first_meaningful_child = false;
+                }
+            }
+        });
+    }
+
+    fn check_markup_document(ctx: &mut LintContext<'_>, document: &MarkupDocument<'_>) {
+        let list_context_depth = Cell::new(0usize);
+        document.walk_tree(
+            &mut |element| {
+                let has_list_context_ancestor = list_context_depth.get() > 0;
+                Self::check_markup_element(ctx, &element, has_list_context_ancestor);
+
+                if Self::is_list_context_element(&element) {
+                    list_context_depth.set(list_context_depth.get() + 1);
+                }
+            },
+            &mut |element| {
+                if Self::is_list_context_element(&element) {
+                    list_context_depth.set(list_context_depth.get().saturating_sub(1));
+                }
+            },
+        );
+    }
+}
+
+impl MarkupRule for UseList {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_document(&self, ctx: &mut MarkupContext<'_, '_>, document: &MarkupDocument) {
+        Self::check_markup_document(ctx.lint(), document);
+    }
+}
+
 impl Rule for UseList {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn jsx_needs_lowering(&self) -> bool {
+        true
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
@@ -71,12 +173,12 @@ impl Rule for UseList {
         let tag = element.tag;
 
         // Skip if already in list context
-        if LIST_CONTEXT_TAGS.contains(&tag) {
+        if Self::is_list_context_tag(tag) {
             return;
         }
 
         // Skip if ancestor is list context
-        if ctx.has_ancestor(|a| LIST_CONTEXT_TAGS.contains(&a.tag.as_str())) {
+        if ctx.has_ancestor(|a| Self::is_list_context_tag(a.tag.as_str())) {
             return;
         }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           322 |                   322 |                 0 |             283 |     265 |             671 |      199 |           362 |           520 |
+| Linter                     |           323 |                   323 |                 0 |             284 |     268 |             671 |      204 |           363 |           522 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         322 |             224 |       98 |
-| old AST/parser   |         241 |             209 |       32 |
+| S0               |         323 |             224 |       99 |
+| old AST/parser   |         242 |             209 |       33 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         265 |             200 |       65 |
+| raw OXC          |         268 |             200 |       68 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:40`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:41`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 58 omitted.
+Additional test/dev rows are in the TSV: 59 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,9 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	40	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	40	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	40	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	41	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	41	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	41	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1045,6 +1045,9 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/placeholder_label_opt
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/placeholder_label_option_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/require_datetime_tests.rs	7	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/require_datetime_tests.rs	7	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/use_list_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/use_list_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/use_list_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/output.rs	20	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/output/agent.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/output/html.rs	6	s0	S0	stage	vize_s0	preferred	1
@@ -1115,7 +1118,7 @@ linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/heading_level
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/landmark_roles.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/placeholder_label_option.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/use_list.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/a11y/use_list.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	32	s0	S0	stage	vize_s0	preferred	3
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_dupe_style_properties.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/html/no_duplicate_class.rs	29	s0	S0	stage	vize_s0	preferred	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 30, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 31, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 117, `ir` 23, `ir-lowered` 7, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (30 = 30 `markup-facade` rules)
+- JSX lanes: `fallback` 116, `ir` 23, `ir-lowered` 8, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (31 = 31 `markup-facade` rules)
 - classification: neutral-core-candidate **87** · vue-dialect-bound **136** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -75,7 +75,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/placeholder-label-option`                 | template-family | `opinionated/a11y/placeholder_label_option.rs`         | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/role-has-required-aria-props`             | template-family | `a11y/role_has_required_aria_props.rs`                 | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/tabindex-no-positive`                     | template-family | `a11y/tabindex_no_positive.rs`                         | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
-| `a11y/use-list`                                 | template-family | `opinionated/a11y/use_list.rs`                         | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `a11y/use-list`                                 | template-family | `opinionated/a11y/use_list.rs`                         | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `css/no-display-none`                           | css             | `css/no_display_none.rs`                               | css-text                       | yes (style-blocks)               | no                          | —                                                                                                   | vue-dialect-bound      |
 | `css/no-hardcoded-values`                       | css             | `css/no_hardcoded_values.rs`                           | css-text                       | yes (style-blocks)               | no                          | —                                                                                                   | neutral-core-candidate |
 | `css/no-id-selectors`                           | css             | `css/no_id_selectors.rs`                               | css-text                       | yes (style-blocks)               | no                          | —                                                                                                   | neutral-core-candidate |


### PR DESCRIPTION
## Summary
- port `a11y/use-list` to the Patina markup facade via `MarkupRule`/`as_markup_rule()`
- keep JSX/TSX on the lowered markup lane to preserve legacy fallback behavior for string-literal children, comments, and fragment-spliced children
- add focused markup and linter routing regressions for ancestor list contexts, components, unicode bullets, first-child boundaries, source ranges, and single-report partitioning
- refresh Davinci rule parity and consumer migration surface inventories

Closes #5314.

## Validation
- `git diff --check`
- `cargo fmt --all -- --check`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `node tools/davinci/croquis-consumers.mjs --check`
- `node tools/davinci/matrix-gen.mjs --check`
- `node tools/davinci/assertion-lint.mjs`
- `node --test tests/tooling/davinci-assertion-lint.test.ts`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo test -p vize_patina --lib use_list --locked`
- `cargo test -p vize_patina --lib markup::tests::use_list_tests --locked`
- `cargo test -p vize_patina --lib linter::tests::jsx_use_list --locked`
- `cargo test -p vize_patina --lib linter::tests::jsx_streaming --locked`
- `cargo check -q -p vize_patina --all-targets --locked`
- `cargo test -q -p vize_patina --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `pnpm install --frozen-lockfile --prefer-offline`
- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -q --workspace --locked`
- `cargo clippy -q --workspace --locked -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -q -p vize_maestro --tests --locked -- -D warnings`
- `bash tools/github/check-maestro-feature-contract.sh`
- `cargo build -q -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 --locked`
- `cargo build -q -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 --no-default-features --locked`
- `cargo test -q -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus --locked -- --nocapture`
- `cargo test -q -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli --locked`
- `cargo test -q -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 --locked`
- `cargo test -q -p vize_vitrine --no-default-features --features wasm --locked`
- `cargo bench -q -p vize_s1_to_s2 --bench davinci_storage -- --quick`
- `cargo bench -q -p vize_patina --bench davinci_markup -- --quick`
- `node tools/davinci/bench-compare.mjs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root`

Note: `cargo clippy --workspace --all-targets --locked -- -D warnings -D clippy::wildcard_imports` is stricter than CI and still reports pre-existing `vize_carton` test-only lint errors on `origin/main`; the workflow-equivalent clippy commands above pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5315"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790642842&installation_model_id=422833&pr_number=5315&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5315&signature=e863198d53040d35088413b699d215d6b9db079cbbe2203780ac8ca590c23ecd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved the `a11y/use-list` rule across Vue templates and JSX/TSX.
  * Added more accurate detection of bullet-prefixed text, including Unicode bullets and spacing variations.
  * Reduced false positives within lists, preformatted content, scripts, styles, components, and other markup boundaries.
  * Improved diagnostic locations and reporting order across supported file types.

* **Tests**
  * Added comprehensive coverage for template, lowered JSX, and direct JSX scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->