### PR TITLE
fix(davinci): match static class patch flags

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_static_class_patch.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_static_class_patch.rs
@@ -1,0 +1,27 @@
+//! P2-11 static class literal patch-flag witnesses.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    ("string", r#"<div :class="'card'"></div>"#),
+    ("array", r#"<div :class="['card', `quiet`]"></div>"#),
+    (
+        "object",
+        r#"<div :class="{ card: true, quiet: false }"></div>"#,
+    ),
+    (
+        "text_and_array",
+        r#"<p :class="['copy']">{{ message }}</p>"#,
+    ),
+];
+
+#[test]
+fn s2_static_class_literal_patch_flags_match_the_shipped_dom_lane() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_s1_to_s2/src/emit/props.rs
+++ b/crates/vize_s1_to_s2/src/emit/props.rs
@@ -2,6 +2,7 @@
 
 use alloc::vec::Vec as StdVec;
 
+use oxc_ast::ast::{ArrayExpressionElement, Expression, ObjectPropertyKind};
 use vize_s0::String;
 use vize_s2::op::{Attribute, BindingOp};
 
@@ -126,7 +127,8 @@ pub(super) fn bind_patch(
                 }
                 Ok(BindName::Static(raw_name)) => match raw_name {
                     "ref" => flag |= 512,
-                    "class" if !is_component => flag |= 2,
+                    "class" if !is_component && class_bind_needs_patch(bind) => flag |= 2,
+                    "class" if !is_component => {}
                     "style" if !is_component => flag |= 4,
                     "key" => {}
                     _ => {
@@ -196,6 +198,47 @@ pub(super) fn bind_patch(
     Patch {
         flag,
         dynamic_props,
+    }
+}
+
+fn class_bind_needs_patch(bind: &vize_s2::op::BindOp<'_>) -> bool {
+    js_value(bind).is_ok_and(|js| !is_static_class_expr(js.ast))
+}
+
+fn is_static_class_expr(expr: &Expression<'_>) -> bool {
+    match unwrap_expr(expr) {
+        Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BigIntLiteral(_) => true,
+        Expression::TemplateLiteral(template) => template.expressions.is_empty(),
+        Expression::ArrayExpression(array) => array.elements.iter().all(static_class_array_element),
+        Expression::ObjectExpression(object) => object.properties.iter().all(|property| {
+            let ObjectPropertyKind::ObjectProperty(property) = property else {
+                return false;
+            };
+            !property.computed && is_static_class_expr(&property.value)
+        }),
+        _ => false,
+    }
+}
+
+fn static_class_array_element(element: &ArrayExpressionElement<'_>) -> bool {
+    element
+        .as_expression()
+        .is_some_and(|expr| is_static_class_expr(expr))
+}
+
+fn unwrap_expr<'a>(mut expr: &'a Expression<'a>) -> &'a Expression<'a> {
+    loop {
+        match expr {
+            Expression::ParenthesizedExpression(paren) => expr = &paren.expression,
+            Expression::TSAsExpression(ts_as) => expr = &ts_as.expression,
+            Expression::TSNonNullExpression(ts_non_null) => expr = &ts_non_null.expression,
+            Expression::TSSatisfiesExpression(ts_satisfies) => expr = &ts_satisfies.expression,
+            _ => return expr,
+        }
     }
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           916 |                   432 |               484 |             140 |     371 |             939 |      488 |           484 |           593 |
+| Compiler                   |           916 |                   432 |               484 |             140 |     371 |             939 |      488 |           484 |           594 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |


### PR DESCRIPTION
## Summary
- treat statically-known :class values on plain elements like static class output for patch flags
- avoid emitting CLASS or PROPS patch flags for literal, static array, and static object class expressions
- add DOM differential coverage for static class literals, arrays, objects, and mixed text cases

## Verification
- cargo fmt --all --check
- cargo test -p vize_atelier_dom --test davinci_s2_static_class_patch --features vize_s1_to_s2/davinci-differential -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_patch_flags --test davinci_s2_colon --test davinci_s2_dynamic_bind_keys --features vize_s1_to_s2/davinci-differential -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_static --test emit_on --test emit_model --test emit_unsupported_census --test emit_unsupported_direct -- --nocapture
- git diff --check HEAD~1 HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790681464&installation_model_id=422833&pr_number=5380&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5380&signature=2beb231d2e9297d1ddcd09a1d9be89f7c8facc45571313fb56866fcd6f270f23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->