### PR TITLE
perf(davinci): gate p2-11 dom allocations

### DIFF
--- a/.github/actions/upload-davinci-compact-storage-bench-reports/action.yml
+++ b/.github/actions/upload-davinci-compact-storage-bench-reports/action.yml
@@ -1,12 +1,12 @@
-name: Upload Davinci compact-storage bench reports
-description: Uploads compact-storage bench JSON reports for Davinci wall-budget baselines.
+name: Upload Davinci allocation bench reports
+description: Uploads allocation bench JSON reports for Davinci wall-budget baselines.
 runs:
   using: composite
   steps:
     - name: Upload reports
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: davinci-compact-storage-bench-reports
+        name: davinci-allocation-bench-reports
         path: bench/results/davinci/*.json
         if-no-files-found: error
         retention-days: 14

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -374,9 +374,9 @@ jobs:
         run: cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports && cargo clippy -p vize_maestro --tests -- -D warnings && rust-script tools/commands/ci/github/check-maestro-feature-contract.rs
       - name: Davinci no_std stage-library portability lanes (TS-24)
         run: cargo build -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 && cargo build -p vize_davinci -p vize_s1 -p vize_s2 -p vize_s1_to_s2 --lib --target wasm32-wasip2 --no-default-features
-      - name: Davinci compact-storage allocation gate
-        run: cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && rust-script tools/commands/davinci/bench-compare.rs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root
-      - name: Upload Davinci compact-storage bench reports
+      - name: Davinci allocation gate
+        run: cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && rust-script tools/commands/davinci/bench-compare.rs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench s1_to_s2_emit_p2_11_dom_surface --bench patina_jsx_markup_one_root
+      - name: Upload Davinci allocation bench reports
         if: ${{ always() }}
         uses: ./.github/actions/upload-davinci-compact-storage-bench-reports
       - name: Install Pkl CLI

--- a/crates/vize_s1_to_s2/benches/davinci_storage.rs
+++ b/crates/vize_s1_to_s2/benches/davinci_storage.rs
@@ -1,11 +1,12 @@
-//! Allocation regression probes for compact S1-to-S2 storage.
+//! Allocation regression probes for S1-to-S2 lowering and S2 DOM emit.
 //!
 //! Setup stays outside each measured stage. The `v-for` case therefore
-//! accounts lowering's textual split and alias collection, while the `v-on`
-//! case accounts only S2 DOM emission, including modifier classification.
-//! Exact `allocs` budgets make both probes deterministic and
-//! machine-independent. Exact peak-byte budgets are platform-specific; wall
-//! time remains report-only until the reference runner records it.
+//! accounts lowering's textual split and alias collection, while the DOM emit
+//! cases account only S2 DOM emission, including modifier classification and
+//! the P2-11 late-surface matrix. Exact `allocs` budgets make the probes
+//! deterministic and machine-independent. Exact peak-byte budgets are
+//! platform-specific; wall time remains report-only until the reference runner
+//! records it.
 
 use criterion::{Criterion, criterion_group};
 use davinci_harness::stage::bench_stage_with_metrics;
@@ -19,6 +20,23 @@ const VFOR_THREE_ALIASES: &str = r#"<li v-for="(item, key, index) in items">{{ i
 const VON_TWO_PER_BUCKET: &str =
     r#"<button @keyup.capture.once.stop.prevent.enter.escape="handler"></button>"#;
 // v-on-storage-synthetic:end
+const P2_11_DOM_SURFACE: &str = r#"
+<div :foo-bar.camel="camelValue" v-bind.prop="nativeBag" v-on.once.capture="nativeHandlers">
+  <component :is="view" v-model:[field].trim="draft[field]" @update:modelValue="sync">
+    <template #header="{ row }" v-if="showHeader">
+      <slot :name="row.slot" :item="row" @[row.event].once="row.handler">
+        fallback {{ row.label }}
+      </slot>
+    </template>
+    <template v-for="item in items" #default>
+      <input v-model.trim="item.value" :key="item.id" v-show="item.visible">
+      <span v-text="item.label"></span>
+      <div v-html="item.html"></div>
+      <p v-cloak>{{ item.note }}</p>
+    </template>
+  </component>
+</div>
+"#;
 
 fn davinci_storage(criterion: &mut Criterion) {
     let vfor_id = cstr!("s1_to_s2_lower_vfor_three_aliases");
@@ -48,6 +66,23 @@ fn davinci_storage(criterion: &mut Criterion) {
         |window| {
             let allocator = Allocator::new();
             let (tree, errors) = parse(&allocator, VON_TWO_PER_BUCKET);
+            let mut lowered = lower(&allocator, &tree, &errors);
+            let facts = vize_s1_to_s2::pass::run_transform(&mut lowered, &mut NoObserver);
+            window.measure(|| {
+                let emitted = emit_dom(&lowered, &facts).expect("fixture must emit");
+                (emitted.preamble.len(), emitted.code.len())
+            })
+        },
+    );
+
+    let p2_11_id = cstr!("s1_to_s2_emit_p2_11_dom_surface");
+    bench_stage_with_metrics(
+        criterion,
+        &p2_11_id,
+        "synthetic:p2-11-dom-surface",
+        |window| {
+            let allocator = Allocator::new();
+            let (tree, errors) = parse(&allocator, P2_11_DOM_SURFACE);
             let mut lowered = lower(&allocator, &tree, &errors);
             let facts = vize_s1_to_s2::pass::run_transform(&mut lowered, &mut NoObserver);
             window.measure(|| {

--- a/davinci-road/plan/budgets.toml
+++ b/davinci-road/plan/budgets.toml
@@ -189,6 +189,11 @@ davinci_pipeline_no_observer = { wall_p50_ns = 0, allocs = 0, rss_peak_bytes = 0
 s1_to_s2_lower_vfor_three_aliases = { wall_p50_ns = 0, allocs = 10, rss_peak_bytes = 0, wall_tolerance = 0.10 }
 s1_to_s2_emit_von_two_per_bucket = { wall_p50_ns = 0, allocs = 18, rss_peak_bytes = 0, wall_tolerance = 0.10 }
 
+# P2-11 S2 DOM emit surface probe. Setup excludes parse/lower/transform; the
+# measured window is emit-only over late DOM surfaces, so exact allocs guard
+# the output path before the production-lane switch.
+s1_to_s2_emit_p2_11_dom_surface = { wall_p50_ns = 0, allocs = 60, rss_peak_bytes = 0, wall_tolerance = 0.10 }
+
 # Patina direct-IR JSX markup probe. The measured window is the per-rule
 # `visit_with` loop over a one-root, diagnostic-free JSX module; root
 # discovery streams into the walker, so the *measured* zero is the witness

--- a/tests/tooling/davinci-budgets.test.ts
+++ b/tests/tooling/davinci-budgets.test.ts
@@ -31,9 +31,10 @@ const budgets = parseTomlLite(budgetsText) as {
   allocation_peak: Record<string, Record<string, number>>;
 };
 
-const COMPACT_STORAGE_STAGE_WINDOWS = new Set([
+const EXPLICIT_STAGE_WINDOWS = new Set([
   "s1_to_s2_lower_vfor_three_aliases",
   "s1_to_s2_emit_von_two_per_bucket",
+  "s1_to_s2_emit_p2_11_dom_surface",
 ]);
 
 // --- bench-id enumeration from the bench sources -------------------------
@@ -165,7 +166,7 @@ test("every budget entry carries exactly the documented fields within the tolera
       id.includes("_transform_") ||
       id.startsWith("atelier_vapor_lower_") ||
       id.startsWith("atelier_ssr_codegen_") ||
-      COMPACT_STORAGE_STAGE_WINDOWS.has(id);
+      EXPLICIT_STAGE_WINDOWS.has(id);
     const ceiling = stageWindow ? 0.1 : 0.05;
     assert.ok(
       tolerance <= ceiling,

--- a/tests/tooling/davinci-portability-lane.test.ts
+++ b/tests/tooling/davinci-portability-lane.test.ts
@@ -61,7 +61,7 @@ test("TS-24: the wasm32-wasip2 lanes ride the required clippy-and-test job", () 
   assert.doesNotMatch(job, /cargo build[^\n]*-p (?:vize_s0|vize_carton)[^\n]*wasm32-wasip2/);
   assert.match(
     job,
-    /cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && rust-script tools\/commands\/davinci\/bench-compare\.rs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root/u,
+    /cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick && cargo bench -p vize_patina --bench davinci_markup -- --quick && rust-script tools\/commands\/davinci\/bench-compare\.rs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench s1_to_s2_emit_p2_11_dom_surface --bench patina_jsx_markup_one_root/u,
   );
 });
 

--- a/tests/tooling/github-workflows-davinci-bench.test.ts
+++ b/tests/tooling/github-workflows-davinci-bench.test.ts
@@ -16,7 +16,7 @@ interface WorkflowJob {
   steps?: WorkflowStep[];
 }
 
-test("check workflow uploads Davinci compact-storage bench reports", () => {
+test("check workflow uploads Davinci allocation bench reports", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
   const action = readRepoFile(
     ".github",
@@ -27,9 +27,7 @@ test("check workflow uploads Davinci compact-storage bench reports", () => {
   const jobs = (parse(workflow) as { jobs?: Record<string, WorkflowJob> }).jobs ?? {};
   const actionSteps = (parse(action) as { runs?: { steps?: WorkflowStep[] } }).runs?.steps ?? [];
   const steps = jobs["clippy-and-test"]?.steps ?? [];
-  const gateIndex = steps.findIndex(
-    (step) => step.name === "Davinci compact-storage allocation gate",
-  );
+  const gateIndex = steps.findIndex((step) => step.name === "Davinci allocation gate");
 
   assert.notEqual(gateIndex, -1);
   assert.match(
@@ -42,10 +40,10 @@ test("check workflow uploads Davinci compact-storage bench reports", () => {
   );
   assert.match(
     steps[gateIndex].run ?? "",
-    /rust-script tools\/commands\/davinci\/bench-compare\.rs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench patina_jsx_markup_one_root/,
+    /rust-script tools\/commands\/davinci\/bench-compare\.rs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench s1_to_s2_emit_p2_11_dom_surface --bench patina_jsx_markup_one_root/,
   );
   assert.deepEqual(steps[gateIndex + 1], {
-    name: "Upload Davinci compact-storage bench reports",
+    name: "Upload Davinci allocation bench reports",
     if: "${{ always() }}",
     uses: "./.github/actions/upload-davinci-compact-storage-bench-reports",
   });
@@ -54,7 +52,7 @@ test("check workflow uploads Davinci compact-storage bench reports", () => {
       name: "Upload reports",
       uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
       with: {
-        name: "davinci-compact-storage-bench-reports",
+        name: "davinci-allocation-bench-reports",
         path: "bench/results/davinci/*.json",
         "if-no-files-found": "error",
         "retention-days": 14,


### PR DESCRIPTION
## Summary

- Add an emit-only S1-to-S2 benchmark for late P2-11 DOM surfaces.
- Register the measured exact allocation budget for `s1_to_s2_emit_p2_11_dom_surface`.
- Include the new bench in the CI Davinci allocation gate and artifact upload checks.

## Verification

- `cargo bench -p vize_s1_to_s2 --bench davinci_storage -- --quick`
- `rust-script tools/commands/davinci/bench-compare.rs --bench s1_to_s2_lower_vfor_three_aliases --bench s1_to_s2_emit_von_two_per_bucket --bench s1_to_s2_emit_p2_11_dom_surface --bench patina_jsx_markup_one_root`
- `node --test tests/tooling/davinci-budgets.test.ts tests/tooling/github-workflows-davinci-bench.test.ts tests/tooling/davinci-portability-lane.test.ts`
- `cargo test -p vize_s1_to_s2 --test emit_model`
- `cargo test -p vize_atelier_dom --test davinci_s2_dynamic_bind_keys --test davinci_s2_model --test davinci_s2_slots --test davinci_s2_show --test davinci_s2_html --test davinci_s2_text --test davinci_s2_cloak`
- `node tools/davinci/assertion-lint.mjs`
- `cargo fmt --check -p vize_s1_to_s2`
- `git diff --check`

## Notes

This adds the allocation ratchet for the S2 DOM emit lane. It does not switch the shipped DOM path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790671336&installation_model_id=422833&pr_number=5360&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5360&signature=e77be442540039d771c387fa4edf6f76c776cfed068a6e658c46892c65e95008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added coverage for a complex DOM emission benchmark involving modifiers, dynamic bindings, slots, loops, and directives.
  * Added performance budgets and comparison tracking to help detect regressions in this scenario.

* **CI & Tooling**
  * Updated benchmark gates, portability checks, and report uploads to include the new allocation benchmark.
  * Renamed benchmark reports and artifacts from compact-storage to allocation for clearer reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->