### PR TITLE
test(davinci): pin corpus comparison count

### DIFF
--- a/davinci-road/plan/phase-2-records/p2-11.md
+++ b/davinci-road/plan/phase-2-records/p2-11.md
@@ -203,8 +203,25 @@ by an accidental unresolvable release graph edge.
 
 The series is not done. Waiver budget remains zero. The old DOM lane remains
 the shipped path; the hydrated full-corpus comparison count, patch-flag
-equivalence and DOM allocation budget are still task-level blockers. The flag's
-deletion is still an exit-gate line, not this record's to tick.
+equivalence and DOM allocation budget are still task-level blockers. The
+comparison-count blocker must record 144 DOM-output comparisons, one for each
+current manifest project row. The flag's deletion is still an exit-gate line,
+not this record's to tick.
+
+## Hydrated corpus differential count contract
+
+The P2-11 TS-25 corpus record counts project rows, not hydrated checkout
+directories. On the current `tests/_fixtures/vue-ecosystem-fixtures.json`
+manifest, the full compiler-surface lane is **144 DOM-output comparisons**:
+one comparison per project row. Those rows sit under **142 ecosystem fixture
+paths** because `tests/_fixtures/_git/primevue` contributes three project rows:
+`primevue`, `primevue-volt`, and `primevue-showcase`. A run that records
+142 DOM-output comparisons is stale even if every fixture path is hydrated.
+
+This is still a blocker. The landed P2-11 witnesses are direct S2-vs-shipped
+fixture comparisons; the task is not complete until a clean hydrated corpus run
+records 144 zero-divergence DOM-output comparisons for the P2-11 differential
+lane.
 
 ## Not series installments
 

--- a/davinci-road/plan/phase-2-tasks.md
+++ b/davinci-road/plan/phase-2-tasks.md
@@ -243,9 +243,10 @@ directive and object-spread increments. Installment 40 pins the publish graph
 firewall: unpublished Davinci stage crates stay out of publishable release
 graphs, and S2 DOM witnesses in published crates must remain stripped
 dev-dependencies. The task remains blocked on a hydrated full-corpus run with an
-exact comparison count, the remaining patch-flag equivalence program, and the DOM
-allocation budget; the old lane remains the production path. See the
-[series record](./phase-2-records/p2-11.md).
+exact comparison count: 144 DOM-output comparisons, one per project row in the
+current manifest, not the 142 ecosystem fixture paths. The remaining patch-flag
+equivalence program and DOM allocation budget also remain blockers; the old lane
+remains the production path. See the [series record](./phase-2-records/p2-11.md).
 
 **Steps:**
 
@@ -255,7 +256,7 @@ allocation budget; the old lane remains the production path. See the
 - [ ] **Waiver budget: zero.** DOM emitted output is the hard byte-parity bar (charter #23) and this is the most output-visible surface in the phase; any corpus diff is a bug in this task, exactly as P1-9 ran it
 - [ ] Patch-flag equivalence fixtures (the flags the new path computes must equal the old path's, per node, exactly)
 
-**Acceptance:** `node tools/davinci/corpus-diff.mjs --surface compiler --shards 2 --timeout-ms 600000` empty across the 142-project manifest with scope proof, run from clean fixtures (TS-11); differential lane zero divergence with its comparison count recorded (TS-25); patch-flag equivalence fixtures exact (TS-1/TS-2); DOM bench `allocs` re-recorded in `budgets.toml` (TS-10); TS-13. **Deps:** P2-9. **Non-goals:** SSR and Vapor backends (phase 3); source maps from a structured S4 emitter (P3-9); deleting the relief codegen-node universe; the vapor run-then-discard double transform (P3-6).
+**Acceptance:** `node tools/davinci/corpus-diff.mjs --surface compiler --shards 2 --timeout-ms 600000` empty across the 144-project manifest with scope proof, run from clean fixtures (TS-11); differential lane zero divergence with its comparison count recorded as 144 DOM-output comparisons (TS-25); patch-flag equivalence fixtures exact (TS-1/TS-2); DOM bench `allocs` re-recorded in `budgets.toml` (TS-10); TS-13. **Deps:** P2-9. **Non-goals:** SSR and Vapor backends (phase 3); source maps from a structured S4 emitter (P3-9); deleting the relief codegen-node universe; the vapor run-then-discard double transform (P3-6).
 
 ## P2-12a — Phase-start baselines and pinned targets
 

--- a/davinci-road/plan/phase-2.md
+++ b/davinci-road/plan/phase-2.md
@@ -96,9 +96,11 @@ counts or fixture availability changes.
   patch-flag shapes now have an explicit per-node S2-vs-shipped witness,
   and the publish graph firewall now rejects accidental release-graph edges
   from published crates into unpublished Davinci stage crates. The
-  full-corpus exact comparison count, remaining patch-flag equivalence program
-  and DOM allocation budget remain open. The old DOM lane is still the shipped
-  compiler path.
+  full-corpus exact comparison count remains open and must record
+  144 DOM-output comparisons over the current project-row manifest, not the
+  142 ecosystem fixture paths. The remaining patch-flag equivalence program
+  and DOM allocation budget also remain open. The old DOM lane is still the
+  shipped compiler path.
 - **Untouched and dependency-blocked: 4 of 22 — P2-12b, P2-16, P2-17 and
   P2-20.** P2-12b depends on P2-12a, P2-11 and P2-3; P2-16 depends on P2-11;
   P2-17 depends on P2-11, P2-12b and P2-13; P2-20 depends on all of P2-1

--- a/tests/tooling/davinci-corpus-comparison-count.test.ts
+++ b/tests/tooling/davinci-corpus-comparison-count.test.ts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { test } from "node:test";
+
+import {
+  buildArtifact,
+  expectedComparisonCount,
+  verifyScope,
+} from "../../tools/davinci/lib/corpus-baseline-artifact.mjs";
+import { requiredSection } from "./support/davinci-phase2-ledger.ts";
+
+type ManifestProject = {
+  id: string;
+  fixturePath: string;
+};
+
+type Manifest = {
+  projects: ManifestProject[];
+};
+
+function read(url: URL): string {
+  return fs.readFileSync(url, "utf8");
+}
+
+function currentManifest(): Manifest {
+  return JSON.parse(
+    read(new URL("../../tests/_fixtures/vue-ecosystem-fixtures.json", import.meta.url)),
+  );
+}
+
+function uniqueFixturePathCount(manifest: Manifest): number {
+  return new Set(manifest.projects.map((project) => project.fixturePath)).size;
+}
+
+function duplicateFixtureGroups(manifest: Manifest): Array<[string, string[]]> {
+  const byPath = new Map<string, string[]>();
+  for (const project of manifest.projects) {
+    const ids = byPath.get(project.fixturePath) ?? [];
+    ids.push(project.id);
+    byPath.set(project.fixturePath, ids);
+  }
+  return [...byPath.entries()].filter(([, ids]) => ids.length > 1);
+}
+
+function syntheticCompilerArtifact(projects: ManifestProject[]) {
+  return buildArtifact(
+    projects.map((project, index) => ({
+      surface: "compiler",
+      project: project.id,
+      file_count: index + 1,
+      content_hash: `${index}`.repeat(64).slice(0, 64),
+    })),
+    { projects },
+  );
+}
+
+test("corpus comparison counts use project rows, not unique fixture paths", () => {
+  const projects = [
+    { id: "primevue", fixturePath: "tests/_fixtures/_git/primevue" },
+    { id: "primevue-volt", fixturePath: "tests/_fixtures/_git/primevue" },
+    { id: "primevue-showcase", fixturePath: "tests/_fixtures/_git/primevue" },
+  ];
+  const artifact = syntheticCompilerArtifact(projects);
+
+  assert.equal(expectedComparisonCount({ projects }, ["compiler"]), 3);
+  assert.deepEqual(verifyScope(artifact, { projects }, ["compiler"], "synthetic"), []);
+
+  const stale = {
+    ...artifact,
+    scope: { ...artifact.scope, row_count: 2 },
+    rows: artifact.rows.slice(0, 2),
+  };
+  assert.match(
+    verifyScope(stale, { projects }, ["compiler"], "synthetic stale").join("\n"),
+    /synthetic stale: 2 rows != 3 projects x 1 surfaces = 3/u,
+  );
+});
+
+test("P2-11 DOM differential docs pin the hydrated full-corpus comparison count", () => {
+  const manifest = currentManifest();
+  const compilerComparisons = expectedComparisonCount(manifest, ["compiler"]);
+  const fixturePaths = uniqueFixturePathCount(manifest);
+  const duplicateGroups = duplicateFixtureGroups(manifest);
+
+  assert.equal(compilerComparisons, 144, "intentional ratchet for the current manifest");
+  assert.equal(fixturePaths, 142, "sanity check: fixture paths are not comparison rows");
+  assert.deepEqual(duplicateGroups, [
+    ["tests/_fixtures/_git/primevue", ["primevue", "primevue-volt", "primevue-showcase"]],
+  ]);
+
+  const phase = read(new URL("../../davinci-road/plan/phase-2.md", import.meta.url));
+  const tasks = read(new URL("../../davinci-road/plan/phase-2-tasks.md", import.meta.url));
+  const record = read(new URL("../../davinci-road/plan/phase-2-records/p2-11.md", import.meta.url));
+  const countSection = requiredSection(
+    record,
+    /^## Hydrated corpus differential count contract/mu,
+    /^## Not series installments/mu,
+    "P2-11 hydrated corpus differential count contract",
+  );
+
+  for (const source of [phase, tasks, countSection]) {
+    assert.match(source, /\b144 DOM-output comparisons\b/u);
+  }
+  assert.match(tasks, /\b144-project manifest\b/u);
+  assert.doesNotMatch(tasks, /\b142-project manifest\b/u);
+  assert.match(countSection, /\b142 ecosystem fixture\s+paths\b/u);
+  assert.match(countSection, /`primevue`, `primevue-volt`, and `primevue-showcase`/u);
+  assert.match(countSection, /\b142 DOM-output comparisons is stale\b/u);
+});

--- a/tools/davinci/corpus-baseline.mjs
+++ b/tools/davinci/corpus-baseline.mjs
@@ -26,7 +26,12 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
-import { buildArtifact, renderArtifact, verifyScope } from "./lib/corpus-baseline-artifact.mjs";
+import {
+  buildArtifact,
+  expectedComparisonCount,
+  renderArtifact,
+  verifyScope,
+} from "./lib/corpus-baseline-artifact.mjs";
 import {
   BASELINE_PATH,
   BASELINE_REL,
@@ -135,8 +140,9 @@ async function main() {
 
   const elapsedSeconds = Math.round((Date.now() - startedAt) / 1000);
   const outLabel = outPath === BASELINE_PATH ? BASELINE_REL : path.relative(repoRoot, outPath);
+  const expectedComparisons = expectedComparisonCount(manifest, SURFACES);
   log(
-    `wrote ${outLabel}: ${artifact.scope.row_count} rows (${artifact.scope.projects_run} projects x ${artifact.scope.surfaces_per_project} surfaces, ${artifact.scope.total_file_count} files) in ${elapsedSeconds}s`,
+    `wrote ${outLabel}: ${artifact.scope.row_count}/${expectedComparisons} comparisons (${artifact.scope.projects_run} projects x ${artifact.scope.surfaces_per_project} surfaces, ${artifact.scope.total_file_count} files) in ${elapsedSeconds}s`,
   );
 }
 

--- a/tools/davinci/corpus-diff.mjs
+++ b/tools/davinci/corpus-diff.mjs
@@ -35,6 +35,7 @@ import path from "node:path";
 import {
   buildArtifact,
   diffRows,
+  expectedComparisonCount,
   renderArtifact,
   verifyScope,
 } from "./lib/corpus-baseline-artifact.mjs";
@@ -226,8 +227,9 @@ async function main() {
     unstableDrift.length === 0
       ? ""
       : ` (${unstableDrift.length} filed unstable row(s) drifted without gating)`;
+  const expectedFreshComparisons = expectedComparisonCount(manifest, surfaces);
   log(
-    `corpus-diff: PASS in ${elapsedSeconds}s — zero gating drift across ${freshRows.length} rows (${fresh.scope.projects_run} projects x ${fresh.scope.surfaces_per_project} surfaces, ${fresh.scope.total_file_count} files); scope proof matches ${manifest.projects.length}-project manifest${filterNote}${unstableNote}`,
+    `corpus-diff: PASS in ${elapsedSeconds}s — zero gating drift across ${freshRows.length}/${expectedFreshComparisons} comparisons (${fresh.scope.projects_run} projects x ${fresh.scope.surfaces_per_project} surfaces, ${fresh.scope.total_file_count} files); scope proof matches ${manifest.projects.length}-project manifest${filterNote}${unstableNote}`,
   );
 }
 

--- a/tools/davinci/lib/corpus-baseline-artifact.mjs
+++ b/tools/davinci/lib/corpus-baseline-artifact.mjs
@@ -52,6 +52,10 @@ export function renderArtifact(artifact) {
   return `${JSON.stringify(artifact, null, 2)}\n`;
 }
 
+export function expectedComparisonCount(manifest, surfaces) {
+  return manifest.projects.length * surfaces.length;
+}
+
 /**
  * Scope proof (TS-11): the artifact must cover every manifest project on
  * every requested surface, and must not be a zero-file run. Returns a list
@@ -80,7 +84,7 @@ export function verifyScope(artifact, manifest, surfaces, label) {
   if (scope.row_count !== rows.length) {
     reasons.push(`${label}: scope.row_count ${scope.row_count} != ${rows.length} rows`);
   }
-  const expectedRowCount = manifestIds.length * expectedSurfaces.length;
+  const expectedRowCount = expectedComparisonCount(manifest, expectedSurfaces);
   if (rows.length !== expectedRowCount) {
     reasons.push(
       `${label}: ${rows.length} rows != ${manifestIds.length} projects x ${expectedSurfaces.length} surfaces = ${expectedRowCount}`,


### PR DESCRIPTION
## Summary

- Add a shared `expectedComparisonCount()` helper for Davinci corpus baseline scope proof.
- Make corpus baseline/diff logs print actual/expected comparison counts.
- Add a fail-closed P2-11 test proving corpus comparisons are counted by manifest project row, not unique fixture path.
- Update the Phase 2 P2-11 records to pin the current 144 DOM-output comparison contract.

## Verification

- `node --test tests/tooling/davinci-corpus-comparison-count.test.ts tests/tooling/davinci-phase2-ledger.test.ts tests/tooling/davinci-corpus-formatter-contract.test.ts`
- `node tools/davinci/assertion-lint.mjs`
- `git diff --check`

## Notes

This records the comparison-count contract only. It does not claim the hydrated full-corpus zero-divergence run is complete.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5359"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790671163&installation_model_id=422833&pr_number=5359&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5359&signature=ff2d23638f03e3733e2d26d57022baff83436ce42c451e627e6951862bc79263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected corpus comparison counting to account for every project row, including projects sharing the same fixture path.
  * Updated validation to detect incomplete or stale comparison results.

* **Tooling**
  * Comparison and baseline reports now display actual results alongside the expected total.
  * The current full-corpus requirement is standardized at 144 DOM-output comparisons.

* **Tests**
  * Added coverage for duplicate fixture paths, stale comparison artifacts, and the 144-comparison project manifest requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->