### PR TITLE
feat(ui-tooling): add source install dry-run planner

### DIFF
--- a/npm/ui/tooling/package.json
+++ b/npm/ui/tooling/package.json
@@ -8,18 +8,20 @@
   "exports": {
     "./authoring-contract": "./authoring-contract.ts",
     "./authoring-gate": "./authoring-gate.ts",
-    "./lint-sfc": "./lint-sfc.ts"
+    "./lint-sfc": "./lint-sfc.ts",
+    "./source-install-planner": "./source-install-planner.ts"
   },
   "scripts": {
-    "check": "vp check authoring-contract.ts authoring-gate.ts authoring-gate-events.test.ts authoring-gate-filenames.test.ts authoring-gate-slots.test.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts type-member-parser.ts",
-    "fmt": "vp fmt --write authoring-contract.ts authoring-contract.md authoring-gate.ts authoring-gate-events.test.ts authoring-gate-filenames.test.ts authoring-gate-slots.test.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts type-member-parser.ts",
-    "test": "vp exec node --test authoring-gate-events.test.ts authoring-gate-filenames.test.ts authoring-gate-slots.test.ts authoring-gate.test.ts lint-sfc.test.ts"
+    "check": "vp check authoring-contract.ts authoring-gate.ts authoring-gate-events.test.ts authoring-gate-filenames.test.ts authoring-gate-slots.test.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts source-install-planner.ts source-install-planner.test.ts source-install-planner.types.test-d.ts type-member-parser.ts && tsc --noEmit -p tsconfig.json",
+    "fmt": "vp fmt --write authoring-contract.ts authoring-contract.md authoring-gate.ts authoring-gate-events.test.ts authoring-gate-filenames.test.ts authoring-gate-slots.test.ts authoring-gate.test.ts lint-sfc.ts lint-sfc.test.ts source-install-planner.ts source-install-planner.behavior.md source-install-planner.test.ts source-install-planner.types.test-d.ts type-member-parser.ts",
+    "test": "vp exec node --test authoring-gate-events.test.ts authoring-gate-filenames.test.ts authoring-gate-slots.test.ts authoring-gate.test.ts lint-sfc.test.ts source-install-planner.test.ts"
   },
   "dependencies": {
     "@vue/compiler-sfc": "catalog:vue-stable"
   },
   "devDependencies": {
     "@types/node": "catalog:typescript",
+    "typescript": "catalog:typescript",
     "vite-plus": "catalog:vite-stack"
   },
   "engines": {

--- a/npm/ui/tooling/source-install-planner.behavior.md
+++ b/npm/ui/tooling/source-install-planner.behavior.md
@@ -1,0 +1,37 @@
+# Vize UI Source Install Planner Contract
+
+`@vizejs/ui-tooling` publishes schema version 1 of the source install dry-run
+planner from `./source-install-planner`. The planner is a pure TypeScript
+primitive for repository tooling; it does not read from or write to the
+filesystem.
+
+## Inputs
+
+- `mode` is `"dry-run"`; mutating install modes are outside this foundation.
+- `requestedFamilies` names the source-owned UI families requested by a caller.
+- `sourceFiles` is the caller-provided set of known files, grouped by family
+  name, with source path, destination path, source digest, and optional
+  destination digest.
+- `destinationRoot` is normalized once and joined with each relative
+  destination path for machine-readable target paths.
+
+## Output
+
+- `schemaVersion` is `1`.
+- `actions` are sorted by target path, destination path, source path, family
+  name, and operation.
+- Each action is one of `create`, `overwrite`, `skip`, or `conflict`.
+- `diagnostics` are stable records with `code`, `familyName`, `path`, and
+  `message`.
+- `ok` is true only when no diagnostics exist and no action is a conflict.
+
+## Safety
+
+- Unknown requested families fail closed with no actions.
+- Unsupported runtime modes fail closed with no actions.
+- Source and destination paths must be relative file paths.
+- Absolute paths, empty paths, NUL bytes, and `..` traversal segments are
+  rejected before any writable action can be produced.
+- Duplicate destination paths become conflict actions.
+- Dry-run planning never mutates the destination root; filesystem discovery and
+  writes must stay outside this primitive.

--- a/npm/ui/tooling/source-install-planner.test.ts
+++ b/npm/ui/tooling/source-install-planner.test.ts
@@ -1,0 +1,212 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  UI_SOURCE_INSTALL_PLAN_SCHEMA_VERSION,
+  createUiSourceInstallDryRunPlan,
+  type UiSourceInstallPlanInput,
+} from "./source-install-planner.ts";
+
+function plan(input: Partial<UiSourceInstallPlanInput> = {}) {
+  return createUiSourceInstallDryRunPlan({
+    mode: "dry-run",
+    requestedFamilies: ["button"],
+    destinationRoot: "/workspace/ui",
+    sourceFiles: [
+      {
+        familyName: "button",
+        sourcePath: "src/button.ts",
+        destinationPath: "button.ts",
+        sourceDigest: "sha256:button",
+        destinationDigest: null,
+      },
+    ],
+    ...input,
+  });
+}
+
+void test("emits deterministic dry-run actions in destination path order", () => {
+  const input: UiSourceInstallPlanInput = {
+    mode: "dry-run",
+    requestedFamilies: ["switch", "button", "input", "button"],
+    destinationRoot: "/workspace/ui",
+    sourceFiles: [
+      {
+        familyName: "switch",
+        sourcePath: "src/switch.ts",
+        destinationPath: "form/switch.ts",
+        sourceDigest: "sha256:switch",
+        destinationDigest: "sha256:switch",
+      },
+      {
+        familyName: "input",
+        sourcePath: "src/input.ts",
+        destinationPath: "form/input.ts",
+        sourceDigest: "sha256:input-next",
+        destinationDigest: "sha256:input-prev",
+      },
+      {
+        familyName: "button",
+        sourcePath: "src/button.ts",
+        destinationPath: "actions/button.ts",
+        sourceDigest: "sha256:button",
+        destinationDigest: null,
+      },
+    ],
+  };
+
+  const output = createUiSourceInstallDryRunPlan(input);
+  const reordered = createUiSourceInstallDryRunPlan({
+    ...input,
+    requestedFamilies: [...input.requestedFamilies].reverse(),
+    sourceFiles: [...input.sourceFiles].reverse(),
+  });
+
+  assert.equal(JSON.stringify(output), JSON.stringify(reordered));
+  assert.deepEqual(output.requestedFamilies, ["button", "input", "switch"]);
+  assert.deepEqual(
+    output.actions.map((action) => [action.destinationPath, action.operation]),
+    [
+      ["actions/button.ts", "create"],
+      ["form/input.ts", "overwrite"],
+      ["form/switch.ts", "skip"],
+    ],
+  );
+});
+
+void test("fails closed when a requested family is unknown", () => {
+  const output = plan({ requestedFamilies: ["button", "ghost"] });
+
+  assert.equal(output.ok, false);
+  assert.deepEqual(output.actions, []);
+  assert.deepEqual(output.diagnostics, [
+    {
+      code: "unknown-family",
+      familyName: "ghost",
+      path: null,
+      message: 'Unknown UI source family "ghost"',
+    },
+  ]);
+});
+
+void test("fails closed for unsupported runtime modes", () => {
+  const output = createUiSourceInstallDryRunPlan({
+    mode: "write",
+    requestedFamilies: ["button"],
+    destinationRoot: "/workspace/ui",
+    sourceFiles: [],
+  } as unknown as UiSourceInstallPlanInput);
+
+  assert.equal(output.ok, false);
+  assert.deepEqual(output.actions, []);
+  assert.deepEqual(output.diagnostics, [
+    {
+      code: "unsupported-mode",
+      familyName: null,
+      path: null,
+      message: 'Unsupported UI source install mode; expected "dry-run"',
+    },
+  ]);
+});
+
+void test("rejects path traversal before producing a writable action", () => {
+  const output = plan({
+    sourceFiles: [
+      {
+        familyName: "button",
+        sourcePath: "src/../button.ts",
+        destinationPath: "../button.ts",
+        sourceDigest: "sha256:button",
+      },
+    ],
+  });
+
+  assert.equal(output.ok, false);
+  assert.deepEqual(
+    output.actions.map((action) => [action.operation, action.reason, action.targetPath]),
+    [["conflict", "path-traversal", null]],
+  );
+  assert.deepEqual(
+    output.diagnostics.map((diagnostic) => [diagnostic.code, diagnostic.path]),
+    [
+      ["path-traversal", "../button.ts"],
+      ["path-traversal", "src/../button.ts"],
+    ],
+  );
+});
+
+void test("reports duplicate destination paths as conflicts", () => {
+  const output = plan({
+    requestedFamilies: ["button", "input"],
+    sourceFiles: [
+      {
+        familyName: "input",
+        sourcePath: "src/input.ts",
+        destinationPath: "field.ts",
+        sourceDigest: "sha256:input",
+      },
+      {
+        familyName: "button",
+        sourcePath: "src/button.ts",
+        destinationPath: "field.ts",
+        sourceDigest: "sha256:button",
+      },
+    ],
+  });
+
+  assert.equal(output.ok, false);
+  assert.deepEqual(
+    output.actions.map((action) => [action.familyName, action.operation, action.reason]),
+    [
+      ["button", "conflict", "duplicate-destination"],
+      ["input", "conflict", "duplicate-destination"],
+    ],
+  );
+});
+
+void test("keeps the JSON shape stable for machine consumers", () => {
+  const output = plan();
+
+  assert.equal(output.schemaVersion, UI_SOURCE_INSTALL_PLAN_SCHEMA_VERSION);
+  assert.equal(
+    JSON.stringify(output, null, 2),
+    `{
+  "schemaVersion": 1,
+  "mode": "dry-run",
+  "ok": true,
+  "destinationRoot": "/workspace/ui",
+  "requestedFamilies": [
+    "button"
+  ],
+  "actions": [
+    {
+      "operation": "create",
+      "reason": "destination-missing",
+      "familyName": "button",
+      "sourcePath": "src/button.ts",
+      "destinationPath": "button.ts",
+      "targetPath": "/workspace/ui/button.ts",
+      "sourceDigest": "sha256:button",
+      "destinationDigest": null
+    }
+  ],
+  "diagnostics": []
+}`,
+  );
+});
+
+void test("does not mutate the destination root in dry-run mode", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "ui-source-install-plan-"));
+  try {
+    assert.deepEqual(await readdir(directory), []);
+    const output = plan({ destinationRoot: directory });
+
+    assert.equal(output.actions[0]?.operation, "create");
+    assert.deepEqual(await readdir(directory), []);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/npm/ui/tooling/source-install-planner.ts
+++ b/npm/ui/tooling/source-install-planner.ts
@@ -1,0 +1,340 @@
+import path from "node:path";
+
+export const UI_SOURCE_INSTALL_PLAN_SCHEMA_VERSION = 1;
+
+export type UiSourceInstallMode = "dry-run";
+export type UiSourceInstallActionOperation = "create" | "overwrite" | "skip" | "conflict";
+export type UiSourceInstallActionReason =
+  | "destination-current"
+  | "destination-different"
+  | "destination-missing"
+  | "duplicate-destination"
+  | "invalid-path"
+  | "path-traversal";
+export type UiSourceInstallDiagnosticCode =
+  | "duplicate-destination"
+  | "invalid-path"
+  | "path-traversal"
+  | "unsupported-mode"
+  | "unknown-family";
+
+export interface UiSourceInstallKnownFile {
+  readonly familyName: string;
+  readonly sourcePath: string;
+  readonly destinationPath: string;
+  readonly sourceDigest: string;
+  readonly destinationDigest?: string | null;
+}
+
+export interface UiSourceInstallPlanInput {
+  readonly mode: UiSourceInstallMode;
+  readonly requestedFamilies: readonly string[];
+  readonly destinationRoot: string;
+  readonly sourceFiles: readonly UiSourceInstallKnownFile[];
+}
+
+export interface UiSourceInstallAction {
+  readonly operation: UiSourceInstallActionOperation;
+  readonly reason: UiSourceInstallActionReason;
+  readonly familyName: string;
+  readonly sourcePath: string;
+  readonly destinationPath: string;
+  readonly targetPath: string | null;
+  readonly sourceDigest: string;
+  readonly destinationDigest: string | null;
+}
+
+export interface UiSourceInstallDiagnostic {
+  readonly code: UiSourceInstallDiagnosticCode;
+  readonly familyName: string | null;
+  readonly path: string | null;
+  readonly message: string;
+}
+
+export interface UiSourceInstallPlan {
+  readonly schemaVersion: typeof UI_SOURCE_INSTALL_PLAN_SCHEMA_VERSION;
+  readonly mode: UiSourceInstallMode;
+  readonly ok: boolean;
+  readonly destinationRoot: string;
+  readonly requestedFamilies: readonly string[];
+  readonly actions: readonly UiSourceInstallAction[];
+  readonly diagnostics: readonly UiSourceInstallDiagnostic[];
+}
+
+interface NormalizedPath {
+  readonly path: string | null;
+  readonly code: "invalid-path" | "path-traversal" | null;
+}
+
+interface SelectedFile {
+  readonly familyName: string;
+  readonly sourcePath: string;
+  readonly destinationPath: string;
+  readonly targetPath: string | null;
+  readonly sourceDigest: string;
+  readonly destinationDigest: string | null;
+  readonly diagnostics: readonly UiSourceInstallDiagnostic[];
+}
+
+const WINDOWS_ABSOLUTE_PATH = /^[A-Za-z]:\//u;
+
+export function createUiSourceInstallDryRunPlan(
+  input: UiSourceInstallPlanInput,
+): UiSourceInstallPlan {
+  const destinationRoot = normalizeDestinationRoot(input.destinationRoot);
+  const requestedFamilies = sortedUnique(input.requestedFamilies.map(normalizeName));
+  const diagnostics: UiSourceInstallDiagnostic[] = [];
+
+  if ((input as { readonly mode?: unknown }).mode !== "dry-run") {
+    diagnostics.push({
+      code: "unsupported-mode",
+      familyName: null,
+      path: null,
+      message: 'Unsupported UI source install mode; expected "dry-run"',
+    });
+    return createPlan(destinationRoot, requestedFamilies, [], diagnostics);
+  }
+
+  const knownFamilies = new Set(
+    input.sourceFiles.map((file) => normalizeName(file.familyName)).filter(Boolean),
+  );
+  const unknownFamilies = requestedFamilies.filter((family) => !knownFamilies.has(family));
+  if (unknownFamilies.length > 0) {
+    diagnostics.push(...unknownFamilies.map(createUnknownFamilyDiagnostic));
+    return createPlan(destinationRoot, requestedFamilies, [], diagnostics);
+  }
+
+  const selectedFiles = input.sourceFiles
+    .map(normalizeKnownFile(destinationRoot))
+    .filter((file) => requestedFamilies.includes(file.familyName));
+
+  const destinationCounts = countDestinationPaths(selectedFiles);
+  const actions = selectedFiles.map((file) =>
+    createAction(file, destinationCounts.get(file.destinationPath) ?? 0),
+  );
+
+  diagnostics.push(...selectedFiles.flatMap((file) => file.diagnostics));
+  diagnostics.push(...duplicateDestinationDiagnostics(selectedFiles, destinationCounts));
+
+  return createPlan(destinationRoot, requestedFamilies, actions, diagnostics);
+}
+
+function createPlan(
+  destinationRoot: string,
+  requestedFamilies: readonly string[],
+  actions: readonly UiSourceInstallAction[],
+  diagnostics: readonly UiSourceInstallDiagnostic[],
+): UiSourceInstallPlan {
+  const sortedActions = [...actions].sort(compareActions);
+  const sortedDiagnostics = [...diagnostics].sort(compareDiagnostics);
+
+  return {
+    schemaVersion: UI_SOURCE_INSTALL_PLAN_SCHEMA_VERSION,
+    mode: "dry-run",
+    ok:
+      sortedDiagnostics.length === 0 &&
+      sortedActions.every((action) => action.operation !== "conflict"),
+    destinationRoot,
+    requestedFamilies,
+    actions: sortedActions,
+    diagnostics: sortedDiagnostics,
+  };
+}
+
+function normalizeName(value: string): string {
+  return value.trim();
+}
+
+function sortedUnique(values: readonly string[]): readonly string[] {
+  return [...new Set(values.filter((value) => value.length > 0))].sort(compareText);
+}
+
+function normalizeDestinationRoot(value: string): string {
+  const normalized = value.trim().replaceAll("\\", "/");
+  if (normalized.length === 0) return ".";
+
+  const compact = path.posix.normalize(normalized);
+  return compact.length > 1 && compact.endsWith("/") ? compact.slice(0, -1) : compact;
+}
+
+function normalizeRelativePath(value: string): NormalizedPath {
+  const normalizedSeparators = value.trim().replaceAll("\\", "/");
+  if (normalizedSeparators.length === 0 || normalizedSeparators.includes("\0")) {
+    return { path: null, code: "invalid-path" };
+  }
+
+  if (
+    normalizedSeparators.startsWith("/") ||
+    normalizedSeparators.startsWith("//") ||
+    WINDOWS_ABSOLUTE_PATH.test(normalizedSeparators)
+  ) {
+    return { path: null, code: "invalid-path" };
+  }
+
+  if (normalizedSeparators.split("/").includes("..")) {
+    return { path: null, code: "path-traversal" };
+  }
+
+  const compact = path.posix.normalize(normalizedSeparators);
+  if (compact === "." || compact.startsWith("../")) {
+    return { path: null, code: "path-traversal" };
+  }
+
+  return { path: compact, code: null };
+}
+
+function joinDestinationPath(destinationRoot: string, destinationPath: string): string {
+  if (destinationRoot === ".") return destinationPath;
+  if (destinationRoot === "/") return `/${destinationPath}`;
+  return `${destinationRoot}/${destinationPath}`;
+}
+
+function normalizeKnownFile(destinationRoot: string) {
+  return (file: UiSourceInstallKnownFile): SelectedFile => {
+    const familyName = normalizeName(file.familyName);
+    const source = normalizeRelativePath(file.sourcePath);
+    const destination = normalizeRelativePath(file.destinationPath);
+    const diagnostics = [
+      createPathDiagnostic("source", familyName, file.sourcePath, source.code),
+      createPathDiagnostic("destination", familyName, file.destinationPath, destination.code),
+    ].filter((diagnostic): diagnostic is UiSourceInstallDiagnostic => diagnostic != null);
+
+    return {
+      familyName,
+      sourcePath: source.path ?? file.sourcePath,
+      destinationPath: destination.path ?? file.destinationPath,
+      targetPath:
+        destination.path == null ? null : joinDestinationPath(destinationRoot, destination.path),
+      sourceDigest: file.sourceDigest,
+      destinationDigest: file.destinationDigest ?? null,
+      diagnostics,
+    };
+  };
+}
+
+function countDestinationPaths(files: readonly SelectedFile[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const file of files) {
+    if (file.targetPath == null) continue;
+    counts.set(file.destinationPath, (counts.get(file.destinationPath) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function createAction(file: SelectedFile, destinationCount: number): UiSourceInstallAction {
+  const conflictReason = firstConflictReason(file, destinationCount);
+  if (conflictReason != null) return action(file, "conflict", conflictReason);
+  if (file.destinationDigest == null) return action(file, "create", "destination-missing");
+  if (file.destinationDigest === file.sourceDigest)
+    return action(file, "skip", "destination-current");
+  return action(file, "overwrite", "destination-different");
+}
+
+function action(
+  file: SelectedFile,
+  operation: UiSourceInstallActionOperation,
+  reason: UiSourceInstallActionReason,
+): UiSourceInstallAction {
+  return {
+    operation,
+    reason,
+    familyName: file.familyName,
+    sourcePath: file.sourcePath,
+    destinationPath: file.destinationPath,
+    targetPath: file.targetPath,
+    sourceDigest: file.sourceDigest,
+    destinationDigest: file.destinationDigest,
+  };
+}
+
+function firstConflictReason(
+  file: SelectedFile,
+  destinationCount: number,
+): UiSourceInstallActionReason | null {
+  if (file.diagnostics.some((diagnostic) => diagnostic.code === "path-traversal")) {
+    return "path-traversal";
+  }
+  if (file.diagnostics.length > 0) return "invalid-path";
+  return destinationCount > 1 ? "duplicate-destination" : null;
+}
+
+function createUnknownFamilyDiagnostic(familyName: string): UiSourceInstallDiagnostic {
+  return {
+    code: "unknown-family",
+    familyName,
+    path: null,
+    message: `Unknown UI source family "${familyName}"`,
+  };
+}
+
+function createPathDiagnostic(
+  label: "destination" | "source",
+  familyName: string,
+  filePath: string,
+  code: "invalid-path" | "path-traversal" | null,
+): UiSourceInstallDiagnostic | null {
+  if (code == null) return null;
+
+  const detail =
+    code === "path-traversal"
+      ? "path traversal segments are not allowed"
+      : "paths must be non-empty relative file paths";
+  return {
+    code,
+    familyName,
+    path: filePath,
+    message: `Rejecting ${label} path "${filePath}" for ${familyName}: ${detail}`,
+  };
+}
+
+function duplicateDestinationDiagnostics(
+  files: readonly SelectedFile[],
+  counts: ReadonlyMap<string, number>,
+): readonly UiSourceInstallDiagnostic[] {
+  return files.flatMap((file): readonly UiSourceInstallDiagnostic[] => {
+    if (file.targetPath == null || (counts.get(file.destinationPath) ?? 0) <= 1) return [];
+
+    return [
+      {
+        code: "duplicate-destination",
+        familyName: file.familyName,
+        path: file.destinationPath,
+        message: `Destination path "${file.destinationPath}" is planned more than once`,
+      },
+    ];
+  });
+}
+
+function compareActions(left: UiSourceInstallAction, right: UiSourceInstallAction): number {
+  return (
+    compareNullable(left.targetPath, right.targetPath) ||
+    compareText(left.destinationPath, right.destinationPath) ||
+    compareText(left.sourcePath, right.sourcePath) ||
+    compareText(left.familyName, right.familyName) ||
+    compareText(left.operation, right.operation)
+  );
+}
+
+function compareDiagnostics(
+  left: UiSourceInstallDiagnostic,
+  right: UiSourceInstallDiagnostic,
+): number {
+  return (
+    compareNullable(left.path, right.path) ||
+    compareNullable(left.familyName, right.familyName) ||
+    compareText(left.code, right.code) ||
+    compareText(left.message, right.message)
+  );
+}
+
+function compareNullable(left: string | null, right: string | null): number {
+  if (left === right) return 0;
+  if (left === null) return 1;
+  if (right === null) return -1;
+  return compareText(left, right);
+}
+
+function compareText(left: string, right: string): number {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}

--- a/npm/ui/tooling/source-install-planner.types.test-d.ts
+++ b/npm/ui/tooling/source-install-planner.types.test-d.ts
@@ -1,0 +1,51 @@
+/** Compile-only assertions for the UI source install planner contract. */
+
+import {
+  UI_SOURCE_INSTALL_PLAN_SCHEMA_VERSION,
+  createUiSourceInstallDryRunPlan,
+  type UiSourceInstallActionOperation,
+  type UiSourceInstallMode,
+  type UiSourceInstallPlan,
+} from "./source-install-planner.ts";
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Condition extends true> = Condition;
+
+const output = createUiSourceInstallDryRunPlan({
+  mode: "dry-run",
+  requestedFamilies: ["button"],
+  destinationRoot: "src/components",
+  sourceFiles: [
+    {
+      familyName: "button",
+      sourcePath: "src/button.ts",
+      destinationPath: "button.ts",
+      sourceDigest: "sha256:button",
+    },
+  ],
+});
+
+type _PlannerModeIsDryRunOnly = Expect<Equal<UiSourceInstallMode, "dry-run">>;
+type _PlanSchemaVersionIsLiteral = Expect<
+  Equal<typeof output.schemaVersion, typeof UI_SOURCE_INSTALL_PLAN_SCHEMA_VERSION>
+>;
+type _PlanShapeIsClosed = Expect<Equal<typeof output, UiSourceInstallPlan>>;
+type _OperationsAreClosed = Expect<
+  Equal<UiSourceInstallActionOperation, "conflict" | "create" | "overwrite" | "skip">
+>;
+
+createUiSourceInstallDryRunPlan({
+  // @ts-expect-error dry-run is the only supported planner mode in this slice.
+  mode: "write",
+  requestedFamilies: ["button"],
+  destinationRoot: "src/components",
+  sourceFiles: [],
+});
+
+// @ts-expect-error plan actions are immutable to callers.
+output.actions.push(output.actions[0]);
+// @ts-expect-error planner output cannot be marked successful by consumers.
+output.ok = true;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1197,6 +1197,9 @@ importers:
       '@types/node':
         specifier: catalog:typescript
         version: 25.9.2
+      typescript:
+        specifier: catalog:typescript
+        version: 6.0.3
       vite-plus:
         specifier: catalog:vite-stack
         version: 0.1.24(@tsdown/css@0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(tsx@4.23.12)(yaml@2.9.0))(@types/node@25.9.2)(@voidzero-dev/vite-plus-core@0.1.24(@tsdown/css@0.22.14(jiti@2.7.0)(postcss@8.5.26)(tsdown@0.22.14)(tsx@4.23.12)(yaml@2.9.0))(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)


### PR DESCRIPTION
## Summary
- add a deterministic dry-run planner for installing UI source families
- fail closed for unknown families, invalid paths, duplicate destinations, and unsupported runtime modes
- include behavior and type coverage, and wire the tooling package check to run tsc

Closes #4896

## Verification
- vp install --frozen-lockfile --prefer-offline
- vp exec pnpm check
- vp exec pnpm test
- vp exec pnpm pack --dry-run
- git diff --check origin/main...HEAD
- git diff --check
- forbidden-term scan over .github and npm/ui