### PR TITLE
fix(davinci): normalize bare object style binds

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_style_merge.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_style_merge.rs
@@ -24,6 +24,22 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<div style="color: red" :style="{ fontSize: x }"></div>"#,
     ),
     (
+        "bare_object_literal",
+        r#"<div :style="{ color: textColor }"></div>"#,
+    ),
+    (
+        "bare_object_static_value",
+        r#"<div :style="{ color: 'red' }"></div>"#,
+    ),
+    (
+        "bare_object_spread",
+        r#"<div :style="{ ...styles }"></div>"#,
+    ),
+    (
+        "bare_object_computed_key",
+        r#"<div :style="{ [prop]: 'red' }"></div>"#,
+    ),
+    (
         "css_function_semicolon",
         r#"<div style="background: url(a;b); color: red" :style="s"></div>"#,
     ),

--- a/crates/vize_s1_to_s2/src/emit/style.rs
+++ b/crates/vize_s1_to_s2/src/emit/style.rs
@@ -1,6 +1,5 @@
 //! Static style-attribute serialization used by dynamic `:style` merges.
 
-use oxc_ast::ast::Expression;
 use vize_s2::expr::JsExpr;
 use vize_s2::op::{Attribute, BindOp};
 
@@ -15,9 +14,7 @@ pub(super) fn emit_style_value(
     js: &JsExpr<'_>,
     skip_normalize: bool,
 ) {
-    let bare_object_literal =
-        static_style.is_none() && matches!(js.ast, Expression::ObjectExpression(_));
-    let wrap = !skip_normalize && !bare_object_literal;
+    let wrap = !skip_normalize;
     if wrap {
         cx.buf.use_normalize_style();
         cx.buf.push(Buf::normalize_style_alias());


### PR DESCRIPTION
## Summary
- wrap S2 DOM static-name `:style` binds with `_normalizeStyle(...)` unless the value is already inside a `mergeProps` segment
- add shipped DOM lane byte-for-byte witnesses for bare object style literals, static values, spreads, and computed keys
- keep the existing `skip_normalize` contract for spread/merge ordering

## Tests
- `cargo test -p vize_atelier_dom --test davinci_s2_style_merge -- --nocapture`
- `cargo test -p vize_s1_to_s2 --test emit_static -- --nocapture`
- `cargo test -p vize_s1_to_s2 --test emit_merge -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_root_hoist -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_patch_flags s2_patch_flags_match_the_shipped_dom_lane_per_node -- --exact --nocapture`
- `cargo test -p vize_s1_to_s2 --tests -- --format terse`
- `cargo test -p vize_atelier_dom --tests -- --format terse`
- `git diff --check`
- `cargo fmt --all -- --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy -p vize_maestro --tests -- -D warnings`
- `rust-script tools/commands/ci/github/check-maestro-feature-contract.rs`
- `cargo test -p vize_atelier_core -p vize_atelier_dom -- --format terse`

`cargo test --workspace -- --format terse` was also attempted with a TypeScript 7 `CORSA_PATH`, but this clean local worktree has no installed `node_modules/vue`; it stopped at `workspace Vue package missing`. The PR CI install environment is the authoritative full-suite check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790710241&installation_model_id=422833&pr_number=5429&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5429&signature=a804e519517dc7dfa7bc21d72f57ca52e725ad0e34a97fdbb5e19e2bb5318045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->