### PR TITLE
test(davinci): pin v-memo patch flags

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_memo.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_memo.rs
@@ -9,6 +9,9 @@
 
 mod support;
 
+use vize_s0::Allocator;
+use vize_s1_to_s2::emit_dom_source;
+
 const BATTERY: &[(&str, &str)] = &[
     ("native_text", r#"<div v-memo="[id]">x</div>"#),
     (
@@ -51,7 +54,84 @@ const BATTERY: &[(&str, &str)] = &[
     ),
 ];
 
+struct PatchCase {
+    name: &'static str,
+    src: &'static str,
+    sites: &'static [&'static str],
+}
+
+const PATCH_CASES: &[PatchCase] = &[
+    PatchCase {
+        name: "native_text",
+        src: r#"<div v-memo="[id]">x</div>"#,
+        sites: &[],
+    },
+    PatchCase {
+        name: "native_interpolation",
+        src: r#"<div v-memo="[id]">{{ msg }}</div>"#,
+        sites: &["1 /* TEXT */"],
+    },
+    PatchCase {
+        name: "native_dynamic_prop_keeps_array_only",
+        src: r#"<div v-memo="[id]" :id="id">{{ msg }}</div>"#,
+        sites: &["1 /* TEXT */"],
+    },
+    PatchCase {
+        name: "component_root",
+        src: r#"<Foo v-memo="[prop]" :prop="prop" />"#,
+        sites: &["8 /* PROPS */, [\"prop\"]"],
+    },
+    PatchCase {
+        name: "native_v_for",
+        src: r#"<div v-for="item in items" :key="item.id" v-memo="[item.selected]">{{ item.name }}</div>"#,
+        sites: &["1 /* TEXT */", "128 /* KEYED_FRAGMENT */"],
+    },
+    PatchCase {
+        name: "component_v_for",
+        src: r#"<Foo v-for="item in items" :key="item.id" v-memo="[item.selected]" :prop="item.prop" />"#,
+        sites: &["8 /* PROPS */, [\"prop\"]", "128 /* KEYED_FRAGMENT */"],
+    },
+    PatchCase {
+        name: "unkeyed_v_for",
+        src: r#"<div v-for="item in items" v-memo="[item.selected]">{{ item.name }}</div>"#,
+        sites: &["1 /* TEXT */", "256 /* UNKEYED_FRAGMENT */"],
+    },
+];
+
 #[test]
 fn s2_v_memo_matches_the_shipped_dom_lane_byte_for_byte() {
     support::assert_s2_matches_shipped(BATTERY);
+}
+
+#[test]
+fn s2_v_memo_patch_flags_match_the_shipped_dom_lane_per_node() {
+    let battery: Vec<_> = PATCH_CASES
+        .iter()
+        .map(|case| (case.name, case.src))
+        .collect();
+    support::assert_s2_matches_shipped(&battery);
+
+    let mut mismatches = Vec::new();
+    for case in PATCH_CASES {
+        let expected: Vec<_> = case.sites.iter().map(|site| site.to_string()).collect();
+        let old = support::shipped(case.src);
+        let allocator = Allocator::new();
+        let new = emit_dom_source(&allocator, case.src)
+            .unwrap_or_else(|error| panic!("{}: S2 emit refused: {error:?}", case.name))
+            .assembled();
+        let old_sites = support::patch_sites(&old);
+        let new_sites = support::patch_sites(&new);
+
+        if old_sites != expected || new_sites != expected {
+            mismatches.push(format!(
+                "{}: expected={expected:?} old={old_sites:?} new={new_sites:?}",
+                case.name
+            ));
+        }
+    }
+    assert!(
+        mismatches.is_empty(),
+        "v-memo patch flag mismatches:\n{}",
+        mismatches.join("\n")
+    );
 }

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           916 |                   432 |               484 |             140 |     371 |             939 |      488 |           484 |           597 |
+| Compiler                   |           918 |                   434 |               484 |             140 |     371 |             939 |      490 |           485 |           597 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
@@ -61,10 +61,10 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          21 |               4 |       17 |
-| S0               |         840 |             477 |      363 |
+| S0               |         841 |             477 |      364 |
 | S1               |           5 |               1 |        4 |
 | S2               |          15 |               1 |       14 |
-| S1->S2           |          35 |               2 |       33 |
+| S1->S2           |          36 |               2 |       34 |
 | old AST/parser   |          75 |              55 |       20 |
 | Croquis analysis |          65 |              56 |        9 |
 | raw OXC          |         371 |             343 |       28 |
@@ -91,7 +91,7 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | `crates/vize_atelier_sfc/src/compile_script/props/tests.rs:4` | test/dev | S0 15                                         |    15 |
 | `crates/vize_atelier_core/tests/s2_support/compare.rs:10`     | test/dev | Davinci 2<br>S0 4<br>S1 1<br>S2 1<br>S1->S2 3 |    11 |
 
-Additional test/dev rows are in the TSV: 201 omitted.
+Additional test/dev rows are in the TSV: 202 omitted.
 
 ### Linter
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -290,6 +290,8 @@ compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_dynamic_von_
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_filters.rs	12	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_html.rs	12	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_html.rs	12	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_memo.rs	12	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_memo.rs	12	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_outlets.rs	14	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	2


### PR DESCRIPTION
## Summary
- add a P2-11 S2-vs-shipped patch-site witness for v-memo
- pin v-memo TEXT/PROPS/fragment flags across native, component, keyed, and unkeyed forms
- refresh the generated Davinci consumer migration surface inventory for the new test imports

## Tests
- cargo test -p vize_atelier_dom --test davinci_s2_memo
- cargo fmt --all -- --check
- cargo clippy -p vize_atelier_dom --test davinci_s2_memo -- -D warnings
- node --test tests/tooling/davinci-matrices.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

## Notes
- test/generated-docs only; no production behavior change