### PR TITLE
fix(davinci): keep slot text facts aligned

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_text_facts.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_text_facts.rs
@@ -1,0 +1,37 @@
+//! P2-11 text-fact id witnesses for component slot children.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "slot_element_compound_with_static_tail",
+        r#"<Foo><strong>{{ points }} points</strong></Foo>"#,
+    ),
+    (
+        "once_static_slot_sibling_before_compound_text",
+        r#"<Foo v-once><i>x</i><span>{{ points }} points</span></Foo>"#,
+    ),
+    (
+        "conditional_slot_template_compound_text",
+        r#"<Foo><template v-if="layout === 'grid' || position === 'inside'" #files-top="{ files }"><div v-if="files?.length"><p>Files ({{ files?.length }})</p></div></template></Foo>"#,
+    ),
+    (
+        "slot_element_compound_with_quoted_interp",
+        r#"<Foo><div v-if="searchValue.length"><span>Add "{{ searchValue }}" as a new Client</span></div></Foo>"#,
+    ),
+    (
+        "component_slot_root_compound_text",
+        r#"<VbCard><va-hover #default="{ hover }"><div>slot - {{ hover }}</div></va-hover></VbCard>"#,
+    ),
+];
+
+#[test]
+fn s2_text_fact_ids_match_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_s1_to_s2/src/emit/once.rs
+++ b/crates/vize_s1_to_s2/src/emit/once.rs
@@ -7,7 +7,7 @@ use vize_s2::op::{BindingOp, ComponentOp, ElementOp, Op};
 use super::buf::Buf;
 use super::builtin;
 use super::directive;
-use super::hoist::{emit_hoisted_element, is_hoistable};
+use super::hoist::is_hoistable;
 use super::js::asset_ident;
 use super::vnode;
 use super::{EmitCx, EmitError};
@@ -131,6 +131,7 @@ pub(super) fn emit_hoisted_child(
     if cx.once_depth == 0 || !is_hoistable(element) {
         return Ok(false);
     }
-    emit_hoisted_element(cx, element)?;
+    let alias = super::hoist::hoist_static_element(cx, element);
+    cx.buf.push(alias.as_str());
     Ok(true)
 }

--- a/crates/vize_s1_to_s2/src/pass/vslot/consume.rs
+++ b/crates/vize_s1_to_s2/src/pass/vslot/consume.rs
@@ -100,10 +100,15 @@ pub(super) enum ChildKind {
     /// answer the extraneous-children diagnostic reads (the legacy
     /// `has_implicit_child`): `false` for a slot-carrying non-template
     /// element or component, `true` otherwise, and for `ui.if`/`ui.for`
-    /// the recursive any-branch answer.
+    /// the recursive any-branch answer. `default_slot` is the shared
+    /// implicit-default predicate: component children that own their
+    /// own `v-slot` still belong to the parent default slot, but a
+    /// structural slot-template carrier does not.
     Content {
         /// Whether the child counts for the extraneous diagnostic.
         implicit: bool,
+        /// Whether the child synthesizes the parent default slot group.
+        default_slot: bool,
     },
 }
 
@@ -116,9 +121,12 @@ fn region_implicit(views: &[ChildView]) -> bool {
     let mut slot_templates = 0usize;
     for view in views {
         match &view.kind {
-            ChildKind::Content { implicit: true } => return true,
+            ChildKind::Content { implicit: true, .. } => return true,
             ChildKind::SlotTemplate(_) => slot_templates += 1,
-            ChildKind::Content { implicit: false } | ChildKind::Filler => {}
+            ChildKind::Content {
+                implicit: false, ..
+            }
+            | ChildKind::Filler => {}
         }
     }
     slot_templates > 1
@@ -130,20 +138,48 @@ fn has_slot_template(views: &[ChildView]) -> bool {
         .any(|view| matches!(view.kind, ChildKind::SlotTemplate(_)))
 }
 
+fn region_default_slot(views: &[ChildView]) -> bool {
+    views.iter().any(|view| {
+        matches!(
+            view.kind,
+            ChildKind::Content {
+                default_slot: true,
+                ..
+            }
+        )
+    })
+}
+
+fn branch_from_template(wrapper: Option<&WrapperKeys>, branch_index: usize) -> bool {
+    wrapper
+        .and_then(|keys| keys.from_template.get(branch_index).copied())
+        .unwrap_or(false)
+}
+
 fn if_branch_implicit(
     wrapper: Option<&WrapperKeys>,
     branch_index: usize,
     views: &[ChildView],
 ) -> bool {
     region_implicit(views)
-        || (wrapper
-            .and_then(|keys| keys.from_template.get(branch_index).copied())
-            .unwrap_or(false)
-            && has_slot_template(views))
+        || (branch_from_template(wrapper, branch_index) && has_slot_template(views))
+}
+
+fn if_branch_default_slot(
+    wrapper: Option<&WrapperKeys>,
+    branch_index: usize,
+    views: &[ChildView],
+) -> bool {
+    region_default_slot(views)
+        || (branch_from_template(wrapper, branch_index) && has_slot_template(views))
 }
 
 fn for_region_implicit(from_template: bool, views: &[ChildView]) -> bool {
     region_implicit(views) || (from_template && has_slot_template(views))
+}
+
+fn for_region_default_slot(from_template: bool, views: &[ChildView]) -> bool {
+    region_default_slot(views) || (from_template && has_slot_template(views))
 }
 
 /// Visit one region's ops in page order, returning their views.
@@ -186,6 +222,7 @@ fn visit<'a>(walk: &mut PageWalk, channels: &mut Channels<'_>, op: &Op<'a>) -> C
                 // it is content for the implicit default.
                 ChildKind::Content {
                     implicit: slots.is_empty(),
+                    default_slot: true,
                 }
             };
             ChildView {
@@ -209,7 +246,10 @@ fn visit<'a>(walk: &mut PageWalk, channels: &mut Channels<'_>, op: &Op<'a>) -> C
             ChildView {
                 id,
                 span: component.span,
-                kind: ChildKind::Content { implicit },
+                kind: ChildKind::Content {
+                    implicit,
+                    default_slot: true,
+                },
             }
         }
         Op::Text(text) => ChildView {
@@ -218,25 +258,36 @@ fn visit<'a>(walk: &mut PageWalk, channels: &mut Channels<'_>, op: &Op<'a>) -> C
             kind: if text.content.trim().is_empty() {
                 ChildKind::Filler
             } else {
-                ChildKind::Content { implicit: true }
+                ChildKind::Content {
+                    implicit: true,
+                    default_slot: true,
+                }
             },
         },
         Op::Interpolation(interpolation) => ChildView {
             id,
             span: interpolation.span,
-            kind: ChildKind::Content { implicit: true },
+            kind: ChildKind::Content {
+                implicit: true,
+                default_slot: true,
+            },
         },
         Op::If(if_op) => {
             let wrapper = id.and_then(|id| channels.wrappers.get(id));
             let mut implicit = false;
+            let mut default_slot = false;
             for (branch_index, branch) in if_op.branches.iter().enumerate() {
                 let views = region(walk, channels, &branch.region.ops);
                 implicit |= if_branch_implicit(wrapper, branch_index, &views);
+                default_slot |= if_branch_default_slot(wrapper, branch_index, &views);
             }
             ChildView {
                 id,
                 span: if_op.span,
-                kind: ChildKind::Content { implicit },
+                kind: ChildKind::Content {
+                    implicit,
+                    default_slot,
+                },
             }
         }
         Op::For(for_op) => {
@@ -247,6 +298,7 @@ fn visit<'a>(walk: &mut PageWalk, channels: &mut Channels<'_>, op: &Op<'a>) -> C
                 span: for_op.span,
                 kind: ChildKind::Content {
                     implicit: for_region_implicit(from_template, &views),
+                    default_slot: for_region_default_slot(from_template, &views),
                 },
             }
         }
@@ -269,7 +321,10 @@ fn visit<'a>(walk: &mut PageWalk, channels: &mut Channels<'_>, op: &Op<'a>) -> C
             ChildView {
                 id,
                 span: slot.span,
-                kind: ChildKind::Content { implicit: true },
+                kind: ChildKind::Content {
+                    implicit: true,
+                    default_slot: true,
+                },
             }
         }
     }

--- a/crates/vize_s1_to_s2/src/pass/vslot/group.rs
+++ b/crates/vize_s1_to_s2/src/pass/vslot/group.rs
@@ -4,10 +4,10 @@
 //!
 //! The two halves keep the legacy lane's two distinct predicates
 //! deliberately: **grouping** synthesizes the implicit default from
-//! `Content { implicit: true }` only (so a kept `<template v-if
-//! v-slot>` under `ui.if` does not become a default group — P2-11
-//! `createSlots` owns that child), while the **extraneous** diagnostic
-//! uses the same descending answer the legacy `has_implicit_child`
+//! the shared default-slot predicate (a component that owns its own
+//! `v-slot` is still content for the parent default slot; a structural
+//! slot-template carrier is not), while the **extraneous** diagnostic
+//! uses the narrower descending answer the legacy `has_implicit_child`
 //! computed. The structural-directive duplicate guard is vacuous here:
 //! the carrier sits under `ui.if` / `ui.for` and never reaches this
 //! grouping as a `SlotTemplate` child.
@@ -106,9 +106,15 @@ fn collect(
         }
     }
 
-    let has_content = children
-        .iter()
-        .any(|child| matches!(child.kind, ChildKind::Content { implicit: true }));
+    let has_content = children.iter().any(|child| {
+        matches!(
+            child.kind,
+            ChildKind::Content {
+                default_slot: true,
+                ..
+            }
+        )
+    });
     if own.is_empty() && has_content && !groups.iter().any(|group| group.name.text() == "default") {
         channels.provenance.push(ProvenanceRecord {
             rule: String::from(RULE_IMPLICIT_DEFAULT),
@@ -189,12 +195,15 @@ fn validate(
                 }
                 seen.push(text);
             }
-            ChildKind::Content { implicit: true } => {
+            ChildKind::Content { implicit: true, .. } => {
                 if first_implicit.is_none() {
                     first_implicit = Some(child.span);
                 }
             }
-            ChildKind::Content { implicit: false } | ChildKind::Filler => {}
+            ChildKind::Content {
+                implicit: false, ..
+            }
+            | ChildKind::Filler => {}
         }
     }
     if has_template_slots

--- a/crates/vize_s1_to_s2/tests/vslot_pass.rs
+++ b/crates/vize_s1_to_s2/tests/vslot_pass.rs
@@ -143,6 +143,36 @@ fn the_implicit_default_group_is_synthesized_from_non_slot_content() {
 }
 
 #[test]
+fn a_slot_bearing_component_child_still_synthesizes_the_parent_default() {
+    // `collect_slots` excludes only direct `<template v-slot>` carriers
+    // from the default slot. A component that owns its own `v-slot`
+    // remains a normal VNode child of the parent component.
+    let source = r#"<Card><Child v-slot="row"><span>{{ row }}</span></Child></Card>"#;
+    with_transformed(source, |lowered, _, facts, _| {
+        assert_eq!(lowered.diagnostics, vec![]);
+        let entries = facts.slot_facts.sorted_entries();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].0, id(0));
+        assert_eq!(
+            entries[0].1.groups,
+            vec![SlotGroup {
+                name: SlotName::Static {
+                    text: "default".into(),
+                    origin: ScopeOrigin::Synthesized {
+                        rule: RULE_IMPLICIT_DEFAULT.into(),
+                    },
+                },
+                params: SlotParams::Absent,
+                carrier: SlotCarrier::Implicit,
+            }]
+        );
+        assert_eq!(entries[1].0, id(1));
+        assert_eq!(entries[1].1.groups[0].carrier, SlotCarrier::Component);
+    });
+    assert_transformed_sound(source, "slot-bearing-component-child");
+}
+
+#[test]
 fn a_slot_prop_never_captures_an_outer_authored_binding() {
     // The hygiene pin across the slot boundary: the same spelling in a
     // v-for scope outside and a slot-props scope inside stays two

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           916 |                   432 |               484 |             140 |     371 |             939 |      488 |           484 |           596 |
+| Compiler                   |           916 |                   432 |               484 |             140 |     371 |             939 |      488 |           484 |           597 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |


### PR DESCRIPTION
## Summary
- keep compound slot text facts attached to the emitted default-slot path, including slot-bearing component children
- fix `v-once` static-child hoist emission so child aliases are not double-minted
- split slot child presence from default-slot synthesis so structural named-slot carriers do not invent default groups
- add DOM parity witnesses for slot compound text, quoted interpolations, conditional named-slot carriers, component slot roots, and once-wrapped static siblings
- refresh the generated Davinci consumer-migration inventory after the new witness file

## Tests
- cargo fmt --all --check
- git diff --check origin/main...HEAD
- node --test tests/tooling/davinci-matrices.test.ts
- cargo test -p vize_s1_to_s2 --test vslot_pass --test emit_slots --test emit_create_slots -- --nocapture
- cargo test -p vize_atelier_core --test davinci_s2_transform --features vize_s1_to_s2/davinci-differential -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_create_slots_wrappers --test vslot_pass -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_text_facts --test davinci_s2_once --features vize_s1_to_s2/davinci-differential -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_create_slots --test emit_slots --test davinci_dom_corpus --features davinci-differential -- --nocapture

## Notes
- Local full-corpus closure could not run because this worktree has unhydrated fixture gitlinks; the GitHub Actions lane is the closure gate.
- `node --test tests/tooling/source-file-lengths.test.ts` still hits the local MoonBit lexscan issue in `.mooncakes/moonbitlang/x/path/win32/path.mbt`; CI covers the source-length gate.