### PR TITLE
test(ui): guard family directory layout

### DIFF
--- a/npm/ui/core/src/directory-layout.test.ts
+++ b/npm/ui/core/src/directory-layout.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { test } from "vite-plus/test";
+
+const sourceRoot = path.resolve("src");
+const familySfcPattern =
+  /^families\/[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*\.vue$/u;
+
+const grandfatheredRootSfcFiles = [
+  "action-button.vue",
+  "alert-dialog-content.vue",
+  "alert.vue",
+  "announcer-provider.vue",
+  "aspect-ratio.vue",
+  "avatar.vue",
+  "badge.vue",
+  "block-ui.vue",
+  "blockquote.vue",
+  "breadcrumb-item.vue",
+  "breadcrumb-link.vue",
+  "breadcrumb-list.vue",
+  "breadcrumb-separator.vue",
+  "breadcrumb.vue",
+  "card.vue",
+  "checkbox-control.vue",
+  "cluster.vue",
+  "code.vue",
+  "collapsible-content.vue",
+  "collapsible-root.vue",
+  "collapsible-trigger.vue",
+  "container.vue",
+  "deterministic-id-provider.vue",
+  "empty-state.vue",
+  "error-summary.vue",
+  "field-description.vue",
+  "field-error-message.vue",
+  "field-label.vue",
+  "field.vue",
+  "grid.vue",
+  "heading.vue",
+  "kbd.vue",
+  "link-anchor.vue",
+  "list.vue",
+  "listbox-item.vue",
+  "listbox.vue",
+  "live-region.vue",
+  "meter.vue",
+  "pagination-ellipsis.vue",
+  "pagination-item.vue",
+  "pagination-list.vue",
+  "pagination-next.vue",
+  "pagination-page.vue",
+  "pagination-previous.vue",
+  "pagination.vue",
+  "portal.vue",
+  "positioner-arrow.vue",
+  "positioner.vue",
+  "presence.vue",
+  "primitive-element.vue",
+  "progress-bar.vue",
+  "radio-group-item.vue",
+  "radio-group.vue",
+  "search-field.vue",
+  "separator.vue",
+  "skeleton.vue",
+  "spacer.vue",
+  "spinner.vue",
+  "stack.vue",
+  "stepper-content.vue",
+  "stepper-item.vue",
+  "stepper-list.vue",
+  "stepper-root.vue",
+  "stepper-trigger.vue",
+  "switch-control.vue",
+  "tabs-content.vue",
+  "tabs-list.vue",
+  "tabs-root.vue",
+  "tabs-trigger.vue",
+  "text-input.vue",
+  "text.vue",
+  "textarea-control.vue",
+  "toggle-button.vue",
+  "toggle-group-item.vue",
+  "toggle-group.vue",
+  "transition.vue",
+  "visually-hidden.vue",
+] as const;
+
+test("new public SFCs live in family directories", () => {
+  assert.deepEqual(rootSfcFiles(), grandfatheredRootSfcFiles);
+});
+
+test("family SFCs keep area and primitive directory segments", () => {
+  const files = collectVueFiles(path.join(sourceRoot, "families"))
+    .map((filename) => toPosixPath(path.relative(sourceRoot, filename)))
+    .sort();
+  const offenders = files.filter((filename) => !familySfcPattern.test(filename));
+
+  assert.ok(files.length > 0);
+  assert.deepEqual(offenders, []);
+});
+
+function rootSfcFiles(): readonly string[] {
+  return fs
+    .readdirSync(sourceRoot, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".vue"))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function collectVueFiles(directory: string): readonly string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const filename = path.join(directory, entry.name);
+    if (entry.isDirectory()) return collectVueFiles(filename);
+    return entry.isFile() && entry.name.endsWith(".vue") ? [filename] : [];
+  });
+}
+
+function toPosixPath(filename: string): string {
+  return filename.split(path.sep).join(path.posix.sep);
+}


### PR DESCRIPTION
## Summary
- add a UI package regression test for the preferred family directory shape
- keep the existing root SFCs as an explicit grandfathered set
- require new family SFCs to live under src/families/<area>/<primitive>/

## Verification
- vp test run src/directory-layout.test.ts
- vp check src/directory-layout.test.ts
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790700852&installation_model_id=422833&pr_number=5421&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5421&signature=7711f9f5d29333e2bbe63954e7a02361a3152640662353d4f7b927e6830540f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->