### PR TITLE
refactor(patina): migrate vue/no-textarea-mustache to markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -25,6 +25,7 @@ mod jsx_no_inline_style;
 mod jsx_no_multi_spaces;
 mod jsx_no_redundant_roles;
 mod jsx_no_role_presentation_on_focusable;
+mod jsx_no_textarea_mustache;
 mod jsx_placeholder_label_option;
 mod jsx_require_datetime;
 mod jsx_streaming;

--- a/crates/vize_patina/src/linter/tests/jsx_no_textarea_mustache.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_no_textarea_mustache.rs
@@ -1,0 +1,232 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::vue::NoTextareaMustache;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+fn diagnostic_slices<'a>(source: &'a str, result: &LintResult) -> Vec<&'a str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| &source[diagnostic.start as usize..diagnostic.end as usize])
+        .collect()
+}
+
+#[test]
+fn no_textarea_mustache_fires_on_jsx_and_tsx_markup() {
+    let linter = linter_with(Box::new(NoTextareaMustache));
+    let source = r#"const A = () => <textarea>{message}</textarea>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(diagnostic_rules(&result), vec!["vue/no-textarea-mustache"]);
+    assert_eq!(result.error_count, 1);
+    assert_eq!(result.warning_count, 0);
+    assert_eq!(diagnostic_slices(source, &result), vec![r#"{message}"#]);
+
+    let diag = &result.diagnostics[0];
+    assert_eq!(diag.severity, Severity::Error);
+    assert_eq!(
+        diag.message,
+        "Mustache interpolation inside textarea is not allowed"
+    );
+    assert_eq!(
+        diag.help.as_deref(),
+        Some("Use v-model instead of mustache interpolation in textarea")
+    );
+    assert!(diag.fix.is_none());
+
+    let tsx = r#"const A = (): JSX.Element => <textarea>{message}</textarea>;"#;
+    let tsx_result = linter.lint_jsx(tsx, "test.tsx", JsxLang::Tsx);
+    assert_eq!(
+        diagnostic_slices(tsx, &tsx_result),
+        vec![r#"{message}"#],
+        "TSX should use the same authored source range"
+    );
+}
+
+#[test]
+fn no_textarea_mustache_preserves_jsx_clean_boundaries() {
+    let linter = linter_with(Box::new(NoTextareaMustache));
+    for source in [
+        r#"const A = () => <textarea defaultValue={message} />;"#,
+        r#"const A = () => <div>{message}</div>;"#,
+        r#"const A = () => <Textarea>{message}</Textarea>;"#,
+        r#"const A = () => <TEXTAREA>{message}</TEXTAREA>;"#,
+        r#"const A = () => <Forms.textarea>{message}</Forms.textarea>;"#,
+        r#"const A = () => <svg:textarea>{message}</svg:textarea>;"#,
+        r#"const A = () => <textarea><span>{message}</span></textarea>;"#,
+        r#"const A = () => <textarea>{/* comment */}</textarea>;"#,
+        r#"const A = () => <textarea>{"message"}</textarea>;"#,
+        r#"const A = () => <textarea>{cond && <span />}</textarea>;"#,
+        r#"const A = () => <textarea>{condition ? <span /> : <em />}</textarea>;"#,
+        r#"const A = () => <textarea>{items.map(() => <span />)}</textarea>;"#,
+        r#"const A = () => <Comp fallback={<textarea>{message}</textarea>} />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.error_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.warning_count, 0, "must not warn for {source}");
+    }
+}
+
+#[test]
+fn no_textarea_mustache_reports_multiple_jsx_expressions_in_source_order() {
+    let linter = linter_with(Box::new(NoTextareaMustache));
+    let source = r#"const A = () => <textarea>{first}{second}</textarea>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["vue/no-textarea-mustache", "vue/no-textarea-mustache"]
+    );
+    assert_eq!(result.error_count, 2);
+    assert_eq!(result.warning_count, 0);
+    assert_eq!(
+        diagnostic_slices(source, &result),
+        vec![r#"{first}"#, r#"{second}"#]
+    );
+}
+
+#[test]
+fn no_textarea_mustache_reports_direct_jsx_expression_shapes() {
+    let linter = linter_with(Box::new(NoTextareaMustache));
+    for (source, expected) in [
+        (
+            r#"const A = () => <textarea>{a + b}</textarea>;"#,
+            r#"{a + b}"#,
+        ),
+        (
+            r#"const A = () => <textarea>{null}</textarea>;"#,
+            r#"{null}"#,
+        ),
+        (r#"const A = () => <textarea>{0}</textarea>;"#, r#"{0}"#),
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(diagnostic_rules(&result), vec!["vue/no-textarea-mustache"]);
+        assert_eq!(result.error_count, 1);
+        assert_eq!(result.warning_count, 0);
+        assert_eq!(diagnostic_slices(source, &result), vec![expected]);
+    }
+}
+
+#[test]
+fn no_textarea_mustache_keeps_jsx_template_literal_as_expression() {
+    let linter = linter_with(Box::new(NoTextareaMustache));
+    let source = r#"const A = () => <textarea>{`message`}</textarea>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(diagnostic_rules(&result), vec!["vue/no-textarea-mustache"]);
+    assert_eq!(result.error_count, 1);
+    assert_eq!(result.warning_count, 0);
+    assert_eq!(diagnostic_slices(source, &result), vec![r#"{`message`}"#]);
+}
+
+#[test]
+fn no_textarea_mustache_reports_jsx_fragment_children_after_lowering() {
+    let linter = linter_with(Box::new(NoTextareaMustache));
+    let source = r#"const A = () => <textarea><>{message}</></textarea>;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(diagnostic_rules(&result), vec!["vue/no-textarea-mustache"]);
+    assert_eq!(result.error_count, 1);
+    assert_eq!(result.warning_count, 0);
+    assert_eq!(diagnostic_slices(source, &result), vec![r#"{message}"#]);
+}
+
+#[test]
+fn migrated_no_textarea_mustache_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(NoTextareaMustache));
+    let result = linter.lint_jsx(
+        r#"const A = () => <textarea>{message}</textarea>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated no-textarea-mustache rule must report once: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.error_count, 1);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn no_textarea_mustache_honors_jsx_lowered_markup_rule_config() {
+    let source = r#"const A = () => <textarea>{message}</textarea>;"#;
+    let warning = linter_with(Box::new(NoTextareaMustache))
+        .with_rule_severity_overrides(vec![("vue/no-textarea-mustache".into(), Severity::Warning)])
+        .lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert_eq!(warning.error_count, 0);
+    assert_eq!(warning.warning_count, 1);
+    assert_eq!(warning.diagnostics[0].severity, Severity::Warning);
+
+    let disabled = linter_with(Box::new(NoTextareaMustache))
+        .with_disabled_rules(vec!["vue/no-textarea-mustache".into()])
+        .lint_jsx(source, "test.jsx", JsxLang::Jsx);
+    assert!(
+        disabled.diagnostics.is_empty(),
+        "disabled lowered-markup rules must not report: {:?}",
+        disabled.diagnostics
+    );
+}
+
+#[test]
+fn no_textarea_mustache_sfc_offsets_template_diagnostics() {
+    let source = r#"<script setup lang="ts">
+const message = "hello";
+</script>
+
+<template>
+  <textarea>{{ message }}</textarea>
+</template>
+"#;
+    let linter = linter_with(Box::new(NoTextareaMustache));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(diagnostic_rules(&result), vec!["vue/no-textarea-mustache"]);
+    assert_eq!(diagnostic_slices(source, &result), vec![r#"{{ message }}"#]);
+
+    let expected = source.find(r#"{{ message }}"#).unwrap() as u32;
+    let diag = &result.diagnostics[0];
+    assert_eq!(
+        diag.start, expected,
+        "SFC diagnostic must be offset into file coordinates"
+    );
+    assert_eq!(diag.end, expected + r#"{{ message }}"#.len() as u32);
+}
+
+#[test]
+fn no_textarea_mustache_sfc_does_not_lint_script_tsx() {
+    let source = r#"<script setup lang="tsx">
+const A = () => <textarea>{message}</textarea>;
+</script>
+"#;
+    let linter = linter_with(Box::new(NoTextareaMustache));
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(
+        result.error_count, 0,
+        "SFC no-textarea-mustache must not inspect JSX inside script blocks: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 0);
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -29,6 +29,7 @@ mod no_multi_spaces_tests;
 mod no_redundant_roles_tests;
 mod no_role_presentation_on_focusable_jsx_tests;
 mod no_role_presentation_on_focusable_tests;
+mod no_textarea_mustache_tests;
 mod placeholder_label_option_tests;
 mod require_datetime_tests;
 mod use_list_tests;

--- a/crates/vize_patina/src/markup/tests/no_textarea_mustache_tests.rs
+++ b/crates/vize_patina/src/markup/tests/no_textarea_mustache_tests.rs
@@ -1,0 +1,224 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::vue::NoTextareaMustache;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> Vec<(u32, u32)> {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, errors) = parser.parse();
+    assert!(
+        errors.is_empty(),
+        "template fixture must parse without errors: {errors:?}"
+    );
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics()
+        .iter()
+        .map(|diagnostic| (diagnostic.start, diagnostic.end))
+        .collect()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> Vec<(u32, u32)> {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    assert!(
+        lowered.diagnostics.is_empty(),
+        "JSX fixture must lower without diagnostics: {:?}",
+        lowered.diagnostics
+    );
+
+    let mut ranges = Vec::new();
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        ranges.extend(
+            lint.diagnostics()
+                .iter()
+                .map(|diagnostic| (diagnostic.start, diagnostic.end)),
+        );
+    }
+    ranges
+}
+
+fn slices<'a>(source: &'a str, ranges: &[(u32, u32)]) -> Vec<&'a str> {
+    ranges
+        .iter()
+        .map(|(start, end)| &source[*start as usize..*end as usize])
+        .collect()
+}
+
+#[test]
+fn no_textarea_mustache_template_boundaries() {
+    let rule = NoTextareaMustache;
+    for (source, expected, label) in [
+        (
+            r#"<textarea v-model="message"></textarea>"#,
+            Vec::<&str>::new(),
+            "v-model is the valid replacement",
+        ),
+        (
+            r#"<div>{{ message }}</div>"#,
+            Vec::<&str>::new(),
+            "mustache outside textarea stays clean",
+        ),
+        (
+            r#"<Textarea>{{ message }}</Textarea>"#,
+            Vec::<&str>::new(),
+            "component spelling stays clean",
+        ),
+        (
+            r#"<TEXTAREA>{{ message }}</TEXTAREA>"#,
+            Vec::<&str>::new(),
+            "legacy tag check is lowercase exact",
+        ),
+        (
+            r#"<textarea><span>{{ message }}</span></textarea>"#,
+            vec![r#"{{ message }}"#],
+            "textarea rawtext keeps legacy interpolation behavior",
+        ),
+        (
+            r#"<textarea><!-- comment --></textarea>"#,
+            Vec::<&str>::new(),
+            "comments stay clean",
+        ),
+        (
+            r#"<textarea>{{ message }}</textarea>"#,
+            vec![r#"{{ message }}"#],
+            "direct mustache warns",
+        ),
+        (
+            r#"<textarea v-model="model">{{ message }}</textarea>"#,
+            vec![r#"{{ message }}"#],
+            "v-model does not suppress a direct mustache",
+        ),
+        (
+            r#"<textarea>{{ first }}{{ second }}</textarea>"#,
+            vec![r#"{{ first }}"#, r#"{{ second }}"#],
+            "each direct mustache reports in source order",
+        ),
+    ] {
+        let ranges = run_over_template(&rule, source);
+        assert_eq!(
+            slices(source, &ranges),
+            expected,
+            "template boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn no_textarea_mustache_jsx_lowered_boundaries() {
+    let rule = NoTextareaMustache;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <textarea defaultValue={message} />;"#,
+            Vec::<&str>::new(),
+            "defaultValue prop is clean",
+        ),
+        (
+            r#"const A = () => <div>{message}</div>;"#,
+            Vec::<&str>::new(),
+            "expression outside textarea stays clean",
+        ),
+        (
+            r#"const A = () => <Textarea>{message}</Textarea>;"#,
+            Vec::<&str>::new(),
+            "component spelling stays clean",
+        ),
+        (
+            r#"const A = () => <Forms.textarea>{message}</Forms.textarea>;"#,
+            Vec::<&str>::new(),
+            "member component spelling stays clean",
+        ),
+        (
+            r#"const A = () => <svg:textarea>{message}</svg:textarea>;"#,
+            Vec::<&str>::new(),
+            "qualified textarea tag stays clean",
+        ),
+        (
+            r#"const A = () => <textarea><span>{message}</span></textarea>;"#,
+            Vec::<&str>::new(),
+            "nested child expression is not a direct textarea child",
+        ),
+        (
+            r#"const A = () => <textarea>{/* comment */}</textarea>;"#,
+            Vec::<&str>::new(),
+            "empty expression comments stay clean",
+        ),
+        (
+            r#"const A = () => <textarea>{message}</textarea>;"#,
+            vec![r#"{message}"#],
+            "direct expression warns",
+        ),
+        (
+            r#"const A = () => <textarea>{a + b}</textarea>;"#,
+            vec![r#"{a + b}"#],
+            "complex direct expression warns",
+        ),
+        (
+            r#"const A = () => <textarea>{null}</textarea>;"#,
+            vec![r#"{null}"#],
+            "null direct expression stays an interpolation",
+        ),
+        (
+            r#"const A = () => <textarea>{0}</textarea>;"#,
+            vec![r#"{0}"#],
+            "numeric direct expression stays an interpolation",
+        ),
+        (
+            r#"const A = () => <textarea>{"message"}</textarea>;"#,
+            Vec::<&str>::new(),
+            "literal string expression lowers to static text",
+        ),
+        (
+            r#"const A = () => <textarea>{condition ? <span /> : <em />}</textarea>;"#,
+            Vec::<&str>::new(),
+            "lowered ternary element arms are not mustache interpolation",
+        ),
+        (
+            r#"const A = () => <textarea>{cond && <span />}</textarea>;"#,
+            Vec::<&str>::new(),
+            "lowered control-flow element child is not a mustache interpolation",
+        ),
+        (
+            r#"const A = () => <textarea>{items.map(() => <span />)}</textarea>;"#,
+            Vec::<&str>::new(),
+            "lowered list element child is not a mustache interpolation",
+        ),
+        (
+            r#"const A = () => <Comp fallback={<textarea>{message}</textarea>} />;"#,
+            Vec::<&str>::new(),
+            "JSX prop values stay outside the lowered child surface",
+        ),
+        (
+            r#"const A = () => <textarea>{`message`}</textarea>;"#,
+            vec![r#"{`message`}"#],
+            "template literal expression remains an interpolation",
+        ),
+        (
+            r#"const A = () => <textarea>{first}{second}</textarea>;"#,
+            vec![r#"{first}"#, r#"{second}"#],
+            "multiple direct expressions report in source order",
+        ),
+        (
+            r#"const A = () => <textarea><>{message}</></textarea>;"#,
+            vec![r#"{message}"#],
+            "lowered fragments are transparent under textarea",
+        ),
+    ] {
+        assert_eq!(
+            slices(source, &run_over_jsx_lowered(&rule, source)),
+            expected,
+            "lowered JSX boundary changed for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/vue/no_textarea_mustache.rs
+++ b/crates/vize_patina/src/rules/vue/no_textarea_mustache.rs
@@ -19,8 +19,9 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupContext, MarkupElement, MarkupNode, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, TemplateChildNode};
+use vize_relief::ElementNode;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-textarea-mustache",
@@ -33,27 +34,51 @@ static META: RuleMeta = RuleMeta {
 /// Disallow mustache in textarea
 pub struct NoTextareaMustache;
 
+impl NoTextareaMustache {
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        // Preserve the legacy exact lowercase tag check. In JSX, capitalized
+        // `<Textarea>` remains a component and must not be treated as native.
+        if !element.is_unqualified_tag_exact("textarea") {
+            return;
+        }
+
+        element.walk_children(&mut |child| {
+            if let MarkupNode::Interpolation(range) = child {
+                ctx.error_at_with_help(
+                    ctx.t("vue/no-textarea-mustache.message"),
+                    range,
+                    ctx.t("vue/no-textarea-mustache.help"),
+                );
+            }
+        });
+    }
+}
+
+impl MarkupRule for NoTextareaMustache {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        Self::check_element(ctx.lint(), element);
+    }
+}
+
 impl Rule for NoTextareaMustache {
     fn meta(&self) -> &'static RuleMeta {
         &META
     }
 
-    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        // Only check <textarea> elements
-        if element.tag != "textarea" {
-            return;
-        }
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
 
-        // Check for interpolation in children
-        for child in element.children.iter() {
-            if let TemplateChildNode::Interpolation(interp) = child {
-                ctx.error_with_help(
-                    ctx.t("vue/no-textarea-mustache.message"),
-                    &interp.loc,
-                    ctx.t("vue/no-textarea-mustache.help"),
-                );
-            }
-        }
+    fn jsx_needs_lowering(&self) -> bool {
+        true
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           326 |                   326 |                 0 |             285 |     280 |             672 |      219 |           368 |           530 |
+| Linter                     |           327 |                   327 |                 0 |             286 |     280 |             672 |      221 |           369 |           532 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,8 +99,8 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         326 |             224 |      102 |
-| old AST/parser   |         243 |             207 |       36 |
+| S0               |         327 |             224 |      103 |
+| old AST/parser   |         244 |             207 |       37 |
 | Croquis analysis |          42 |              38 |        4 |
 | raw OXC          |         280 |             203 |       77 |
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:44`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:45`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 62 omitted.
+Additional test/dev rows are in the TSV: 63 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -994,9 +994,9 @@ linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	ra
 linter	Linter	source	crates/vize_patina/src/markup/jsx_roots.rs	2	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/jsx_roots.rs	2	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/source_ranges.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	44	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	44	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	44	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	45	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	45	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	45	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1052,6 +1052,8 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_jsx_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_tests.rs	5	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_textarea_mustache_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_textarea_mustache_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/placeholder_label_option_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/placeholder_label_option_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/placeholder_label_option_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1478,7 +1480,7 @@ linter	Linter	source	crates/vize_patina/src/rules/vue/no_reserved_component_name
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_template_key.rs	27	s0	S0	stage	vize_s0	preferred	2
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_template_key.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	4
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_template_target_blank.rs	32	old_ast	old AST/parser	old	vize_relief	legacy	3
-linter	Linter	source	crates/vize_patina/src/rules/vue/no_textarea_mustache.rs	23	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/no_textarea_mustache.rs	24	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_undefined_refs.rs	8	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_undefined_refs.rs	8	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_unsafe_url.rs	46	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 34, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 35, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 113, `ir` 25, `ir-lowered` 9, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (34 = 34 `markup-facade` rules)
+- JSX lanes: `fallback` 112, `ir` 25, `ir-lowered` 10, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (35 = 35 `markup-facade` rules)
 - classification: neutral-core-candidate **88** · vue-dialect-bound **135** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -236,7 +236,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `vue/no-template-lang`                          | template-family | `opinionated/vue/no_template_lang.rs`                  | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
 | `vue/no-template-shadow`                        | template-family | `opinionated/vue/no_template_shadow.rs`                | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-template-target-blank`                  | template-family | `vue/no_template_target_blank.rs`                      | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |
-| `vue/no-textarea-mustache`                      | template-family | `vue/no_textarea_mustache.rs`                          | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
+| `vue/no-textarea-mustache`                      | template-family | `vue/no_textarea_mustache.rs`                          | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-undefined-refs`                         | template-family | `vue/no_undefined_refs.rs`                             | template-ast                   | yes (template-visitor)           | yes (fallback)              | ctx 1                                                                                               | neutral-core-candidate |
 | `vue/no-unsafe-url`                             | template-family | `vue/no_unsafe_url.rs`                                 | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-unsandboxed-iframe`                     | template-family | `vue/no_unsandboxed_iframe.rs`                         | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |


### PR DESCRIPTION
Fixes #5336

## Summary
- migrate `vue/no-textarea-mustache` to the Patina markup facade while preserving the legacy visitor path
- keep JSX on the lowered IR fallback path to preserve current diagnostics and boundary behavior
- add Vue template, JSX/TSX, SFC offset, rule-config, parser/lowering, and duplicate-backend regression coverage
- refresh Davinci rule parity and consumer migration inventories

## Validation
- `cargo fmt --all -- --check`
- `cargo test -q -p vize_patina --lib no_textarea_mustache --locked`
- `cargo test -q -p vize_patina --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -q --workspace --locked`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `node tools/davinci/croquis-consumers.mjs --check`
- `node tools/davinci/matrix-gen.mjs --check`
- `node tools/fixtures/patina-rule-map.mjs --check`
- `node tools/davinci/assertion-lint.mjs`
- `node --test tests/tooling/davinci-assertion-lint.test.ts`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo bench -q -p vize_patina --bench davinci_markup -- --quick`
- `node tools/davinci/bench-compare.mjs --bench patina_jsx_markup_one_root`
- `cargo bench -q -p vize_patina --bench markup_ir_bench -- --quick`
- `git diff --check`

## Risk
- behavior-preserving migration only; no rollout
- JSX remains `ir-lowered` intentionally

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790655654&installation_model_id=422833&pr_number=5337&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5337&signature=3c7fe206b6f5b4f618bb77547309760cb711b8a9a29ea68cc3f094cf13eec2a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `vue/no-textarea-mustache` linting for Vue templates, JSX, and TSX.
  * Added accurate diagnostics for interpolations inside lowercase `<textarea>` elements.
  * Improved handling of fragments, nested content, comments, components, and source ranges.

* **Documentation**
  * Updated rule coverage and parity information to reflect expanded JSX support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->