### PR TITLE
fix(davinci): admit keyed slot template forwarding

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
@@ -163,6 +163,10 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<Foo><template v-for="(v, k, i) in n" #header>x</template></Foo>"#,
     ),
     (
+        "create_slots_for_keyed_dynamic_forwarded_outlet",
+        r#"<Foo><template v-for="(_, name) in $slots" :key="name" #[name]="slotData"><slot :name="name" v-bind="slotData || {}" /></template></Foo>"#,
+    ),
+    (
         "create_slots_default_interp",
         r#"<Foo>hello {{ msg }}<template #header v-if="ok">x</template></Foo>"#,
     ),

--- a/crates/vize_s1_to_s2/src/emit/slots.rs
+++ b/crates/vize_s1_to_s2/src/emit/slots.rs
@@ -1,18 +1,15 @@
 //! Slot objects (`withCtx` / `_: 1|2`) from [`SlotFacts`].
 //!
-//! Implicit default, static / dynamic named `<template>` groups, and
-//! component-root `v-slot` (bare spellings key `default`; named spellings
-//! preserve their authored slot name).
+//! Implicit default, named `<template>` groups, and component-root `v-slot`.
 //! Conditional / looped slot templates go through [`super::create_slots`].
-//! Outlets (`renderSlot`) live in [`super::outlet`]. A `v-slots` spread
-//! is the children argument when it is the only slot source, or
-//! `...expr` closing an authored slot object (no `_` flag).
+//! Outlets live in [`super::outlet`]. A `v-slots` spread is the children
+//! argument when it is the only slot source, or `...expr` closes a slot object.
 
 use alloc::vec::Vec as StdVec;
 
 use vize_s0::String;
 use vize_s2::expr::ExprRef;
-use vize_s2::op::{BindingOp, ElementOp, Op, Region, TextOp};
+use vize_s2::op::{BindingOp, DynamicName, ElementOp, Op, Region, TextOp};
 use vize_s2::scope::ScopeOrigin;
 
 use super::EmitCx;
@@ -71,7 +68,7 @@ pub(super) fn has_dynamic_names(facts: &SlotFacts) -> bool {
     facts
         .groups
         .iter()
-        .any(|group| matches!(group.name, SlotName::Dynamic { .. }))
+        .any(|g| matches!(g.name, SlotName::Dynamic { .. }))
 }
 
 pub(super) fn admit_default(children: &Region<'_>) -> Result<(), EmitError> {
@@ -83,15 +80,7 @@ fn walk_admit(region: &Region<'_>) -> Result<(), EmitError> {
         match op {
             Op::Text(_) | Op::Interpolation(_) => {}
             Op::Element(element) if is_slot_template(element) => {
-                if element.bindings.iter().any(|binding| {
-                    !matches!(
-                        binding,
-                        BindingOp::SlotContent(_)
-                            | BindingOp::VueOnce(_)
-                            | BindingOp::VueMemo(_)
-                            | BindingOp::VueCloak(_)
-                    )
-                }) {
+                if element.bindings.iter().any(|b| !is_inert_slot_binding(b)) {
                     return Err(EmitError::unsupported_at(
                         Reason::SlotDefaultShape,
                         element.span,
@@ -111,6 +100,23 @@ fn walk_admit(region: &Region<'_>) -> Result<(), EmitError> {
         }
     }
     Ok(())
+}
+
+fn is_inert_slot_binding(binding: &BindingOp<'_>) -> bool {
+    match binding {
+        BindingOp::SlotContent(_)
+        | BindingOp::VueOnce(_)
+        | BindingOp::VueMemo(_)
+        | BindingOp::VueCloak(_) => true,
+        BindingOp::Bind(bind)
+            if matches!(bind.name, Some(DynamicName::Static("key")))
+                && bind.modifiers.is_empty()
+                && matches!(bind.value, Some(ExprRef::Js(_))) =>
+        {
+            true
+        }
+        _ => false,
+    }
 }
 
 pub(super) fn emit_slots(

--- a/crates/vize_s1_to_s2/tests/emit_create_slots.rs
+++ b/crates/vize_s1_to_s2/tests/emit_create_slots.rs
@@ -104,6 +104,26 @@ fn static_attrs_on_looped_slot_templates_are_elided() {
 }
 
 #[test]
+fn key_bindings_on_looped_slot_templates_are_elided() {
+    assert_eq!(
+        assembled(r#"<Foo><template v-for="i in n" #header :key="i">x</template></Foo>"#),
+        assembled(r#"<Foo><template v-for="i in n" #header>x</template></Foo>"#)
+    );
+}
+
+#[test]
+fn key_bindings_on_dynamic_forwarding_slot_templates_are_elided() {
+    assert_eq!(
+        assembled(
+            r#"<Foo><template v-for="(_, name) in $slots" :key="name" #[name]="slotData"><slot :name="name" v-bind="slotData || {}" /></template></Foo>"#
+        ),
+        assembled(
+            r#"<Foo><template v-for="(_, name) in $slots" #[name]="slotData"><slot :name="name" v-bind="slotData || {}" /></template></Foo>"#
+        )
+    );
+}
+
+#[test]
 fn inert_builtin_bindings_on_looped_slot_templates_are_elided() {
     let plain = assembled(r#"<Foo><template v-for="i in n" #header>x</template></Foo>"#);
     assert_eq!(


### PR DESCRIPTION
## Summary
- admit inert `:key` bindings on slot template carriers so looped dynamic slot forwarding matches the shipped DOM lane
- add S1-to-S2 regression coverage plus a DOM byte-for-byte oracle for the dynamic forwarding shape
- keep non-inert slot template bindings in `slot_default_shape`

## Verification
- rebased onto latest `origin/main` (`2c5465d94`, includes #5379, #5380, and #5386)
- compared against #5386 head (`144fc43d3`); no file overlap with this slot patch
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `CARGO_INCREMENTAL=0 cargo test -p vize_s1_to_s2 --test emit_create_slots`
- `CARGO_INCREMENTAL=0 cargo test -p vize_atelier_dom --test davinci_s2_slots`
- `CARGO_INCREMENTAL=0 cargo test -p vize_atelier_dom --test davinci_s2_outlets`
- `CARGO_INCREMENTAL=0 cargo test -p vize_s1_to_s2 --test emit_unsupported_census committed_fixture_refusal_census_is_pinned`
- `VIZE_DAVINCI_UNSUPPORTED_CENSUS_CORPUS=/Users/ubugeeei/Source/github.com/ubugeeei/vize--p2-9-corpus/tests/_fixtures/_git CARGO_INCREMENTAL=0 cargo test -p vize_s1_to_s2 --test emit_unsupported_census optional_hydrated_corpus_census_is_deterministic -- --nocapture`

Diagnostic #5386 comparison used a scratch worktree at #5386 head plus this slot commit. The full DOM corpus assertion still fails because other residuals/divergences remain, but `slot_default_shape` is absent from the refusal map:

```text
davinci DOM corpus sweep: files=41580 parsed=41580 templates=41223 compared=38338 old_error_skips=2867 s2_refusals=18 divergences=25744
davinci DOM corpus refusal reasons: {"bind_value_not_js": 3, "if_condition_not_js": 1, "missing_text_facts": 4, "slot_facts_missing_group": 9, "text_expression_not_emittable": 1}
```
