### PR TITLE
refactor(patina): move heading-has-content onto markup facade

### DIFF
--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -8,6 +8,7 @@ mod directives;
 mod jsx;
 mod jsx_deprecated_attr;
 mod jsx_fallback;
+mod jsx_heading_has_content;
 mod jsx_heading_levels;
 mod jsx_iframe_has_title;
 mod jsx_interactive_supports_focus;

--- a/crates/vize_patina/src/linter/tests/jsx_heading_has_content.rs
+++ b/crates/vize_patina/src/linter/tests/jsx_heading_has_content.rs
@@ -1,0 +1,128 @@
+use crate::diagnostic::Severity;
+use crate::linter::{LintResult, Linter};
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::HeadingHasContent;
+use vize_atelier_jsx::JsxLang;
+
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(rule);
+    Linter::with_registry(registry)
+}
+
+fn diagnostic_rules(result: &LintResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.rule_name.as_ref())
+        .collect()
+}
+
+#[test]
+fn heading_has_content_fires_on_jsx_and_tsx_ir() {
+    let linter = linter_with(Box::new(HeadingHasContent));
+    let source = r#"const A = () => <h1 />;"#;
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        diagnostic_rules(&result),
+        vec!["a11y/heading-has-content"],
+        "JSX heading without content must flag through IR: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+
+    let diag = &result.diagnostics[0];
+    let element = "<h1 />";
+    let h1_start = source.find(element).unwrap() as u32;
+    assert_eq!(diag.start, h1_start);
+    assert_eq!(&source[diag.start as usize..diag.end as usize], element);
+    assert_eq!(diag.severity, Severity::Warning);
+    assert!(diag.help.is_some(), "diagnostic should keep rule help");
+
+    let tsx = linter.lint_jsx(
+        "const A = (): JSX.Element => <h1 />;",
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        diagnostic_rules(&tsx),
+        vec!["a11y/heading-has-content"],
+        "TSX heading without content must also flag through IR"
+    );
+    assert_eq!(tsx.warning_count, 1);
+    assert_eq!(tsx.error_count, 0);
+}
+
+#[test]
+fn heading_has_content_preserves_legacy_jsx_boundaries() {
+    let linter = linter_with(Box::new(HeadingHasContent));
+    for source in [
+        r#"const A = () => <h1>Title</h1>;"#,
+        r#"const A = () => <h1>{title}</h1>;"#,
+        r#"const A = () => <h1>{0}</h1>;"#,
+        r#"const A = () => <h1>{'Title'}</h1>;"#,
+        r#"const A = () => <h1><span>Title</span></h1>;"#,
+        r#"const A = () => <h1><slot /></h1>;"#,
+        r#"const A = () => <h1><><slot /></></h1>;"#,
+        r#"const A = () => <h1 aria-hidden="true" />;"#,
+        r#"const A = () => <h1 aria-label="" />;"#,
+        r#"const A = () => <h1 aria-label={title} />;"#,
+        r#"const A = () => <h1 aria-labelledby={labelId} />;"#,
+        r#"const A = () => <H1 />;"#,
+        r#"const A = () => <Headings.h1 />;"#,
+        r#"const A = () => <svg:h1 />;"#,
+        r#"const A = () => <Comp render={<h1 />} />;"#,
+        r#"const A = () => <Comp render={() => <h1 />} />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            result.warning_count, 0,
+            "must stay clean for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+
+    for source in [
+        r#"const A = () => <h1 />;"#,
+        r#"const A = () => <h1>{}</h1>;"#,
+        r#"const A = () => <h1>{''}</h1>;"#,
+        r#"const A = () => <h1>{' '}</h1>;"#,
+        r#"const A = () => <h1>{ok && <span>Title</span>}</h1>;"#,
+        r#"const A = () => <h1>{ok ? <span>Title</span> : null}</h1>;"#,
+        r#"const A = () => <h1>{items.map((item) => <span>{item}</span>)}</h1>;"#,
+        r#"const A = () => <h1 aria-hidden />;"#,
+        r#"const A = () => <h1 aria-hidden="True" />;"#,
+        r#"const A = () => <h1 aria-hidden={true} />;"#,
+        r#"const A = () => <h1 ARIA-LABEL="Title" />;"#,
+        r#"const A = () => <h1 a11y:aria-label="Title" />;"#,
+        r#"const A = () => <h1 {...attrs} />;"#,
+    ] {
+        let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+        assert_eq!(
+            diagnostic_rules(&result),
+            vec!["a11y/heading-has-content"],
+            "must keep one warning for {source}: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(result.warning_count, 1);
+        assert_eq!(result.error_count, 0, "must not error for {source}");
+    }
+}
+
+#[test]
+fn migrated_heading_has_content_reports_once_not_per_backend() {
+    let linter = linter_with(Box::new(HeadingHasContent));
+    let result = linter.lint_jsx(r#"const A = () => <h1 />;"#, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated heading-has-content rule must report once: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.error_count, 0);
+}

--- a/crates/vize_patina/src/markup.rs
+++ b/crates/vize_patina/src/markup.rs
@@ -47,7 +47,7 @@ use crate::context::LintContext;
 use crate::ir::{ByteRange, TemplateSyntax};
 use oxc_ast::ast::{
     JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXChild, JSXElement,
-    JSXElementName, JSXExpression, JSXFragment, JSXText, Program,
+    JSXElementName, JSXFragment, JSXText, Program,
 };
 use oxc_ast_visit::{Visit, walk::walk_program};
 use oxc_span::Span;
@@ -156,7 +156,9 @@ impl<'a> MarkupDocument<'a> {
         exit: &mut impl FnMut(MarkupElement<'a>),
     ) {
         match self.inner {
-            MarkupDocumentInner::Relief(root) => walk_relief_children(&root.children, enter, exit),
+            MarkupDocumentInner::Relief(root) => {
+                relief_children::walk_relief_children(&root.children, enter, exit);
+            }
             MarkupDocumentInner::Jsx { program, offset } => {
                 jsx_roots::walk_jsx_program(program, offset, enter, exit)
             }
@@ -876,6 +878,10 @@ enum MarkupTextInner<'a> {
         node: *const JSXText<'a>,
         offset: u32,
     },
+    Static {
+        content: &'a str,
+        range: ByteRange,
+    },
 }
 
 ///<'a> Text node view.
@@ -900,11 +906,19 @@ impl<'a> MarkupText<'a> {
         }
     }
 
+    pub(super) const fn from_static(content: &'a str, range: ByteRange) -> Self {
+        Self {
+            inner: MarkupTextInner::Static { content, range },
+            _marker: PhantomData,
+        }
+    }
+
     /// Raw text content.
     pub fn content(&self) -> &'a str {
         match self.inner {
             MarkupTextInner::Relief(node) => node.content,
             MarkupTextInner::Jsx { node, .. } => jsx_text_ref(node).value.as_str(),
+            MarkupTextInner::Static { content, .. } => content,
         }
     }
 
@@ -913,6 +927,7 @@ impl<'a> MarkupText<'a> {
         match self.inner {
             MarkupTextInner::Relief(node) => loc_to_range(&node.loc),
             MarkupTextInner::Jsx { node, offset } => span_to_range(jsx_text_ref(node).span, offset),
+            MarkupTextInner::Static { range, .. } => range,
         }
     }
 
@@ -954,60 +969,6 @@ impl<'a> MarkupNode<'a> {
             TemplateChildNode::For(for_node) => Self::For(loc_to_range(&for_node.loc)),
             other => Self::Other(loc_to_range(other.loc())),
         }
-    }
-
-    fn from_jsx_child(child: &'a JSXChild<'a>, offset: u32) -> Self {
-        match child {
-            JSXChild::Text(text) => Self::Text(MarkupText::from_jsx(&**text as *const _, offset)),
-            JSXChild::Element(element) => Self::Element(MarkupElement::from_jsx_element(
-                &**element as *const _,
-                offset,
-            )),
-            JSXChild::Fragment(fragment) => Self::Element(MarkupElement::from_jsx_fragment(
-                &**fragment as *const _,
-                offset,
-            )),
-            JSXChild::ExpressionContainer(container) => match &container.expression {
-                JSXExpression::EmptyExpression(_) => {
-                    Self::Comment(span_to_range(container.span, offset))
-                }
-                _ => Self::Interpolation(span_to_range(container.span, offset)),
-            },
-            JSXChild::Spread(spread) => Self::Interpolation(span_to_range(spread.span, offset)),
-        }
-    }
-}
-
-fn walk_relief_children<'a>(
-    children: &'a [TemplateChildNode<'a>],
-    enter: &mut impl FnMut(MarkupElement<'a>),
-    exit: &mut impl FnMut(MarkupElement<'a>),
-) {
-    for child in children {
-        match child {
-            TemplateChildNode::Element(element) => {
-                let element = MarkupElement::new(element);
-                enter(element);
-                walk_relief_children(element_children_relief(element), enter, exit);
-                exit(element);
-            }
-            TemplateChildNode::If(if_node) => {
-                for branch in if_node.branches.iter() {
-                    walk_relief_children(&branch.children, enter, exit);
-                }
-            }
-            TemplateChildNode::For(for_node) => {
-                walk_relief_children(&for_node.children, enter, exit);
-            }
-            _ => {}
-        }
-    }
-}
-
-fn element_children_relief<'a>(element: MarkupElement<'a>) -> &'a [TemplateChildNode<'a>] {
-    match element.inner {
-        MarkupElementInner::Relief(node) => &node.children,
-        _ => &[],
     }
 }
 
@@ -1310,6 +1271,7 @@ pub struct MarkupContext<'ctx, 'a> {
     is_template: bool,
     analysis: Option<&'a Croquis>,
     element_stack: SmallVec<[MarkupElement<'a>; 32]>,
+    jsx_attribute_value_depth: u32,
 }
 
 impl<'ctx, 'a> MarkupContext<'ctx, 'a> {
@@ -1325,6 +1287,7 @@ impl<'ctx, 'a> MarkupContext<'ctx, 'a> {
             is_template: document.is_template(),
             analysis: document.analysis(),
             element_stack: SmallVec::new(),
+            jsx_attribute_value_depth: 0,
             lint,
         }
     }
@@ -1392,6 +1355,18 @@ impl<'ctx, 'a> MarkupContext<'ctx, 'a> {
         self.ancestor_elements().any(predicate)
     }
 
+    /// Whether the current JSX element was reached through an attribute value.
+    ///
+    /// The legacy JSX fallback only lowered render roots and their children. It
+    /// did not lint JSX passed as props such as `<Comp render={<h1 />} />`.
+    /// Rules that are migrating from the fallback can use this to preserve that
+    /// visible boundary while the facade still exposes attribute-value roots for
+    /// rules that intentionally inspect them.
+    #[inline]
+    pub const fn is_jsx_attribute_value(&self) -> bool {
+        self.jsx_attribute_value_depth > 0
+    }
+
     #[inline]
     fn push_element(&mut self, element: MarkupElement<'a>) {
         self.element_stack.push(element);
@@ -1400,6 +1375,16 @@ impl<'ctx, 'a> MarkupContext<'ctx, 'a> {
     #[inline]
     fn pop_element(&mut self) -> Option<MarkupElement<'a>> {
         self.element_stack.pop()
+    }
+
+    #[inline]
+    fn push_jsx_attribute_value(&mut self) {
+        self.jsx_attribute_value_depth += 1;
+    }
+
+    #[inline]
+    fn pop_jsx_attribute_value(&mut self) {
+        self.jsx_attribute_value_depth = self.jsx_attribute_value_depth.saturating_sub(1);
     }
 }
 
@@ -1566,7 +1551,9 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
         match element.inner {
             MarkupElementInner::Relief(node) => self.visit_relief_children(&node.children),
             MarkupElementInner::JsxElement { node, offset } => {
+                self.ctx.push_jsx_attribute_value();
                 jsx_roots::visit_attribute_roots(self, jsx_element_ref(node), offset);
+                self.ctx.pop_jsx_attribute_value();
                 self.visit_jsx_children(&jsx_element_ref(node).children, offset)
             }
             MarkupElementInner::JsxFragment { node, offset } => {
@@ -1629,6 +1616,11 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
                         jsx_roots::visit_expression_container_roots(self, container, offset);
                     }
                 }
+                MarkupNode::If(_) | MarkupNode::For(_) => {
+                    if let JSXChild::ExpressionContainer(container) = child {
+                        jsx_roots::visit_expression_container_roots(self, container, offset);
+                    }
+                }
                 _ => {}
             }
         }
@@ -1636,7 +1628,9 @@ impl<'rule, 'ctx, 'mc, 'a, R: MarkupRule + ?Sized> MarkupDocumentVisitor<'rule, 
 }
 
 mod exact;
+mod jsx_child;
 mod jsx_roots;
+mod relief_children;
 mod source_ranges;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_patina/src/markup/jsx_child.rs
+++ b/crates/vize_patina/src/markup/jsx_child.rs
@@ -1,0 +1,165 @@
+use super::{MarkupElement, MarkupNode, MarkupText, span_to_range};
+use oxc_ast::ast::{
+    ArrowFunctionExpression, CallExpression, ConditionalExpression, Expression, Function, JSXChild,
+    JSXExpression, LogicalOperator, Statement,
+};
+
+impl<'a> MarkupNode<'a> {
+    pub(super) fn from_jsx_child(child: &'a JSXChild<'a>, offset: u32) -> Self {
+        match child {
+            JSXChild::Text(text) => Self::Text(MarkupText::from_jsx(&**text as *const _, offset)),
+            JSXChild::Element(element) => Self::Element(MarkupElement::from_jsx_element(
+                &**element as *const _,
+                offset,
+            )),
+            JSXChild::Fragment(fragment) => Self::Element(MarkupElement::from_jsx_fragment(
+                &**fragment as *const _,
+                offset,
+            )),
+            JSXChild::ExpressionContainer(container) => match &container.expression {
+                JSXExpression::EmptyExpression(_) => {
+                    Self::Comment(span_to_range(container.span, offset))
+                }
+                JSXExpression::StringLiteral(string) => Self::Text(MarkupText::from_static(
+                    string.value.as_str(),
+                    span_to_range(string.span, offset),
+                )),
+                expression if jsx_expression_is_conditional_markup(expression) => {
+                    Self::If(span_to_range(container.span, offset))
+                }
+                expression if jsx_expression_is_list_markup(expression) => {
+                    Self::For(span_to_range(container.span, offset))
+                }
+                _ => Self::Interpolation(span_to_range(container.span, offset)),
+            },
+            JSXChild::Spread(spread) => Self::Interpolation(span_to_range(spread.span, offset)),
+        }
+    }
+}
+
+fn jsx_expression_is_conditional_markup(expr: &JSXExpression<'_>) -> bool {
+    let Some(expr) = jsx_expression_as_expression(expr) else {
+        return false;
+    };
+    match unwrap_jsx_parens(expr) {
+        Expression::LogicalExpression(logical) => {
+            logical.operator == LogicalOperator::And && expression_is_direct_jsx(&logical.right)
+        }
+        Expression::ConditionalExpression(conditional) => conditional_has_jsx_arm(conditional),
+        _ => false,
+    }
+}
+
+fn jsx_expression_is_list_markup(expr: &JSXExpression<'_>) -> bool {
+    let Some(Expression::CallExpression(call)) =
+        jsx_expression_as_expression(expr).map(unwrap_jsx_parens)
+    else {
+        return false;
+    };
+    map_call_returns_render_child(call)
+}
+
+fn map_call_returns_render_child(call: &CallExpression<'_>) -> bool {
+    let Expression::StaticMemberExpression(member) = unwrap_jsx_parens(&call.callee) else {
+        return false;
+    };
+    if member.property.name.as_str() != "map" || member.optional || call.arguments.len() != 1 {
+        return false;
+    }
+
+    let Some(argument) = call
+        .arguments
+        .first()
+        .and_then(|argument| argument.as_expression())
+    else {
+        return false;
+    };
+
+    match unwrap_jsx_parens(argument) {
+        Expression::ArrowFunctionExpression(arrow) => arrow_returns_render_child(arrow),
+        Expression::FunctionExpression(function) => function_returns_render_child(function),
+        _ => false,
+    }
+}
+
+fn arrow_returns_render_child(arrow: &ArrowFunctionExpression<'_>) -> bool {
+    if arrow.expression {
+        let Some(Statement::ExpressionStatement(statement)) = arrow.body.statements.first() else {
+            return false;
+        };
+        expression_returns_render_child(&statement.expression)
+    } else {
+        statements_return_render_child(&arrow.body.statements)
+    }
+}
+
+fn function_returns_render_child(function: &Function<'_>) -> bool {
+    let Some(body) = function.body.as_ref() else {
+        return false;
+    };
+    statements_return_render_child(&body.statements)
+}
+
+fn statements_return_render_child(statements: &[Statement<'_>]) -> bool {
+    statements.iter().any(|statement| {
+        let Statement::ReturnStatement(statement) = statement else {
+            return false;
+        };
+        statement
+            .argument
+            .as_ref()
+            .is_some_and(|argument| expression_returns_render_child(argument))
+    })
+}
+
+fn expression_returns_render_child(expr: &Expression<'_>) -> bool {
+    match unwrap_jsx_parens(expr) {
+        Expression::JSXElement(_) | Expression::JSXFragment(_) => true,
+        Expression::LogicalExpression(_) | Expression::ConditionalExpression(_) => {
+            expression_is_conditional_markup(expr)
+        }
+        Expression::CallExpression(call) => map_call_returns_render_child(call),
+        _ => false,
+    }
+}
+
+fn expression_is_conditional_markup(expr: &Expression<'_>) -> bool {
+    match unwrap_jsx_parens(expr) {
+        Expression::LogicalExpression(logical) => {
+            logical.operator == LogicalOperator::And && expression_is_direct_jsx(&logical.right)
+        }
+        Expression::ConditionalExpression(conditional) => conditional_has_jsx_arm(conditional),
+        _ => false,
+    }
+}
+
+fn conditional_has_jsx_arm(conditional: &ConditionalExpression<'_>) -> bool {
+    if expression_is_direct_jsx(&conditional.consequent) {
+        return true;
+    }
+    match unwrap_jsx_parens(&conditional.alternate) {
+        Expression::ConditionalExpression(nested) => conditional_has_jsx_arm(nested),
+        other => expression_is_direct_jsx(other),
+    }
+}
+
+fn expression_is_direct_jsx(expr: &Expression<'_>) -> bool {
+    matches!(
+        unwrap_jsx_parens(expr),
+        Expression::JSXElement(_) | Expression::JSXFragment(_)
+    )
+}
+
+fn unwrap_jsx_parens<'e, 'a>(mut expr: &'e Expression<'a>) -> &'e Expression<'a> {
+    while let Expression::ParenthesizedExpression(inner) = expr {
+        expr = &inner.expression;
+    }
+    expr
+}
+
+fn jsx_expression_as_expression<'e, 'a>(expr: &'e JSXExpression<'a>) -> Option<&'e Expression<'a>> {
+    match expr {
+        JSXExpression::EmptyExpression(_) => None,
+        other => other.as_expression(),
+    }
+}

--- a/crates/vize_patina/src/markup/relief_children.rs
+++ b/crates/vize_patina/src/markup/relief_children.rs
@@ -1,0 +1,35 @@
+use super::{MarkupElement, MarkupElementInner};
+use vize_relief::TemplateChildNode;
+
+pub(super) fn walk_relief_children<'a>(
+    children: &'a [TemplateChildNode<'a>],
+    enter: &mut impl FnMut(MarkupElement<'a>),
+    exit: &mut impl FnMut(MarkupElement<'a>),
+) {
+    for child in children {
+        match child {
+            TemplateChildNode::Element(element) => {
+                let element = MarkupElement::new(element);
+                enter(element);
+                walk_relief_children(element_children(element), enter, exit);
+                exit(element);
+            }
+            TemplateChildNode::If(if_node) => {
+                for branch in if_node.branches.iter() {
+                    walk_relief_children(&branch.children, enter, exit);
+                }
+            }
+            TemplateChildNode::For(for_node) => {
+                walk_relief_children(&for_node.children, enter, exit);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn element_children<'a>(element: MarkupElement<'a>) -> &'a [TemplateChildNode<'a>] {
+    match element.inner {
+        MarkupElementInner::Relief(node) => &node.children,
+        _ => &[],
+    }
+}

--- a/crates/vize_patina/src/markup/tests.rs
+++ b/crates/vize_patina/src/markup/tests.rs
@@ -10,6 +10,7 @@
 mod ancestry_tests;
 mod anchor_is_valid_jsx_tests;
 mod deprecated_attr_tests;
+mod heading_has_content_tests;
 mod heading_levels_tests;
 mod iframe_has_title_jsx_tests;
 mod iframe_has_title_tests;

--- a/crates/vize_patina/src/markup/tests/heading_has_content_tests.rs
+++ b/crates/vize_patina/src/markup/tests/heading_has_content_tests.rs
@@ -1,0 +1,246 @@
+use crate::context::LintContext;
+use crate::ir::TemplateSyntax;
+use crate::markup::{MarkupContext, MarkupDocument, MarkupRule};
+use crate::rules::a11y::HeadingHasContent;
+use vize_atelier_jsx::JsxLang;
+use vize_s0::Allocator;
+
+fn run_over_template<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let parser = vize_armature::Parser::new(&allocator, source);
+    let (root, _errors) = parser.parse();
+    let document = MarkupDocument::new(&root, TemplateSyntax::Vue);
+
+    let mut lint = LintContext::new(&allocator, source, "test.vue");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+fn run_over_jsx_lowered<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let lowered =
+        vize_atelier_jsx::lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+
+    let mut total = 0;
+    for lowered_root in &lowered.roots {
+        let document = MarkupDocument::new(&lowered_root.root, TemplateSyntax::Vue);
+        let mut lint = LintContext::new(&allocator, source, "test.jsx");
+        let mut ctx = MarkupContext::new(&mut lint, &document);
+        document.visit_with(rule, &mut ctx);
+        total += lint.diagnostics().len();
+    }
+    total
+}
+
+fn run_over_jsx_oxc<R: MarkupRule>(rule: &R, source: &str) -> usize {
+    let oxc_allocator = oxc_allocator::Allocator::default();
+    let parsed = vize_atelier_jsx::parse_module(&oxc_allocator, source, JsxLang::Jsx);
+    let document = MarkupDocument::from_jsx(&parsed.program, TemplateSyntax::Vue, 0);
+
+    let lint_allocator = Allocator::with_capacity(source.len() * 4 + 1024);
+    let mut lint = LintContext::new(&lint_allocator, source, "test.jsx");
+    let mut ctx = MarkupContext::new(&mut lint, &document);
+    document.visit_with(rule, &mut ctx);
+    lint.diagnostics().len()
+}
+
+#[test]
+fn heading_has_content_template_contract() {
+    let rule = HeadingHasContent;
+    for (source, expected, label) in [
+        (r#"<h1>Hello World</h1>"#, 0, "text"),
+        (r#"<h2>{{ title }}</h2>"#, 0, "interpolation"),
+        (r#"<h1><span>Title</span></h1>"#, 0, "nested text"),
+        (r#"<h1><slot></slot></h1>"#, 0, "default slot"),
+        (
+            r#"<h1 aria-hidden="true"></h1>"#,
+            0,
+            "static aria-hidden true",
+        ),
+        (
+            r#"<h1 aria-label="Dashboard"></h1>"#,
+            0,
+            "static aria-label",
+        ),
+        (
+            r#"<h1 aria-label=""></h1>"#,
+            0,
+            "empty static aria-label exists",
+        ),
+        (r#"<h1 :aria-label="title"></h1>"#, 0, "bound aria-label"),
+        (
+            r#"<h1 :aria-labelledby="labelId"></h1>"#,
+            0,
+            "bound aria-labelledby",
+        ),
+        (r#"<h1></h1>"#, 1, "empty heading"),
+        (r#"<h1>   </h1>"#, 1, "whitespace text"),
+        (r#"<h1 aria-hidden></h1>"#, 1, "valueless aria-hidden"),
+        (
+            r#"<h1 aria-hidden="True"></h1>"#,
+            1,
+            "case-sensitive hidden value",
+        ),
+        (
+            r#"<h1 :aria-hidden="true"></h1>"#,
+            1,
+            "bound aria-hidden ignored",
+        ),
+        (
+            r#"<h1 ARIA-LABEL="Title"></h1>"#,
+            1,
+            "aria label name is exact",
+        ),
+        (
+            r#"<h1 a11y:aria-label="Title"></h1>"#,
+            1,
+            "namespaced aria-label ignored",
+        ),
+        (r#"<H1></H1>"#, 0, "component-like uppercase tag"),
+        (r#"<svg:h1></svg:h1>"#, 0, "qualified tag"),
+    ] {
+        assert_eq!(
+            run_over_template(&rule, source),
+            expected,
+            "template case changed for {label}"
+        );
+    }
+}
+
+#[test]
+fn heading_has_content_jsx_direct_matches_lowered_boundaries() {
+    let rule = HeadingHasContent;
+    for (source, expected, label) in [
+        (r#"const A = () => <h1>Hello World</h1>;"#, 0, "text"),
+        (r#"const A = () => <h1>{title}</h1>;"#, 0, "interpolation"),
+        (
+            r#"const A = () => <h1>{0}</h1>;"#,
+            0,
+            "numeric interpolation",
+        ),
+        (
+            r#"const A = () => <h1>{'Title'}</h1>;"#,
+            0,
+            "string literal text",
+        ),
+        (
+            r#"const A = () => <h1><span>Title</span></h1>;"#,
+            0,
+            "nested text",
+        ),
+        (r#"const A = () => <h1><slot /></h1>;"#, 0, "slot outlet"),
+        (
+            r#"const A = () => <h1><><slot /></></h1>;"#,
+            0,
+            "fragment slot",
+        ),
+        (
+            r#"const A = () => <h1 aria-hidden="true" />;"#,
+            0,
+            "static hidden",
+        ),
+        (
+            r#"const A = () => <h1 aria-label="Dashboard" />;"#,
+            0,
+            "static aria-label",
+        ),
+        (
+            r#"const A = () => <h1 aria-label="" />;"#,
+            0,
+            "empty aria-label",
+        ),
+        (
+            r#"const A = () => <h1 aria-label={title} />;"#,
+            0,
+            "bound aria-label",
+        ),
+        (
+            r#"const A = () => <h1 aria-labelledby={labelId} />;"#,
+            0,
+            "bound aria-labelledby",
+        ),
+        (
+            r#"const A = () => <H1 />;"#,
+            0,
+            "component-like uppercase tag",
+        ),
+        (r#"const A = () => <Headings.h1 />;"#, 0, "member tag"),
+        (r#"const A = () => <svg:h1 />;"#, 0, "qualified tag"),
+        (
+            r#"const A = () => <Comp render={<h1 />} />;"#,
+            0,
+            "attribute JSX root is outside legacy fallback boundary",
+        ),
+        (
+            r#"const A = () => <Comp render={() => <h1 />} />;"#,
+            0,
+            "attribute callback JSX root is outside legacy fallback boundary",
+        ),
+        (r#"const A = () => <h1 />;"#, 1, "empty heading"),
+        (r#"const A = () => <h1>{}</h1>;"#, 1, "empty expression"),
+        (
+            r#"const A = () => <h1>{''}</h1>;"#,
+            1,
+            "empty string literal",
+        ),
+        (
+            r#"const A = () => <h1>{' '}</h1>;"#,
+            1,
+            "space string literal",
+        ),
+        (
+            r#"const A = () => <h1>{ok && <span>Title</span>}</h1>;"#,
+            1,
+            "conditional child does not prove stable content",
+        ),
+        (
+            r#"const A = () => <h1>{ok ? <span>Title</span> : null}</h1>;"#,
+            1,
+            "ternary child does not prove stable content",
+        ),
+        (
+            r#"const A = () => <h1>{items.map((item) => <span>{item}</span>)}</h1>;"#,
+            1,
+            "mapped child does not prove stable content",
+        ),
+        (
+            r#"const A = () => <h1 aria-hidden />;"#,
+            1,
+            "valueless aria-hidden",
+        ),
+        (
+            r#"const A = () => <h1 aria-hidden="True" />;"#,
+            1,
+            "case-sensitive hidden value",
+        ),
+        (
+            r#"const A = () => <h1 aria-hidden={true} />;"#,
+            1,
+            "bound aria-hidden ignored",
+        ),
+        (
+            r#"const A = () => <h1 ARIA-LABEL="Title" />;"#,
+            1,
+            "aria label name is exact",
+        ),
+        (
+            r#"const A = () => <h1 a11y:aria-label="Title" />;"#,
+            1,
+            "namespaced aria-label ignored",
+        ),
+        (
+            r#"const A = () => <h1 {...attrs} />;"#,
+            1,
+            "spread attrs do not prove content",
+        ),
+    ] {
+        let direct = run_over_jsx_oxc(&rule, source);
+        assert_eq!(direct, expected, "JSX direct case changed for {label}");
+        assert_eq!(
+            direct,
+            run_over_jsx_lowered(&rule, source),
+            "JSX direct and lowered fallback diverged for {label}"
+        );
+    }
+}

--- a/crates/vize_patina/src/rules/a11y/heading_has_content.rs
+++ b/crates/vize_patina/src/rules/a11y/heading_has_content.rs
@@ -8,9 +8,11 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{
+    MarkupBindingKind, MarkupContext, MarkupElement, MarkupElementKind, MarkupNode, MarkupRule,
+};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use crate::rules::a11y::helpers::is_slot_element;
-use vize_relief::{ElementNode, ExpressionNode, PropNode, TemplateChildNode};
+use vize_relief::ElementNode;
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/heading-has-content",
@@ -25,47 +27,110 @@ static META: RuleMeta = RuleMeta {
 pub struct HeadingHasContent;
 
 impl HeadingHasContent {
-    fn is_heading(tag: &str) -> bool {
-        matches!(tag, "h1" | "h2" | "h3" | "h4" | "h5" | "h6")
+    fn is_heading(element: &MarkupElement<'_>) -> bool {
+        ["h1", "h2", "h3", "h4", "h5", "h6"]
+            .iter()
+            .any(|tag| element.is_unqualified_tag_exact(tag))
     }
 
-    fn has_accessible_content(element: &ElementNode) -> bool {
-        // Check for aria-label or aria-labelledby
-        for prop in &element.props {
-            if let PropNode::Attribute(attr) = prop
-                && (attr.name == "aria-label" || attr.name == "aria-labelledby")
-            {
-                return true;
+    fn has_accessible_name(element: &MarkupElement<'_>) -> bool {
+        let mut found = false;
+        element.walk_bindings(&mut |binding| {
+            if found {
+                return;
             }
-            if let PropNode::Directive(dir) = prop
-                && dir.name == "bind"
-                && let Some(ExpressionNode::Simple(arg)) = &dir.arg
-                && (arg.content == "aria-label" || arg.content == "aria-labelledby")
+
+            if matches!(
+                binding.kind(),
+                MarkupBindingKind::Attribute | MarkupBindingKind::Bind
+            ) && (binding.is_unqualified_arg_exact("aria-label")
+                || binding.is_unqualified_arg_exact("aria-labelledby"))
             {
-                return true;
+                found = true;
             }
+        });
+        found
+    }
+
+    fn is_hidden_from_accessibility_tree(element: &MarkupElement<'_>) -> bool {
+        let mut hidden = false;
+        element.walk_bindings(&mut |binding| {
+            if hidden {
+                return;
+            }
+
+            if binding.kind() == MarkupBindingKind::Attribute
+                && binding.is_unqualified_arg_exact("aria-hidden")
+                && binding.static_value() == Some("true")
+            {
+                hidden = true;
+            }
+        });
+        hidden
+    }
+
+    fn has_accessible_content(element: &MarkupElement<'_>) -> bool {
+        if Self::has_accessible_name(element) {
+            return true;
         }
 
-        // Check for content in children
-        for child in &element.children {
-            match child {
-                TemplateChildNode::Text(text) if !text.content.trim().is_empty() => {
-                    return true;
-                }
-                TemplateChildNode::Interpolation(_) => {
-                    return true;
-                }
-                TemplateChildNode::Element(el) if is_slot_element(el) => {
-                    return true;
-                }
-                TemplateChildNode::Element(el) if Self::has_accessible_content(el) => {
-                    return true;
-                }
-                _ => {}
+        let mut has_content = false;
+        element.walk_children(&mut |child| match child {
+            MarkupNode::Text(text) if text.is_significant() => {
+                has_content = true;
             }
+            MarkupNode::Interpolation(_) => {
+                has_content = true;
+            }
+            MarkupNode::Element(child_element)
+                if child_element.kind() == MarkupElementKind::Slot
+                    || child_element.is_unqualified_tag_exact("slot") =>
+            {
+                has_content = true;
+            }
+            MarkupNode::Element(child_element) if Self::has_accessible_content(&child_element) => {
+                has_content = true;
+            }
+            MarkupNode::Text(_)
+            | MarkupNode::Element(_)
+            | MarkupNode::Comment(_)
+            | MarkupNode::If(_)
+            | MarkupNode::For(_)
+            | MarkupNode::Other(_) => {}
+        });
+
+        has_content
+    }
+
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        if !Self::is_heading(element) || Self::is_hidden_from_accessibility_tree(element) {
+            return;
         }
 
-        false
+        if !Self::has_accessible_content(element) {
+            ctx.warn_at_with_help(
+                ctx.t_fmt(
+                    "a11y/heading-has-content.message",
+                    &[("tag", element.tag())],
+                ),
+                element.range(),
+                ctx.t("a11y/heading-has-content.help"),
+            );
+        }
+    }
+}
+
+impl MarkupRule for HeadingHasContent {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        if ctx.is_jsx_attribute_value() {
+            return;
+        }
+
+        Self::check_element(ctx.lint(), element);
     }
 }
 
@@ -74,29 +139,12 @@ impl Rule for HeadingHasContent {
         &META
     }
 
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
-        if !Self::is_heading(element.tag) {
-            return;
-        }
-
-        // Check for aria-hidden="true" (skip check if hidden)
-        for prop in &element.props {
-            if let PropNode::Attribute(attr) = prop
-                && attr.name == "aria-hidden"
-                && let Some(val) = &attr.value
-                && val.content == "true"
-            {
-                return;
-            }
-        }
-
-        if !Self::has_accessible_content(element) {
-            ctx.warn_with_help(
-                ctx.t_fmt("a11y/heading-has-content.message", &[("tag", element.tag)]),
-                &element.loc,
-                ctx.t("a11y/heading-has-content.help"),
-            );
-        }
+        Self::check_element(ctx, &MarkupElement::new(element));
     }
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -46,7 +46,7 @@ observational guard for planning only. It does not change rollout state.
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           916 |                   432 |               484 |             140 |     371 |             939 |      488 |           484 |           593 |
-| Linter                     |           330 |                   330 |                 0 |             288 |     283 |             669 |      232 |           372 |           535 |
+| Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
@@ -99,10 +99,10 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         330 |             224 |      106 |
-| old AST/parser   |         246 |             207 |       39 |
+| S0               |         331 |             224 |      107 |
+| old AST/parser   |         248 |             208 |       40 |
 | Croquis analysis |          42 |              38 |        4 |
-| raw OXC          |         283 |             200 |       83 |
+| raw OXC          |         287 |             201 |       86 |
 
 #### Top source and manifest files
 
@@ -114,7 +114,7 @@ Scope: lint command plus Patina rule engine. This is a lexical inventory, not a 
 | `crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs:46` | source   | S0 2<br>old AST/parser 4<br>Croquis analysis 3              |     9 |
 | `crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs:1`       | source   | S0 1<br>raw OXC 6                                           |     7 |
 
-Additional source/manifest rows are in the TSV: 309 omitted.
+Additional source/manifest rows are in the TSV: 311 omitted.
 
 #### Top test/dev files
 
@@ -122,11 +122,11 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------- | ----: |
 | `crates/vize_patina/src/output/tests.rs:4`                                       | test/dev | S0 23                                                       |    23 |
 | `crates/vize_patina/src/rules/vue/no_unused_components.rs:39`                    | test/dev | S0 1<br>old AST/parser 2<br>Croquis analysis 3<br>raw OXC 7 |    13 |
-| `crates/vize_patina/src/markup/tests.rs:48`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
+| `crates/vize_patina/src/markup/tests.rs:49`                                      | test/dev | S0 1<br>old AST/parser 3<br>raw OXC 6                       |    10 |
 | `crates/vize_patina/src/rules/script/no_use_computed_property_like_method.rs:36` | test/dev | S0 1<br>raw OXC 5                                           |     6 |
 | `crates/vize_patina/src/rules/vue/no_mutating_props.rs:62`                       | test/dev | S0 3<br>old AST/parser 2<br>Croquis analysis 1              |     6 |
 
-Additional test/dev rows are in the TSV: 66 omitted.
+Additional test/dev rows are in the TSV: 67 omitted.
 
 ### Typechecker
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -992,12 +992,14 @@ linter	Linter	source	crates/vize_patina/src/markup.rs	48	raw_oxc	raw OXC	raw	oxc
 linter	Linter	source	crates/vize_patina/src/markup.rs	48	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/exact.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
+linter	Linter	source	crates/vize_patina/src/markup/jsx_child.rs	2	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/jsx_roots.rs	2	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 linter	Linter	source	crates/vize_patina/src/markup/jsx_roots.rs	2	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
+linter	Linter	source	crates/vize_patina/src/markup/relief_children.rs	2	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/markup/source_ranges.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	48	s0	S0	stage	vize_s0	preferred	1
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	48	old_ast	old AST/parser	old	vize_armature	legacy	3
-linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	48	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	49	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	49	old_ast	old AST/parser	old	vize_armature	legacy	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests.rs	49	raw_oxc	raw OXC	raw	oxc_allocator	raw	6
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/ancestry_tests.rs	10	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/ancestry_tests.rs	10	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/ancestry_tests.rs	10	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1006,6 +1008,9 @@ linter	Linter	test/dev	crates/vize_patina/src/markup/tests/anchor_is_valid_jsx_t
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/deprecated_attr_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/heading_has_content_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/heading_has_content_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
+linter	Linter	test/dev	crates/vize_patina/src/markup/tests/heading_has_content_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/heading_levels_tests.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/heading_levels_tests.rs	6	old_ast	old AST/parser	old	vize_armature	legacy	1
 linter	Linter	test/dev	crates/vize_patina/src/markup/tests/heading_levels_tests.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	3
@@ -1089,7 +1094,7 @@ linter	Linter	source	crates/vize_patina/src/rules/a11y/aria_role.rs	17	old_ast	o
 linter	Linter	source	crates/vize_patina/src/rules/a11y/aria_unsupported_elements.rs	14	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/click_events_have_key_events.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/form_control_has_label.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
-linter	Linter	source	crates/vize_patina/src/rules/a11y/heading_has_content.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1
+linter	Linter	source	crates/vize_patina/src/rules/a11y/heading_has_content.rs	15	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	s0	S0	stage	vize_s0	preferred	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/helpers.rs	6	old_ast	old AST/parser	old	vize_relief	legacy	1
 linter	Linter	source	crates/vize_patina/src/rules/a11y/iframe_has_title.rs	13	old_ast	old AST/parser	old	vize_relief	legacy	1

--- a/davinci-road/plan/rule-parity.md
+++ b/davinci-road/plan/rule-parity.md
@@ -34,10 +34,10 @@ Per-rule registration surface, SFC/JSX path membership, croquis usage, and a fir
 
 - **total rules: 245**
 - by family: template-family 158, script 71, css 10, musea 6
-- by surface (a rule can have several): `css-text` 10, `markup-facade` 38, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
+- by surface (a rule can have several): `css-text` 10, `markup-facade` 39, `musea-blocks` 6, `script-oxc` 65, `script-source` 6, `sfc-source` 9, `template-ast` 152, `type-aware-corsa` 5
 - path membership: SFC `lint_sfc` 239 · JSX `lint_jsx` 147 · **SFC∩JSX 147** · SFC-only 92 · JSX-only 0 · neither 6 (6 musea + 0 unregistered)
-- JSX lanes: `fallback` 109, `ir` 26, `ir-lowered` 12, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (38 = 38 `markup-facade` rules)
-- classification: neutral-core-candidate **90** · vue-dialect-bound **133** · container-bound **22** (0 overridden)
+- JSX lanes: `fallback` 108, `ir` 27, `ir-lowered` 12, `no-jsx-hooks` 11 — `ir` + `ir-lowered` is the markup-facade migration list (39 = 39 `markup-facade` rules)
+- classification: neutral-core-candidate **91** · vue-dialect-bound **132** · container-bound **22** (0 overridden)
 - croquis adoption: **23** rules touch vize_croquis (18 direct imports, 12 via context analysis)
 
 ## Full table
@@ -54,7 +54,7 @@ Sorted by rule name. File paths are relative to `crates/vize_patina/src/rules/`.
 | `a11y/aria-unsupported-elements`                | template-family | `a11y/aria_unsupported_elements.rs`                    | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/click-events-have-key-events`             | template-family | `a11y/click_events_have_key_events.rs`                 | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
 | `a11y/form-control-has-label`                   | template-family | `a11y/form_control_has_label.rs`                       | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
-| `a11y/heading-has-content`                      | template-family | `a11y/heading_has_content.rs`                          | template-ast                   | yes (template-visitor)           | yes (fallback)              | —                                                                                                   | vue-dialect-bound      |
+| `a11y/heading-has-content`                      | template-family | `a11y/heading_has_content.rs`                          | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/heading-levels`                           | template-family | `opinionated/a11y/heading_levels.rs`                   | template-ast, markup-facade    | yes (template-visitor)           | yes (ir-lowered)            | —                                                                                                   | neutral-core-candidate |
 | `a11y/iframe-has-title`                         | template-family | `a11y/iframe_has_title.rs`                             | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | neutral-core-candidate |
 | `a11y/img-alt`                                  | template-family | `a11y/img_alt.rs`                                      | template-ast, markup-facade    | yes (template-visitor)           | yes (ir)                    | —                                                                                                   | vue-dialect-bound      |


### PR DESCRIPTION
Closes #5357

## Summary
- move a11y/heading-has-content onto the Patina markup facade
- preserve template and JSX fallback behavior with direct-vs-lowered parity tests
- split JSX child classification/relief traversal helpers and regenerate Davinci inventories

## Tests
- cargo test -p vize_patina heading_has_content -- --nocapture
- cargo test -p vize_patina
- cargo clippy -p vize_patina --all-targets -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- git diff --check
- node tools/davinci/rule-parity.mjs --check
- node tools/davinci/consumer-migration-surfaces.mjs --check
- node tools/davinci/sourcelocation-inventory.mjs --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/davinci-assertion-lint.test.ts tests/tooling/davinci-matrices.test.ts tests/tooling/source-file-lengths.test.ts
- cargo bench -p vize_patina --bench davinci_markup -- --quick
- node tools/davinci/bench-compare.mjs --bench patina_jsx_markup_one_root

No rollout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790674813&installation_model_id=422833&pr_number=5366&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5366&signature=b5333e39b87a69be75cdbbf3556e6425d031c725cce07219dc034c5f5c4d0875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved heading content accessibility checks across templates and JSX/TSX.
  * Headings now recognize text, interpolations, nested content, slots, and valid accessibility attributes more consistently.
  * Conditional and list-rendered JSX content is handled during analysis.

* **Bug Fixes**
  * Prevented duplicate diagnostics when checking migrated rules.
  * Improved handling of empty headings, whitespace-only content, and invalid accessibility attributes.

* **Tests**
  * Added comprehensive coverage for template, JSX, and TSX heading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->