### PR TITLE
test(davinci): harden s1 lowering fuzz oracle

### DIFF
--- a/tests/fuzz/fuzz_targets/s1_lowering.rs
+++ b/tests/fuzz/fuzz_targets/s1_lowering.rs
@@ -10,18 +10,20 @@
 //
 // The target asserts more than no-crash, so a logic break surfaces as a
 // fuzz finding: the page-order id accounting law (`op_count` equals the
-// folio's op count) and the S2 folio round-trip law (the canonical
-// `Full`-mode print re-parses to the same document) must hold on every
-// input.
+// folio's op count), canonical S2 verifier invariants, lowering side-table id
+// resolution, and the S2 folio round-trip law (the canonical `Full`-mode print
+// re-parses to the same document) must hold on every input.
 //
 // The corpus is seeded from the `<template>` blocks of repository .vue
 // fixtures by `tools/fuzz/seed_corpus.mjs`.
 use libfuzzer_sys::fuzz_target;
 use vize_davinci::folio::{Folio, FolioMode};
+use vize_davinci::side_table::SideTable;
 use vize_s0::Allocator;
 use vize_s1::parse;
 use vize_s1_to_s2::lower;
 use vize_s2::folio::DisegnoFolio;
+use vize_s2::verify::{Rigor, verify, verify_table};
 
 fuzz_target!(|data: &[u8]| {
     let Ok(source) = std::str::from_utf8(data) else {
@@ -37,6 +39,17 @@ fuzz_target!(|data: &[u8]| {
     let lowered = lower(&allocator, &tree, &errors);
     let folio = DisegnoFolio::of(&lowered.root.ops);
     assert_eq!(u64::from(lowered.op_count), folio.op_count());
+    assert_eq!(verify(&folio, Rigor::Canonical), vec![]);
+    assert_eq!(verify_table(&folio, &lowered.scopes), vec![]);
+    assert_eq!(verify_table(&folio, &lowered.texts), vec![]);
+    assert_eq!(verify_table(&folio, &lowered.wrappers), vec![]);
+    assert_eq!(verify_table(&folio, &lowered.for_wrappers), vec![]);
+    let provenance_ids: SideTable<()> = lowered
+        .provenance
+        .iter()
+        .filter_map(|record| record.node.map(|node| (node, ())))
+        .collect();
+    assert_eq!(verify_table(&folio, &provenance_ids), vec![]);
     let printed = folio.print_to_string(FolioMode::Full);
     let reparsed = DisegnoFolio::parse(printed.as_str()).expect("canonical print must re-parse");
     assert_eq!(reparsed, folio);


### PR DESCRIPTION
## Summary
- Extend the `s1_lowering` fuzz oracle beyond no-crash/id-count/roundtrip checks.
- Assert canonical S2 verifier invariants and lowering side-table id resolution for scopes, text facts, wrapper facts, for-wrapper facts, and provenance nodes.

## Notes
- No production compiler path or shipped user behavior changes.
- Current `origin/main` already reports missing Corsa guidance as `typescript@^7`; this PR only hardens Davinci fuzz coverage.

## Tests
- `cargo fmt --all -- --check`
- `cargo check --manifest-path tests/fuzz/Cargo.toml --bins`
- `cargo test -p vize_s1_to_s2`
- `cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus -- --nocapture`
- `cargo +nightly fuzz run --fuzz-dir tests/fuzz s1_lowering -- -runs=0 -max_len=65536 -timeout=25 -rss_limit_mb=4096 -malloc_limit_mb=2048`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790711865&installation_model_id=422833&pr_number=5432&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5432&signature=07cbd031501592e5c2c09e1e4b2ffde2d2a77691b288be1e9833a7a512039bfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->