### PR TITLE
fix(davinci): gate component prop hoists by subtree facts

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_root_hoist.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_root_hoist.rs
@@ -17,6 +17,10 @@ const BATTERY: &[(&str, &str)] = &[
         "root_static_props_with_static_nested_dynamic_text",
         r#"<div class="wrapper"><span>{{ msg }}</span></div>"#,
     ),
+    (
+        "component_static_props_with_component_slot",
+        r#"<Foo class="panel"><Bar /></Foo>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -22,6 +22,7 @@ use super::flag::emit_patch_flag;
 use super::hoist::compact_props_object;
 use super::js::asset_ident;
 use super::props::{admit_bindings, apply_static_ref_patch, bind_patch, emit_bind_props};
+use super::props_static;
 use super::slots;
 
 pub(super) fn collect_names<'a>(root: &Region<'a>) -> StdVec<&'a str> {
@@ -226,10 +227,12 @@ fn emit_call(
     let has_hoist_attrs = !hoist_attrs.is_empty();
     let static_nested = builtin::has_static_nested(&component.children);
     let builtin_helper = builtin::helper(component.name).is_some();
-    let hoisted_static_props = if !has_binds
+    let can_hoist_static_props = !has_binds
         && !has_custom
         && if_key.is_none()
         && has_hoist_attrs
+        && props_static::root_should_hoist(cx, id);
+    let hoisted_static_props = if can_hoist_static_props
         && ((!array && (facts.is_some() || create) && (!builtin_helper || static_nested))
             || (array && static_nested))
     {
@@ -240,12 +243,7 @@ fn emit_call(
     } else {
         None
     };
-    let unused_hoist = hoisted_static_props.is_none()
-        && !has_binds
-        && !has_custom
-        && if_key.is_none()
-        && has_hoist_attrs
-        && static_nested;
+    let unused_hoist = hoisted_static_props.is_none() && can_hoist_static_props && static_nested;
     if unused_hoist {
         cx.buf
             .push_hoist(compact_props_object(hoist_attrs.iter().copied()));


### PR DESCRIPTION
## Summary
- reuse the static subtree facts gate for component static-props hoists
- keep component slots containing component children inline to match the shipped DOM lane
- add a byte-for-byte DOM witness for the component-slot case

## Verification
- cargo fmt --check
- git diff --check fix/davinci-root-props-hoist-parity...HEAD
- cargo clippy -p vize_s1_to_s2 -- -D warnings -D clippy::wildcard_imports
- cargo test -p vize_atelier_dom --test davinci_s2_root_hoist --test davinci_s2_dom --test davinci_s2_patch_flags_static
- cargo test -p vize_s1_to_s2 --test emit_static
- node --test tests/tooling/davinci-matrices.test.ts
- rust-script tools/commands/davinci/consumer-migration-surfaces.rs --check