### PR TITLE
fix(ui): reject duplicate button group item values

### DIFF
--- a/npm/ui/core/scripts/check-size.mjs
+++ b/npm/ui/core/scripts/check-size.mjs
@@ -5,7 +5,7 @@ import { gzipSync } from "node:zlib";
 const distributionDirectory = new URL("../dist/", import.meta.url);
 const staticImportPattern = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["'](\.\.?\/[^"']+)["']/g;
 const budgets = new Map([
-  ["index.mjs", 172_700],
+  ["index.mjs", 172_750],
   ["alert.mjs", 1_050],
   ["announcer.mjs", 4_100],
   ["aspect-ratio.mjs", 1_500],

--- a/npm/ui/core/src/families/actions/button-group/button-group-context.ts
+++ b/npm/ui/core/src/families/actions/button-group/button-group-context.ts
@@ -36,7 +36,7 @@ export interface ButtonGroupContextValue {
   readonly registerItem: (item: ButtonGroupItemRegistration) => () => void;
   readonly requestItemPress: (value: string, nativeEvent: MouseEvent) => void;
   readonly setActiveValue: (value: string) => void;
-  readonly syncActiveValue: () => void;
+  readonly syncActiveValue: (item?: ButtonGroupItemRegistration) => void;
 }
 
 export const buttonGroupContext = createContext<ButtonGroupContextValue>("ButtonGroup");

--- a/npm/ui/core/src/families/actions/button-group/button-group-item.vue
+++ b/npm/ui/core/src/families/actions/button-group/button-group-item.vue
@@ -78,13 +78,14 @@ const slotState = computed<ButtonGroupItemSlotState>(() => ({
   value,
 }));
 
-const unregister = context.registerItem({
+const registration = {
   disabled: itemDisabled,
   element,
   value: () => value,
-});
+};
+const unregister = context.registerItem(registration);
 
-watch([itemDisabled, () => value], () => context.syncActiveValue(), { flush: "post" });
+watch([itemDisabled, () => value], () => context.syncActiveValue(registration), { flush: "sync" });
 onUnmounted(unregister);
 
 function onClick(event: MouseEvent): void {

--- a/npm/ui/core/src/families/actions/button-group/button-group.behavior.md
+++ b/npm/ui/core/src/families/actions/button-group/button-group.behavior.md
@@ -9,7 +9,8 @@
 | B5  | `button-group-item.vue` | disabled                  | disabled groups and items suppress activation and leave tab order safely | `disabled groups and items suppress activation`                |
 | B6  | `button-group-item.vue` | custom element semantics  | non-native items receive `role="button"` and synthesize keyboard clicks  | `custom items expose button semantics and keyboard activation` |
 | B7  | both                    | public instance           | root and items expose focus methods and immutable state snapshots        | `exposes focus, focusValue, activeValue, and item state`       |
-| B8  | `button-group-item.vue` | provider boundary         | items fail loudly when rendered outside a matching group provider        | `items require a matching group provider`                      |
+| B8  | `button-group-item.vue` | duplicate value           | mount and reactive value changes reject duplicate item values            | `rejects duplicate item values...`                             |
+| B9  | `button-group-item.vue` | provider boundary         | items fail loudly when rendered outside a matching group provider        | `items require a matching group provider`                      |
 
 ## Contract
 
@@ -23,5 +24,8 @@ through `data-vize-ui`, `data-state`, `data-disabled`, `data-orientation`,
 defaults to a single tab stop with arrow-key movement because that is the WAI-ARIA
 toolbar expectation. Consumers may explicitly set `rovingFocus` on either role.
 
-Items require a string `value` so item-level and group-level `press` events are
-stable across polymorphic rendering, slot changes, and DOM reordering.
+Items require a unique string `value` so item-level and group-level `press`
+events, `activeValue`, roving tabindex, and `focusValue()` stay stable across
+polymorphic rendering, slot changes, and DOM reordering. Duplicate values throw
+`VIZE_UI_BUTTON_GROUP_VALUE_DUPLICATE` during registration or reactive value
+changes before more than one item can own the active tab stop.

--- a/npm/ui/core/src/families/actions/button-group/button-group.test.ts
+++ b/npm/ui/core/src/families/actions/button-group/button-group.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 
+import { mount } from "@vue/test-utils";
 import { test } from "vite-plus/test";
 import { defineComponent, h, nextTick } from "vue";
 
@@ -229,6 +230,56 @@ test("exposes focus, focusValue, activeValue, and item state", async () => {
   itemExpose.focus();
   assert.ok(handle.activeElement() === publish);
   handle.unmount();
+});
+
+test("rejects duplicate item values before roving focus becomes ambiguous", async () => {
+  assert.throws(
+    () =>
+      mountInteraction(ButtonGroup, {
+        props: { ariaLabel: "Actions", role: "toolbar" },
+        slots: {
+          default: () => [
+            h(ButtonGroupItem, { value: "save" }, () => "Save"),
+            h(ButtonGroupItem, { value: "save" }, () => "Duplicate save"),
+          ],
+        },
+      }),
+    /VIZE_UI_BUTTON_GROUP_VALUE_DUPLICATE/,
+  );
+
+  const Probe = defineComponent({
+    props: {
+      secondaryValue: { type: String, default: "publish" },
+    },
+    setup: (props) => () =>
+      h(ButtonGroup, { ariaLabel: "Actions", role: "toolbar" }, () => [
+        h(ButtonGroupItem, { value: "save" }, () => "Save"),
+        h(ButtonGroupItem, { value: props.secondaryValue }, () => "Publish"),
+      ]),
+  });
+  const errors: unknown[] = [];
+  const container = document.createElement("div");
+  document.body.append(container);
+  const wrapper = mount(Probe, {
+    attachTo: container,
+    global: {
+      config: {
+        errorHandler(error) {
+          errors.push(error);
+        },
+      },
+    },
+  });
+
+  await nextTick();
+  await wrapper.setProps({ secondaryValue: "save" });
+  assert.equal(errors.length, 1);
+  assert.match(
+    errors[0] instanceof Error ? errors[0].message : String(errors[0]),
+    /VIZE_UI_BUTTON_GROUP_VALUE_DUPLICATE/,
+  );
+  wrapper.unmount();
+  container.remove();
 });
 
 test("items require a matching group provider", () => {

--- a/npm/ui/core/src/families/actions/button-group/button-group.vue
+++ b/npm/ui/core/src/families/actions/button-group/button-group.vue
@@ -128,7 +128,17 @@ function getOrderedItems(): readonly ButtonGroupItemRegistration[] {
   });
 }
 
-function syncActiveValue(): void {
+function validateItemValue(item: ButtonGroupItemRegistration): void {
+  const itemValue = item.value();
+  for (const registered of items) {
+    if (registered !== item && registered.value() === itemValue) {
+      throw new Error("VIZE_UI_BUTTON_GROUP_VALUE_DUPLICATE");
+    }
+  }
+}
+
+function syncActiveValue(item?: ButtonGroupItemRegistration): void {
+  if (item !== undefined) validateItemValue(item);
   if (disabledState.value || !rovingFocusState.value) {
     activeValue.value = null;
     return;
@@ -193,6 +203,7 @@ function getItemState(itemDisabled: boolean): ButtonGroupItemState {
 }
 
 function registerItem(item: ButtonGroupItemRegistration): () => void {
+  validateItemValue(item);
   items.add(item);
   syncActiveValue();
   void nextTick(syncActiveValue);


### PR DESCRIPTION
## Summary
- reject duplicate ButtonGroupItem values during initial registration
- validate reactive item value changes before roving focus can become ambiguous
- document the stable VIZE_UI_BUTTON_GROUP_VALUE_DUPLICATE diagnostic

## Tests
- vp check src/families/actions/button-group/button-group.vue src/families/actions/button-group/button-group-item.vue src/families/actions/button-group/button-group-context.ts src/families/actions/button-group/button-group.test.ts scripts/check-size.mjs
- vp test run src/families/actions/button-group/button-group.test.ts src/families/actions/button-group/button-group-ssr.test.ts src/families/actions/button-group/button-group.types.test-d.ts
- node scripts/check-size.mjs
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790680280&installation_model_id=422833&pr_number=5375&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5375&signature=aeb4fe55225e104bd0dcab99478eb293467bdd19b56d0a340a7e00bd9be27131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Button groups now detect duplicate item values during setup and when values change.
  * Clear validation errors are shown when duplicate values are provided, preventing ambiguous active-item behavior.
  * Active-item synchronization is now applied immediately for more consistent button group state.

* **Documentation**
  * Updated button group behavior guidance to require unique string values and document duplicate-value validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->