### PR TITLE
refactor(patina): move form-control-has-label onto markup facade

### DIFF
--- a/crates/vize_patina/src/rules/a11y/form_control_has_label.rs
+++ b/crates/vize_patina/src/rules/a11y/form_control_has_label.rs
@@ -10,10 +10,11 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::{ElementNode, ExpressionNode, PropNode};
+use vize_relief::ElementNode;
 
-use super::helpers::get_static_or_bound_literal_attribute_value;
+use super::helpers::string_literal_value;
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/form-control-has-label",
@@ -29,17 +30,20 @@ pub struct FormControlHasLabel;
 
 impl FormControlHasLabel {
     /// Check if an element is a form control that needs a label
-    fn is_form_control(tag: &str) -> bool {
-        matches!(tag, "input" | "select" | "textarea")
+    fn is_form_control(element: &MarkupElement<'_>) -> bool {
+        element.is_unqualified_tag_exact("input")
+            || element.is_unqualified_tag_exact("select")
+            || element.is_unqualified_tag_exact("textarea")
     }
 
     /// Check if the input type doesn't need a label (hidden, submit, etc.)
-    fn is_exempt_input_type(element: &ElementNode) -> bool {
-        if element.tag != "input" {
+    fn is_exempt_input_type(element: &MarkupElement<'_>) -> bool {
+        if !element.is_unqualified_tag_exact("input") {
             return false;
         }
 
-        let Some(input_type) = get_static_or_bound_literal_attribute_value(element, "type") else {
+        let Some(input_type) = Self::get_static_or_bound_literal_attribute_value(element, "type")
+        else {
             return false;
         };
 
@@ -50,99 +54,87 @@ impl FormControlHasLabel {
     }
 
     /// Check if element has aria-label or aria-labelledby
-    fn has_aria_label(element: &ElementNode) -> bool {
-        for prop in &element.props {
-            match prop {
-                PropNode::Attribute(attr) => {
-                    if (attr.name == "aria-label" || attr.name == "aria-labelledby")
-                        && attr
-                            .value
-                            .as_ref()
-                            .is_some_and(|v| !v.content.trim().is_empty())
-                    {
-                        return true;
-                    }
-                }
-                PropNode::Directive(dir) => {
-                    if dir.name == "bind"
-                        && let Some(ExpressionNode::Simple(arg)) = &dir.arg
-                        && (arg.content == "aria-label" || arg.content == "aria-labelledby")
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+    fn has_aria_label(element: &MarkupElement<'_>) -> bool {
+        Self::has_non_empty_static_attribute(element, "aria-label")
+            || Self::has_non_empty_static_attribute(element, "aria-labelledby")
+            || Self::has_bound_attribute(element, "aria-label")
+            || Self::has_bound_attribute(element, "aria-labelledby")
     }
 
     /// Check if element has an id (potentially used by a label)
-    fn has_id(element: &ElementNode) -> bool {
-        for prop in &element.props {
-            match prop {
-                PropNode::Attribute(attr) => {
-                    if attr.name == "id"
-                        && attr
-                            .value
-                            .as_ref()
-                            .is_some_and(|v| !v.content.trim().is_empty())
-                    {
-                        return true;
-                    }
-                }
-                PropNode::Directive(dir) => {
-                    if dir.name == "bind"
-                        && let Some(ExpressionNode::Simple(arg)) = &dir.arg
-                        && arg.content == "id"
-                    {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+    fn has_id(element: &MarkupElement<'_>) -> bool {
+        Self::has_non_empty_static_attribute(element, "id")
+            || Self::has_bound_attribute(element, "id")
     }
 
     /// Check if element has a placeholder (weak but sometimes acceptable)
-    fn has_placeholder(element: &ElementNode) -> bool {
-        for prop in &element.props {
-            if let PropNode::Attribute(attr) = prop
-                && attr.name == "placeholder"
-                && attr
-                    .value
-                    .as_ref()
-                    .is_some_and(|v| !v.content.trim().is_empty())
-            {
-                return true;
-            }
-        }
-        false
+    fn has_placeholder(element: &MarkupElement<'_>) -> bool {
+        Self::has_non_empty_static_attribute(element, "placeholder")
     }
 
     /// Check if element has a title attribute
-    fn has_title(element: &ElementNode) -> bool {
-        for prop in &element.props {
-            if let PropNode::Attribute(attr) = prop
-                && attr.name == "title"
-                && attr
-                    .value
-                    .as_ref()
-                    .is_some_and(|v| !v.content.trim().is_empty())
-            {
-                return true;
+    fn has_title(element: &MarkupElement<'_>) -> bool {
+        Self::has_non_empty_static_attribute(element, "title")
+    }
+
+    fn has_bound_attribute(element: &MarkupElement<'_>, name: &str) -> bool {
+        let mut found = false;
+        element.walk_bindings(&mut |binding| {
+            if binding.kind() == MarkupBindingKind::Bind && binding.is_unqualified_arg_exact(name) {
+                found = true;
             }
-        }
-        false
-    }
-}
-
-impl Rule for FormControlHasLabel {
-    fn meta(&self) -> &'static RuleMeta {
-        &META
+        });
+        found
     }
 
-    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if !Self::is_form_control(element.tag) {
+    fn has_non_empty_static_attribute(element: &MarkupElement<'_>, name: &str) -> bool {
+        let mut found = false;
+        element.walk_bindings(&mut |binding| {
+            if binding.kind() == MarkupBindingKind::Attribute
+                && binding.is_unqualified_arg_exact(name)
+                && binding
+                    .static_value()
+                    .is_some_and(|value| !value.trim().is_empty())
+            {
+                found = true;
+            }
+        });
+        found
+    }
+
+    fn get_static_or_bound_literal_attribute_value<'a>(
+        element: &MarkupElement<'a>,
+        name: &str,
+    ) -> Option<&'a str> {
+        let mut result = None;
+        element.walk_bindings(&mut |binding| {
+            if result.is_some() {
+                return;
+            }
+
+            if binding.kind() == MarkupBindingKind::Attribute
+                && binding.is_unqualified_arg_exact(name)
+            {
+                result = Some(binding.static_value());
+                return;
+            }
+
+            if binding.kind() == MarkupBindingKind::Bind
+                && binding.is_unqualified_arg_exact(name)
+                && let Some(value) = binding.expression().and_then(string_literal_value)
+            {
+                result = Some(Some(value));
+            }
+        });
+        result.flatten()
+    }
+
+    fn check_element(
+        ctx: &mut LintContext<'_>,
+        element: &MarkupElement<'_>,
+        has_label_ancestor: bool,
+    ) {
+        if !Self::is_form_control(element) {
             return;
         }
 
@@ -155,7 +147,7 @@ impl Rule for FormControlHasLabel {
         let has_label = Self::has_aria_label(element)
             || Self::has_id(element)
             || Self::has_title(element)
-            || ctx.has_ancestor(|parent| parent.tag.as_str() == "label");
+            || has_label_ancestor;
 
         if !has_label {
             let help = if Self::has_placeholder(element) {
@@ -164,15 +156,46 @@ impl Rule for FormControlHasLabel {
                 ctx.t("a11y/form-control-has-label.help")
             };
 
-            ctx.warn_with_help(
+            ctx.warn_at_with_help(
                 ctx.t_fmt(
                     "a11y/form-control-has-label.message",
-                    &[("tag", element.tag)],
+                    &[("tag", element.tag())],
                 ),
-                &element.loc,
+                element.range(),
                 help,
             );
         }
+    }
+}
+
+impl MarkupRule for FormControlHasLabel {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        let has_label_ancestor =
+            ctx.has_ancestor(|parent| parent.is_unqualified_tag_exact("label"));
+        Self::check_element(ctx.lint(), element, has_label_ancestor);
+    }
+}
+
+impl Rule for FormControlHasLabel {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn jsx_needs_lowering(&self) -> bool {
+        true
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        let has_label_ancestor = ctx.has_ancestor(|parent| parent.tag.as_str() == "label");
+        Self::check_element(ctx, &MarkupElement::new(element), has_label_ancestor);
     }
 }
 
@@ -181,6 +204,7 @@ mod tests {
     use super::FormControlHasLabel;
     use crate::linter::Linter;
     use crate::rule::RuleRegistry;
+    use vize_atelier_jsx::JsxLang;
 
     fn create_linter() -> Linter {
         let mut registry = RuleRegistry::new();
@@ -188,78 +212,108 @@ mod tests {
         Linter::with_registry(registry)
     }
 
+    fn assert_template_warnings(source: &str, expected: usize) {
+        let result = create_linter().lint_template(source, "test.vue");
+        assert_eq!(result.warning_count, expected, "{:?}", result.diagnostics);
+    }
+
+    fn assert_jsx_warnings(source: &str, expected: usize) {
+        let result = create_linter().lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(result.warning_count, expected, "{:?}", result.diagnostics);
+    }
+
     #[test]
     fn test_valid_with_id() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<input type="text" id="name" />"#, "test.vue");
-        assert_eq!(result.warning_count, 0);
+        assert_template_warnings(r#"<input type="text" id="name" />"#, 0);
     }
 
     #[test]
     fn test_valid_with_aria_label() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<input type="text" aria-label="Name" />"#, "test.vue");
-        assert_eq!(result.warning_count, 0);
+        assert_template_warnings(r#"<input type="text" aria-label="Name" />"#, 0);
     }
 
     #[test]
     fn test_valid_hidden_input() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<input type="hidden" value="token" />"#, "test.vue");
-        assert_eq!(result.warning_count, 0);
+        assert_template_warnings(r#"<input type="hidden" value="token" />"#, 0);
     }
 
     #[test]
     fn test_valid_bound_literal_hidden_input() {
-        let linter = create_linter();
-        let result =
-            linter.lint_template(r#"<input :type="'hidden'" value="token" />"#, "test.vue");
-        assert_eq!(result.warning_count, 0);
+        assert_template_warnings(r#"<input :type="'hidden'" value="token" />"#, 0);
     }
 
     #[test]
     fn test_valid_submit_button() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<input type="submit" value="Submit" />"#, "test.vue");
-        assert_eq!(result.warning_count, 0);
+        assert_template_warnings(r#"<input type="submit" value="Submit" />"#, 0);
     }
 
     #[test]
     fn test_valid_inside_label() {
-        let linter = create_linter();
-        let result =
-            linter.lint_template(r#"<label>Name <input type="text" /></label>"#, "test.vue");
-        assert_eq!(result.warning_count, 0);
+        assert_template_warnings(r#"<label>Name <input type="text" /></label>"#, 0);
     }
 
     #[test]
     fn test_valid_inside_label_nested_span() {
-        let linter = create_linter();
-        let result = linter.lint_template(
+        assert_template_warnings(
             r#"<label><span><input type="checkbox" /></span></label>"#,
-            "test.vue",
+            0,
         );
-        assert_eq!(result.warning_count, 0);
     }
 
     #[test]
     fn test_invalid_no_label() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<input type="text" />"#, "test.vue");
-        assert_eq!(result.warning_count, 1);
+        assert_template_warnings(r#"<input type="text" />"#, 1);
     }
 
     #[test]
     fn test_invalid_select_no_label() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<select><option>A</option></select>"#, "test.vue");
-        assert_eq!(result.warning_count, 1);
+        assert_template_warnings(r#"<select><option>A</option></select>"#, 1);
     }
 
     #[test]
     fn test_invalid_textarea_no_label() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<textarea></textarea>"#, "test.vue");
-        assert_eq!(result.warning_count, 1);
+        assert_template_warnings(r#"<textarea></textarea>"#, 1);
+    }
+
+    #[test]
+    fn test_valid_jsx_with_id() {
+        assert_jsx_warnings(r#"const Field = () => <input type="text" id="name" />;"#, 0);
+    }
+
+    #[test]
+    fn test_valid_jsx_with_bound_aria_label() {
+        assert_jsx_warnings(
+            r#"const Field = () => <input type="text" aria-label={label} />;"#,
+            0,
+        );
+    }
+
+    #[test]
+    fn test_valid_jsx_bound_literal_hidden_input() {
+        assert_jsx_warnings(
+            r#"const Field = () => <input type={'hidden'} value={token} />;"#,
+            0,
+        );
+    }
+
+    #[test]
+    fn test_valid_jsx_inside_label_nested_span() {
+        assert_jsx_warnings(
+            r#"const Field = () => <label><span><input type="checkbox" /></span></label>;"#,
+            0,
+        );
+    }
+
+    #[test]
+    fn test_invalid_jsx_no_label() {
+        assert_jsx_warnings(r#"const Field = () => <input type="text" />;"#, 1);
+    }
+
+    #[test]
+    fn test_invalid_jsx_dynamic_title_is_not_label() {
+        assert_jsx_warnings(
+            r#"const Field = () => <input type="text" title={title} />;"#,
+            1,
+        );
     }
 }

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1084,7 +1084,7 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/aria_props.rs	16	old_ast	
 linter	Linter	source	crates/vize_patina/src/rules/a11y/aria_role.rs	17	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/a11y/aria_unsupported_elements.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/click_events_have_key_events.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/a11y/form_control_has_label.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/a11y/form_control_has_label.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/heading_has_content.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,10 +34,10 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 36, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 37, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 111, `ir` 25, `ir-lowered` 11, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (36 = 36 `markup-facade` rules)
-- classification: neutral-core-candidate **88** · vue-dialect-bound **135** · container-bound **22** (0 overridden)
+- JSX lanes: `fallback` 110, `ir` 25, `ir-lowered` 12, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (37 = 37 `markup-facade` rules)
+- classification: neutral-core-candidate **89** · vue-dialect-bound **134** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
 ## Full table
@@ -53,7 +53,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/aria-role`                                | template-family | `a11y/aria_role.rs`                                    | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/aria-unsupported-elements`                | template-family | `a11y/aria_unsupported_elements.rs`                    | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/click-events-have-key-events`             | template-family | `a11y/click_events_have_key_events.rs`                 | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
-| `a11y/form-control-has-label`                   | template-family | `a11y/form_control_has_label.rs`                       | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
+| `a11y/form-control-has-label`                   | template-family | `a11y/form_control_has_label.rs`                       | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `a11y/heading-has-content`                      | template-family | `a11y/heading_has_content.rs`                          | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/heading-levels`                           | template-family | `opinionated/a11y/heading_levels.rs`                   | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `a11y/iframe-has-title`                         | template-family | `a11y/iframe_has_title.rs`                             | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |


### PR DESCRIPTION
## Summary
- move `a11y/form-control-has-label` onto the Patina markup facade while keeping the legacy template visitor entry point
- run JSX through the lowered markup lane to preserve bound string-literal `type` and legacy dynamic-title behavior
- regenerate Davinci rule-parity and consumer migration surface artifacts

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p vize_patina form_control_has_label -- --nocapture`
- `cargo test -p vize_patina`
- `cargo clippy -p vize_patina --all-targets -- -D warnings`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/davinci-matrices.test.ts`
- `node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `cargo test --workspace`

Closes #5349

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790664622&installation_model_id=422833&pr_number=5350&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5350&signature=60b0115c45e080b0b6348ebdb7db6baa52a0e4bddd24147b48d83c4602049c31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility linting for form controls, including support for labels and common labeling attributes across JSX patterns.
  * Added coverage for additional JSX form-control scenarios.

* **Refactor**
  * Standardized form-control label checks across supported markup analysis paths.
  * Updated rule classification and processing coverage in the rule-parity matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->