### PR TITLE
ci(davinci): gate hydrated s2 dom corpus

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -49,6 +49,14 @@ on:
         options:
           - enforce
           - record-only
+      davinci_dom_corpus_mode:
+        description: "Davinci S2 DOM corpus gate handling"
+        required: false
+        default: "enforce"
+        type: choice
+        options:
+          - enforce
+          - record-only
   schedule:
     # Weekly full ecosystem sweep. Manual dispatches provide on-demand release evidence.
     - cron: "37 5 * * 0"
@@ -283,37 +291,7 @@ jobs:
           VIZE_SYNTAX_HIGHLIGHTER_OUTCOME: ${{ steps.syntax_highlighter.outcome }}
           VIZE_GLYPH_OUTCOME: ${{ steps.glyph.outcome }}
           VIZE_TYPECHECK_DIVERGENCE_OUTCOME: ${{ steps.typecheck_divergence.outcome }}
-        run: |
-          core_tools_verdict="$VIZE_CORE_TOOLS_OUTCOME"
-          if [[ "$CORE_TOOLS_MODE" == "record-only" && "$core_tools_verdict" == "failure" ]]; then
-            core_tools_verdict=success
-          fi
-          typecheck_dependencies_verdict="$VIZE_TYPECHECK_DEPENDENCIES_OUTCOME"
-          if [[ "$TYPECHECK_DEPENDENCIES_MODE" == "record-only" && "$typecheck_dependencies_verdict" == "failure" ]]; then
-            typecheck_dependencies_verdict=success
-          fi
-          lint_divergence_verdict="$VIZE_LINT_DIVERGENCE_OUTCOME"
-          if [[ "$LINT_DIVERGENCE_MODE" == "record-only" && "$lint_divergence_verdict" == "failure" ]]; then
-            lint_divergence_verdict=success
-          fi
-          lsp_verdict="$VIZE_LSP_OUTCOME"
-          if [[ "$LSP_MODE" == "record-only" && "$lsp_verdict" == "failure" ]]; then
-            lsp_verdict=success
-          fi
-          typecheck_divergence_verdict="$VIZE_TYPECHECK_DIVERGENCE_OUTCOME"
-          if [[ "$TYPECHECK_DIVERGENCE_MODE" == "record-only" && "$typecheck_divergence_verdict" == "failure" ]]; then
-            typecheck_divergence_verdict=success
-          fi
-          rust-script tools/commands/fixtures/real-project-surface-verdict.rs \
-            --output "$FIXTURE_REPORT_DIR/surface-verdict.json" \
-            --surface "waiver-audit=$VIZE_WAIVER_AUDIT_OUTCOME" \
-            --surface "typecheck-dependencies=$typecheck_dependencies_verdict" \
-            --surface "core-tools=$core_tools_verdict" \
-            --surface "lsp=$lsp_verdict" \
-            --surface "lint-divergence=$lint_divergence_verdict" \
-            --surface "syntax-highlighter=$VIZE_SYNTAX_HIGHLIGHTER_OUTCOME" \
-            --surface "glyph=$VIZE_GLYPH_OUTCOME" \
-            --surface "typecheck-divergence=$typecheck_divergence_verdict"
+        run: node tools/fixtures/real-project-surface-verdict.mjs --from-workflow-env --output "$FIXTURE_REPORT_DIR/surface-verdict.json"
 
       - name: Publish shard summary
         if: ${{ always() }}
@@ -326,5 +304,46 @@ jobs:
         with:
           name: real-project-matrix-${{ matrix.shard }}
           path: ${{ env.FIXTURE_REPORT_DIR }}
+          if-no-files-found: error
+          retention-days: 30
+
+  davinci-dom-corpus:
+    name: s2 dom corpus
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 120
+    env:
+      VIZE_DAVINCI_DOM_CORPUS_MODE: ${{ inputs.davinci_dom_corpus_mode || 'enforce' }}
+    steps:
+      - name: Checkout matrix commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Setup Wild linker
+        uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
+        with:
+          wild-version: "0.9.0"
+      - uses: ./.github/actions/setup-rust-sticky-cache
+        with:
+          key: davinci-dom-corpus
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}
+      - name: Select and hydrate full fixture corpus
+        run: node tools/fixtures/davinci-dom-corpus-workflow.mjs hydrate
+      - name: Run S2 DOM differential corpus
+        id: davinci_dom_corpus
+        continue-on-error: true
+        run: node tools/fixtures/davinci-dom-corpus-workflow.mjs run
+      - name: Finalize S2 DOM corpus evidence
+        if: ${{ always() }}
+        env:
+          VIZE_DAVINCI_DOM_CORPUS_OUTCOME: ${{ steps.davinci_dom_corpus.outcome }}
+        run: node tools/fixtures/davinci-dom-corpus-workflow.mjs finalize
+      - name: Upload S2 DOM corpus evidence
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: real-project-davinci-dom-corpus
+          path: real-project-davinci-dom-corpus
           if-no-files-found: error
           retention-days: 30

--- a/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
+++ b/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import {
+  corpusEvidenceLines,
+  parseFixtureGitlinks,
+  verdictFor,
+} from "../../tools/fixtures/davinci-dom-corpus-workflow.mjs";
+import { findStep, readRealProjectMatrixWorkflow } from "./support/real-project-matrix-workflow.ts";
+
+const helperSource = readFileSync("tools/fixtures/davinci-dom-corpus-workflow.mjs", "utf8");
+
+test("real-project workflow carries a full-canonical S2 DOM corpus job", () => {
+  const workflow = readRealProjectMatrixWorkflow();
+  const job = workflow.jobs?.["davinci-dom-corpus"];
+  assert.ok(job, "missing davinci-dom-corpus job");
+  const steps = job.steps ?? [];
+
+  assert.equal(job.name, "s2 dom corpus");
+  assert.equal(job["runs-on"], "blacksmith-32vcpu-ubuntu-2404");
+  assert.equal(job["timeout-minutes"], 120);
+  assert.equal(
+    job.env?.VIZE_DAVINCI_DOM_CORPUS_MODE,
+    "${{ inputs.davinci_dom_corpus_mode || 'enforce' }}",
+  );
+
+  const checkout = steps.find((step) => step.uses?.startsWith("actions/checkout@"));
+  assert.match(checkout?.uses ?? "", /de0fac2e4500dabe0009e67214ff5f5447ce83dd/);
+  assert.deepEqual(checkout?.with, { "persist-credentials": false });
+  assert.ok(steps.some((step) => step.uses?.startsWith("dtolnay/rust-toolchain@")));
+  assert.ok(steps.some((step) => step.uses === "./.github/actions/setup-rust-sticky-cache"));
+
+  const hydrate = findStep(steps, "Select and hydrate full fixture corpus");
+  assert.equal(hydrate.run, "node tools/fixtures/davinci-dom-corpus-workflow.mjs hydrate");
+  for (const pattern of [
+    /git", \["ls-files", "--stage", "--", corpusRoot\]/,
+    /expectedGitlinks = 146/,
+    /artifactDir = "real-project-davinci-dom-corpus"/,
+    /selected-gitlinks\.txt/,
+    /"submodule",\s+"update",\s+"--init",\s+"--checkout",\s+"--depth",\s+"1",\s+"--jobs",\s+"8"/,
+    /"submodule", "status", "--", corpusRoot/,
+  ]) {
+    assert.match(helperSource, pattern);
+  }
+
+  const corpus = findStep(steps, "Run S2 DOM differential corpus");
+  assert.equal(corpus.id, "davinci_dom_corpus");
+  assert.equal(corpus["continue-on-error"], true);
+  assert.equal(corpus.run, "node tools/fixtures/davinci-dom-corpus-workflow.mjs run");
+  assert.match(helperSource, /VIZE_DAVINCI_DIFFERENTIAL_CORPUS: corpusRoot/);
+  assert.match(helperSource, /"cargo",/);
+  assert.match(helperSource, /"test",\s+"-p",\s+"vize_s1_to_s2"/);
+  assert.match(helperSource, /"davinci-differential"/);
+  assert.match(helperSource, /"davinci_dom_corpus"/);
+  assert.match(helperSource, /dom-corpus\.log/);
+
+  const finalize = findStep(steps, "Finalize S2 DOM corpus evidence");
+  assert.equal(finalize.if, "${{ always() }}");
+  assert.deepEqual(finalize.env, {
+    VIZE_DAVINCI_DOM_CORPUS_OUTCOME: "${{ steps.davinci_dom_corpus.outcome }}",
+  });
+  assert.equal(finalize.run, "node tools/fixtures/davinci-dom-corpus-workflow.mjs finalize");
+  assert.match(helperSource, /"record-only"/);
+  assert.match(helperSource, /summary\.json/);
+  assert.match(helperSource, /davinci-differential corpus scope\|davinci DOM corpus sweep/);
+  assert.match(helperSource, /Davinci S2 DOM corpus failed/);
+
+  const upload = findStep(steps, "Upload S2 DOM corpus evidence");
+  assert.equal(upload.if, "${{ always() }}");
+  assert.equal(upload.uses, "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a");
+  assert.deepEqual(upload.with, {
+    name: "real-project-davinci-dom-corpus",
+    path: "real-project-davinci-dom-corpus",
+    "if-no-files-found": "error",
+    "retention-days": 30,
+  });
+});
+
+test("S2 DOM corpus workflow helper extracts canonical evidence", () => {
+  assert.deepEqual(
+    parseFixtureGitlinks(
+      [
+        "100644 0123456789012345678901234567890123456789 0\tignored.txt",
+        "160000 b6011381bc34a6b85ad669363513cb1a2eea6438 0\ttests/_fixtures/_git/airi",
+        "160000 3ee62adffdcdfa4a37b2ed4e9c30636655d5fcd1 0\ttests/_fixtures/_git/create-vue",
+      ].join("\n"),
+    ),
+    ["tests/_fixtures/_git/airi", "tests/_fixtures/_git/create-vue"],
+  );
+  assert.deepEqual(
+    corpusEvidenceLines("\u001B[32mdavinci DOM corpus sweep: compared=1\u001B[0m\nx"),
+    ["\u001B[32mdavinci DOM corpus sweep: compared=1\u001B[0m"],
+  );
+  assert.equal(verdictFor("failure", "record-only"), "success");
+  assert.equal(verdictFor("cancelled", "record-only"), "cancelled");
+});

--- a/tests/tooling/real-project-matrix-summary.test.ts
+++ b/tests/tooling/real-project-matrix-summary.test.ts
@@ -34,32 +34,11 @@ test("real-project workflow gates every measured surface on one verdict", () => 
     VIZE_TYPECHECK_DIVERGENCE_OUTCOME: "${{ steps.typecheck_divergence.outcome }}",
   });
   for (const pattern of [
-    /real-project-surface-verdict\.rs/,
-    /surface-verdict\.json/,
-    /core_tools_verdict="\$VIZE_CORE_TOOLS_OUTCOME"/,
-    /\[\[ "\$CORE_TOOLS_MODE" == "record-only"/,
-    /--surface "core-tools=\$core_tools_verdict"/,
-    /typecheck_dependencies_verdict="\$VIZE_TYPECHECK_DEPENDENCIES_OUTCOME"/,
-    /\[\[ "\$TYPECHECK_DEPENDENCIES_MODE" == "record-only"/,
-    /--surface "typecheck-dependencies=\$typecheck_dependencies_verdict"/,
-    /lint_divergence_verdict="\$VIZE_LINT_DIVERGENCE_OUTCOME"/,
-    /\[\[ "\$LINT_DIVERGENCE_MODE" == "record-only"/,
-    /--surface "lint-divergence=\$lint_divergence_verdict"/,
-    /lsp_verdict="\$VIZE_LSP_OUTCOME"/,
-    /\[\[ "\$LSP_MODE" == "record-only"/,
-    /--surface "lsp=\$lsp_verdict"/,
-    /typecheck_divergence_verdict="\$VIZE_TYPECHECK_DIVERGENCE_OUTCOME"/,
-    /\[\[ "\$TYPECHECK_DIVERGENCE_MODE" == "record-only"/,
-    /--surface "typecheck-divergence=\$typecheck_divergence_verdict"/,
+    /real-project-surface-verdict\.mjs/,
+    /--from-workflow-env/,
+    /--output "\$FIXTURE_REPORT_DIR\/surface-verdict\.json"/,
   ]) {
     assert.match(verdict.run ?? "", pattern);
-  }
-  for (const [surface, variable] of [
-    ["waiver-audit", "VIZE_WAIVER_AUDIT_OUTCOME"],
-    ["syntax-highlighter", "VIZE_SYNTAX_HIGHLIGHTER_OUTCOME"],
-    ["glyph", "VIZE_GLYPH_OUTCOME"],
-  ]) {
-    assert.match(verdict.run ?? "", new RegExp(`--surface "${surface}=\\$${variable}"`));
   }
 });
 

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -28,6 +28,7 @@ test("real-project workflow schedules every balanced fixture shard", () => {
     "lint_divergence_mode",
     "lsp_mode",
     "typecheck_divergence_mode",
+    "davinci_dom_corpus_mode",
   ]);
   assert.deepEqual(dispatch.inputs?.core_tools_mode, {
     description: "Core tool surface handling",
@@ -65,6 +66,13 @@ test("real-project workflow schedules every balanced fixture shard", () => {
   });
   assert.deepEqual(dispatch.inputs?.typecheck_divergence_mode, {
     description: "Typechecker baseline divergence gate handling",
+    required: false,
+    default: "enforce",
+    type: "choice",
+    options: ["enforce", "record-only"],
+  });
+  assert.deepEqual(dispatch.inputs?.davinci_dom_corpus_mode, {
+    description: "Davinci S2 DOM corpus gate handling",
     required: false,
     default: "enforce",
     type: "choice",
@@ -262,37 +270,22 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.equal(divergence.env?.BUDGET_MODE, "${{ inputs.typecheck_divergence_mode || 'enforce' }}");
 
   const surfaceVerdict = findStep(steps, "Enforce all real-project surface verdicts");
-  assert.match(
-    surfaceVerdict.run ?? "",
-    /lint_divergence_verdict="\$VIZE_LINT_DIVERGENCE_OUTCOME"/,
+  assert.match(surfaceVerdict.run ?? "", /real-project-surface-verdict\.mjs/);
+  assert.match(surfaceVerdict.run ?? "", /--from-workflow-env/);
+  assert.equal(
+    surfaceVerdict.env?.TYPECHECK_DEPENDENCIES_MODE,
+    "${{ inputs.typecheck_dependencies_mode || 'enforce' }}",
   );
-  assert.match(
-    surfaceVerdict.run ?? "",
-    /\$LINT_DIVERGENCE_MODE" == "record-only"[\s\S]*?lint_divergence_verdict=success/,
+  assert.equal(
+    surfaceVerdict.env?.LINT_DIVERGENCE_MODE,
+    "${{ inputs.lint_divergence_mode || 'enforce' }}",
   );
-  assert.match(surfaceVerdict.run ?? "", /--surface "lint-divergence=\$lint_divergence_verdict"/);
-  assert.match(
-    surfaceVerdict.run ?? "",
-    /typecheck_dependencies_verdict="\$VIZE_TYPECHECK_DEPENDENCIES_OUTCOME"/,
+  assert.equal(
+    surfaceVerdict.env?.TYPECHECK_DIVERGENCE_MODE,
+    "${{ inputs.typecheck_divergence_mode || 'enforce' }}",
   );
-  assert.match(
-    surfaceVerdict.run ?? "",
-    /\$TYPECHECK_DEPENDENCIES_MODE" == "record-only"[\s\S]*?typecheck_dependencies_verdict=success/,
-  );
-  assert.match(
-    surfaceVerdict.run ?? "",
-    /--surface "typecheck-dependencies=\$typecheck_dependencies_verdict"/,
-  );
-  assert.match(
-    surfaceVerdict.run ?? "",
-    /typecheck_divergence_verdict="\$VIZE_TYPECHECK_DIVERGENCE_OUTCOME"/,
-  );
-  assert.match(
-    surfaceVerdict.run ?? "",
-    /\$TYPECHECK_DIVERGENCE_MODE" == "record-only"[\s\S]*?typecheck_divergence_verdict=success/,
-  );
-  assert.match(
-    surfaceVerdict.run ?? "",
-    /--surface "typecheck-divergence=\$typecheck_divergence_verdict"/,
+  assert.equal(
+    surfaceVerdict.env?.VIZE_LINT_DIVERGENCE_OUTCOME,
+    "${{ steps.lint_divergence.outcome }}",
   );
 });

--- a/tests/tooling/real-project-surface-verdict.test.ts
+++ b/tests/tooling/real-project-surface-verdict.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import {
+  createRealProjectSurfaceResultsFromWorkflow,
   createRealProjectSurfaceVerdict,
   realProjectSurfaceNames,
 } from "../../tools/fixtures/real-project-surface-verdict.mjs";
@@ -58,4 +59,33 @@ test("the real-project surface verdict rejects missing, duplicate, unknown, and 
       ),
     /invalid outcome for glyph/,
   );
+});
+
+test("workflow surface inputs preserve enforce modes and soften only record-only failures", () => {
+  const results = createRealProjectSurfaceResultsFromWorkflow({
+    VIZE_WAIVER_AUDIT_OUTCOME: "success",
+    TYPECHECK_DEPENDENCIES_MODE: "record-only",
+    VIZE_TYPECHECK_DEPENDENCIES_OUTCOME: "failure",
+    CORE_TOOLS_MODE: "enforce",
+    VIZE_CORE_TOOLS_OUTCOME: "success",
+    LSP_MODE: "record-only",
+    VIZE_LSP_OUTCOME: "cancelled",
+    LINT_DIVERGENCE_MODE: "record-only",
+    VIZE_LINT_DIVERGENCE_OUTCOME: "failure",
+    VIZE_SYNTAX_HIGHLIGHTER_OUTCOME: "success",
+    VIZE_GLYPH_OUTCOME: "success",
+    TYPECHECK_DIVERGENCE_MODE: "record-only",
+    VIZE_TYPECHECK_DIVERGENCE_OUTCOME: "failure",
+  });
+
+  assert.deepEqual(results, [
+    { name: "waiver-audit", outcome: "success" },
+    { name: "typecheck-dependencies", outcome: "success" },
+    { name: "core-tools", outcome: "success" },
+    { name: "lsp", outcome: "cancelled" },
+    { name: "lint-divergence", outcome: "success" },
+    { name: "syntax-highlighter", outcome: "success" },
+    { name: "glyph", outcome: "success" },
+    { name: "typecheck-divergence", outcome: "success" },
+  ]);
 });

--- a/tools/fixtures/davinci-dom-corpus-workflow.mjs
+++ b/tools/fixtures/davinci-dom-corpus-workflow.mjs
@@ -1,0 +1,186 @@
+import { spawn, spawnSync } from "node:child_process";
+import { createWriteStream, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const artifactDir = "real-project-davinci-dom-corpus";
+export const corpusRoot = "tests/_fixtures/_git";
+export const expectedGitlinks = 146;
+
+const ansiEscapePattern = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
+
+function stripAnsi(value) {
+  return value.replace(ansiEscapePattern, "");
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+    ...options,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed with exit code ${result.status}`);
+  }
+  return result.stdout ?? "";
+}
+
+export function parseFixtureGitlinks(indexOutput) {
+  return indexOutput
+    .split(/\r?\n/)
+    .flatMap((line) => {
+      const match = /^160000 [0-9a-f]{40} 0\t(.+)$/.exec(line);
+      return match ? [match[1]] : [];
+    })
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function selectedGitlinks() {
+  return parseFixtureGitlinks(run("git", ["ls-files", "--stage", "--", corpusRoot]));
+}
+
+export function verdictFor(outcome, mode) {
+  return mode === "record-only" && outcome === "failure" ? "success" : outcome;
+}
+
+export function corpusEvidenceLines(logText) {
+  return logText
+    .split(/\r?\n/)
+    .filter((line) =>
+      /davinci-differential corpus scope|davinci DOM corpus sweep/.test(stripAnsi(line)),
+    );
+}
+
+export function hydrateCorpus() {
+  mkdirSync(artifactDir, { recursive: true });
+  const fixturePaths = selectedGitlinks();
+  if (fixturePaths.length !== expectedGitlinks) {
+    console.error(
+      `::error title=Unexpected fixture gitlinks::expected ${expectedGitlinks}, got ${fixturePaths.length}`,
+    );
+    return 1;
+  }
+  writeFileSync(`${artifactDir}/selected-gitlinks.txt`, `${fixturePaths.join("\n")}\n`);
+  run("git", [
+    "submodule",
+    "update",
+    "--init",
+    "--checkout",
+    "--depth",
+    "1",
+    "--jobs",
+    "8",
+    "--",
+    ...fixturePaths,
+  ]);
+  const status = run("git", ["submodule", "status", "--", corpusRoot]);
+  writeFileSync(`${artifactDir}/submodule-status.txt`, status);
+  return 0;
+}
+
+export async function runCorpus() {
+  mkdirSync(artifactDir, { recursive: true });
+  const log = createWriteStream(`${artifactDir}/dom-corpus.log`, { flags: "w" });
+  const child = spawn(
+    "cargo",
+    [
+      "test",
+      "-p",
+      "vize_s1_to_s2",
+      "--features",
+      "davinci-differential",
+      "--test",
+      "davinci_dom_corpus",
+      "--",
+      "--nocapture",
+    ],
+    {
+      env: {
+        ...process.env,
+        VIZE_DAVINCI_DIFFERENTIAL_CORPUS: corpusRoot,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  child.stdout.on("data", (chunk) => {
+    process.stdout.write(chunk);
+    log.write(chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+    log.write(chunk);
+  });
+  return await new Promise((resolvePromise) => {
+    child.on("close", (code) => {
+      log.end();
+      resolvePromise(code ?? 1);
+    });
+    child.on("error", (error) => {
+      log.end();
+      console.error(error instanceof Error ? error.message : String(error));
+      resolvePromise(1);
+    });
+  });
+}
+
+export async function finalizeCorpus(environment = process.env) {
+  mkdirSync(artifactDir, { recursive: true });
+  const mode = environment.VIZE_DAVINCI_DOM_CORPUS_MODE ?? "enforce";
+  const outcome = environment.VIZE_DAVINCI_DOM_CORPUS_OUTCOME ?? "failure";
+  const verdict = verdictFor(outcome, mode);
+  writeFileSync(`${artifactDir}/summary.json`, `${JSON.stringify({ mode, outcome, verdict })}\n`);
+  await appendCorpusSummary(mode, outcome, verdict, environment.GITHUB_STEP_SUMMARY);
+  if (verdict !== "success") {
+    console.error(`::error title=Davinci S2 DOM corpus failed::mode=${mode} verdict=${verdict}`);
+    return 1;
+  }
+  return 0;
+}
+
+async function appendCorpusSummary(mode, outcome, verdict, summaryPath) {
+  if (!summaryPath) return;
+  const gitlinkCount = readOptional(`${artifactDir}/selected-gitlinks.txt`)
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean).length;
+  const logText = readOptional(`${artifactDir}/dom-corpus.log`);
+  const evidence = corpusEvidenceLines(logText);
+  await appendFile(
+    summaryPath,
+    [
+      "## Davinci S2 DOM Corpus",
+      "",
+      `- mode: \`${mode}\``,
+      `- outcome: \`${outcome}\``,
+      `- verdict: \`${verdict}\``,
+      `- gitlinks: \`${gitlinkCount}\``,
+      "",
+      ...evidence,
+      "",
+    ].join("\n"),
+  );
+}
+
+function readOptional(path) {
+  try {
+    return readFileSync(path, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+async function main() {
+  const command = process.argv[2];
+  if (command === "hydrate") return hydrateCorpus();
+  if (command === "run") return await runCorpus();
+  if (command === "finalize") return await finalizeCorpus();
+  console.error("usage: davinci-dom-corpus-workflow.mjs hydrate|run|finalize");
+  return 1;
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  process.exitCode = await main();
+}

--- a/tools/fixtures/real-project-surface-verdict.mjs
+++ b/tools/fixtures/real-project-surface-verdict.mjs
@@ -15,6 +15,47 @@ export const realProjectSurfaceNames = [
 
 const validOutcomes = new Set(["success", "failure", "cancelled", "skipped"]);
 
+function recordOnlyVerdict(outcome, mode) {
+  return mode === "record-only" && outcome === "failure" ? "success" : outcome;
+}
+
+export function createRealProjectSurfaceResultsFromWorkflow(environment = process.env) {
+  return [
+    { name: "waiver-audit", outcome: environment.VIZE_WAIVER_AUDIT_OUTCOME },
+    {
+      name: "typecheck-dependencies",
+      outcome: recordOnlyVerdict(
+        environment.VIZE_TYPECHECK_DEPENDENCIES_OUTCOME,
+        environment.TYPECHECK_DEPENDENCIES_MODE,
+      ),
+    },
+    {
+      name: "core-tools",
+      outcome: recordOnlyVerdict(environment.VIZE_CORE_TOOLS_OUTCOME, environment.CORE_TOOLS_MODE),
+    },
+    {
+      name: "lsp",
+      outcome: recordOnlyVerdict(environment.VIZE_LSP_OUTCOME, environment.LSP_MODE),
+    },
+    {
+      name: "lint-divergence",
+      outcome: recordOnlyVerdict(
+        environment.VIZE_LINT_DIVERGENCE_OUTCOME,
+        environment.LINT_DIVERGENCE_MODE,
+      ),
+    },
+    { name: "syntax-highlighter", outcome: environment.VIZE_SYNTAX_HIGHLIGHTER_OUTCOME },
+    { name: "glyph", outcome: environment.VIZE_GLYPH_OUTCOME },
+    {
+      name: "typecheck-divergence",
+      outcome: recordOnlyVerdict(
+        environment.VIZE_TYPECHECK_DIVERGENCE_OUTCOME,
+        environment.TYPECHECK_DIVERGENCE_MODE,
+      ),
+    },
+  ];
+}
+
 export function createRealProjectSurfaceVerdict(results, environment = process.env) {
   const expected = new Set(realProjectSurfaceNames);
   const seen = new Set();
@@ -53,10 +94,15 @@ export function createRealProjectSurfaceVerdict(results, environment = process.e
 
 function parseArguments(argv) {
   let output = null;
+  let fromWorkflowEnv = false;
   const results = [];
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
     const value = argv[index + 1];
+    if (argument === "--from-workflow-env") {
+      fromWorkflowEnv = true;
+      continue;
+    }
     if (argument === "--output" && output == null && value && !value.startsWith("--")) {
       output = resolve(value);
       index += 1;
@@ -72,12 +118,16 @@ function parseArguments(argv) {
     throw new Error(`unknown or incomplete argument: ${argument}`);
   }
   if (output == null) throw new Error("--output is required");
-  return { output, results };
+  if (fromWorkflowEnv && results.length > 0) {
+    throw new Error("--from-workflow-env cannot be combined with --surface");
+  }
+  return { output, fromWorkflowEnv, results };
 }
 
 function main() {
-  const { output, results } = parseArguments(process.argv.slice(2));
-  const artifact = createRealProjectSurfaceVerdict(results);
+  const { output, fromWorkflowEnv, results } = parseArguments(process.argv.slice(2));
+  const surfaces = fromWorkflowEnv ? createRealProjectSurfaceResultsFromWorkflow() : results;
+  const artifact = createRealProjectSurfaceVerdict(surfaces);
   mkdirSync(dirname(output), { recursive: true });
   writeFileSync(output, `${JSON.stringify(artifact, null, 2)}\n`);
   if (artifact.status !== "success") {


### PR DESCRIPTION
## Summary
- add a full-canonical S2 DOM corpus job to the real-project matrix workflow
- hydrate all 146 indexed fixture gitlinks before running the env-gated davinci_dom_corpus lane
- move the long workflow shell into reusable Node helpers so the workflow stays inside the source-length gate
- add workflow/helper coverage for the new input, artifact, and enforce/record-only verdict handling

## Verification
- vp check
- node --test tests/tooling/real-project-matrix-summary.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/real-project-surface-verdict.test.ts tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
- node --test tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts tests/tooling/real-project-surface-verdict.test.ts tests/tooling/github-workflows.test.ts tests/tooling/github-workflows-check.test.ts tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-lowering-ci-lane.test.ts tests/tooling/davinci-corpus-hydration.test.ts tests/tooling/davinci-corpus-comparison-count.test.ts
- node --check tools/fixtures/davinci-dom-corpus-workflow.mjs
- node --check tools/fixtures/real-project-surface-verdict.mjs
- git diff --check
- wc -l .github/workflows/real-project-matrix.yml -> 349

## Note
- source length check was attempted locally, but the MoonBit runner stopped in moonbitlang/x/path/win32 lexscan before reaching repository files; the CI failure path was addressed by keeping the workflow below 350 lines
- a manual enforce run on the prior head produced canonical closure evidence for 146 submodules and revealed 26,453 S2 DOM output divergences; follow-up implementation PRs will use that artifact to drive the remaining P2-11 closure work