### PR TITLE
refactor(patina): port no-bare-strings to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -14,6 +14,7 @@ mod jsx_interactive_supports_focus;
 mod jsx_media_has_caption;
 mod jsx_mouse_events_have_key_events;
 mod jsx_no_aria_hidden_on_focusable;
+mod jsx_no_bare_strings_in_template;
 mod jsx_no_boolean_attr_value;
 mod jsx_no_consecutive_br;
 mod jsx_no_dupe_style_properties;

--- a/crates/vize_patina/src/linter/tests/jsx_no_bare_strings_in_template.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_bare_strings_in_template.rs
@@ -1,0 +1,200 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::vue::NoBareStringsInTemplate;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+fn diagnostic_slices<'a>(source: &'a str, result: &LintResult) -> Vec<&'a str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| &source[diagnostic.start as usize..diagnostic.end as usize])
+        .collect()
+}
+
+#[test]
+fn no_bare_strings_fires_on_jsx_and_tsx_lowered_markup() {
+    let linter = linter_with(Box::new(NoBareStringsInTemplate));
+    let source = r#"const A = () => <div>Hello</div>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["vue/no-bare-strings-in-template"],
+        "JSX bare text must flag through the lowered markup pass: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+
+    let diag = &result.diagnostics[0];
+    let text_start = source.find("Hello").unwrap() as u32;
+    assert_eq!(diag.start, text_start);
+    assert_eq!(&source[diag.start as usize..diag.end as usize], "Hello");
+    assert_eq!(diag.severity, Severity::Warning);
+    assert_eq!(
+        diag.help.as_deref(),
+        Some(
+            "Move the text into a translation function, e.g. {{ $t('key') }} for content or :title=\"$t('key')\" for an attribute."
+        )
+    );
+    assert_eq!(diag.fix.as_ref().map(|_| "some"), None);
+
+    let tsx = linter.lint_jsx(
+        r#"const A = (): JSX.Element => <div>こんにちは</div>;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["vue/no-bare-strings-in-template"],
+        "TSX bare text must also flag through the lowered markup pass"
+    );
+}
+
+#[test]
+fn no_bare_strings_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(NoBareStringsInTemplate));
+    for source in [
+        r#"const A = () => <div>{label}</div>;"#,
+        r#"const A = () => <div>{t('hello')}</div>;"#,
+        r#"const A = () => <div>123</div>;"#,
+        r#"const A = () => <div>-</div>;"#,
+        r#"const A = () => <div>{'-'}</div>;"#,
+        r#"const A = () => <img alt={caption} />;"#,
+        r#"const A = () => <img title={title} />;"#,
+        r#"const A = () => <img html:alt="a cat" />;"#,
+        r#"const A = () => <div class="container"></div>;"#,
+        r#"const A = () => <script>const label = "Hello";</script>;"#,
+        r#"const A = () => <style>{`.x::before { content: "Hello"; }`}</style>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+
+    for source in [
+        r#"const A = () => <div>Hello</div>;"#,
+        r#"const A = () => <div>こんにちは</div>;"#,
+        r#"const A = () => <img alt="a cat" />;"#,
+        r#"const A = () => <input placeholder="Search" />;"#,
+        r#"const A = () => <div aria-label="Menu" />;"#,
+        r#"const A = () => <button TITLE="Close" />;"#,
+        r#"const A = () => <div>{'Hello'}</div>;"#,
+        r#"const A = () => <div>{/* comment */}Hello</div>;"#,
+        r#"const A = () => <MyPanel>Hello</MyPanel>;"#,
+        r#"const A = () => <div>{cond && <span>Hello</span>}</div>;"#,
+        r#"const A = () => <ul>{items.map((item) => <li>{'Hello'}</li>)}</ul>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 1,
+            "must keep warning for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+}
+
+#[test]
+fn no_bare_strings_reports_multiple_jsx_targets_in_source_order() {
+    let linter = linter_with(Box::new(NoBareStringsInTemplate));
+    let source = r#"const A = () => <button title="Close"><span>Save</span></button>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec![
+            "vue/no-bare-strings-in-template",
+            "vue/no-bare-strings-in-template"
+        ]
+    );
+    assert_eq!(result.warning_count, 2);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        diagnostic_slices(source, &result),
+        vec![r#"title="Close""#, "Save"]
+    );
+}
+
+#[test]
+fn migrated_no_bare_strings_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(NoBareStringsInTemplate));
+    let result = linter.lint_jsx(
+        r#"const A = () => <div>Hello</div>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated no-bare-strings rule must report once: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn no_bare_strings_sfc_offsets_template_diagnostics() {
+    let source = r#"<script setup lang="ts">
+const label = "Hello";
+</script>
+
+<template>
+  <div>Hello</div>
+</template>
+"#;
+    let linter = linter_with(Box::new(NoBareStringsInTemplate));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["vue/no-bare-strings-in-template"],
+        "SFC template bare text must report once: {:?}",
+        result.diagnostics
+    );
+
+    let diag = &result.diagnostics[0];
+    let text_start = source.rfind("Hello").unwrap() as u32;
+    assert_eq!(
+        diag.start, text_start,
+        "SFC diagnostic must be offset into file coordinates"
+    );
+    assert_eq!(&source[diag.start as usize..diag.end as usize], "Hello");
+}
+
+#[test]
+fn no_bare_strings_sfc_does_not_lint_script_tsx() {
+    let source = r#"<script setup lang="tsx">
+const A = () => <div>Hello</div>;
+</script>
+"#;
+    let linter = linter_with(Box::new(NoBareStringsInTemplate));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        result.warning_count, 0,
+        "SFC no-bare-strings must not inspect JSX inside script blocks: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+}

--- a/crates/vize_patina/src/markup/exact.rs
+++ b/crates/vize_patina/src/markup/exact.rs
@@ -60,6 +60,40 @@ impl<'a> MarkupBinding<'a> {
         }
     }
 
+    /// Whether this binding is an unqualified prop/attribute matching
+    /// case-insensitively.
+    ///
+    /// Keeps namespaced JSX attributes such as `foo:alt` out of HTML-attribute
+    /// rules while preserving legacy template rules that compared written
+    /// attribute names with ASCII-insensitive semantics.
+    pub fn is_unqualified_arg_eq_ignore_ascii_case(&self, expected: &str) -> bool {
+        match self.inner {
+            MarkupBindingInner::ReliefAttribute(node) => node.name.eq_ignore_ascii_case(expected),
+            MarkupBindingInner::ReliefDirective(node) => match relief_directive_kind(node) {
+                MarkupBindingKind::Custom => node.name.eq_ignore_ascii_case(expected),
+                _ => match node.arg.as_ref() {
+                    Some(ExpressionNode::Simple(simple)) => {
+                        simple.content.eq_ignore_ascii_case(expected)
+                    }
+                    _ => false,
+                },
+            },
+            MarkupBindingInner::Jsx { node, .. } => {
+                let attr = jsx_attribute_ref(node);
+                match &attr.name {
+                    JSXAttributeName::Identifier(identifier) => {
+                        match jsx_attribute_binding_kind(attr) {
+                            MarkupBindingKind::On => jsx_attribute_arg_name(attr)
+                                .is_some_and(|arg| arg.eq_ignore_ascii_case(expected)),
+                            _ => identifier.name.as_str().eq_ignore_ascii_case(expected),
+                        }
+                    }
+                    JSXAttributeName::NamespacedName(_) => false,
+                }
+            }
+        }
+    }
+
     /// Whether this binding has a static, unqualified prop/directive argument
     /// with an exact name.
     ///

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -17,6 +17,7 @@ mod media_has_caption_tests;
 mod mouse_events_have_key_events_tests;
 mod no_aria_hidden_on_focusable_jsx_tests;
 mod no_aria_hidden_on_focusable_tests;
+mod no_bare_strings_in_template_tests;
 mod no_boolean_attr_value_tests;
 mod no_consecutive_br_tests;
 mod no_dupe_style_properties_tests;

--- a/crates/vize_patina/src/markup/tests/no_bare_strings_in_template_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_bare_strings_in_template_tests.rs
@@ -1,0 +1,222 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::vue::NoBareStringsInTemplate;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn no_bare_strings_template_markup_boundaries() {
+    let rule = NoBareStringsInTemplate;
+    for (source, expected, label) in [
+        (r#"<div>hello</div>"#, 1, "bare latin text warns"),
+        (r#"<div>こんにちは</div>"#, 1, "bare non-ascii text warns"),
+        (
+            r#"<div><span>Save</span></div>"#,
+            1,
+            "nested element owns text",
+        ),
+        (
+            r#"<button title="Close">x</button>"#,
+            2,
+            "target attr and direct text both warn",
+        ),
+        (r#"<img alt="a cat" />"#, 1, "target static attr warns"),
+        (
+            r#"<input placeholder="Search" />"#,
+            1,
+            "placeholder attr warns",
+        ),
+        (r#"<div aria-label="Menu"></div>"#, 1, "aria attr warns"),
+        (
+            r#"<button TITLE="Close"></button>"#,
+            1,
+            "target attrs keep case-insensitive matching",
+        ),
+        (
+            r#"<div>{{ $t('hello') }}</div>"#,
+            0,
+            "interpolation is dynamic",
+        ),
+        (
+            r#"<img :alt="$t('cat')" />"#,
+            0,
+            "bound target attr is dynamic",
+        ),
+        ("<div>   </div>", 0, "whitespace-only text is clean"),
+        (r#"<div>-</div>"#, 0, "punctuation-only text is clean"),
+        (r#"<div>123</div>"#, 0, "number-only text is clean"),
+        (
+            r#"<div class="container"></div>"#,
+            0,
+            "non-target attr is clean",
+        ),
+        (
+            r#"<script>const label = "Hello";</script>"#,
+            0,
+            "script text is clean",
+        ),
+        (
+            r#"<style>.button::before { content: "Hello"; }</style>"#,
+            0,
+            "style text is clean",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn no_bare_strings_jsx_direct_matches_lowered_for_static_boundaries() {
+    let rule = NoBareStringsInTemplate;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <div>hello</div>;"#,
+            1,
+            "bare latin text warns",
+        ),
+        (
+            r#"const A = () => <div>こんにちは</div>;"#,
+            1,
+            "bare non-ascii text warns",
+        ),
+        (
+            r#"const A = () => <button title="Close">x</button>;"#,
+            2,
+            "target attr and direct text both warn",
+        ),
+        (
+            r#"const A = () => <img alt="a cat" />;"#,
+            1,
+            "target static attr warns",
+        ),
+        (
+            r#"const A = () => <img alt={caption} />;"#,
+            0,
+            "dynamic target attr is clean",
+        ),
+        (
+            r#"const A = () => <img html:alt="a cat" />;"#,
+            0,
+            "namespaced target attr is not unqualified",
+        ),
+        (
+            r#"const A = () => <button TITLE="Close" />;"#,
+            1,
+            "case-insensitive target attr warns",
+        ),
+        (
+            r#"const A = () => <div>{label}</div>;"#,
+            0,
+            "expression-only child is clean",
+        ),
+        (
+            r#"const A = () => <script>const label = "Hello";</script>;"#,
+            0,
+            "script text is clean",
+        ),
+        (
+            r#"const A = () => <style>{`.x { color: red; }`}</style>;"#,
+            0,
+            "style expression is clean",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(
+            direct, expected,
+            "direct JSX markup boundary changed for {label}"
+        );
+        assert_eq!(
+            run_over_jsx_lowered(&rule, source),
+            expected,
+            "lowered JSX markup boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn no_bare_strings_jsx_lowered_preserves_string_expression_children() {
+    let rule = NoBareStringsInTemplate;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <div>{'Hello'}</div>;"#,
+            1,
+            "single-quoted string expression lowers to text",
+        ),
+        (
+            r#"const A = () => <div>{"Hello"}</div>;"#,
+            1,
+            "double-quoted string expression lowers to text",
+        ),
+        (
+            r#"const A = () => <div>{`Hello`}</div>;"#,
+            0,
+            "template string expression stays dynamic",
+        ),
+        (
+            r#"const A = () => <div>{/* comment */}Hello</div>;"#,
+            1,
+            "comments do not hide following text",
+        ),
+        (
+            r#"const A = () => <div><>{'Hello'}</></div>;"#,
+            1,
+            "fragment string expression still warns after lowering",
+        ),
+        (
+            r#"const A = () => <div>{cond && <span>Hello</span>}</div>;"#,
+            1,
+            "nested conditional element text still warns",
+        ),
+    ] {
+        assert_eq!(
+            run_over_jsx_lowered(&rule, source),
+            expected,
+            "lowered JSX string boundary changed for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/vue/no_bare_strings_in_template.rs
+++ b/crates/vize_patina/src/rules/vue/no_bare_strings_in_template.rs
@@ -40,8 +40,9 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBindingKind, MarkupContext, MarkupElement, MarkupNode, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, PropNode, TemplateChildNode};
+use vize_relief::ElementNode;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-bare-strings-in-template",
@@ -67,46 +68,75 @@ const TARGET_ATTRIBUTES: &[&str] = &[
 /// Disallow raw human-readable text directly in the template.
 pub struct NoBareStringsInTemplate;
 
-impl Rule for NoBareStringsInTemplate {
-    fn meta(&self) -> &'static RuleMeta {
-        &META
-    }
-
-    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+impl NoBareStringsInTemplate {
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
         // The content of <script>/<style> is code/CSS, never user-facing copy.
-        if is_raw_text_element(element.tag) {
+        if is_raw_text_element(element.tag()) {
             return;
         }
 
         // Bare text content of the element (direct text children only; nested
         // elements are visited on their own).
-        for child in element.children.iter() {
-            if let TemplateChildNode::Text(text) = child
-                && has_bare_string(text.content)
+        element.walk_children(&mut |child| {
+            if let MarkupNode::Text(text) = child
+                && has_bare_string(text.content())
             {
-                ctx.warn_with_help(
+                ctx.warn_at_with_help(
                     ctx.t("vue/no-bare-strings-in-template.message"),
-                    &text.loc,
+                    text.range(),
                     ctx.t("vue/no-bare-strings-in-template.help"),
                 );
             }
-        }
+        });
 
         // Bare string in a user-facing static attribute. Bound attributes
         // (`:title="..."`) are directives, so they are skipped here.
-        for prop in element.props.iter() {
-            if let PropNode::Attribute(attr) = prop
-                && is_target_attribute(attr.name)
-                && let Some(value) = &attr.value
-                && has_bare_string(value.content)
+        element.walk_bindings(&mut |binding| {
+            if binding.kind() == MarkupBindingKind::Attribute
+                && TARGET_ATTRIBUTES
+                    .iter()
+                    .any(|target| binding.is_unqualified_arg_eq_ignore_ascii_case(target))
+                && let Some(value) = binding.static_value()
+                && has_bare_string(value)
             {
-                ctx.warn_with_help(
+                ctx.warn_at_with_help(
                     ctx.t("vue/no-bare-strings-in-template.message"),
-                    &attr.loc,
+                    binding.range(),
                     ctx.t("vue/no-bare-strings-in-template.help"),
                 );
             }
-        }
+        });
+    }
+}
+
+impl MarkupRule for NoBareStringsInTemplate {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        Self::check_element(ctx.lint(), element);
+    }
+}
+
+impl Rule for NoBareStringsInTemplate {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn jsx_needs_lowering(&self) -> bool {
+        // The legacy JSX fallback turns string expression children such as
+        // `{'Hello'}` into text nodes. Keep JSX on the lowered markup lane so
+        // the i18n rule does not silently stop reporting those authored strings.
+        true
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
 
@@ -114,14 +144,6 @@ impl Rule for NoBareStringsInTemplate {
 /// therefore never user-facing copy.
 fn is_raw_text_element(tag: &str) -> bool {
     tag.eq_ignore_ascii_case("script") || tag.eq_ignore_ascii_case("style")
-}
-
-/// Whether `name` is one of the user-facing attributes whose literal value
-/// should be internationalized.
-fn is_target_attribute(name: &str) -> bool {
-    TARGET_ATTRIBUTES
-        .iter()
-        .any(|target| name.eq_ignore_ascii_case(target))
 }
 
 /// Whether `text` contains human-readable copy: at least one alphabetic

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           323 |                   323 |                 0 |             284 |     268 |             671 |      204 |           363 |           522 |
+| Linter                     |           324 |                   324 |                 0 |             285 |     271 |             671 |      209 |           364 |           524 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         323 |             224 |       99 |
-| old AST/parser   |         242 |             209 |       33 |
+| S0               |         324 |             224 |      100 |
+| old AST/parser   |         243 |             209 |       34 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         268 |             200 |       68 |
+| raw OXC          |         271 |             200 |       71 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:41`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:42`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 59 omitted.
+Additional test/dev rows are in the TSV: 60 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,9 +991,9 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	41	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	41	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	41	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	42	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	42	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	42	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1017,6 +1017,9 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_foc
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_jsx_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_aria_hidden_on_focusable_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_bare_strings_in_template_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_bare_strings_in_template_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_bare_strings_in_template_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_boolean_attr_value_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_boolean_attr_value_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_boolean_attr_value_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1405,7 +1408,7 @@ linter	Linter	source	crates/vize_patina/src/rules/vue/html_quotes.rs	46	old_ast	
 linter	Linter	source	crates/vize_patina/src/rules/vue/html_quotes/value_range.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/html_quotes/value_range.rs	86	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/mustache_interpolation_spacing.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_bare_strings_in_template.rs	44	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_bare_strings_in_template.rs	45	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_child_content.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_filter.rs	42	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_deprecated_filter.rs	42	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 31, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 32, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 116, `ir` 23, `ir-lowered` 8, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (31 = 31 `markup-facade` rules)
+- JSX lanes: `fallback` 115, `ir` 23, `ir-lowered` 9, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (32 = 32 `markup-facade` rules)
 - classification: neutral-core-candidate **87** · vue-dialect-bound **136** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -203,7 +203,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `vue/multi-word-component-names`                | template-family | `opinionated/vue/multi_word_component_names.rs`        | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `vue/mustache-interpolation-spacing`            | template-family | `vue/mustache_interpolation_spacing.rs`                | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-array-index-key`                        | template-family | `opinionated/vue/no_array_index_key.rs`                | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
-| `vue/no-bare-strings-in-template`               | template-family | `vue/no_bare_strings_in_template.rs`                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `vue/no-bare-strings-in-template`               | template-family | `vue/no_bare_strings_in_template.rs`                   | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `vue/no-boolean-attr-value`                     | template-family | `opinionated/vue/no_boolean_attr_value.rs`             | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `vue/no-child-content`                          | template-family | `vue/no_child_content.rs`                              | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-deprecated-filter`                      | template-family | `vue/no_deprecated_filter.rs`                          | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |


### PR DESCRIPTION
## Summary

- Port `vue/no-bare-strings-in-template` to the Davinci markup facade.
- Preserve lowered JSX compatibility for authored string-expression children.
- Add focused template, JSX, and markup facade regression tests.
- Update Davinci rule parity and consumer migration inventories.

Fixes #5319

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize_patina --lib no_bare_strings --locked`
- `cargo test -p vize_patina --lib markup::tests::no_bare_strings_in_template_tests --locked`
- `cargo test -p vize_patina --lib linter::tests::jsx_no_bare_strings_in_template --locked`
- `cargo test -q -p vize_patina --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `node tools/davinci/croquis-consumers.mjs --check`
- `node tools/davinci/matrix-gen.mjs --check`
- `node tools/davinci/assertion-lint.mjs`
- `node --test tests/tooling/davinci-assertion-lint.test.ts`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `cargo test -p vize_patina --lib preset::tests::eslint_vue_rule_map --locked`
- `node tools/fixtures/patina-rule-map.mjs --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -q --workspace --locked`
- `cargo build -q -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 --locked`
- `cargo build -q -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 --no-default-features --locked`
- `cargo test -q -p vize_vitrine --no-default-features --features wasm --locked`
- `cargo test -q -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus --locked -- --nocapture`
- `cargo test -q -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli --locked`
- `cargo test -q -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 --locked`
- `cargo clippy -q -p vize_maestro --tests --locked -- -D warnings`
- `bash tools/github/check-maestro-feature-contract.sh`
- `cargo bench -q -p vize_patina --bench davinci_markup -- --quick`
- `node tools/davinci/bench-compare.mjs --bench patina_jsx_markup_one_root`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790645626&installation_model_id=422833&pr_number=5320&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5320&signature=fb10717f564ad1b776f30ec3a3c38029185f96a7039ba869ae1f1d829d556231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of bare text in Vue templates, JSX, and TSX markup.
  - Preserved correct handling for interpolations, attributes, fragments, and script/style content.
  - Diagnostics now report accurate locations, severity, and guidance without automatic fixes.

- **Tests**
  - Added comprehensive coverage across template and JSX parsing scenarios.

- **Documentation**
  - Updated rule-parity and migration tracking to reflect expanded markup support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->