### PR TITLE
refactor(patina): move permitted-contents onto markup facade

### DIFF
--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -31,6 +31,7 @@ mod no_redundant_roles_tests;
 mod no_role_presentation_on_focusable_jsx_tests;
 mod no_role_presentation_on_focusable_tests;
 mod no_textarea_mustache_tests;
+mod permitted_contents_tests;
 mod placeholder_label_option_tests;
 mod require_datetime_tests;
 mod use_list_tests;

--- a/crates/vize_patina/src/markup/tests/permitted_contents_tests.rs
+++ b/crates/vize_patina/src/markup/tests/permitted_contents_tests.rs
@@ -1,0 +1,146 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::vue::PermittedContents;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+#[test]
+fn permitted_contents_template_markup_ancestor_boundaries() {
+    let rule = PermittedContents;
+    for (source, expected, label) in [
+        (
+            r#"<span><div>block</div></span>"#,
+            1,
+            "block element inside phrasing ancestor",
+        ),
+        (
+            r##"<main><a href="#"><div>block</div></a></main>"##,
+            0,
+            "transparent anchor inherits a flow parent",
+        ),
+        (
+            r#"<span><a><div>block</div></a></span>"#,
+            1,
+            "transparent anchor does not hide phrasing ancestor",
+        ),
+        (
+            r##"<a href="#"><button>click</button></a>"##,
+            1,
+            "interactive element inside interactive ancestor",
+        ),
+        (
+            r#"<ul><div>not li</div></ul>"#,
+            1,
+            "constrained list parent rejects non-li child",
+        ),
+        (r#"<ul><li>item</li></ul>"#, 0, "li is a valid list child"),
+        (
+            r#"<ul><MyItem /></ul>"#,
+            0,
+            "unknown component child stays exempt",
+        ),
+        (
+            r#"<ul><motion.div>item</motion.div></ul>"#,
+            1,
+            "configured intrinsic member component keeps its native content model",
+        ),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template markup boundary changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn permitted_contents_jsx_lowered_matches_legacy_fallback_boundaries() {
+    let rule = PermittedContents;
+    for (source, expected, label) in [
+        (
+            r#"const A = () => <span><div>block</div></span>;"#,
+            1,
+            "block element inside phrasing ancestor",
+        ),
+        (
+            r##"const A = () => <main><a href="#"><div>block</div></a></main>;"##,
+            0,
+            "transparent anchor inherits a flow parent",
+        ),
+        (
+            r#"const A = () => <span><a><div>block</div></a></span>;"#,
+            1,
+            "transparent anchor does not hide phrasing ancestor",
+        ),
+        (
+            r##"const A = () => <a href="#"><button>click</button></a>;"##,
+            1,
+            "interactive element inside interactive ancestor",
+        ),
+        (
+            r#"const A = () => <ul><div>not li</div></ul>;"#,
+            1,
+            "constrained list parent rejects non-li child",
+        ),
+        (
+            r#"const A = () => <ul><li>item</li></ul>;"#,
+            0,
+            "li is a valid list child",
+        ),
+        (
+            r#"const A = () => <ul><MyItem /></ul>;"#,
+            0,
+            "unknown component child stays exempt",
+        ),
+        (
+            r#"const A = () => <table><MyRow /></table>;"#,
+            0,
+            "unknown component can render a table row",
+        ),
+        (
+            r#"const A = () => <select><div>bad</div></select>;"#,
+            1,
+            "constrained select parent rejects non-option child",
+        ),
+        (
+            r#"const A = () => <ul><motion.div>item</motion.div></ul>;"#,
+            0,
+            "member JSX tags lower to dynamic components and stay exempt",
+        ),
+    ] {
+        assert_eq!(
+            run_over_jsx_lowered(&rule, source),
+            expected,
+            "lowered JSX boundary changed for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/vue/permitted_contents.rs
+++ b/crates/vize_patina/src/rules/vue/permitted_contents.rs
@@ -29,6 +29,7 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupContext, MarkupElement, MarkupElementKind, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::{ElementNode, ElementType};
 use vize_s0::is_html_tag;
@@ -153,12 +154,92 @@ fn nearest_non_transparent_parent<'ctx, 'a>(
     })
 }
 
+fn nearest_non_transparent_markup_parent<'a>(
+    ctx: &MarkupContext<'_, 'a>,
+) -> Option<MarkupElement<'a>> {
+    ctx.ancestor_elements()
+        .rev()
+        .find(|ancestor| !is_transparent_parent(content_model_tag(ancestor.tag())))
+}
+
 #[derive(Default)]
 pub struct PermittedContents;
+
+impl PermittedContents {
+    fn check_markup_element<'a>(ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        match element.kind() {
+            MarkupElementKind::Template | MarkupElementKind::Slot => return,
+            MarkupElementKind::Element | MarkupElementKind::Component => {}
+        }
+
+        let raw_tag = element.tag();
+        let tag = content_model_tag(raw_tag);
+        let has_intrinsic_mapping = tag != raw_tag;
+        let is_unknown_component = element.is_component() && !has_intrinsic_mapping;
+
+        if !is_unknown_component
+            && is_block_element(tag)
+            && let Some(parent) = nearest_non_transparent_markup_parent(ctx)
+        {
+            let parent_raw_tag = parent.tag();
+            let parent_tag = content_model_tag(parent_raw_tag);
+            if is_phrasing_only_parent(parent_tag) {
+                let message = ctx.lint().t_fmt(
+                    "vue/permitted-contents.block_in_inline",
+                    &[("child", raw_tag), ("parent", parent_raw_tag)],
+                );
+                ctx.lint().error_at(message, element.range());
+            }
+        }
+
+        if !is_unknown_component
+            && is_interactive_element(tag)
+            && ctx
+                .has_ancestor(|ancestor| is_interactive_element(content_model_tag(ancestor.tag())))
+        {
+            let message = ctx.lint().t_fmt(
+                "vue/permitted-contents.interactive_nesting",
+                &[("tag", raw_tag)],
+            );
+            ctx.lint().error_at(message, element.range());
+        }
+
+        if !is_unknown_component && let Some(parent) = ctx.parent_element() {
+            let parent_tag = content_model_tag(parent.tag());
+            if let Some(allowed) = required_children(parent_tag)
+                && !allowed.contains(&tag)
+            {
+                let message = ctx.lint().t_fmt(
+                    "vue/permitted-contents.invalid_child",
+                    &[("child", raw_tag), ("parent", parent.tag())],
+                );
+                ctx.lint().error_at(message, element.range());
+            }
+        }
+    }
+}
+
+impl MarkupRule for PermittedContents {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        Self::check_markup_element(ctx, element);
+    }
+}
 
 impl Rule for PermittedContents {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn jsx_needs_lowering(&self) -> bool {
+        true
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           328 |                   328 |                 0 |             287 |     280 |             669 |      226 |           370 |           533 |
+| Linter                     |           329 |                   329 |                 0 |             288 |     280 |             669 |      228 |           371 |           534 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,8 +99,8 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         328 |             224 |      104 |
-| old AST/parser   |         245 |             207 |       38 |
+| S0               |         329 |             224 |      105 |
+| old AST/parser   |         246 |             207 |       39 |
 | Croquis analysis |          42 |              38 |        4 |
 | raw OXC          |         280 |             200 |       80 |
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:46`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:47`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 64 omitted.
+Additional test/dev rows are in the TSV: 65 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -993,9 +993,9 @@ linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	ra
 linter	Linter	source	crates/vize_patina/src/markup/jsx_roots.rs	2	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/jsx_roots.rs	2	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/source_ranges.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	46	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	46	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	46	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	47	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	47	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	47	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/ancestry_tests.rs	10	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/ancestry_tests.rs	10	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/ancestry_tests.rs	10	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1056,6 +1056,8 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_role_presentation_on_focusable_tests.rs	5	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_textarea_mustache_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/no_textarea_mustache_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/permitted_contents_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/permitted_contents_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/placeholder_label_option_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/placeholder_label_option_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/placeholder_label_option_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1518,8 +1520,8 @@ linter	Linter	test/dev	crates/vize_patina/src/rules/vue/no_v_for_template_key_on
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_html.rs	41	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs	27	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/no_v_text_v_html_on_component.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/permitted_contents.rs	33	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	source	crates/vize_patina/src/rules/vue/permitted_contents.rs	33	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/permitted_contents.rs	34	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	source	crates/vize_patina/src/rules/vue/permitted_contents.rs	34	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/prop_name_casing.rs	40	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/prop_name_casing/declarations.rs	13	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/vue/require_component_is.rs	25	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,9 +34,9 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 35, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 36, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 112, `ir` 25, `ir-lowered` 10, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (35 = 35 `markup-facade` rules)
+- JSX lanes: `fallback` 111, `ir` 25, `ir-lowered` 11, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (36 = 36 `markup-facade` rules)
 - classification: neutral-core-candidate **88** · vue-dialect-bound **135** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
@@ -253,7 +253,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `vue/no-v-html`                                 | template-family | `vue/no_v_html.rs`                                     | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-v-text`                                 | template-family | `opinionated/vue/no_v_text.rs`                         | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/no-v-text-v-html-on-component`             | template-family | `vue/no_v_text_v_html_on_component.rs`                 | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
-| `vue/permitted-contents`                        | template-family | `vue/permitted_contents.rs`                            | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | neutral-core-candidate |
+| `vue/permitted-contents`                        | template-family | `vue/permitted_contents.rs`                            | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `vue/prefer-props-shorthand`                    | template-family | `opinionated/vue/prefer_props_shorthand.rs`            | template-ast                   | yes (template-visitor)           | yes (fallback)              | direct 1: `naming::names_match`                                                                     | vue-dialect-bound      |
 | `vue/prefer-true-attribute-shorthand`           | template-family | `opinionated/vue/prefer_true_attribute_shorthand.rs`   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `vue/prop-name-casing`                          | template-family | `vue/prop_name_casing.rs`                              | template-ast                   | yes (template-visitor)           | yes (fallback)              | ctx 1                                                                                               | container-bound        |


### PR DESCRIPTION
## Summary

- Move vue/permitted-contents onto the Davinci markup facade while keeping the legacy template visitor path intact.
- Keep JSX behavior-compatible by routing this rule through the lowered markup lane.
- Update Davinci rule parity and consumer migration surface matrices.

Closes #5345

## Tests

- cargo fmt --all -- --check
- git diff --check
- cargo test -q -p vize_patina --lib permitted_contents --locked
- cargo test -q -p vize_patina --locked
- cargo clippy -q -p vize_patina --all-targets --locked -- -D warnings -D clippy::wildcard_imports
- node tools/davinci/rule-parity.mjs --check
- node tools/davinci/consumer-migration-surfaces.mjs --check
- node tools/davinci/matrix-gen.mjs --check
- node tools/davinci/assertion-lint.mjs
- node --test tests/tooling/davinci-assertion-lint.test.ts tests/tooling/source-file-lengths.test.ts
- VIZE_TEST_REQUIRE_TSGO=1 cargo test -q --workspace --locked
- cargo bench -q -p vize_patina --bench davinci_markup -- --quick

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790662404&installation_model_id=422833&pr_number=5346&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5346&signature=4511961fcf85a922bd57e76af6b22603575ca85b53bf9891153ae5d8cca98450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved permitted-content validation across templates and lowered JSX.
  - More accurately detects invalid nesting involving phrasing, interactive, list, table, select, anchor, and component elements.
  - Aligns JSX diagnostics with template validation behavior.

- **Tests**
  - Added cross-backend coverage for permitted-content boundary cases.

- **Documentation**
  - Updated rule parity and migration tracking information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->