### PR TITLE
fix(davinci): preserve slot helper order

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_helper_composition.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_helper_composition.rs
@@ -1,0 +1,53 @@
+//! P2-11 helper ordering and component-slot composition witnesses.
+//!
+//! These are reduced from the hydrated DOM corpus divergences where
+//! component slots combine text helpers, conditional comment helpers,
+//! and slot wrappers in one helper preamble.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "component_text_then_if_span",
+        r#"<Foo>hello<span v-if="ok">x</span></Foo>"#,
+    ),
+    (
+        "component_if_span_then_text",
+        r#"<Foo><span v-if="ok">x</span>hello</Foo>"#,
+    ),
+    (
+        "component_template_if_text_then_text",
+        r#"<Foo><template v-if="ok">x</template>hello</Foo>"#,
+    ),
+    (
+        "component_text_then_template_if_text",
+        r#"<Foo>hello<template v-if="ok">x</template></Foo>"#,
+    ),
+    (
+        "component_text_then_conditional_named_slot",
+        r#"<Foo>hello<template #header v-if="ok">x</template></Foo>"#,
+    ),
+    (
+        "component_conditional_named_slot_then_text",
+        r#"<Foo><template #header v-if="ok">x</template>hello</Foo>"#,
+    ),
+    (
+        "component_nested_text_then_if_component",
+        r#"<Foo>hello<Bar v-if="ok">x</Bar></Foo>"#,
+    ),
+    (
+        "component_if_component_then_text",
+        r#"<Foo><Bar v-if="ok">x</Bar>hello</Foo>"#,
+    ),
+];
+
+#[test]
+fn s2_helper_composition_matches_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -139,7 +139,7 @@ fn prefer_transform_helpers(buf: &mut Buf, region: &Region<'_>) {
                 buf.prefer(Helper::CreateBlock);
                 buf.prefer(Helper::CreateElementBlock);
                 buf.prefer(Helper::Fragment);
-                buf.prefer(Helper::CreateComment);
+                // Let `emit_if` mark CreateComment where slot text can precede it.
                 for branch in if_op.branches.iter() {
                     prefer_transform_helpers(buf, &branch.region);
                 }

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           924 |                   440 |               484 |             140 |     371 |             939 |      496 |           487 |           597 |
+| Compiler                   |           924 |                   440 |               484 |             140 |     371 |             939 |      496 |           487 |           598 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |


### PR DESCRIPTION
## Summary
- Keep CreateComment out of the transform-preferred helper list so slot text emitted before a conditional keeps the shipped same-rank helper order.
- Add reduced component-slot helper composition witnesses for text, conditional, component, and named-slot combinations.
- Refresh the consumer migration surface summary for the added scanned test file and keep the source length gate at 350 lines.

## Verification
- cargo fmt --check
- git diff --check
- wc -l crates/vize_s1_to_s2/src/emit.rs crates/vize_atelier_dom/tests/davinci_s2_helper_composition.rs
- rust-script tools/commands/davinci/consumer-migration-surfaces.rs --check
- RUNNER_TEMP=<tmp> GITHUB_PATH=<tmp> GITHUB_ENV=<tmp> node .github/actions/setup-moonbit/install-moonbit.mjs
- MOON_BIN=<tmp>/moon MOON_HOME=<tmp>/moonbit node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/davinci-matrices.test.ts
- cargo test -p vize_atelier_dom --test davinci_s2_helper_composition --test davinci_s2_slots --test davinci_s2_dom --test davinci_s2_builtins --test davinci_s2_outlets
- cargo test -p vize_s1_to_s2 --test emit_if --test emit_create_slots --test emit_create_slots_wrappers
- cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture