### PR TITLE
fix(davinci): hoist static vnode children in dynamic parents

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_static_vnode_hoist.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_static_vnode_hoist.rs
@@ -1,0 +1,33 @@
+//! Static child vnode hoists, compared byte-for-byte.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "nested_select_static_option_before_for",
+        r#"<div><select v-model="msg"><option value=""> Select </option><option v-for="item in items" :value="item">{{ item }}</option></select></div>"#,
+    ),
+    (
+        "v_if_static_child_and_text",
+        r#"<div v-if="ok"><span></span> x</div>"#,
+    ),
+    (
+        "v_if_static_child_with_attrs",
+        r#"<div v-if="ok"><span class="x">hello</span></div>"#,
+    ),
+    (
+        "nested_v_show_static_child",
+        r#"<div><span v-show="ok"><b>Downloading update</b></span></div>"#,
+    ),
+];
+
+#[test]
+fn s2_static_child_vnode_hoists_match_the_shipped_dom_lane() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -41,6 +41,7 @@ fn emit_block(
     element: &ElementOp<'_>,
     if_key: Option<&str>,
     for_item: bool,
+    allow_hoist: bool,
 ) -> Result<(), EmitError> {
     directive::wrap_element(cx, element, |cx| {
         cx.buf.use_open_block();
@@ -48,7 +49,15 @@ fn emit_block(
         cx.buf.push("(");
         cx.buf.push(Buf::open_block_alias());
         cx.buf.push("(), ");
-        emit_call(cx, element, true, if_key, (false, None), for_item, false)?;
+        emit_call(
+            cx,
+            element,
+            true,
+            if_key,
+            (allow_hoist, None),
+            for_item,
+            false,
+        )?;
         cx.buf.push(")");
         Ok(())
     })
@@ -83,14 +92,14 @@ fn emit_nested(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) -> Result<(), EmitE
     super::memo::emit_cached(cx, &element.bindings, |cx| {
         directive::wrap_element(cx, element, |cx| {
             cx.buf.use_create_element_vnode();
-            emit_call(cx, element, false, None, (false, None), false, false)
+            emit_call(cx, element, false, None, (true, None), false, false)
         })
     })
 }
 
 fn emit_nested_block(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) -> Result<(), EmitError> {
     super::memo::emit_cached(cx, &element.bindings, |cx| {
-        emit_block(cx, element, None, false)
+        emit_block(cx, element, None, false, false)
     })
 }
 
@@ -99,7 +108,7 @@ pub(super) fn emit_if_branch_element(
     element: &ElementOp<'_>,
     key: &str,
 ) -> Result<(), EmitError> {
-    emit_block(cx, element, Some(key), false)
+    emit_block(cx, element, Some(key), false, true)
 }
 
 pub(super) fn emit_for_item_element(
@@ -118,7 +127,7 @@ pub(super) fn emit_for_item_element(
                 emit_call(cx, element, false, key, (false, None), true, false)
             });
         }
-        emit_block(cx, element, key, true)
+        emit_block(cx, element, key, true, false)
     })
 }
 
@@ -143,9 +152,9 @@ pub(super) fn emit_call(
     cx.buf.push(element.tag);
     cx.buf.push("\"");
     let has_children = !element.children.ops.is_empty();
-    let has_runtime_child_hoist = allow_hoist
-        && block
-        && (directive::has_runtime(&element.bindings)
+    let hoist_static_children = allow_hoist
+        && (if_key.is_some()
+            || directive::has_runtime(&element.bindings)
             || super::model::first_runtime_model(element).is_some());
     let has_memo = super::memo::has(&element.bindings);
     let memo_block = block && has_memo && !(if_key.is_some() && !for_item);
@@ -214,7 +223,7 @@ pub(super) fn emit_call(
                 cx,
                 &element.children,
                 force_array_children,
-                has_runtime_child_hoist,
+                hoist_static_children,
             )
         })?;
     } else if emit_flag {

--- a/crates/vize_s1_to_s2/tests/emit_if.rs
+++ b/crates/vize_s1_to_s2/tests/emit_if.rs
@@ -72,17 +72,17 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 
 #[test]
 fn mixed_text_in_a_v_if_lists_comment_before_text() {
-    // Nested static vnode hoist (`_hoisted_1 = /*#__PURE__*/ _createElementVNode`)
-    // is a later P2-11 realization; this pin is helper rank only.
     assert_eq!(
         assembled(r#"<div v-if="ok"><span></span> x</div>"#),
         "\
 const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode, createTextVNode: _createTextVNode } = Vue
 
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode(\"span\")
+
 function render(_ctx, _cache, $props, $setup, $data, $options) {
   return (ok)
     ? (_openBlock(), _createElementBlock(\"div\", { key: 0 }, [
-      _createElementVNode(\"span\"),
+      _hoisted_1,
       _createTextVNode(\" x\")
     ]))
     : _createCommentVNode(\"v-if\", true)

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           926 |                   442 |               484 |             140 |     371 |             939 |      498 |           488 |           600 |
+| Compiler                   |           926 |                   442 |               484 |             140 |     371 |             939 |      498 |           488 |           601 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |


### PR DESCRIPTION
## Summary
- allow static child vnode hoists under dynamic native parents when the shipped DOM lane hoists them
- keep root props hoist gating unchanged by carrying child-hoist permission separately
- add byte-for-byte DOM witnesses for nested v-model, v-if, and runtime directive parents

## Verification
- cargo fmt --check
- git diff --check origin/fix/davinci-root-props-hoist-parity...HEAD
- cargo clippy -p vize_s1_to_s2 -- -D warnings -D clippy::wildcard_imports
- cargo test -p vize_atelier_dom --test davinci_s2_static_vnode_hoist --test davinci_s2_root_hoist --test davinci_s2_model --test davinci_s2_dom
- cargo test -p vize_s1_to_s2 --test emit_static --test emit_if --test emit_model --test emit_comp
- node --test tests/tooling/davinci-matrices.test.ts
- rust-script tools/commands/davinci/consumer-migration-surfaces.rs --check