### PR TITLE
test(davinci): run dom corpus lane in ci

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -383,7 +383,7 @@ jobs:
         run: npm install --global @pkl-community/pkl@0.27.2
       - name: Test
         env: { VIZE_TEST_REQUIRE_TSGO: "1" }
-        run: cargo test --workspace && cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus -- --nocapture && cargo test -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli && cargo test -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 && cargo test -p vize_vitrine --no-default-features --features wasm
+        run: cargo test --workspace && cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus -- --nocapture && cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture && cargo test -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli && cargo test -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 && cargo test -p vize_vitrine --no-default-features --features wasm
   coverage:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30

--- a/tests/tooling/davinci-lowering-ci-lane.test.ts
+++ b/tests/tooling/davinci-lowering-ci-lane.test.ts
@@ -3,10 +3,12 @@ import { test } from "node:test";
 
 import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
 
-const ts20LoweringCorpusCommand =
+const s1ToS2LoweringCorpusCommand =
   "cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus -- --nocapture";
+const s1ToS2DomCorpusCommand =
+  "cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture";
 
-test("TS-20 lowering corpus lane rides the required clippy-and-test job", () => {
+test("feature-gated S1-to-S2 corpus lanes ride the required clippy-and-test job", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
   const clippyJob = workflowJobBody(workflow, "clippy-and-test");
   const testReportJob = workflowJobBody(workflow, "test-report");
@@ -14,10 +16,15 @@ test("TS-20 lowering corpus lane rides the required clippy-and-test job", () => 
   const suites = readRepoFile("davinci-road", "plan", "test-suites.md");
 
   assert.match(suites, /\| TS-20 \| Lowering totality fuzz\s+\| `cargo test -p vize_s1_to_s2`/);
-  assert.match(
-    manifest,
-    /^\[\[test\]\]\nname = "davinci_lowering_corpus"\nrequired-features = \["davinci-differential"\]$/m,
-  );
+  for (const name of ["davinci_lowering_corpus", "davinci_dom_corpus"]) {
+    assert.match(
+      manifest,
+      new RegExp(
+        `^\\[\\[test\\]\\]\\nname = "${name}"\\nrequired-features = \\["davinci-differential"\\]$`,
+        "m",
+      ),
+    );
+  }
 
   assert.doesNotMatch(
     clippyJob,
@@ -27,7 +34,11 @@ test("TS-20 lowering corpus lane rides the required clippy-and-test job", () => 
   assert.match(testReportJob, /- clippy-and-test\b/);
   assert.match(clippyJob, /run: cargo test --workspace && /);
   assert.ok(
-    clippyJob.includes(ts20LoweringCorpusCommand),
-    "the feature-gated TS-20 corpus entry must run explicitly after cargo test --workspace",
+    clippyJob.includes(s1ToS2LoweringCorpusCommand),
+    "the feature-gated lowering corpus entry must run explicitly after cargo test --workspace",
+  );
+  assert.ok(
+    clippyJob.includes(s1ToS2DomCorpusCommand),
+    "the feature-gated DOM corpus entry must run explicitly after cargo test --workspace",
   );
 });


### PR DESCRIPTION
## Summary
- run the feature-gated S1-to-S2 DOM corpus explicitly in the required PR check job
- extend the workflow guard so both S1-to-S2 corpus lanes stay wired into CI

## Validation
- node --test tests/tooling/davinci-lowering-ci-lane.test.ts
- git diff --check origin/main...HEAD && git diff --check

The heavier corpus command is intentionally validated by GitHub Actions.