### PR TITLE
fix(davinci): emit if branches containing v-for

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_if_for.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_if_for.rs
@@ -1,0 +1,29 @@
+//! P2-11 `v-if` / `v-for` co-carrier branch emission.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "native_unkeyed",
+        r#"<div v-if="ok" v-for="i in n">{{ i }}</div>"#,
+    ),
+    (
+        "native_keyed",
+        r#"<div v-if="ok" v-for="i in n" :key="i">{{ i }}</div>"#,
+    ),
+    (
+        "component_keyed",
+        r#"<Foo v-if="ok" v-for="item in list" :key="item" />"#,
+    ),
+];
+
+#[test]
+fn s2_if_for_co_carriers_match_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_s1_to_s2/src/emit/vif.rs
+++ b/crates/vize_s1_to_s2/src/emit/vif.rs
@@ -140,6 +140,10 @@ fn emit_branch(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<
             cx.walk.skip(slot.bindings.len());
             super::outlet::emit_outlet(cx, slot, Some(key), true)
         }
+        [Op::For(for_op)] => {
+            let id = cx.walk.mint();
+            super::emit_for_op(cx, for_op, id, Some(key))
+        }
         _ => Err(EmitError::unsupported_at(
             Reason::IfBranchShape,
             branch.span,

--- a/crates/vize_s1_to_s2/tests/emit_if.rs
+++ b/crates/vize_s1_to_s2/tests/emit_if.rs
@@ -138,6 +138,40 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+fn a_v_if_v_for_branch_keys_the_list_fragment() {
+    assert_eq!(
+        assembled(r#"<div v-if="ok" v-for="i in n">{{ i }}</div>"#),
+        "\
+const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode, renderList: _renderList } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (ok)
+    ? (_openBlock(true), _createElementBlock(_Fragment, { key: 0 }, _renderList(n, (i) => {
+      return (_openBlock(), _createElementBlock(\"div\", null, _toDisplayString(i), 1 /* TEXT */))
+    }), 256 /* UNKEYED_FRAGMENT */))
+    : _createCommentVNode(\"v-if\", true)
+}"
+    );
+}
+
+#[test]
+fn a_keyed_v_if_v_for_keeps_the_item_key() {
+    assert_eq!(
+        assembled(r#"<div v-if="ok" v-for="i in n" :key="i">{{ i }}</div>"#),
+        "\
+const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode, renderList: _renderList } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (ok)
+    ? (_openBlock(true), _createElementBlock(_Fragment, { key: 0 }, _renderList(n, (i) => {
+      return (_openBlock(), _createElementBlock(\"div\", { key: i }, _toDisplayString(i), 1 /* TEXT */))
+    }), 128 /* KEYED_FRAGMENT */))
+    : _createCommentVNode(\"v-if\", true)
+}"
+    );
+}
+
+#[test]
 fn a_template_fragment_v_if_matches_the_shipped_snapshot() {
     assert_eq!(
         assembled(r#"<template v-if="ok"><span></span><span></span></template>"#),

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           916 |                   432 |               484 |             140 |     371 |             939 |      488 |           484 |           593 |
+| Compiler                   |           916 |                   432 |               484 |             140 |     371 |             939 |      488 |           484 |           594 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |


### PR DESCRIPTION
## Summary
- Emit `ui.if` branches whose branch region is a single `ui.for`, preserving the branch key on the outer list fragment.
- Pin keyed and unkeyed `v-if`/`v-for` co-carrier output in S1-to-S2 emit tests.
- Add a focused atelier DOM byte-for-byte differential test for native and component co-carriers.
- Refresh the generated consumer migration surface count for the added test file.

## Verification
- `vp install --frozen-lockfile --prefer-offline`
- `cargo fmt --check`
- `cargo test -p vize_s1_to_s2 --test emit_if -- --nocapture`
- `cargo test -p vize_s1_to_s2 --test emit_unsupported_direct -- --nocapture`
- `cargo test -p vize_s1_to_s2 --test emit_unsupported_census -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_if_for -- --nocapture`
- `cargo clippy -p vize_s1_to_s2 --test emit_if --test emit_unsupported_direct --test emit_unsupported_census -- -D warnings`
- `cargo clippy -p vize_atelier_dom --test davinci_s2_if_for -- -D warnings`
- `rust-script tools/commands/davinci/consumer-migration-surfaces.rs --check`
- `node --test tests/tooling/davinci-matrices.test.ts`
- Hydrated corpus counter on `/Users/ubugeeei/Source/github.com/ubugeeei/vize--p2-9-corpus/tests/_fixtures/_git`: `files=41580 emitted=41480 diagnostics=15 unsupported=85`; no `if_branch_shape` bucket remained. Remaining buckets: `slot_default_shape=48`, `unsupported_binding_kind=19`, `slot_facts_missing_group=9`, `missing_text_facts=4`, `bind_value_not_js=3`, `if_condition_not_js=1`, `text_expression_not_emittable=1`.