### PR TITLE
test(davinci): refresh corpus baseline scope

### DIFF
--- a/davinci-road/plan/corpus-baseline-notes.md
+++ b/davinci-road/plan/corpus-baseline-notes.md
@@ -254,3 +254,29 @@ Evidence recorded before re-recording (TS-11: investigate, never average):
 This section's baseline (568 rows at `d96852a18` + this branch) blesses
 the post-sync behavior so the TS-11 gate stays meaningful for phase-1 PRs.
 If #4340 changes the materialization behavior, that PR re-records again.
+
+## Re-record 3 — 144-project phase-2 scope (2026-08-30)
+
+Phase 2's DOM exit gate measures the 144-project manifest. The committed
+baseline still covered the 142-project scope, so `corpus-diff --surface
+compiler` failed before it could run the fresh compiler lane:
+`manifest_project_count 142 != manifest 144`; `primevue-volt` and
+`primevue-showcase` were missing on all four surfaces. The failure was the
+intended scope proof, not a DOM drift.
+
+The refresh first made `lew-ui` use its checked-in `tsconfig.json`. Its
+empty matrix tsconfig let the typechecker report the same authored files as
+both `lib/...` and package-root-relative paths, which the matrix validator
+correctly rejected as unclassified transitive authored files. With the
+fixture tsconfig in the registry, the single-project matrix typechecker run
+is clean.
+
+Reference command:
+
+```sh
+node tools/davinci/corpus-baseline.mjs --clean-fixtures --shards 2 --timeout-ms 600000 --out .vize/davinci-baseline-144.json
+```
+
+Result: 576/576 comparisons, 144 projects x 4 surfaces, 156274 files.
+The compiler-surface proof against the refreshed artifact passed with
+144/144 comparisons and 37448 compiler files.

--- a/tests/_fixtures/davinci-baseline.json
+++ b/tests/_fixtures/davinci-baseline.json
@@ -35,8 +35,8 @@
     ]
   },
   "scope": {
-    "manifest_project_count": 142,
-    "projects_run": 142,
+    "manifest_project_count": 144,
+    "projects_run": 144,
     "surfaces": [
       "compiler",
       "formatter",
@@ -44,13 +44,13 @@
       "typechecker"
     ],
     "surfaces_per_project": 4,
-    "row_count": 568,
-    "total_file_count": 151464,
+    "row_count": 576,
+    "total_file_count": 156274,
     "file_count_by_surface": {
-      "compiler": 35169,
-      "formatter": 35169,
-      "linter": 35169,
-      "typechecker": 45957
+      "compiler": 37448,
+      "formatter": 37448,
+      "linter": 37448,
+      "typechecker": 43930
     }
   },
   "rows": [
@@ -58,37 +58,37 @@
       "surface": "compiler",
       "project": "airi",
       "file_count": 586,
-      "content_hash": "cc2f94d991bd010b7ff68ea347956958be28da0b73b881963c1829101478e7c1"
+      "content_hash": "20b5da25bbcbb8b18af6f552bb7957f208154c5a2a0565a93496477b42af5c77"
     },
     {
       "surface": "compiler",
       "project": "alexandrie",
       "file_count": 202,
-      "content_hash": "fbb46533bf0e6becdb59d0d07c0fc55e0022f669f0a8a3ca760b395e572ddaa2"
+      "content_hash": "0944406209119da44f1c28121d48e33ea20550e2ebbf6f52e044d82982fb74a3"
     },
     {
       "surface": "compiler",
       "project": "ant-design-vue",
       "file_count": 731,
-      "content_hash": "b5d85991b1b9d127dd460a1501c4c40b87e11371115250af9153167518d41d99"
+      "content_hash": "acc61847be72e9053686fd3d0d03a8c0bc365187598f1516af375520d4645347"
     },
     {
       "surface": "compiler",
       "project": "antares",
       "file_count": 94,
-      "content_hash": "a8bf87a31a4c7f837ea0ad2d1a2a96b082f88d8a615b1c09dfdd3bc3fac814f5"
+      "content_hash": "93501898dc1caedbb80508c86212f8b3be404678dec4e869e745d6d1ecda7b3a"
     },
     {
       "surface": "compiler",
       "project": "arco-design-pro-vue",
       "file_count": 86,
-      "content_hash": "d4805a7ac88ca7e337a0bc1d812493ac464ae86f3891a8d4bf233a183cd3dac0"
+      "content_hash": "d3517e168d3dc834c76808cce966d2622d225bbe6531461522e8a1f427e77fa4"
     },
     {
       "surface": "compiler",
       "project": "automa",
       "file_count": 215,
-      "content_hash": "e54b4a0042cf24b5c478c3b053522fcf42fb174776378b1a2df20ddbecec5ec1"
+      "content_hash": "8968c2efbec95eea521434c19a42975672c27b5240cbebad7b8e7e6ed189628d"
     },
     {
       "surface": "compiler",
@@ -100,31 +100,31 @@
       "surface": "compiler",
       "project": "bootstrap-vue",
       "file_count": 22,
-      "content_hash": "8d23d02eac672e3fe5cf0b2be76a233e468cfec8b28de1a4228237502870598c"
+      "content_hash": "3529ee4a69f1c7c875540e4c7e3086c8a480de45efce2891d3feb2cf951b35c2"
     },
     {
       "surface": "compiler",
       "project": "buefy",
       "file_count": 431,
-      "content_hash": "6c10caadc91cf50302352d82225143e22f0d10ebd884cc68c0a03c04c7150403"
+      "content_hash": "c633e0b793e7a60f947d6714a326b000a42e817ca646631c75261fb059f9d0ba"
     },
     {
       "surface": "compiler",
       "project": "bym-vue-echarts",
       "file_count": 37,
-      "content_hash": "39fb1162f6313abc6fb490bc32345248bc322138748706ded04d5bc7f1760021"
+      "content_hash": "d72ea24780422094f75e2c59f1a24b9aadca191bc62c81479ddca494e09fe57d"
     },
     {
       "surface": "compiler",
       "project": "crater",
       "file_count": 311,
-      "content_hash": "35d58c7c43b169fb164c5d17b854e7fcea7a3900386ae93064af21e8d30f61b1"
+      "content_hash": "39bbe766e37d8506df347ccf83d327d890cdf6db1d612464ac632279b54301ce"
     },
     {
       "surface": "compiler",
       "project": "create-vue",
       "file_count": 42,
-      "content_hash": "e4a65b267ef5139e9e4013213252d9066f957a1c09d895ec5e1dcb624508dd0b"
+      "content_hash": "ae0faf4cbe2418620e36c9b4b185c08f79c41fd6f5a9ab9a54ddbfb1fcd9bdce"
     },
     {
       "surface": "compiler",
@@ -136,25 +136,25 @@
       "surface": "compiler",
       "project": "cube-ui",
       "file_count": 164,
-      "content_hash": "e979415ccf1f8ea7895002684a2912d588680295b6c05a0ae87696184842aac2"
+      "content_hash": "6dbf48bf788f0c69e350d3c2a9ae1946823314707dbca3709e592b0f5c99db79"
     },
     {
       "surface": "compiler",
       "project": "dashy",
       "file_count": 175,
-      "content_hash": "b47b5af5df0002256ae13e2d18dd0b64cff6ca22e74ec4c0e01213d76c05bb96"
+      "content_hash": "d6bfc04ccfa449057134498780f26d8813edb2a95f3d6df2f7017ca3f9aa40e1"
     },
     {
       "surface": "compiler",
       "project": "datav",
       "file_count": 76,
-      "content_hash": "8949b8795ec13725eeae24b73ae8c864e500fdcf95eab8177f810ed53c5f56a0"
+      "content_hash": "8a5c7828f3504cbf916ccb2e5c79954eb4416ee78105dfb95de894881cc22b73"
     },
     {
       "surface": "compiler",
       "project": "dbx",
       "file_count": 376,
-      "content_hash": "0d9ad802ccbcdf989f3051b43d20213a00c09c815456924d456cfd1947fbbd8f"
+      "content_hash": "0fc02d0a140da0100d708e86f173c6b42d44c6080f33e06039dd1caa89ffa59c"
     },
     {
       "surface": "compiler",
@@ -166,7 +166,7 @@
       "surface": "compiler",
       "project": "directus",
       "file_count": 576,
-      "content_hash": "ee4e48da05829c67e2a4b26b3dbb8e2ff50d677f146df7d6c9adf45a88d64a84"
+      "content_hash": "93437c92ae795cf9b7aa499153eff21b855d5a729bb376250cf1eefd22b8de63"
     },
     {
       "surface": "compiler",
@@ -178,31 +178,31 @@
       "surface": "compiler",
       "project": "douyin",
       "file_count": 128,
-      "content_hash": "bb435d89577b1f160ba8356143786c54b65709f9b9e6fefaf1077e11cb2d9821"
+      "content_hash": "3fc5f547325d1758672943016a52bbed94c057197342510e90aafbf6932c2ec7"
     },
     {
       "surface": "compiler",
       "project": "element",
       "file_count": 155,
-      "content_hash": "49d88358c42c2b2ae68dc14b81eedcc9a5d68d992111bdf53037a251b39903fa"
+      "content_hash": "476b767213d3fd4f5054ae60c8564f5dd048abe12d0b56fc70f6089c88fcb1b8"
     },
     {
       "surface": "compiler",
       "project": "element-plus",
       "file_count": 823,
-      "content_hash": "0f74f481183fc83763e825275d2d20a64c5f75298db64d7926c6cc2918bdeed7"
+      "content_hash": "74ef7fbda6aa7dc528ad5dc4fb1790135084b901c02869c82a3b68f1160510c8"
     },
     {
       "surface": "compiler",
       "project": "element-plus-x",
       "file_count": 334,
-      "content_hash": "dc4f33b313cc3c4f9c9c3c0a51e560dd0b7dffbfc2bd1e9194933d757d1eb669"
+      "content_hash": "b3d483724e3d9f0d943a61a0daa0c8142d8fce4523faea5ed6e659d2a08cac5f"
     },
     {
       "surface": "compiler",
       "project": "elk",
       "file_count": 259,
-      "content_hash": "b1d5a9cb29d1096e0b038499485aa4ee526d309056361011d418ac08722f1af8"
+      "content_hash": "766011a62f95c13803bb2d22bd7926e12beceab59ecb53654d483421c0102e33"
     },
     {
       "surface": "compiler",
@@ -214,115 +214,115 @@
       "surface": "compiler",
       "project": "filebrowser",
       "file_count": 58,
-      "content_hash": "a4430d4534d7fda61908f682f67640b67c8b747b88990ec0c7c753b1cfc0c320"
+      "content_hash": "4c75e9a6c00c9c4f2a5b883ffea7f17feecb76566ea22a7c72e451e422dd2bdd"
     },
     {
       "surface": "compiler",
       "project": "frappe-builder",
       "file_count": 159,
-      "content_hash": "2d99664f76b5e94bc873cf3b3ce5eced431636a97b0122af4dac7224291054c8"
+      "content_hash": "ac37736042b984c0853bcc74c1814477dd7d919ae58acc436f4af322964cf416"
     },
     {
       "surface": "compiler",
       "project": "frappe-crm",
       "file_count": 339,
-      "content_hash": "6f62eefbc1a8a461bc0b91a219e21667b7f33e2d4a2f5c03f0e45cb82e2449e9"
+      "content_hash": "f0db290fde14ce9ec9a8ac556ef81f76c43264ecd57f2475f5595ac62903f024"
     },
     {
       "surface": "compiler",
       "project": "frpc-desktop",
       "file_count": 13,
-      "content_hash": "1692d1e7c60d5000c04b18a2ad08f0514315783e6aad40d379c5d18a6503b361"
+      "content_hash": "fd49e0ee6fb2b72b5a0937070f2e5bf481b44c380a7e7305c73679f7ef822ed0"
     },
     {
       "surface": "compiler",
       "project": "gogocode",
       "file_count": 186,
-      "content_hash": "010fdea03cf9f3cd38ee9510d86cf7c220e0e7f5702aa21ecd1a58b6feb06931"
+      "content_hash": "bf6caf32af71b1b6eff3da3c2b975beb2a2626804325017c37af57ef0c229be1"
     },
     {
       "surface": "compiler",
       "project": "gridea",
       "file_count": 26,
-      "content_hash": "031243bf7e9e8613d20d058d43d20ba1ae5bdfac50f10870877d5796c7ef4009"
+      "content_hash": "c929dcf854f21a4a701b8b653cca54449bcd5735b3ada2adc43ec2a35c59b032"
     },
     {
       "surface": "compiler",
       "project": "gui-for-singbox",
       "file_count": 98,
-      "content_hash": "fd5a96cb90affd23ed9bcf9b6a235b454252e225c277e54545db89cd82b3bd74"
+      "content_hash": "b14ce3b9399a9249adc7c6ca9f6741818903a4a9e5d4786d340e6928a233eec7"
     },
     {
       "surface": "compiler",
       "project": "habitica",
       "file_count": 352,
-      "content_hash": "569be7595aa2b6441c5fb5dfd316f790ed0d38f6128f90c0c537d9447a2b4ac6"
+      "content_hash": "d38808041064653cb6d00dbb51f8827446eaf7dd4d9d0f78a2a2779def18c8a4"
     },
     {
       "surface": "compiler",
       "project": "heyui",
       "file_count": 76,
-      "content_hash": "8b9524460eb6807f7a3eda8ab9ea34e26c1629529f710ce7ff11e237e5b47304"
+      "content_hash": "1dff6e424acb39a8a8a7115004952545114ee76a46ef12438a5eb68601d254bd"
     },
     {
       "surface": "compiler",
       "project": "hoppscotch",
       "file_count": 365,
-      "content_hash": "182fd1e755d1b023bfecf6f14f945edfa71ba9741277dd2016a32ae78ce06cac"
+      "content_hash": "d023e99a4396f7c56aba7c371a0ad96e7f46b031694ccf39d1b5c25572ceca28"
     },
     {
       "surface": "compiler",
       "project": "inertia",
       "file_count": 459,
-      "content_hash": "fbfc9fe87284321e6fabb834e54b8684637753fef2c8e4febf4d254b590e6e13"
+      "content_hash": "c8ab5841489cb3e1a5853c8993f33954c49898c83f0d97c9dfc553f55f77d965"
     },
     {
       "surface": "compiler",
       "project": "inspira-ui",
       "file_count": 512,
-      "content_hash": "1def3a2a7dec6e61281958d5d7008c18e354fe1807cd3f9caa670494a6099209"
+      "content_hash": "e2c75256e870d46780200a451149c050738a54977b27ca03e4a097c69b8a4947"
     },
     {
       "surface": "compiler",
       "project": "jellyfin-vue",
       "file_count": 136,
-      "content_hash": "17ec17f6abd96f248e2c186fc35c398ca5311b654b058c8c387c04a4181cb794"
+      "content_hash": "f132c6705b7cebbeb5cb42c9ffab164f2d36d5ac01d8c94e902108904219c639"
     },
     {
       "surface": "compiler",
       "project": "koel",
       "file_count": 337,
-      "content_hash": "120e753b97abfd657446472210b378c4449405e682b7a3f10a650f9022eaeed0"
+      "content_hash": "f8c342c6395b17ccb0ad038a23ac49f843da997160e684d2e329b4f8fc3e12a4"
     },
     {
       "surface": "compiler",
       "project": "laravel-breeze",
       "file_count": 54,
-      "content_hash": "7e0987e11b1e6e2f92275bdb3753854541cd5185abdede4751b330bfa8c8ace2"
+      "content_hash": "922ba8da5b1b3646c1b2fedfb070ec7680875fbf7aa5be01a75b42dc6fef2e67"
     },
     {
       "surface": "compiler",
       "project": "layoutit-grid",
       "file_count": 112,
-      "content_hash": "af4a8dcbb75819b12c71535040187edfc2bbcc76898235ed51bdd5754e493946"
+      "content_hash": "791d04e408dab484be7b5c4f54de6239e8be89ecdcb4a2eb934e9df3ae7a382d"
     },
     {
       "surface": "compiler",
       "project": "lew-ui",
       "file_count": 429,
-      "content_hash": "9fa28a61876533db0a8cae7b51a014e9ec6a041a27647079d8d92f1851e16947"
+      "content_hash": "d2a269d175af286fd478cfc5507bb647abb84cb655d285aa43fa7232ba20bd4d"
     },
     {
       "surface": "compiler",
       "project": "lx-music-desktop",
       "file_count": 122,
-      "content_hash": "9ded848cc7c2d20ba83231ea67690bd3b3f542db930a501484813434fbf95b44"
+      "content_hash": "93329cef7de31e79dc5055f8fe9be8e30d0b83cc84d9926f6d946de75a1ad4df"
     },
     {
       "surface": "compiler",
       "project": "mall-admin-web",
       "file_count": 83,
-      "content_hash": "5c986a6fd58697c0ba124e05ed9184a85dd5d084b3e8d90048e52991888522fb"
+      "content_hash": "caddf7fb597ad64030efaa685031d7ebdbfee8915347b61e78213f3cbeb01ea4"
     },
     {
       "surface": "compiler",
@@ -334,37 +334,37 @@
       "surface": "compiler",
       "project": "mealie",
       "file_count": 205,
-      "content_hash": "aeac6ac05003597052e2f78d355e806f111ebfa02681d3e9008d8e8d5b5f38d0"
+      "content_hash": "ceea3ee0a4493befd5958dab7193966e574b0920acd11a87b7314f68e427843d"
     },
     {
       "surface": "compiler",
       "project": "mint-ui",
       "file_count": 69,
-      "content_hash": "ccee79a79c8567015200396e981cba2ab2ec365066b663769579c80b0578f78d"
+      "content_hash": "136ede3451c123e62bd67bbc5bb09d69eb4e2474e3883ffbd3ac2e740d8591cc"
     },
     {
       "surface": "compiler",
       "project": "misskey",
       "file_count": 583,
-      "content_hash": "77dc90cc28fb9ee908579c8622093a52cd2c6ce26f0236d0076a3dff601e5935"
+      "content_hash": "e9559a220f042479f406ba7e1225bc5e8aff374462c7e623c0351b1162585b13"
     },
     {
       "surface": "compiler",
       "project": "mobile-web-best-practice",
       "file_count": 7,
-      "content_hash": "47bdfd954b365a8032078237962dd3e5b91a290375228d7f6d43819e45444d10"
+      "content_hash": "c2e77120657a6f149708a61e4e2ae8b0b6a94fd4c4ce5e65851e7a09603521e2"
     },
     {
       "surface": "compiler",
       "project": "motion-vue",
       "file_count": 74,
-      "content_hash": "e9afa7bc23d42316458d85e1720af0b623d386badd070b5f45118f4ef78dfd31"
+      "content_hash": "51c36a308414c76a6f2f69b7701b023145a43da040a758f13f5ced58ba9cb823"
     },
     {
       "surface": "compiler",
       "project": "multiple-select",
       "file_count": 62,
-      "content_hash": "17ec6ceed3a1ed993ecca644452809dbd4d41fc1b94c8e6dda8228c23b0417bd"
+      "content_hash": "7f9c114adb09471f881c9f300daea24d2a116c5aec69b42b9bc5fa7939cdddbe"
     },
     {
       "surface": "compiler",
@@ -376,13 +376,13 @@
       "surface": "compiler",
       "project": "music-website",
       "file_count": 47,
-      "content_hash": "a355310e225f216808108958fc314557b2e8b88a6914f6a606d526824e688277"
+      "content_hash": "8ff9d149367a2d9476beac3a3483e522666952444bb0547ea4a3f559c96f9a2a"
     },
     {
       "surface": "compiler",
       "project": "naive-ui",
       "file_count": 1720,
-      "content_hash": "239b4eaf0854d45df81b6e082ca4a784d75e958bdcab337af84f1383b86e5bfe"
+      "content_hash": "b72a4f036e22b3ccd9ceb454047d2c5be4d55e2a7e193c0ddfd7ab1902b34625"
     },
     {
       "surface": "compiler",
@@ -394,7 +394,7 @@
       "surface": "compiler",
       "project": "nutui",
       "file_count": 1228,
-      "content_hash": "08efce4da88d5341982fafa132039f21cca831d82a23bbbd0f15d6748cc803fd"
+      "content_hash": "72aae84eaa6a5474fc61e9d08868f963fc1548bdcd42401bdce2b05ff2ff1e02"
     },
     {
       "surface": "compiler",
@@ -406,79 +406,91 @@
       "surface": "compiler",
       "project": "piclist",
       "file_count": 56,
-      "content_hash": "5cb95acc9d73a86cd4c1ccc95ad962690cf784e75fde9278b30faf622654f76f"
+      "content_hash": "4551d822a49d381395d387bcc0049ebdd55278455a2f26279f64ac2e3aeab4db"
     },
     {
       "surface": "compiler",
       "project": "pinia",
       "file_count": 24,
-      "content_hash": "d5a99cd4170872c0f879191733acfe97fc4403c375f3965598fc183d8d97dfb7"
+      "content_hash": "e01caa255c591b8ea143243b821a8bb09944084025cf86cc77460067615f543c"
     },
     {
       "surface": "compiler",
       "project": "pinry",
       "file_count": 29,
-      "content_hash": "53c4c06708fa4f12e530e7b94436624a4cd29eb4ac6aeeed3e0badc903e0ec72"
+      "content_hash": "b768012d5fd620adb4e16ed12b8c067bcf6bef9817020346ce92aa26dcb90557"
     },
     {
       "surface": "compiler",
       "project": "portal-vue",
       "file_count": 42,
-      "content_hash": "ee0bbed44f349b25a449c48c788bd9f7f6cb539b62a1b15ce74021969e0a3674"
+      "content_hash": "903a38096476474cf614c75ae4f1c14ca86f0efd045fa4829a8d9937fbdcaadb"
     },
     {
       "surface": "compiler",
       "project": "prevue",
       "file_count": 24,
-      "content_hash": "f593e3f4a95752d890202b9640024202d8038aaebe01b3ddaa8ede8d9c54e162"
+      "content_hash": "60455a865ef9bf5f759f21c645a54346506bd51c517dbe4cbbf9912cfb9f98bd"
     },
     {
       "surface": "compiler",
       "project": "primevue",
       "file_count": 2610,
-      "content_hash": "34fb27f2dacf3bcde407e995797dc683113290498b81bab70a8c21df7a5e3b74"
+      "content_hash": "0cc14ebacafadeeb590a2698f012a0829631b008a88c6d5f830b6b4ff1465be7"
+    },
+    {
+      "surface": "compiler",
+      "project": "primevue-showcase",
+      "file_count": 1651,
+      "content_hash": "7f977d74e77025b1162378963649bcb32fc4fa4c774442128b56af2cdca522c5"
+    },
+    {
+      "surface": "compiler",
+      "project": "primevue-volt",
+      "file_count": 628,
+      "content_hash": "f13c3d74a68476356890313be4fc97a9920f9e3035f857f9fa7cb167b4873d71"
     },
     {
       "surface": "compiler",
       "project": "reka-ui",
       "file_count": 729,
-      "content_hash": "303738a21d80443014e2982460e872d4680ada80df79e5908b1b4c2f50fd973d"
+      "content_hash": "0e66cad19865fa0442e2577700b342b9bf1406e74246309c7b266fdfb3c7183b"
     },
     {
       "surface": "compiler",
       "project": "scalar",
       "file_count": 2007,
-      "content_hash": "257adab0986d2057a1075e08dbc2f5f3e751caa0baa3944aafd0ecec651aeab5"
+      "content_hash": "4cf07333300421ef86e79c1342c2dc4aa67e91d2c24c524e41bb4b18d292d163"
     },
     {
       "surface": "compiler",
       "project": "shadcn-vue",
       "file_count": 6514,
-      "content_hash": "b4ef3669bcc1ddf89aa0d3eb686fb351d58e31d54241a3b7d58398766e69b5ad"
+      "content_hash": "7a5c1eb155e37c10c244d40e0b00dc9b9a3dd57c6ea53b0320cb320f5715b598"
     },
     {
       "surface": "compiler",
       "project": "sigma-file-manager",
       "file_count": 298,
-      "content_hash": "01351b47eb0a2193771303a3ca7c2452475767f3bf704321166a0f1577f91837"
+      "content_hash": "98f37c3353feeb58902bfde8038875b51498de36b49f487386198892ba9bcbf7"
     },
     {
       "surface": "compiler",
       "project": "solidtime",
       "file_count": 389,
-      "content_hash": "bb6c1164e6440193e42a782bdaa12da8e7a6e4da956a6ff79f6626ce5bf178fc"
+      "content_hash": "020fb351afe372e8fb54a525e1f721551a51e1d51faa53a607981746442796c3"
     },
     {
       "surface": "compiler",
       "project": "soybean-admin",
       "file_count": 90,
-      "content_hash": "87a3ce9d074b24eb4ed015a3c49e37c93dbfd7d48fc058380ad7a76e30b727ef"
+      "content_hash": "7dc851408890cdf12242be96e672b4ba60c2011d089f3097a02249feb93b79c1"
     },
     {
       "surface": "compiler",
       "project": "splayer",
       "file_count": 154,
-      "content_hash": "df55b0359ac1bbb5fbc8a382344ff42f2b4a490b187aa906bc465ea2be393829"
+      "content_hash": "b989fdc4adb0962165b239cfaf2a640c4e3f5253c1f5ccc22c072306370c6ec2"
     },
     {
       "surface": "compiler",
@@ -490,31 +502,31 @@
       "surface": "compiler",
       "project": "tailwind-config-viewer",
       "file_count": 29,
-      "content_hash": "21a911a3f2d5c1b0e2b88470bb8e2e30c3f4ba06f56d5c864f67cca6bfb2c39e"
+      "content_hash": "efe9a6cfe8284615f339a2043f6af8b0a2144391b9e3f1a7927dc546b955ae86"
     },
     {
       "surface": "compiler",
       "project": "tdesign",
       "file_count": 82,
-      "content_hash": "ab2d7ef0e08d175d0c0bd41fd956316bd524412370201a8054610b12bd3a8882"
+      "content_hash": "03a47c59662ae8dbab44db35b777fc3e0f14ee8eb826aeb0e56b2b296a7c9b8e"
     },
     {
       "surface": "compiler",
       "project": "tiny-rdm",
       "file_count": 140,
-      "content_hash": "fb5c2fcafa69b148f291fcef8567a559a5c9f179890c153c6f5a3bb9c3a047b7"
+      "content_hash": "a2b2fc08179a277633e7969187f8e8ce08a2bd9d64726f92b71c0491064fdbae"
     },
     {
       "surface": "compiler",
       "project": "uni-app",
       "file_count": 58,
-      "content_hash": "e08b04e55b1ce1bb7a5bc1a3283cf21790f225190bdccd52d53c844ac1312bf3"
+      "content_hash": "6a2d16bc743c0ec3cee44cf1a070d5ae99a20ae7750fb3408522a28be641b063"
     },
     {
       "surface": "compiler",
       "project": "v-charts",
       "file_count": 33,
-      "content_hash": "da8746e05f84f88eba63e2f51f3cc491b2409d6a2e2d267f95c5cd76f848ba7a"
+      "content_hash": "5c33a4258d4ce7cd384e2126877eaeb56fbb656aa3c88c74dfc224f95c0660e0"
     },
     {
       "surface": "compiler",
@@ -526,61 +538,61 @@
       "surface": "compiler",
       "project": "vant",
       "file_count": 129,
-      "content_hash": "bc27099e84ffcdaa5f5a3cb8c09098d1d92efd1634386e0b5abdabf578e4f084"
+      "content_hash": "0c3e41dd0fa2ae2fdce0ed41dabd67c016b124c1f49bb8b8efde900d183591a4"
     },
     {
       "surface": "compiler",
       "project": "vant-demo",
       "file_count": 15,
-      "content_hash": "fb2c37c0fdf228df5b2b62e91ca9aa67b3c65dfc8916554fc6c256261484810d"
+      "content_hash": "79b24a18aff6a4097e41dac5f02bc81af3d1923d0e31941bdbbf7214550beabf"
     },
     {
       "surface": "compiler",
       "project": "varlet",
       "file_count": 226,
-      "content_hash": "99017272405c2f238a27d15b77d2a20d5572aa8b86ab62b46047ccf44eec0dcd"
+      "content_hash": "17ef3324eabb0ab7040cd263c9da78eb59bd11e8621b621a3260036890b3bdbf"
     },
     {
       "surface": "compiler",
       "project": "vaul-vue",
       "file_count": 21,
-      "content_hash": "b8d72b453aa7f883d4f69df628fc5d984e693528f04b25d4fc4b509a2a69cafd"
+      "content_hash": "02b0e1e147dc1fe2cf1121158320dd7bb170c3c80d905491fa005db0f26f6bb4"
     },
     {
       "surface": "compiler",
       "project": "vee-validate",
       "file_count": 83,
-      "content_hash": "17bad4239ede1ffc218235769764b466ecfe316e3a1897447c54b3d2619d8354"
+      "content_hash": "3bef21e73b44a1db143ec7313459ff648b281b9164ad4e4641109711b7013a52"
     },
     {
       "surface": "compiler",
       "project": "vitepress",
       "file_count": 95,
-      "content_hash": "52cff7896cd41379951aeb1ce8299951fd4a0ff90afe6cfccef8687f394fbb05"
+      "content_hash": "a73314e04998cbef6bb5f18118bb63b9998c46b47ae80e3adca01969bc5cc56c"
     },
     {
       "surface": "compiler",
       "project": "voicevox",
       "file_count": 134,
-      "content_hash": "4976dc7d17cf9f73e29fa00cac4d6858ee4597504af4d907a612838e84e936fc"
+      "content_hash": "380c9a2e8db67d557dcfe643bed82399a5c8a499786df9f418dc358bc95b82c6"
     },
     {
       "surface": "compiler",
       "project": "vonic",
       "file_count": 87,
-      "content_hash": "487724fb8864def5cc853357dd006df0b8ad6f6891ac987bf02549441607d5bd"
+      "content_hash": "03d54fb16c765df521cdfc8ce780cd7d342294e97664a146a70af40af104b344"
     },
     {
       "surface": "compiler",
       "project": "vue-apexcharts",
       "file_count": 11,
-      "content_hash": "00a38347c0826e0e329e3966bc4c3c1ec027d2b3ddb10909bb4bac0e95c82e72"
+      "content_hash": "d345f064362e3cceecf3a37efddaa319502366c8f6733b04a007f073645e5edd"
     },
     {
       "surface": "compiler",
       "project": "vue-bits",
       "file_count": 323,
-      "content_hash": "21e5c9d11015926f98e533e77bee0ac64dc13e626ac12120f8f301437c0ae787"
+      "content_hash": "513449ecf8cff90d27f2fcc65098f9ec759b9ad8bfc1ebf319148e43c3aaacc1"
     },
     {
       "surface": "compiler",
@@ -592,7 +604,7 @@
       "surface": "compiler",
       "project": "vue-calendar",
       "file_count": 2,
-      "content_hash": "0029beea01c2c9c8d74b4a3754255f0786250cd5c42da91df55c610a1eac0a1a"
+      "content_hash": "2e18a5cf5110757e75445e45b969eb3fcb8d120d6faf50be647f00564eec4e3c"
     },
     {
       "surface": "compiler",
@@ -604,13 +616,13 @@
       "surface": "compiler",
       "project": "vue-charts",
       "file_count": 193,
-      "content_hash": "3f4594ec9fa28aef62d0b4a79a892c22e96cf90fccf912886982d49ffedec102"
+      "content_hash": "606cbc3ba43295805c16e6938e2c2df30b44823f17efe9e9fd11f1ee3895356b"
     },
     {
       "surface": "compiler",
       "project": "vue-core-vapor",
       "file_count": 105,
-      "content_hash": "d9e201597cc3c6aa63630fcb7db4c85e8a628724e9d7ac2384824541f9da4596"
+      "content_hash": "427dcbfe0a4b151577737389d936bdee9f2ae7026bccf19dbddb01afe1e77c61"
     },
     {
       "surface": "compiler",
@@ -622,37 +634,37 @@
       "surface": "compiler",
       "project": "vue-data-ui",
       "file_count": 403,
-      "content_hash": "9bedd33567ec27bb474a7d45f4cb9cc54373ed6b2fc4b79373a8f0225ba358d2"
+      "content_hash": "9eeb358979f410dde59e9dfdf0d67e210e874c8075c8544c71c7c6cdcae960bf"
     },
     {
       "surface": "compiler",
       "project": "vue-datepicker",
       "file_count": 19,
-      "content_hash": "8b91d6d3e42f89febe228a56ce9ecc6137517080cb48dbaea53867f92501b11e"
+      "content_hash": "44ac01816433a0246be42bce0323eefa8ba940d9f9e13d5a3cac15f3eef69408"
     },
     {
       "surface": "compiler",
       "project": "vue-devtools-v6",
       "file_count": 121,
-      "content_hash": "b9e8f82977c140d2d319d3fe6c5dad82f53ae39f08ede247a5cb60d573a0de14"
+      "content_hash": "2d8d5467fbd9f2cfd3859ea3caa5a90d55cd75e897d92a973d637b795c502847"
     },
     {
       "surface": "compiler",
       "project": "vue-draggable-next",
       "file_count": 30,
-      "content_hash": "521fb4439963ca8d8daa6d50b4ce1c42d54c933cca38c2ead35a45507ff4387a"
+      "content_hash": "a1ccc8c55bba8f9ee1c2742cc109eb69483179c8f23fef7e51b3bc8f22bd5ee3"
     },
     {
       "surface": "compiler",
       "project": "vue-draggable-plus",
       "file_count": 36,
-      "content_hash": "77fb857bdf2f80afc1d6a8a0e633b614b438960147870d97645c63a297f01085"
+      "content_hash": "940add13e066fe770af8f4e7aef8cb89d4d31d9fa9f58f73854d68b427531b2e"
     },
     {
       "surface": "compiler",
       "project": "vue-draggable-resizable",
       "file_count": 53,
-      "content_hash": "fecf7fc31b545c2db8783b7e69802bb4d4f19b679e8ac5175bc67ba7ddc26cf9"
+      "content_hash": "c3e054a60b31d7936a19847007e3076476b63f5d4658600da1a4ae8905ce8992"
     },
     {
       "surface": "compiler",
@@ -664,25 +676,25 @@
       "surface": "compiler",
       "project": "vue-echarts",
       "file_count": 15,
-      "content_hash": "ce8560097b17ffe2850c2b573fe769cb601abb973efa5ae741c67429b806bfac"
+      "content_hash": "7c5eef4b4540f50e68652dc5f62fd16ae589fca98659945c7bc9ea187174d32e"
     },
     {
       "surface": "compiler",
       "project": "vue-element-admin",
       "file_count": 131,
-      "content_hash": "5ed9c8d6d7a919761a2444eeb6593277b2ef3dfdeb41465f979da6253a4ba9a8"
+      "content_hash": "59afc555ff64e7e6470dc99c246faf0b40f1e4fb5d47d98a66896a8eddb7ad3c"
     },
     {
       "surface": "compiler",
       "project": "vue-fabric-editor",
       "file_count": 72,
-      "content_hash": "7e2f0facfab6417c04c3fb6adf8dabc85b96b3fd9e9a08e8507ff1b81d6ae45d"
+      "content_hash": "376c45ac01f694b9771628a8c9da39a15f498a1ece27ab64c1b1e29001cdc188"
     },
     {
       "surface": "compiler",
       "project": "vue-flow",
       "file_count": 194,
-      "content_hash": "6f0818421546357b07a7cdb055132aead99c1a78244c1fcd3b008bd2cb0bd320"
+      "content_hash": "b6cf824f8927db652a9434015301bb5e876208d9e91f8a4f22d7e96f40bf6216"
     },
     {
       "surface": "compiler",
@@ -700,7 +712,7 @@
       "surface": "compiler",
       "project": "vue-js-modal",
       "file_count": 19,
-      "content_hash": "705ac574345cc8753b9869175dc4b752c7deffad654253a4ac8dc48ffdbdb7f4"
+      "content_hash": "ac6d61566f6fea3034c764d124ead1515987ee6baf759c52a008218a51d378b5"
     },
     {
       "surface": "compiler",
@@ -718,19 +730,19 @@
       "surface": "compiler",
       "project": "vue-manage-system",
       "file_count": 40,
-      "content_hash": "1c5d03c00e49d4b474e652e535affa5ed64d4c98cc91e9c2e1ea24aab5cad663"
+      "content_hash": "48ff0d702a233840cedca1e36b2d64c4c86358aabf196e381440d8d01d9c1fc6"
     },
     {
       "surface": "compiler",
       "project": "vue-material",
       "file_count": 347,
-      "content_hash": "534839445056ce81ca8ff086d34ae0ee50e6b76c015d63be7bd450eec9b7ebff"
+      "content_hash": "91aaae441887ca055e8d93a18a1c7a6f082a7ad953ef986ebecb464ed596d154"
     },
     {
       "surface": "compiler",
       "project": "vue-multiselect",
       "file_count": 36,
-      "content_hash": "c07df3666ccdfa3a5fcb144e87661c39f5274a6933463ebd5e2d07f7bcd7da18"
+      "content_hash": "2a7e6b7f70985bddf63bdf93181b6482a5e76cc5765ca08fd6b74d885fc71db8"
     },
     {
       "surface": "compiler",
@@ -742,61 +754,61 @@
       "surface": "compiler",
       "project": "vue-netcore",
       "file_count": 121,
-      "content_hash": "88121fe7bdc74c6eb2b3b9806547adec073cc148276d0aa3517d81baf81d1908"
+      "content_hash": "88c30208aaf9c141694fbc6e72fc1679952c4d0c298486b337d09e80a306d8b7"
     },
     {
       "surface": "compiler",
       "project": "vue-pure-admin",
       "file_count": 255,
-      "content_hash": "a07c6325dc449856e1784401e5b87ff1026cc0d9c1db8e1f52afb0bd708911e2"
+      "content_hash": "2ec2c0a2e6bfc6c71870d878a2e384ca9e84b13c189ad55b030b41ea93da4a44"
     },
     {
       "surface": "compiler",
       "project": "vue-router",
       "file_count": 115,
-      "content_hash": "6152a1d65471853004eb68817da9acb34fd2b734d0982640a047235809433abc"
+      "content_hash": "7c09b2b0caab962ffc335de05bd8a6e534f7982465ff9b9c5353cb2d862fb7a6"
     },
     {
       "surface": "compiler",
       "project": "vue-select",
       "file_count": 4,
-      "content_hash": "47b392506e1e08bff621e1a90017fa23bb64048284b44e7b3e4ab3bd50a149a6"
+      "content_hash": "5b77879874e73f8797f656ce0c7a505dc6a272d4278fbf1c06eb3feac9b79998"
     },
     {
       "surface": "compiler",
       "project": "vue-sonner",
       "file_count": 26,
-      "content_hash": "ecdaeb726190e826e8f99ed33a5d1cca18d6ec318e8d86f787cf8233a0d40b6f"
+      "content_hash": "9f041f2c99234daa668c8fe9bae9b1a566610e9657432239246e7224c965fd5b"
     },
     {
       "surface": "compiler",
       "project": "vue-storefront",
       "file_count": 45,
-      "content_hash": "645f925a9c4537c359e5531c3adea11fc7c7bb79d8eb582d364a491e4e7c2beb"
+      "content_hash": "3cf61cb16041dc824f89efd0d6df588efb258fd1bf9cee20fe662b2083a456d5"
     },
     {
       "surface": "compiler",
       "project": "vue-termui",
       "file_count": 77,
-      "content_hash": "074408da1de46278051af82854da6497b6a5c691008c851a4508914291e445fe"
+      "content_hash": "f7f505b841c8fbf66bed4e3e0030ab8d1059787a241ca2450a13ad694d4e5349"
     },
     {
       "surface": "compiler",
       "project": "vue-tui",
       "file_count": 19,
-      "content_hash": "23960689a925ee31f22de4374ccdddbd35ef79ecafcaef366d7e85a69849928c"
+      "content_hash": "140b39a306081f591eba2aed99681b7ad3dc8ee5e332df845bdea74ccd590efa"
     },
     {
       "surface": "compiler",
       "project": "vue-uploader",
       "file_count": 8,
-      "content_hash": "1bf4b1c4c3dfef7524b7baad497a872dea3334a2d8d33080f4ac72d1f1880797"
+      "content_hash": "99cb060c0a6d92c1e8bced982135fe99124fdaf3b504c9ba76fb4b8e04208855"
     },
     {
       "surface": "compiler",
       "project": "vue-vben-admin",
       "file_count": 613,
-      "content_hash": "cbcce91d93bcd72c0abc0a243e152607dba8049074dfcd22eadd1574791d5e0c"
+      "content_hash": "211f28ec83d06aa564fee258fc6eaf8c81c50513fabb61a4b4c732c01361a3b8"
     },
     {
       "surface": "compiler",
@@ -808,13 +820,13 @@
       "surface": "compiler",
       "project": "vue-virtual-scroller",
       "file_count": 18,
-      "content_hash": "53a15f5d14eaba819e6537493cbe30dabcff290339491e41bfee1fb1a815e3c1"
+      "content_hash": "efb5c518bbae80eccc09fe17a90206b828151655ef5e9a59cdb23e9bbb16086e"
     },
     {
       "surface": "compiler",
       "project": "vue2-elm",
       "file_count": 55,
-      "content_hash": "13e81ae9d72a760941ccd90ff54fa4a2e663123023e2aff37f5f9f6b7f85506a"
+      "content_hash": "9ad7f7878b1af4f6301bb9133bafbf459cd6f02449e7eaee00a71f99ac898bf5"
     },
     {
       "surface": "compiler",
@@ -826,25 +838,25 @@
       "surface": "compiler",
       "project": "vue3-antd-admin",
       "file_count": 99,
-      "content_hash": "973293b1867cdf3aa9c52c695b7525fe1773ee7633df318a90341948a8b0a81b"
+      "content_hash": "1521a4885db306854d7a532a8d18479e1810ef17539aa24672faed85097216bf"
     },
     {
       "surface": "compiler",
       "project": "vuefes-japan-speakers",
       "file_count": 15,
-      "content_hash": "5786bf5e95721dd32ffc0ed9d2428d895372b8081e0d4127a39b51632dfa4b10"
+      "content_hash": "56e011f78b127ee7b3d7273922919ef9fa8544cb61d199d893ddb90e233696b9"
     },
     {
       "surface": "compiler",
       "project": "vuelidate",
       "file_count": 28,
-      "content_hash": "e56d20372fda6ea9068501a6e183f4f940866b001b691003a797773cf26e33f3"
+      "content_hash": "75d3ad0a2faa50a1099f62c1863e61057a752792072738616a9b6785ce28b2b6"
     },
     {
       "surface": "compiler",
       "project": "vuepress",
       "file_count": 38,
-      "content_hash": "14fda08cbafa5678fdee86d9eb5d15825345e0c2495b69d2ad70f9847ee23a25"
+      "content_hash": "60d8716d9a362f4bf7d55b3e8ea50dddaf7967f57f60871ca389ff22f5c3fc5b"
     },
     {
       "surface": "compiler",
@@ -856,31 +868,31 @@
       "surface": "compiler",
       "project": "vuestic-admin",
       "file_count": 99,
-      "content_hash": "2fedc0abc1152256069f3ab52aba75c80f9177385651a7e68bf73b5bd1ecc0bf"
+      "content_hash": "5f8187823ff038db11fc3efe2b776f2c7dbb03e57d4c7e394e32c0a36ff4eb3b"
     },
     {
       "surface": "compiler",
       "project": "vuestic-ui",
       "file_count": 1019,
-      "content_hash": "7ae545e22ae4d9e2bc13b4fe94a4df800c336f632cffa5ff398e62e567ef4bd1"
+      "content_hash": "e5c896e4a99768ae82321f8e11214b4b2fee75704bb83dfb6663fcdc7591ce90"
     },
     {
       "surface": "compiler",
       "project": "vuetify",
       "file_count": 1255,
-      "content_hash": "a86fa26c6fac990b0a67cce559d037b20b59bcab18069f4be6304576461f4cc9"
+      "content_hash": "0e489f8d97e1ecc76bf805ce7b1aadfa4929947569474edce9c90f2ebf259141"
     },
     {
       "surface": "compiler",
       "project": "vuetorrent",
       "file_count": 145,
-      "content_hash": "9a0edefea8d5b7e61c0009aff9f6ba71540361f01d5d662b4d6a3c3255bc8807"
+      "content_hash": "bf2109ef92f43d35c7346db2d559f31eb2ca0968ed1456fcae21f30756cc8d24"
     },
     {
       "surface": "compiler",
       "project": "vux",
       "file_count": 312,
-      "content_hash": "3d88c8d9e44bb47c262fc8712211ea4da75a957a20c67419ec7657fc3a493c56"
+      "content_hash": "e83edb1059eebc24b9e21871033e7a781135d54841dd5e64c126baca07ddfe8e"
     },
     {
       "surface": "compiler",
@@ -892,19 +904,19 @@
       "surface": "compiler",
       "project": "wave-ui",
       "file_count": 219,
-      "content_hash": "6c1985eecc670add252581d5573b75048165d7368dcd5279365deb41c839a4aa"
+      "content_hash": "d0650ffe831e60b61c22ea0aa6725c3d5fefdb55494e49eb4ffcf2af0f773cfe"
     },
     {
       "surface": "compiler",
       "project": "youtube-dl-gui",
       "file_count": 83,
-      "content_hash": "217f67cc0b1a728eb2c68652fafec80fe26d33b1108c8c2461d6afc91dc80dc5"
+      "content_hash": "0c7b1dc1d030c72e66acdb900e6ba4aa137ffe38bd3b976dda43b9bb08f92051"
     },
     {
       "surface": "compiler",
       "project": "zy-player",
       "file_count": 13,
-      "content_hash": "0de1699da1cbb9577be50a63797a79094854fb0ee0c2ce4599407c315e445fb9"
+      "content_hash": "d8668a3722e9f8439ce7dcc964c2d1adf8a8703c2e75a8118ff1655ed0f66fa1"
     },
     {
       "surface": "formatter",
@@ -1289,6 +1301,18 @@
       "project": "primevue",
       "file_count": 2610,
       "content_hash": "cadc619aa875f92b632c5105b10fcf580bc777f70e04f9c814ce4b40f336fa8c"
+    },
+    {
+      "surface": "formatter",
+      "project": "primevue-showcase",
+      "file_count": 1651,
+      "content_hash": "d210cf8a333cb21b74fc97c203c41c552b2dcf3542e58ccadc6d4d32e620dd30"
+    },
+    {
+      "surface": "formatter",
+      "project": "primevue-volt",
+      "file_count": 628,
+      "content_hash": "f2ce6737982ea05aee069fdb74cc342fe6b93720a33069c6c48b4ce9c400e895"
     },
     {
       "surface": "formatter",
@@ -1762,115 +1786,115 @@
       "surface": "linter",
       "project": "airi",
       "file_count": 586,
-      "content_hash": "3b3fc93a52274cbb161168d36767a78c74304b34f4e21fa5144839d30513e9dc"
+      "content_hash": "77bfc2f2b107887e9487968cbb70a23cf1c17bab15fb60eb85438bd63a69dad1"
     },
     {
       "surface": "linter",
       "project": "alexandrie",
       "file_count": 202,
-      "content_hash": "72bb7893e433b5008371042437069852aefb54c9c4d5d51e6f89a3cdcb38a5e8"
+      "content_hash": "55cb6bf2df3fd508c4f8e26c72035c4e8aaf674d8c649fcb4c65e3db12a0b51c"
     },
     {
       "surface": "linter",
       "project": "ant-design-vue",
       "file_count": 731,
-      "content_hash": "12c38bcb35dbc51f23f036eafb172423896f4ff6faed36682132486031d4c088"
+      "content_hash": "557f3f4470bd6975ae1171d903246e54ded37e9a7238e653d8051b33d6355f5b"
     },
     {
       "surface": "linter",
       "project": "antares",
       "file_count": 94,
-      "content_hash": "589ffd1fe0eefb4c0267f07f086c9332aa9d897435460d0950254fc0c41bb9b5"
+      "content_hash": "fea65bce0d17ecceda6becc67f3605402b28a3eddb548526ec922cf487c69cb5"
     },
     {
       "surface": "linter",
       "project": "arco-design-pro-vue",
       "file_count": 86,
-      "content_hash": "7f3db430e028d84b247c5004da5c7996fb1d20c80d9da025a24c23333c92898c"
+      "content_hash": "e1cb361ed0fb97ee8f9316c33ff3b2cacdf3d3bfbdfca1f0e277bad6e91d5ea7"
     },
     {
       "surface": "linter",
       "project": "automa",
       "file_count": 215,
-      "content_hash": "a0d0e4627188fe736271eeddc209a27f579f6aae98bea2c3abfc796407844d84"
+      "content_hash": "12a6655bcd605df7d50737d61f721a74970e765dd65b3f82429c1d3d28ba8492"
     },
     {
       "surface": "linter",
       "project": "better-scroll",
       "file_count": 65,
-      "content_hash": "88ac24e61cf0afbaa2096185ed2afc7d93ef82a9833e3ce838167b1fd26a2d10"
+      "content_hash": "3bab01e73be2b0fca1d03e18edc9f5c75afac2d03e4b36d348baf10cc94e3153"
     },
     {
       "surface": "linter",
       "project": "bootstrap-vue",
       "file_count": 22,
-      "content_hash": "77509fa6b7d39d8d5a199c8b78abefc73e35bd76883043decd35563722c34537"
+      "content_hash": "51db3c0efb653e3a26de5c45d7df1a07088eaa0d996a08c2e5a5ff4df9b60b2d"
     },
     {
       "surface": "linter",
       "project": "buefy",
       "file_count": 431,
-      "content_hash": "aa64d6efa9f0124bb0f45b1b37201f3f1346d1284d12c477c333b22145e70d39"
+      "content_hash": "3c235338a41e9c642f1a39b5f5c549e597397b86ecf6461c06cc1c05b262e754"
     },
     {
       "surface": "linter",
       "project": "bym-vue-echarts",
       "file_count": 37,
-      "content_hash": "ce9ec742438ffc722385958de549af69d199e095e09a90b3aa5004d83a99be9e"
+      "content_hash": "dd9d9ecd8cdb024080ef735191a9c98e6fa29cade8be25bd32a6df6df9edaaef"
     },
     {
       "surface": "linter",
       "project": "crater",
       "file_count": 311,
-      "content_hash": "cc86babbff7b7b278ca1c0f912797f568803b54975578dd80227ee35bdf1e568"
+      "content_hash": "3657a08a2e0d23dd43b47b4b66eb362237c7eef236203129ed3ac48d7d70beaf"
     },
     {
       "surface": "linter",
       "project": "create-vue",
       "file_count": 42,
-      "content_hash": "4ead46304282b10daa537a6e028b53486d9f0b8e1cb10fec9eecc4d7e6c0bf00"
+      "content_hash": "f14375b35826f9d6dea4b0d3ec1fb3490b21dc758a493da2cca325d1a1761ab4"
     },
     {
       "surface": "linter",
       "project": "cssgridgenerator",
       "file_count": 9,
-      "content_hash": "688911b2e0209a13d7ea19e705dae9af541771aa3ec7a1870fcd7a3d8260df9c"
+      "content_hash": "5e06faef32f04257fca44c74e519fbe803080e00bb5889991089861e4076d0c3"
     },
     {
       "surface": "linter",
       "project": "cube-ui",
       "file_count": 164,
-      "content_hash": "63616ee7016992a4632f27345684837f642e04e7a8415fb6a7bc38e9aabedb6f"
+      "content_hash": "2ea3e4b14cc49ae0b631b4942dae1a3733bbc5ebc5adc90976607ae8f9139b8e"
     },
     {
       "surface": "linter",
       "project": "dashy",
       "file_count": 175,
-      "content_hash": "db1d1302b1762e21abf5103a38c4df9a7bf07f2fe359b693c50a3387a255e42b"
+      "content_hash": "ae998b1f6ec90a7c54c918d8e3a2a2aece5bb5a32202bb375ffcae05c007f7f1"
     },
     {
       "surface": "linter",
       "project": "datav",
       "file_count": 76,
-      "content_hash": "910ae9872dea173a72da108d54994427100fba42df9dad96a82d0ade133c5ecb"
+      "content_hash": "6b45d7c1beba3f66cb11628d0450a361db0ecca51eab51fcb0e569bc703cc2e0"
     },
     {
       "surface": "linter",
       "project": "dbx",
       "file_count": 376,
-      "content_hash": "9f998290ec7464763364c9174edd7b1a9ef671e5d72fc2eb8fc59936a70f6c28"
+      "content_hash": "3f2513b20e69f95bdd3f334d3ac21dd74b211bfa8fca31cdf713c16acc727823"
     },
     {
       "surface": "linter",
       "project": "dho-web-client",
       "file_count": 215,
-      "content_hash": "95fdd87bd302e4e6925b8ecbac6a1a869190dd753457611fd1555fb3c1a7215b"
+      "content_hash": "2425ae977228a992ebc26d61c34752aeb10343f62db7c9a852965b90e1f5e7ff"
     },
     {
       "surface": "linter",
       "project": "directus",
       "file_count": 576,
-      "content_hash": "e0be025fd65b4c1c9b66e8b0448cc608c00a19c003516074b0df4e5325221e69"
+      "content_hash": "4baf5f31b85254dac114cc5331487f446a2717da2fe28748c93bb0eb6bab7bae"
     },
     {
       "surface": "linter",
@@ -1882,223 +1906,223 @@
       "surface": "linter",
       "project": "douyin",
       "file_count": 128,
-      "content_hash": "f151f5089021a2dcefe18ba3acd6b834f88386599c28a60e7b32743fcf67777a"
+      "content_hash": "826de08a2d867350239ee2bb6e00e0526240b8b8d41d165d4a0f5d50d7f15b97"
     },
     {
       "surface": "linter",
       "project": "element",
       "file_count": 155,
-      "content_hash": "75673a69560b5bc03ec26eab9041d777a704313520551ec4ff07b07d6ece5092"
+      "content_hash": "f5520be967c0e3d409faf9c00c11139a16dabde96ea9c6e1e0100906a11f7d3f"
     },
     {
       "surface": "linter",
       "project": "element-plus",
       "file_count": 823,
-      "content_hash": "8d7ec5cdd157097d01c8d172565d97f9884ff510dd387f7ed59d50612dbfd482"
+      "content_hash": "f584824fa44b2f472d133855c6af03a997909d539470b97047619962ec40cf73"
     },
     {
       "surface": "linter",
       "project": "element-plus-x",
       "file_count": 334,
-      "content_hash": "27f406059b3103d5171414d20076f42b39e8cf3d61971cb1e1bbb405968b3bc9"
+      "content_hash": "360d504462ff4b17969f03735e9071af5727297876e4b897e4d4f04b254c54ab"
     },
     {
       "surface": "linter",
       "project": "elk",
       "file_count": 259,
-      "content_hash": "1af00fecdeaea4153d48f2d2d892cef52c1d2c2bfac5a24f253de897a2a93ec0"
+      "content_hash": "85d84cda401c0aaf2c6ab4e791a274a843b40de06c70aa030b96708301ae61a7"
     },
     {
       "surface": "linter",
       "project": "epic-spinners",
       "file_count": 50,
-      "content_hash": "cf2c2e30cd421e1eada0bde376b99cc167c079bb228014c9148a8408c88438c2"
+      "content_hash": "2c8003d68ab5b1cce160378b20610e30a3030c4559204da8e5b48e07dc77b7dc"
     },
     {
       "surface": "linter",
       "project": "filebrowser",
       "file_count": 58,
-      "content_hash": "d1869c2edf2dc5232e736482da5d3d777df96342708c42df15c0458b56f264b9"
+      "content_hash": "0c666a6c433cfef69f8594370c38aae32276b237f6e91051f16d2483dd79cbac"
     },
     {
       "surface": "linter",
       "project": "frappe-builder",
       "file_count": 159,
-      "content_hash": "7084b4e883e58d49a0efcdaaf560708bd7e98da3d393741d1c70d2d73bdd0d2d"
+      "content_hash": "13fdec78ab28da69c253fe283d79c567a86cb0b994195bb22d33f7cde13ed8ab"
     },
     {
       "surface": "linter",
       "project": "frappe-crm",
       "file_count": 339,
-      "content_hash": "b7d2d880add31c74716e02969d14b7b7cdf778aa97f91e1c0fce0ba92b9cdc5d"
+      "content_hash": "d25fb6226c29e01b448aeb6865e4964c691aa4351d93b8b3fa7abb1d396cccaa"
     },
     {
       "surface": "linter",
       "project": "frpc-desktop",
       "file_count": 13,
-      "content_hash": "303e8de7dbbde2fef8b223c30ff0ec29af32c8480ed512523293d5d8a9414459"
+      "content_hash": "917b58bf7321d75968d6dbefb2f7d245175d2794a470d3fb7073fc3de32446fb"
     },
     {
       "surface": "linter",
       "project": "gogocode",
       "file_count": 186,
-      "content_hash": "a15a5aa56f9acdd016c8d3923268ff779799dbcceef1f12b4490ec4ca97a5635"
+      "content_hash": "2f3001d12bc08194192761dadccf5ea0e8e78b17782603d8926a13c6c0485bb1"
     },
     {
       "surface": "linter",
       "project": "gridea",
       "file_count": 26,
-      "content_hash": "929d467f3ae22a864597bbe2ea9357e7d9157596f618ec3995c3154a13383015"
+      "content_hash": "a22a7f2369ca57d02c3fc89af5f3b2b5d78fddd12a85574c584743e88279161b"
     },
     {
       "surface": "linter",
       "project": "gui-for-singbox",
       "file_count": 98,
-      "content_hash": "8dde354d3c8107266155b6043ff09d2ca915e8e4223953f3520a7e6e8cf203de"
+      "content_hash": "cb8dd83c51f18df6ca88a90e283fba28502fb87773f1fc83bac79289f2709ef3"
     },
     {
       "surface": "linter",
       "project": "habitica",
       "file_count": 352,
-      "content_hash": "08ffecd06a6ca3ca8db3e20fabd8f7fdfef99bbe77f1443b26433c46b88c50b8"
+      "content_hash": "c374511a196df72d19664baeee3010e15702c661b20d9b8d0cd96f87a0f85470"
     },
     {
       "surface": "linter",
       "project": "heyui",
       "file_count": 76,
-      "content_hash": "8b6964d72140da501e365b7f31fa82d7fa489fee58794c832fded9ebf81b60ea"
+      "content_hash": "a3b71a8a5785b121fd13c3d677b83426f5286afcd6012a011b4207b57697be91"
     },
     {
       "surface": "linter",
       "project": "hoppscotch",
       "file_count": 365,
-      "content_hash": "d0ca2083f202e0f17193d02f3f6e555e941529d0a978ff3d6a7bc23c67289bd7"
+      "content_hash": "84e6afbafe1f25e7033310a444d14bc2d77c88d2fce8c7177b94d365d2fe174a"
     },
     {
       "surface": "linter",
       "project": "inertia",
       "file_count": 459,
-      "content_hash": "6799cbc36c137cbd5622c12dbff77949f7ca4c3f4460440b70275f09a3dfcf57"
+      "content_hash": "1201fd7b71505d69788c154c57c3723a1c481d62784a4967312b02810c40bedb"
     },
     {
       "surface": "linter",
       "project": "inspira-ui",
       "file_count": 512,
-      "content_hash": "3ed5f8bf00e51924505f9c8648c6056a6ac0e5f51caaa94271397a54cd2842ef"
+      "content_hash": "579fcf9b775030a0e9d51a137e505bf615ccff07cddc39504007b3eda2899ab1"
     },
     {
       "surface": "linter",
       "project": "jellyfin-vue",
       "file_count": 136,
-      "content_hash": "64499c4a31170e169437e45f6ca26b1d98780cf2b437e4f7573c7a6a273410f6"
+      "content_hash": "04e49f87d497829027990907c8cbd5328a7a3f008c3c4f8f7df8fe8cffe06937"
     },
     {
       "surface": "linter",
       "project": "koel",
       "file_count": 337,
-      "content_hash": "193615d0e1cdbf1257946cc5b83157375596207ecfa2d85be05731882c1f0eb3"
+      "content_hash": "10066139408d1dac8532b3e8486cf5e7cdfe222ea33eddb49f1f45f28a8cb5e2"
     },
     {
       "surface": "linter",
       "project": "laravel-breeze",
       "file_count": 54,
-      "content_hash": "5e0c01af9282931f6c695d110c6c6c774e51a94810b7ffd72ee5d4d4585f212c"
+      "content_hash": "af0ceaa0031c71b9a566c369db5c4903f3d0314c1c84115a463b7d125d9069ff"
     },
     {
       "surface": "linter",
       "project": "layoutit-grid",
       "file_count": 112,
-      "content_hash": "e3cf3fba3193b83dae74bc8d4011817f2704a866953e1250d4c87332f6c73f2d"
+      "content_hash": "252a9f42fad37eb0f32173bb4442ed0f941d92487f40c20f7dec92b0ada7202b"
     },
     {
       "surface": "linter",
       "project": "lew-ui",
       "file_count": 429,
-      "content_hash": "a0d8f531ce5f4d363c185869a88d0a3dfc736253c0eba5d5188e811ff9196c0f"
+      "content_hash": "e25077775f077148b449f0efd45eef241a9cdc52917d197f870141b3e3c34775"
     },
     {
       "surface": "linter",
       "project": "lx-music-desktop",
       "file_count": 122,
-      "content_hash": "b45ae6ba75cc76cca8782c74564862ce2e22934d675ebac4d10839101291267a"
+      "content_hash": "389973fe51d43f1b2077e43b50f3b416e5d4dea2a80957386454229f9143f542"
     },
     {
       "surface": "linter",
       "project": "mall-admin-web",
       "file_count": 83,
-      "content_hash": "1e5ef5f619ed5c387b6424f538ee7f07e712d459cec71cce13b72820be47610c"
+      "content_hash": "269ec0f8ae52cbc31e247ea6acd361050c2f7f5458221f2c0dc8bf0f2ffdfa4d"
     },
     {
       "surface": "linter",
       "project": "mavon-editor",
       "file_count": 6,
-      "content_hash": "2a8f8767024f66abab319b6e0bee43bdc10af6dbf5ccbb35f3e724998438d4cf"
+      "content_hash": "0ab4543fbe4f89e06f426e25dee45824531924265ad596d0eb293490069c60ed"
     },
     {
       "surface": "linter",
       "project": "mealie",
       "file_count": 205,
-      "content_hash": "acd98637d0130a5b467cf23193012163e7afbc3944d8ea8cae47891e493facdf"
+      "content_hash": "51261e67c0c296fd7fe2a16814c75258c287cf95ebdef04eebaa14492b93739c"
     },
     {
       "surface": "linter",
       "project": "mint-ui",
       "file_count": 69,
-      "content_hash": "60cb643fd77cd915ff9c73e128a20760ebcb19e5cd069752f167ce2e25378e0b"
+      "content_hash": "1163005a2d8bed02126cadd3d4ea9e74ec16d60dbd85c7a34e2191edfcb03729"
     },
     {
       "surface": "linter",
       "project": "misskey",
       "file_count": 583,
-      "content_hash": "5598b9d074d867c9784272da5c6bf9dd4b652e55645c7cdf0de1fc516a81c230"
+      "content_hash": "ea524601cd0c4a748c7e50120fe083471d7b9a8dd11016acf657240bf6019206"
     },
     {
       "surface": "linter",
       "project": "mobile-web-best-practice",
       "file_count": 7,
-      "content_hash": "fc6f5a4791facfc42e0b9a19cc3d7b2bd34864dbb9829efd8edc4b0a3498a297"
+      "content_hash": "f1164f2508060ff236a92232701378bbd5558770b8d1a5e46a4ca28a67cc966d"
     },
     {
       "surface": "linter",
       "project": "motion-vue",
       "file_count": 74,
-      "content_hash": "04ffff47e5d8559c4405050d46edd253559a69a88338a5ca02897e961ae6f1bf"
+      "content_hash": "34b7b40bc588bbaa6e587ad225bb595c21db329699e0e2a1d460507cc864f21b"
     },
     {
       "surface": "linter",
       "project": "multiple-select",
       "file_count": 62,
-      "content_hash": "f6d7e3d27b01750b8c2a9eba17d20ff3e9bf8691932547c81a90aa1f080eea21"
+      "content_hash": "07a8ead9e3fdd8abdd9b4e14e796378c09c0dbf54e4b6630942bae046bd9cfdb"
     },
     {
       "surface": "linter",
       "project": "muse-ui",
       "file_count": 3,
-      "content_hash": "fd922fe61dbcc0ac7a0b47ad41076ae0e847109a181fe8c4063a6888e7296bfa"
+      "content_hash": "b6119993cbd937a413efaf728b26f52f964ec60dd37330ac0c0dcac7c1e73cb1"
     },
     {
       "surface": "linter",
       "project": "music-website",
       "file_count": 47,
-      "content_hash": "6a812035237bcce13280f7809e02808ae9e85b1ea10e6ac2879d4207d69c5ec0"
+      "content_hash": "cfde216ba06b02a8dbe9e244259ddc71f20077d488fb68c2e0ff430eb2065b88"
     },
     {
       "surface": "linter",
       "project": "naive-ui",
       "file_count": 1720,
-      "content_hash": "084d0d9c35108fca296a139960ebba3ab513c045b3869cdb211a106078d89ced"
+      "content_hash": "59a82495c9096ffaa0cf697b8136522d535ea6b1ad4c4fb92bacd41ef2705163"
     },
     {
       "surface": "linter",
       "project": "nativescript-vue",
       "file_count": 17,
-      "content_hash": "4fd7654dab85f5dde56c4e27d53ccdec8eebb0362be790e489bc07e994ac5ffb"
+      "content_hash": "b39adcf63ea64ef7b811d6be2b8db9e5e5df777445ef34793ae559d3413a8d3d"
     },
     {
       "surface": "linter",
       "project": "nutui",
       "file_count": 1228,
-      "content_hash": "f287eaf42152cbf34de04615e91134d9cc45b48470925ad69a677378d9dbc9fd"
+      "content_hash": "4e2b97c30b6183b4044193d5d1a34e7ecf9da37a1e2f52c257464496984272a7"
     },
     {
       "surface": "linter",
@@ -2110,169 +2134,181 @@
       "surface": "linter",
       "project": "piclist",
       "file_count": 56,
-      "content_hash": "80c3909f9817e80088aa55d09b10ab2e25c0d0d0845f6e96c454422b6c62c67e"
+      "content_hash": "32fd27f35b8765573889056f7b4d3773e700473cf26606ba0cd7f26e137fa26a"
     },
     {
       "surface": "linter",
       "project": "pinia",
       "file_count": 24,
-      "content_hash": "06cc0b087322b687242dcc7c87ca516e3d8d75c8c590f585a8e2262d8ed754ad"
+      "content_hash": "81754f23b5ff9dee3882e730ff4d1ce57400b93911756839f3eff315ca5a89e1"
     },
     {
       "surface": "linter",
       "project": "pinry",
       "file_count": 29,
-      "content_hash": "8520b490d808bf0fd6d95a147283e2f84f2588cfead74282e8b971e0922e695b"
+      "content_hash": "49438ed5200f7fb7699d3382ab8730120348d787c41f6dc27378cfd23fe161cb"
     },
     {
       "surface": "linter",
       "project": "portal-vue",
       "file_count": 42,
-      "content_hash": "ba75363958fc27962f13e8929cf357f966fa5eb3c1e494b5a415d9504e72cd65"
+      "content_hash": "d3c669957e4ec33ab12a0d1adee0c5ff9416a01f8b1bd65674ebf2a5af57917d"
     },
     {
       "surface": "linter",
       "project": "prevue",
       "file_count": 24,
-      "content_hash": "bf14e0c89b7c46e2016183342094ce42547bdbe116d62781d7f096a6c9e4c79c"
+      "content_hash": "1a5183b4c3be32463c1d1342796da676280e667a5af3898e7339ae43b1e27a3d"
     },
     {
       "surface": "linter",
       "project": "primevue",
       "file_count": 2610,
-      "content_hash": "9e0aea1fafc97809a5bb93a5f873dcf20a104313b4f09bb4f5b76c7d16a348e3"
+      "content_hash": "b50498139a453f656bb502ed01c39e7c35cbcab59fd8f54fac3cd859aaf3121b"
+    },
+    {
+      "surface": "linter",
+      "project": "primevue-showcase",
+      "file_count": 1651,
+      "content_hash": "2bd65d090cf58d6fc3136853534c8097a9a75cf436b2bca0ad2afb0a1c09459b"
+    },
+    {
+      "surface": "linter",
+      "project": "primevue-volt",
+      "file_count": 628,
+      "content_hash": "e21ee2ceced9b72c9a38db905584b81e67a7bca8424a4579d6c28d11fdc10054"
     },
     {
       "surface": "linter",
       "project": "reka-ui",
       "file_count": 729,
-      "content_hash": "b5955e867d870653940bf94269ec10e9ffdf4e4d32a5d0fe7760a49e4eb9b538"
+      "content_hash": "8174bf7e683f64757b015d402482c999222502b542c2b8ae32f17505c55671ff"
     },
     {
       "surface": "linter",
       "project": "scalar",
       "file_count": 2007,
-      "content_hash": "a3c9c747c24450298ff98b3387695e36fd477433ae3118dd00a2a3eb774bcc2f"
+      "content_hash": "74a59050c6ca34633cf6a0ea932990c308969b75f2b62b9287a6e34538188bf2"
     },
     {
       "surface": "linter",
       "project": "shadcn-vue",
       "file_count": 6514,
-      "content_hash": "87c71ac779bc80328564be717efa24e083bd8193c800428d6d9bb9f616fb7886"
+      "content_hash": "6e5b629d73674ea3961f9f47f1a958bbb62269e213a9f63a661e0860b7ec7942"
     },
     {
       "surface": "linter",
       "project": "sigma-file-manager",
       "file_count": 298,
-      "content_hash": "88dcce0c06acecac79f7ba15bc5124aa97862f0492c1cf7ea338191f442f23b4"
+      "content_hash": "f67a00802725a166303cf877ba238b42a3825f88259e73cb19d99ac8cfa14294"
     },
     {
       "surface": "linter",
       "project": "solidtime",
       "file_count": 389,
-      "content_hash": "ea172841e98fb71e3e03c0d5c085a4bfd75e1de2bd1f37bc0f50d04eb387aafc"
+      "content_hash": "9aeddee72e2e4f2cd7be98bc538f275d00729b081e6ff857766b2dc63ae51f33"
     },
     {
       "surface": "linter",
       "project": "soybean-admin",
       "file_count": 90,
-      "content_hash": "cbc7e73fac8acfe945acd2635f1f4efc1e5b979c35f12b46ff619f06b1e0326d"
+      "content_hash": "82dd632c00c66fd59c7a2a0f86cc1b90a39cd0af9e85b9b42f31df8f9e3a39d6"
     },
     {
       "surface": "linter",
       "project": "splayer",
       "file_count": 154,
-      "content_hash": "5a1bd2d2e1916ba2ad6ea7612a51b27699cc134e0dfd03a0f1eb34556f466d04"
+      "content_hash": "aa7daea85871ae0c1c511351917afb5469500002a5ff844d29edae2727fa6df1"
     },
     {
       "surface": "linter",
       "project": "splitpanes",
       "file_count": 9,
-      "content_hash": "72e44973058a2df8cc7c9bcadd4f68c3baf73cf1b1c7242d2f89a00053437c10"
+      "content_hash": "38d67d0c516345c8b1e18aecbf9b0138b1b02a1321b1b130a7cdb443814f37d5"
     },
     {
       "surface": "linter",
       "project": "tailwind-config-viewer",
       "file_count": 29,
-      "content_hash": "fb1af9914bf94060bb2710a472d5c37be772e5c493619047722dfe22fca19472"
+      "content_hash": "4257e6d3b1b6571f566b753001e64f284c61963caeef8c96b901d6c27c7c2915"
     },
     {
       "surface": "linter",
       "project": "tdesign",
       "file_count": 82,
-      "content_hash": "160e3a1699a9ee7c0a550659125d6def615aa1b60216845071394ae286191e23"
+      "content_hash": "43c5173dbceb86623d02ef10b805f9a0cbaa9fcd42fd6aeb39e02d3c4d47d605"
     },
     {
       "surface": "linter",
       "project": "tiny-rdm",
       "file_count": 140,
-      "content_hash": "260e1d78bbbc5f539f413c41a13960da6b096792895f23d7b7970be25cc3a0f7"
+      "content_hash": "7aaeb563b816bf2fe74fb45909b345542475ec5224434b49bf25dc67314f81ac"
     },
     {
       "surface": "linter",
       "project": "uni-app",
       "file_count": 58,
-      "content_hash": "39f83fd009980afc27623ea5b4e2eee28421a1474bdf10d94bfe597cbf432f4a"
+      "content_hash": "1e2871957aa830c27ae7912f24815b79f0b5d04f97f4a203a221f7afd4b53608"
     },
     {
       "surface": "linter",
       "project": "v-charts",
       "file_count": 33,
-      "content_hash": "f6f0c91900e29ed34b2ea895e0b9e28c188e8a6ef2ad470ca7500b8e7e99867b"
+      "content_hash": "649d238520df5808457583083eb66f9e26e3bca327a77cbbd8c2a1a9fcb8eb9f"
     },
     {
       "surface": "linter",
       "project": "v-viewer",
       "file_count": 6,
-      "content_hash": "f7263214dfb8f18f5a7c9610e46215375c0d69d64260dbe326c3af1a01ee0f71"
+      "content_hash": "df4c5790dbc1b4e216df2028887efd1752b5998fbac78c760bda33cfc8e7f8dc"
     },
     {
       "surface": "linter",
       "project": "vant",
       "file_count": 129,
-      "content_hash": "325f1ac95f0b05803a0b336f5b7ee05046efd90454e695745e3f17d8a55d68ba"
+      "content_hash": "6d1b882f8423b0049e789cdfabf038b6d8ebfc927632b77b8f509bfdd60b3e34"
     },
     {
       "surface": "linter",
       "project": "vant-demo",
       "file_count": 15,
-      "content_hash": "4d0d95531b19b02d88a1293a8f7c456664c73cc4d76112b86299c56986e85935"
+      "content_hash": "aa71f166888a94c029243d514e4d0f77a0d7bcd202b2670dcf759b9811b3539f"
     },
     {
       "surface": "linter",
       "project": "varlet",
       "file_count": 226,
-      "content_hash": "e1e460374ee50eb9143d5ec2d0d201a0430402fa79de91bd4aebe681908d6231"
+      "content_hash": "9dccdca7641ae3a22ca952e2fec9e84ff28a559cc7f29b9473780f4d12bb364e"
     },
     {
       "surface": "linter",
       "project": "vaul-vue",
       "file_count": 21,
-      "content_hash": "47de9a663b256c59b5167695dae196e39a1a2ecc8419242035f5747840a6c03d"
+      "content_hash": "364234c8455164f0bd27b19d93d031fc4cd36f89b6805560732befa88178ce11"
     },
     {
       "surface": "linter",
       "project": "vee-validate",
       "file_count": 83,
-      "content_hash": "46a9170b56a833f111fed69c0c889a6e4f2ceb1a4945572cf2038596de693cdf"
+      "content_hash": "c23374b42a909d2d867a96f4417f508af83eb295b34e2a764c94054b102280a9"
     },
     {
       "surface": "linter",
       "project": "vitepress",
       "file_count": 95,
-      "content_hash": "d5985b2193efa6066e226196b69f9640ad6e76e124c59f32f30a982e4840c514"
+      "content_hash": "643c6c49f53286c25adf65a37d7c0848bab711a6e561225b83e36986ea9b6e07"
     },
     {
       "surface": "linter",
       "project": "voicevox",
       "file_count": 134,
-      "content_hash": "48a349ad3ee17e28d15b4cd60c035d9b84734d4576b0f16a3bbd6d1892c8c0f8"
+      "content_hash": "afb1c5beaee468d64bedf9944e21272b087b7d06ff87de2a1eba59f95372cd7c"
     },
     {
       "surface": "linter",
       "project": "vonic",
       "file_count": 87,
-      "content_hash": "649425ba86934099b0d9a849b1bdec7a9c78781827661f47166fb4ae16b14637"
+      "content_hash": "28beb35b0084f66ab1f677f42965e4d0b18e4888e80ce6c111a603cd2e67de55"
     },
     {
       "surface": "linter",
@@ -2284,109 +2320,109 @@
       "surface": "linter",
       "project": "vue-bits",
       "file_count": 323,
-      "content_hash": "080a53d8b5b101f9b12c080f09689c620592a3a9e859f566aec311b2af7081cf"
+      "content_hash": "28fc08d4111324e5bf237f1a7722db1a41ce11f642523552ae8e10d2122b1b78"
     },
     {
       "surface": "linter",
       "project": "vue-cal-v4",
       "file_count": 16,
-      "content_hash": "5390ce06cdbd279e0fea0dedeb1553f4c3b623a0df85d06edb2dffc26e199c0d"
+      "content_hash": "fa5233f42c30cab6434dea20967892fc5df25124e9a36785c9f1843f03189efe"
     },
     {
       "surface": "linter",
       "project": "vue-calendar",
       "file_count": 2,
-      "content_hash": "768be74aa706ce2a77d662d7ae0c5b2da36f5aef582b85294ded71f536bbcadb"
+      "content_hash": "fa35a0450eaa3f411629a8c063f5ec843aa481110bfa6b33d54cd896946a9a2f"
     },
     {
       "surface": "linter",
       "project": "vue-chartjs",
       "file_count": 11,
-      "content_hash": "121c79ab6348b39e0d84b9a1cc6ab0b4ea6de582105b9ba0eb9ea865d2f93bf9"
+      "content_hash": "7001f5b88b3de91f07f3be67ad3ef0950aadc3f1686d5083594636cd40cdfa29"
     },
     {
       "surface": "linter",
       "project": "vue-charts",
       "file_count": 193,
-      "content_hash": "db7a702d0271c5ab8af5bcbd89823de365b4be9da80783a3544494e40b8b0e2c"
+      "content_hash": "e71472221ff092a9accaf4cdcd6d4c729c5e6bff35fea02f9cbc6121af3dae75"
     },
     {
       "surface": "linter",
       "project": "vue-core-vapor",
       "file_count": 105,
-      "content_hash": "44376c0426116b5803835bac410cb93b8f748bb233c175efff077be198683e2c"
+      "content_hash": "a9652adcbf7c328a9c47a5086ea135ee972b79feedb773651342e37442669022"
     },
     {
       "surface": "linter",
       "project": "vue-cropper",
       "file_count": 4,
-      "content_hash": "77904583091c73e96989f23d3ed9fce98dbded47129ae0dec2237a34de7457ea"
+      "content_hash": "81fefc6b613145ea36f5f8320c45e7b3b026860dc7a5b5640d8ac6dba036b9da"
     },
     {
       "surface": "linter",
       "project": "vue-data-ui",
       "file_count": 403,
-      "content_hash": "8ee242a26fa79838b3b5cbd6b82a7ba2a7f887a089cee7e1b55134e3988c6bcf"
+      "content_hash": "92dcb38ddef962a960d1c8a084899eb67824e64ff5cb77e50e09a0641606add5"
     },
     {
       "surface": "linter",
       "project": "vue-datepicker",
       "file_count": 19,
-      "content_hash": "52c8a56a7ff75360e89b80fb9c16147bd23bd2a51cb47327192c39b4c6fdec5c"
+      "content_hash": "91f0d3a3aafb01a70fe71d8694c08cbd1849f504a052bea7d55bb55f9806facc"
     },
     {
       "surface": "linter",
       "project": "vue-devtools-v6",
       "file_count": 121,
-      "content_hash": "f3c7c9678b0415fbf6f45f3cd67c5f2f0eaf8c2b31337e194751103f0dd74650"
+      "content_hash": "c9aaa258b5e55efc697ec2b63940a44d8034d61ebec6826d953de2c66d3b0e7c"
     },
     {
       "surface": "linter",
       "project": "vue-draggable-next",
       "file_count": 30,
-      "content_hash": "a9ed704bdaf7b81ee2368ad49b3230f3907b962f3f5ffa418956fcba98a88586"
+      "content_hash": "2d95dbce834be61aec4aef6dab7e413c7a995d0eee3fb212ee81f6be256a6b18"
     },
     {
       "surface": "linter",
       "project": "vue-draggable-plus",
       "file_count": 36,
-      "content_hash": "cf968d0a18a2e052576830d4fa0f40c54e1ee30b6ca2ec711b54e86b797cae41"
+      "content_hash": "e72d4c175929419e1e1954213a25355259145cf5d5dc5cf79f54f46b8409738c"
     },
     {
       "surface": "linter",
       "project": "vue-draggable-resizable",
       "file_count": 53,
-      "content_hash": "e85bca8e283da48bfa06a3b92482cad6c15e50744306bf8fcf7a32d8a155f7c4"
+      "content_hash": "9e44469c211b804db9c445033f6afb43031906e7166713a46f3cb280795eb328"
     },
     {
       "surface": "linter",
       "project": "vue-dropzone",
       "file_count": 18,
-      "content_hash": "9f06064b956791f3b5aa96552c5e66e8207a6d83fa0edbb6b53454e08f0d169b"
+      "content_hash": "870f029c292fd7b73164fce11816560138db75932747845f6de39fc051577d52"
     },
     {
       "surface": "linter",
       "project": "vue-echarts",
       "file_count": 15,
-      "content_hash": "d2792563380186381c556a580958f1ef02bcf4fa6bd1b6badb01d24205f30930"
+      "content_hash": "59313467bedbb17912c537502c157913531f2ff174b73118c5e9a54a6069b7d0"
     },
     {
       "surface": "linter",
       "project": "vue-element-admin",
       "file_count": 131,
-      "content_hash": "c9862e4c12680a81af87506df74413a2a82637f18fb1b9e9fe79cec8c858dabc"
+      "content_hash": "a3312fe9b9f2aea2f1807f445f16cac93d08e3a01cf5466680d6511676ee3fbe"
     },
     {
       "surface": "linter",
       "project": "vue-fabric-editor",
       "file_count": 72,
-      "content_hash": "4ee8502ef7639e520339ef56af879978573225cb55f361287d55ec92b31250af"
+      "content_hash": "f43e5f37c2bcb9af5315a6ffc2b3b4022b37010caae342a78221363ff889a2f6"
     },
     {
       "surface": "linter",
       "project": "vue-flow",
       "file_count": 194,
-      "content_hash": "f6294a3107625491378ba9848361b9db8a31fbfbf142672ecb81449c4ab0809e"
+      "content_hash": "3cebd318a3b3792151c8435b19e43b457191cee325ded75cdb030e424f635cbe"
     },
     {
       "surface": "linter",
@@ -2398,13 +2434,13 @@
       "surface": "linter",
       "project": "vue-grid-layout",
       "file_count": 5,
-      "content_hash": "a4a09f1d02b4f691972a162d6005a787ca1689fa49a21fb0fff3b01d07a29792"
+      "content_hash": "cd3bf3b205189a50c188bb580e065b0979788d0cccc6492c9e7e4b1e400f39ff"
     },
     {
       "surface": "linter",
       "project": "vue-js-modal",
       "file_count": 19,
-      "content_hash": "0985a2e42308096f43258af29d1d0f63dfa1e143ac7b5d70dbae38561958f06b"
+      "content_hash": "51c33c076487828b099c0d24550655b6ab9e1190437de34bcddbf94d17228345"
     },
     {
       "surface": "linter",
@@ -2416,25 +2452,25 @@
       "surface": "linter",
       "project": "vue-lottie",
       "file_count": 2,
-      "content_hash": "33639d3e09672b1732cc5679c60a7e1842a3b38a5e0b5cdb4b6ecc617b689f31"
+      "content_hash": "f7bd402f175f5fa96b2f1d045650974caa005c1036d8ac7b20d7fdb060db5cab"
     },
     {
       "surface": "linter",
       "project": "vue-manage-system",
       "file_count": 40,
-      "content_hash": "05847b4e7f163c8f9af291009ab0013c93f096353562652dc7739e6477a95971"
+      "content_hash": "84b8537f20bd3b6141d549e620f4ec460ef280bbb7451d537f3cdb367230af18"
     },
     {
       "surface": "linter",
       "project": "vue-material",
       "file_count": 347,
-      "content_hash": "c8eb6a05cb253ef2d34effe844e4821184a093df70146eaa3100738e817c078f"
+      "content_hash": "70e68215bef07a0f6c5f3be95b826b2495f9e8fec370c84acbbe307a414af2c9"
     },
     {
       "surface": "linter",
       "project": "vue-multiselect",
       "file_count": 36,
-      "content_hash": "b46db17505ea5dac2948c840ec31368daf100c65c2f553d1afa75e404398e825"
+      "content_hash": "6fa29c549cdcf3d92160d6dde8a88e50181561db623c94dfaf7f20cfa9325d1c"
     },
     {
       "surface": "linter",
@@ -2446,61 +2482,61 @@
       "surface": "linter",
       "project": "vue-netcore",
       "file_count": 121,
-      "content_hash": "0b7a5a1bb74f883bf422ece87419fd722d67f22287a425a512e1128301b1b363"
+      "content_hash": "3a4f0d94d5c3ed24be1b09700594c5858d93dd35ccefc7c4e1d44df58451bd67"
     },
     {
       "surface": "linter",
       "project": "vue-pure-admin",
       "file_count": 255,
-      "content_hash": "e7d36f02f495980bfb562cb8e96ee482004468545d656d1554c60a41927e9d5b"
+      "content_hash": "c6192be88961e3b80b83f49508efc9922109dd6b14af612ee642bbed7099b00f"
     },
     {
       "surface": "linter",
       "project": "vue-router",
       "file_count": 115,
-      "content_hash": "2a27ce4559c03703a9f1231a4bf617574b2f5a380d170b77d0eeab11f9497b30"
+      "content_hash": "b77132724ab7fe16d3ab7e88c8d53a17a1aeb13f9bf9d4ad19eee94a99ce133f"
     },
     {
       "surface": "linter",
       "project": "vue-select",
       "file_count": 4,
-      "content_hash": "620804ff076fb7c7d2efa3e6525befd84f390dc80b35f32e65e2c20d3fa67323"
+      "content_hash": "2a97c181453d5da061e8544249d2b56845f9897ae66e0b781cd4c1f0ce0a6ab2"
     },
     {
       "surface": "linter",
       "project": "vue-sonner",
       "file_count": 26,
-      "content_hash": "0f686f06636a1259b6c627fa1081fa4019c089b53fd357fdab7e6313b5f0e8f1"
+      "content_hash": "6a73d8be189276a9822407f1feae98a28c6522006bc56379f9f57b4c86e000fa"
     },
     {
       "surface": "linter",
       "project": "vue-storefront",
       "file_count": 45,
-      "content_hash": "7fcbfbb32165ceb185154c5999304daba927fa01994dace7882b4185441809b6"
+      "content_hash": "d15dd9554575fc1894ee217a72d8c597ff3100c537d583020c11f365fffbbbe9"
     },
     {
       "surface": "linter",
       "project": "vue-termui",
       "file_count": 77,
-      "content_hash": "e5968eaaf72022e47c31241095aeac2a448daad3d4c313174b1882417bd5d65e"
+      "content_hash": "4b7cafb46423d90b1895f5b1833b50b4b59205386252a423812a75e4f8c48f98"
     },
     {
       "surface": "linter",
       "project": "vue-tui",
       "file_count": 19,
-      "content_hash": "5272d54109298ad74c8fb4c6125568122b798c1c5f01c2156d86da6aa7f5dccf"
+      "content_hash": "a8b6d82ef71722f73a6deb3fd3a0a026b888a94c9f9f01ad3ef074a5b0c4a219"
     },
     {
       "surface": "linter",
       "project": "vue-uploader",
       "file_count": 8,
-      "content_hash": "f3ca38028cd12ffe11c37a1d4883f0e3f78957b357cec1bc746f3865dc2eaa54"
+      "content_hash": "00acadd06586e4f13da629d3bb798a306adfb4a0a5ccc1a114ae18d10f55271b"
     },
     {
       "surface": "linter",
       "project": "vue-vben-admin",
       "file_count": 613,
-      "content_hash": "13c3f072d2337f5ea71e4ccf24aadc0b2a3c44d2557c29eb8c47c3cae0992327"
+      "content_hash": "1c286e0cdacf7f83550568348b7e52827f7df2be23e190a9e70b8a386189ae5d"
     },
     {
       "surface": "linter",
@@ -2512,25 +2548,25 @@
       "surface": "linter",
       "project": "vue-virtual-scroller",
       "file_count": 18,
-      "content_hash": "13f3fac8cb09573d864c7230bfbd38324617b37d58af666380129a44862539a4"
+      "content_hash": "3c541e2d0b3f4ae82c310f62238932c3083869cf23d6b3d15f5048a51439286a"
     },
     {
       "surface": "linter",
       "project": "vue2-elm",
       "file_count": 55,
-      "content_hash": "bebe1531e46d64f3046279d01988ca6476f0dbc5fbd7f9b15aa8d75a12106e98"
+      "content_hash": "5e58107acd62a25d98bb1d51331bc2c5cb2bb6907c37fe458a1d135264ac7076"
     },
     {
       "surface": "linter",
       "project": "vue3-admin-design",
       "file_count": 7,
-      "content_hash": "b4ab063be21bb355d50fed16a60906c3642c53138e6d7468eb5dfc79167ec6d3"
+      "content_hash": "f3f5e9b13a732d53ac761025f36593a7fedfff82a8f5b6fe7bd3f612ae79b4dc"
     },
     {
       "surface": "linter",
       "project": "vue3-antd-admin",
       "file_count": 99,
-      "content_hash": "925cb63b8c463489357447eb0b5402e55e5a777c52f3dc806d04c9d089172cde"
+      "content_hash": "4366148f3ba5f84ee3828e98f58abb2168920b1ba5a7bd6c0b9c19c51390fe30"
     },
     {
       "surface": "linter",
@@ -2542,49 +2578,49 @@
       "surface": "linter",
       "project": "vuelidate",
       "file_count": 28,
-      "content_hash": "0edeb211f401d6b4c4147844350f06486248e409902de7d573cfd78f1cf018e5"
+      "content_hash": "27cc54456e7fc9ff429257a01f06a68e3ae0a0d46dd6a42117cbd6997fb02696"
     },
     {
       "surface": "linter",
       "project": "vuepress",
       "file_count": 38,
-      "content_hash": "da609b17071ab5387ba88169ad0679a8b9dc63fc44d647d03abcf17f2e9789fa"
+      "content_hash": "cc987172ea92008751066419f834d3343bbf03f3b238f7af78417cb8160f67a8"
     },
     {
       "surface": "linter",
       "project": "vuesax",
       "file_count": 58,
-      "content_hash": "6dedc70ed72826d2d92bbca725bae0efb9600e252e68047530518799a3ef243d"
+      "content_hash": "e3f4ce9f7beaad0255356958d30bbab6ddd314afeac01891a493f4546d0eae3a"
     },
     {
       "surface": "linter",
       "project": "vuestic-admin",
       "file_count": 99,
-      "content_hash": "c986b5660f8d740a4a7dd6b0a2050698d9d884ea8ab28a5bf6bc7674764a7088"
+      "content_hash": "c5e322e8735c6b6a40b9b6e72b3209cb16c2d86e43d8f2c1661fef16afabfa7c"
     },
     {
       "surface": "linter",
       "project": "vuestic-ui",
       "file_count": 1019,
-      "content_hash": "4eceb0df47da026edef7afdd599864b066fd045a959d2ca7e3732a726381dec1"
+      "content_hash": "7780d3b0a07905c74de160a4ae4c7c6b84838a73429330e875f3cb12e8fe6ac6"
     },
     {
       "surface": "linter",
       "project": "vuetify",
       "file_count": 1255,
-      "content_hash": "7ad4b094cb24ff8bd7ff53e8baa592609287257d7c547dac2fa54022df7af2b4"
+      "content_hash": "131f50b656c025e8b121c1a5f182fd19abc21490d57a1fecc691429a1fafd852"
     },
     {
       "surface": "linter",
       "project": "vuetorrent",
       "file_count": 145,
-      "content_hash": "5335d674d6489194f8c132b38bcabbf8373d0d5d4899fa850f3fe49c18d254b4"
+      "content_hash": "47912117fc9b2174e86822b18ddcc7fd504b3e47f92eace325dc1a608e896d98"
     },
     {
       "surface": "linter",
       "project": "vux",
       "file_count": 312,
-      "content_hash": "02a577c6bff651ef13fedf51c1c391c93ad37cbdf96242f7f3d31aae4cbdd910"
+      "content_hash": "b2626b5831a7c98c19f4a352a1c09f839d55d4865d24106aa674e271dce4a31e"
     },
     {
       "surface": "linter",
@@ -2596,871 +2632,883 @@
       "surface": "linter",
       "project": "wave-ui",
       "file_count": 219,
-      "content_hash": "4b9a8c4cedc437976b0ac081c4bbacc338540f697d3780e7b53cafaa7bfbe871"
+      "content_hash": "0fa30e684977fce701d1286de32b9272c56b3664548f88a5bd835a79a12dc708"
     },
     {
       "surface": "linter",
       "project": "youtube-dl-gui",
       "file_count": 83,
-      "content_hash": "3b9c2a10589ce37ba18c696a793c5e63d9a637ea640c61b83fc86734708cc9fc"
+      "content_hash": "d9374ddac0263a929ab8901bb9dd5d6279ac51db3155bc29e0c2f069072d301b"
     },
     {
       "surface": "linter",
       "project": "zy-player",
       "file_count": 13,
-      "content_hash": "30d80fc952e2eca006a2a95afadadb270bacd5362eac3aaed994873ea3f271e0"
+      "content_hash": "7a9b582f8e0feae3a0dbeb775bc1a4e501d5e1e93e36c4eb8fd9b58cf2823178"
     },
     {
       "surface": "typechecker",
       "project": "airi",
       "file_count": 1083,
-      "content_hash": "0865b1a43f569466f952f9a07ea22bd912985d0aec84fc34b058da9dbfac096a"
+      "content_hash": "d10e0afa1a35d04c0ee06d958cd0420b564f8a405472f2d0bc1b2173f7131b7f"
     },
     {
       "surface": "typechecker",
       "project": "alexandrie",
       "file_count": 217,
-      "content_hash": "261013e8ceadddcc60f69196f769c9d275449fd96fbe325f09d2ff296044b0aa"
+      "content_hash": "70aee5e902097e0221acb1b7f8203277d1d70f335b9a7786ea6bf5a5547f2126"
     },
     {
       "surface": "typechecker",
       "project": "ant-design-vue",
       "file_count": 1948,
-      "content_hash": "9f4f54e535bdf8e451f0a45f7f2be0b026e4c54fefe7950e7fa3ce475de11159"
+      "content_hash": "ed60a381fd614e6b70a7aab66dd3008cd87dcc85d8ff1fdf9ca6b9143aa41b6b"
     },
     {
       "surface": "typechecker",
       "project": "antares",
-      "file_count": 188,
-      "content_hash": "9323f76716f0ca3c39256e5adaf99d3cd376bdb97b859da02fefcd4187df9234"
+      "file_count": 96,
+      "content_hash": "4144ce6edefde5d3130d058bfce9d19e0992a39425b0a63d0092c52851ac5fb8"
     },
     {
       "surface": "typechecker",
       "project": "arco-design-pro-vue",
       "file_count": 87,
-      "content_hash": "f6f4dff1418bb2e1894888554801918f887a2c8948c01be1cec86f468b9cd339"
+      "content_hash": "ef9d18934857a66fb407ae644b2615523cbeab57442939ec0ae0415f4c6dfd93"
     },
     {
       "surface": "typechecker",
       "project": "automa",
       "file_count": 215,
-      "content_hash": "98b86b24fc8c16adeeae15012f22f9a7b8d946a0366760dc87c7a68dab067669"
+      "content_hash": "41468f7f5a3437cee5fc55459d1a2633942e369375c22805a158c7c0674f0b33"
     },
     {
       "surface": "typechecker",
       "project": "better-scroll",
-      "file_count": 128,
-      "content_hash": "3c4bab412766fe8705e4492470618b7f476ae41384c03049aab4938ceaef2e3b"
+      "file_count": 65,
+      "content_hash": "85c1f4762c62d9cc4d414cbe1075e6f6e3edb8d8a758c3307a97fcb02a4ab4a4"
     },
     {
       "surface": "typechecker",
       "project": "bootstrap-vue",
       "file_count": 22,
-      "content_hash": "668b73b600da22a69179346f11c89841c052cbb9fcf708e3718c9aefbfba5776"
+      "content_hash": "e78b01cd67bceec3404cd067e3c71fe668d140e1e243bc9e53660e48ba0c073e"
     },
     {
       "surface": "typechecker",
       "project": "buefy",
       "file_count": 543,
-      "content_hash": "1b49c7e1995141b4afbcbc08324e08c9b6402270a2cf82db33dd6d9decd53c83"
+      "content_hash": "08e1f35e8fbf45e3ef5af83ffa1044130d35983961d57f7a37657a20b434a217"
     },
     {
       "surface": "typechecker",
       "project": "bym-vue-echarts",
       "file_count": 37,
-      "content_hash": "e2397dc6be3eb2a5721c15588c4f87984d393d4ed8b97c2e8459a0d9b9ee2456"
+      "content_hash": "0b722da951c3a7dd24818190150a577168932eced635c22906b4a6f62fe4061d"
     },
     {
       "surface": "typechecker",
       "project": "crater",
       "file_count": 311,
-      "content_hash": "e45a00d66dca01738823a1ca1243d6c16db9ba82b0bb07dcdf0a994b43088ac7"
+      "content_hash": "15a96b04bc3cd00c481553f7da80cbdcf96fd543e659424efe54d1933177df60"
     },
     {
       "surface": "typechecker",
       "project": "create-vue",
       "file_count": 42,
-      "content_hash": "422884456ee5bc7fbd876a2bd049c9daa50f528121f38116d1a62c926bcc5aa4"
+      "content_hash": "68bf93743efd1b6e098263646e592daa202be9566128031957211ac909ea65e7"
     },
     {
       "surface": "typechecker",
       "project": "cssgridgenerator",
       "file_count": 9,
-      "content_hash": "a0dc25b1f0ee64c235ba16ce8c7c75c1285d939f0d94382372b3a4b17d29b752"
+      "content_hash": "dfa9ad743f3635a054c615b45e3c5781765ff97e7d2c4a7b0f0cbbc0c89a9657"
     },
     {
       "surface": "typechecker",
       "project": "cube-ui",
       "file_count": 164,
-      "content_hash": "acfe1f8c0f4c881ad2c5c64d1567cc2ef705d1d45b12fe4ae9bb301521e73bb7"
+      "content_hash": "19b824992e30086023e0922c264c65f549e403efa03ace37e38ca6f06c061fbd"
     },
     {
       "surface": "typechecker",
       "project": "dashy",
       "file_count": 228,
-      "content_hash": "cd5918ec55259e44a1c29bc452a623b8655776125208e4b366644c08496b414b"
+      "content_hash": "0a19b29fcc84a4520554881091b955b22d095f6b3a8083eebdf394abf7281a76"
     },
     {
       "surface": "typechecker",
       "project": "datav",
       "file_count": 76,
-      "content_hash": "743983dd887bdff5295ebe6a44d896cd08a9dc99e574af83802080ae0f0f32e2"
+      "content_hash": "e9d83fd592144a4fcefc23d25127c55cdd0b1087d077ecdce50b2666ac6453c9"
     },
     {
       "surface": "typechecker",
       "project": "dbx",
       "file_count": 404,
-      "content_hash": "1f432dfc7e77449861e53a6938fd094be64397f46b45f793f4596bdcd1d91db6"
+      "content_hash": "84eb469a02684887f7cec6a77f5d06465dc508f3fbf8957b8b2b4e38f2a60798"
     },
     {
       "surface": "typechecker",
       "project": "dho-web-client",
-      "file_count": 247,
-      "content_hash": "a1a488aa0c13538c2c2a9ecfb8e3f91ea8609fd51980a9b2c124403f3a9b76f6"
+      "file_count": 215,
+      "content_hash": "72b870c49d429854446848d889a49d3cdfd5ae13fe6af18884f487382ba657d3"
     },
     {
       "surface": "typechecker",
       "project": "directus",
       "file_count": 926,
-      "content_hash": "4651c0b3bff0c2236134bce7fdbd949503d0fb70a64e5472397789ee850700e5"
+      "content_hash": "b62d0551a33880c7d69f130cc354fc58e5c05c76fdffc682b1bf1e75fabc58ff"
     },
     {
       "surface": "typechecker",
       "project": "docsify",
       "file_count": 0,
-      "content_hash": "c2b33361d311de14ed754d47eec1920c350584abf3624a1f530a38b73eb1e800"
+      "content_hash": "dbd6b39af74a41307d19a4ec935f7f3b78826279435068e75e3c394951a5ed2b"
     },
     {
       "surface": "typechecker",
       "project": "douyin",
       "file_count": 146,
-      "content_hash": "9683aebfe49b479f8db57e19528b59b333ef1bd49ff1388420ad0441688df6d1"
+      "content_hash": "75b12e75314dca4e6a57fd8e922e93aaa881695d96c7d0ad9d5ac3965502faa9"
     },
     {
       "surface": "typechecker",
       "project": "element",
       "file_count": 155,
-      "content_hash": "d6d96a1949be3655ae3146fe1b642145b6f42f43ef7f85c3bb9a937fd0885b0d"
+      "content_hash": "102c0703f4b443946953272e53a5342f50367e68890e1d08b94249fb6bfcdf38"
     },
     {
       "surface": "typechecker",
       "project": "element-plus",
       "file_count": 1518,
-      "content_hash": "4bdb330323999a33d1b19d1d03ab2aa38abf64063b5819b35c7df2a351f02e39"
+      "content_hash": "ffcba8fc46cb3ff6a6712d99bf96d2cba0d8b74fd388f164b527ff0951c2ba10"
     },
     {
       "surface": "typechecker",
       "project": "element-plus-x",
       "file_count": 361,
-      "content_hash": "7a821f87cf5f02c6978c224370a9d69e5d7aac82d0a0b5117493d9901123d654"
+      "content_hash": "53a795deb5052202edbfb7a5037ab9791f315599fcff4d4d8d074f0726ca176c"
     },
     {
       "surface": "typechecker",
       "project": "elk",
       "file_count": 262,
-      "content_hash": "5e0d3371bf8c4cdeca8b234e344bbcf01a092b8fa9c3a40aba625715982011f7"
+      "content_hash": "bcd1bda062606bbe274edd1c22ca722606be716d1e1f540866f4a2d569e2ce16"
     },
     {
       "surface": "typechecker",
       "project": "epic-spinners",
       "file_count": 51,
-      "content_hash": "3630ed1be4aba689d0156fc08322395c7e948104f375761c57e540cca67fe323"
+      "content_hash": "e6e3ce0605454a8f72d67edd26ab9f1918555b79e90cad4ea41036fc019a7bdc"
     },
     {
       "surface": "typechecker",
       "project": "filebrowser",
       "file_count": 85,
-      "content_hash": "ccc4eb54265e7687dbe097eebb9778b7ce140d3c2912a5fb73284a01121aee21"
+      "content_hash": "c324b9f4b9f10cc5dbc3fe285210b15a506e99ce4e135ff323a574b53e0f6deb"
     },
     {
       "surface": "typechecker",
       "project": "frappe-builder",
       "file_count": 168,
-      "content_hash": "b0bdd1c176fb8527f6b41172918585afac547b1893498a1229a7d864e7f98ec2"
+      "content_hash": "6dd6c2a5264d69acc3b6a9714c2f7aad43a2e9f272d7387e2beb799df9ce957f"
     },
     {
       "surface": "typechecker",
       "project": "frappe-crm",
       "file_count": 342,
-      "content_hash": "32ce4f7d5700d274819795156552f95ae6e3f0d41322614aa98f632e4b192000"
+      "content_hash": "1d5e4c483fa54c8271ce4d23ce495d0e15fe8972033e329fef5f99a7ef6f0f61"
     },
     {
       "surface": "typechecker",
       "project": "frpc-desktop",
-      "file_count": 27,
-      "content_hash": "3454bd7f6375212796bcf7fd2dee39e7d44bd25c25a32169c34287bfa48a940f"
+      "file_count": 16,
+      "content_hash": "3ef2467b0ed0d111cc850dcba91bda374024a5754ed8ec1c161ac8b88ae3aeb4"
     },
     {
       "surface": "typechecker",
       "project": "gogocode",
       "file_count": 186,
-      "content_hash": "a97622d54a469594f09db2b39e94f4c2246808ce39496e1caa6b85c97059433f"
+      "content_hash": "1e3a28eee94cb44a045f42cd34a817b751f847b150aea528ebdc0bfc15a7544b"
     },
     {
       "surface": "typechecker",
       "project": "gridea",
       "file_count": 41,
-      "content_hash": "e1800632eecfd2672851baab4c081a8fadac256b73866a523ba49d6023fdf8a0"
+      "content_hash": "d966d27b2862b7bb841f0853fc098c33cc7eaf756021f48b1ed4001fe9a352d8"
     },
     {
       "surface": "typechecker",
       "project": "gui-for-singbox",
       "file_count": 99,
-      "content_hash": "721335e559fe38934d9d3dea79c2485e1a25fd6947dda298b481507e3a76dc3d"
+      "content_hash": "f8d6736e83d608c7a91381567b8c905f375cadba2b48e6ba4644a2bc9adee14d"
     },
     {
       "surface": "typechecker",
       "project": "habitica",
       "file_count": 352,
-      "content_hash": "709ca20291a10654e465aca31fbf7b8cceefe2e48b9ae09c42c233310b14e9f6"
+      "content_hash": "9455995c1bb9c326441f220e0fc1954376f7800c6da421f252ef2f0d9e1ad4cc"
     },
     {
       "surface": "typechecker",
       "project": "heyui",
       "file_count": 76,
-      "content_hash": "de07a39a3a67431c2e0159262512bf1fa05a87b4c5e7358b01d8cbc9926965ff"
+      "content_hash": "72fd3bd53c0155c311cbc12757b6b438a9819c0cb5209a09a57339468a2a7749"
     },
     {
       "surface": "typechecker",
       "project": "hoppscotch",
-      "file_count": 717,
-      "content_hash": "fa79571e667b9e84cecd512f78087846a021ecdd2ae50b2f5bb29fd783f99a8d"
+      "file_count": 643,
+      "content_hash": "97b8f0006d7bcc959a166a549b23b0bc3d5c2d96ee59c4ecc664865386efdf64"
     },
     {
       "surface": "typechecker",
       "project": "inertia",
       "file_count": 460,
-      "content_hash": "395fa61ec42073a8eb912c7625c73a642469a58f7330f2116c81f5fc01e016df"
+      "content_hash": "3b47a7e374b0902aec2f5b1addb50011a938a63b8f1d9d63297c896b901b4c55"
     },
     {
       "surface": "typechecker",
       "project": "inspira-ui",
       "file_count": 545,
-      "content_hash": "962756784690a602c33883a9a93c1713eb395fe60da70d61bc674e652b1a2960"
+      "content_hash": "a7ba832bad3209986848b0bff4ecf18266ac3fa6972f8266378ba85ea2dc3f71"
     },
     {
       "surface": "typechecker",
       "project": "jellyfin-vue",
       "file_count": 208,
-      "content_hash": "20a7800ff28223cfff9337863da1da1d9805ca0961722cbea947a26153bdfe42"
+      "content_hash": "65371667af4c770ca86c1ee21584807b643f6cf82f88f350cb53c4582bb0756e"
     },
     {
       "surface": "typechecker",
       "project": "koel",
       "file_count": 468,
-      "content_hash": "0d3aa5a46935c1d72bc3bf752e1f9a5e40e8d9fcb6423e0edc1a596944de9383"
+      "content_hash": "2369c07c218e28bc5e1df0757763d0e5f54f26958ff23e08886cc73e103b7328"
     },
     {
       "surface": "typechecker",
       "project": "laravel-breeze",
       "file_count": 54,
-      "content_hash": "897d461e87fefb8ff4d9c7a7d13fe50833188cdca0b1a25b3b731ff41149b16c"
+      "content_hash": "7101c771da85d62f2232c00d2709ea32040a5d321e90252ba8ef748933f9f97c"
     },
     {
       "surface": "typechecker",
       "project": "layoutit-grid",
       "file_count": 114,
-      "content_hash": "efacb7086ebb93b7b36c4b43d0e113f028f6461a71a02d2220e23c17b91eda51"
+      "content_hash": "504609f66a3565ff1d8c3cc199ff898d3ea3f2c8f6fcaf30a5d5f8be24f22e40"
     },
     {
       "surface": "typechecker",
       "project": "lew-ui",
       "file_count": 876,
-      "content_hash": "047f05d82999a4db5d9890fcdb758e7b988d16b83438460b18c80f5a19ab75d0"
+      "content_hash": "52a8e577c13323b7d8e1ec23bfbc7ceb4785df53c2b3bff844ce2a94615d0254"
     },
     {
       "surface": "typechecker",
       "project": "lx-music-desktop",
       "file_count": 271,
-      "content_hash": "ad75bf5fac8585191f66366d0f8296090a5cf408a107df12e6ba9e27c578e75b"
+      "content_hash": "f531748a492215c88979c64753479d6d159633c7283669694374ad5b559527c6"
     },
     {
       "surface": "typechecker",
       "project": "mall-admin-web",
       "file_count": 123,
-      "content_hash": "443ab50044d249b2c5f68f48d31936c22845aa581798901000d80e34ec05e003"
+      "content_hash": "546485554774cb4ef7f5b9af853329950a0e2145c4880189a33d10114c530051"
     },
     {
       "surface": "typechecker",
       "project": "mavon-editor",
       "file_count": 6,
-      "content_hash": "c2a0251dc03d38312c473a7cf4fe63eef84b53996ff96a362269725eb83dbc69"
+      "content_hash": "f08905243dbdf8a5a64d6e6bff8715a09100fca86cfffaa875042f356f955034"
     },
     {
       "surface": "typechecker",
       "project": "mealie",
       "file_count": 206,
-      "content_hash": "092e0432fc606a2076d31be5cf19da6e81a3a0c97bb3644f35cc659629593543"
+      "content_hash": "396f99e7aa18dc895ecccaba1c399fe0873edb84ee4b0d21562d9d01f7b2d40e"
     },
     {
       "surface": "typechecker",
       "project": "mint-ui",
       "file_count": 69,
-      "content_hash": "af83204c598ff0537b2efe92504ec3c9d54379e25eb7443ef58801ca4fc1260e"
+      "content_hash": "f133b859c62aa8fac70ba787f1273f0322478ec96b233441787948841e4458a5"
     },
     {
       "surface": "typechecker",
       "project": "misskey",
       "file_count": 788,
-      "content_hash": "874377c59d9460fd916284ace120c9c78ffc8eccf737878ee81cf148decff8f2"
+      "content_hash": "90574c6131cdc464c231cc730e98f21b086d64046e9f70b192d41b4a2def2aa1"
     },
     {
       "surface": "typechecker",
       "project": "mobile-web-best-practice",
       "file_count": 24,
-      "content_hash": "78f207b5c83034bc13aa872d86d5492924bd6335217f616dd7337eb16755acd8"
+      "content_hash": "cae17815e380c655cc80fee099765af0cd3bba3129e43cf69b62525caa8d3cfa"
     },
     {
       "surface": "typechecker",
       "project": "motion-vue",
       "file_count": 91,
-      "content_hash": "e2bc7552712e8502fb1b5ac40c272d7192c6baa8eb713a7aeca124e6b80edf09"
+      "content_hash": "b7f379d4584dd83a83ae3eb0705f9829c11f671cc7adf3485d7a807cd9fab772"
     },
     {
       "surface": "typechecker",
       "project": "multiple-select",
       "file_count": 62,
-      "content_hash": "7b94f66a6dbeaf2a95fef680b62f1b3eab3ea19270449bc6cab59efedc1a7b0d"
+      "content_hash": "438daf36a3dc066ffae12070a9e89d8a60de72e39f7267bce0cd9de6f5aec6dc"
     },
     {
       "surface": "typechecker",
       "project": "muse-ui",
       "file_count": 3,
-      "content_hash": "f436322782dc3cc53bbcfecb3591f7c9558cb7846332cb88b69b1553667c29fc"
+      "content_hash": "73697213325c66ff29708635d768bbe6e4a18ea2427306c5d70a1f5c957b849e"
     },
     {
       "surface": "typechecker",
       "project": "music-website",
       "file_count": 61,
-      "content_hash": "4def86591750cb73de9b853ee1c3c3ec57245d066806d69c34007f3ea7237f76"
+      "content_hash": "a0f34f93a2beb1003068e101a24201aae69948a788743d43835e9eedbb6c6a3e"
     },
     {
       "surface": "typechecker",
       "project": "naive-ui",
       "file_count": 2980,
-      "content_hash": "aab0302abf44a747c97d08f61e11504e6657804ed32b40e31ae261d26ef05703"
+      "content_hash": "09a3ad8e50901e4e473b675cd379c7fb1178ca8aa195b86c3bc1df4a4d117a68"
     },
     {
       "surface": "typechecker",
       "project": "nativescript-vue",
       "file_count": 19,
-      "content_hash": "feee487803bfa8d7b7c0fc4194c79e5ea116d6cc52f850262ba7336bed73fb1d"
+      "content_hash": "592bcf0bd4e04779907f129b6f961eca367a59e737e54c0b5365cfa7b17f0d9f"
     },
     {
       "surface": "typechecker",
       "project": "nutui",
-      "file_count": 1372,
-      "content_hash": "dc6fef162304780bdd06caeac43e412074e9e2a34543e55e8dc57d0f9c5722b6"
+      "file_count": 1345,
+      "content_hash": "9e19a82486bff6c947951d86d848f09f3d50a6937d1347662ddc313a958eefcb"
     },
     {
       "surface": "typechecker",
       "project": "petite-vue",
       "file_count": 0,
-      "content_hash": "c2b33361d311de14ed754d47eec1920c350584abf3624a1f530a38b73eb1e800"
+      "content_hash": "dbd6b39af74a41307d19a4ec935f7f3b78826279435068e75e3c394951a5ed2b"
     },
     {
       "surface": "typechecker",
       "project": "piclist",
-      "file_count": 88,
-      "content_hash": "4c0804ee9fa78d46216a5bab7e41db8988c284736d4a26c4232203fac4cbd325"
+      "file_count": 56,
+      "content_hash": "df0709193f51de2250a930a049445fffdef7b128e351b1ff270aa783e11afcfe"
     },
     {
       "surface": "typechecker",
       "project": "pinia",
       "file_count": 57,
-      "content_hash": "2df70b286ffa7e891a80ffd58c9b0919b920065afe3aae84d02f91c989f8e022"
+      "content_hash": "ab378e842ae25b418c92864714ae6ce94639063e124ce434bcc2a256f989010a"
     },
     {
       "surface": "typechecker",
       "project": "pinry",
       "file_count": 29,
-      "content_hash": "ed075375dc75de1c6066d614753daec99c5f5d725a81c034f89527c778d621f0"
+      "content_hash": "5b7a66c9840fa3eb4df2d57ca7154527e7e17f01fca408d41664b7442a9244c4"
     },
     {
       "surface": "typechecker",
       "project": "portal-vue",
       "file_count": 51,
-      "content_hash": "79fa545acad4f58c88c0c7ad7db1414774fdc02a192ef273dac843f8a0eb572f"
+      "content_hash": "af78826ce70d9ca013e3ce39e425ce804f7fbe20d61236f492d8a22680fab736"
     },
     {
       "surface": "typechecker",
       "project": "prevue",
       "file_count": 28,
-      "content_hash": "6702e1f465d1f468dd52dc9d7f2172c4000fb42f3d4c7fb0bef5b7fffab2d764"
+      "content_hash": "b7f145f6f648847c93e3760d0c948125b05ef15689e9773d02e5906a794161ae"
     },
     {
       "surface": "typechecker",
       "project": "primevue",
-      "file_count": 2615,
-      "content_hash": "d0b4c6d6a50a730138b669ea9367ff890bf4a44a8c9df655d63dce89facc6dcf"
+      "file_count": 280,
+      "content_hash": "0f5ecd44083dc3a805bf024ccb571f79503988324a079e4722d0ba49485fd9d7"
+    },
+    {
+      "surface": "typechecker",
+      "project": "primevue-showcase",
+      "file_count": 1651,
+      "content_hash": "2465d2ff81c66eebf57bfab922051a90eff33895cf6a017ae7cc7bb0ac13d2f3"
+    },
+    {
+      "surface": "typechecker",
+      "project": "primevue-volt",
+      "file_count": 629,
+      "content_hash": "4b0ea3d1c665d0c1e1943f1ace967e600bdcc0f39e330b4b3b4cdcf772de35a2"
     },
     {
       "surface": "typechecker",
       "project": "reka-ui",
       "file_count": 928,
-      "content_hash": "f865b2d4dc236ec63fab8ceb4cac4043cf4f28c8f94b7146db06327b2050939e"
+      "content_hash": "c909f4daaf0c8c6aed3a93520da983d2fa195f5588700cee7d312a73cf8cd22f"
     },
     {
       "surface": "typechecker",
       "project": "scalar",
       "file_count": 2184,
-      "content_hash": "4cf7dcddaff59a66e949cc49a1b7812ceb5da00945c6b106b60e715679d242a3"
+      "content_hash": "651fa9cbde017443fe3ead3eb3e3e8c24bda315c2478720fc42674eef656f980"
     },
     {
       "surface": "typechecker",
       "project": "shadcn-vue",
       "file_count": 6887,
-      "content_hash": "8ffe303220d52d526b5a3cad0d25b3113012f15c543ff60498a10bd2ec13c636"
+      "content_hash": "d1408126838f1f0b1418f714340fb95aa7ad2be075f938d69c26602f7701767a"
     },
     {
       "surface": "typechecker",
       "project": "sigma-file-manager",
-      "file_count": 647,
-      "content_hash": "91a8ae8e34f816a35b16be23912c67d2ec65cf3d1263025217aa39c2fed3bb94"
+      "file_count": 352,
+      "content_hash": "ce046273bc614973a04746d41a01f59f911b618d8296586212ecc7da159dff71"
     },
     {
       "surface": "typechecker",
       "project": "solidtime",
-      "file_count": 493,
-      "content_hash": "90a7201ede7b9ce6b8571a6621c4cafcd1ae9c03530d6d16e42d471e76003dc2"
+      "file_count": 433,
+      "content_hash": "7eed34f8746c0f66f98161625cd982b9241ed3af056ec94c6c2e8bbbdd3171ce"
     },
     {
       "surface": "typechecker",
       "project": "soybean-admin",
-      "file_count": 140,
-      "content_hash": "75f2e3b8a1e40d8d840e85c902771d53155279d9eeeb3f51d2d15f60894efc8f"
+      "file_count": 104,
+      "content_hash": "3d81ecaee43ea7e7ffbee570a70e2c7155be43a2e30531bd4feb2c2adfdfbc5c"
     },
     {
       "surface": "typechecker",
       "project": "splayer",
       "file_count": 271,
-      "content_hash": "349e3c306f9a247793afb3d7dec9e5f8eff6f7c281863cd8ce8aa031dc66e104"
+      "content_hash": "c531903e462aa49e323003161fbab49e2a961184f573db9a7aaaeefc000aec3a"
     },
     {
       "surface": "typechecker",
       "project": "splitpanes",
       "file_count": 9,
-      "content_hash": "ec85e42bd3a7eddc9eddd635b9d1ae3e4cdd62c1db14805ea1a04cebe7455788"
+      "content_hash": "a9652824d92cc334a948e85f7ac5d8bf2e26e64ec179840c78c842a8687d3ad1"
     },
     {
       "surface": "typechecker",
       "project": "tailwind-config-viewer",
       "file_count": 29,
-      "content_hash": "f38c377fe82e8e97b07051511b4c6064abb0d39cfe21a16d12900e9f11f6d8f0"
+      "content_hash": "b0213b8875025bed70d7ed663fc9ba81a2bcacfb4dca3c0fe50ff611a424b0df"
     },
     {
       "surface": "typechecker",
       "project": "tdesign",
       "file_count": 82,
-      "content_hash": "79777cf08e4f77886164ac97e11aa6cd00da5a852e1fa27b6cea5c0daa27a994"
+      "content_hash": "7dd380b156a8b7683ca169baf14906bccdf826d535dc9ef019834beab9b1d6e7"
     },
     {
       "surface": "typechecker",
       "project": "tiny-rdm",
       "file_count": 140,
-      "content_hash": "352bd304e7ffffab298da0b8df30b8e77f2c698256d9ab201d8d1da461d8de70"
+      "content_hash": "14fff740ae911bd2de485967d70fea345e1bc895e7ea5c7956f05643bb6aa945"
     },
     {
       "surface": "typechecker",
       "project": "uni-app",
       "file_count": 59,
-      "content_hash": "20174f58e45de091160f1290c54f0846bde2a6d784560db0cf8a8d70223c374d"
+      "content_hash": "b3cfc6456581eaa877f9a86438ae1192d1a705aed9366a6fb7275cfd5628c1fc"
     },
     {
       "surface": "typechecker",
       "project": "v-charts",
       "file_count": 33,
-      "content_hash": "f2d9e7a2fbf72083da13ad793e3ed370c1ff54b84777d0152aaf693408b71c47"
+      "content_hash": "ce691a6ce39e93b7be3e6c06ff22b492d6af38458ac5e4360aae7e2cd5975d37"
     },
     {
       "surface": "typechecker",
       "project": "v-viewer",
       "file_count": 9,
-      "content_hash": "7fabd0b29312fdc3631705ff1360bd12a7533bc392346cb249f49b8d3a05657a"
+      "content_hash": "e4339cfb9ce76b5a69f5b3ecbd669876c0b3d6259c0ffee3180c592f4130971d"
     },
     {
       "surface": "typechecker",
       "project": "vant",
       "file_count": 483,
-      "content_hash": "17c8b68feb80cdd20d4c1636b1d71c1708f40a48abc8133eee29169734363707"
+      "content_hash": "ff8c7b28f2c42421e694a939a00112e47558314edcc11b2f669fecb5a6a66420"
     },
     {
       "surface": "typechecker",
       "project": "vant-demo",
       "file_count": 16,
-      "content_hash": "a9e5504d30f06ff3029ea16893abec1de345f42c6fdf1e3d7433d90827823898"
+      "content_hash": "ee221918dae0ed2a1d4085bf8a5d7290466916057be53da2d404c522be9cfcae"
     },
     {
       "surface": "typechecker",
       "project": "varlet",
       "file_count": 693,
-      "content_hash": "38ea3189a39ebde547519d5a82366ddb1c76153af673026ffa6df87c3913cc19"
+      "content_hash": "aaef93884b30749903cac6f1c7b8ed8fafdcd1c6d44fd3b82769f0754418b132"
     },
     {
       "surface": "typechecker",
       "project": "vaul-vue",
       "file_count": 30,
-      "content_hash": "988ba375648993897e036729f17cb93cb8b55e245fc310e7297b320c9dadc7fe"
+      "content_hash": "d335bef8f641342f74e6cb0e647d82aa7be27d4117bec5cea3ea9af7462a175e"
     },
     {
       "surface": "typechecker",
       "project": "vee-validate",
       "file_count": 83,
-      "content_hash": "ee34b21a6fe1b6524ab9ea05de4dae961e1a0a825238aa1892877dae674229be"
+      "content_hash": "5421761c7d6d7643b8371c5306f1a702e5ca974f288940d2815ecc8d1c2991af"
     },
     {
       "surface": "typechecker",
       "project": "vitepress",
       "file_count": 115,
-      "content_hash": "d59bfd4954124916bc83d6f66c8cae2bdf4aafcc746681d14c498d2afcec1bfa"
+      "content_hash": "d892ec9b330e013b185880c5ac087c3877fd4dc141c021f36b26b2f228475905"
     },
     {
       "surface": "typechecker",
       "project": "voicevox",
       "file_count": 322,
-      "content_hash": "cd37c2441f54204e7d152c8c77f892803b0669512a5c47888fd08025a39ea00a"
+      "content_hash": "a928375c0b0ba13a6589daf251b578c7cd2ee540db872e36253fea0c05457f58"
     },
     {
       "surface": "typechecker",
       "project": "vonic",
       "file_count": 87,
-      "content_hash": "09288ca5fd3379d70efe0b04ff0b4d5ab2e39bfb987dfcf4b92557718906b549"
+      "content_hash": "ba8ab5766648d0d21fc137cd0789d04a093174cd78f3d297ea04760025214a98"
     },
     {
       "surface": "typechecker",
       "project": "vue-apexcharts",
       "file_count": 11,
-      "content_hash": "fb35effe1d2b641c14254d4b4d7064d36f098908b7bb9f12aab17e76139c33b4"
+      "content_hash": "3c9005a9864021ba575cf6e7f0d218d482e69688a7bd7b464b1b10ed0f06d10f"
     },
     {
       "surface": "typechecker",
       "project": "vue-bits",
-      "file_count": 475,
-      "content_hash": "d066726956f6851cb11b937aa3ae2c798701ba1920cb6435f06024767058fed5"
+      "file_count": 327,
+      "content_hash": "d9bc39e97f76176b0b433d67035f886d38a143f36c70665135429c5d464c6a67"
     },
     {
       "surface": "typechecker",
       "project": "vue-cal-v4",
       "file_count": 16,
-      "content_hash": "e7527edda6717561dd4658fcdd24e1e59b8821db287aa0371610e3331d10e161"
+      "content_hash": "d5039b06063f97f64be3e227d0d02953cc0ca1230352fb467519edb81cebb6ed"
     },
     {
       "surface": "typechecker",
       "project": "vue-calendar",
       "file_count": 2,
-      "content_hash": "6014a9ad31f1a24578744c85ede59b58253e5cdc28b0880fee39398110f456ab"
+      "content_hash": "e7fda5de27508a8165df929ec66592a1c3501ea4cdada9495a0558fc6cc8bad9"
     },
     {
       "surface": "typechecker",
       "project": "vue-chartjs",
       "file_count": 23,
-      "content_hash": "7d5eb1c3c0fc2ec4e5fa7ee4b5e6873ffc84dc5b18a2f4f0fdacdb2e728344ac"
+      "content_hash": "987ccd68df3719ab990eccf494d63a79d36938b94901f17c6113beaf8e16575e"
     },
     {
       "surface": "typechecker",
       "project": "vue-charts",
       "file_count": 197,
-      "content_hash": "357d366a17e611fadb3aea29588432f4cf9014ba32af67e4deb57d2a923fc10c"
+      "content_hash": "45c7defa0bfaed54ac60abeb3965a22bc2edc253479489874ad721137459cc0b"
     },
     {
       "surface": "typechecker",
       "project": "vue-core-vapor",
-      "file_count": 302,
-      "content_hash": "ae89eb323357915d96901c166bf550f6807abe19251559cadfc85eaba8254269"
+      "file_count": 107,
+      "content_hash": "55bd25d03513b2874f0302e0a61865b1457f7ee7fae043142efdcff57b102d9c"
     },
     {
       "surface": "typechecker",
       "project": "vue-cropper",
       "file_count": 5,
-      "content_hash": "65b0fe1df2818c3edb927329dfc1ca680979ab7fb134c8f05593e49f37899608"
+      "content_hash": "3eacef66011938ee3342449cf5c89d4c8b595108a24a884bb86aa55bda1c1e3b"
     },
     {
       "surface": "typechecker",
       "project": "vue-data-ui",
       "file_count": 403,
-      "content_hash": "4642c27757a6d340e1b6c9cda71a519deeaa988b17cf99cb95e442cba0c65362"
+      "content_hash": "9687bada383c0e2981d15199b8556392f4f819802d0ff174685af33f99d9dc02"
     },
     {
       "surface": "typechecker",
       "project": "vue-datepicker",
       "file_count": 19,
-      "content_hash": "69751d0d6f105930bf45d216ca94b9f990dafa594efbfb0985248904e5c98ef4"
+      "content_hash": "3a14eb2a0db9e004266898322b48fa37d41e851e99d3296b9dc3da193e29cf60"
     },
     {
       "surface": "typechecker",
       "project": "vue-devtools-v6",
-      "file_count": 165,
-      "content_hash": "6022a8300686a0668bcc4311a30828f37ce009ec28cc6c3d3b13989452d52972"
+      "file_count": 146,
+      "content_hash": "1157062a95cf3eae0ec44f43cb478736fa2ff1365a93a5d4b6eca12f4cd490df"
     },
     {
       "surface": "typechecker",
       "project": "vue-draggable-next",
       "file_count": 30,
-      "content_hash": "89ea12685b3f0c6978915ef57dfc0af4c356e160e214ed0632211644c0f5ee1e"
+      "content_hash": "8b504e237fb7acc0170367384dd135d2b885a6746b3fc4d11e9efa5d02536a8f"
     },
     {
       "surface": "typechecker",
       "project": "vue-draggable-plus",
-      "file_count": 43,
-      "content_hash": "b5645a178e818fe62b7ef71ebde5f12da6b7142b099f48d7285b20e688a7c0ff"
+      "file_count": 36,
+      "content_hash": "de8bef0944e9571ee509be7bfe870b5231ef80c621313a88bed8578ad1ca184b"
     },
     {
       "surface": "typechecker",
       "project": "vue-draggable-resizable",
       "file_count": 53,
-      "content_hash": "46b87a070d63eaaaedd25b416ef67f7e8bdd5e5842d14f6578e6cd33e8e59c33"
+      "content_hash": "52fcd5478e54c49c04af2a4b3f3eedc743cf2176f1f8b339fb1933026b116aba"
     },
     {
       "surface": "typechecker",
       "project": "vue-dropzone",
       "file_count": 18,
-      "content_hash": "839ce83364d548e1bfd5c91d57aea3991894a5da8ca109208c1a44c474e29d2f"
+      "content_hash": "abd95d487dbfcb102bdcc78ab056d6aab3b609315dda8041040f3b963ba9a3f7"
     },
     {
       "surface": "typechecker",
       "project": "vue-echarts",
       "file_count": 63,
-      "content_hash": "904f1c082de13dc221ef888cb67179f482aecb52aaa410e29ef6f8438b220fa9"
+      "content_hash": "13ccd72926489e5d0549d25ebfb7bfafc08ec06053d595bce2bfcf396d8be90b"
     },
     {
       "surface": "typechecker",
       "project": "vue-element-admin",
       "file_count": 131,
-      "content_hash": "d1adf416b12a6c0dff52d150ceabc9e5f6e1cc6dd7e23081d197f5ace740a4d0"
+      "content_hash": "7263f32227eb7b0ac8b0ca8e28e3c047bab01b08f55898e01b24f642e4b5dd7d"
     },
     {
       "surface": "typechecker",
       "project": "vue-fabric-editor",
-      "file_count": 92,
-      "content_hash": "648820e8c36c9a62e939dd05fc76c892c7589cc308515480e0704326f0cbbf78"
+      "file_count": 76,
+      "content_hash": "df526542ae24057e1490380034cd9d72caa0a6b2bc105194f15855ddab9b41af"
     },
     {
       "surface": "typechecker",
       "project": "vue-flow",
       "file_count": 336,
-      "content_hash": "fd8124205d4ce81e11d57e06d765e492f0a0506123634a308db213d6f64a8e35"
+      "content_hash": "9bd4e7b5e09ec67047372a31f514fdef5aff7ec87ee5ef2fa788aae408ce7989"
     },
     {
       "surface": "typechecker",
       "project": "vue-fullpage-js",
       "file_count": 2,
-      "content_hash": "6bd2d790feb5b4220a6b94df599595f49ec5c54346cc23be4c16ca1eee7b18d0"
+      "content_hash": "510db45704f6859e19311a10bf6bb2e4372671ec02c72625a241242dce66f237"
     },
     {
       "surface": "typechecker",
       "project": "vue-grid-layout",
       "file_count": 5,
-      "content_hash": "041bd312a2264c5ccbcf19b3a9b46162cda5cc4fa74602411269ecf5ac5afab3"
+      "content_hash": "11d83271d6640eedea973bc003072ec493548567dc58c1d5b0977d93dc5afe34"
     },
     {
       "surface": "typechecker",
       "project": "vue-js-modal",
       "file_count": 19,
-      "content_hash": "989f05504cc6131861a03674ae92d1a7e5bf67c32cc4478c04febb6d2edd6c4a"
+      "content_hash": "f58ebac1b012be00dee65a965e00d4726d81f61120f0147d74c2bb1d201d56c7"
     },
     {
       "surface": "typechecker",
       "project": "vue-jsx-vapor",
       "file_count": 1,
-      "content_hash": "440f5b1e1df8b2441eb0e17cac7cdea2180b837174171e037f632292a8746536"
+      "content_hash": "c810efdfda1f157b9ee186e5f50087c2f5f6ba30970f34dd68c588dee9f5667e"
     },
     {
       "surface": "typechecker",
       "project": "vue-lottie",
       "file_count": 2,
-      "content_hash": "e99a4fe778e07e38587ed7d722a1c9f36f08c19336a47b8724a38bdbcdecfca3"
+      "content_hash": "7b37fe1f484f66710600231d152d1b551036fcc755d186ebd2952152f1f4dcb0"
     },
     {
       "surface": "typechecker",
       "project": "vue-manage-system",
       "file_count": 55,
-      "content_hash": "82c21e6e0bcaa5ebb1bda5a650dfea223b8acb0c479e22a5b782f64096ccf60c"
+      "content_hash": "5f0f7f148dbd94c95581aa6bb1a53f23ac00ba5239395a07c6ea5a92320be922"
     },
     {
       "surface": "typechecker",
       "project": "vue-material",
       "file_count": 347,
-      "content_hash": "c74e28ed0f001ce6ef817fb36f5cc17cabbe08094c6c25915a377663fb9efaf5"
+      "content_hash": "5cfc6704308b0debf17952ca1fe770e456ae983ab41422e5402b0f42c3fc2a27"
     },
     {
       "surface": "typechecker",
       "project": "vue-multiselect",
       "file_count": 36,
-      "content_hash": "2e9fae6aedadcb4bb2f8a1035c60c1a895aed839e65fab5ccbf3887d01be3f33"
+      "content_hash": "edc5ca8bb56cb2d3d2c5497d0d8d84d7286463935c6be83e6bb486071c118b0f"
     },
     {
       "surface": "typechecker",
       "project": "vue-native-core",
       "file_count": 0,
-      "content_hash": "c2b33361d311de14ed754d47eec1920c350584abf3624a1f530a38b73eb1e800"
+      "content_hash": "dbd6b39af74a41307d19a4ec935f7f3b78826279435068e75e3c394951a5ed2b"
     },
     {
       "surface": "typechecker",
       "project": "vue-netcore",
       "file_count": 121,
-      "content_hash": "ef3b58207932bdc1b7c5e4e9ae0a22f6c9914808b7933fdafa2c8231d23d99aa"
+      "content_hash": "2362c95bfcdd2e5c0a199471a22537a30cbe4a3b2c75b761e8e406b701149c29"
     },
     {
       "surface": "typechecker",
       "project": "vue-pure-admin",
       "file_count": 414,
-      "content_hash": "372df35ccc900722fb4d7119a39d1a800dc326bc3ad3a85d8e4d42732b227bf5"
+      "content_hash": "4d16c4f35ec86d3ce2298143a80c4befbce953924bcedc2de4291955272485c4"
     },
     {
       "surface": "typechecker",
       "project": "vue-router",
       "file_count": 181,
-      "content_hash": "2be849e155d2f4cdf17f8339dd50ae0b2f1d3bb5fbc24bed2799d50654c2940f"
+      "content_hash": "cced736378c155b1df5b7ebfacce6570f80aecdc82afbad29ca02de48c971c86"
     },
     {
       "surface": "typechecker",
       "project": "vue-select",
       "file_count": 4,
-      "content_hash": "fd9e6324e61e9564193969525c3c96acc6fb317562d3a7c2fb88fe47d62d785a"
+      "content_hash": "2efeb1c63d762a04e1226f14475e59eb0500c060e7da183c80d8af894609e6e5"
     },
     {
       "surface": "typechecker",
       "project": "vue-sonner",
-      "file_count": 34,
-      "content_hash": "e779c6703d5fd28641c985a6263fcb36a967889f9fc5884296da9a4b6967fee3"
+      "file_count": 30,
+      "content_hash": "4d9dd8bbef3d46095f011079f2928cd17d95242ddfdc984bfa1bae113248f164"
     },
     {
       "surface": "typechecker",
       "project": "vue-storefront",
       "file_count": 49,
-      "content_hash": "5fb05f2d5ac0bc6d1da4e3813a5bbfa54915fb89ee5264d8320b7df9ab2485ff"
+      "content_hash": "becddc13d88c943ea4f5ab02bf4a35ad137160c9cba9656dd1580f507c45f9e1"
     },
     {
       "surface": "typechecker",
       "project": "vue-termui",
       "file_count": 120,
-      "content_hash": "f3d501956f86a7a7ff8d3dbed0b13f00bf8a81563b0ba6c76c903a4436bd0187"
+      "content_hash": "7a9e553f2f10431affa12433bafbbd056b1337167eb9b9366488104c0d799fe1"
     },
     {
       "surface": "typechecker",
       "project": "vue-tui",
       "file_count": 47,
-      "content_hash": "d79d3cefe7a83cf52b101afc72bdf46f758e3e1a4dcaf73cbcced385a35340b0"
+      "content_hash": "711267ce4793b4a45dd87c2a2b2f2507fe85793f2ed96558d14d754511a54f40"
     },
     {
       "surface": "typechecker",
       "project": "vue-uploader",
       "file_count": 8,
-      "content_hash": "525700aebc08163177f3b4aff31943ec0474323b5daf25af8a8f112e0d4319ca"
+      "content_hash": "f9ac630eb8f9b5f042fc5a38aa35e9d1d0980a6e6d1cb472ab912141f4728dca"
     },
     {
       "surface": "typechecker",
       "project": "vue-vben-admin",
-      "file_count": 811,
-      "content_hash": "e344ccf9a4a334ac4fed597138d8601ad73347ffcd83e6546326b2c93d7dbe83"
+      "file_count": 162,
+      "content_hash": "fdde8c661e7bcc0722203dfdb307d827c77d390adad15f27963975b8c9b56de2"
     },
     {
       "surface": "typechecker",
       "project": "vue-vine",
       "file_count": 4,
-      "content_hash": "db89fe5bd0ddc92d0106843a10d3900a4c4b18d59e5029e1d4db619b80bac437"
+      "content_hash": "a17c7a362b65c85f5ff009198893fe4d06434d5c78a90122e8e4b53e8293e293"
     },
     {
       "surface": "typechecker",
       "project": "vue-virtual-scroller",
       "file_count": 39,
-      "content_hash": "cf68b631e76b9a86dc1a596a711056b0d706cbec47d9afb3313078b337eb2b6b"
+      "content_hash": "9776d68375c82b9af57a1b0d136bd3672c1d00b6454a48486960cb3981d3acb1"
     },
     {
       "surface": "typechecker",
       "project": "vue2-elm",
       "file_count": 55,
-      "content_hash": "406510f523da596614c84158cb3fd98dd52ab601b40e6e7af0a9056a33c24a9a"
+      "content_hash": "3a952e52eec549f5ca0af72d006a83f2b34695c83d2c0290a42ab3cb7c6557ef"
     },
     {
       "surface": "typechecker",
       "project": "vue3-admin-design",
-      "file_count": 37,
-      "content_hash": "ec736d8dd0a8bba918f6fb1a0c538a06311fd924561e5a73936051ab10af40ea"
+      "file_count": 7,
+      "content_hash": "8dfaf61999875c487d45bc646f4f0af5b50a04ade5f77fc9799b399f9be5b17c"
     },
     {
       "surface": "typechecker",
       "project": "vue3-antd-admin",
-      "file_count": 280,
-      "content_hash": "6d67f4a7fbb8dfaa3cfe0c662237ff49d9b9aed4c173f85f27c2ccbf1244d566"
+      "file_count": 176,
+      "content_hash": "542219d99b1e284173773bff75fee9237843bd8152c1c47cf14f5e3e59167bf9"
     },
     {
       "surface": "typechecker",
       "project": "vuefes-japan-speakers",
       "file_count": 21,
-      "content_hash": "b09b700c03ea126a6825724a5a68df4f8855e03fb9c0768f4b268eb04964ccb5"
+      "content_hash": "30439b27c578be529db09e6c439148088db22e24b231ba1587417952bcfd5454"
     },
     {
       "surface": "typechecker",
       "project": "vuelidate",
       "file_count": 28,
-      "content_hash": "5f11f2750f9ef2e9735cb5f1f8a3506362e62b5f91bd5de157378ae148736fdf"
+      "content_hash": "f42d38196290582129d05b93f95e0f8b1bb40f00699f97344c0373090559434b"
     },
     {
       "surface": "typechecker",
       "project": "vuepress",
       "file_count": 38,
-      "content_hash": "50a272d59fdd7bc5a06ce78746d0bdd9f678bdb3bdcf15d6f4d8148d2f31f1b8"
+      "content_hash": "1ae9b66a1d86469b4288827d7a621dd2fc96fe46d48c7ae7fb4a2bcbc4af60b6"
     },
     {
       "surface": "typechecker",
       "project": "vuesax",
       "file_count": 58,
-      "content_hash": "c414d0c9976b6beeb583ebdb3f3282dca59421728a20804b8d31ddd691e58b04"
+      "content_hash": "c6f7bee869043281545b6cb63f07ca2dfc046649e251e4babf4f2be24c85db26"
     },
     {
       "surface": "typechecker",
       "project": "vuestic-admin",
       "file_count": 129,
-      "content_hash": "e9414a045dcc3fcd7afb6fba49f4223855b153454417bc90af0d0de7a927a8b1"
+      "content_hash": "41fa5160d3b26e2a8b59091fb0459debae27b1ffc5df5d41b2e7443bb4ac34ec"
     },
     {
       "surface": "typechecker",
       "project": "vuestic-ui",
       "file_count": 1533,
-      "content_hash": "b2aed4bb16b043229f68657c24b3a75db3f7e8f7371d8bf72b9d55ba22c7e64e"
+      "content_hash": "33cad308729d7a83c680d228f8e5c92cd94940ae03f587917b7125fcbb381d20"
     },
     {
       "surface": "typechecker",
       "project": "vuetify",
       "file_count": 1255,
-      "content_hash": "36174fd1b1de6bbe09c1d6c59382b24d52e3642812f45d440f4ddacffe83a182"
+      "content_hash": "85052349115f745ee27fe99c6336b48004b112560bc234f41f9defd93669ffe7"
     },
     {
       "surface": "typechecker",
       "project": "vuetorrent",
-      "file_count": 287,
-      "content_hash": "6f26f8afd66d94d7439ebbb6581f1c10e17200ffc0870d0015ea920f15c22637"
+      "file_count": 209,
+      "content_hash": "891e48a03ab52abf6a0f88df95fb045d3011599d6fa52d07c6ee94348713a49c"
     },
     {
       "surface": "typechecker",
       "project": "vux",
       "file_count": 312,
-      "content_hash": "806f8ce5b61d89fb59775eea55022b89b3111ed7d9eab0efe3b995449ee085ca"
+      "content_hash": "c189b195c7635463322cef310ed62de7966acd960c6ace16041d25df0d475ed5"
     },
     {
       "surface": "typechecker",
       "project": "wakapi",
       "file_count": 0,
-      "content_hash": "c2b33361d311de14ed754d47eec1920c350584abf3624a1f530a38b73eb1e800"
+      "content_hash": "dbd6b39af74a41307d19a4ec935f7f3b78826279435068e75e3c394951a5ed2b"
     },
     {
       "surface": "typechecker",
       "project": "wave-ui",
       "file_count": 219,
-      "content_hash": "8ddf2a6c0a2da930c4bc1350a13918f28f6d2d55d5cc4e294a0a7e1d50186ed7"
+      "content_hash": "137ba4e039ee7cee21a0134171f7b303b03930ec61d7c298dd3fdd4a3fd977d6"
     },
     {
       "surface": "typechecker",
       "project": "youtube-dl-gui",
       "file_count": 140,
-      "content_hash": "5a0d8d90874aa979bdeadb07c88fb8e55fbec99b7ce14b0bb8c85ae4f1ed1804"
+      "content_hash": "22980e9d4e172f7deea244b5d7a7060c5cbb8fe04e34912bcfed158eeae81bd8"
     },
     {
       "surface": "typechecker",
       "project": "zy-player",
       "file_count": 13,
-      "content_hash": "23164f37c3ccaba08ebaee40945af195dc3bca8037ca8632fe532b64fb1ffb96"
+      "content_hash": "1b359876f9c52d242e1792dbc443c1dae4ca482fc372f24c69dd9f460e6785b9"
     }
   ]
 }

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -3810,6 +3810,7 @@
       "vueGlobs": [
         "**/*.vue"
       ],
+      "tsconfig": "tsconfig.json",
       "coverage": [
         "compiler",
         "linter",

--- a/tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts
@@ -124,3 +124,10 @@ test("PrimeVue Showcase is measured under the app tsconfig, sharing the PrimeVue
     "prepare",
   ]);
 });
+
+test("Lew UI typechecks under its fixture tsconfig", () => {
+  const registry = readRegistry();
+  const project = registry.projects.find((candidate) => candidate.id === "lew-ui");
+
+  assert.equal(project?.tsconfig, "tsconfig.json");
+});


### PR DESCRIPTION
## Summary
- refresh the Davinci corpus baseline for the 144-project manifest
- make Lew UI use its checked-in tsconfig for the typechecker matrix
- record the 2026-08-30 baseline re-record evidence

## Verification
- vp check --fix
- node --test tests/tooling/davinci-corpus-comparison-count.test.ts tests/tooling/davinci-corpus-formatter-contract.test.ts tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/vue-ecosystem-typecheck-corpus.test.ts
- node tools/davinci/assertion-lint.mjs
- git diff --check
- node tools/fixtures/tool-matrix-report.mjs --project lew-ui --tool typechecker --vize-bin /Users/ubugeeei/Source/github.com/ubugeeei/vize--p2-9-corpus/target/release/vize --output-dir .vize/davinci-corpus/lew-ui-tsconfig-check --timeout-ms 600000
- node tools/davinci/corpus-baseline.mjs --clean-fixtures --shards 2 --timeout-ms 600000 --out .vize/davinci-baseline-144.json => 576/576 comparisons, 144 projects x 4 surfaces, 156274 files
- node tools/davinci/corpus-diff.mjs --baseline .vize/davinci-baseline-144.json --write-fresh .vize/davinci-compiler-fresh.json --surface compiler --shards 2 --timeout-ms 600000 --vize-bin /Users/ubugeeei/Source/github.com/ubugeeei/vize--p2-9-corpus/target/release/vize --clean-fixtures => PASS, 144/144 compiler comparisons, 37448 files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790676842&installation_model_id=422833&pr_number=5369&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5369&signature=edac1145feb7fe0653b8177efbd21c054d407c9e3d5a4e1a162959084d92c679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the phase-two baseline records to cover 144 projects and 576 surface comparisons.
  * Documented successful compiler-surface validation across all included projects and 37,448 files.

* **Tests**
  * Added coverage confirming the affected project uses its TypeScript configuration during validation.

* **Chores**
  * Refreshed fixture configuration to ensure type-checking results are classified and reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->