### PR TITLE
test(davinci): pin v-once patch flag sites

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_once.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_once.rs
@@ -9,32 +9,97 @@
 
 mod support;
 
-const BATTERY: &[(&str, &str)] = &[
-    ("simple", r#"<div v-once>x</div>"#),
-    ("interpolation", r#"<div v-once>{{ msg }}</div>"#),
-    ("dynamic_class", r#"<div v-once :class="cls">content</div>"#),
-    (
-        "dynamic_style",
-        r#"<div v-once :style="style">content</div>"#,
-    ),
-    ("nested_static", r#"<div v-once><span>x</span></div>"#),
-    (
-        "nested_dynamic",
-        r#"<div v-once><span :class="cls">{{ msg }}</span></div>"#,
-    ),
-    ("v_if_branch", r#"<div v-if="ok" v-once>x</div>"#),
-    ("component", r#"<Foo v-once />"#),
-    (
-        "component_with_props_and_slot",
-        r#"<Foo v-once :title="title"><span>x</span></Foo>"#,
-    ),
-    (
-        "inside_v_for",
-        r#"<div v-for="item in items" :key="item.id"><span v-once>{{ item.static }}</span></div>"#,
-    ),
+use vize_s0::Allocator;
+use vize_s1_to_s2::emit_dom_source;
+
+struct Case {
+    name: &'static str,
+    src: &'static str,
+    sites: &'static [&'static str],
+}
+
+const CASES: &[Case] = &[
+    Case {
+        name: "simple",
+        src: r#"<div v-once>x</div>"#,
+        sites: &[],
+    },
+    Case {
+        name: "interpolation",
+        src: r#"<div v-once>{{ msg }}</div>"#,
+        sites: &["1 /* TEXT */"],
+    },
+    Case {
+        name: "dynamic_class",
+        src: r#"<div v-once :class="cls">content</div>"#,
+        sites: &["2 /* CLASS */"],
+    },
+    Case {
+        name: "dynamic_style",
+        src: r#"<div v-once :style="style">content</div>"#,
+        sites: &["4 /* STYLE */"],
+    },
+    Case {
+        name: "nested_static",
+        src: r#"<div v-once><span>x</span></div>"#,
+        sites: &[],
+    },
+    Case {
+        name: "nested_dynamic",
+        src: r#"<div v-once><span :class="cls">{{ msg }}</span></div>"#,
+        sites: &["3 /* TEXT, CLASS */"],
+    },
+    Case {
+        name: "v_if_branch",
+        src: r#"<div v-if="ok" v-once>x</div>"#,
+        sites: &[],
+    },
+    Case {
+        name: "component",
+        src: r#"<Foo v-once />"#,
+        sites: &[],
+    },
+    Case {
+        name: "component_with_props_and_slot",
+        src: r#"<Foo v-once :title="title"><span>x</span></Foo>"#,
+        sites: &[],
+    },
+    Case {
+        name: "inside_v_for",
+        src: r#"<div v-for="item in items" :key="item.id"><span v-once>{{ item.static }}</span></div>"#,
+        sites: &["1 /* TEXT */", "128 /* KEYED_FRAGMENT */"],
+    },
 ];
 
 #[test]
 fn s2_v_once_matches_the_shipped_dom_lane_byte_for_byte() {
-    support::assert_s2_matches_shipped(BATTERY);
+    let battery: Vec<_> = CASES.iter().map(|case| (case.name, case.src)).collect();
+    support::assert_s2_matches_shipped(&battery);
+}
+
+#[test]
+fn s2_v_once_patch_flags_match_the_shipped_dom_lane_per_node() {
+    let mut mismatches = Vec::new();
+    for case in CASES {
+        let expected: Vec<_> = case.sites.iter().map(|site| site.to_string()).collect();
+        let old = support::shipped(case.src);
+        let allocator = Allocator::new();
+        let new = emit_dom_source(&allocator, case.src)
+            .unwrap_or_else(|error| panic!("{}: S2 emit refused: {error:?}", case.name))
+            .assembled();
+        let old_sites = support::patch_sites(&old);
+        let new_sites = support::patch_sites(&new);
+
+        if old_sites != expected || new_sites != expected {
+            mismatches.push(format!(
+                "{}: expected={expected:?} old={old_sites:?} new={new_sites:?}",
+                case.name
+            ));
+        }
+    }
+    assert!(
+        mismatches.is_empty(),
+        "v-once patch flag mismatches:\n{}",
+        mismatches.join("\n")
+    );
 }

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           918 |                   434 |               484 |             140 |     371 |             939 |      490 |           485 |           597 |
+| Compiler                   |           920 |                   436 |               484 |             140 |     371 |             939 |      492 |           486 |           597 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
@@ -61,10 +61,10 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          21 |               4 |       17 |
-| S0               |         841 |             477 |      364 |
+| S0               |         842 |             477 |      365 |
 | S1               |           5 |               1 |        4 |
 | S2               |          15 |               1 |       14 |
-| S1->S2           |          36 |               2 |       34 |
+| S1->S2           |          37 |               2 |       35 |
 | old AST/parser   |          75 |              55 |       20 |
 | Croquis analysis |          65 |              56 |        9 |
 | raw OXC          |         371 |             343 |       28 |
@@ -91,7 +91,7 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | `crates/vize_atelier_sfc/src/compile_script/props/tests.rs:4` | test/dev | S0 15                                         |    15 |
 | `crates/vize_atelier_core/tests/s2_support/compare.rs:10`     | test/dev | Davinci 2<br>S0 4<br>S1 1<br>S2 1<br>S1->S2 3 |    11 |
 
-Additional test/dev rows are in the TSV: 202 omitted.
+Additional test/dev rows are in the TSV: 203 omitted.
 
 ### Linter
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -292,6 +292,8 @@ compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_html.rs	12	s
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_html.rs	12	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_memo.rs	12	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_memo.rs	12	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_once.rs	12	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_once.rs	12	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_outlets.rs	14	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	2


### PR DESCRIPTION
Summary
- add per-node patch flag site assertions to the existing Davinci v-once DOM parity witness
- keep the change test-only with no production behavior change

Verification
- cargo fmt --all --check
- cargo check -p vize_atelier_dom --tests --features vize_s1_to_s2/davinci-differential
- cargo test -p vize_atelier_dom --test davinci_s2_once --test davinci_s2_patch_flags --test davinci_s2_recent_patch_flags --features vize_s1_to_s2/davinci-differential -- --nocapture
- git diff --check
- wc -l crates/vize_atelier_dom/tests/davinci_s2_once.rs

Note
- node --test tests/tooling/source-file-lengths.test.ts was also attempted locally, but the local MoonBit toolchain fails while compiling tools/moon/.mooncakes/moonbitlang/x/path/win32/path.mbt before this test-only file can be assessed. The changed file is 105 lines.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790690113&installation_model_id=422833&pr_number=5400&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5400&signature=10a53a7538aa7f776fc3fc55c01b244d328b380aef3076e08a620dee34f28a57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for DOM patch generation across multiple scenarios.
  * Added validation to ensure emitted patch locations match the shipped DOM behavior.

* **Documentation**
  * Updated the consumer migration inventory with revised compiler totals and test/development surface counts.
  * Refreshed reported migration-site and omitted-row totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->