### PR TITLE
fix(davinci): gate static prop hoists by subtree facts

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_root_hoist.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_root_hoist.rs
@@ -1,0 +1,25 @@
+//! Root static-props hoist position gates, compared byte-for-byte.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "root_static_props_with_component_child",
+        r#"<div class="wrapper"><Foo /></div>"#,
+    ),
+    (
+        "root_static_props_with_static_nested_dynamic_text",
+        r#"<div class="wrapper"><span>{{ msg }}</span></div>"#,
+    ),
+];
+
+#[test]
+fn s2_root_hoist_position_gates_match_the_shipped_dom_lane() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_atelier_dom/tests/davinci_s2_root_hoist.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_root_hoist.rs
@@ -21,6 +21,10 @@ const BATTERY: &[(&str, &str)] = &[
         "component_static_props_with_component_slot",
         r#"<Foo class="panel"><Bar /></Foo>"#,
     ),
+    (
+        "root_static_props_with_slotted_component_child",
+        r#"<div id="root"><Foo id="x">hello</Foo></div>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_root_hoist.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_root_hoist.rs
@@ -17,6 +17,10 @@ const BATTERY: &[(&str, &str)] = &[
         "root_static_props_with_static_nested_dynamic_text",
         r#"<div class="wrapper"><span>{{ msg }}</span></div>"#,
     ),
+    (
+        "component_static_props_with_component_slot",
+        r#"<Foo class="panel"><Bar /></Foo>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_static_vnode_hoist.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_static_vnode_hoist.rs
@@ -1,0 +1,33 @@
+//! Static child vnode hoists, compared byte-for-byte.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "nested_select_static_option_before_for",
+        r#"<div><select v-model="msg"><option value=""> Select </option><option v-for="item in items" :value="item">{{ item }}</option></select></div>"#,
+    ),
+    (
+        "v_if_static_child_and_text",
+        r#"<div v-if="ok"><span></span> x</div>"#,
+    ),
+    (
+        "v_if_static_child_with_attrs",
+        r#"<div v-if="ok"><span class="x">hello</span></div>"#,
+    ),
+    (
+        "nested_v_show_static_child",
+        r#"<div><span v-show="ok"><b>Downloading update</b></span></div>"#,
+    ),
+];
+
+#[test]
+fn s2_static_child_vnode_hoists_match_the_shipped_dom_lane() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -90,6 +90,7 @@ mod tpl;
 mod vfor;
 mod vif;
 mod vnode;
+mod vnode_children;
 mod vtext;
 
 use alloc::vec::Vec as StdVec;

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -94,7 +94,6 @@ mod vnode_children;
 mod vtext;
 
 use alloc::vec::Vec as StdVec;
-
 use vize_davinci::diagnostic::Severity;
 use vize_davinci::id::NodeId;
 use vize_davinci::pass::BudgetObserver;

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -22,6 +22,7 @@ use super::flag::emit_patch_flag;
 use super::hoist::compact_props_object;
 use super::js::asset_ident;
 use super::props::{admit_bindings, apply_static_ref_patch, bind_patch, emit_bind_props};
+use super::props_static;
 use super::slots;
 
 pub(super) fn collect_names<'a>(root: &Region<'a>) -> StdVec<&'a str> {
@@ -226,10 +227,12 @@ fn emit_call(
     let has_hoist_attrs = !hoist_attrs.is_empty();
     let static_nested = builtin::has_static_nested(&component.children);
     let builtin_helper = builtin::helper(component.name).is_some();
-    let hoisted_static_props = if !has_binds
+    let can_hoist_static_props = !has_binds
         && !has_custom
         && if_key.is_none()
         && has_hoist_attrs
+        && props_static::root_should_hoist(cx, id);
+    let hoisted_static_props = if can_hoist_static_props
         && ((!array && (facts.is_some() || create) && (!builtin_helper || static_nested))
             || (array && static_nested))
     {
@@ -240,12 +243,7 @@ fn emit_call(
     } else {
         None
     };
-    let unused_hoist = hoisted_static_props.is_none()
-        && !has_binds
-        && !has_custom
-        && if_key.is_none()
-        && has_hoist_attrs
-        && static_nested;
+    let unused_hoist = hoisted_static_props.is_none() && can_hoist_static_props && static_nested;
     if unused_hoist {
         cx.buf
             .push_hoist(compact_props_object(hoist_attrs.iter().copied()));

--- a/crates/vize_s1_to_s2/src/emit/fragment.rs
+++ b/crates/vize_s1_to_s2/src/emit/fragment.rs
@@ -88,7 +88,7 @@ fn emit_unique(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> {
         Op::Element(element) => {
             let _id = cx.walk.mint();
             cx.walk.skip(element.bindings.len());
-            vnode::emit_unique_element(cx, element)
+            vnode::emit_unique_element(cx, element, _id)
         }
         Op::Component(component) => {
             let id = cx.walk.mint();
@@ -160,9 +160,9 @@ fn emit_units(cx: &mut EmitCx<'_>, op: &Op<'_>, first: &mut bool) -> Result<(), 
         Op::Interpolation(interp) => emit_interp(cx, interp, first),
         Op::Element(element) => {
             start_item(cx, first);
-            let _id = cx.walk.mint();
+            let id = cx.walk.mint();
             cx.walk.skip(element.bindings.len());
-            vnode::emit_fragment_element(cx, element)
+            vnode::emit_fragment_element(cx, element, id)
         }
         Op::Component(component) => {
             start_item(cx, first);

--- a/crates/vize_s1_to_s2/src/emit/once.rs
+++ b/crates/vize_s1_to_s2/src/emit/once.rs
@@ -31,7 +31,12 @@ pub(super) fn emit_element(
             cx.buf.use_create_element_vnode();
             cx.once_depth += 1;
             let result = vnode::emit_call(
-                cx, element, /* block */ false, key, /* hoist */ false, for_item,
+                cx,
+                element,
+                /* block */ false,
+                key,
+                /* hoist */ (false, None),
+                for_item,
                 /* once */ true,
             );
             cx.once_depth -= 1;

--- a/crates/vize_s1_to_s2/src/emit/props_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static.rs
@@ -1,7 +1,10 @@
 //! Inline static props for native element calls.
 
+use vize_davinci::id::NodeId;
 use vize_s0::String;
 use vize_s2::op::{Attribute, BindingOp, DynamicName};
+
+use crate::pass::StaticLevel;
 
 use super::EmitCx;
 use super::EmitError;
@@ -10,6 +13,19 @@ use super::js::{escape_js_string, is_valid_js_identifier};
 use super::props::{Piece, bind_value_is_static_patchless, pieces, static_bind_key};
 use super::props_bind::{StaticBindKey, StaticBindKeyCasing};
 use super::props_value::bind_value;
+
+pub(super) fn root_should_hoist(cx: &EmitCx<'_>, id: Option<NodeId>) -> bool {
+    let Some(fact) = id.and_then(|id| cx.facts.static_facts.get(id)) else {
+        return false;
+    };
+    if !fact.props_hoistable {
+        return false;
+    }
+    match fact.level {
+        StaticLevel::FullyStatic | StaticLevel::HasDynamicText => true,
+        StaticLevel::NotStatic => fact.foreign || fact.nested_static,
+    }
+}
 
 pub(super) fn root_hoist_props(
     attributes: &[Attribute<'_>],

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -41,6 +41,7 @@ fn emit_block(
     element: &ElementOp<'_>,
     if_key: Option<&str>,
     for_item: bool,
+    allow_hoist: bool,
 ) -> Result<(), EmitError> {
     directive::wrap_element(cx, element, |cx| {
         cx.buf.use_open_block();
@@ -48,7 +49,15 @@ fn emit_block(
         cx.buf.push("(");
         cx.buf.push(Buf::open_block_alias());
         cx.buf.push("(), ");
-        emit_call(cx, element, true, if_key, (false, None), for_item, false)?;
+        emit_call(
+            cx,
+            element,
+            true,
+            if_key,
+            (allow_hoist, None),
+            for_item,
+            false,
+        )?;
         cx.buf.push(")");
         Ok(())
     })
@@ -83,14 +92,14 @@ fn emit_nested(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) -> Result<(), EmitE
     super::memo::emit_cached(cx, &element.bindings, |cx| {
         directive::wrap_element(cx, element, |cx| {
             cx.buf.use_create_element_vnode();
-            emit_call(cx, element, false, None, (false, None), false, false)
+            emit_call(cx, element, false, None, (true, None), false, false)
         })
     })
 }
 
 fn emit_nested_block(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) -> Result<(), EmitError> {
     super::memo::emit_cached(cx, &element.bindings, |cx| {
-        emit_block(cx, element, None, false)
+        emit_block(cx, element, None, false, false)
     })
 }
 
@@ -99,7 +108,7 @@ pub(super) fn emit_if_branch_element(
     element: &ElementOp<'_>,
     key: &str,
 ) -> Result<(), EmitError> {
-    emit_block(cx, element, Some(key), false)
+    emit_block(cx, element, Some(key), false, true)
 }
 
 pub(super) fn emit_for_item_element(
@@ -118,7 +127,7 @@ pub(super) fn emit_for_item_element(
                 emit_call(cx, element, false, key, (false, None), true, false)
             });
         }
-        emit_block(cx, element, key, true)
+        emit_block(cx, element, key, true, false)
     })
 }
 
@@ -143,9 +152,9 @@ pub(super) fn emit_call(
     cx.buf.push(element.tag);
     cx.buf.push("\"");
     let has_children = !element.children.ops.is_empty();
-    let has_runtime_child_hoist = allow_hoist
-        && block
-        && (directive::has_runtime(&element.bindings)
+    let hoist_static_children = allow_hoist
+        && (if_key.is_some()
+            || directive::has_runtime(&element.bindings)
             || super::model::first_runtime_model(element).is_some());
     let has_memo = super::memo::has(&element.bindings);
     let memo_block = block && has_memo && !(if_key.is_some() && !for_item);
@@ -214,7 +223,7 @@ pub(super) fn emit_call(
                 cx,
                 &element.children,
                 force_array_children,
-                has_runtime_child_hoist,
+                hoist_static_children,
             )
         })?;
     } else if emit_flag {

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -2,17 +2,18 @@
 
 use vize_davinci::id::NodeId;
 use vize_s0::ensure_sufficient_stack;
-use vize_s2::op::{BindingOp, ElementOp, Op, Region};
+use vize_s2::op::{BindingOp, ElementOp, Op};
 
 use super::EmitCx;
 use super::EmitError;
 use super::UnsupportedReason as Reason;
 use super::buf::Buf;
-use super::children::{children_need_text_flag, emit_create_text_vnode, emit_text_like};
+use super::children::children_need_text_flag;
 use super::directive;
 use super::flag::emit_patch_flag;
 use super::namespace;
 use super::props::{admit_element_bindings, apply_static_ref_patch, bind_patch, emit_bind_props};
+use super::vnode_children::emit_children;
 
 pub(super) fn emit_unique_element(
     cx: &mut EmitCx<'_>,
@@ -158,8 +159,9 @@ pub(super) fn emit_call(
             || super::model::first_runtime_model(element).is_some());
     let has_memo = super::memo::has(&element.bindings);
     let memo_block = block && has_memo && !(if_key.is_some() && !for_item);
-    let force_array_children =
-        once || memo_block || (directive::has_custom(&element.bindings) && allow_hoist && block);
+    let force_array_children = once
+        || memo_block
+        || (directive::has_custom(&element.bindings) && allow_hoist && block && if_key.is_none());
     let has_binds = has_prop_bindings(&element.bindings);
     let hoisted_props =
         if allow_hoist && if_key.is_none() && super::props_static::root_should_hoist(cx, id) {
@@ -266,52 +268,6 @@ fn has_cloak(bindings: &[BindingOp<'_>]) -> bool {
     bindings
         .iter()
         .any(|binding| matches!(binding, BindingOp::VueCloak(_)))
-}
-
-fn emit_children(
-    cx: &mut EmitCx<'_>,
-    children: &Region<'_>,
-    force_array: bool,
-    hoist_static_children: bool,
-) -> Result<(), EmitError> {
-    let ops = &children.ops;
-    if !force_array
-        && ops
-            .iter()
-            .all(|op| matches!(op, Op::Text(_) | Op::Interpolation(_)))
-    {
-        return emit_text_like(cx, ops);
-    }
-    cx.buf.push("[");
-    cx.buf.indent();
-    let mut i = 0;
-    let mut first = true;
-    while i < ops.len() {
-        if matches!(ops[i], Op::Text(_) | Op::Interpolation(_)) {
-            let start = i;
-            while i < ops.len() && matches!(ops[i], Op::Text(_) | Op::Interpolation(_)) {
-                i += 1;
-            }
-            if !first {
-                cx.buf.push(",");
-            }
-            cx.buf.newline();
-            first = false;
-            emit_create_text_vnode(cx, &ops[start..i])?;
-            continue;
-        }
-        if !first {
-            cx.buf.push(",");
-        }
-        cx.buf.newline();
-        first = false;
-        emit_array_child(cx, &ops[i], hoist_static_children)?;
-        i += 1;
-    }
-    cx.buf.deindent();
-    cx.buf.newline();
-    cx.buf.push("]");
-    Ok(())
 }
 
 pub(super) fn emit_array_child(

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -1,5 +1,6 @@
 //! Static native HTML element / children emission.
 
+use vize_davinci::id::NodeId;
 use vize_s0::ensure_sufficient_stack;
 use vize_s2::op::{BindingOp, ElementOp, Op, Region};
 
@@ -16,6 +17,7 @@ use super::props::{admit_element_bindings, apply_static_ref_patch, bind_patch, e
 pub(super) fn emit_unique_element(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
+    id: Option<NodeId>,
 ) -> Result<(), EmitError> {
     if super::once::has(&element.bindings) {
         return super::once::emit_element(cx, element, None, false);
@@ -27,7 +29,7 @@ pub(super) fn emit_unique_element(
             cx.buf.push("(");
             cx.buf.push(Buf::open_block_alias());
             cx.buf.push("(), ");
-            emit_call(cx, element, true, None, true, false, false)?;
+            emit_call(cx, element, true, None, (true, id), false, false)?;
             cx.buf.push(")");
             Ok(())
         })
@@ -37,7 +39,6 @@ pub(super) fn emit_unique_element(
 fn emit_block(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
-    allow_hoist: bool,
     if_key: Option<&str>,
     for_item: bool,
 ) -> Result<(), EmitError> {
@@ -47,7 +48,7 @@ fn emit_block(
         cx.buf.push("(");
         cx.buf.push(Buf::open_block_alias());
         cx.buf.push("(), ");
-        emit_call(cx, element, true, if_key, allow_hoist, for_item, false)?;
+        emit_call(cx, element, true, if_key, (false, None), for_item, false)?;
         cx.buf.push(")");
         Ok(())
     })
@@ -56,6 +57,7 @@ fn emit_block(
 pub(super) fn emit_fragment_element(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
+    id: Option<NodeId>,
 ) -> Result<(), EmitError> {
     if super::once::has(&element.bindings) {
         return super::once::emit_element(cx, element, None, false);
@@ -66,7 +68,7 @@ pub(super) fn emit_fragment_element(
     super::memo::emit_cached(cx, &element.bindings, |cx| {
         directive::wrap_element(cx, element, |cx| {
             cx.buf.use_create_element_vnode();
-            emit_call(cx, element, false, None, true, false, false)
+            emit_call(cx, element, false, None, (true, id), false, false)
         })
     })
 }
@@ -81,14 +83,14 @@ fn emit_nested(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) -> Result<(), EmitE
     super::memo::emit_cached(cx, &element.bindings, |cx| {
         directive::wrap_element(cx, element, |cx| {
             cx.buf.use_create_element_vnode();
-            emit_call(cx, element, false, None, false, false, false)
+            emit_call(cx, element, false, None, (false, None), false, false)
         })
     })
 }
 
 fn emit_nested_block(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) -> Result<(), EmitError> {
     super::memo::emit_cached(cx, &element.bindings, |cx| {
-        emit_block(cx, element, false, None, false)
+        emit_block(cx, element, None, false)
     })
 }
 
@@ -97,7 +99,7 @@ pub(super) fn emit_if_branch_element(
     element: &ElementOp<'_>,
     key: &str,
 ) -> Result<(), EmitError> {
-    emit_block(cx, element, false, Some(key), false)
+    emit_block(cx, element, Some(key), false)
 }
 
 pub(super) fn emit_for_item_element(
@@ -113,10 +115,10 @@ pub(super) fn emit_for_item_element(
         if stable {
             return directive::wrap_element(cx, element, |cx| {
                 cx.buf.use_create_element_vnode();
-                emit_call(cx, element, false, key, false, true, false)
+                emit_call(cx, element, false, key, (false, None), true, false)
             });
         }
-        emit_block(cx, element, false, key, true)
+        emit_block(cx, element, key, true)
     })
 }
 
@@ -125,11 +127,12 @@ pub(super) fn emit_call(
     element: &ElementOp<'_>,
     block: bool,
     if_key: Option<&str>,
-    allow_hoist: bool,
+    hoist: (bool, Option<NodeId>),
     for_item: bool,
     once: bool,
 ) -> Result<(), EmitError> {
-    admit_native(element)?;
+    admit_element_bindings(&element.attributes, &element.bindings)?;
+    let (allow_hoist, id) = hoist;
     let alias = if block {
         Buf::create_element_block_alias()
     } else {
@@ -149,11 +152,12 @@ pub(super) fn emit_call(
     let force_array_children =
         once || memo_block || (directive::has_custom(&element.bindings) && allow_hoist && block);
     let has_binds = has_prop_bindings(&element.bindings);
-    let hoisted_props = if allow_hoist && if_key.is_none() {
-        super::props_static::root_hoist_props(&element.attributes, &element.bindings)?
-    } else {
-        None
-    };
+    let hoisted_props =
+        if allow_hoist && if_key.is_none() && super::props_static::root_should_hoist(cx, id) {
+            super::props_static::root_hoist_props(&element.attributes, &element.bindings)?
+        } else {
+            None
+        };
     let hoist = hoisted_props.is_some();
     let patch = bind_patch(&element.bindings, false, if_key, for_item);
     let text_flag = !once && !memo_block && children_need_text_flag(&element.children);
@@ -234,10 +238,6 @@ pub(super) fn emit_call(
     }
     cx.buf.push(")");
     Ok(())
-}
-
-fn admit_native(element: &ElementOp<'_>) -> Result<(), EmitError> {
-    admit_element_bindings(&element.attributes, &element.bindings)
 }
 
 fn has_prop_bindings(bindings: &[BindingOp<'_>]) -> bool {

--- a/crates/vize_s1_to_s2/src/emit/vnode_children.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_children.rs
@@ -1,0 +1,52 @@
+//! Native element child-list emission.
+
+use vize_s2::op::{Op, Region};
+
+use super::children::{emit_create_text_vnode, emit_text_like};
+use super::{EmitCx, EmitError};
+
+pub(super) fn emit_children(
+    cx: &mut EmitCx<'_>,
+    children: &Region<'_>,
+    force_array: bool,
+    hoist_static_children: bool,
+) -> Result<(), EmitError> {
+    let ops = &children.ops;
+    if !force_array
+        && ops
+            .iter()
+            .all(|op| matches!(op, Op::Text(_) | Op::Interpolation(_)))
+    {
+        return emit_text_like(cx, ops);
+    }
+    cx.buf.push("[");
+    cx.buf.indent();
+    let mut i = 0;
+    let mut first = true;
+    while i < ops.len() {
+        if matches!(ops[i], Op::Text(_) | Op::Interpolation(_)) {
+            let start = i;
+            while i < ops.len() && matches!(ops[i], Op::Text(_) | Op::Interpolation(_)) {
+                i += 1;
+            }
+            if !first {
+                cx.buf.push(",");
+            }
+            cx.buf.newline();
+            first = false;
+            emit_create_text_vnode(cx, &ops[start..i])?;
+            continue;
+        }
+        if !first {
+            cx.buf.push(",");
+        }
+        cx.buf.newline();
+        first = false;
+        super::vnode::emit_array_child(cx, &ops[i], hoist_static_children)?;
+        i += 1;
+    }
+    cx.buf.deindent();
+    cx.buf.newline();
+    cx.buf.push("]");
+    Ok(())
+}

--- a/crates/vize_s1_to_s2/tests/emit_comp.rs
+++ b/crates/vize_s1_to_s2/tests/emit_comp.rs
@@ -180,20 +180,19 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
-fn static_props_hoists_keep_their_queued_aliases() {
+fn component_static_props_hoist_after_inline_root_props() {
     assert_eq!(
         assembled(r#"<div id="root"><Foo id="x">hello</Foo></div>"#),
         pin("\
 const { resolveComponent: _resolveComponent, createVNode: _createVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, createTextVNode: _createTextVNode, withCtx: _withCtx } = Vue
 
-const _hoisted_1 = { id: \"root\" }
-const _hoisted_2 = { id: \"x\" }
+const _hoisted_1 = { id: \"x\" }
 
 function render(_ctx, _cache, $props, $setup, $data, $options) {
   const _component_Foo = _resolveComponent(\"Foo\")
 
-  return (_openBlock(), _createElementBlock(\"div\", _hoisted_1, [
-    _createVNode(_component_Foo, _hoisted_2, {
+  return (_openBlock(), _createElementBlock(\"div\", { id: \"root\" }, [
+    _createVNode(_component_Foo, _hoisted_1, {
       default: _withCtx(() => [
         _createTextVNode(\"hello\")
       ]),

--- a/crates/vize_s1_to_s2/tests/emit_dirs.rs
+++ b/crates/vize_s1_to_s2/tests/emit_dirs.rs
@@ -151,6 +151,25 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+fn v_if_text_stays_inlined() {
+    assert_eq!(
+        assembled(r#"<div v-if="ok" v-example>hello</div>"#),
+        pin("\
+const { resolveDirective: _resolveDirective, withDirectives: _withDirectives, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective(\"example\")
+
+  return (ok)
+    ? _withDirectives((_openBlock(), _createElementBlock(\"div\", { key: 0 }, \"hello\", 512 /* NEED_PATCH */)), [
+      [_directive_example]
+    ])
+    : _createCommentVNode(\"v-if\", true)
+}")
+    );
+}
+
+#[test]
 fn a_v_for_item_emits_empty_props_without_need_patch() {
     assert_eq!(
         assembled(r#"<div v-for="i in n" v-example></div>"#),

--- a/crates/vize_s1_to_s2/tests/emit_if.rs
+++ b/crates/vize_s1_to_s2/tests/emit_if.rs
@@ -72,17 +72,17 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 
 #[test]
 fn mixed_text_in_a_v_if_lists_comment_before_text() {
-    // Nested static vnode hoist (`_hoisted_1 = /*#__PURE__*/ _createElementVNode`)
-    // is a later P2-11 realization; this pin is helper rank only.
     assert_eq!(
         assembled(r#"<div v-if="ok"><span></span> x</div>"#),
         "\
 const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode, createTextVNode: _createTextVNode } = Vue
 
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode(\"span\")
+
 function render(_ctx, _cache, $props, $setup, $data, $options) {
   return (ok)
     ? (_openBlock(), _createElementBlock(\"div\", { key: 0 }, [
-      _createElementVNode(\"span\"),
+      _hoisted_1,
       _createTextVNode(\" x\")
     ]))
     : _createCommentVNode(\"v-if\", true)

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           926 |                   442 |               484 |             140 |     371 |             939 |      498 |           488 |           600 |
+| Compiler                   |           926 |                   442 |               484 |             140 |     371 |             939 |      498 |           488 |           601 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           926 |                   442 |               484 |             140 |     371 |             939 |      498 |           488 |           599 |
+| Compiler                   |           926 |                   442 |               484 |             140 |     371 |             939 |      498 |           488 |           600 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |


### PR DESCRIPTION
## Summary
- Gate native and component static-props hoists with the hoist-static fact table instead of only the prop surface.
- Pass native owner ids through the DOM emitter so root and fragment roots can mirror shipped hoist positions.
- Hoist static child vnodes under dynamic native parents where the shipped DOM lane hoists them, without loosening root props hoists.
- Add byte-for-byte witnesses for root/component static props and static vnode children under v-model, v-if, and runtime directive parents.

## Verification
- cargo fmt --check
- git diff --check origin/fix/davinci-root-props-hoist-parity...HEAD
- cargo clippy -p vize_s1_to_s2 -- -D warnings -D clippy::wildcard_imports
- cargo test -p vize_atelier_dom --test davinci_s2_static_vnode_hoist --test davinci_s2_root_hoist --test davinci_s2_model --test davinci_s2_dom
- cargo test -p vize_s1_to_s2 --test emit_static --test emit_if --test emit_model --test emit_comp
- node --test tests/tooling/davinci-matrices.test.ts
- rust-script tools/commands/davinci/consumer-migration-surfaces.rs --check

## Corpus Evidence
- Real Project Matrix run 33323351251: S2 DOM corpus record-only verdict succeeded with s2_refusals=0 and divergences=20599 before the static-vnode follow-up was merged into this branch.
- Previous post-#5413/#5415/#5416 corpus count was 23907 divergences, so the static-props gate reduced the corpus by 3308 cases before the latest static-vnode change.

## CI
- Auto-merge is enabled.
- GitHub Actions is running again on the latest head after the stacked static-vnode follow-up merged into this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static vnode and prop hoisting across conditional, loop, fragment, and component-rendering scenarios.
  * Refined hoisting decisions so eligible static content is reused while root properties remain inline when appropriate.
  * Improved handling of component slots, nested static elements, and directive-bound conditional content.

* **Tests**
  * Added coverage for static child vnode hoisting and component-slot scenarios.
  * Updated compiler output expectations for refined hoisting behavior.

* **Documentation**
  * Updated the consumer migration inventory to reflect the latest scanned-file count.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->