### PR TITLE
refactor(patina): add markup context ancestry substrate

### DIFF
--- a/crates/vize_patina/src/markup.rs
+++ b/crates/vize_patina/src/markup.rs
@@ -49,10 +49,7 @@ use oxc_ast::ast::{
     JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXChild, JSXElement,
     JSXElementName, JSXExpression, JSXFragment, JSXText, Program,
 };
-use oxc_ast_visit::{
-    Visit,
-    walk::{walk_jsx_element, walk_jsx_fragment, walk_program},
-};
+use oxc_ast_visit::{Visit, walk::walk_program};
 use oxc_span::Span;
 use std::marker::PhantomData;
 use vize_croquis::Croquis;
@@ -60,7 +57,7 @@ use vize_relief::{
     AttributeNode, DirectiveNode, ElementNode, ElementType, ExpressionNode, ForNode, IfNode,
     PropNode, RootNode, SourceLocation, TemplateChildNode, TextNode,
 };
-use vize_s0::{String, profile};
+use vize_s0::{SmallVec, String, profile};
 
 /// High-level classification for a markup element.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -161,7 +158,7 @@ impl<'a> MarkupDocument<'a> {
         match self.inner {
             MarkupDocumentInner::Relief(root) => walk_relief_children(&root.children, enter, exit),
             MarkupDocumentInner::Jsx { program, offset } => {
-                walk_jsx_program(program, offset, enter, exit)
+                jsx_roots::walk_jsx_program(program, offset, enter, exit)
             }
         }
     }
@@ -275,12 +272,12 @@ impl<'a> MarkupElement<'a> {
                 }
             }
             MarkupElementInner::JsxElement { node, offset } => {
-                for child in jsx_element_ref(node).jsx_children() {
+                for child in &jsx_element_ref(node).children {
                     visitor(MarkupNode::from_jsx_child(child, offset));
                 }
             }
             MarkupElementInner::JsxFragment { node, offset } => {
-                for child in jsx_fragment_ref(node).jsx_children() {
+                for child in &jsx_fragment_ref(node).children {
                     visitor(MarkupNode::from_jsx_child(child, offset));
                 }
             }
@@ -1007,46 +1004,6 @@ fn walk_relief_children<'a>(
     }
 }
 
-fn walk_jsx_program<'a>(
-    program: &'a Program<'a>,
-    offset: u32,
-    enter: &mut impl FnMut(MarkupElement<'a>),
-    exit: &mut impl FnMut(MarkupElement<'a>),
-) {
-    struct JsxMarkupWalker<'enter, 'exit, FEnter, FExit> {
-        offset: u32,
-        enter: &'enter mut FEnter,
-        exit: &'exit mut FExit,
-    }
-
-    impl<'ast, FEnter, FExit> Visit<'ast> for JsxMarkupWalker<'_, '_, FEnter, FExit>
-    where
-        FEnter: FnMut(MarkupElement<'ast>),
-        FExit: FnMut(MarkupElement<'ast>),
-    {
-        fn visit_jsx_element(&mut self, it: &JSXElement<'ast>) {
-            let element = MarkupElement::from_jsx_element(it as *const _, self.offset);
-            (self.enter)(element);
-            walk_jsx_element(self, it);
-            (self.exit)(element);
-        }
-
-        fn visit_jsx_fragment(&mut self, it: &JSXFragment<'ast>) {
-            let element = MarkupElement::from_jsx_fragment(it as *const _, self.offset);
-            (self.enter)(element);
-            walk_jsx_fragment(self, it);
-            (self.exit)(element);
-        }
-    }
-
-    let mut walker = JsxMarkupWalker {
-        offset,
-        enter,
-        exit,
-    };
-    walk_program(&mut walker, program);
-}
-
 fn element_children_relief<'a>(element: MarkupElement<'a>) -> &'a [TemplateChildNode<'a>] {
     match element.inner {
         MarkupElementInner::Relief(node) => &node.children,
@@ -1087,22 +1044,6 @@ fn jsx_text_ref<'a>(node: *const JSXText<'a>) -> &'a JSXText<'a> {
     // OXC allocator for the current program. The markup adapter only exposes
     // shared reads, and all adapters are dropped before the program is dropped.
     unsafe { &*node }
-}
-
-trait JsxChildContainer<'a> {
-    fn jsx_children(&self) -> &oxc_allocator::Vec<'a, JSXChild<'a>>;
-}
-
-impl<'a> JsxChildContainer<'a> for JSXElement<'a> {
-    fn jsx_children(&self) -> &oxc_allocator::Vec<'a, JSXChild<'a>> {
-        &self.children
-    }
-}
-
-impl<'a> JsxChildContainer<'a> for JSXFragment<'a> {
-    fn jsx_children(&self) -> &oxc_allocator::Vec<'a, JSXChild<'a>> {
-        &self.children
-    }
 }
 
 #[inline]
@@ -1368,6 +1309,7 @@ pub struct MarkupContext<'ctx, 'a> {
     syntax: TemplateSyntax,
     is_template: bool,
     analysis: Option<&'a Croquis>,
+    element_stack: SmallVec<[MarkupElement<'a>; 32]>,
 }
 
 impl<'ctx, 'a> MarkupContext<'ctx, 'a> {
@@ -1382,6 +1324,7 @@ impl<'ctx, 'a> MarkupContext<'ctx, 'a> {
             syntax: document.syntax(),
             is_template: document.is_template(),
             analysis: document.analysis(),
+            element_stack: SmallVec::new(),
             lint,
         }
     }
@@ -1416,6 +1359,47 @@ impl<'ctx, 'a> MarkupContext<'ctx, 'a> {
     #[inline]
     pub fn analysis(&self) -> Option<&'a Croquis> {
         self.analysis
+    }
+
+    /// Current element being visited.
+    ///
+    /// The current element is pushed before [`MarkupRule::enter_element`] and
+    /// popped after [`MarkupRule::exit_element`], matching the legacy template
+    /// visitor's [`LintContext`] element-stack timing.
+    #[inline]
+    pub fn current_element(&self) -> Option<MarkupElement<'a>> {
+        self.element_stack.last().copied()
+    }
+
+    /// Parent element of the current markup element, if any.
+    #[inline]
+    pub fn parent_element(&self) -> Option<MarkupElement<'a>> {
+        self.element_stack
+            .get(self.element_stack.len().checked_sub(2)?)
+            .copied()
+    }
+
+    /// Ancestor elements of the current markup element, root first.
+    #[inline]
+    pub fn ancestor_elements(&self) -> impl DoubleEndedIterator<Item = MarkupElement<'a>> + '_ {
+        let ancestor_len = self.element_stack.len().saturating_sub(1);
+        self.element_stack[..ancestor_len].iter().copied()
+    }
+
+    /// Check whether any ancestor of the current element matches `predicate`.
+    #[inline]
+    pub fn has_ancestor(&self, predicate: impl FnMut(MarkupElement<'a>) -> bool) -> bool {
+        self.ancestor_elements().any(predicate)
+    }
+
+    #[inline]
+    fn push_element(&mut self, element: MarkupElement<'a>) {
+        self.element_stack.push(element);
+    }
+
+    #[inline]
+    fn pop_element(&mut self) -> Option<MarkupElement<'a>> {
+        self.element_stack.pop()
     }
 }
 
@@ -1564,6 +1548,8 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
     }
 
     fn visit_element(&mut self, element: MarkupElement<'a>) {
+        self.ctx.push_element(element);
+
         self.set_rule();
         self.rule.enter_element(self.ctx, &element);
 
@@ -1581,15 +1567,21 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
             MarkupElementInner::Relief(node) => self.visit_relief_children(&node.children),
             MarkupElementInner::JsxElement { node, offset } => {
                 jsx_roots::visit_attribute_roots(self, jsx_element_ref(node), offset);
-                self.visit_jsx_children(jsx_element_ref(node).jsx_children(), offset)
+                self.visit_jsx_children(&jsx_element_ref(node).children, offset)
             }
             MarkupElementInner::JsxFragment { node, offset } => {
-                self.visit_jsx_children(jsx_fragment_ref(node).jsx_children(), offset)
+                self.visit_jsx_children(&jsx_fragment_ref(node).children, offset)
             }
         }
 
         self.set_rule();
         self.rule.exit_element(self.ctx, &element);
+
+        let popped = self.ctx.pop_element();
+        debug_assert!(
+            popped.is_some(),
+            "markup visitor must pop the element it just visited"
+        );
     }
 
     fn visit_jsx_program(&mut self, program: &'a Program<'a>, offset: u32) {

--- a/crates/vize_patina/src/markup/jsx_roots.rs
+++ b/crates/vize_patina/src/markup/jsx_roots.rs
@@ -1,11 +1,14 @@
 use super::{MarkupDocumentVisitor, MarkupElement, MarkupRule};
 use oxc_ast::ast::{
     Expression, JSXAttributeItem, JSXAttributeValue, JSXElement, JSXExpressionContainer,
-    JSXFragment,
+    JSXFragment, Program,
 };
 use oxc_ast_visit::{
     Visit,
-    walk::{walk_expression, walk_jsx_expression_container},
+    walk::{
+        walk_expression, walk_jsx_element, walk_jsx_expression_container, walk_jsx_fragment,
+        walk_program,
+    },
 };
 use std::marker::PhantomData;
 
@@ -38,6 +41,46 @@ where
             self.offset,
         ));
     }
+}
+
+pub(super) fn walk_jsx_program<'a>(
+    program: &'a Program<'a>,
+    offset: u32,
+    enter: &mut impl FnMut(MarkupElement<'a>),
+    exit: &mut impl FnMut(MarkupElement<'a>),
+) {
+    struct JsxMarkupWalker<'enter, 'exit, FEnter, FExit> {
+        offset: u32,
+        enter: &'enter mut FEnter,
+        exit: &'exit mut FExit,
+    }
+
+    impl<'ast, FEnter, FExit> Visit<'ast> for JsxMarkupWalker<'_, '_, FEnter, FExit>
+    where
+        FEnter: FnMut(MarkupElement<'ast>),
+        FExit: FnMut(MarkupElement<'ast>),
+    {
+        fn visit_jsx_element(&mut self, it: &JSXElement<'ast>) {
+            let element = MarkupElement::from_jsx_element(it as *const _, self.offset);
+            (self.enter)(element);
+            walk_jsx_element(self, it);
+            (self.exit)(element);
+        }
+
+        fn visit_jsx_fragment(&mut self, it: &JSXFragment<'ast>) {
+            let element = MarkupElement::from_jsx_fragment(it as *const _, self.offset);
+            (self.enter)(element);
+            walk_jsx_fragment(self, it);
+            (self.exit)(element);
+        }
+    }
+
+    let mut walker = JsxMarkupWalker {
+        offset,
+        enter,
+        exit,
+    };
+    walk_program(&mut walker, program);
 }
 
 pub(super) fn visit_expression_container_roots<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized>(

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -7,6 +7,7 @@
 // Wrapped in an inline `#[cfg(test)] mod` (the repo convention for split
 // test files) so the Davinci assertion lint, which only scans inline
 // `#[cfg(test)] mod` bodies under `src/`, keeps covering these tests.
+mod ancestry_tests;
 mod deprecated_attr_tests;
 mod heading_levels_tests;
 mod iframe_has_title_jsx_tests;

--- a/crates/vize_patina/src/markup/tests/ancestry_tests.rs
+++ b/crates/vize_patina/src/markup/tests/ancestry_tests.rs
@@ -1,0 +1,295 @@
+use std::cell::RefCell;
+
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{
+    MarkupBinding, MarkupContext, MarkupDirective, MarkupDocument, MarkupElement, MarkupRule,
+    MarkupText,
+};
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+#[derive(Default)]
+struct AncestryProbe {
+    entries: RefCell<Vec<String>>,
+    exits: RefCell<Vec<String>>,
+    callbacks: RefCell<Vec<String>>,
+}
+
+impl MarkupRule for AncestryProbe {
+    fn name(&self) -> &'static str {
+        "test/markup-ancestry"
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        self.entries
+            .borrow_mut()
+            .push(snapshot("enter", ctx, element));
+    }
+
+    fn exit_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        self.exits.borrow_mut().push(snapshot("exit", ctx, element));
+    }
+
+    fn enter_binding<'a>(
+        &self,
+        ctx: &mut MarkupContext<'_, 'a>,
+        element: &MarkupElement<'a>,
+        binding: &MarkupBinding<'a>,
+    ) {
+        if element.is_tag("section") {
+            self.callbacks.borrow_mut().push(format!(
+                "binding:{} {}",
+                binding.arg_name().unwrap_or("-"),
+                stack_snapshot(ctx)
+            ));
+        }
+    }
+
+    fn enter_directive<'a>(
+        &self,
+        ctx: &mut MarkupContext<'_, 'a>,
+        element: &MarkupElement<'a>,
+        directive: &MarkupDirective<'a>,
+    ) {
+        if element.is_tag("section") {
+            self.callbacks.borrow_mut().push(format!(
+                "directive:{}:{} {}",
+                directive.name(),
+                directive.arg_name().unwrap_or("-"),
+                stack_snapshot(ctx)
+            ));
+        }
+    }
+
+    fn enter_text<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, text: &MarkupText<'a>) {
+        if !text.content().trim().is_empty() {
+            self.callbacks
+                .borrow_mut()
+                .push(format!("text {}", stack_snapshot(ctx)));
+        }
+    }
+
+    fn enter_interpolation(&self, ctx: &mut MarkupContext<'_, '_>, _range: crate::ir::ByteRange) {
+        self.callbacks
+            .borrow_mut()
+            .push(format!("interpolation {}", stack_snapshot(ctx)));
+    }
+}
+
+fn snapshot(label: &str, ctx: &MarkupContext<'_, '_>, element: &MarkupElement<'_>) -> String {
+    let parent = ctx
+        .parent_element()
+        .map(tag_name)
+        .unwrap_or_else(|| "-".to_owned());
+    let current = ctx
+        .current_element()
+        .map(tag_name)
+        .unwrap_or_else(|| "-".to_owned());
+    let ancestors = ctx.ancestor_elements().map(tag_name).collect::<Vec<_>>();
+    let has_section = ctx.has_ancestor(|ancestor| ancestor.is_tag("section"));
+
+    format!(
+        "{label}:{} current={current} parent={parent} ancestors=[{}] has_section={has_section}",
+        tag_name(*element),
+        ancestors.join("/")
+    )
+}
+
+fn stack_snapshot(ctx: &MarkupContext<'_, '_>) -> String {
+    let parent = ctx
+        .parent_element()
+        .map(tag_name)
+        .unwrap_or_else(|| "-".to_owned());
+    let current = ctx
+        .current_element()
+        .map(tag_name)
+        .unwrap_or_else(|| "-".to_owned());
+    let ancestors = ctx.ancestor_elements().map(tag_name).collect::<Vec<_>>();
+
+    format!(
+        "current={current} parent={parent} ancestors=[{}]",
+        ancestors.join("/")
+    )
+}
+
+fn tag_name(element: MarkupElement<'_>) -> String {
+    let tag = element.tag();
+    if tag.is_empty() {
+        "#fragment".to_owned()
+    } else {
+        tag.to_owned()
+    }
+}
+
+fn run_over_template(source: &str) -> AncestryProbe {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, errors) = parser.parse();
+    assert!(errors.is_empty(), "template parse errors: {errors:?}");
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let probe = AncestryProbe::default();
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(&probe, &mut ctx);
+    probe
+}
+
+fn run_over_jsx_oxc(source: &str) -> AncestryProbe {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let probe = AncestryProbe::default();
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(&probe, &mut ctx);
+    probe
+}
+
+fn run_over_jsx_lowered(source: &str) -> Vec<String> {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut entries = Vec::new();
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let probe = AncestryProbe::default();
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(&probe, &mut ctx);
+        entries.extend(probe.entries.into_inner());
+    }
+    entries
+}
+
+#[test]
+fn template_callbacks_observe_the_current_element_stack() {
+    let probe = run_over_template(
+        r#"<section id="root" @click="go">hello {{ name }}<span>leaf</span></section>"#,
+    );
+
+    assert_eq!(
+        probe.callbacks.into_inner(),
+        vec![
+            "binding:id current=section parent=- ancestors=[]",
+            "binding:click current=section parent=- ancestors=[]",
+            "directive:on:click current=section parent=- ancestors=[]",
+            "text current=section parent=- ancestors=[]",
+            "interpolation current=section parent=- ancestors=[]",
+            "text current=span parent=section ancestors=[section]",
+        ]
+    );
+}
+
+#[test]
+fn jsx_callbacks_observe_the_current_element_stack() {
+    let probe = run_over_jsx_oxc(
+        r#"const C = () => <section id="root" onClick={go}>hello {name}<span>leaf</span></section>;"#,
+    );
+
+    assert_eq!(
+        probe.callbacks.into_inner(),
+        vec![
+            "binding:id current=section parent=- ancestors=[]",
+            "binding:Click current=section parent=- ancestors=[]",
+            "directive:on:Click current=section parent=- ancestors=[]",
+            "text current=section parent=- ancestors=[]",
+            "interpolation current=section parent=- ancestors=[]",
+            "text current=span parent=section ancestors=[section]",
+        ]
+    );
+}
+
+#[test]
+fn template_ancestry_tracks_current_parent_and_root_first_ancestors() {
+    let probe = run_over_template("<section><p><span>Text</span></p></section><aside></aside>");
+
+    assert_eq!(
+        probe.entries.into_inner(),
+        vec![
+            "enter:section current=section parent=- ancestors=[] has_section=false",
+            "enter:p current=p parent=section ancestors=[section] has_section=true",
+            "enter:span current=span parent=p ancestors=[section/p] has_section=true",
+            "enter:aside current=aside parent=- ancestors=[] has_section=false",
+        ]
+    );
+    assert_eq!(
+        probe.exits.into_inner(),
+        vec![
+            "exit:span current=span parent=p ancestors=[section/p] has_section=true",
+            "exit:p current=p parent=section ancestors=[section] has_section=true",
+            "exit:section current=section parent=- ancestors=[] has_section=false",
+            "exit:aside current=aside parent=- ancestors=[] has_section=false",
+        ],
+        "exit hooks must see the element before it is popped"
+    );
+}
+
+#[test]
+fn template_directive_scopes_do_not_reset_element_ancestry() {
+    let probe = run_over_template(
+        r#"<section><p v-if="ok"></p><ul><li v-for="item in items"><span></span></li></ul><footer></footer></section>"#,
+    );
+
+    assert_eq!(
+        probe.entries.into_inner(),
+        vec![
+            "enter:section current=section parent=- ancestors=[] has_section=false",
+            "enter:p current=p parent=section ancestors=[section] has_section=true",
+            "enter:ul current=ul parent=section ancestors=[section] has_section=true",
+            "enter:li current=li parent=ul ancestors=[section/ul] has_section=true",
+            "enter:span current=span parent=li ancestors=[section/ul/li] has_section=true",
+            "enter:footer current=footer parent=section ancestors=[section] has_section=true",
+        ]
+    );
+}
+
+#[test]
+fn jsx_ancestry_tracks_elements_and_fragments() {
+    let probe =
+        run_over_jsx_oxc("const C = () => <section><><p><span /></p></><aside /></section>;");
+
+    assert_eq!(
+        probe.entries.into_inner(),
+        vec![
+            "enter:section current=section parent=- ancestors=[] has_section=false",
+            "enter:#fragment current=#fragment parent=section ancestors=[section] has_section=true",
+            "enter:p current=p parent=#fragment ancestors=[section/#fragment] has_section=true",
+            "enter:span current=span parent=p ancestors=[section/#fragment/p] has_section=true",
+            "enter:aside current=aside parent=section ancestors=[section] has_section=true",
+        ]
+    );
+}
+
+#[test]
+fn jsx_attribute_value_roots_keep_the_host_traversal_parent() {
+    let probe = run_over_jsx_oxc("const C = () => <Panel header={<ul><li /></ul>}><p /></Panel>;");
+
+    assert_eq!(
+        probe.entries.into_inner(),
+        vec![
+            "enter:Panel current=Panel parent=- ancestors=[] has_section=false",
+            "enter:ul current=ul parent=Panel ancestors=[Panel] has_section=false",
+            "enter:li current=li parent=ul ancestors=[Panel/ul] has_section=false",
+            "enter:p current=p parent=Panel ancestors=[Panel] has_section=false",
+        ]
+    );
+}
+
+#[test]
+fn lowered_jsx_roots_get_the_same_template_stack_contract() {
+    assert_eq!(
+        run_over_jsx_lowered(
+            "const C = () => <section>{items.map((item) => <p key={item.id}><span /></p>)}</section>;",
+        ),
+        vec![
+            "enter:section current=section parent=- ancestors=[] has_section=false",
+            "enter:p current=p parent=section ancestors=[section] has_section=true",
+            "enter:span current=span parent=p ancestors=[section/p] has_section=true",
+        ]
+    );
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           327 |                   327 |                 0 |             286 |     280 |             672 |      221 |           369 |           532 |
+| Linter                     |           328 |                   328 |                 0 |             287 |     280 |             669 |      226 |           370 |           533 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         327 |             224 |      103 |
-| old AST/parser   |         244 |             207 |       37 |
+| S0               |         328 |             224 |      104 |
+| old AST/parser   |         245 |             207 |       38 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         280 |             203 |       77 |
+| raw OXC          |         280 |             200 |       80 |
 
 #### Top source and manifest files
 
@@ -111,8 +111,8 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 | `crates/vize_patina/src/linter/engine.rs:25`                                        | source   | S0 5<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |    13 |
 | `crates/vize_patina/Cargo.toml:13`                                                  | manifest | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 6 |    10 |
 | `crates/vize_patina/src/rules/script/no_ref_as_operand.rs:29`                       | source   | S0 1<br>raw OXC 9                                           |    10 |
-| `crates/vize_patina/src/markup.rs:48`                                               | source   | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |     9 |
 | `crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs:46` | source   | S0 2<br>old AST/parser 4<br>Croquis analysis 3              |     9 |
+| `crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs:1`       | source   | S0 1<br>raw OXC 6                                           |     7 |
 
 Additional source/manifest rows are in the TSV: 309 omitted.
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:45`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:46`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 63 omitted.
+Additional test/dev rows are in the TSV: 64 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -986,7 +986,6 @@ linter	Linter	test/dev	crates/vize_patina/src/linter/tests/recovered_parse_analy
 linter	Linter	source	crates/vize_patina/src/markup.rs	48	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/markup.rs	48	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/markup.rs	48	croquis	Croquis analysis	old	vize_croquis	legacy	1
-linter	Linter	source	crates/vize_patina/src/markup.rs	48	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	source	crates/vize_patina/src/markup.rs	48	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/markup.rs	48	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
@@ -994,9 +993,12 @@ linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	ra
 linter	Linter	source	crates/vize_patina/src/markup/jsx_roots.rs	2	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/jsx_roots.rs	2	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/source_ranges.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	45	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	45	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	45	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	46	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	46	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	46	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/ancestry_tests.rs	10	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/ancestry_tests.rs	10	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/ancestry_tests.rs	10	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3


### PR DESCRIPTION
Fixes #5340

## Summary
- add current/parent/ancestor accessors to Patina `MarkupContext`
- thread an inline `SmallVec` ancestry stack through the markup visitor hot path without changing callback order or diagnostics
- move the JSX program walker into `markup/jsx_roots.rs` and remove the local JSX child shim to keep `markup.rs` under source-length budget
- add template/direct-JSX/lowered-JSX regression coverage for element, fragment, attribute-root, callback, sibling, and exit-stack boundaries
- refresh the Davinci consumer migration inventory

## Validation
- `cargo fmt --all -- --check`
- `cargo test -q -p vize_patina --lib ancestry --locked`
- `cargo test -q -p vize_patina --lib markup --locked`
- `cargo test -q -p vize_patina --lib jsx --locked`
- `cargo test -q -p vize_patina --lib use_list --locked`
- `cargo test -q -p vize_patina --locked`
- `cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports`
- `VIZE_TEST_REQUIRE_TSGO=1 cargo test -q --workspace --locked`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node tools/davinci/sourcelocation-inventory.mjs --check`
- `node tools/davinci/croquis-consumers.mjs --check`
- `node tools/davinci/matrix-gen.mjs --check`
- `node tools/fixtures/patina-rule-map.mjs --check`
- `node tools/davinci/assertion-lint.mjs`
- `node --test tests/tooling/davinci-assertion-lint.test.ts`
- `node --test --test-concurrency=1 tests/tooling/davinci-matrices.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo bench -q -p vize_patina --bench davinci_markup -- --quick`
- `node tools/davinci/bench-compare.mjs --bench patina_jsx_markup_one_root`
- `cargo bench -q -p vize_patina --bench markup_ir_bench -- --quick`
- `git diff --check`

## Risk
- behavior-preserving substrate only; no rule migration and no rollout
- visitor hot path is benchmarked and uses inline stack storage for ordinary depth

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790659258&installation_model_id=422833&pr_number=5341&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5341&signature=8385ee12c9fbaee4131698445a21e53a125c60ff3576d682061247d7785220dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Markup rules can now access the current element, parent element, and full ancestor chain while processing templates and JSX.
  - Ancestry tracking works consistently across Vue templates, JSX, fragments, directives, interpolations, and lowered JSX.

- **Bug Fixes**
  - Improved traversal consistency for JSX attribute values and nested element structures.

- **Tests**
  - Added coverage validating element-stack behavior and ancestry across supported markup formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->