### PR TITLE
test(ui): guard sfc lint preset wiring

### DIFF
--- a/npm/ui/core/src/sfc-lint.test.ts
+++ b/npm/ui/core/src/sfc-lint.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 // Paths are resolved from the package cwd: the runner virtualizes import.meta.url.
 import path from "node:path";
 
@@ -231,4 +232,22 @@ test("discovers every SFC with the opinionated Vize contract", async () => {
     })),
   );
   assert.equal(formatSfcLintResults(results), "");
+});
+
+test("package lint:sfc stays wired to the shared Vize SFC gate", async () => {
+  const manifest = JSON.parse(await readFile(path.resolve("package.json"), "utf8")) as {
+    scripts?: Record<string, string>;
+  };
+  const lintScript = await readFile(path.resolve("scripts/lint-sfc.ts"), "utf8");
+
+  assert.equal(
+    manifest.scripts?.["lint:sfc"],
+    "vp exec node scripts/lint-sfc.ts src && vp exec node scripts/check-renderers.ts src",
+  );
+  assert.match(lintScript, /import \{ lintPatinaSfc \} from "@vizejs\/native";/);
+  assert.match(lintScript, /lintFiles\(lintPatinaSfc, sourceRoots\)/);
+  assert.match(
+    lintScript,
+    /runSfcLintCli\(lintPatinaSfc, sourceRoots\.length > 0 \? sourceRoots : "src"\)/,
+  );
 });

--- a/tests/tooling/oxlint-spelling.test.ts
+++ b/tests/tooling/oxlint-spelling.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import { normalizeRepoText, root } from "./support/github-workflows.ts";
+
+const USER_VISIBLE_LINT_SURFACES = [
+  ".github",
+  "CONTRIBUTING.md",
+  "README.md",
+  "docs",
+  "examples",
+  "npm/cli/package.json",
+  "npm/cli/src",
+  "npm/oxlint/package.json",
+  "npm/oxlint/src",
+  "npm/ui/core/package.json",
+  "npm/ui/core/scripts",
+  "npm/ui/tooling",
+  "package.json",
+  "pnpm-workspace.yaml",
+] as const;
+
+const TEXT_EXTENSIONS = new Set([
+  ".cjs",
+  ".cts",
+  ".js",
+  ".json",
+  ".jsonc",
+  ".md",
+  ".mjs",
+  ".mts",
+  ".svg",
+  ".ts",
+  ".tsx",
+  ".vue",
+  ".yaml",
+  ".yml",
+]);
+
+const IGNORED_DIRECTORIES = new Set([".git", ".vitepress", "dist", "node_modules"]);
+
+test("user-visible oxlint docs and scripts do not spell oxlint as oxint", () => {
+  const offenders: string[] = [];
+
+  for (const relativePath of collectLintSurfaceFiles()) {
+    const source = normalizeRepoText(fs.readFileSync(path.join(root, relativePath), "utf8"));
+    const lines = source.split("\n");
+    for (const [index, line] of lines.entries()) {
+      if (/\boxint\b/iu.test(line)) {
+        offenders.push(`${relativePath}:${index + 1}: ${line.trim()}`);
+      }
+    }
+  }
+
+  assert.deepEqual(offenders, []);
+});
+
+function collectLintSurfaceFiles(): string[] {
+  return USER_VISIBLE_LINT_SURFACES.flatMap((surface) => collectFiles(surface)).sort();
+}
+
+function collectFiles(relativePath: string): string[] {
+  const fullPath = path.join(root, relativePath);
+  const stat = fs.statSync(fullPath);
+
+  if (stat.isFile()) {
+    return isTextFile(fullPath) ? [relativePath] : [];
+  }
+
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(fullPath, { withFileTypes: true })) {
+    if (entry.isDirectory() && IGNORED_DIRECTORIES.has(entry.name)) continue;
+    files.push(...collectFiles(path.join(relativePath, entry.name)));
+  }
+  return files;
+}
+
+function isTextFile(filename: string): boolean {
+  return TEXT_EXTENSIONS.has(path.extname(filename));
+}


### PR DESCRIPTION
## Summary
- lock the UI package `lint:sfc` script to the shared Vize SFC lint and renderer conformance gates
- assert that the SFC lint wrapper uses `lintPatinaSfc` with the opinionated, type-aware contract
- add a tooling test that rejects the user-visible `oxint` typo across lint docs and scripts

## Tests
- `vp test run src/sfc-lint.test.ts`
- `node --test --test-concurrency=1 tests/tooling/oxlint-spelling.test.ts`
- `vp check npm/ui/core/src/sfc-lint.test.ts tests/tooling/oxlint-spelling.test.ts`
- `vp run --filter ./npm/ui/core lint:sfc`
- `git diff --check`

Refs #4899
Refs #4894

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790682030&installation_model_id=422833&pr_number=5382&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5382&signature=fa3871709b483744c0efd77c114f1cdede7c32ba7cd9c3bef92a4270c486a421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->