### PR TITLE
fix(davinci): match v-for child prop layout

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_v_for_child_props.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_v_for_child_props.rs
@@ -1,0 +1,55 @@
+//! P2-11 corpus regression: nested children of a `v-for` item keep the shipped
+//! props object layout instead of inheriting the item-root compact form.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "audio_dynamic_source_inside_for",
+        r#"<audio v-for="(url, index) in recordedUrls" :key="index" controls><source :src="url" type="audio/wav"></audio>"#,
+    ),
+    (
+        "audio_dynamic_source_inside_for_after_static_controls",
+        r#"
+<div>
+  <div>
+    <select v-model="constraintId">
+      <option value="">
+        Select
+      </option>
+      <option v-for="(item, index) of audioInputs" :key="index" :value="item.deviceId">
+        {{ item.label }}
+      </option>
+    </select>
+  </div>
+  <div space-x-2>
+    <button @click="handleStart">
+      Start
+    </button>
+    <button @click="handleCancel">
+      Cancel
+    </button>
+    <button @click="handleStop">
+      Stop
+    </button>
+  </div>
+  <div>
+    <audio v-for="(url, index) in recordedUrls" :key="index" controls>
+      <source :src="url" type="audio/wav">
+    </audio>
+  </div>
+</div>
+"#,
+    ),
+];
+
+#[test]
+fn s2_v_for_child_props_match_the_shipped_dom_lane() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_s1_to_s2/src/emit/merge.rs
+++ b/crates/vize_s1_to_s2/src/emit/merge.rs
@@ -132,7 +132,7 @@ pub(super) fn emit_spread_props(
     bindings: &[BindingOp<'_>],
     if_key: Option<&str>,
     skip_is: bool,
-    empty_key_multiline: bool,
+    for_item: bool,
     is_plain_element: bool,
 ) -> Result<(), EmitError> {
     let args = merge_args(attributes, bindings, if_key, skip_is)?;
@@ -166,8 +166,9 @@ pub(super) fn emit_spread_props(
                     pieces,
                     *if_key,
                     true,
-                    empty_key_multiline,
+                    for_item,
                     is_plain_element,
+                    for_item,
                 )?;
             }
         }

--- a/crates/vize_s1_to_s2/src/emit/props.rs
+++ b/crates/vize_s1_to_s2/src/emit/props.rs
@@ -302,6 +302,7 @@ pub(super) fn emit_bind_props(
         false,
         for_item && super::directive::has_custom(bindings),
         is_plain_element,
+        for_item,
     )?;
     if normalize {
         cx.buf.push(")");

--- a/crates/vize_s1_to_s2/src/emit/props_object.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_object.rs
@@ -21,6 +21,7 @@ pub(super) fn emit_props_object(
     skip_normalize: bool,
     empty_key_multiline: bool,
     is_plain_element: bool,
+    for_item: bool,
 ) -> Result<(), EmitError> {
     let skip_class = pieces_have_named(pieces, "class");
     let skip_style = pieces_have_named(pieces, "style");
@@ -53,7 +54,7 @@ pub(super) fn emit_props_object(
     let multiline = !compact_multiline
         && ((if_key.is_some() && !visible.is_empty())
             || pieces_have_inline_on(pieces)
-            || (!cx.in_v_for
+            || (!for_item
                 && (visible.len() + extra > 1
                     || pieces_have_named(pieces, "class")
                     || pieces_have_named(pieces, "style")

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           926 |                   442 |               484 |             140 |     371 |             939 |      498 |           488 |           601 |
+| Compiler                   |           926 |                   442 |               484 |             140 |     371 |             939 |      498 |           488 |           602 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |


### PR DESCRIPTION
## Summary
- keep S2 props object multiline layout for nested children inside a v-for item
- add a real-corpus reducer for the AIRI audio/source pattern that previously compacted child props under ambient v-for state
- refresh the consumer migration surface inventory count changed by this source edit
- leave the shipped DOM lane and rollout flags unchanged

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vize_atelier_dom --test davinci_s2_v_for_child_props --test davinci_s2_static_vnode_hoist -- --nocapture
- cargo test -p vize_s1_to_s2
- cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture
- cargo test -p vize_atelier_dom --tests
- node --test tests/tooling/davinci-matrices.test.ts tests/tooling/package-manifests-corsa-runtime.test.ts tests/tooling/release-smoke-init-toolchain.test.ts tests/tooling/davinci-phase2-ledger.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts tests/tooling/davinci-corpus-comparison-count.test.ts
- corepack pnpm exec vp run --workspace-root check:ci

## Corpus note
The latest hydrated main run 33335526598 still fails P2-11 with 14911 divergences. This PR fixes one sampled props-layout family; it does not switch rollout behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prop handling for nested elements rendered inside `v-for` loops.
  * Preserved the correct props object structure for child elements, including nested media and form elements.

* **Tests**
  * Added regression coverage for nested children in `v-for` templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->