### PR TITLE
fix(ui): keep icon expose reactive

### DIFF
--- a/npm/ui/core/src/families/layout/icon/icon-button.behavior.md
+++ b/npm/ui/core/src/families/layout/icon/icon-button.behavior.md
@@ -1,3 +1,5 @@
+# IconButton
+
 | Case                     | Required behavior                                                                                                                                                    |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `icon-button.vue` source | Owns the canonical IconButton SFC implementation and every row in this table.                                                                                        |

--- a/npm/ui/core/src/families/layout/icon/icon.behavior.md
+++ b/npm/ui/core/src/families/layout/icon/icon.behavior.md
@@ -1,3 +1,5 @@
+# Icon
+
 | Case                 | Required behavior                                                                                                                                              |
 | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `icon.vue` source    | Owns the canonical Icon SFC implementation and every row in this table.                                                                                        |

--- a/npm/ui/core/src/families/layout/icon/icon.test.ts
+++ b/npm/ui/core/src/families/layout/icon/icon.test.ts
@@ -206,15 +206,17 @@ test("passes slot state and exposes live icon state", async () => {
     "img:false:lg:none:close-icon-description:0 0 24 24",
   );
 
-  await handle.wrapper.setProps({ ariaHidden: true, size: "xs" });
+  await handle.wrapper.setProps({ ariaHidden: true, size: "xs", viewBox: "0 0 16 16" });
   assert.equal(exposed.ariaState, "decorative");
   assert.equal(exposed.decorative, true);
   assert.equal(exposed.descriptionId, undefined);
   assert.equal(exposed.size, "xs");
+  assert.equal(exposed.viewBox, "0 0 16 16");
+  assert.equal(root.getAttribute("viewBox"), "0 0 16 16");
   assert.equal(root.getAttribute("data-aria-state"), "decorative");
   assert.equal(
     root.querySelector("path")?.getAttribute("data-slot-state"),
-    "decorative:true:xs:none:none:0 0 24 24",
+    "decorative:true:xs:none:none:0 0 16 16",
   );
   handle.unmount();
 });

--- a/npm/ui/core/src/families/layout/icon/icon.vue
+++ b/npm/ui/core/src/families/layout/icon/icon.vue
@@ -47,6 +47,7 @@ const generatedDescriptionId = useDeterministicId({
   hint: "icon-description",
 });
 
+const viewBoxValue = computed(() => viewBox);
 const sizeValue = computed<IconSize>(() => size);
 const hasTitle = computed(() => hasText(title));
 const hasDescription = computed(() => hasText(description));
@@ -84,7 +85,7 @@ const slotState = computed<IconSlotState>(() => ({
   descriptionId: descriptionIdValue.value,
   size: sizeValue.value,
   titleId: titleIdValue.value,
-  viewBox,
+  viewBox: viewBoxValue.value,
 }));
 
 type IconSetupExpose = Omit<
@@ -97,7 +98,7 @@ type IconSetupExpose = Omit<
   readonly element: typeof element;
   readonly size: typeof sizeValue;
   readonly titleId: typeof titleIdValue;
-  readonly viewBox: string;
+  readonly viewBox: typeof viewBoxValue;
 };
 
 const exposed = {
@@ -107,7 +108,7 @@ const exposed = {
   element,
   size: sizeValue,
   titleId: titleIdValue,
-  viewBox,
+  viewBox: viewBoxValue,
 } satisfies IconSetupExpose;
 
 defineExpose(exposed);


### PR DESCRIPTION
Summary:
- Keep Icon expose and slot viewBox values reactive after prop updates.
- Add top-level behavior headings for Icon and IconButton docs.
- Cover live viewBox updates in the Icon behavior test.

Verification:
- `vp install --frozen-lockfile --prefer-offline`
- `vp check src/families/layout/icon/icon.vue src/families/layout/icon/icon.test.ts src/families/layout/icon/icon.behavior.md src/families/layout/icon/icon-button.behavior.md`
- `vp test run src/families/layout/icon/icon.test.ts src/families/layout/icon/icon-ssr.test.ts src/families/layout/icon/icon-button.test.ts src/families/layout/icon/icon-button-ssr.test.ts`
- `vp exec vue-tsc --noEmit -p tsconfig.typecheck.json`
- `vp exec node scripts/lint-sfc.ts src`
- `vp pack`
- `node scripts/check-size.mjs`
- `node scripts/check-tree-shaking.mjs`
- `vp test run src/families/layout/icon/icon.types.test-d.ts src/family-catalog.test.ts src/sfc-lint.test.ts`
- `git diff --check origin/main...HEAD`

Refs #4907

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790669880&installation_model_id=422833&pr_number=5358&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5358&signature=afcb92cb123b6dbad8f1417dbe1d622d65897d9ab6e9dce6aa97c7fdbdc327de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->