### PR TITLE
test(davinci): pin createSlots patch sites

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_slots.rs
@@ -11,6 +11,9 @@
 
 mod support;
 
+use vize_s0::Allocator;
+use vize_s1_to_s2::emit_dom_source;
+
 const BATTERY: &[(&str, &str)] = &[
     (
         "named_header_text",
@@ -253,6 +256,91 @@ const UNSUPPORTED_BATTERY: &[(&str, &str, support::ExpectedRefusal)] = &[(
 #[test]
 fn s2_named_slots_match_the_shipped_dom_lane_byte_for_byte() {
     support::assert_s2_matches_shipped(BATTERY);
+}
+
+const DYN_SLOTS: &[&str] = &["2 /* DYNAMIC */", "1024 /* DYNAMIC_SLOTS */"];
+const TEXT_SLOTS: &[&str] = &[
+    "1 /* TEXT */",
+    "2 /* DYNAMIC */",
+    "1024 /* DYNAMIC_SLOTS */",
+];
+const UNWRAPPED_IF_SITES: &[&str] = &["64 /* STABLE_FRAGMENT */", "1 /* STABLE */"];
+const UNWRAPPED_FOR_SITES: &[&str] = &[
+    "64 /* STABLE_FRAGMENT */",
+    "256 /* UNKEYED_FRAGMENT */",
+    "1 /* STABLE */",
+];
+
+const PATCH_SITE_CASES: &[(&str, &str, &[&str])] = &[
+    (
+        "create_slots_if",
+        r#"<Foo><template #header v-if="ok">x</template></Foo>"#,
+        DYN_SLOTS,
+    ),
+    (
+        "create_slots_if_v_once",
+        r#"<Foo><template #header v-if="ok" v-once>x</template></Foo>"#,
+        DYN_SLOTS,
+    ),
+    (
+        "create_slots_for",
+        r#"<Foo><template v-for="i in n" #header>x</template></Foo>"#,
+        DYN_SLOTS,
+    ),
+    (
+        "create_slots_for_v_memo",
+        r#"<Foo><template v-for="i in n" #header v-memo="[i]">x</template></Foo>"#,
+        DYN_SLOTS,
+    ),
+    (
+        "create_slots_dynamic_name",
+        r#"<Foo><template #[name] v-if="ok">x</template></Foo>"#,
+        DYN_SLOTS,
+    ),
+    (
+        "create_slots_default_interp",
+        r#"<Foo>hello {{ msg }}<template #header v-if="ok">x</template></Foo>"#,
+        TEXT_SLOTS,
+    ),
+    (
+        "unwrapped_if_nested_slot_keeps_siblings",
+        r#"<Foo><template v-if="ok"><span>x</span><template #header>y</template></template></Foo>"#,
+        UNWRAPPED_IF_SITES,
+    ),
+    (
+        "unwrapped_for_nested_slot_keeps_siblings",
+        r#"<Foo><template v-for="i in n"><span>x</span><template #header>y</template></template></Foo>"#,
+        UNWRAPPED_FOR_SITES,
+    ),
+];
+
+#[test]
+fn s2_create_slots_patch_sites_match_the_shipped_dom_lane_per_node() {
+    let battery: Vec<_> = PATCH_SITE_CASES
+        .iter()
+        .map(|(name, src, _)| (*name, *src))
+        .collect();
+    support::assert_s2_matches_shipped(&battery);
+
+    let mut mismatches = Vec::new();
+    for (name, src, sites) in PATCH_SITE_CASES {
+        let expected: Vec<_> = sites.iter().map(|site| site.to_string()).collect();
+        let old = support::shipped(src);
+        let allocator = Allocator::new();
+        let new = emit_dom_source(&allocator, src)
+            .unwrap_or_else(|error| panic!("{name}: S2 emit refused: {error:?}"))
+            .assembled();
+        let old_sites = support::patch_sites(&old);
+        let new_sites = support::patch_sites(&new);
+
+        if old_sites != expected || new_sites != expected {
+            mismatches.push(format!(
+                "{name}: expected={expected:?} old={old_sites:?} new={new_sites:?}",
+            ));
+        }
+    }
+    let report = mismatches.join("\n");
+    assert!(mismatches.is_empty(), "patch site mismatches:\n{report}");
 }
 
 #[test]

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           922 |                   438 |               484 |             140 |     371 |             939 |      494 |           486 |           597 |
+| Compiler                   |           924 |                   440 |               484 |             140 |     371 |             939 |      496 |           487 |           597 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
@@ -61,10 +61,10 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          21 |               4 |       17 |
-| S0               |         843 |             477 |      366 |
+| S0               |         844 |             477 |      367 |
 | S1               |           5 |               1 |        4 |
 | S2               |          15 |               1 |       14 |
-| S1->S2           |          38 |               2 |       36 |
+| S1->S2           |          39 |               2 |       37 |
 | old AST/parser   |          75 |              55 |       20 |
 | Croquis analysis |          65 |              56 |        9 |
 | raw OXC          |         371 |             343 |       28 |
@@ -91,7 +91,7 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | `crates/vize_atelier_sfc/src/compile_script/props/tests.rs:4` | test/dev | S0 15                                         |    15 |
 | `crates/vize_atelier_core/tests/s2_support/compare.rs:10`     | test/dev | Davinci 2<br>S0 4<br>S1 1<br>S2 1<br>S1->S2 3 |    11 |
 
-Additional test/dev rows are in the TSV: 203 omitted.
+Additional test/dev rows are in the TSV: 204 omitted.
 
 ### Linter
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -302,6 +302,8 @@ compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_recent_patch
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_recent_patch_flags.rs	12	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_show.rs	13	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_show.rs	13	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_slots.rs	14	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_slots.rs	14	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_text.rs	12	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_text.rs	12	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_teardown_without_stack_guard.rs	25	s0	S0	stage	vize_s0	preferred	1


### PR DESCRIPTION
## Summary
- pin createSlots patch-site comments per node against the shipped DOM lane
- cover v-if, v-for, dynamic names, v-once, v-memo, default text, and unwrapped template paths
- refresh the consumer migration surface inventory for the added witness

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_slots -- --nocapture
- node --test tests/tooling/davinci-matrices.test.ts
- cargo fmt --all --check
- git diff --check origin/main...HEAD && git diff --check