### PR TITLE
fix(davinci): skip static literal bind patch sites

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
@@ -60,21 +60,6 @@ const CASES: &[Case] = &[
         sites: &["8 /* PROPS */, [\"id\"]"],
     },
     Case {
-        name: "static_literal_prop",
-        src: r#"<div :id="'fixed'"></div>"#,
-        sites: &[],
-    },
-    Case {
-        name: "component_static_literal_prop",
-        src: r#"<Foo :side-offset="4" />"#,
-        sites: &[],
-    },
-    Case {
-        name: "component_static_class_array",
-        src: r#"<Foo :class="['card']" />"#,
-        sites: &[],
-    },
-    Case {
         name: "full_props",
         src: r#"<div :[key]="value"></div>"#,
         sites: &["16 /* FULL_PROPS */"],

--- a/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
@@ -60,6 +60,21 @@ const CASES: &[Case] = &[
         sites: &["8 /* PROPS */, [\"id\"]"],
     },
     Case {
+        name: "static_literal_prop",
+        src: r#"<div :id="'fixed'"></div>"#,
+        sites: &[],
+    },
+    Case {
+        name: "component_static_literal_prop",
+        src: r#"<Foo :side-offset="4" />"#,
+        sites: &[],
+    },
+    Case {
+        name: "component_static_class_array",
+        src: r#"<Foo :class="['card']" />"#,
+        sites: &[],
+    },
+    Case {
         name: "full_props",
         src: r#"<div :[key]="value"></div>"#,
         sites: &["16 /* FULL_PROPS */"],

--- a/crates/vize_atelier_dom/tests/davinci_s2_patch_flags_static.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_patch_flags_static.rs
@@ -1,0 +1,49 @@
+//! Static literal bind patch-flag witnesses split from the broad S2 corpus.
+
+mod support;
+
+use vize_s0::Allocator;
+use vize_s1_to_s2::emit_dom_source;
+
+struct Case {
+    name: &'static str,
+    src: &'static str,
+}
+
+const CASES: &[Case] = &[
+    Case {
+        name: "static_literal_prop",
+        src: "<div :id=\"'fixed'\"></div>",
+    },
+    Case {
+        name: "component_static_literal_prop",
+        src: "<Foo :side-offset=\"4\" />",
+    },
+    Case {
+        name: "component_static_class_array",
+        src: "<Foo :class=\"['card']\" />",
+    },
+];
+
+#[test]
+fn static_literal_bind_patch_flags_match_the_shipped_dom_lane() {
+    let battery: Vec<_> = CASES.iter().map(|case| (case.name, case.src)).collect();
+    support::assert_s2_matches_shipped(&battery);
+
+    for case in CASES {
+        let allocator = Allocator::new();
+        let old = support::shipped(case.src);
+        let new = emit_dom_source(&allocator, case.src).expect(case.name);
+
+        assert!(
+            support::patch_sites(&old).is_empty(),
+            "{} shipped output should not mark static literal binds as patch sites",
+            case.name
+        );
+        assert!(
+            support::patch_sites(new.assembled().as_str()).is_empty(),
+            "{} S2 output should not mark static literal binds as patch sites",
+            case.name
+        );
+    }
+}

--- a/crates/vize_s1_to_s2/src/emit/props.rs
+++ b/crates/vize_s1_to_s2/src/emit/props.rs
@@ -2,7 +2,7 @@
 
 use alloc::vec::Vec as StdVec;
 
-use oxc_ast::ast::{ArrayExpressionElement, Expression, ObjectPropertyKind};
+use oxc_ast::ast::{Argument, ArrayExpressionElement, Expression, ObjectPropertyKind};
 use vize_s0::String;
 use vize_s2::op::{Attribute, BindingOp};
 
@@ -128,10 +128,12 @@ pub(super) fn bind_patch(
                 }
                 Ok(BindName::Static(raw_name)) => match raw_name {
                     "ref" => flag |= 512,
-                    "class" if !is_component && class_bind_needs_patch(bind) => flag |= 2,
-                    "class" if !is_component => {}
+                    "class" if bind_value_is_static_patchless(bind) => {}
+                    "class" if !is_component => flag |= 2,
+                    "style" if bind_value_is_static_patchless(bind) => {}
                     "style" if !is_component => flag |= 4,
                     "key" => {}
+                    key if key.ends_with("Modifiers") || bind_value_is_static_patchless(bind) => {}
                     _ => {
                         flag |= 8;
                         let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
@@ -202,39 +204,56 @@ pub(super) fn bind_patch(
     }
 }
 
-fn class_bind_needs_patch(bind: &vize_s2::op::BindOp<'_>) -> bool {
+pub(super) fn bind_value_is_static_patchless(bind: &vize_s2::op::BindOp<'_>) -> bool {
     match bind_value(bind) {
-        Ok(value) => match value.js() {
-            Some(js) => !is_static_class_expr(js.ast),
-            None => true,
-        },
+        Ok(value) => value.js().is_some_and(|js| is_static_bound_expr(js.ast)),
         Err(_) => false,
     }
 }
 
-fn is_static_class_expr(expr: &Expression<'_>) -> bool {
+fn is_static_bound_expr(expr: &Expression<'_>) -> bool {
     match unwrap_expr(expr) {
         Expression::StringLiteral(_)
         | Expression::BooleanLiteral(_)
         | Expression::NullLiteral(_)
         | Expression::NumericLiteral(_)
-        | Expression::BigIntLiteral(_) => true,
+        | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_) => true,
         Expression::TemplateLiteral(template) => template.expressions.is_empty(),
-        Expression::ArrayExpression(array) => array.elements.iter().all(static_class_array_element),
+        Expression::UnaryExpression(unary) => is_static_bound_expr(&unary.argument),
+        Expression::ArrayExpression(array) => array.elements.iter().all(static_array_element),
         Expression::ObjectExpression(object) => object.properties.iter().all(|property| {
             let ObjectPropertyKind::ObjectProperty(property) = property else {
                 return false;
             };
-            !property.computed && is_static_class_expr(&property.value)
+            is_static_bound_expr(&property.value)
         }),
+        Expression::CallExpression(call)
+            if matches!(
+                &call.callee,
+                Expression::Identifier(ident)
+                    if matches!(ident.name.as_str(), "_normalizeClass" | "_normalizeStyle")
+            ) =>
+        {
+            call.arguments.iter().all(static_argument)
+        }
         _ => false,
     }
 }
 
-fn static_class_array_element(element: &ArrayExpressionElement<'_>) -> bool {
-    element
-        .as_expression()
-        .is_some_and(|expr| is_static_class_expr(expr))
+fn static_argument(argument: &Argument<'_>) -> bool {
+    match argument {
+        Argument::SpreadElement(_) => false,
+        _ => argument.as_expression().is_some_and(is_static_bound_expr),
+    }
+}
+
+fn static_array_element(element: &ArrayExpressionElement<'_>) -> bool {
+    match element {
+        ArrayExpressionElement::SpreadElement(_) => false,
+        ArrayExpressionElement::Elision(_) => true,
+        _ => element.as_expression().is_some_and(is_static_bound_expr),
+    }
 }
 
 fn unwrap_expr<'a>(mut expr: &'a Expression<'a>) -> &'a Expression<'a> {

--- a/crates/vize_s1_to_s2/src/emit/props_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static.rs
@@ -1,38 +1,39 @@
 //! Inline static props for native element calls.
 
-use alloc::vec::Vec as StdVec;
-
 use vize_s0::String;
-use vize_s2::op::{Attribute, BindingOp};
+use vize_s2::op::{Attribute, BindingOp, DynamicName};
 
 use super::EmitCx;
 use super::EmitError;
 use super::hoist::{push_attr_pair, unique_attrs};
 use super::js::{escape_js_string, is_valid_js_identifier};
 use super::props::{Piece, bind_value_is_static_patchless, pieces, static_bind_key};
-use super::props_bind::StaticBindKeyCasing;
+use super::props_bind::{StaticBindKey, StaticBindKeyCasing};
 use super::props_value::bind_value;
 
 pub(super) fn root_hoist_props(
     attributes: &[Attribute<'_>],
     bindings: &[BindingOp<'_>],
 ) -> Result<Option<String>, EmitError> {
+    if !can_root_hoist_props(attributes, bindings) {
+        return Ok(None);
+    }
+
     let mut out = String::from("{ ");
-    let mut seen: StdVec<String> = StdVec::new();
     let mut emitted = 0usize;
-    for piece in pieces(attributes, bindings, false)? {
+    let pieces = pieces(attributes, bindings, false)?;
+    for (index, piece) in pieces.iter().enumerate() {
         let mut prop = String::default();
-        let Some(key) = static_hoist_prop(&mut prop, &piece)? else {
+        let Some(key) = static_hoist_prop(&mut prop, piece)? else {
             return Ok(None);
         };
-        if seen.iter().any(|seen| seen == key.as_str()) {
+        if has_prior_hoist_key(&pieces[..index], key.as_str())? {
             continue;
         }
         if emitted > 0 {
             out.push_str(", ");
         }
         out.push_str(prop.as_str());
-        seen.push(key);
         emitted += 1;
     }
     if emitted == 0 {
@@ -42,26 +43,95 @@ pub(super) fn root_hoist_props(
     Ok(Some(out))
 }
 
-fn static_hoist_prop(out: &mut String, piece: &Piece<'_>) -> Result<Option<String>, EmitError> {
+fn can_root_hoist_props(attributes: &[Attribute<'_>], bindings: &[BindingOp<'_>]) -> bool {
+    if attributes.is_empty() && bindings.is_empty() {
+        return false;
+    }
+
+    if attributes.iter().any(|attr| attr.name == "ref") {
+        return false;
+    }
+
+    bindings.iter().all(root_binding_can_hoist)
+}
+
+fn root_binding_can_hoist(binding: &BindingOp<'_>) -> bool {
+    let BindingOp::Bind(bind) = binding else {
+        return false;
+    };
+
+    if !matches!(bind.name, Some(DynamicName::Static(_))) {
+        return false;
+    }
+
+    if !bind_value_is_static_patchless(bind) {
+        return false;
+    }
+
+    let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
+        return false;
+    };
+
+    !matches!(key.as_str(), "ref" | "class")
+}
+
+fn static_hoist_prop<'a>(
+    out: &mut String,
+    piece: &Piece<'a>,
+) -> Result<Option<HoistKey<'a>>, EmitError> {
+    let Some(key) = hoist_key(piece)? else {
+        return Ok(None);
+    };
     match piece {
-        Piece::Attr(attr) if attr.name != "ref" => {
+        Piece::Attr(attr) => {
             push_attr_pair(out, attr);
-            Ok(Some(String::from(attr.name)))
         }
-        Piece::Bind(bind) if bind_value_is_static_patchless(bind) => {
-            let key = static_bind_key(bind, StaticBindKeyCasing::Preserve)?;
-            let key = String::from(key.as_str());
-            if matches!(key.as_str(), "ref" | "class") {
-                return Ok(None);
-            }
+        Piece::Bind(bind) => {
             push_key(out, key.as_str());
             out.push_str(": ");
             if let Some(js) = bind_value(bind)?.js() {
                 out.push_str(js.source);
             }
-            Ok(Some(key))
+        }
+        _ => return Ok(None),
+    }
+    Ok(Some(key))
+}
+
+fn has_prior_hoist_key(pieces: &[Piece<'_>], key: &str) -> Result<bool, EmitError> {
+    for piece in pieces {
+        if hoist_key(piece)?.is_some_and(|prior| prior.as_str() == key) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn hoist_key<'a>(piece: &Piece<'a>) -> Result<Option<HoistKey<'a>>, EmitError> {
+    match piece {
+        Piece::Attr(attr) if attr.name != "ref" => Ok(Some(HoistKey::Borrowed(attr.name))),
+        Piece::Bind(bind) if bind_value_is_static_patchless(bind) => {
+            let key = static_bind_key(bind, StaticBindKeyCasing::Preserve)?;
+            if matches!(key.as_str(), "ref" | "class") {
+                return Ok(None);
+            }
+            Ok(Some(HoistKey::StaticBind(key)))
         }
         _ => Ok(None),
+    }
+}
+
+enum HoistKey<'a> {
+    Borrowed(&'a str),
+    StaticBind(StaticBindKey<'a>),
+}
+
+impl HoistKey<'_> {
+    fn as_str(&self) -> &str {
+        match self {
+            Self::Borrowed(text) => text,
+            Self::StaticBind(key) => key.as_str(),
+        }
     }
 }
 

--- a/crates/vize_s1_to_s2/src/emit/props_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static.rs
@@ -1,18 +1,78 @@
 //! Inline static props for native element calls.
 
+use alloc::vec::Vec as StdVec;
+
 use vize_s0::String;
-use vize_s2::op::{Attribute, ElementOp};
+use vize_s2::op::{Attribute, BindingOp};
 
 use super::EmitCx;
+use super::EmitError;
 use super::hoist::{push_attr_pair, unique_attrs};
+use super::js::{escape_js_string, is_valid_js_identifier};
+use super::props::{Piece, bind_value_is_static_patchless, pieces, static_bind_key};
+use super::props_bind::StaticBindKeyCasing;
+use super::props_value::bind_value;
 
-pub(super) fn root_should_hoist(element: &ElementOp<'_>) -> bool {
-    element.bindings.is_empty()
-        && !element.attributes.is_empty()
-        && element
-            .attributes
-            .iter()
-            .all(|attribute| attribute.name != "ref")
+pub(super) fn root_hoist_props(
+    attributes: &[Attribute<'_>],
+    bindings: &[BindingOp<'_>],
+) -> Result<Option<String>, EmitError> {
+    let mut out = String::from("{ ");
+    let mut seen: StdVec<String> = StdVec::new();
+    let mut emitted = 0usize;
+    for piece in pieces(attributes, bindings, false)? {
+        let mut prop = String::default();
+        let Some(key) = static_hoist_prop(&mut prop, &piece)? else {
+            return Ok(None);
+        };
+        if seen.iter().any(|seen| seen == key.as_str()) {
+            continue;
+        }
+        if emitted > 0 {
+            out.push_str(", ");
+        }
+        out.push_str(prop.as_str());
+        seen.push(key);
+        emitted += 1;
+    }
+    if emitted == 0 {
+        return Ok(None);
+    }
+    out.push_str(" }");
+    Ok(Some(out))
+}
+
+fn static_hoist_prop(out: &mut String, piece: &Piece<'_>) -> Result<Option<String>, EmitError> {
+    match piece {
+        Piece::Attr(attr) if attr.name != "ref" => {
+            push_attr_pair(out, attr);
+            Ok(Some(String::from(attr.name)))
+        }
+        Piece::Bind(bind) if bind_value_is_static_patchless(bind) => {
+            let key = static_bind_key(bind, StaticBindKeyCasing::Preserve)?;
+            let key = String::from(key.as_str());
+            if matches!(key.as_str(), "ref" | "class") {
+                return Ok(None);
+            }
+            push_key(out, key.as_str());
+            out.push_str(": ");
+            if let Some(js) = bind_value(bind)?.js() {
+                out.push_str(js.source);
+            }
+            Ok(Some(key))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn push_key(out: &mut String, key: &str) {
+    if !is_valid_js_identifier(key) {
+        out.push('"');
+        out.push_str(escape_js_string(key).as_str());
+        out.push('"');
+        return;
+    }
+    out.push_str(key);
 }
 
 pub(super) fn emit_inline<'a>(

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -10,7 +10,6 @@ use super::buf::Buf;
 use super::children::{children_need_text_flag, emit_create_text_vnode, emit_text_like};
 use super::directive;
 use super::flag::emit_patch_flag;
-use super::hoist::compact_props_object;
 use super::namespace;
 use super::props::{admit_element_bindings, apply_static_ref_patch, bind_patch, emit_bind_props};
 
@@ -150,7 +149,12 @@ pub(super) fn emit_call(
     let force_array_children =
         once || memo_block || (directive::has_custom(&element.bindings) && allow_hoist && block);
     let has_binds = has_prop_bindings(&element.bindings);
-    let hoist = allow_hoist && if_key.is_none() && super::props_static::root_should_hoist(element);
+    let hoisted_props = if allow_hoist && if_key.is_none() {
+        super::props_static::root_hoist_props(&element.attributes, &element.bindings)?
+    } else {
+        None
+    };
+    let hoist = hoisted_props.is_some();
     let patch = bind_patch(&element.bindings, false, if_key, for_item);
     let text_flag = !once && !memo_block && children_need_text_flag(&element.children);
     let mut flag = patch.flag;
@@ -177,7 +181,7 @@ pub(super) fn emit_call(
     if hoist {
         let props_alias = cx
             .buf
-            .hoist_root_props(compact_props_object(element.attributes.iter()));
+            .hoist_root_props(hoisted_props.expect("checked hoisted props"));
         cx.buf.push(", ");
         cx.buf.push(props_alias.as_str());
     } else if if_key.is_some() || has_binds {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           924 |                   440 |               484 |             140 |     371 |             939 |      496 |           487 |           598 |
+| Compiler                   |           926 |                   442 |               484 |             140 |     371 |             939 |      498 |           488 |           599 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
@@ -61,10 +61,10 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          21 |               4 |       17 |
-| S0               |         844 |             477 |      367 |
+| S0               |         845 |             477 |      368 |
 | S1               |           5 |               1 |        4 |
 | S2               |          15 |               1 |       14 |
-| S1->S2           |          39 |               2 |       37 |
+| S1->S2           |          40 |               2 |       38 |
 | old AST/parser   |          75 |              55 |       20 |
 | Croquis analysis |          65 |              56 |        9 |
 | raw OXC          |         371 |             343 |       28 |
@@ -91,7 +91,7 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | `crates/vize_atelier_sfc/src/compile_script/props/tests.rs:4` | test/dev | S0 15                                         |    15 |
 | `crates/vize_atelier_core/tests/s2_support/compare.rs:10`     | test/dev | Davinci 2<br>S0 4<br>S1 1<br>S2 1<br>S1->S2 3 |    11 |
 
-Additional test/dev rows are in the TSV: 204 omitted.
+Additional test/dev rows are in the TSV: 205 omitted.
 
 ### Linter
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -296,6 +296,8 @@ compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_once.rs	12	s
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_once.rs	12	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_outlets.rs	14	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_outlets.rs	14	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags_static.rs	5	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags_static.rs	5	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_recent_patch_flags.rs	12	s0	S0	stage	vize_s0	preferred	1

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -73,7 +73,7 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
 | s1_to_s2 | `alloc::vec::Vec`       |    37 |           37 |        156 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    52 |           54 |        228 |
+| s1_to_s2 | `vize_s0::String`       |    52 |           54 |        233 |
 | s1_to_s2 | `vize_s0::Vec`          |    14 |           14 |         56 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     2 |            2 |          4 |
 

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -53,7 +53,7 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props.rs	1	2	1	4	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_bind.rs	1	5	1	2	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_object.rs	1	5	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props_object_merge.rs	0	0	1	1	0	0	0	0
-s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props_static.rs	0	0	1	1	0	0	0	0
+s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props_static.rs	0	0	1	6	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/slots.rs	1	5	1	6	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/tpl.rs	0	0	1	3	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/vfor.rs	0	0	1	4	0	0	0	0


### PR DESCRIPTION
## Summary
- Treat static literal `ui.bind` values as patchless for static-name props, matching the shipped DOM lane.
- Hoist root static literal bind props into the root props object when the shipped lane does.
- Add S2 DOM patch-flag witnesses for static literal props and component static class arrays.

## Verification
- `vp install --frozen-lockfile --prefer-offline`
- `vp check`
- `cargo fmt --check`
- `cargo test -p vize_atelier_dom --test davinci_s2_patch_flags`
- `cargo test -p vize_atelier_dom --test davinci_s2_static_class_patch`
- `cargo test -p vize_atelier_dom --test davinci_s2_builtins`
- `cargo test -p vize_s1_to_s2 --test emit_static`
- `cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture`
- `git diff --check HEAD~1..HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790696688&installation_model_id=422833&pr_number=5413&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5413&signature=f94ede4056cfe026372a9755ab0c3f64bae74b49b634715ab2431218f24d6b16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->