### PR TITLE
fix(davinci): cover p2-11 event model slot residuals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4028,6 +4028,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "vize_s1"
+version = "0.387.0"
+dependencies = [
+ "davinci_test_support",
+ "vize_armature",
+ "vize_carton",
+ "vize_relief",
+]
+
+[[package]]
 name = "vize_s1_to_s2"
 version = "0.387.0"
 dependencies = [
@@ -4037,22 +4047,14 @@ dependencies = [
  "insta",
  "oxc_ast",
  "oxc_ast_visit",
+ "oxc_parser",
+ "oxc_span",
  "vize_atelier_sfc",
  "vize_carton",
  "vize_croquis",
  "vize_davinci",
  "vize_s1",
  "vize_s2",
-]
-
-[[package]]
-name = "vize_s1"
-version = "0.387.0"
-dependencies = [
- "davinci_test_support",
- "vize_armature",
- "vize_carton",
- "vize_relief",
 ]
 
 [[package]]

--- a/crates/vize_atelier_dom/tests/davinci_s2_colon.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_colon.rs
@@ -16,6 +16,10 @@ const BATTERY: &[(&str, &str)] = &[
     ("upd_Foo", r#"<div @update:Foo="h"></div>"#),
     ("custom_el", r#"<div @customEvent="h"></div>"#),
     ("custom_comp", r#"<Foo @customEvent="h" />"#),
+    (
+        "multi_statement",
+        r#"<div @click="open = false; save();"></div>"#,
+    ),
     ("vue_mounted", r#"<div @vue:mounted="h"></div>"#),
     ("vue_comp", r#"<Foo @vue:mounted="h" />"#),
     ("vnode_hook", r#"<div @vnode-before-mount="h"></div>"#),

--- a/crates/vize_atelier_dom/tests/davinci_s2_model.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_model.rs
@@ -44,6 +44,10 @@ const BATTERY: &[(&str, &str)] = &[
     ("fragment", r#"<input v-model="a"><input v-model="b">"#),
     ("comp", r#"<Foo v-model="msg" />"#),
     ("comp_arg", r#"<Foo v-model:title="pageTitle" />"#),
+    (
+        "comp_kebab_arg",
+        r#"<Foo v-model:auto-send="autoSendEnabled" />"#,
+    ),
     ("comp_dynamic_arg", r#"<Foo v-model:[field]="msg" />"#),
     (
         "comp_dynamic_arg_mod",

--- a/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
@@ -34,6 +34,10 @@ const BATTERY: &[(&str, &str)] = &[
         "<Foo><template #header><span></span></template></Foo>",
     ),
     (
+        "implicit_default_svg",
+        "<Foo><svg><path d=\"M0 0\" /></svg></Foo>",
+    ),
+    (
         "named_header_extra_attr",
         r#"<Foo><template #header id="x">x</template></Foo>"#,
     ),

--- a/crates/vize_s1_to_s2/Cargo.toml
+++ b/crates/vize_s1_to_s2/Cargo.toml
@@ -30,6 +30,8 @@ davinci-differential = []
 [dependencies]
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
+oxc_parser = { workspace = true }
+oxc_span = { workspace = true }
 vize_s0 = { workspace = true }
 vize_davinci = { workspace = true }
 vize_s1 = { workspace = true }

--- a/crates/vize_s1_to_s2/src/emit/hoist.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist.rs
@@ -34,15 +34,17 @@ pub(super) fn hoist_static_element(cx: &mut EmitCx<'_>, element: &ElementOp<'_>)
 }
 
 pub(super) fn is_hoistable(element: &ElementOp<'_>) -> bool {
-    element.namespace == Namespace::Html
-        && element.bindings.is_empty()
-        && element.children.ops.iter().all(is_hoistable_child)
+    element.namespace == Namespace::Html && is_static_element_tree(element)
 }
 
-fn is_hoistable_child(op: &Op<'_>) -> bool {
+pub(super) fn is_static_element_tree(element: &ElementOp<'_>) -> bool {
+    element.bindings.is_empty() && element.children.ops.iter().all(is_static_tree_child)
+}
+
+fn is_static_tree_child(op: &Op<'_>) -> bool {
     match op {
         Op::Text(_) => true,
-        Op::Element(element) => is_hoistable(element),
+        Op::Element(element) => is_static_element_tree(element),
         _ => false,
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/model_key.rs
+++ b/crates/vize_s1_to_s2/src/emit/model_key.rs
@@ -1,6 +1,6 @@
 //! Object key spelling for component `ui.model` product props.
 
-use vize_s0::String;
+use vize_s0::{String, camelize};
 use vize_s2::expr::JsExpr;
 
 use super::EmitCx;
@@ -67,7 +67,7 @@ pub(super) fn modifiers_key(name: ModelName<'_>) -> ModelModifiersKey<'_> {
 
 pub(super) fn static_update_key(prop: &str) -> String {
     let mut key = String::from("onUpdate:");
-    key.push_str(prop);
+    key.push_str(camelize(prop).as_str());
     key
 }
 

--- a/crates/vize_s1_to_s2/src/emit/on.rs
+++ b/crates/vize_s1_to_s2/src/emit/on.rs
@@ -1,6 +1,5 @@
-//! Static-name `ui.on` (`@click` / `v-on:click`), dynamic-name `ui.on`
-//! (`@[event]`), including event / key / option modifiers
-//! (`withModifiers` / `withKeys`, `onClickOnce`, …).
+//! Static/dynamic `ui.on` emission (`@click`, `@[event]`) with event,
+//! key, and option modifiers (`withModifiers`, `withKeys`, `onClickOnce`, …).
 //! Object `v-on` lives in [`super::merge`].
 
 use oxc_ast::ast::{ChainElement, Expression};
@@ -8,10 +7,7 @@ use vize_s0::{SmallVec, String, camelize, capitalize};
 use vize_s2::expr::{ExprRef, JsExpr, OpaqueReason};
 use vize_s2::op::{DynamicName, OnOp};
 
-use super::EmitCx;
-use super::EmitError;
-use super::UnsupportedReason as Reason;
-use super::buf::Buf;
+use super::{EmitCx, EmitError, UnsupportedReason as Reason, buf::Buf};
 
 // The checked modifier inventory in `tests/tooling/davinci-v-on-storage.test.ts`
 // selects two inline entries per classifier bucket. Authored directives remain
@@ -255,9 +251,7 @@ fn classify_modifier_buckets<'a>(
     let mut keys = KeyModifiers::new();
     for modifier in modifiers {
         match modifier {
-            // Vue 2's `.native` event sugar is stripped by the shipped
-            // lane before handler wrapping, and does not affect the event
-            // key. Keep the authored modifier accepted but inert here.
+            // Vue 2's `.native` sugar is stripped before handler wrapping.
             "native" => {}
             "capture" | "once" | "passive" if keep_options => options.push(modifier),
             "capture" | "once" | "passive" => {}
@@ -311,8 +305,6 @@ fn is_function(expr: &Expression<'_>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(target_pointer_width = "64")]
-    use super::Classified;
     use super::classify_modifiers;
 
     #[test]
@@ -350,7 +342,7 @@ mod tests {
     #[cfg(target_pointer_width = "64")]
     #[test]
     fn inline_storage_stack_tradeoff_is_pinned() {
-        assert_eq!(core::mem::size_of::<Classified<'_>>(), 120);
+        assert_eq!(core::mem::size_of::<super::Classified<'_>>(), 120);
         assert_eq!(core::mem::size_of::<alloc::vec::Vec<&str>>() * 3, 72);
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/on.rs
+++ b/crates/vize_s1_to_s2/src/emit/on.rs
@@ -5,7 +5,7 @@
 
 use oxc_ast::ast::{ChainElement, Expression};
 use vize_s0::{SmallVec, String, camelize, capitalize};
-use vize_s2::expr::{ExprRef, JsExpr};
+use vize_s2::expr::{ExprRef, JsExpr, OpaqueReason};
 use vize_s2::op::{DynamicName, OnOp};
 
 use super::EmitCx;
@@ -42,6 +42,7 @@ pub(super) fn admit_on(on: &OnOp<'_>) -> Result<(), EmitError> {
     classify(on)?;
     match on.handler {
         None | Some(ExprRef::Js(_)) => Ok(()),
+        Some(ExprRef::Opaque(opaque)) if opaque.reason == OpaqueReason::MultiStatement => Ok(()),
         Some(expr) => Err(EmitError::unsupported_at(
             Reason::OnHandlerNotJs,
             expr.span(),
@@ -167,6 +168,11 @@ pub(super) fn emit_wrapped_handler(
     }
     match on.handler {
         Some(ExprRef::Js(js)) => emit_handler(cx, js),
+        Some(ExprRef::Opaque(opaque)) if opaque.reason == OpaqueReason::MultiStatement => {
+            cx.buf.push("$event => {");
+            cx.buf.push(opaque.source);
+            cx.buf.push("}");
+        }
         None => cx.buf.push("() => {}"),
         Some(expr) => {
             return Err(EmitError::unsupported_at(

--- a/crates/vize_s1_to_s2/src/emit/on_dynamic.rs
+++ b/crates/vize_s1_to_s2/src/emit/on_dynamic.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec as StdVec;
 
 use oxc_ast::ast::{BindingIdentifier, Expression, IdentifierReference};
 use oxc_ast_visit::Visit;
-use vize_s2::expr::{ExprRef, JsExpr};
+use vize_s2::expr::{ExprRef, JsExpr, OpaqueReason};
 use vize_s2::op::{DynamicName, OnOp};
 
 use super::buf::Buf;
@@ -19,6 +19,7 @@ pub(super) fn admit(on: &OnOp<'_>) -> Result<(), EmitError> {
     dynamic_name(on)?;
     match on.handler {
         None | Some(ExprRef::Js(_)) => Ok(()),
+        Some(ExprRef::Opaque(opaque)) if opaque.reason == OpaqueReason::MultiStatement => Ok(()),
         Some(expr) => Err(EmitError::unsupported_at(
             Reason::OnHandlerNotJs,
             expr.span(),

--- a/crates/vize_s1_to_s2/src/emit/props_object.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_object.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec as StdVec;
 use vize_s0::Span;
-use vize_s2::expr::ExprRef;
+use vize_s2::expr::{ExprRef, OpaqueReason};
 use vize_s2::op::{Attribute, BindOp, BindingOp, DynamicName, OnOp, VueHtmlOp, VueTextOp};
 
 use super::EmitCx;
@@ -246,7 +246,8 @@ fn pieces_have_named(pieces: &[Piece<'_>], name: &str) -> bool {
 fn pieces_have_inline_on(pieces: &[Piece<'_>]) -> bool {
     pieces.iter().any(|piece| match piece {
         Piece::On(event) => on::forces_inline_on(event)
-            || matches!(event.handler, Some(ExprRef::Js(js)) if on::is_inline_handler_source(js.source)),
+            || matches!(event.handler, Some(ExprRef::Js(js)) if on::is_inline_handler_source(js.source))
+            || matches!(event.handler, Some(ExprRef::Opaque(opaque)) if opaque.reason == OpaqueReason::MultiStatement),
         Piece::ModelUpdate { .. } => true,
         _ => false,
     })

--- a/crates/vize_s1_to_s2/src/emit/slots.rs
+++ b/crates/vize_s1_to_s2/src/emit/slots.rs
@@ -12,7 +12,7 @@ use alloc::vec::Vec as StdVec;
 
 use vize_s0::String;
 use vize_s2::expr::ExprRef;
-use vize_s2::op::{BindingOp, ElementOp, Namespace, Op, Region, TextOp};
+use vize_s2::op::{BindingOp, ElementOp, Op, Region, TextOp};
 use vize_s2::scope::ScopeOrigin;
 
 use super::EmitCx;
@@ -20,7 +20,7 @@ use super::EmitError;
 use super::UnsupportedReason as Reason;
 use super::buf::Buf;
 use super::children::{emit_create_text_vnode, emit_slot_text_child};
-use super::hoist::{emit_hoisted_element, is_hoistable};
+use super::hoist::{emit_hoisted_element, is_static_element_tree};
 use super::js::{escape_js_string, is_valid_js_identifier};
 use super::vnode::emit_array_child;
 use crate::pass::{SlotCarrier, SlotFacts, SlotName, SlotParams};
@@ -99,15 +99,7 @@ fn walk_admit(region: &Region<'_>) -> Result<(), EmitError> {
                 }
                 walk_admit(&element.children)?;
             }
-            Op::Element(element) => {
-                if element.namespace != Namespace::Html {
-                    return Err(EmitError::unsupported_at(
-                        Reason::SlotDefaultShape,
-                        element.span,
-                    ));
-                }
-                walk_admit(&element.children)?;
-            }
+            Op::Element(element) => walk_admit(&element.children)?,
             Op::Component(component) => walk_admit(&component.children)?,
             Op::If(if_op) => {
                 for branch in if_op.branches.iter() {
@@ -324,7 +316,9 @@ pub(super) fn capture(
 fn emit_slot_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> {
     match op {
         Op::Text(_) | Op::Interpolation(_) => emit_slot_text_child(cx, op),
-        Op::Element(element) if is_hoistable(element) => emit_hoisted_element(cx, element),
+        Op::Element(element) if is_static_element_tree(element) => {
+            emit_hoisted_element(cx, element)
+        }
         Op::Element(_) | Op::Component(_) | Op::If(_) | Op::For(_) | Op::Slot(_) => {
             emit_array_child(cx, op)
         }

--- a/crates/vize_s1_to_s2/src/lower/bindop.rs
+++ b/crates/vize_s1_to_s2/src/lower/bindop.rs
@@ -27,7 +27,7 @@ use vize_s2::op::{BindOp, BindingOp, DynamicName, OnOp, VueSyncOp};
 use super::cx::{Cx, attr_slice, attr_span};
 use super::directive::{Arg, Directive};
 use super::element::attr_value_text;
-use super::expr::{desc, expr_at, filter_expr_at};
+use super::expr::{desc, expr_at, filter_expr_at, handler_expr_at};
 
 /// The provenance rule of the same-name expansion.
 pub(crate) const RULE_SAME_NAME: &str = "normalize.bind.same-name";
@@ -176,7 +176,7 @@ pub(crate) fn lower_on<'a>(
     }
     let handler = attr_value_text(element, index)
         .filter(|text| !text.trim().is_empty())
-        .map(|text| expr_at(cx, text));
+        .map(|text| handler_expr_at(cx, text));
     cx.record(
         "lower.on",
         node,

--- a/crates/vize_s1_to_s2/src/lower/expr.rs
+++ b/crates/vize_s1_to_s2/src/lower/expr.rs
@@ -13,6 +13,8 @@
 //! `Compound` have no P2-8 producer, see the record) are assigned by
 //! [`opaque_at`], the only constructor that names a reason directly.
 
+use oxc_parser::Parser;
+use oxc_span::SourceType;
 use vize_s0::{Span, String, cstr};
 use vize_s2::expr::{ExprRef, OpaqueExpr, OpaqueReason, VueFilterExpr};
 
@@ -30,6 +32,31 @@ pub(crate) fn trimmed<'a>(cx: &Cx<'a>, text: &'a str) -> (&'a str, Span) {
 pub(crate) fn expr_at<'a>(cx: &Cx<'a>, text: &'a str) -> ExprRef<'a> {
     let (slice, span) = trimmed(cx, text);
     ExprRef::parse_js_in(cx.allocator, slice, span)
+}
+
+/// `v-on` handler admission: a lone expression keeps the retained JS
+/// payload, while a valid statement body that cannot be represented by one
+/// expression is classified explicitly as `Opaque(MultiStatement)`.
+pub(crate) fn handler_expr_at<'a>(cx: &Cx<'a>, text: &'a str) -> ExprRef<'a> {
+    let expr = expr_at(cx, text);
+    let ExprRef::Opaque(opaque) = expr else {
+        return expr;
+    };
+    if opaque.reason != OpaqueReason::ParseRejected || !parses_as_program(cx, opaque.source) {
+        return expr;
+    }
+    opaque_at(cx, OpaqueReason::MultiStatement, opaque.source, opaque.span)
+}
+
+fn parses_as_program(cx: &Cx<'_>, source: &str) -> bool {
+    Parser::new(
+        cx.allocator.as_oxc(),
+        source,
+        SourceType::ts().with_module(true),
+    )
+    .parse()
+    .diagnostics
+    .is_empty()
 }
 
 /// Interpolation / `v-bind` value admission: Vue 2 pipe filters first

--- a/crates/vize_s1_to_s2/tests/emit_model.rs
+++ b/crates/vize_s1_to_s2/tests/emit_model.rs
@@ -164,6 +164,24 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+fn a_kebab_component_model_camelizes_the_update_listener() {
+    assert_eq!(
+        assembled(r#"<Foo v-model:auto-send="autoSendEnabled" />"#),
+        pin("\
+const { resolveComponent: _resolveComponent, openBlock: _openBlock, createBlock: _createBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, {
+    \"auto-send\": autoSendEnabled,
+    \"onUpdate:autoSend\": $event => ((autoSendEnabled) = $event)
+  }, null, 8 /* PROPS */, [\"auto-send\", \"onUpdate:autoSend\"]))
+}")
+    );
+}
+
+#[test]
 fn a_dynamic_component_model_uses_computed_props() {
     assert_eq!(
         assembled(r#"<Foo v-model:[field]="msg" />"#),

--- a/crates/vize_s1_to_s2/tests/emit_on.rs
+++ b/crates/vize_s1_to_s2/tests/emit_on.rs
@@ -67,6 +67,21 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+fn a_multi_statement_click_wraps_as_a_block_body() {
+    assert_eq!(
+        assembled(r#"<div @click="open = false; save();"></div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", {
+    onClick: $event => {open = false; save();}
+  }, null, 8 /* PROPS */, [\"onClick\"]))
+}"
+    );
+}
+
+#[test]
 fn a_click_stop_wraps_with_modifiers() {
     assert_eq!(
         assembled(r#"<div @click.stop="handler"></div>"#),


### PR DESCRIPTION
## Summary
- classify valid multi-statement `v-on` handlers as `Opaque(MultiStatement)` and emit them byte-verbatim as block handler bodies while keeping invalid handlers refused
- camelize static component `v-model` update listener keys such as `v-model:auto-send` to match the shipped DOM lane
- admit static SVG/MathML default-slot children through the shipped hoist shape and pin the slot witness

## Verification
- `cargo fmt --all --check`
- `cargo test -p vize_s1_to_s2 --test emit_on --test emit_model --test emit_unsupported_census --test emit_unsupported_direct -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_colon --test davinci_s2_model --test davinci_s2_slots --test davinci_s2_dom_namespace --features vize_s1_to_s2/davinci-differential -- --nocapture`
- `git diff --check`

## Corpus Smoke
- `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=/Users/ubugeeei/Source/github.com/ubugeeei/vize--p2-9-corpus/tests/_fixtures/_git cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture`
- Expected diagnostic failure: compared 38205 templates, S2 refusals reduced from 425 to 151; `on_handler_not_js` is 0 and `slot_default_shape` is 40. Divergences remain and P2-11 is not complete yet.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790678892&installation_model_id=422833&pr_number=5373&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5373&signature=9885ec5acb02bd58c81255368e36ab2255416c7ec4ea7ed204944121d4ace9ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Event handlers containing multiple statements now compile and run correctly.
  - Kebab-case `v-model` arguments now generate properly matched update listeners.
  - Components with implicit default slots containing SVG content are supported.
  - Static elements nested within slots are handled more reliably.

- **Bug Fixes**
  - Improved event-handler detection and emission for complex click and input interactions.

- **Tests**
  - Added regression coverage for multi-statement handlers, kebab-case `v-model`, and SVG slot content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->