### PR TITLE
refactor(patina): move anchor-is-valid onto markup facade

### DIFF
--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -8,6 +8,7 @@
 // test files) so the Davinci assertion lint, which only scans inline
 // `#[cfg(test)] mod` bodies under `src/`, keeps covering these tests.
 mod ancestry_tests;
+mod anchor_is_valid_jsx_tests;
 mod deprecated_attr_tests;
 mod heading_levels_tests;
 mod iframe_has_title_jsx_tests;

--- a/crates/vize_patina/src/markup/tests/anchor_is_valid_jsx_tests.rs
+++ b/crates/vize_patina/src/markup/tests/anchor_is_valid_jsx_tests.rs
@@ -1,0 +1,115 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::AnchorIsValid;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn anchor_is_valid_jsx_direct_matches_lowered() {
+    let rule = AnchorIsValid;
+    for (source, expected, label) in [
+        (
+            r#"const Link = () => <a href="/about">About</a>;"#,
+            0,
+            "static valid href",
+        ),
+        (
+            r#"const Link = () => <a href={url}>Link</a>;"#,
+            0,
+            "dynamic href",
+        ),
+        (
+            r##"const Link = () => <a href={'#'}>Link</a>;"##,
+            0,
+            "dynamic hash expression stays valid like fallback",
+        ),
+        (
+            r#"const Link = () => <a href="">Link</a>;"#,
+            1,
+            "empty href",
+        ),
+        (
+            r##"const Link = () => <a href="#">Link</a>;"##,
+            1,
+            "hash href",
+        ),
+        (
+            r#"const Link = () => <a href="javascript:void(0)">Link</a>;"#,
+            1,
+            "javascript href",
+        ),
+        (
+            r#"const Link = () => <a href>Link</a>;"#,
+            1,
+            "valueless href",
+        ),
+        (r#"const Link = () => <a>Link</a>;"#, 1, "missing href"),
+        (
+            r#"const Link = () => <a {...props}>Link</a>;"#,
+            1,
+            "spread props do not prove href",
+        ),
+        (
+            r#"const Link = () => <a href="" href="/about">Link</a>;"#,
+            1,
+            "first static duplicate href wins",
+        ),
+        (
+            r##"const Link = () => <a href={url} href="#">Link</a>;"##,
+            0,
+            "first dynamic duplicate href wins",
+        ),
+        (
+            r#"const Link = () => <A href="/about">Link</A>;"#,
+            0,
+            "capitalized component is not an anchor tag",
+        ),
+        (
+            r#"const Link = () => <Link.a href="/about">Link</Link.a>;"#,
+            0,
+            "member JSX tag is not an anchor tag",
+        ),
+        (
+            r#"const Link = () => <svg:a href="/about">Link</svg:a>;"#,
+            0,
+            "namespaced JSX tag is not an anchor tag",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(direct, expected, "JSX direct case failed: {label}");
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "JSX direct and lowered fallback diverged for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/a11y/anchor_is_valid.rs
+++ b/crates/vize_patina/src/rules/a11y/anchor_is_valid.rs
@@ -22,9 +22,10 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBinding, MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use crate::rules::url::has_javascript_scheme;
-use vize_relief::{ElementNode, ElementType, ExpressionNode, PropNode};
+use vize_relief::ElementNode;
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/anchor-is-valid",
@@ -38,67 +39,92 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct AnchorIsValid;
 
+impl AnchorIsValid {
+    fn check_static_href(ctx: &mut LintContext<'_>, binding: MarkupBinding<'_>, value: &str) {
+        let trimmed = value.trim();
+        let help = ctx.t("a11y/anchor-is-valid.help");
+
+        if trimmed.is_empty() {
+            ctx.warn_at_with_help(
+                ctx.t("a11y/anchor-is-valid.message_empty"),
+                binding.range(),
+                help,
+            );
+        } else if trimmed == "#" {
+            ctx.warn_at_with_help(
+                ctx.t("a11y/anchor-is-valid.message_hash"),
+                binding.range(),
+                help,
+            );
+        } else if has_javascript_scheme(trimmed) {
+            ctx.warn_at_with_help(
+                ctx.t("a11y/anchor-is-valid.message_javascript"),
+                binding.range(),
+                help,
+            );
+        }
+    }
+
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        if element.is_component() {
+            return;
+        }
+
+        if !element.is_unqualified_tag_exact("a") {
+            return;
+        }
+
+        let mut saw_href = false;
+        element.walk_bindings(&mut |binding| {
+            if saw_href {
+                return;
+            }
+
+            match binding.kind() {
+                MarkupBindingKind::Attribute if binding.is_unqualified_arg_exact("href") => {
+                    saw_href = true;
+                    Self::check_static_href(ctx, binding, binding.static_value().unwrap_or(""));
+                }
+                MarkupBindingKind::Bind if binding.is_static_unqualified_arg_exact("href") => {
+                    saw_href = true;
+                }
+                MarkupBindingKind::On | MarkupBindingKind::Model | MarkupBindingKind::Custom => {}
+                MarkupBindingKind::Attribute => {}
+                MarkupBindingKind::Bind => {}
+            }
+        });
+
+        if !saw_href {
+            ctx.warn_at_with_help(
+                ctx.t("a11y/anchor-is-valid.message_missing"),
+                element.range(),
+                ctx.t("a11y/anchor-is-valid.help"),
+            );
+        }
+    }
+}
+
+impl MarkupRule for AnchorIsValid {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        Self::check_element(ctx.lint(), element);
+    }
+}
+
 impl Rule for AnchorIsValid {
     fn meta(&self) -> &'static RuleMeta {
         &META
     }
 
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if element.tag_type == ElementType::Component {
-            return;
-        }
-
-        if element.tag != "a" {
-            return;
-        }
-
-        for prop in &element.props {
-            match prop {
-                PropNode::Attribute(attr) if attr.name == "href" => {
-                    let value = attr.value.as_ref().map(|v| v.content).unwrap_or("");
-                    let trimmed = value.trim();
-
-                    if trimmed.is_empty() {
-                        ctx.warn_with_help(
-                            ctx.t("a11y/anchor-is-valid.message_empty"),
-                            &attr.loc,
-                            ctx.t("a11y/anchor-is-valid.help"),
-                        );
-                    } else if trimmed == "#" {
-                        ctx.warn_with_help(
-                            ctx.t("a11y/anchor-is-valid.message_hash"),
-                            &attr.loc,
-                            ctx.t("a11y/anchor-is-valid.help"),
-                        );
-                    } else if has_javascript_scheme(trimmed) {
-                        ctx.warn_with_help(
-                            ctx.t("a11y/anchor-is-valid.message_javascript"),
-                            &attr.loc,
-                            ctx.t("a11y/anchor-is-valid.help"),
-                        );
-                    }
-                    return;
-                }
-                PropNode::Directive(dir) if dir.name == "bind" => {
-                    if let Some(ExpressionNode::Simple(arg)) = &dir.arg
-                        && arg.is_static
-                        && arg.content == "href"
-                    {
-                        // Dynamic binding - assume valid
-                        return;
-                    }
-                }
-                _ => {}
-            }
-        }
-
-        // No href at all - this is covered by anchor-has-content,
-        // but we also flag it here as it's a more specific issue
-        ctx.warn_with_help(
-            ctx.t("a11y/anchor-is-valid.message_missing"),
-            &element.loc,
-            ctx.t("a11y/anchor-is-valid.help"),
-        );
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
 
@@ -107,6 +133,7 @@ mod tests {
     use super::AnchorIsValid;
     use crate::linter::Linter;
     use crate::rule::RuleRegistry;
+    use vize_atelier_jsx::JsxLang;
 
     fn create_linter() -> Linter {
         let mut registry = RuleRegistry::new();
@@ -114,81 +141,93 @@ mod tests {
         Linter::with_registry(registry)
     }
 
+    fn assert_template_warnings(source: &str, expected: usize) {
+        let result = create_linter().lint_template(source, "test.vue");
+        assert_eq!(result.warning_count, expected, "{:?}", result.diagnostics);
+    }
+
+    fn assert_jsx_warnings(source: &str, expected: usize) {
+        let result = create_linter().lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(result.warning_count, expected, "{:?}", result.diagnostics);
+    }
+
     #[test]
     fn test_valid_href() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<a href="/about">About</a>"#, "test.vue");
-        assert_eq!(result.warning_count, 0);
+        assert_template_warnings(r#"<a href="/about">About</a>"#, 0);
     }
 
     #[test]
     fn test_valid_dynamic_href() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<a :href="url">Link</a>"#, "test.vue");
-        assert_eq!(result.warning_count, 0);
+        assert_template_warnings(r#"<a :href="url">Link</a>"#, 0);
     }
 
     #[test]
     fn test_invalid_dynamic_href_argument() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<a :[href]="url">Link</a>"#, "test.vue");
-        assert_eq!(result.warning_count, 1);
+        assert_template_warnings(r#"<a :[href]="url">Link</a>"#, 1);
     }
 
     #[test]
     fn test_invalid_empty_href() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<a href="">Link</a>"#, "test.vue");
-        assert_eq!(result.warning_count, 1);
+        assert_template_warnings(r#"<a href="">Link</a>"#, 1);
     }
 
     #[test]
     fn test_invalid_hash_href() {
-        let linter = create_linter();
-        let result = linter.lint_template(r##"<a href="#">Link</a>"##, "test.vue");
-        assert_eq!(result.warning_count, 1);
+        assert_template_warnings(r##"<a href="#">Link</a>"##, 1);
     }
 
     #[test]
     fn test_invalid_javascript_href() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<a href="javascript:void(0)">Link</a>"#, "test.vue");
-        assert_eq!(result.warning_count, 1);
+        assert_template_warnings(r#"<a href="javascript:void(0)">Link</a>"#, 1);
     }
 
     #[test]
     fn test_invalid_mixed_case_javascript_href() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<a href="JaVaScRiPt:void(0)">Link</a>"#, "test.vue");
-        assert_eq!(result.warning_count, 1);
+        assert_template_warnings(r#"<a href="JaVaScRiPt:void(0)">Link</a>"#, 1);
     }
 
     #[test]
     fn test_invalid_obfuscated_javascript_href() {
-        let linter = create_linter();
-        let result =
-            linter.lint_template(r#"<a href="java&#x0A;script:void(0)">Link</a>"#, "test.vue");
-        assert_eq!(result.warning_count, 1);
+        assert_template_warnings(r#"<a href="java&#x0A;script:void(0)">Link</a>"#, 1);
     }
 
     #[test]
     fn test_valid_similar_javascript_scheme() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<a href="javascriptx:void(0)">Link</a>"#, "test.vue");
-        assert_eq!(result.warning_count, 0);
+        assert_template_warnings(r#"<a href="javascriptx:void(0)">Link</a>"#, 0);
     }
 
     #[test]
     fn test_invalid_no_href() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<a>Link</a>"#, "test.vue");
-        assert_eq!(result.warning_count, 1);
+        assert_template_warnings(r#"<a>Link</a>"#, 1);
     }
 
     #[test]
     fn test_valid_component_skipped() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<NuxtLink>Link</NuxtLink>"#, "test.vue");
-        assert_eq!(result.warning_count, 0);
+        assert_template_warnings(r#"<NuxtLink>Link</NuxtLink>"#, 0);
+    }
+
+    #[test]
+    fn test_valid_jsx_href() {
+        assert_jsx_warnings(r#"const Link = () => <a href="/about">About</a>;"#, 0);
+    }
+
+    #[test]
+    fn test_valid_jsx_dynamic_href() {
+        assert_jsx_warnings(r#"const Link = () => <a href={url}>Link</a>;"#, 0);
+    }
+
+    #[test]
+    fn test_invalid_jsx_hash_href() {
+        assert_jsx_warnings(r##"const Link = () => <a href="#">Link</a>;"##, 1);
+    }
+
+    #[test]
+    fn test_invalid_jsx_no_href() {
+        assert_jsx_warnings(r#"const Link = () => <a>Link</a>;"#, 1);
+    }
+
+    #[test]
+    fn test_invalid_jsx_spread_does_not_prove_href() {
+        assert_jsx_warnings(r#"const Link = () => <a {...props}>Link</a>;"#, 1);
     }
 }

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           914 |                   430 |               484 |             139 |     371 |             938 |      486 |           482 |           591 |
-| Linter                     |           329 |                   329 |                 0 |             288 |     280 |             669 |      228 |           371 |           534 |
+| Linter                     |           330 |                   330 |                 0 |             288 |     283 |             669 |      232 |           372 |           535 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         329 |             224 |      105 |
+| S0               |         330 |             224 |      106 |
 | old AST/parser   |         246 |             207 |       39 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         280 |             200 |       80 |
+| raw OXC          |         283 |             200 |       83 |
 
 #### Top source and manifest files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:47`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:48`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 65 omitted.
+Additional test/dev rows are in the TSV: 66 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -993,12 +993,14 @@ linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	ra
 linter	Linter	source	crates/vize_patina/src/markup/jsx_roots.rs	2	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/jsx_roots.rs	2	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/source_ranges.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	47	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	47	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	47	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	48	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	48	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	48	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/ancestry_tests.rs	10	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/ancestry_tests.rs	10	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/ancestry_tests.rs	10	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/anchor_is_valid_jsx_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/anchor_is_valid_jsx_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1079,7 +1081,7 @@ linter	Linter	source	crates/vize_patina/src/output/text.rs	12	s0	S0	stage	vize_s
 linter	Linter	source	crates/vize_patina/src/rule.rs	7	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/alt_text.rs	29	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/anchor_has_content.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	2
-linter	Linter	source	crates/vize_patina/src/rules/a11y/anchor_is_valid.rs	27	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/a11y/anchor_is_valid.rs	28	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/aria_props.rs	16	old_ast	old AST/parser	old	vize_relief	legacy	2
 linter	Linter	source	crates/vize_patina/src/rules/a11y/aria_role.rs	17	old_ast	old AST/parser	old	vize_relief	legacy	3
 linter	Linter	source	crates/vize_patina/src/rules/a11y/aria_unsupported_elements.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,10 +34,10 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 37, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 38, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 110, `ir` 25, `ir-lowered` 12, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (37 = 37 `markup-facade` rules)
-- classification: neutral-core-candidate **89** · vue-dialect-bound **134** · container-bound **22** (0 overridden)
+- JSX lanes: `fallback` 109, `ir` 26, `ir-lowered` 12, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (38 = 38 `markup-facade` rules)
+- classification: neutral-core-candidate **90** · vue-dialect-bound **133** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
 ## Full table
@@ -48,7 +48,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | ----------------------------------------------- | --------------- | ------------------------------------------------------ | ------------------------------ | -------------------------------- | --------------------------- | --------------------------------------------------------------------------------------------------- | ---------------------- |
 | `a11y/alt-text`                                 | template-family | `a11y/alt_text.rs`                                     | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/anchor-has-content`                       | template-family | `a11y/anchor_has_content.rs`                           | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
-| `a11y/anchor-is-valid`                          | template-family | `a11y/anchor_is_valid.rs`                              | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
+| `a11y/anchor-is-valid`                          | template-family | `a11y/anchor_is_valid.rs`                              | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/aria-props`                               | template-family | `a11y/aria_props.rs`                                   | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/aria-role`                                | template-family | `a11y/aria_role.rs`                                    | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/aria-unsupported-elements`                | template-family | `a11y/aria_unsupported_elements.rs`                    | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |


### PR DESCRIPTION
## Summary
- move `a11y/anchor-is-valid` onto the Patina markup facade while keeping the legacy template visitor entry point
- preserve source-order href behavior for static, dynamic, dynamic-arg, duplicate, and spread cases across Vue template and JSX paths
- add direct OXC vs lowered JSX parity coverage and regenerate Davinci migration inventories

## Tests
- `cargo fmt --all -- --check`
- `cargo test -p vize_patina anchor_is_valid -- --nocapture`
- `cargo test -p vize_patina`
- `cargo clippy -p vize_patina --all-targets -- -D warnings`
- `node tools/davinci/rule-parity.mjs --check`
- `node tools/davinci/consumer-migration-surfaces.mjs --check`
- `node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts`
- `node --test tests/tooling/davinci-matrices.test.ts`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `cargo test -p vize_canon batch::type_checker::tests::recent_issues::empty_required_props::v_for_empty_usages_are_isolated_inside_the_callback -- --exact --nocapture`
- `cargo test --workspace`

Closes #5352

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790667700&installation_model_id=422833&pr_number=5355&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5355&signature=ed86c120958a0b8af4b8fee650d821bcb0d2e5f41627c1c7a5e066b158573c67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility validation for JSX links, including static, dynamic, empty, hash, JavaScript, missing, spread, and duplicate `href` values.
  * Ensured consistent `anchor-is-valid` diagnostics across JSX parsing paths.

* **Tests**
  * Added comprehensive JSX coverage for anchor validation scenarios.
  * Expanded parity checks between direct and transformed JSX analysis.

* **Documentation**
  * Updated rule-parity and migration tracking records to reflect the improved JSX support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->