### PR TITLE
feat(davinci): surface p2-12b build walk counts

### DIFF
--- a/crates/vize/src/commands/build/runner/profile_facts.rs
+++ b/crates/vize/src/commands/build/runner/profile_facts.rs
@@ -90,6 +90,7 @@ fn record_source_facts(
     profiler.record_counter("source.block.style.count", style_count as u64);
 
     record_lane(settings);
+    record_davinci_plan(settings);
     record_dialect(settings.dialect);
     record_template_syntax(settings.template_syntax);
     record_cache_status(cache_status);
@@ -103,13 +104,15 @@ fn file_note(
     cache_status: StatsCacheStatus,
 ) -> String {
     cstr!(
-        "lane {}, plate source.sfc, dialect {}, syntax {}, blocks template {} B / script {} B / styles {}, cache {}",
+        "lane {}, plate source.sfc, dialect {}, syntax {}, blocks template {} B / script {} B / styles {}, davinci planned groups {} / passes {}, cache {}",
         lane_label(settings),
         dialect_label(settings.dialect),
         template_syntax_label(settings.template_syntax),
         template_size,
         script_size,
         style_count,
+        settings.davinci.planned_groups,
+        settings.davinci.planned_passes,
         cache_status.label()
     )
 }
@@ -124,6 +127,19 @@ fn record_lane(settings: &CompileFileSettings) {
         }
         _ => profiler.record_counter("lane.atelier.dom.requests", 1),
     }
+}
+
+fn record_davinci_plan(settings: &CompileFileSettings) {
+    let profiler = global_profiler();
+    profiler.record_counter(
+        "davinci.build.planned_groups",
+        u64::from(settings.davinci.planned_groups),
+    );
+    profiler.record_counter(
+        "davinci.build.planned_passes",
+        u64::from(settings.davinci.planned_passes),
+    );
+    profiler.record_counter("davinci.build.files", 1);
 }
 
 fn record_dialect(dialect: VueVersion) {

--- a/crates/vize/src/commands/build/runner/settings.rs
+++ b/crates/vize/src/commands/build/runner/settings.rs
@@ -63,6 +63,12 @@ pub(super) struct DavinciBuildSettings {
     /// The selected backend's legacy plan (`legacy_plan::{DOM,SSR,VAPOR}`)
     /// in the canonical pipeline-grammar spelling.
     pub(super) plan_string: String,
+    /// P2-3 budget observer output for the selected plan. This is named
+    /// "planned groups" at reporting sites because the real compile path still
+    /// runs legacy stages until the S2 backend becomes a production dependency.
+    pub(super) planned_groups: u32,
+    /// Pass entries described by the selected plan.
+    pub(super) planned_passes: u32,
     /// The plan's stage name - the attribution for a panic the driver did
     /// not see (an unattributable real-compile ICE).
     pub(super) stage: &'static str,
@@ -89,6 +95,7 @@ impl CompileFileSettings {
         let ssr = args.ssr;
         let vapor = args.vapor || build_config.vapor.unwrap_or(false);
         let (plan, mode) = davinci_ice::compile_plan(ssr, vapor);
+        let budget = davinci_ice::plan_budget(plan);
         let inject = args.davinci_inject_panic.as_deref().map(|spec| {
             davinci_ice::parse_inject_spec(spec, plan).unwrap_or_else(|error| {
                 eprintln!("\x1b[31mError:\x1b[0m --davinci-inject-panic: {error}");
@@ -125,6 +132,8 @@ impl CompileFileSettings {
             record_profile_totals: args.profile,
             davinci: DavinciBuildSettings {
                 plan_string: davinci_ice::plan_string(plan),
+                planned_groups: budget.walks,
+                planned_passes: budget.passes,
                 stage: plan.stage,
                 mode,
                 inject,

--- a/crates/vize/src/commands/davinci_ice.rs
+++ b/crates/vize/src/commands/davinci_ice.rs
@@ -84,6 +84,19 @@ pub(crate) fn compile_plan(ssr: bool, vapor: bool) -> (&'static Pipeline, &'stat
     }
 }
 
+/// Measure the selected build plan through the P2-3 budget observer.
+///
+/// This is intentionally plan-level accounting: today the real build stages
+/// are still the legacy compile path, so the observer reports planned fusion
+/// groups for the selected backend. When the build path is routed through the
+/// pass manager, this helper remains the place that turns observer output into
+/// build-profile counters.
+pub(crate) fn plan_budget(plan: &Pipeline) -> BudgetObserver {
+    let mut budget = BudgetObserver::new();
+    run_pipeline(plan, &mut budget, |_| Ok(())).expect("compile plans use no-op pass bodies");
+    budget
+}
+
 /// `(ssr, vapor)` for a recorded mode name; `None` for an unknown mode.
 pub(crate) fn mode_flags(mode: &str) -> Option<(bool, bool)> {
     match mode {
@@ -247,6 +260,55 @@ pub(crate) fn source_repro(
     };
     folio.normalize();
     folio
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{compile_plan, plan_budget};
+    use vize_davinci::pass::{Fusability, PassDesc, PassKind, Pipeline, Preserved};
+
+    #[test]
+    fn compile_plan_budget_matches_selected_backend_groups() {
+        for (ssr, vapor, expected_mode) in [
+            (false, false, "dom"),
+            (true, false, "ssr"),
+            (false, true, "vapor"),
+        ] {
+            let (plan, mode) = compile_plan(ssr, vapor);
+            let budget = plan_budget(plan);
+
+            assert_eq!(mode, expected_mode);
+            assert_eq!(budget.pipelines, 1);
+            assert_eq!(budget.walks as usize, plan.group_count());
+            assert_eq!(budget.passes as usize, plan.passes.len());
+            assert_eq!(budget.failures, 0);
+        }
+    }
+
+    #[test]
+    fn plan_budget_counts_a_fused_build_group_once() {
+        const PASSES: &[PassDesc] = &[
+            PassDesc::new(
+                "facts",
+                PassKind::Optional,
+                Fusability::Fusable,
+                Preserved::ALL,
+            ),
+            PassDesc::new(
+                "emit",
+                PassKind::Optional,
+                Fusability::Fusable,
+                Preserved::ALL,
+            ),
+        ];
+        const PLAN: Pipeline = Pipeline::new("s2", PASSES);
+
+        let budget = plan_budget(&PLAN);
+
+        assert_eq!(budget.walks, 1);
+        assert_eq!(budget.passes, 2);
+        assert_eq!(budget.fusion_ratio_hundredths(), Some(200));
+    }
 }
 
 /// Write `folio` as `{stem}.repro.folio` under `dir`, creating `dir` first

--- a/crates/vize/src/commands/davinci_ice.rs
+++ b/crates/vize/src/commands/davinci_ice.rs
@@ -45,6 +45,10 @@ use vize_davinci::pass::{
 };
 use vize_s0::{FxHashMap, String, cstr};
 
+mod budget;
+
+pub(crate) use budget::plan_budget;
+
 /// `artifact-stage` value for an embedded authored source.
 pub(crate) const ARTIFACT_STAGE_SOURCE: &str = "source";
 /// `[repro.config]` key naming the backend mode (`dom`/`ssr`/`vapor`).
@@ -82,19 +86,6 @@ pub(crate) fn compile_plan(ssr: bool, vapor: bool) -> (&'static Pipeline, &'stat
     } else {
         (&legacy_plan::DOM, "dom")
     }
-}
-
-/// Measure the selected build plan through the P2-3 budget observer.
-///
-/// This is intentionally plan-level accounting: today the real build stages
-/// are still the legacy compile path, so the observer reports planned fusion
-/// groups for the selected backend. When the build path is routed through the
-/// pass manager, this helper remains the place that turns observer output into
-/// build-profile counters.
-pub(crate) fn plan_budget(plan: &Pipeline) -> BudgetObserver {
-    let mut budget = BudgetObserver::new();
-    run_pipeline(plan, &mut budget, |_| Ok(())).expect("compile plans use no-op pass bodies");
-    budget
 }
 
 /// `(ssr, vapor)` for a recorded mode name; `None` for an unknown mode.
@@ -260,55 +251,6 @@ pub(crate) fn source_repro(
     };
     folio.normalize();
     folio
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{compile_plan, plan_budget};
-    use vize_davinci::pass::{Fusability, PassDesc, PassKind, Pipeline, Preserved};
-
-    #[test]
-    fn compile_plan_budget_matches_selected_backend_groups() {
-        for (ssr, vapor, expected_mode) in [
-            (false, false, "dom"),
-            (true, false, "ssr"),
-            (false, true, "vapor"),
-        ] {
-            let (plan, mode) = compile_plan(ssr, vapor);
-            let budget = plan_budget(plan);
-
-            assert_eq!(mode, expected_mode);
-            assert_eq!(budget.pipelines, 1);
-            assert_eq!(budget.walks as usize, plan.group_count());
-            assert_eq!(budget.passes as usize, plan.passes.len());
-            assert_eq!(budget.failures, 0);
-        }
-    }
-
-    #[test]
-    fn plan_budget_counts_a_fused_build_group_once() {
-        const PASSES: &[PassDesc] = &[
-            PassDesc::new(
-                "facts",
-                PassKind::Optional,
-                Fusability::Fusable,
-                Preserved::ALL,
-            ),
-            PassDesc::new(
-                "emit",
-                PassKind::Optional,
-                Fusability::Fusable,
-                Preserved::ALL,
-            ),
-        ];
-        const PLAN: Pipeline = Pipeline::new("s2", PASSES);
-
-        let budget = plan_budget(&PLAN);
-
-        assert_eq!(budget.walks, 1);
-        assert_eq!(budget.passes, 2);
-        assert_eq!(budget.fusion_ratio_hundredths(), Some(200));
-    }
 }
 
 /// Write `folio` as `{stem}.repro.folio` under `dir`, creating `dir` first

--- a/crates/vize/src/commands/davinci_ice/budget.rs
+++ b/crates/vize/src/commands/davinci_ice/budget.rs
@@ -1,0 +1,65 @@
+//! Build-profile accounting for the selected Davinci plan.
+
+use vize_davinci::pass::{BudgetObserver, Pipeline, run_pipeline};
+
+/// Measure the selected build plan through the P2-3 budget observer.
+///
+/// This is intentionally plan-level accounting: today the real build stages
+/// are still the legacy compile path, so the observer reports planned fusion
+/// groups for the selected backend. Once builds route through the pass manager,
+/// this remains the profile-counter adapter.
+pub(crate) fn plan_budget(plan: &Pipeline) -> BudgetObserver {
+    let mut budget = BudgetObserver::new();
+    run_pipeline(plan, &mut budget, |_| Ok(())).expect("compile plans use no-op pass bodies");
+    budget
+}
+
+#[cfg(test)]
+mod tests {
+    use super::plan_budget;
+    use crate::commands::davinci_ice::compile_plan;
+    use vize_davinci::pass::{Fusability, PassDesc, PassKind, Pipeline, Preserved};
+
+    #[test]
+    fn compile_plan_budget_matches_selected_backend_groups() {
+        for (ssr, vapor, expected_mode) in [
+            (false, false, "dom"),
+            (true, false, "ssr"),
+            (false, true, "vapor"),
+        ] {
+            let (plan, mode) = compile_plan(ssr, vapor);
+            let budget = plan_budget(plan);
+
+            assert_eq!(mode, expected_mode);
+            assert_eq!(budget.pipelines, 1);
+            assert_eq!(budget.walks as usize, plan.group_count());
+            assert_eq!(budget.passes as usize, plan.passes.len());
+            assert_eq!(budget.failures, 0);
+        }
+    }
+
+    #[test]
+    fn plan_budget_counts_a_fused_build_group_once() {
+        const PASSES: &[PassDesc] = &[
+            PassDesc::new(
+                "facts",
+                PassKind::Optional,
+                Fusability::Fusable,
+                Preserved::ALL,
+            ),
+            PassDesc::new(
+                "emit",
+                PassKind::Optional,
+                Fusability::Fusable,
+                Preserved::ALL,
+            ),
+        ];
+        const PLAN: Pipeline = Pipeline::new("s2", PASSES);
+
+        let budget = plan_budget(&PLAN);
+
+        assert_eq!(budget.walks, 1);
+        assert_eq!(budget.passes, 2);
+        assert_eq!(budget.fusion_ratio_hundredths(), Some(200));
+    }
+}

--- a/crates/vize/tests/build_profile_cli.rs
+++ b/crates/vize/tests/build_profile_cli.rs
@@ -72,6 +72,10 @@ fn build_stats_profile_reports_source_plate_facts() {
         "source.block.template.bytes",
         "source.cache.hit.files",
         "source.cache.bypass.self_component.files",
+        "Davinci plan",
+        "davinci.build.files",
+        "davinci.build.planned_groups",
+        "davinci.build.planned_passes",
         "Product lanes",
         "lane.atelier.dom.requests",
         "Vue dialects",
@@ -79,6 +83,7 @@ fn build_stats_profile_reports_source_plate_facts() {
         "Template syntax",
         "template_syntax.standard.files",
         "lane atelier.dom, plate source.sfc",
+        "davinci planned groups 2 / passes 2",
     ] {
         assert!(stderr.contains(expected), "missing {expected:?}\n{stderr}");
     }

--- a/crates/vize_curator/src/profile.rs
+++ b/crates/vize_curator/src/profile.rs
@@ -100,6 +100,7 @@ pub fn render_profile_report(report: &ProfileReport<'_>) -> String {
         "cache.stats_compile.",
     );
     render_counter_table(&mut out, report, "Source facts", "source.");
+    render_counter_table(&mut out, report, "Davinci plan", "davinci.build.");
     render_counter_table(&mut out, report, "Product lanes", "lane.");
     render_counter_table(&mut out, report, "Vue dialects", "dialect.");
     render_counter_table(&mut out, report, "Template syntax", "template_syntax.");


### PR DESCRIPTION
## Summary
- measure the selected Davinci build plan with the P2-3 budget observer
- surface planned group/pass counters in build profile facts and reports
- pin the profile CLI and plan-budget regression coverage

## Verification
- cargo fmt --all --check
- cargo test -p vize --lib davinci_ice
- cargo test -p vize --test build_profile_cli -- --nocapture
- cargo test -p vize_curator profile_report_snapshot
- node --test tests/tooling/davinci-traversal-budgets.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790679151&installation_model_id=422833&pr_number=5374&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5374&signature=73c1898073272f2edefd870162d7254bdc225aa45dd6af29eabe4c2867fe3df8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->