### PR TITLE
refactor(patina): port no-multi-spaces to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -21,6 +21,7 @@ mod jsx_no_dupe_style_properties;
 mod jsx_no_duplicate_class;
 mod jsx_no_duplicate_dt;
 mod jsx_no_i_for_icon;
+mod jsx_no_multi_spaces;
 mod jsx_no_redundant_roles;
 mod jsx_no_role_presentation_on_focusable;
 mod jsx_placeholder_label_option;

--- a/crates/vize_patina/src/linter/tests/jsx_no_multi_spaces.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_multi_spaces.rs
@@ -1,0 +1,169 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::vue::NoMultiSpaces;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+fn diagnostic_slices<'a>(source: &'a str, result: &LintResult) -> Vec<&'a str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| &source[diagnostic.start as usize..diagnostic.end as usize])
+        .collect()
+}
+
+#[test]
+fn no_multi_spaces_fires_on_jsx_and_tsx_markup() {
+    let linter = linter_with(Box::new(NoMultiSpaces::default()));
+    let source = r#"const A = () => <div className="foo"  id="bar" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(diagnostic_rules(&result), vec!["vue/no-multi-spaces"]);
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(diagnostic_slices(source, &result), vec!["  "]);
+
+    let diag = &result.diagnostics[0];
+    assert_eq!(diag.severity, Severity::Warning);
+    assert_eq!(diag.message, "Multiple consecutive spaces");
+    assert_eq!(diag.help, None);
+    let fix = diag
+        .fix
+        .as_ref()
+        .expect("no-multi-spaces must stay fixable");
+    assert_eq!(fix.message, "Replace multiple spaces with single space");
+    assert_eq!(fix.edits.len(), 1);
+    assert_eq!(fix.edits[0].start, diag.start);
+    assert_eq!(fix.edits[0].end, diag.end);
+    assert_eq!(fix.edits[0].new_text, " ");
+
+    let tsx = r#"const A = (): JSX.Element => <div  data-id="bar" />;"#;
+    let tsx_result = linter.lint_jsx(tsx, "test.tsx", JsxLang::Tsx);
+    assert_eq!(
+        diagnostic_slices(tsx, &tsx_result),
+        vec!["  "],
+        "TSX should use the same authored source gap"
+    );
+}
+
+#[test]
+fn no_multi_spaces_preserves_jsx_clean_boundaries() {
+    let linter = linter_with(Box::new(NoMultiSpaces::default()));
+    for source in [
+        r#"const A = () => <div className="foo" id="bar" />;"#,
+        r#"const A = () => <div className="foo" />;"#,
+        r#"const A = () => <div />;"#,
+        r#"const A = () => <div {...props} />;"#,
+        r#"const A = () => <div prop={{ spaced: true }} id="bar" />;"#,
+        r#"const A = () => <button
+  className="btn"
+  disabled={isDisabled}
+/>;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+}
+
+#[test]
+fn no_multi_spaces_reports_multiple_jsx_gaps_in_source_order() {
+    let linter = linter_with(Box::new(NoMultiSpaces::default()));
+    let source = r#"const A = () => <div  className="foo"  {...props}  id="bar"  data-x="y" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec![
+            "vue/no-multi-spaces",
+            "vue/no-multi-spaces",
+            "vue/no-multi-spaces",
+            "vue/no-multi-spaces"
+        ]
+    );
+    assert_eq!(result.warning_count, 4);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        diagnostic_slices(source, &result),
+        vec!["  ", "  ", "  ", "  "]
+    );
+}
+
+#[test]
+fn migrated_no_multi_spaces_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(NoMultiSpaces::default()));
+    let result = linter.lint_jsx(
+        r#"const A = () => <div  className="foo" />;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated no-multi-spaces rule must report once: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn no_multi_spaces_sfc_offsets_template_diagnostics() {
+    let source = r#"<script setup lang="ts">
+const value = 1;
+</script>
+
+<template>
+  <div  class="foo"></div>
+</template>
+"#;
+    let linter = linter_with(Box::new(NoMultiSpaces::default()));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(diagnostic_rules(&result), vec!["vue/no-multi-spaces"]);
+    assert_eq!(diagnostic_slices(source, &result), vec!["  "]);
+
+    let expected = source.rfind("  class").unwrap() as u32;
+    let diag = &result.diagnostics[0];
+    assert_eq!(
+        diag.start, expected,
+        "SFC diagnostic must be offset into file coordinates"
+    );
+    assert_eq!(diag.end, expected + 2);
+}
+
+#[test]
+fn no_multi_spaces_sfc_does_not_lint_script_tsx() {
+    let source = r#"<script setup lang="tsx">
+const A = () => <div  className="foo" />;
+</script>
+"#;
+    let linter = linter_with(Box::new(NoMultiSpaces::default()));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        result.warning_count, 0,
+        "SFC no-multi-spaces must not inspect JSX inside script blocks: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+}

--- a/crates/vize_patina/src/markup.rs
+++ b/crates/vize_patina/src/markup.rs
@@ -37,7 +37,6 @@
 //!   conditional/list scope, comment).
 //!
 //! # Driving rules
-//!
 //! Implement [`MarkupRule`] (default-empty `enter_*` hooks) and run it with
 //! [`MarkupDocumentVisitor`], which projects the hooks from either backend. The
 //! visitor threads a [`MarkupContext`] wrapping the existing [`LintContext`], so
@@ -1646,5 +1645,6 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
 }
 
 mod exact;
+mod source_ranges;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_patina/src/markup/source_ranges.rs
+++ b/crates/vize_patina/src/markup/source_ranges.rs
@@ -1,0 +1,33 @@
+use super::{MarkupElement, MarkupElementInner, jsx_element_ref, loc_to_range, span_to_range};
+use crate::ir::ByteRange;
+use oxc_ast::ast::JSXAttributeItem;
+
+impl MarkupElement<'_> {
+    /// Visit the byte ranges of every item written on the opening tag.
+    ///
+    /// Unlike [`Self::walk_bindings`], this includes JSX spread attributes.
+    /// Formatting-shaped rules that only need authored source windows can use
+    /// this without assigning semantic meaning to spreads.
+    pub fn walk_opening_item_ranges(&self, visitor: &mut impl FnMut(ByteRange)) {
+        match self.inner {
+            MarkupElementInner::Relief(node) => {
+                for prop in &node.props {
+                    visitor(loc_to_range(prop.loc()));
+                }
+            }
+            MarkupElementInner::JsxElement { node, offset } => {
+                for attribute in &jsx_element_ref(node).opening_element.attributes {
+                    match attribute {
+                        JSXAttributeItem::Attribute(attr) => {
+                            visitor(span_to_range(attr.span, offset));
+                        }
+                        JSXAttributeItem::SpreadAttribute(spread) => {
+                            visitor(span_to_range(spread.span, offset));
+                        }
+                    }
+                }
+            }
+            MarkupElementInner::JsxFragment { .. } => {}
+        }
+    }
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -24,6 +24,7 @@ mod no_dupe_style_properties_tests;
 mod no_duplicate_class_tests;
 mod no_duplicate_dt_tests;
 mod no_i_for_icon_tests;
+mod no_multi_spaces_tests;
 mod no_redundant_roles_tests;
 mod no_role_presentation_on_focusable_jsx_tests;
 mod no_role_presentation_on_focusable_tests;

--- a/crates/vize_patina/src/markup/tests/no_multi_spaces_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_multi_spaces_tests.rs
@@ -1,0 +1,172 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::vue::NoMultiSpaces;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> Vec<(u32, u32)> {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics()
+        .iter()
+        .map(|diagnostic| (diagnostic.start, diagnostic.end))
+        .collect()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> Vec<(u32, u32)> {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut ranges = Vec::new();
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        ranges.extend(
+            lint.diagnostics()
+                .iter()
+                .map(|diagnostic| (diagnostic.start, diagnostic.end)),
+        );
+    }
+    ranges
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> Vec<(u32, u32)> {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics()
+        .iter()
+        .map(|diagnostic| (diagnostic.start, diagnostic.end))
+        .collect()
+}
+
+fn slices<'a>(source: &'a str, ranges: &[(u32, u32)]) -> Vec<&'a str> {
+    ranges
+        .iter()
+        .map(|(start, end)| &source[*start as usize..*end as usize])
+        .collect()
+}
+
+#[test]
+fn no_multi_spaces_template_boundaries() {
+    let rule = NoMultiSpaces::default();
+    for (source, expected, label) in [
+        (
+            r#"<div class="foo" id="bar"></div>"#,
+            Vec::<&str>::new(),
+            "single spaces are clean",
+        ),
+        (
+            r#"<div  class="foo"></div>"#,
+            vec!["  "],
+            "multiple spaces before first attr",
+        ),
+        (
+            r#"<div class="foo"  id="bar"></div>"#,
+            vec!["  "],
+            "multiple spaces between attrs",
+        ),
+        (
+            "<div class=\"foo\"\t\tid=\"bar\"></div>",
+            vec!["\t\t"],
+            "multiple tabs between attrs",
+        ),
+        (
+            r#"<button
+  class="btn"
+  :disabled="isDisabled"
+></button>"#,
+            Vec::<&str>::new(),
+            "multiline attributes stay clean",
+        ),
+        (
+            r#"<div :class="{  active: isActive }"  id="panel"></div>"#,
+            vec!["  "],
+            "directive expression internals are ignored but attr gap is checked",
+        ),
+    ] {
+        let ranges = run_over_template(&rule, source);
+        assert_eq!(
+            slices(source, &ranges),
+            expected,
+            "template boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn no_multi_spaces_jsx_direct_matches_lowered_boundaries() {
+    let rule = NoMultiSpaces::default();
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <div className="foo" id="bar" />;"#,
+            Vec::<&str>::new(),
+            "single spaces are clean",
+        ),
+        (
+            r#"const A = () => <div  className="foo" />;"#,
+            vec!["  "],
+            "multiple spaces before first prop",
+        ),
+        (
+            r#"const A = () => <div className="foo"  id="bar" />;"#,
+            vec!["  "],
+            "multiple spaces between props",
+        ),
+        (
+            "const A = () => <div className=\"foo\"\t\tid=\"bar\" />;",
+            vec!["\t\t"],
+            "multiple tabs between props",
+        ),
+        (
+            r#"const A = () => <Button.Icon  aria-label="Save" />;"#,
+            vec!["  "],
+            "member component tag gap maps to authored source",
+        ),
+        (
+            r#"const A = () => <svg:path  stroke="currentColor" />;"#,
+            vec!["  "],
+            "namespaced JSX tag gap maps to authored source",
+        ),
+        (
+            r#"const A = () => <div {...props}  id="bar" />;"#,
+            vec!["  "],
+            "spread props participate in legacy opening item windows",
+        ),
+        (
+            r#"const A = () => <button
+  className="btn"
+  disabled={isDisabled}
+/>;"#,
+            Vec::<&str>::new(),
+            "multiline JSX props stay clean",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(
+            slices(source, &direct),
+            expected,
+            "JSX direct boundary failed for {label}"
+        );
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "JSX direct and lowered fallback diverged for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/vue/no_multi_spaces.rs
+++ b/crates/vize_patina/src/rules/vue/no_multi_spaces.rs
@@ -18,6 +18,8 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::{Fix, LintDiagnostic, Severity, TextEdit};
+use crate::ir::ByteRange;
+use crate::markup::{MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::ElementNode;
 
@@ -48,26 +50,40 @@ impl Rule for NoMultiSpaces {
         &META
     }
 
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        let props: Vec<_> = element.props.iter().collect();
-        if props.is_empty() {
-            return;
-        }
+        self.check_element(ctx, &MarkupElement::new(element));
+    }
+}
 
-        let first_prop_start = props[0].loc().span.start as usize;
-        let tag_end = element.loc.span.start as usize + 1 + element.tag.len();
-        self.check_gap(ctx, tag_end, first_prop_start);
+impl MarkupRule for NoMultiSpaces {
+    fn name(&self) -> &'static str {
+        META.name
+    }
 
-        for pair in props.windows(2) {
-            let prev_end = pair[0].loc().span.end as usize;
-            let curr_start = pair[1].loc().span.start as usize;
-            self.check_gap(ctx, prev_end, curr_start);
-        }
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        self.check_element(ctx.lint(), element);
     }
 }
 
 impl NoMultiSpaces {
-    fn check_gap<'a>(&self, ctx: &mut LintContext<'a>, gap_start: usize, gap_end: usize) {
+    fn check_element(&self, ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        let mut previous_binding_end = None;
+
+        element.walk_opening_item_ranges(&mut |range| {
+            let gap_start = previous_binding_end
+                .unwrap_or_else(|| tag_name_end_hint(element.range(), element.tag()));
+            self.check_gap(ctx, gap_start, range.start);
+            previous_binding_end = Some(range.end);
+        });
+    }
+
+    fn check_gap(&self, ctx: &mut LintContext<'_>, gap_start: u32, gap_end: u32) {
+        let gap_start = gap_start as usize;
+        let gap_end = gap_end as usize;
         let gap_start = first_whitespace_offset(ctx.source, gap_start, gap_end);
         if gap_end <= gap_start {
             return;
@@ -93,6 +109,13 @@ impl NoMultiSpaces {
             .with_fix(fix),
         );
     }
+}
+
+fn tag_name_end_hint(range: ByteRange, tag: &str) -> u32 {
+    // For JSX member/namespaced tags the facade tag can be shorter than the
+    // written tag. Starting early is fine because `first_whitespace_offset`
+    // advances to the actual gap before checking it.
+    range.start.saturating_add(1 + tag.len() as u32)
 }
 
 fn is_invalid_gap(gap: &str) -> bool {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           324 |                   324 |                 0 |             285 |     271 |             671 |      209 |           364 |           524 |
+| Linter                     |           325 |                   325 |                 0 |             286 |     275 |             672 |      214 |           366 |           527 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         324 |             224 |      100 |
-| old AST/parser   |         243 |             209 |       34 |
+| S0               |         325 |             224 |      101 |
+| old AST/parser   |         244 |             209 |       35 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         271 |             200 |       71 |
+| raw OXC          |         275 |             201 |       74 |
 
 #### Top source and manifest files
 
@@ -111,10 +111,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 | `crates/vize_patina/src/linter/engine.rs:25`                                        | source   | S0 5<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |    13 |
 | `crates/vize_patina/Cargo.toml:13`                                                  | manifest | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 6 |    10 |
 | `crates/vize_patina/src/rules/script/no_ref_as_operand.rs:29`                       | source   | S0 1<br>raw OXC 9                                           |    10 |
-| `crates/vize_patina/src/markup.rs:49`                                               | source   | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |     9 |
+| `crates/vize_patina/src/markup.rs:48`                                               | source   | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |     9 |
 | `crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs:46` | source   | S0 2<br>old AST/parser 4<br>Croquis analysis 3              |     9 |
 
-Additional source/manifest rows are in the TSV: 307 omitted.
+Additional source/manifest rows are in the TSV: 308 omitted.
 
 #### Top test/dev files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 307 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:42`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:43`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 60 omitted.
+Additional test/dev rows are in the TSV: 61 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -983,17 +983,18 @@ linter	Linter	test/dev	crates/vize_patina/src/linter/tests.rs	3	s0	S0	stage	vize
 linter	Linter	test/dev	crates/vize_patina/src/linter/tests/jsx_streaming.rs	13	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/linter/tests/nuxt.rs	2	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/linter/tests/recovered_parse_analysis.rs	11	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/markup.rs	49	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/markup.rs	49	old_ast	old AST/parser	old	vize_relief	legacy	2
-linter	Linter	source	crates/vize_patina/src/markup.rs	49	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
-linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	source	crates/vize_patina/src/markup.rs	49	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
+linter	Linter	source	crates/vize_patina/src/markup.rs	48	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/markup.rs	48	old_ast	old AST/parser	old	vize_relief	legacy	2
+linter	Linter	source	crates/vize_patina/src/markup.rs	48	croquis	Croquis analysis	old	vize_croquis	legacy	1
+linter	Linter	source	crates/vize_patina/src/markup.rs	48	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	source	crates/vize_patina/src/markup.rs	48	raw_oxc	raw OXC	raw	oxc_ast	raw	1
+linter	Linter	source	crates/vize_patina/src/markup.rs	48	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	42	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	42	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	42	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	source	crates/vize_patina/src/markup/source_ranges.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	43	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	43	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	43	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1036,6 +1037,9 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_dt_tests
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_multi_spaces_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_multi_spaces_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_multi_spaces_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_redundant_roles_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_redundant_roles_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_redundant_roles_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1436,7 +1440,7 @@ linter	Linter	source	crates/vize_patina/src/rules/vue/no_duplicate_attributes.rs
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_duplicate_attributes.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_invalid_html_attribute.rs	10	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_lone_template.rs	30	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_multi_spaces.rs	22	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_multi_spaces.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root.rs	23	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root.rs	23	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_multiple_template_root/tests.rs	13	s0	S0	stage	vize_s0	preferred	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 32, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 33, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 115, `ir` 23, `ir-lowered` 9, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (32 = 32 `markup-facade` rules)
+- JSX lanes: `fallback` 114, `ir` 24, `ir-lowered` 9, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (33 = 33 `markup-facade` rules)
 - classification: neutral-core-candidate **87** · vue-dialect-bound **136** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -222,7 +222,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `vue/no-inline-style`                           | template-family | `opinionated/vue/no_inline_style.rs`                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-invalid-html-attribute`                 | template-family | `vue/no_invalid_html_attribute.rs`                     | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `vue/no-lone-template`                          | template-family | `vue/no_lone_template.rs`                              | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
-| `vue/no-multi-spaces`                           | template-family | `vue/no_multi_spaces.rs`                               | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `vue/no-multi-spaces`                           | template-family | `vue/no_multi_spaces.rs`                               | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `vue/no-multiple-objects-in-class`              | template-family | `opinionated/vue/no_multiple_objects_in_class.rs`      | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-multiple-template-root`                 | template-family | `vue/no_multiple_template_root.rs`                     | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-mutating-props`                         | template-family | `vue/no_mutating_props.rs`                             | template-ast, sfc-source       | yes (template-visitor+sfc-hooks) | yes (fallback)              | direct 1: `reactivity::ReactiveKind`; ctx 2                                                         | container-bound        |

--- a/davinci-road/plan/sourcelocation-inventory.md
+++ b/davinci-road/plan/sourcelocation-inventory.md
@@ -28,7 +28,7 @@ any read — or any deleted carrier — comes back.
 - Reads of `span.start` / `span.end` are **not** inventoried: they are
   the surviving offset representation — the pre-migration
   `start.offset` / `end.offset` reads moved to them verbatim
-  (299 loc-shaped span-read sites across
+  (295 loc-shaped span-read sites across
   8 crates at generation time).
 - `#[cfg(test)]` code inside `src/` is included and reported in the
   "in test code" column: a site counts as test code when its file is a test


### PR DESCRIPTION
## Summary

- port `vue/no-multi-spaces` to the Davinci markup facade while preserving the legacy template visitor path
- add authored-source JSX/TSX coverage for whitespace gaps, member/namespaced tags, spread attributes, multiline props, SFC offsets, and no duplicate backend reports
- update Davinci rule parity, migration surface, and SourceLocation inventories

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_patina --lib no_multi_spaces --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `node tools/davinci/rule-parity.mjs --check && node tools/davinci/consumer-migration-surfaces.mjs --check && node tools/davinci/sourcelocation-inventory.mjs --check && node tools/davinci/croquis-consumers.mjs --check && node tools/davinci/matrix-gen.mjs --check && node tools/davinci/assertion-lint.mjs`
- `node --test tests/tooling/davinci-assertion-lint.test.ts`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo test -p vize_patina --lib preset::tests::eslint_vue_rule_map --locked`
- `node tools/fixtures/patina-rule-map.mjs --check`
- `cargo test -q -p vize_patina --locked`
- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -q --workspace --locked`
- `cargo build -q -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 --locked`
- `cargo build -q -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 --locked --no-default-features`
- `cargo test -q -p vize_vitrine --no-default-features --features wasm --locked`
- `cargo test -q -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus --locked -- --nocapture`
- `cargo test -q -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli --locked`
- `cargo test -q -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 --locked`
- `cargo clippy -q -p vize_maestro --tests --locked -- -D warnings`
- `bash tools/github/check-maestro-feature-contract.sh`
- `cargo bench -q -p vize_patina --bench davinci_markup -- --quick`
- `node tools/davinci/bench-compare.mjs --bench patina_jsx_markup_one_root`
- `cargo bench -q -p vize_patina --bench markup_ir_bench -- --quick`

Fixes #5323

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790648432&installation_model_id=422833&pr_number=5324&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5324&signature=fbf5ff94b349f47815bd6470278e8979e07a6412330a15efa081c05620bed373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->