### PR TITLE
test(ui): harden toggle prop contract

### DIFF
--- a/npm/ui/core/src/toggle.types.test-d.ts
+++ b/npm/ui/core/src/toggle.types.test-d.ts
@@ -1,7 +1,8 @@
 /** Compile-only assertions for the public toggle contract. */
 
-import type { ComputedRef } from "vue";
+import type { Component, ComputedRef } from "vue";
 
+import { Toggle } from "./toggle.ts";
 import type { ToggleExpose, ToggleSlotState } from "./toggle.ts";
 
 type Equal<Left, Right> =
@@ -11,15 +12,46 @@ type Equal<Left, Right> =
 type Expect<Condition extends true> = Condition;
 
 declare const toggle: ToggleExpose;
+declare const componentTarget: Component;
+
+type ToggleProps = InstanceType<typeof Toggle>["$props"];
 
 type _PressedIsComputedBoolean = Expect<Equal<typeof toggle.pressed, ComputedRef<boolean>>>;
+type _TypePropIsLiteral = Expect<
+  Equal<NonNullable<ToggleProps["type"]>, "button" | "reset" | "submit">
+>;
+type _ModelValueIsBoolean = Expect<Equal<Exclude<ToggleProps["modelValue"], undefined>, boolean>>;
+type _DefaultPressedIsBoolean = Expect<
+  Equal<Exclude<ToggleProps["defaultPressed"], undefined>, boolean>
+>;
 type _SlotStateIsLiteral = Expect<
   Equal<ToggleSlotState, { readonly disabled: boolean; readonly pressed: boolean }>
 >;
 
+const nativeHost: ToggleProps = {
+  ariaLabel: "Bold",
+  defaultPressed: true,
+  type: "submit",
+};
+const customHost: ToggleProps = {
+  as: componentTarget,
+  disabled: false,
+  modelValue: true,
+  native: false,
+};
+
 toggle.setPressed(true);
 toggle.reset();
 toggle.focus();
+
+// @ts-expect-error native button type is limited to platform button submit modes.
+const badButtonType: ToggleProps = { type: "menu" };
+
+// @ts-expect-error controlled pressed state is boolean.
+const badModelValue: ToggleProps = { modelValue: "true" };
+
+// @ts-expect-error disabled state is boolean.
+const badDisabled: ToggleProps = { disabled: "true" };
 
 // @ts-expect-error pressed values are booleans.
 toggle.setPressed("true");
@@ -27,4 +59,10 @@ toggle.setPressed("true");
 // @ts-expect-error slot state always includes the pressed boolean.
 const missingPressed: ToggleSlotState = { disabled: false };
 
+void Toggle;
+void badButtonType;
+void badDisabled;
+void badModelValue;
+void customHost;
 void missingPressed;
+void nativeHost;


### PR DESCRIPTION
## Summary
- strengthen Toggle compile-time prop assertions for native button type, pressed state, disabled state, and custom hosts
- keep runtime behavior unchanged while closing gaps in the public SFC contract

Refs #4900

## Verification
- vp install --frozen-lockfile --prefer-offline
- vp check src scripts vite.config.ts tsconfig.typecheck.json
- vp exec vue-tsc --noEmit -p tsconfig.typecheck.json --pretty false
- vp exec node scripts/check-renderers.ts src
- vp test run
- vp pack
- vp exec node scripts/check-size.mjs
- vp exec node scripts/check-tree-shaking.mjs
- git diff --check origin/main..HEAD
- forbidden-term scan over diff and commit message

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790652833&installation_model_id=422833&pr_number=5333&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5333&signature=15cfa7eda3fe7174be55cd38b1b3a4a72375d5f540b2945eb0d69a211a629ed6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->