### PR TITLE
test(davinci): gate s2 dom corpus evidence

### DIFF
--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
@@ -32,12 +32,15 @@ const BATTERY: &[(&str, &str)] = &[
 #[derive(Default)]
 struct Report {
     files: u64,
+    unreadable_count: u64,
     parsed: u64,
     templates: u64,
     compared: u64,
     old_error_skips: u64,
     s2_refusal_count: u64,
     divergence_count: u64,
+    unreadable: Vec<String>,
+    old_error_samples: Vec<String>,
     s2_refusal_reasons: BTreeMap<&'static str, u64>,
     s2_refusal_samples: BTreeMap<&'static str, Vec<String>>,
     s2_refusals: Vec<String>,
@@ -76,15 +79,25 @@ fn dom_emit_agrees_on_sfc_templates_body() {
 
     let mut corpus = Report::default();
     for file in &sweep.files {
-        let Ok(source) = fs::read_to_string(file) else {
-            continue;
+        let source = match fs::read_to_string(file) {
+            Ok(source) => source,
+            Err(error) => {
+                corpus.unreadable_count += 1;
+                if corpus.unreadable.len() < 20 {
+                    corpus
+                        .unreadable
+                        .push(format!("{}: {error}", file.display()));
+                }
+                continue;
+            }
         };
         let context = file.to_string_lossy();
         compare_sfc_template(context.as_ref(), &source, &mut corpus);
     }
     eprintln!(
-        "davinci DOM corpus sweep: files={} parsed={} templates={} compared={} old_error_skips={} s2_refusals={} divergences={}",
+        "davinci DOM corpus sweep: files={} unreadable={} parsed={} templates={} compared={} old_error_skips={} s2_refusals={} divergences={}",
         corpus.files,
+        corpus.unreadable_count,
         corpus.parsed,
         corpus.templates,
         corpus.compared,
@@ -122,6 +135,12 @@ fn compare_sfc_template(name: &str, source: &str, report: &mut Report) {
     let (_, errors, old) = vize_atelier_dom::compile_template(&old_allocator, &template.content);
     if !errors.is_empty() {
         report.old_error_skips += 1;
+        if report.old_error_samples.len() < 20 {
+            report.old_error_samples.push(format!(
+                "{name}: {} old-lane errors: {errors:?}",
+                errors.len()
+            ));
+        }
         return;
     }
     let old = format!("{}\n{}", old.preamble, old.code);
@@ -203,8 +222,15 @@ fn assert_empty(label: &str, values: &[String]) {
 
 fn assert_clean_corpus(report: &Report) {
     assert!(
-        report.s2_refusal_count == 0 && report.divergence_count == 0,
-        "corpus S2 refusals ({}) by reason {:?}:\n{}\n\ncorpus divergences ({}):\n{}",
+        report.unreadable_count == 0
+            && report.old_error_skips == 0
+            && report.s2_refusal_count == 0
+            && report.divergence_count == 0,
+        "corpus unreadable files ({}):\n{}\n\ncorpus old-lane error skips ({}):\n{}\n\ncorpus S2 refusals ({}) by reason {:?}:\n{}\n\ncorpus divergences ({}):\n{}",
+        report.unreadable_count,
+        report.unreadable.join("\n"),
+        report.old_error_skips,
+        report.old_error_samples.join("\n"),
         report.s2_refusal_count,
         report.s2_refusal_reasons,
         report.s2_refusals.join("\n"),

--- a/npm/ui/core/src/theme-scope.test.ts
+++ b/npm/ui/core/src/theme-scope.test.ts
@@ -11,10 +11,27 @@ import {
 } from "./theme-scope.ts";
 import type { ThemeDensityScale, ThemePresetName } from "./theme-scope.ts";
 
-function runBootstrapScript(script: string): void {
+type ThemeTestStorage = Pick<Storage, "clear" | "getItem" | "setItem">;
+
+function createThemeTestStorage(): ThemeTestStorage {
+  const values = new Map<string, string>();
+  return {
+    clear() {
+      values.clear();
+    },
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    },
+  };
+}
+
+function runBootstrapScript(script: string, storage: ThemeTestStorage): void {
   runInNewContext(script, {
     document,
-    globalThis: { localStorage },
+    globalThis: { localStorage: storage },
   });
 }
 
@@ -66,24 +83,25 @@ test("normalizes nested theme scope attributes and restores imperative scopes", 
 
 test("creates a storage-backed no-flash theme bootstrap script", () => {
   const root = document.documentElement;
+  const storage = createThemeTestStorage();
   root.removeAttribute(themePresetAttribute);
   root.removeAttribute(themeDensityAttribute);
-  localStorage.clear();
-  localStorage.setItem(themeScopeStorageKeys.presets, "paper signal signal");
-  localStorage.setItem(themeScopeStorageKeys.density, "compact");
+  storage.clear();
+  storage.setItem(themeScopeStorageKeys.presets, "paper signal signal");
+  storage.setItem(themeScopeStorageKeys.density, "compact");
 
   const script = createThemeBootstrapScript({
     fallback: { presets: "atelier", density: "comfortable" },
   });
-  runBootstrapScript(script);
+  runBootstrapScript(script, storage);
   assert.equal(root.getAttribute(themePresetAttribute), "paper signal");
   assert.equal(root.getAttribute(themeDensityAttribute), "compact");
 
   root.removeAttribute(themePresetAttribute);
   root.removeAttribute(themeDensityAttribute);
-  localStorage.setItem(themeScopeStorageKeys.presets, "atelier bogus");
-  localStorage.setItem(themeScopeStorageKeys.density, "dense");
-  runBootstrapScript(script);
+  storage.setItem(themeScopeStorageKeys.presets, "atelier bogus");
+  storage.setItem(themeScopeStorageKeys.density, "dense");
+  runBootstrapScript(script, storage);
   assert.equal(root.getAttribute(themePresetAttribute), "atelier");
   assert.equal(root.getAttribute(themeDensityAttribute), "comfortable");
 
@@ -94,5 +112,5 @@ test("creates a storage-backed no-flash theme bootstrap script", () => {
 
   root.removeAttribute(themePresetAttribute);
   root.removeAttribute(themeDensityAttribute);
-  localStorage.clear();
+  storage.clear();
 });

--- a/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
+++ b/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
@@ -1,10 +1,17 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 
 import {
   corpusEvidenceLines,
+  expectedDomOutputComparisons,
+  expectedGitlinks,
+  parseCorpusEvidence,
   parseFixtureGitlinks,
+  validateCorpusEvidence,
   verdictFor,
 } from "../../tools/fixtures/davinci-dom-corpus-workflow.mjs";
 import { findStep, readRealProjectMatrixWorkflow } from "./support/real-project-matrix-workflow.ts";
@@ -62,6 +69,7 @@ test("real-project workflow carries a full-canonical S2 DOM corpus job", () => {
   });
   assert.equal(finalize.run, "node tools/fixtures/davinci-dom-corpus-workflow.mjs finalize");
   assert.match(helperSource, /"record-only"/);
+  assert.match(helperSource, /expectedDomOutputComparisons = 144/);
   assert.match(helperSource, /summary\.json/);
   assert.match(helperSource, /davinci-differential corpus scope\|davinci DOM corpus sweep/);
   assert.match(helperSource, /Davinci S2 DOM corpus failed/);
@@ -94,4 +102,98 @@ test("S2 DOM corpus workflow helper extracts canonical evidence", () => {
   );
   assert.equal(verdictFor("failure", "record-only"), "success");
   assert.equal(verdictFor("cancelled", "record-only"), "cancelled");
+  assert.equal(expectedGitlinks, 146);
+  assert.equal(expectedDomOutputComparisons, 144);
+});
+
+test("S2 DOM corpus workflow gitlink constant matches the checkout index", () => {
+  const indexed = parseFixtureGitlinks(
+    execFileSync("git", ["ls-files", "--stage", "--", "tests/_fixtures/_git"], {
+      encoding: "utf8",
+    }),
+  );
+
+  assert.equal(indexed.length, expectedGitlinks);
+});
+
+test("S2 DOM corpus workflow validates closure evidence artifacts", () => {
+  const artifact = mkdtempSync(join(tmpdir(), "vize-dom-corpus-"));
+  try {
+    writeFileSync(
+      join(artifact, "selected-gitlinks.txt"),
+      Array.from({ length: 146 }, (_, index) => `tests/_fixtures/_git/project-${index}`)
+        .join("\n")
+        .concat("\n"),
+    );
+    writeFileSync(
+      join(artifact, "submodule-status.txt"),
+      Array.from(
+        { length: 146 },
+        (_, index) =>
+          ` 0123456789abcdef0123456789abcdef01234567 tests/_fixtures/_git/project-${index}`,
+      )
+        .join("\n")
+        .concat("\n"),
+    );
+    writeFileSync(
+      join(artifact, "dom-corpus.log"),
+      [
+        "\u001B[32mdavinci-differential corpus scope: root=tests/_fixtures/_git scope=canonical closure_evidence=true submodules=146\u001B[0m",
+        "davinci DOM corpus sweep: files=37448 unreadable=0 parsed=37448 templates=35000 compared=35000 old_error_skips=0 s2_refusals=0 divergences=0",
+      ].join("\n"),
+    );
+
+    const validation = validateCorpusEvidence(artifact);
+    assert.deepEqual(validation.failures, []);
+    assert.equal(validation.manifestDomOutputComparisons, 144);
+    assert.equal(validation.selectedGitlinks, 146);
+    assert.equal(validation.submoduleStatusRows, 146);
+    assert.deepEqual(parseCorpusEvidence(readFileSync(join(artifact, "dom-corpus.log"), "utf8")), {
+      canonicalScope: true,
+      closureEvidence: true,
+      submodules: 146,
+      files: 37448,
+      unreadable: 0,
+      parsed: 37448,
+      templates: 35000,
+      compared: 35000,
+      oldErrorSkips: 0,
+      s2Refusals: 0,
+      divergences: 0,
+    });
+  } finally {
+    rmSync(artifact, { recursive: true, force: true });
+  }
+});
+
+test("S2 DOM corpus workflow rejects stale or dirty evidence artifacts", () => {
+  const artifact = mkdtempSync(join(tmpdir(), "vize-dom-corpus-"));
+  try {
+    writeFileSync(
+      join(artifact, "selected-gitlinks.txt"),
+      Array.from({ length: 142 }, (_, index) => `tests/_fixtures/_git/project-${index}`)
+        .join("\n")
+        .concat("\n"),
+    );
+    writeFileSync(join(artifact, "submodule-status.txt"), "");
+    writeFileSync(
+      join(artifact, "dom-corpus.log"),
+      [
+        "davinci-differential corpus scope: root=/tmp/tests/_fixtures/_git scope=smoke closure_evidence=false",
+        "davinci DOM corpus sweep: files=1 unreadable=3 parsed=1 templates=1 compared=0 old_error_skips=2 s2_refusals=1 divergences=1",
+      ].join("\n"),
+    );
+
+    assert.deepEqual(validateCorpusEvidence(artifact).failures, [
+      "selected gitlinks 142 != 146",
+      "submodule status rows 0 != 146",
+      "corpus log is missing canonical closure evidence",
+      "corpus log submodules 0 != 146",
+      "corpus log proves no DOM-output comparisons",
+      "corpus log skipped inputs: unreadable=3 old_error_skips=2",
+      "corpus log is not clean: s2_refusals=1 divergences=1",
+    ]);
+  } finally {
+    rmSync(artifact, { recursive: true, force: true });
+  }
 });

--- a/tools/fixtures/davinci-dom-corpus-workflow.mjs
+++ b/tools/fixtures/davinci-dom-corpus-workflow.mjs
@@ -4,9 +4,13 @@ import { appendFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { expectedComparisonCount } from "../davinci/lib/corpus-baseline-artifact.mjs";
+import { loadManifest } from "../davinci/lib/corpus-baseline-contract.mjs";
+
 export const artifactDir = "real-project-davinci-dom-corpus";
 export const corpusRoot = "tests/_fixtures/_git";
 export const expectedGitlinks = 146;
+export const expectedDomOutputComparisons = 144;
 
 const ansiEscapePattern = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
 
@@ -51,6 +55,97 @@ export function corpusEvidenceLines(logText) {
     .filter((line) =>
       /davinci-differential corpus scope|davinci DOM corpus sweep/.test(stripAnsi(line)),
     );
+}
+
+export function parseCorpusEvidence(logText) {
+  const evidence = {
+    canonicalScope: false,
+    closureEvidence: false,
+    submodules: 0,
+    files: 0,
+    unreadable: 0,
+    parsed: 0,
+    templates: 0,
+    compared: 0,
+    oldErrorSkips: 0,
+    s2Refusals: 0,
+    divergences: 0,
+  };
+  for (const line of corpusEvidenceLines(logText).map(stripAnsi)) {
+    const scope = /scope=canonical closure_evidence=(true|false) submodules=(\d+)/.exec(line);
+    if (scope) {
+      evidence.canonicalScope = true;
+      evidence.closureEvidence = scope[1] === "true";
+      evidence.submodules = Number(scope[2]);
+      continue;
+    }
+    const sweep =
+      /files=(\d+) unreadable=(\d+) parsed=(\d+) templates=(\d+) compared=(\d+) old_error_skips=(\d+) s2_refusals=(\d+) divergences=(\d+)/.exec(
+        line,
+      );
+    if (sweep) {
+      evidence.files = Number(sweep[1]);
+      evidence.unreadable = Number(sweep[2]);
+      evidence.parsed = Number(sweep[3]);
+      evidence.templates = Number(sweep[4]);
+      evidence.compared = Number(sweep[5]);
+      evidence.oldErrorSkips = Number(sweep[6]);
+      evidence.s2Refusals = Number(sweep[7]);
+      evidence.divergences = Number(sweep[8]);
+    }
+  }
+  return evidence;
+}
+
+export function validateCorpusEvidence(artifact = artifactDir) {
+  const manifestDomOutputComparisons = expectedComparisonCount(loadManifest(), ["compiler"]);
+  const selected = readOptional(`${artifact}/selected-gitlinks.txt`)
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean);
+  const status = readOptional(`${artifact}/submodule-status.txt`)
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean);
+  const evidence = parseCorpusEvidence(readOptional(`${artifact}/dom-corpus.log`));
+  const failures = [];
+  if (manifestDomOutputComparisons !== expectedDomOutputComparisons) {
+    failures.push(
+      `manifest DOM-output comparisons ${manifestDomOutputComparisons} != ${expectedDomOutputComparisons}`,
+    );
+  }
+  if (selected.length !== expectedGitlinks) {
+    failures.push(`selected gitlinks ${selected.length} != ${expectedGitlinks}`);
+  }
+  if (status.length !== expectedGitlinks) {
+    failures.push(`submodule status rows ${status.length} != ${expectedGitlinks}`);
+  }
+  if (!evidence.canonicalScope || !evidence.closureEvidence) {
+    failures.push("corpus log is missing canonical closure evidence");
+  }
+  if (evidence.submodules !== expectedGitlinks) {
+    failures.push(`corpus log submodules ${evidence.submodules} != ${expectedGitlinks}`);
+  }
+  if (evidence.files === 0 || evidence.templates === 0 || evidence.compared === 0) {
+    failures.push("corpus log proves no DOM-output comparisons");
+  }
+  if (evidence.unreadable !== 0 || evidence.oldErrorSkips !== 0) {
+    failures.push(
+      `corpus log skipped inputs: unreadable=${evidence.unreadable} old_error_skips=${evidence.oldErrorSkips}`,
+    );
+  }
+  if (evidence.s2Refusals !== 0 || evidence.divergences !== 0) {
+    failures.push(
+      `corpus log is not clean: s2_refusals=${evidence.s2Refusals} divergences=${evidence.divergences}`,
+    );
+  }
+  return {
+    manifestDomOutputComparisons,
+    selectedGitlinks: selected.length,
+    submoduleStatusRows: status.length,
+    evidence,
+    failures,
+  };
 }
 
 export function hydrateCorpus() {
@@ -129,10 +224,20 @@ export async function finalizeCorpus(environment = process.env) {
   mkdirSync(artifactDir, { recursive: true });
   const mode = environment.VIZE_DAVINCI_DOM_CORPUS_MODE ?? "enforce";
   const outcome = environment.VIZE_DAVINCI_DOM_CORPUS_OUTCOME ?? "failure";
-  const verdict = verdictFor(outcome, mode);
-  writeFileSync(`${artifactDir}/summary.json`, `${JSON.stringify({ mode, outcome, verdict })}\n`);
+  let verdict = verdictFor(outcome, mode);
+  const validation = validateCorpusEvidence();
+  if (outcome === "success" && validation.failures.length > 0) {
+    verdict = "failure";
+  }
+  writeFileSync(
+    `${artifactDir}/summary.json`,
+    `${JSON.stringify({ mode, outcome, verdict, ...validation })}\n`,
+  );
   await appendCorpusSummary(mode, outcome, verdict, environment.GITHUB_STEP_SUMMARY);
   if (verdict !== "success") {
+    for (const failure of validation.failures) {
+      console.error(`::error title=Invalid Davinci S2 DOM corpus evidence::${failure}`);
+    }
     console.error(`::error title=Davinci S2 DOM corpus failed::mode=${mode} verdict=${verdict}`);
     return 1;
   }
@@ -141,10 +246,7 @@ export async function finalizeCorpus(environment = process.env) {
 
 async function appendCorpusSummary(mode, outcome, verdict, summaryPath) {
   if (!summaryPath) return;
-  const gitlinkCount = readOptional(`${artifactDir}/selected-gitlinks.txt`)
-    .trim()
-    .split(/\r?\n/)
-    .filter(Boolean).length;
+  const validation = validateCorpusEvidence();
   const logText = readOptional(`${artifactDir}/dom-corpus.log`);
   const evidence = corpusEvidenceLines(logText);
   await appendFile(
@@ -155,7 +257,10 @@ async function appendCorpusSummary(mode, outcome, verdict, summaryPath) {
       `- mode: \`${mode}\``,
       `- outcome: \`${outcome}\``,
       `- verdict: \`${verdict}\``,
-      `- gitlinks: \`${gitlinkCount}\``,
+      `- manifest DOM-output comparisons: \`${validation.manifestDomOutputComparisons}\``,
+      `- gitlinks: \`${validation.selectedGitlinks}\``,
+      `- submodule status rows: \`${validation.submoduleStatusRows}\``,
+      `- compared templates: \`${validation.evidence.compared}\``,
       "",
       ...evidence,
       "",


### PR DESCRIPTION
## Summary
- fail P2-11 DOM corpus finalization unless the artifact proves canonical 146-gitlink closure evidence and the 144-project compiler manifest target
- make the Rust DOM corpus lane fail closed on unreadable files and old-lane error skips, not only S2 refusals/divergences
- add synthetic workflow-helper tests for valid and stale/dirty evidence artifacts

## Validation
- cargo fmt --all -- --check
- cargo test -p vize_s1_to_s2
- cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture
- node --test tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts tests/tooling/davinci-corpus-comparison-count.test.ts tests/tooling/davinci-phase2-ledger.test.ts tests/tooling/source-file-lengths.test.ts
- corepack pnpm exec vp run --workspace-root check:ci
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790713388&installation_model_id=422833&pr_number=5433&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5433&signature=9c407043624940fd52b394561ab62cf14deee0bece9dcbd1cb76d9df1a7bcd9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded corpus workflow coverage for clean, stale, and modified evidence artifacts.
  * Added checks for expected comparison totals and repository file-link consistency.
  * Improved diagnostics by reporting unreadable files and sampled compilation errors.
  * Made theme bootstrap tests more reliable through isolated storage handling.

* **Chores**
  * Workflow summaries now include validation results and detailed comparison, link, submodule, and template counts.
  * Invalid evidence can no longer be reported as successful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->