### PR TITLE
test(davinci): add p2-11 dom corpus lane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,6 +4050,7 @@ dependencies = [
  "oxc_parser",
  "oxc_semantic",
  "oxc_span",
+ "vize_atelier_dom",
  "vize_atelier_sfc",
  "vize_carton",
  "vize_croquis",

--- a/crates/vize_s1_to_s2/Cargo.toml
+++ b/crates/vize_s1_to_s2/Cargo.toml
@@ -44,6 +44,7 @@ davinci_harness = { workspace = true }
 davinci_test_support.workspace = true
 insta = { workspace = true }
 vize_atelier_sfc = { workspace = true }
+vize_atelier_dom = { workspace = true }
 vize_croquis = { workspace = true }
 
 [[bench]]
@@ -52,4 +53,8 @@ harness = false
 
 [[test]]
 name = "davinci_lowering_corpus"
+required-features = ["davinci-differential"]
+
+[[test]]
+name = "davinci_dom_corpus"
 required-features = ["davinci-differential"]

--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
@@ -1,0 +1,214 @@
+//! Davinci P2-11 DOM corpus-runnable entry.
+//!
+//! This is the P1-6/P1-7 lane shape applied to the S2 DOM emitter without
+//! switching the published compiler path: a committed SFC battery is compared
+//! byte-for-byte against the shipped DOM template emitter, and
+//! `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=<dir>` widens the same comparison to every
+//! SFC template block under the fixture root. The canonical fixture root fails
+//! closed unless its gitlink inventory reconciles (see
+//! `davinci_test_support::corpus`).
+
+use std::{collections::BTreeMap, fs};
+
+use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
+use vize_s0::Allocator;
+use vize_s1_to_s2::{EmitError, emit_dom_source};
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "template_only",
+        r#"<template><div class="x">{{ msg }}</div></template>"#,
+    ),
+    (
+        "script_setup",
+        r#"<script setup>const msg = "hi"</script><template><p>{{ msg }}</p></template>"#,
+    ),
+    (
+        "slot_template",
+        r#"<template><Foo><template #default="{ item }"><span>{{ item }}</span></template></Foo></template>"#,
+    ),
+];
+
+#[derive(Default)]
+struct Report {
+    files: u64,
+    parsed: u64,
+    templates: u64,
+    compared: u64,
+    old_error_skips: u64,
+    s2_refusal_count: u64,
+    divergence_count: u64,
+    s2_refusal_reasons: BTreeMap<&'static str, u64>,
+    s2_refusal_samples: BTreeMap<&'static str, Vec<String>>,
+    s2_refusals: Vec<String>,
+    divergences: Vec<String>,
+}
+
+#[test]
+fn dom_emit_agrees_on_sfc_templates() {
+    std::thread::Builder::new()
+        .stack_size(256 * 1024 * 1024)
+        .spawn(dom_emit_agrees_on_sfc_templates_body)
+        .expect("spawn P2-11 DOM corpus thread")
+        .join()
+        .expect("P2-11 DOM corpus thread must not panic");
+}
+
+fn dom_emit_agrees_on_sfc_templates_body() {
+    let mut report = Report::default();
+    for (name, source) in BATTERY {
+        compare_sfc_template(name, source, &mut report);
+    }
+    assert_eq!(report.templates, BATTERY.len() as u64);
+    assert_eq!(report.old_error_skips, 0, "battery old-lane error skips");
+    assert_empty("battery S2 refusals", &report.s2_refusals);
+    assert_empty("battery divergences", &report.divergences);
+
+    let Some(sweep) = davinci_test_support::corpus::resolve_env_sweep() else {
+        eprintln!("VIZE_DAVINCI_DIFFERENTIAL_CORPUS unset: committed battery only");
+        return;
+    };
+    assert!(
+        !sweep.files.is_empty(),
+        "corpus sweep found no .vue files under {}",
+        sweep.root.display()
+    );
+
+    let mut corpus = Report::default();
+    for file in &sweep.files {
+        let Ok(source) = fs::read_to_string(file) else {
+            continue;
+        };
+        let context = file.to_string_lossy();
+        compare_sfc_template(context.as_ref(), &source, &mut corpus);
+    }
+    eprintln!(
+        "davinci DOM corpus sweep: files={} parsed={} templates={} compared={} old_error_skips={} s2_refusals={} divergences={}",
+        corpus.files,
+        corpus.parsed,
+        corpus.templates,
+        corpus.compared,
+        corpus.old_error_skips,
+        corpus.s2_refusal_count,
+        corpus.divergence_count,
+    );
+    eprintln!(
+        "davinci DOM corpus refusal reasons: {:?}",
+        corpus.s2_refusal_reasons
+    );
+    eprintln!(
+        "davinci DOM corpus refusal samples: {:?}",
+        corpus.s2_refusal_samples
+    );
+    assert!(
+        corpus.compared > 0,
+        "a corpus sweep that compares nothing proves nothing"
+    );
+    assert_clean_corpus(&corpus);
+}
+
+fn compare_sfc_template(name: &str, source: &str, report: &mut Report) {
+    report.files += 1;
+    let Ok(descriptor) = parse_sfc(source, SfcParseOptions::default()) else {
+        return;
+    };
+    report.parsed += 1;
+    let Some(template) = descriptor.template.as_ref() else {
+        return;
+    };
+    report.templates += 1;
+
+    let old_allocator = Allocator::new();
+    let (_, errors, old) = vize_atelier_dom::compile_template(&old_allocator, &template.content);
+    if !errors.is_empty() {
+        report.old_error_skips += 1;
+        return;
+    }
+    let old = format!("{}\n{}", old.preamble, old.code);
+
+    let new_allocator = Allocator::new();
+    let new = match emit_dom_source(&new_allocator, &template.content) {
+        Ok(emit) => emit.assembled(),
+        Err(error) => {
+            report.s2_refusal_count += 1;
+            let reason = refusal_reason(&error);
+            *report.s2_refusal_reasons.entry(reason).or_default() += 1;
+            let samples = report.s2_refusal_samples.entry(reason).or_default();
+            if samples.len() < 5 {
+                samples.push(format!("{name}: {error:?}"));
+            }
+            if report.s2_refusals.len() < 20 {
+                report.s2_refusals.push(format!("{name}: {error:?}"));
+            }
+            return;
+        }
+    };
+
+    report.compared += 1;
+    if old != new {
+        report.divergence_count += 1;
+        if report.divergences.len() < 20 {
+            report.divergences.push(format!(
+                "{name}: old_len={} new_len={} first_diff={} old_window={} new_window={}",
+                old.len(),
+                new.len(),
+                first_diff(&old, &new),
+                mismatch_window(&old, &new),
+                mismatch_window(&new, &old)
+            ));
+        }
+    }
+}
+
+fn refusal_reason(error: &EmitError) -> &'static str {
+    error.reason().map_or("diagnostics", |reason| reason.code())
+}
+
+fn preview(source: &str) -> String {
+    source
+        .lines()
+        .take(4)
+        .collect::<Vec<_>>()
+        .join("\\n")
+        .chars()
+        .take(320)
+        .collect()
+}
+
+fn first_diff(left: &str, right: &str) -> usize {
+    left.as_bytes()
+        .iter()
+        .zip(right.as_bytes())
+        .position(|(left, right)| left != right)
+        .unwrap_or_else(|| left.len().min(right.len()))
+}
+
+fn mismatch_window(source: &str, other: &str) -> String {
+    let diff = first_diff(source, other);
+    let start = source[..diff]
+        .char_indices()
+        .rev()
+        .nth(80)
+        .map_or(0, |(index, _)| index);
+    let end = source[diff..]
+        .char_indices()
+        .nth(180)
+        .map_or(source.len(), |(index, _)| diff + index);
+    preview(&source[start..end])
+}
+
+fn assert_empty(label: &str, values: &[String]) {
+    assert!(values.is_empty(), "{label}:\n{}", values.join("\n"));
+}
+
+fn assert_clean_corpus(report: &Report) {
+    assert!(
+        report.s2_refusal_count == 0 && report.divergence_count == 0,
+        "corpus S2 refusals ({}) by reason {:?}:\n{}\n\ncorpus divergences ({}):\n{}",
+        report.s2_refusal_count,
+        report.s2_refusal_reasons,
+        report.s2_refusals.join("\n"),
+        report.divergence_count,
+        report.divergences.join("\n"),
+    );
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           916 |                   432 |               484 |             140 |     371 |             939 |      488 |           484 |           594 |
+| Compiler                   |           916 |                   432 |               484 |             140 |     371 |             939 |      488 |           484 |           595 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |


### PR DESCRIPTION
Summary:
- Add an env-gated S2 DOM versus shipped DOM corpus comparison lane for Davinci P2-11.
- Keep the default CI path small with a committed SFC battery, while allowing hydrated corpus sweeps through VIZE_DAVINCI_DIFFERENTIAL_CORPUS.
- Group S2 refusal counts and samples so residual work can be routed by reason.

Verification:
- cargo fmt --all --check
- cargo test -p vize_s1_to_s2 --test davinci_dom_corpus --features davinci-differential -- --nocapture
- node --test tests/tooling/davinci-assertion-lint.test.ts
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=/Users/ubugeeei/Source/github.com/ubugeeei/vize--p2-9-corpus/tests/_fixtures/_git cargo test -p vize_s1_to_s2 --test davinci_dom_corpus --features davinci-differential -- --nocapture (expected fail-close residual: files=41580 parsed=41580 templates=41223 compared=38280 old_error_skips=2867 s2_refusals=76 divergences=25695)
- git diff --check HEAD~1