### PR TITLE
refactor(patina): migrate no-inline-style to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -21,6 +21,7 @@ mod jsx_no_dupe_style_properties;
 mod jsx_no_duplicate_class;
 mod jsx_no_duplicate_dt;
 mod jsx_no_i_for_icon;
+mod jsx_no_inline_style;
 mod jsx_no_multi_spaces;
 mod jsx_no_redundant_roles;
 mod jsx_no_role_presentation_on_focusable;

--- a/crates/vize_patina/src/linter/tests/jsx_no_inline_style.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_inline_style.rs
@@ -1,0 +1,192 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::vue::NoInlineStyle;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+fn diagnostic_slices<'a>(source: &'a str, result: &LintResult) -> Vec<&'a str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| &source[diagnostic.start as usize..diagnostic.end as usize])
+        .collect()
+}
+
+#[test]
+fn no_inline_style_fires_on_jsx_and_tsx_markup() {
+    let linter = linter_with(Box::new(NoInlineStyle));
+    let source = r#"const A = () => <div style="color:red" />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(diagnostic_rules(&result), vec!["vue/no-inline-style"]);
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        diagnostic_slices(source, &result),
+        vec![r#"style="color:red""#]
+    );
+
+    let diag = &result.diagnostics[0];
+    assert_eq!(diag.severity, Severity::Warning);
+    assert_eq!(diag.message, "Avoid using inline style attributes");
+    assert_eq!(
+        diag.help.as_deref(),
+        Some("Use CSS classes or scoped styles instead")
+    );
+    assert!(diag.fix.is_none());
+
+    let tsx = r#"const A = (): JSX.Element => <div style={{ color: activeColor }} />;"#;
+    let tsx_result = linter.lint_jsx(tsx, "test.tsx", JsxLang::Tsx);
+    assert_eq!(
+        diagnostic_slices(tsx, &tsx_result),
+        vec![r#"style={{ color: activeColor }}"#],
+        "TSX should use the same authored source range"
+    );
+}
+
+#[test]
+fn no_inline_style_preserves_jsx_clean_boundaries() {
+    let linter = linter_with(Box::new(NoInlineStyle));
+    for source in [
+        r#"const A = () => <div className="foo" />;"#,
+        r#"const A = () => <div {...props} />;"#,
+        r#"const A = () => <div STYLE="color:red" />;"#,
+        r#"const A = () => <div foo:style="x" />;"#,
+        r#"const A = () => <div v-bind:Style={styles} />;"#,
+        r#"const A = () => <div onStyle={handler} />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+}
+
+#[test]
+fn no_inline_style_reports_multiple_jsx_styles_in_source_order() {
+    let linter = linter_with(Box::new(NoInlineStyle));
+    let source = r#"const A = () => <><div style="color:red" /><span style={{ marginTop }} /></>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["vue/no-inline-style", "vue/no-inline-style"]
+    );
+    assert_eq!(result.warning_count, 2);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        diagnostic_slices(source, &result),
+        vec![r#"style="color:red""#, r#"style={{ marginTop }}"#]
+    );
+}
+
+#[test]
+fn no_inline_style_reports_nested_jsx_styles() {
+    let linter = linter_with(Box::new(NoInlineStyle));
+    let source = r#"const A = () => <div>{cond && <span style={dynamicStyles} />}</div>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(diagnostic_rules(&result), vec!["vue/no-inline-style"]);
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        diagnostic_slices(source, &result),
+        vec![r#"style={dynamicStyles}"#]
+    );
+}
+
+#[test]
+fn no_inline_style_supports_jsx_v_bind_style_spelling() {
+    let linter = linter_with(Box::new(NoInlineStyle));
+    let source = r#"const A = () => <div v-bind:style={styles} />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(diagnostic_rules(&result), vec!["vue/no-inline-style"]);
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        diagnostic_slices(source, &result),
+        vec![r#"v-bind:style={styles}"#]
+    );
+}
+
+#[test]
+fn migrated_no_inline_style_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(NoInlineStyle));
+    let result = linter.lint_jsx(
+        r#"const A = () => <div style="color:red" />;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated no-inline-style rule must report once: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn no_inline_style_sfc_offsets_template_diagnostics() {
+    let source = r#"<script setup lang="ts">
+const value = 1;
+</script>
+
+<template>
+  <div style="color:red"></div>
+</template>
+"#;
+    let linter = linter_with(Box::new(NoInlineStyle));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(diagnostic_rules(&result), vec!["vue/no-inline-style"]);
+    assert_eq!(
+        diagnostic_slices(source, &result),
+        vec![r#"style="color:red""#]
+    );
+
+    let expected = source.rfind(r#"style="color:red""#).unwrap() as u32;
+    let diag = &result.diagnostics[0];
+    assert_eq!(
+        diag.start, expected,
+        "SFC diagnostic must be offset into file coordinates"
+    );
+    assert_eq!(diag.end, expected + r#"style="color:red""#.len() as u32);
+}
+
+#[test]
+fn no_inline_style_sfc_does_not_lint_script_tsx() {
+    let source = r#"<script setup lang="tsx">
+const A = () => <div style="color:red" />;
+</script>
+"#;
+    let linter = linter_with(Box::new(NoInlineStyle));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        result.warning_count, 0,
+        "SFC no-inline-style must not inspect JSX inside script blocks: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 0);
+}

--- a/crates/vize_patina/src/markup.rs
+++ b/crates/vize_patina/src/markup.rs
@@ -1165,12 +1165,16 @@ fn relief_directive_kind(node: &DirectiveNode<'_>) -> MarkupBindingKind {
 
 /// The [`MarkupBindingKind`] a JSX attribute projects to.
 ///
-/// JSX has no directive syntax, so the classification is name-driven: a
-/// React-style `onClick` is an event ([`MarkupBindingKind::On`]); an
-/// expression-valued attribute (`class={…}`) is a [`MarkupBindingKind::Bind`];
-/// a plain string attribute (`id="x"`) is a [`MarkupBindingKind::Attribute`].
+/// JSX classification is name/value-driven: `v-bind:x`, React-style `onX`,
+/// expression-valued props, then plain static attributes.
 #[inline]
 fn jsx_attribute_binding_kind(attr: &JSXAttribute<'_>) -> MarkupBindingKind {
+    if let JSXAttributeName::NamespacedName(name) = &attr.name
+        && name.namespace.name.as_str() == "v-bind"
+    {
+        return MarkupBindingKind::Bind;
+    }
+
     let name = jsx_attribute_name(&attr.name);
     if is_jsx_event_handler_name(name) {
         MarkupBindingKind::On
@@ -1230,9 +1234,7 @@ fn loc_to_range(loc: &SourceLocation) -> ByteRange {
     ByteRange::new(loc.span.start, loc.span.end)
 }
 
-// ===========================================================================
 // Scope nodes: conditional (`v-if`) and list (`v-for`).
-// ===========================================================================
 
 /// A conditional scope: a Vue `v-if` / `v-else-if` / `v-else` chain.
 ///
@@ -1352,9 +1354,7 @@ impl<'a> MarkupElement<'a> {
     }
 }
 
-// ===========================================================================
 // Rule-facing trait + driving visitor.
-// ===========================================================================
 
 /// Context handed to [`MarkupRule`] callbacks.
 ///
@@ -1576,11 +1576,11 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
             self.rule.enter_directive(self.ctx, &element, &directive);
         });
 
-        // Children. For the template backend `walk_children` already yields the
-        // projected scopes; for JSX it yields elements/text/interpolations.
+        // Children: template scopes or JSX elements/text/interpolations.
         match element.inner {
             MarkupElementInner::Relief(node) => self.visit_relief_children(&node.children),
             MarkupElementInner::JsxElement { node, offset } => {
+                jsx_roots::visit_attribute_roots(self, jsx_element_ref(node), offset);
                 self.visit_jsx_children(jsx_element_ref(node).jsx_children(), offset)
             }
             MarkupElementInner::JsxFragment { node, offset } => {
@@ -1593,13 +1593,9 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
     }
 
     fn visit_jsx_program(&mut self, program: &'a Program<'a>, offset: u32) {
-        // OXC's `Visit` borrows its walker mutably, so a thin driver adapts
-        // the program walk to this visitor: each outermost JSX element or
-        // fragment streams straight into `visit_element` in source order,
-        // with no root container allocated. The driver never descends —
-        // nested JSX is visited by our own recursion, so an `expr && <x/>`
-        // guard or a `.map(item => <li/>)` callback still yields its `<x/>` /
-        // `<li/>` here as a root we then recurse into.
+        // Stream each outermost JSX element/fragment into `visit_element` in
+        // source order, with no root container allocated. Nested JSX roots are
+        // handled by our own element/attribute/expression recursion.
         struct RootDriver<'visitor, 'rule, 'ctx, 'mc, 'a, R: ?Sized> {
             visitor: &'visitor mut MarkupDocumentVisitor<'rule, 'ctx, 'mc, 'a, R>,
             offset: u32,
@@ -1637,6 +1633,9 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
                 MarkupNode::Interpolation(range) => {
                     self.set_rule();
                     self.rule.enter_interpolation(self.ctx, range);
+                    if let JSXChild::ExpressionContainer(container) = child {
+                        jsx_roots::visit_expression_container_roots(self, container, offset);
+                    }
                 }
                 _ => {}
             }
@@ -1645,6 +1644,7 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
 }
 
 mod exact;
+mod jsx_roots;
 mod source_ranges;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_patina/src/markup/exact.rs
+++ b/crates/vize_patina/src/markup/exact.rs
@@ -54,7 +54,10 @@ impl<'a> MarkupBinding<'a> {
                             _ => identifier.name.as_str() == expected,
                         }
                     }
-                    JSXAttributeName::NamespacedName(_) => false,
+                    JSXAttributeName::NamespacedName(name) => {
+                        name.namespace.name.as_str() == "v-bind"
+                            && name.name.name.as_str() == expected
+                    }
                 }
             }
         }

--- a/crates/vize_patina/src/markup/jsx_roots.rs
+++ b/crates/vize_patina/src/markup/jsx_roots.rs
@@ -1,0 +1,131 @@
+use super::{MarkupDocumentVisitor, MarkupElement, MarkupRule};
+use oxc_ast::ast::{
+    Expression, JSXAttributeItem, JSXAttributeValue, JSXElement, JSXExpressionContainer,
+    JSXFragment,
+};
+use oxc_ast_visit::{
+    Visit,
+    walk::{walk_expression, walk_jsx_expression_container},
+};
+use std::marker::PhantomData;
+
+struct NestedDriver<'visitor, 'a, F: ?Sized> {
+    visitor: &'visitor mut F,
+    offset: u32,
+    _marker: PhantomData<&'a ()>,
+}
+
+impl<'a, F: ?Sized> NestedDriver<'_, 'a, F>
+where
+    F: FnMut(MarkupElement<'a>),
+{
+    fn visit_element(&mut self, element: MarkupElement<'a>) {
+        (self.visitor)(element);
+    }
+}
+
+impl<'a, F: ?Sized> Visit<'a> for NestedDriver<'_, 'a, F>
+where
+    F: FnMut(MarkupElement<'a>),
+{
+    fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
+        self.visit_element(MarkupElement::from_jsx_element(it as *const _, self.offset));
+    }
+
+    fn visit_jsx_fragment(&mut self, it: &JSXFragment<'a>) {
+        self.visit_element(MarkupElement::from_jsx_fragment(
+            it as *const _,
+            self.offset,
+        ));
+    }
+}
+
+pub(super) fn visit_expression_container_roots<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized>(
+    visitor: &mut MarkupDocumentVisitor<'rule, 'ctx, 'mc, 'a, R>,
+    container: &'a JSXExpressionContainer<'a>,
+    offset: u32,
+) {
+    walk_expression_container_roots(container, offset, &mut |element| {
+        visitor.visit_element(element);
+    });
+}
+
+fn walk_expression_container_roots<'a>(
+    container: &'a JSXExpressionContainer<'a>,
+    offset: u32,
+    visitor: &mut impl FnMut(MarkupElement<'a>),
+) {
+    let mut driver = NestedDriver {
+        visitor,
+        offset,
+        _marker: PhantomData,
+    };
+    walk_jsx_expression_container(&mut driver, container);
+}
+
+fn walk_expression_roots<'a>(
+    expression: &'a Expression<'a>,
+    offset: u32,
+    visitor: &mut impl FnMut(MarkupElement<'a>),
+) {
+    let mut driver = NestedDriver {
+        visitor,
+        offset,
+        _marker: PhantomData,
+    };
+    walk_expression(&mut driver, expression);
+}
+
+fn walk_attribute_value_roots<'a>(
+    value: &'a JSXAttributeValue<'a>,
+    offset: u32,
+    visitor: &mut impl FnMut(MarkupElement<'a>),
+) {
+    match value {
+        JSXAttributeValue::StringLiteral(_) => {}
+        JSXAttributeValue::ExpressionContainer(container) => {
+            walk_expression_container_roots(container, offset, visitor);
+        }
+        JSXAttributeValue::Element(element) => {
+            visitor(MarkupElement::from_jsx_element(
+                &**element as *const _,
+                offset,
+            ));
+        }
+        JSXAttributeValue::Fragment(fragment) => {
+            visitor(MarkupElement::from_jsx_fragment(
+                &**fragment as *const _,
+                offset,
+            ));
+        }
+    }
+}
+
+pub(super) fn visit_attribute_roots<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized>(
+    visitor: &mut MarkupDocumentVisitor<'rule, 'ctx, 'mc, 'a, R>,
+    element: &'a JSXElement<'a>,
+    offset: u32,
+) {
+    walk_attribute_roots(element, offset, &mut |element| {
+        visitor.visit_element(element);
+    });
+}
+
+fn walk_attribute_roots<'a>(
+    element: &'a JSXElement<'a>,
+    offset: u32,
+    visitor: &mut impl FnMut(MarkupElement<'a>),
+) {
+    for item in &element.opening_element.attributes {
+        match item {
+            JSXAttributeItem::Attribute(attribute) => {
+                if let Some(value) = attribute.value.as_ref() {
+                    walk_attribute_value_roots(value, offset, visitor);
+                }
+            }
+            JSXAttributeItem::SpreadAttribute(spread) => {
+                walk_expression_roots(&spread.argument, offset, visitor);
+            }
+        }
+    }
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -24,6 +24,7 @@ mod no_dupe_style_properties_tests;
 mod no_duplicate_class_tests;
 mod no_duplicate_dt_tests;
 mod no_i_for_icon_tests;
+mod no_inline_style_tests;
 mod no_multi_spaces_tests;
 mod no_redundant_roles_tests;
 mod no_role_presentation_on_focusable_jsx_tests;

--- a/crates/vize_patina/src/markup/tests/no_inline_style_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_inline_style_tests.rs
@@ -1,0 +1,231 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::vue::NoInlineStyle;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> Vec<(u32, u32)> {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics()
+        .iter()
+        .map(|diagnostic| (diagnostic.start, diagnostic.end))
+        .collect()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> Vec<(u32, u32)> {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut ranges = Vec::new();
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        ranges.extend(
+            lint.diagnostics()
+                .iter()
+                .map(|diagnostic| (diagnostic.start, diagnostic.end)),
+        );
+    }
+    ranges
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> Vec<(u32, u32)> {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics()
+        .iter()
+        .map(|diagnostic| (diagnostic.start, diagnostic.end))
+        .collect()
+}
+
+fn slices<'a>(source: &'a str, ranges: &[(u32, u32)]) -> Vec<&'a str> {
+    ranges
+        .iter()
+        .map(|(start, end)| &source[*start as usize..*end as usize])
+        .collect()
+}
+
+#[test]
+fn no_inline_style_template_boundaries() {
+    let rule = NoInlineStyle;
+    for (source, expected, label) in [
+        (
+            r#"<div class="foo"></div>"#,
+            Vec::<&str>::new(),
+            "class attribute stays clean",
+        ),
+        (
+            r#"<div :class="{ active: isActive }"></div>"#,
+            Vec::<&str>::new(),
+            "dynamic class binding stays clean",
+        ),
+        (
+            r#"<div style="color:red"></div>"#,
+            vec![r#"style="color:red""#],
+            "static style warns",
+        ),
+        (
+            r#"<div style></div>"#,
+            vec!["style"],
+            "valueless style warns",
+        ),
+        (
+            r#"<div style=""></div>"#,
+            vec![r#"style="""#],
+            "empty static style warns",
+        ),
+        (
+            r#"<div :style="{ color: activeColor }"></div>"#,
+            vec![r#":style="{ color: activeColor }""#],
+            "shorthand dynamic style warns",
+        ),
+        (
+            r#"<div :style.prop="styles"></div>"#,
+            vec![r#":style.prop="styles""#],
+            "modifier dynamic style warns",
+        ),
+        (
+            r#"<div v-bind:style="styles"></div>"#,
+            vec![r#"v-bind:style="styles""#],
+            "long-form dynamic style warns",
+        ),
+        (
+            r#"<div v-bind:[style]="styles"></div>"#,
+            vec![r#"v-bind:[style]="styles""#],
+            "legacy dynamic style arg warns",
+        ),
+        (
+            r#"<MyComponent style="color:red" :style="styles" />"#,
+            vec![r#"style="color:red""#, r#":style="styles""#],
+            "component style props keep legacy behavior",
+        ),
+        (
+            r#"<div STYLE="color:red"></div>"#,
+            Vec::<&str>::new(),
+            "attribute name matching remains case-sensitive",
+        ),
+        (
+            r#"<div :Style="styles" v-style="styles" v-bind="attrs" foo:style="x"></div>"#,
+            Vec::<&str>::new(),
+            "non-matching directive and namespaced spellings stay clean",
+        ),
+    ] {
+        let ranges = run_over_template(&rule, source);
+        assert_eq!(
+            slices(source, &ranges),
+            expected,
+            "template boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn no_inline_style_jsx_direct_matches_lowered_boundaries() {
+    let rule = NoInlineStyle;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <div className="foo" />;"#,
+            Vec::<&str>::new(),
+            "className stays clean",
+        ),
+        (
+            r#"const A = () => <div {...props} />;"#,
+            Vec::<&str>::new(),
+            "spread props stay clean",
+        ),
+        (
+            r#"const A = () => <div STYLE="color:red" foo:style="x" />;"#,
+            Vec::<&str>::new(),
+            "uppercase and namespaced style attributes stay clean",
+        ),
+        (
+            r#"const A = () => <div v-bind:Style={styles} />;"#,
+            Vec::<&str>::new(),
+            "v-bind style argument remains case-sensitive",
+        ),
+        (
+            r#"const A = () => <div onStyle={handler} />;"#,
+            Vec::<&str>::new(),
+            "event-shaped prop does not become a style binding",
+        ),
+        (
+            r#"const A = () => <div style="color:red" />;"#,
+            vec![r#"style="color:red""#],
+            "static style warns",
+        ),
+        (
+            r#"const A = () => <div style />;"#,
+            vec!["style"],
+            "valueless style warns",
+        ),
+        (
+            r#"const A = () => <div style="" />;"#,
+            vec![r#"style="""#],
+            "empty static style warns",
+        ),
+        (
+            r#"const A = () => <div style={{ color: activeColor }} />;"#,
+            vec![r#"style={{ color: activeColor }}"#],
+            "expression style warns",
+        ),
+        (
+            r#"const A = () => <div style={dynamicStyles} />;"#,
+            vec![r#"style={dynamicStyles}"#],
+            "identifier expression style warns",
+        ),
+        (
+            r#"const A = () => <div v-bind:style={styles} />;"#,
+            vec![r#"v-bind:style={styles}"#],
+            "JSX directive spelling warns",
+        ),
+        (
+            r#"const A = () => <Widget style="color:red" />;"#,
+            vec![r#"style="color:red""#],
+            "component style props keep legacy behavior",
+        ),
+        (
+            r#"const A = () => <Design.Box style="color:red" />;"#,
+            vec![r#"style="color:red""#],
+            "member component style props keep legacy behavior",
+        ),
+        (
+            r#"const A = () => <div>{cond && <span style={{ color }} />}</div>;"#,
+            vec![r#"style={{ color }}"#],
+            "nested expression-container JSX style warns",
+        ),
+        (
+            r#"const A = () => <><div style="color:red" /><span style={{ marginTop }} /></>;"#,
+            vec![r#"style="color:red""#, r#"style={{ marginTop }}"#],
+            "multiple JSX styles report in source order",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(
+            slices(source, &direct),
+            expected,
+            "JSX direct boundary failed for {label}"
+        );
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "JSX direct and lowered fallback diverged for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/opinionated/vue/no_inline_style.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/no_inline_style.rs
@@ -27,8 +27,9 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBinding, MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, ExpressionNode};
+use vize_relief::ElementNode;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-inline-style",
@@ -42,42 +43,54 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct NoInlineStyle;
 
+impl NoInlineStyle {
+    fn check_binding(ctx: &mut LintContext<'_>, binding: &MarkupBinding<'_>) {
+        if !matches!(
+            binding.kind(),
+            MarkupBindingKind::Attribute | MarkupBindingKind::Bind
+        ) || !binding.is_unqualified_arg_exact("style")
+        {
+            return;
+        }
+
+        ctx.warn_at_with_help(
+            ctx.t("vue/no-inline-style.message"),
+            binding.range(),
+            ctx.t("vue/no-inline-style.help"),
+        );
+    }
+
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        element.walk_bindings(&mut |binding| Self::check_binding(ctx, &binding));
+    }
+}
+
+impl MarkupRule for NoInlineStyle {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_binding<'a>(
+        &self,
+        ctx: &mut MarkupContext<'_, 'a>,
+        _element: &MarkupElement<'a>,
+        binding: &MarkupBinding<'a>,
+    ) {
+        Self::check_binding(ctx.lint(), binding);
+    }
+}
+
 impl Rule for NoInlineStyle {
     fn meta(&self) -> &'static RuleMeta {
         &META
     }
 
-    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        // Check for static style attribute
-        for attr in &element.props {
-            if let vize_relief::PropNode::Attribute(attr) = attr
-                && attr.name == "style"
-            {
-                ctx.warn_with_help(
-                    ctx.t("vue/no-inline-style.message"),
-                    &attr.loc,
-                    ctx.t("vue/no-inline-style.help"),
-                );
-            }
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
 
-            // Check for dynamic :style binding
-            if let vize_relief::PropNode::Directive(dir) = attr
-                && dir.name == "bind"
-                && let Some(arg) = &dir.arg
-            {
-                let arg_content = match arg {
-                    ExpressionNode::Simple(s) => s.content,
-                    _ => "",
-                };
-                if arg_content == "style" {
-                    ctx.warn_with_help(
-                        ctx.t("vue/no-inline-style.message"),
-                        &dir.loc,
-                        ctx.t("vue/no-inline-style.help"),
-                    );
-                }
-            }
-        }
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           325 |                   325 |                 0 |             286 |     275 |             672 |      214 |           366 |           527 |
+| Linter                     |           326 |                   326 |                 0 |             285 |     280 |             672 |      219 |           368 |           530 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         325 |             224 |      101 |
-| old AST/parser   |         244 |             209 |       35 |
+| S0               |         326 |             224 |      102 |
+| old AST/parser   |         243 |             207 |       36 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         275 |             201 |       74 |
+| raw OXC          |         280 |             203 |       77 |
 
 #### Top source and manifest files
 
@@ -114,7 +114,7 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 | `crates/vize_patina/src/markup.rs:48`                                               | source   | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |     9 |
 | `crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs:46` | source   | S0 2<br>old AST/parser 4<br>Croquis analysis 3              |     9 |
 
-Additional source/manifest rows are in the TSV: 308 omitted.
+Additional source/manifest rows are in the TSV: 309 omitted.
 
 #### Top test/dev files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 308 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:43`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:44`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 61 omitted.
+Additional test/dev rows are in the TSV: 62 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -991,10 +991,12 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	48	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	48	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
+linter	Linter	source	crates/vize_patina/src/markup/jsx_roots.rs	2	raw_oxc	raw OXC	raw	oxc_ast	raw	1
+linter	Linter	source	crates/vize_patina/src/markup/jsx_roots.rs	2	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/source_ranges.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	43	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	43	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	43	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	44	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	44	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	44	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1037,6 +1039,9 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_duplicate_dt_tests
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_i_for_icon_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_inline_style_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_inline_style_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_inline_style_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_multi_spaces_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_multi_spaces_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_multi_spaces_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1144,7 +1149,7 @@ linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_array_index
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	32	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_boolean_attr_value.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_empty_component_block.rs	40	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_inline_style.rs	31	old_ast	old AST/parser	old	vize_relief	legacy	3
+linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_inline_style.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 linter	Linter	source	crates/vize_patina/src/rules/opinionated/vue/no_multiple_objects_in_class.rs	27	raw_oxc	raw OXC	raw	oxc_ast	raw	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,10 +34,10 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 33, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 34, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 114, `ir` 24, `ir-lowered` 9, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (33 = 33 `markup-facade` rules)
-- classification: neutral-core-candidate **87** · vue-dialect-bound **136** · container-bound **22** (0 overridden)
+- JSX lanes: `fallback` 113, `ir` 25, `ir-lowered` 9, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (34 = 34 `markup-facade` rules)
+- classification: neutral-core-candidate **88** · vue-dialect-bound **135** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
 ## Full table
@@ -219,7 +219,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `vue/no-dupe-v-else-if`                         | template-family | `vue/no_dupe_v_else_if.rs`                             | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-duplicate-attributes`                   | template-family | `vue/no_duplicate_attributes.rs`                       | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-empty-component-block`                  | template-family | `opinionated/vue/no_empty_component_block.rs`          | sfc-source                     | yes (sfc-hooks)                  | no (no JSX-reachable hooks) | —                                                                                                   | container-bound        |
-| `vue/no-inline-style`                           | template-family | `opinionated/vue/no_inline_style.rs`                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
+| `vue/no-inline-style`                           | template-family | `opinionated/vue/no_inline_style.rs`                   | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `vue/no-invalid-html-attribute`                 | template-family | `vue/no_invalid_html_attribute.rs`                     | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `vue/no-lone-template`                          | template-family | `vue/no_lone_template.rs`                              | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-multi-spaces`                           | template-family | `vue/no_multi_spaces.rs`                               | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |


### PR DESCRIPTION
Fixes #5328

## Summary

- port `vue/no-inline-style` to the Patina markup facade while keeping the legacy template visitor delegated through the same binding helper
- teach direct JSX markup bindings to treat `v-bind:*` as bind-like while ordinary namespaced attrs remain ignored
- visit JSX roots nested in child expressions and attribute values so direct IR coverage matches lowered fallback coverage
- add Vue/JSX/TSX/SFC offset regressions and refresh Davinci rule parity / consumer migration inventories

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize_patina --lib no_inline_style --locked`
- `cargo test -q -p vize_patina --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `node tools/davinci/rule-parity.mjs --check && node tools/davinci/consumer-migration-surfaces.mjs --check && node tools/davinci/sourcelocation-inventory.mjs --check && node tools/davinci/croquis-consumers.mjs --check && node tools/davinci/matrix-gen.mjs --check`
- `node tools/davinci/assertion-lint.mjs && node --test tests/tooling/davinci-assertion-lint.test.ts`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo test -p vize_patina --lib preset::tests::eslint_vue_rule_map --locked`
- `node tools/fixtures/patina-rule-map.mjs --check`
- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -q --workspace --locked`
- `cargo build -q -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 --locked`
- `cargo build -q -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 --no-default-features --locked`
- `cargo test -q -p vize_vitrine --no-default-features --features wasm --locked`
- `cargo test -q -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus --locked -- --nocapture`
- `cargo test -q -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli --locked`
- `cargo test -q -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 --locked`
- `bash tools/github/check-maestro-feature-contract.sh`
- `cargo clippy -q -p vize_maestro --tests --locked -- -D warnings`
- `cargo bench -q -p vize_patina --bench davinci_markup -- --quick`
- `cargo bench -q -p vize_patina --bench markup_ir_bench -- --quick`
- `node tools/davinci/bench-compare.mjs --bench patina_jsx_markup_one_root`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790651593&installation_model_id=422833&pr_number=5329&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5329&signature=791703258eb393720e598eb11cc4db89463e5ee57258f5124f40655488b42565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of inline `style` attributes across Vue templates, JSX, TSX, and SFC files.
  * Added support for nested JSX elements and `v-bind:style` syntax.
  * Improved diagnostic source ranges and prevented false positives for similarly named attributes.

* **Tests**
  * Added comprehensive coverage for valid, invalid, nested, and mixed markup scenarios.

* **Documentation**
  * Updated rule parity and migration tracking documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->