### PR TITLE
fix(davinci): harden p2-11 handler bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4048,6 +4048,7 @@ dependencies = [
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_parser",
+ "oxc_semantic",
  "oxc_span",
  "vize_atelier_sfc",
  "vize_carton",

--- a/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
@@ -38,6 +38,10 @@ const BATTERY: &[(&str, &str)] = &[
         "<Foo><svg><path d=\"M0 0\" /></svg></Foo>",
     ),
     (
+        "implicit_default_mathml",
+        "<Foo><math><mi>x</mi></math></Foo>",
+    ),
+    (
         "named_header_extra_attr",
         r#"<Foo><template #header id="x">x</template></Foo>"#,
     ),

--- a/crates/vize_s1_to_s2/Cargo.toml
+++ b/crates/vize_s1_to_s2/Cargo.toml
@@ -31,6 +31,7 @@ davinci-differential = []
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_parser = { workspace = true }
+oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 vize_s0 = { workspace = true }
 vize_davinci = { workspace = true }

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -7,8 +7,7 @@
 //! P2-9 carve-out. This module writes the JS string **directly from
 //! S2 ops** — it does not mint relief codegen-nodes (`NodeType` 13–20).
 //!
-//! This installment emits **static native HTML / SVG / MathML**,
-//! interpolations,
+//! This installment emits **static native HTML / SVG / MathML**, interpolations,
 //! mixed text siblings, static-name `ui.bind`, static-name `ui.on`
 //! (including event/key/option modifiers), native `ui.if`, **native
 //! `ui.for`**, **object-spread `v-bind`** (`normalizeProps` /
@@ -73,6 +72,7 @@ mod model;
 mod model_key;
 mod namespace;
 mod on;
+mod on_body;
 mod on_dynamic;
 mod once;
 mod outlet;

--- a/crates/vize_s1_to_s2/src/emit/on.rs
+++ b/crates/vize_s1_to_s2/src/emit/on.rs
@@ -165,9 +165,7 @@ pub(super) fn emit_wrapped_handler(
     match on.handler {
         Some(ExprRef::Js(js)) => emit_handler(cx, js),
         Some(ExprRef::Opaque(opaque)) if opaque.reason == OpaqueReason::MultiStatement => {
-            cx.buf.push("$event => {");
-            cx.buf.push(opaque.source);
-            cx.buf.push("}");
+            super::on_body::emit(cx, opaque.source);
         }
         None => cx.buf.push("() => {}"),
         Some(expr) => {
@@ -209,9 +207,7 @@ pub(super) fn emit_handler(cx: &mut EmitCx<'_>, js: &JsExpr<'_>) {
         return;
     }
     if js.source.contains(';') {
-        cx.buf.push("$event => {");
-        cx.buf.push(js.source);
-        cx.buf.push("}");
+        super::on_body::emit(cx, js.source);
     } else {
         cx.buf.push("$event => (");
         cx.buf.push(js.source);

--- a/crates/vize_s1_to_s2/src/emit/on_body.rs
+++ b/crates/vize_s1_to_s2/src/emit/on_body.rs
@@ -1,0 +1,74 @@
+//! Block-body event handlers (`$event => { ... }`).
+
+use super::EmitCx;
+
+pub(super) fn emit(cx: &mut EmitCx<'_>, source: &str) {
+    cx.buf.push("$event => {");
+    cx.buf.push(source);
+    if ends_in_line_comment(source) {
+        cx.buf.newline();
+    }
+    cx.buf.push("}");
+}
+
+fn ends_in_line_comment(source: &str) -> bool {
+    let bytes = source.as_bytes();
+    let mut index = 0usize;
+    let mut state = ScanState::Code;
+    let mut escaped = false;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        match state {
+            ScanState::Code => match byte {
+                b'\'' => enter_string(&mut state, &mut escaped, ScanState::Single),
+                b'"' => enter_string(&mut state, &mut escaped, ScanState::Double),
+                b'`' => enter_string(&mut state, &mut escaped, ScanState::Template),
+                b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                    state = ScanState::Line;
+                    index += 1;
+                }
+                b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                    state = ScanState::Block;
+                    index += 1;
+                }
+                _ => {}
+            },
+            ScanState::Single if escaped => escaped = false,
+            ScanState::Single if byte == b'\\' => escaped = true,
+            ScanState::Single if byte == b'\'' => state = ScanState::Code,
+            ScanState::Single => {}
+            ScanState::Double if escaped => escaped = false,
+            ScanState::Double if byte == b'\\' => escaped = true,
+            ScanState::Double if byte == b'"' => state = ScanState::Code,
+            ScanState::Double => {}
+            ScanState::Template if escaped => escaped = false,
+            ScanState::Template if byte == b'\\' => escaped = true,
+            ScanState::Template if byte == b'`' => state = ScanState::Code,
+            ScanState::Template => {}
+            ScanState::Block if byte == b'*' && bytes.get(index + 1) == Some(&b'/') => {
+                state = ScanState::Code;
+                index += 1;
+            }
+            ScanState::Block => {}
+            ScanState::Line if matches!(byte, b'\n' | b'\r') => state = ScanState::Code,
+            ScanState::Line => {}
+        }
+        index += 1;
+    }
+    matches!(state, ScanState::Line)
+}
+
+fn enter_string(state: &mut ScanState, escaped: &mut bool, next: ScanState) {
+    *state = next;
+    *escaped = false;
+}
+
+#[derive(Clone, Copy)]
+enum ScanState {
+    Code,
+    Single,
+    Double,
+    Template,
+    Block,
+    Line,
+}

--- a/crates/vize_s1_to_s2/src/lower/expr.rs
+++ b/crates/vize_s1_to_s2/src/lower/expr.rs
@@ -13,7 +13,9 @@
 //! `Compound` have no P2-8 producer, see the record) are assigned by
 //! [`opaque_at`], the only constructor that names a reason directly.
 
+use oxc_ast::ast::Statement;
 use oxc_parser::Parser;
+use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
 use vize_s0::{Span, String, cstr};
 use vize_s2::expr::{ExprRef, OpaqueExpr, OpaqueReason, VueFilterExpr};
@@ -42,21 +44,52 @@ pub(crate) fn handler_expr_at<'a>(cx: &Cx<'a>, text: &'a str) -> ExprRef<'a> {
     let ExprRef::Opaque(opaque) = expr else {
         return expr;
     };
-    if opaque.reason != OpaqueReason::ParseRejected || !parses_as_program(cx, opaque.source) {
+    if opaque.reason != OpaqueReason::ParseRejected || !parses_as_handler_body(cx, opaque.source) {
         return expr;
     }
     opaque_at(cx, OpaqueReason::MultiStatement, opaque.source, opaque.span)
 }
 
-fn parses_as_program(cx: &Cx<'_>, source: &str) -> bool {
-    Parser::new(
+fn parses_as_handler_body(cx: &Cx<'_>, source: &str) -> bool {
+    if contains_module_declaration(cx, source) {
+        return false;
+    }
+    let mut wrapped = String::with_capacity(source.len() + 39);
+    wrapped.push_str("const __vize_handler__ = $event => {\n");
+    wrapped.push_str(source);
+    wrapped.push_str("\n};");
+    let parsed = Parser::new(
+        cx.allocator.as_oxc(),
+        wrapped.as_str(),
+        SourceType::ts().with_module(true),
+    )
+    .parse();
+    if !parsed.diagnostics.is_empty() {
+        return false;
+    }
+    let semantic = SemanticBuilder::new_compiler().build(&parsed.program);
+    semantic.diagnostics.is_empty()
+}
+
+fn contains_module_declaration(cx: &Cx<'_>, source: &str) -> bool {
+    let parsed = Parser::new(
         cx.allocator.as_oxc(),
         source,
         SourceType::ts().with_module(true),
     )
-    .parse()
-    .diagnostics
-    .is_empty()
+    .parse();
+    if !parsed.diagnostics.is_empty() {
+        return false;
+    }
+    parsed.program.body.iter().any(|statement| {
+        matches!(
+            statement,
+            Statement::ImportDeclaration(_)
+                | Statement::ExportAllDeclaration(_)
+                | Statement::ExportDefaultDeclaration(_)
+                | Statement::ExportNamedDeclaration(_)
+        )
+    })
 }
 
 /// Interpolation / `v-bind` value admission: Vue 2 pipe filters first

--- a/crates/vize_s1_to_s2/tests/emit_on_handler_body.rs
+++ b/crates/vize_s1_to_s2/tests/emit_on_handler_body.rs
@@ -1,0 +1,86 @@
+//! Event handler-body admission and emission boundaries.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use support::with_transformed;
+use vize_s0::Allocator;
+use vize_s1_to_s2::{UnsupportedReason as Reason, emit_dom, emit_dom_source};
+
+fn assembled(source: &str) -> String {
+    with_transformed(source, |lowered, _folio, facts, _budget| {
+        emit_dom(lowered, facts)
+            .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
+            .assembled()
+            .to_string()
+    })
+}
+
+fn refused_reason(source: &str) -> Option<Reason> {
+    let allocator = Allocator::new();
+    emit_dom_source(&allocator, source)
+        .expect_err(source)
+        .reason()
+}
+
+#[test]
+fn return_statement_handler_is_admitted_in_body_context() {
+    assert_eq!(
+        assembled(r#"<div @click="return false"></div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", {
+    onClick: $event => {return false}
+  }, null, 8 /* PROPS */, [\"onClick\"]))
+}"
+    );
+}
+
+#[test]
+fn line_comment_handler_keeps_the_closing_brace_outside_the_comment() {
+    assert_eq!(
+        assembled(r#"<div @click="foo(); // note"></div>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", {
+    onClick: $event => {foo(); // note
+    }
+  }, null, 8 /* PROPS */, [\"onClick\"]))
+}"
+    );
+}
+
+#[test]
+fn module_only_handler_forms_stay_unsupported() {
+    for source in [
+        r#"<div @click="import thing from 'pkg'"></div>"#,
+        r#"<div @click="export const value = 1"></div>"#,
+    ] {
+        assert_eq!(refused_reason(source), Some(Reason::OnHandlerNotJs));
+    }
+}
+
+#[test]
+fn invalid_body_control_flow_stays_unsupported() {
+    assert_eq!(
+        refused_reason(r#"<div @click="break"></div>"#),
+        Some(Reason::OnHandlerNotJs)
+    );
+}
+
+#[test]
+fn duplicate_lexical_handler_declarations_stay_unsupported() {
+    assert_eq!(
+        refused_reason(r#"<div @click="let value; let value"></div>"#),
+        Some(Reason::OnHandlerNotJs)
+    );
+}

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -73,7 +73,7 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
 | s1_to_s2 | `alloc::vec::Vec`       |    37 |           37 |        156 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    52 |           54 |        224 |
+| s1_to_s2 | `vize_s0::String`       |    52 |           54 |        225 |
 | s1_to_s2 | `vize_s0::Vec`          |    14 |           14 |         56 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     2 |            2 |          4 |
 

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -66,7 +66,7 @@ s1_to_s2	-	crates/vize_s1_to_s2/src/lower/css.rs	0	0	0	0	1	3	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/cx.rs	1	4	1	7	0	0	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/directive.rs	1	6	0	0	0	0	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/element.rs	1	2	0	0	1	4	0	0
-s1_to_s2	-	crates/vize_s1_to_s2/src/lower/expr.rs	0	0	1	3	0	0	0	0
+s1_to_s2	-	crates/vize_s1_to_s2/src/lower/expr.rs	0	0	1	4	0	0	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/forop.rs	1	2	1	5	1	2	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/html.rs	0	0	1	2	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/leaf.rs	0	0	1	5	1	4	0	0


### PR DESCRIPTION
## Summary
- validate v-on multi-statement handlers in the emitted handler-body context
- reject module-only handler declarations, invalid body control flow, and duplicate lexical declarations before assigning multi-statement
- keep closing braces outside trailing line comments in block-body handlers
- add MathML slot parity coverage; keep SVG/MathML static slot hoists because the shipped DOM lane hoists them byte-for-byte

## Verification
- cargo fmt --all --check
- cargo test -p vize_s1_to_s2 --test emit_on --test emit_on_handler_body --test emit_dynamic_on_keys --test emit_unsupported_census --test emit_unsupported_direct -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_colon --test davinci_s2_model --test davinci_s2_slots --features vize_s1_to_s2/davinci-differential -- --nocapture
- git diff --check HEAD~1 HEAD

Note: local source-file-length tooling still fails before evaluating this diff because the local MoonBit toolchain rejects moonbitlang/x/path lexscan targets; touched Rust files are all below the 350-line cap and CI test-scripts remains the authority.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790681304&installation_model_id=422833&pr_number=5379&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5379&signature=a038d7f99096e48037a831b9813f0e052b893834d09fe0c57a0e05cd9203be0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->