### PR TITLE
test(tooling): guard oxlint directory spelling

### DIFF
--- a/tests/tooling/oxlint-spelling.test.ts
+++ b/tests/tooling/oxlint-spelling.test.ts
@@ -3,7 +3,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 
-import { normalizeRepoText, root } from "./support/github-workflows.ts";
+import { normalizeRepoText, readRepoFile, root } from "./support/github-workflows.ts";
+
+const CANONICAL_OXLINT_PACKAGE_DIR = "npm/oxlint";
+const MISSPELLED_OXLINT_PACKAGE_DIR = path.posix.join("npm", "oxint");
 
 const USER_VISIBLE_LINT_SURFACES = [
   ".github",
@@ -13,12 +16,24 @@ const USER_VISIBLE_LINT_SURFACES = [
   "examples",
   "npm/cli/package.json",
   "npm/cli/src",
-  "npm/oxlint/package.json",
-  "npm/oxlint/src",
+  CANONICAL_OXLINT_PACKAGE_DIR,
   "npm/ui/core/package.json",
   "npm/ui/core/scripts",
   "npm/ui/tooling",
   "package.json",
+  "pnpm-workspace.yaml",
+  "tools",
+] as const;
+
+const REPO_LOCAL_LINT_PATH_SURFACES = [
+  ".github",
+  "docs",
+  "examples",
+  "npm",
+  "tests",
+  "tools",
+  "package.json",
+  "pnpm-lock.yaml",
   "pnpm-workspace.yaml",
 ] as const;
 
@@ -57,8 +72,50 @@ test("user-visible oxlint docs and scripts do not spell oxlint as oxint", () => 
   assert.deepEqual(offenders, []);
 });
 
+test("oxlint plugin package lives in the canonical package directory", () => {
+  const canonicalDir = path.join(root, CANONICAL_OXLINT_PACKAGE_DIR);
+  const misspelledDir = path.join(root, MISSPELLED_OXLINT_PACKAGE_DIR);
+  const manifest = JSON.parse(
+    readRepoFile(CANONICAL_OXLINT_PACKAGE_DIR, "package.json"),
+  ) as OxlintPluginManifest;
+
+  assert.equal(fs.statSync(canonicalDir).isDirectory(), true);
+  assert.equal(fs.existsSync(misspelledDir), false);
+  assert.equal(manifest.name, "oxlint-plugin-vize");
+  assert.equal(manifest.repository?.directory, CANONICAL_OXLINT_PACKAGE_DIR);
+});
+
+test("repo-local oxlint package path references use the canonical spelling", () => {
+  const offenders: string[] = [];
+
+  for (const relativePath of collectLintPathFiles()) {
+    const source = normalizeRepoText(fs.readFileSync(path.join(root, relativePath), "utf8"));
+    const lines = source.split("\n");
+    for (const [index, line] of lines.entries()) {
+      if (line.includes(MISSPELLED_OXLINT_PACKAGE_DIR)) {
+        offenders.push(`${relativePath}:${index + 1}: ${line.trim()}`);
+      }
+    }
+  }
+
+  assert.deepEqual(offenders, []);
+});
+
+type OxlintPluginManifest = {
+  readonly name?: unknown;
+  readonly repository?: {
+    readonly directory?: unknown;
+  };
+};
+
 function collectLintSurfaceFiles(): string[] {
   return USER_VISIBLE_LINT_SURFACES.flatMap((surface) => collectFiles(surface)).sort();
+}
+
+function collectLintPathFiles(): string[] {
+  return REPO_LOCAL_LINT_PATH_SURFACES.flatMap((surface) => collectFiles(surface))
+    .filter((relativePath) => relativePath !== "tests/tooling/oxlint-spelling.test.ts")
+    .sort();
 }
 
 function collectFiles(relativePath: string): string[] {


### PR DESCRIPTION
## Summary
- keep npm/oxlint as the canonical plugin package directory
- assert npm/oxint does not return in repo-local tooling, docs, examples, lockfile, or workspace config
- preserve the published package name as oxlint-plugin-vize

Refs #4899

## Verification
- vp check tests/tooling/oxlint-spelling.test.ts
- VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/oxlint-spelling.test.ts
- vp run --filter './npm/oxlint' check
- vp run --filter './npm/oxlint' build
- vp run --filter './npm/oxlint' test
- vp run --filter './examples/oxlint-vize' check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790699334&installation_model_id=422833&pr_number=5418&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5418&signature=94964565d9059daf9b6dfff0283af0984c8f8a6175bcd725ce21e70b24027ce5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->