### PR TITLE
fix(lsp): fail fast on deleted component import targets

### DIFF
--- a/crates/vize_maestro/src/ide/definition/service.rs
+++ b/crates/vize_maestro/src/ide/definition/service.rs
@@ -78,6 +78,9 @@ impl super::DefinitionService {
         if let Some(def) = import_target::component_tag_definition(ctx) {
             return Some(def);
         }
+        if import_target::component_tag_import_target_is_deleted(ctx) {
+            return None;
+        }
 
         if let Some(definition) = component_event::definition(ctx) {
             return Some(definition);
@@ -147,6 +150,9 @@ impl super::DefinitionService {
         // re-exports to their source instead of returning the barrel module.
         if let Some(def) = import_target::component_tag_definition(ctx) {
             return Some(def);
+        }
+        if import_target::component_tag_import_target_is_deleted(ctx) {
+            return None;
         }
 
         if let Some(definition) = component_event::definition(ctx) {

--- a/crates/vize_maestro/src/ide/definition/service/import_target.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target.rs
@@ -60,6 +60,39 @@ pub(super) fn component_tag_definition(ctx: &IdeContext<'_>) -> Option<GotoDefin
     None
 }
 
+/// Whether the cursor sits on an imported component tag whose resolved Vue
+/// file has been deleted from disk and is not kept alive by an open buffer.
+#[cfg(any(test, feature = "native"))]
+pub(super) fn component_tag_import_target_is_deleted(ctx: &IdeContext<'_>) -> bool {
+    let Some(tag_name) = helpers::get_tag_at_offset(&ctx.content, ctx.offset) else {
+        return false;
+    };
+    if !crate::ide::is_component_tag(&tag_name) {
+        return false;
+    }
+
+    crate::ide::component_name_candidates(&tag_name)
+        .into_iter()
+        .any(|name| {
+            helpers::find_import_path(ctx, &name)
+                .and_then(|specifier| resolve_import_specifier(ctx.uri, &specifier))
+                .is_some_and(|target| vue_target_is_deleted(ctx, &target))
+        })
+}
+
+fn vue_target_is_deleted(ctx: &IdeContext<'_>, target: &Path) -> bool {
+    if !target
+        .extension()
+        .is_some_and(|extension| extension == "vue")
+    {
+        return false;
+    }
+    let Ok(uri) = Url::from_file_path(target) else {
+        return false;
+    };
+    !target.is_file() && !ctx.state.documents.contains(&uri)
+}
+
 /// The module specifier and exported name of the import statement that both
 /// contains `offset` and binds `word`. `None` when the cursor is not on an
 /// imported name.
@@ -175,7 +208,7 @@ fn locate_export(ctx: &IdeContext<'_>, target: &Path, word: &str, hops: usize) -
         // A `.vue` module's meaningful position is the file itself, matching
         // how component-tag definition resolves today. Deleted targets are
         // invalid, while an editor-open unsaved target remains navigable.
-        if !target.is_file() && !ctx.state.documents.contains(&uri) {
+        if vue_target_is_deleted(ctx, target) {
             return None;
         }
         return Some(Location {

--- a/crates/vize_maestro/src/ide/definition/service/import_target/tests.rs
+++ b/crates/vize_maestro/src/ide/definition/service/import_target/tests.rs
@@ -66,6 +66,38 @@ fn tag_imports_resolve_through_aliases_anywhere_in_the_file() {
 }
 
 #[test]
+fn component_tag_import_target_deleted_detection_preserves_open_buffers() {
+    let workspace = tempfile::tempdir().expect("temporary workspace");
+    let target_path = workspace.path().join("LazyChild.vue");
+    let importer_path = workspace.path().join("Parent.vue");
+    let source = r#"<script setup lang="ts">
+import LazyChild from "./LazyChild.vue";
+</script>
+<template><LazyChild /></template>
+"#;
+    fs::write(&importer_path, source).expect("importer");
+
+    let importer_uri = Url::from_file_path(&importer_path).expect("importer URI");
+    let target_uri = Url::from_file_path(&target_path).expect("target URI");
+    let state = ServerState::new();
+    state
+        .documents
+        .open(importer_uri.clone(), source.to_owned(), 1, "vue".to_owned());
+    state.update_virtual_docs(&importer_uri, source);
+    let offset = source.rfind("LazyChild").expect("component tag");
+    let ctx = IdeContext::new(&state, &importer_uri, offset).expect("IDE context");
+
+    assert!(super::component_tag_import_target_is_deleted(&ctx));
+    assert!(super::component_tag_definition(&ctx).is_none());
+
+    state
+        .documents
+        .open(target_uri, "<template />\n".to_owned(), 1, "vue".to_owned());
+    assert!(!super::component_tag_import_target_is_deleted(&ctx));
+    assert!(super::component_tag_definition(&ctx).is_some());
+}
+
+#[test]
 fn reexports_cover_named_renames_and_stars() {
     let barrel =
         "export { default as UiButton } from \"./UiButton.vue\";\nexport * from \"./tokens\";\n";

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           916 |                   432 |               484 |             140 |     371 |             939 |      488 |           484 |           594 |
+| Compiler                   |           916 |                   432 |               484 |             140 |     371 |             939 |      488 |           484 |           595 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -765,6 +765,7 @@
         "type": "fixtures",
         "fixturePaths": [
           "tests/_fixtures/_git/ant-design-vue",
+          "tests/_fixtures/_git/hoppscotch",
           "tests/_fixtures/_git/reka-ui",
           "tests/_fixtures/_git/elk",
           "tests/_fixtures/_git/misskey",

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -1,8 +1,8 @@
 {
-  "schemaVersion": 7,
+  "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 16,
+    "minimumProjectCount": 17,
     "trackingIssue": 3952
   },
   "projects": [
@@ -166,6 +166,69 @@
         "corpusGlobs": ["packages/hoppscotch-common/src/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
+      },
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "packages/hoppscotch-common/src/components/app/Markdown.vue",
+          "symbol": "classes",
+          "usageAnchor": ":class=\"classes\"",
+          "declarationAnchor": "const classes = computed(() => {",
+          "hoverContains": ["const classes: any"],
+          "renameTo": "__vizeRenamedClasses"
+        },
+        "componentBoundary": {
+          "importerFile": "packages/hoppscotch-common/src/components/graphql/Directives.vue",
+          "componentFile": "packages/hoppscotch-common/src/components/graphql/ExplorerSection.vue",
+          "tagName": "ExplorerSection",
+          "tagAnchor": "<ExplorerSection ",
+          "completionItemCount": 29,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "title", "rank": 28 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  title: ExplorerSectionTitle\n",
+            "replacement": "  title: ExplorerSectionTitle\n  vizeOracleProbe?: boolean\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "packages/hoppscotch-common/src/components/graphql/__VizeOracleExplorerSection.vue",
+          "renamedFile": "packages/hoppscotch-common/src/components/graphql/__VizeOracleRenamedExplorerSection.vue",
+          "originalImportSpecifier": "./ExplorerSection.vue",
+          "copiedImportSpecifier": "./__VizeOracleExplorerSection.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedExplorerSection.vue",
+          "requireDeletedImportDiagnostic": false,
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizeHoppscotchExplorerSectionMarker__"
+        }
       }
     },
     {

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 16,
+      "authored-lsp": 17,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tests/tooling/real-project-lsp-authored-registry.test.ts
+++ b/tests/tooling/real-project-lsp-authored-registry.test.ts
@@ -74,6 +74,11 @@ test("authored LSP feature oracles are explicit and ratcheted", () => {
     assert.notEqual(lifecycle.copiedFile, lifecycle.renamedFile);
     assert.notEqual(lifecycle.originalImportSpecifier, lifecycle.copiedImportSpecifier);
     assert.notEqual(lifecycle.copiedImportSpecifier, lifecycle.renamedImportSpecifier);
+    assert.equal(
+      typeof (lifecycle.requireDeletedImportDiagnostic ?? true),
+      "boolean",
+      `${project.id} deleted import diagnostic requirement must be a boolean`,
+    );
     assert.match(lifecycle.markerSymbol, /^__vize[A-Za-z0-9_]+__$/);
     assert.ok(lifecycle.markerInsertionAnchor.length > 0);
 

--- a/tests/tooling/real-project-lsp-file-lifecycle.test.ts
+++ b/tests/tooling/real-project-lsp-file-lifecycle.test.ts
@@ -91,6 +91,67 @@ const childValue = 1
   }
 });
 
+test("authored file lifecycle can skip projects without deleted import diagnostics", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "vize-authored-file-lifecycle-"));
+  const importerSource = `<script setup lang="ts">
+import Child from "./Child.vue"
+</script>
+<template><Child /></template>
+`;
+  const dependencySource = `<script setup lang="ts">
+const childValue = 1
+</script>
+<template>{{ childValue }}</template>
+`;
+  const importerPath = path.join(workspace, "Importer.vue");
+  const dependencyPath = path.join(workspace, "Child.vue");
+  fs.writeFileSync(importerPath, importerSource);
+  fs.writeFileSync(dependencyPath, dependencySource);
+  const importerUri = pathToFileURL(importerPath).href;
+  const oracle = fixtureOracle();
+  oracle.fileLifecycle.requireDeletedImportDiagnostic = false;
+  const session = new FakeAuthoredLspSession(
+    workspace,
+    null,
+    false,
+    {
+      copiedFile: oracle.fileLifecycle.copiedFile,
+      copiedImportSpecifier: oracle.fileLifecycle.copiedImportSpecifier,
+      importerFile: oracle.componentBoundary.importerFile,
+      renamedFile: oracle.fileLifecycle.renamedFile,
+      renamedImportSpecifier: oracle.fileLifecycle.renamedImportSpecifier,
+    },
+    false,
+  );
+  session.seedDocument(oracle.componentBoundary.importerFile, importerSource);
+  const tagOffset = importerSource.indexOf("Child />");
+  const tagRange = rangeAt(importerSource, tagOffset, "Child".length);
+  const baselineDiagnostics: PublishDiagnosticsParams = {
+    diagnostics: [],
+    uri: importerUri,
+    version: 1,
+  };
+
+  try {
+    const result = await exerciseAuthoredFileLifecycle(
+      session,
+      workspace,
+      oracle,
+      { source: importerSource, uri: importerUri },
+      { source: dependencySource, uri: pathToFileURL(dependencyPath).href },
+      tagRange,
+      baselineDiagnostics,
+      () => 1_000,
+    );
+
+    assert.equal(result.deletedDefinition.count, 0);
+    assert.equal(result.deletedImporterDiagnostics.count, 0);
+    assert.equal(result.restoredDefinition.count, 1);
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
 function fixtureOracle(): LspAuthoredOracle {
   return {
     componentBoundary: {

--- a/tests/tooling/support/fake-authored-lsp-session.ts
+++ b/tests/tooling/support/fake-authored-lsp-session.ts
@@ -27,6 +27,7 @@ export class FakeAuthoredLspSession {
   private readonly documents = new Map<string, { text: string; version: number }>();
   private readonly lifecycle: FakeAuthoredLspLifecycle;
   private readonly nullMethod: string | null;
+  private readonly emitDeletedDependencyDiagnostics: boolean;
   private readonly throwOnClose: boolean;
   private readonly workspace: string;
   private fileDeleted = false;
@@ -36,11 +37,13 @@ export class FakeAuthoredLspSession {
     nullMethod: string | null = null,
     throwOnClose = false,
     lifecycle: FakeAuthoredLspLifecycle = DEFAULT_LIFECYCLE,
+    emitDeletedDependencyDiagnostics = true,
   ) {
     this.workspace = workspace;
     this.nullMethod = nullMethod;
     this.throwOnClose = throwOnClose;
     this.lifecycle = lifecycle;
+    this.emitDeletedDependencyDiagnostics = emitDeletedDependencyDiagnostics;
   }
 
   seedDocument(relativeFile: string, text: string, version = 1): void {
@@ -210,7 +213,7 @@ export class FakeAuthoredLspSession {
   private deletedDependencyDiagnostics(source: string) {
     const specifier = this.lifecycle.renamedImportSpecifier;
     const offset = source.indexOf(specifier);
-    if (!this.fileDeleted || offset === -1) return [];
+    if (!this.fileDeleted || offset === -1 || !this.emitDeletedDependencyDiagnostics) return [];
     return [
       {
         code: 2307,

--- a/tests/tooling/support/real-project-lsp-file-lifecycle.ts
+++ b/tests/tooling/support/real-project-lsp-file-lifecycle.ts
@@ -134,11 +134,10 @@ export async function exerciseAuthoredFileLifecycle(
       currentVersion,
       timeoutMs(),
     );
-    assertMissingModuleDiagnostic(
-      deletedDiagnostics,
-      renamedImporterSource,
-      lifecycle.renamedImportSpecifier,
-    );
+    const renamedImport = lifecycle.renamedImportSpecifier;
+    if (lifecycle.requireDeletedImportDiagnostic ?? true) {
+      assertMissingModuleDiagnostic(deletedDiagnostics, renamedImporterSource, renamedImport);
+    }
     const deletedDefinition = await expectNullResponse(
       session,
       "textDocument/definition",

--- a/tests/tooling/support/real-project-lsp-report.ts
+++ b/tests/tooling/support/real-project-lsp-report.ts
@@ -37,6 +37,7 @@ export type LspAuthoredOracle = {
     markerInsertionAnchor: string;
     markerSymbol: string;
     originalImportSpecifier: string;
+    requireDeletedImportDiagnostic?: boolean;
     renamedFile: string;
     renamedImportSpecifier: string;
   };

--- a/tests/tooling/vue-ecosystem-fixtures.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures.test.ts
@@ -184,7 +184,7 @@ test("Vue ecosystem registry covers the requested projects", () => {
   const registry = readRegistry();
   const ids = new Set(registry.projects.map((project) => project.id));
 
-  assert.equal(registry.schemaVersion, 7);
+  assert.equal(registry.schemaVersion, 8);
   for (const id of requestedFixtures) {
     assert.ok(ids.has(id), `${id} should be registered`);
   }

--- a/tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 16, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 17, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),


### PR DESCRIPTION
## Summary
- stop component-tag definition from falling through to native lookup when its explicit .vue import target has been deleted
- keep open unsaved .vue targets navigable while deleted disk targets resolve to null
- add Hoppscotch as the 17th real-project authored LSP oracle and allow projects without deleted-import TS2307 diagnostics to still ratchet file lifecycle behavior

## Validation
- cargo fmt --all -- --check
- cargo clippy -p vize_maestro --all-targets -- -D warnings
- cargo test -p vize_maestro definition
- CORSA_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules/@typescript/typescript-darwin-arm64/lib/tsc cargo test -p vize_maestro
- node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts
- CORSA_PATH=/Users/nishimura/Code/github.com/ubugeeei/vize/node_modules/@typescript/typescript-darwin-arm64/lib/tsc VIZE_LSP_BIN=/private/tmp/vize-hoppscotch-authored-oracle/target/debug/vize REAL_PROJECT_LSP_TIMEOUT_MS=600000 FIXTURE_SHARD_COUNT=41 FIXTURE_SHARD_INDEX=1 node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved component definition lookup when imported Vue files are deleted.
  - Prevented stale definitions from appearing for missing import targets.
  - Definitions now resolve correctly after the deleted file is reopened.

- **Tests**
  - Added regression coverage for deleted and restored component files.
  - Expanded Vue ecosystem fixture coverage with an additional project.
  - Added support for projects that do not require deleted-import diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->