### PR TITLE
test(davinci): pin slot outlet patch sites

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_outlets.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_outlets.rs
@@ -11,7 +11,15 @@
 
 mod support;
 
+use vize_s0::Allocator;
 use vize_s0::config::VueVersion;
+use vize_s1_to_s2::emit_dom_source;
+
+struct Case {
+    name: &'static str,
+    src: &'static str,
+    sites: &'static [&'static str],
+}
 
 const BATTERY: &[(&str, &str)] = &[
     ("bare", "<slot></slot>"),
@@ -130,6 +138,125 @@ const BATTERY: &[(&str, &str)] = &[
 #[test]
 fn s2_slot_outlets_match_the_shipped_dom_lane_byte_for_byte() {
     support::assert_s2_matches_shipped(BATTERY);
+}
+
+const PATCH_SITE_CASES: &[Case] = &[
+    Case {
+        name: "dynamic_name",
+        src: r#"<slot :name="n"></slot>"#,
+        sites: &[],
+    },
+    Case {
+        name: "bind_prop",
+        src: r#"<slot :foo="bar"></slot>"#,
+        sites: &[],
+    },
+    Case {
+        name: "dynamic_event",
+        src: r#"<slot @[event]="handler"></slot>"#,
+        sites: &[],
+    },
+    Case {
+        name: "dynamic_prop_and_dynamic_event",
+        src: r#"<slot :[propKey]="value" @[event]="handler"></slot>"#,
+        sites: &[],
+    },
+    Case {
+        name: "object_bind",
+        src: r#"<slot v-bind="obj"></slot>"#,
+        sites: &[],
+    },
+    Case {
+        name: "object_on_modifier",
+        src: r#"<slot v-on.once="listeners"></slot>"#,
+        sites: &[],
+    },
+    Case {
+        name: "vif",
+        src: r#"<slot v-if="ok"></slot>"#,
+        sites: &[],
+    },
+    Case {
+        name: "vif_else",
+        src: r#"<slot v-if="a"></slot><slot v-else></slot>"#,
+        sites: &[],
+    },
+    Case {
+        name: "vfor",
+        src: r#"<slot v-for="i in n"></slot>"#,
+        sites: &["256 /* UNKEYED_FRAGMENT */"],
+    },
+    Case {
+        name: "vfor_dynamic_event_local_name",
+        src: r#"<slot v-for="item in items" @[item.event]="item.handler"></slot>"#,
+        sites: &["256 /* UNKEYED_FRAGMENT */"],
+    },
+    Case {
+        name: "forwarded",
+        src: "<Foo><slot></slot></Foo>",
+        sites: &["3 /* FORWARDED */"],
+    },
+    Case {
+        name: "forwarded_nested",
+        src: "<Foo><div><slot></slot></div></Foo>",
+        sites: &["3 /* FORWARDED */"],
+    },
+    Case {
+        name: "scoped_forwarded",
+        src: r#"<Bar v-slot="p"><Foo><slot></slot></Foo></Bar>"#,
+        sites: &[
+            "2 /* DYNAMIC */",
+            "1024 /* DYNAMIC_SLOTS */",
+            "3 /* FORWARDED */",
+        ],
+    },
+    Case {
+        name: "scoped_forwarded_dynamic_event",
+        src: r#"<Bar v-slot="{ row }"><Foo><slot @[row.event]="row.handler"></slot></Foo></Bar>"#,
+        sites: &[
+            "2 /* DYNAMIC */",
+            "1024 /* DYNAMIC_SLOTS */",
+            "3 /* FORWARDED */",
+        ],
+    },
+    Case {
+        name: "named_mixed_props",
+        src: r#"<slot name="header" foo="1" :bar="b"></slot>"#,
+        sites: &[],
+    },
+];
+
+#[test]
+fn s2_slot_outlet_patch_sites_match_the_shipped_dom_lane_per_node() {
+    let battery: Vec<_> = PATCH_SITE_CASES
+        .iter()
+        .map(|case| (case.name, case.src))
+        .collect();
+    support::assert_s2_matches_shipped(&battery);
+
+    let mut mismatches = Vec::new();
+    for case in PATCH_SITE_CASES {
+        let expected: Vec<_> = case.sites.iter().map(|site| site.to_string()).collect();
+        let old = support::shipped(case.src);
+        let allocator = Allocator::new();
+        let new = emit_dom_source(&allocator, case.src)
+            .unwrap_or_else(|error| panic!("{}: S2 emit refused: {error:?}", case.name))
+            .assembled();
+        let old_sites = support::patch_sites(&old);
+        let new_sites = support::patch_sites(&new);
+
+        if old_sites != expected || new_sites != expected {
+            mismatches.push(format!(
+                "{}: expected={expected:?} old={old_sites:?} new={new_sites:?}",
+                case.name
+            ));
+        }
+    }
+    assert!(
+        mismatches.is_empty(),
+        "slot outlet patch site mismatches:\n{}",
+        mismatches.join("\n")
+    );
 }
 
 const VUE2_BATTERY: &[(&str, &str)] = &[(

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           920 |                   436 |               484 |             140 |     371 |             939 |      492 |           486 |           597 |
+| Compiler                   |           922 |                   438 |               484 |             140 |     371 |             939 |      494 |           486 |           597 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
@@ -61,10 +61,10 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          21 |               4 |       17 |
-| S0               |         842 |             477 |      365 |
+| S0               |         843 |             477 |      366 |
 | S1               |           5 |               1 |        4 |
 | S2               |          15 |               1 |       14 |
-| S1->S2           |          37 |               2 |       35 |
+| S1->S2           |          38 |               2 |       36 |
 | old AST/parser   |          75 |              55 |       20 |
 | Croquis analysis |          65 |              56 |        9 |
 | raw OXC          |         371 |             343 |       28 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -294,7 +294,8 @@ compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_memo.rs	12	s
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_memo.rs	12	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_once.rs	12	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_once.rs	12	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_outlets.rs	14	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_outlets.rs	14	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_outlets.rs	14	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_recent_patch_flags.rs	12	s0	S0	stage	vize_s0	preferred	1


### PR DESCRIPTION
## Summary
- pin slot outlet patch-site and slot-flag comments per node against the shipped DOM lane
- cover empty dynamic prop/event outlets, v-for fragments, forwarded slots, and scoped forwarded slots
- refresh the consumer migration surface inventory for the added witness

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_outlets -- --nocapture
- node --test tests/tooling/davinci-matrices.test.ts
- cargo fmt --all --check
- git diff --check origin/main...HEAD && git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying slot-outlet patch-site behavior across supported outlet scenarios.
  * Confirmed generated output matches the shipped DOM behavior and expected per-node markers.

* **Documentation**
  * Updated the consumer migration inventory to reflect newly tracked compiler-stage references and revised totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->