### PR TITLE
fix(matrix): keep pnpm store out of generated baselines

### DIFF
--- a/tests/tooling/typecheck-baseline-project-composite.test.ts
+++ b/tests/tooling/typecheck-baseline-project-composite.test.ts
@@ -155,6 +155,57 @@ test("materialized baseline include roots follow corpusGlobs instead of sibling 
   }
 });
 
+test("materialized baseline ignores pnpm store dot roots reported from node_modules", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "vize-pnpm-store-baseline-"));
+  const fixtureRoot = path.join(temp, "fixture");
+  const reportDir = path.join(temp, "report");
+  const pnpmVue = "node_modules/.pnpm/vue@3.6.0-beta.10/node_modules/vue/dist/vue.d.ts";
+  const nestedPnpmHelper =
+    "packages/web/node_modules/.pnpm/helper@1.0.0/node_modules/helper/.vitepress/helper.ts";
+  fs.mkdirSync(path.join(fixtureRoot, "apps/showcase/.nuxt"), { recursive: true });
+  fs.mkdirSync(path.dirname(path.join(fixtureRoot, pnpmVue)), { recursive: true });
+  fs.mkdirSync(path.dirname(path.join(fixtureRoot, nestedPnpmHelper)), { recursive: true });
+  fs.mkdirSync(reportDir);
+  fs.writeFileSync(path.join(fixtureRoot, "tsconfig.json"), "{}\n");
+  fs.writeFileSync(path.join(fixtureRoot, "apps/showcase/App.vue"), "<template />\n");
+  fs.writeFileSync(
+    path.join(fixtureRoot, "apps/showcase/.nuxt/imports.d.ts"),
+    "declare const nuxtImport: string;\n",
+  );
+  fs.writeFileSync(path.join(fixtureRoot, pnpmVue), "export {};\n");
+  fs.writeFileSync(path.join(fixtureRoot, nestedPnpmHelper), "export const helper = true;\n");
+  try {
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      {
+        id: "fixture",
+        tsconfig: "tsconfig.json",
+        typecheckPerformance: { corpusGlobs: ["apps/showcase/**/*.vue"] },
+      },
+      {
+        fileCount: 4,
+        files: [
+          { file: "apps/showcase/App.vue" },
+          { file: "apps/showcase/.nuxt/imports.d.ts" },
+          { file: pnpmVue },
+          { file: nestedPnpmHelper },
+        ],
+      },
+    );
+    const config = JSON.parse(project.source);
+    assert.equal(config.include.includes("../apps/showcase/.nuxt/**/*.d.ts"), true);
+    assert.equal(config.include.includes("../apps/showcase/.nuxt/**/*.ts"), true);
+    assert.equal(config.include.includes("../apps/showcase/.nuxt/**/*.vue"), true);
+    assert.deepEqual(
+      config.include.filter((include: string) => include.includes("node_modules/.pnpm")),
+      [],
+    );
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
 test(
   "materialized baseline keeps sibling app declarations out of package-local typecheck",
   vueTscOptions,

--- a/tools/fixtures/typecheck-baseline-project.mjs
+++ b/tools/fixtures/typecheck-baseline-project.mjs
@@ -72,7 +72,8 @@ import { typecheckCorpusGlobs } from "./tool-matrix-command.mjs";
  * `.nuxt/imports.d.ts` and `docs/.vitepress/utils.ts`, while literal
  * `<fixture>/.nuxt/**` or `<fixture>/docs/.vitepress/**` matches them. The
  * source config's own directory and every checked-file dot ancestor are therefore
- * globbed by name.
+ * globbed by name. Installed package manager internals stay excluded even when
+ * Vize reports a dependency path under `node_modules/.pnpm`.
  */
 export function materializeBaselineProject(fixtureRoot, reportDir, project, vizeReport) {
   const sourceProject = project.typecheckPerformance?.baseline?.tsconfig ?? project.tsconfig;
@@ -264,11 +265,19 @@ function dotDirectoryIncludeRoots(fixtureRoot, vizeReport) {
     const segments = entry.file.replaceAll("\\", "/").split("/");
     for (let index = 0; index < segments.length - 1; index += 1) {
       const segment = segments[index];
-      if (!segment.startsWith(".") || segment === "." || segment === "..") continue;
+      if (!isDotDirectory(segment)) continue;
+      if (hasAncestorSegment(segments, index, "node_modules")) continue;
       roots.push(resolve(fixtureRoot, ...segments.slice(0, index + 1)));
     }
   }
   return roots;
+}
+
+function hasAncestorSegment(segments, end, expected) {
+  for (let index = 0; index < end; index += 1) {
+    if (segments[index] === expected) return true;
+  }
+  return false;
 }
 
 function discoverDotDirectoryIncludeRoots(sourceRoots) {


### PR DESCRIPTION
## Summary
- ignore dot-directory include roots below node_modules so `node_modules/.pnpm` cannot leak into generated vue-tsc baseline include globs
- keep real project dot roots like Nuxt `.nuxt` in the baseline includes
- add a regression with both root and nested pnpm store paths

Refs #4461

## Verification
- `VIZE_TEST_WORKSPACE_NODE_MODULES=/Users/nishimura/Code/github.com/ubugeeei/vize/tests/node_modules node --test --test-concurrency=1 tests/tooling/typecheck-baseline-project.test.ts tests/tooling/typecheck-baseline-project-composite.test.ts`
- `VIZE_TEST_WORKSPACE_NODE_MODULES=/Users/nishimura/Code/github.com/ubugeeei/vize/tests/node_modules node --test --test-concurrency=1 tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts tests/tooling/typecheck-dependency-prepare-isolation-tsconfigs.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts`
- `node tools/davinci/assertion-lint.mjs`
- `vp run --workspace-root check:repo`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790678519&installation_model_id=422833&pr_number=5372&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5372&signature=f2e2f5771ef11bebf8a5d0cea61dda06e252289959e5becfb7e7be7d8c7b3b87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->