### PR TITLE
refactor(s2): add S2 folio stage name

### DIFF
--- a/crates/vize_s2/src/folio.rs
+++ b/crates/vize_s2/src/folio.rs
@@ -1,9 +1,9 @@
-//! The disegno folio: the S2 stage dump.
+//! The S2 folio: the stage dump.
 //!
-//! [`DisegnoFolio`] is an **owned document model** of an S2 op tree,
+//! [`S2Folio`] is an **owned document model** of an S2 op tree,
 //! printable and parseable under the `vize_davinci::folio` contract; the
 //! grammar is documented in `davinci-road/plan/folio-format.md` ("Disegno
-//! page"). [`DisegnoFolio::of`] mirrors a live arena tree into the owned
+//! page"). [`S2Folio::of`] mirrors a live arena tree into the owned
 //! model, because arena references cannot persist across a compile
 //! (P1-11's contract) and `parse` must construct values without an arena.
 //!
@@ -47,13 +47,17 @@ pub use owned::{
 /// The root region's ops, in document order. Everything else - the `ops=`
 /// count, section headers, indentation - is the printer's derived
 /// statement about this tree.
+#[doc(alias = "DisegnoFolio")]
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct DisegnoFolio {
+pub struct S2Folio {
     /// The root region's ops.
     pub ops: Vec<FolioOp>,
 }
 
-impl Folio for DisegnoFolio {
+/// Compatibility alias for the original S2 codename type.
+pub type DisegnoFolio = S2Folio;
+
+impl Folio for S2Folio {
     fn print<W: core::fmt::Write>(&self, w: &mut W, mode: FolioMode) -> core::fmt::Result {
         print::print(self, w, mode)
     }

--- a/crates/vize_s2/src/folio/owned.rs
+++ b/crates/vize_s2/src/folio/owned.rs
@@ -4,7 +4,7 @@
 //! One mirror type per lifetime-carrying op type; the lifetime-free op
 //! types ([`Span`], [`Namespace`], [`OpaqueReason`](crate::expr::OpaqueReason))
 //! are reused directly, and the expression mirrors live in [`expr`].
-//! [`DisegnoFolio::of`] is the bridge, and its matches are exhaustive
+//! [`S2Folio::of`] is the bridge, and its matches are exhaustive
 //! with no `_` arm on purpose: a new op variant must break this file
 //! loudly (the same staleness discipline the canary test enforces).
 
@@ -12,7 +12,7 @@ use alloc::vec::Vec;
 
 use vize_s0::{Span, String};
 
-use super::DisegnoFolio;
+use super::S2Folio;
 use crate::op::{Attribute, DynamicName, Namespace, Op, Region};
 
 mod binding;
@@ -163,7 +163,7 @@ pub struct FolioSlot {
     pub span: Span,
 }
 
-impl DisegnoFolio {
+impl S2Folio {
     /// Mirror a live arena tree into the owned document model.
     #[must_use]
     pub fn of(ops: &[Op<'_>]) -> Self {

--- a/crates/vize_s2/src/folio/parse.rs
+++ b/crates/vize_s2/src/folio/parse.rs
@@ -19,7 +19,7 @@ use alloc::vec::Vec;
 use vize_davinci::folio::FolioError;
 use vize_s0::cstr;
 
-use super::DisegnoFolio;
+use super::S2Folio;
 use super::owned::{FolioBinding, FolioOp};
 
 mod binding_line;
@@ -46,7 +46,7 @@ struct Parser {
     seen_ops_field: bool,
 }
 
-pub(super) fn parse(input: &str) -> Result<DisegnoFolio, FolioError> {
+pub(super) fn parse(input: &str) -> Result<S2Folio, FolioError> {
     let mut parser = Parser {
         root: Vec::new(),
         stack: Vec::new(),
@@ -237,7 +237,7 @@ impl Parser {
         }
     }
 
-    fn finish(mut self) -> Result<DisegnoFolio, FolioError> {
+    fn finish(mut self) -> Result<S2Folio, FolioError> {
         if self.section == Section::BeforeHeader {
             return Err(err(0, cstr!("missing [disegno] header")));
         }
@@ -247,6 +247,6 @@ impl Parser {
         while !self.stack.is_empty() {
             self.close_top();
         }
-        Ok(DisegnoFolio { ops: self.root })
+        Ok(S2Folio { ops: self.root })
     }
 }

--- a/crates/vize_s2/src/folio/print.rs
+++ b/crates/vize_s2/src/folio/print.rs
@@ -1,4 +1,4 @@
-//! Canonical printer for [`DisegnoFolio`].
+//! Canonical printer for [`S2Folio`].
 //!
 //! `Full` mode is the injective, parseable form; `Display` elides every
 //! ` @start:end` span - line tails and the spans inside expression
@@ -11,7 +11,7 @@ use core::fmt::{Result, Write};
 
 use vize_s0::Span;
 
-use super::DisegnoFolio;
+use super::S2Folio;
 use super::owned::{FolioAttribute, FolioBinding, FolioExpr, FolioName, FolioOp};
 use crate::op::Namespace;
 use vize_davinci::folio::FolioMode;
@@ -20,7 +20,7 @@ mod binding;
 
 use binding::{print_attribute, print_binding};
 
-pub(super) fn print<W: Write>(folio: &DisegnoFolio, w: &mut W, mode: FolioMode) -> Result {
+pub(super) fn print<W: Write>(folio: &S2Folio, w: &mut W, mode: FolioMode) -> Result {
     writeln!(w, "[disegno]")?;
     writeln!(w, "ops={}", folio.op_count())?;
     writeln!(w)?;

--- a/crates/vize_s2/src/lib.rs
+++ b/crates/vize_s2/src/lib.rs
@@ -21,7 +21,7 @@
 //!   AST, foreign dialect (type-only until phase 6), or the classified
 //!   escape with pessimal documented semantics (P2-5b's decision; record
 //!   in `davinci-road/plan/phase-2-records/p2-5b.md`).
-//! - [`folio`] — [`folio::DisegnoFolio`], the S2 stage dump
+//! - [`folio`] — [`folio::S2Folio`], the S2 stage dump
 //!   (`davinci-road/plan/folio-format.md`, "Disegno page").
 //! - [`verify`] — the between-pass invariant checks (P2-6), debug/CI only:
 //!   local in the GHC `-dcore-lint` sense, and never in a release build.

--- a/crates/vize_s2/src/verify.rs
+++ b/crates/vize_s2/src/verify.rs
@@ -34,10 +34,10 @@
 //!
 //! # One walk, over the owned model
 //!
-//! The checks run over [`DisegnoFolio`], the owned document model, in one
+//! The checks run over [`S2Folio`], the owned document model, in one
 //! traversal — never a second walk per invariant. That is also why there
 //! is no parallel arena-tree walk: the owned model is the single surface
-//! the TS-18 fixture set and a live tree (via `DisegnoFolio::of`, which
+//! the TS-18 fixture set and a live tree (via `S2Folio::of`, which
 //! the folio observer's dump already needs) share, and a duplicated walk
 //! is exactly the drift the P1-8 scanner split taught. Violations are
 //! reported in **page order** — the order `print` emits lines — so
@@ -57,7 +57,7 @@ use core::fmt;
 use vize_davinci::side_table::SideTable;
 use vize_s0::{Span, String, cstr};
 
-use crate::folio::DisegnoFolio;
+use crate::folio::S2Folio;
 
 pub mod observer;
 mod walk;
@@ -155,7 +155,7 @@ const _: () = assert!(size_of::<Violation>() == 40);
 /// check is [`verify_table`] — id resolution needs the table, which the
 /// tree does not carry.
 #[must_use]
-pub fn verify(folio: &DisegnoFolio, rigor: Rigor) -> Vec<Violation> {
+pub fn verify(folio: &S2Folio, rigor: Rigor) -> Vec<Violation> {
     let mut out = Vec::new();
     walk::walk(folio, rigor, &mut out);
     out
@@ -170,7 +170,7 @@ pub fn verify(folio: &DisegnoFolio, rigor: Rigor) -> Vec<Violation> {
 /// `ops=` header states (`folio-format.md`, "Node numbering"). Dangling
 /// references are reported in ascending id order, one violation each.
 #[must_use]
-pub fn verify_table<T>(folio: &DisegnoFolio, table: &SideTable<T>) -> Vec<Violation> {
+pub fn verify_table<T>(folio: &S2Folio, table: &SideTable<T>) -> Vec<Violation> {
     let count = folio.op_count();
     let mut out = Vec::new();
     for (id, _) in table.sorted_entries() {
@@ -188,7 +188,7 @@ pub fn verify_table<T>(folio: &DisegnoFolio, table: &SideTable<T>) -> Vec<Violat
 #[cfg(test)]
 mod tests {
     use super::{Rigor, Violation, ViolationCode, verify, verify_table};
-    use crate::folio::DisegnoFolio;
+    use crate::folio::S2Folio;
     use alloc::vec;
     use vize_davinci::id::NodeId;
     use vize_davinci::side_table::SideTable;
@@ -219,21 +219,21 @@ mod tests {
 
     #[test]
     fn an_empty_page_holds_every_invariant_at_both_rigors() {
-        let folio = DisegnoFolio::default();
+        let folio = S2Folio::default();
         assert_eq!(verify(&folio, Rigor::Raw), vec![]);
         assert_eq!(verify(&folio, Rigor::Canonical), vec![]);
     }
 
     #[test]
     fn an_empty_side_table_dangles_nothing() {
-        let folio = DisegnoFolio::default();
+        let folio = S2Folio::default();
         let table: SideTable<u8> = SideTable::new();
         assert_eq!(verify_table(&folio, &table), vec![]);
     }
 
     #[test]
     fn a_dangling_reference_names_the_id_and_the_count_exactly() {
-        let folio = DisegnoFolio::default();
+        let folio = S2Folio::default();
         let mut table = SideTable::new();
         table.insert(
             NodeId::from_index(4).expect("index 4 has an id"),

--- a/crates/vize_s2/src/verify/observer.rs
+++ b/crates/vize_s2/src/verify/observer.rs
@@ -45,7 +45,7 @@ use vize_davinci::pass::{PassEvent, PassObserver};
 use vize_davinci::side_table::SideTable;
 use vize_s0::{Allocator, ArenaStamp};
 
-use crate::folio::DisegnoFolio;
+use crate::folio::S2Folio;
 
 #[cfg(debug_assertions)]
 use super::{Rigor, Violation, verify, verify_table};
@@ -109,7 +109,7 @@ impl VerifyObserver {
     /// In debug builds, panics with the aggregated page-order report
     /// naming `event`'s pass when any invariant is violated. Empty in
     /// release builds.
-    pub fn check(&self, event: &PassEvent<'_>, folio: &DisegnoFolio) {
+    pub fn check(&self, event: &PassEvent<'_>, folio: &S2Folio) {
         #[cfg(debug_assertions)]
         {
             fail(event, &verify(folio, self.rigor));
@@ -127,12 +127,7 @@ impl VerifyObserver {
     ///
     /// In debug builds, panics with the aggregated report naming
     /// `event`'s pass when a reference dangles. Empty in release builds.
-    pub fn check_table<T>(
-        &self,
-        event: &PassEvent<'_>,
-        folio: &DisegnoFolio,
-        table: &SideTable<T>,
-    ) {
+    pub fn check_table<T>(&self, event: &PassEvent<'_>, folio: &S2Folio, table: &SideTable<T>) {
         #[cfg(debug_assertions)]
         {
             fail(event, &verify_table(folio, table));

--- a/crates/vize_s2/src/verify/walk.rs
+++ b/crates/vize_s2/src/verify/walk.rs
@@ -18,12 +18,12 @@ use alloc::vec::Vec;
 use vize_s0::{Span, cstr};
 
 use super::{Rigor, Violation, ViolationCode};
-use crate::folio::{DisegnoFolio, FolioAttribute, FolioBinding, FolioIf, FolioOp};
+use crate::folio::{FolioAttribute, FolioBinding, FolioIf, FolioOp, S2Folio};
 
 /// The immediate owner of a nested line: its keyword and its span.
 type Owner = Option<(&'static str, Span)>;
 
-pub(super) fn walk(folio: &DisegnoFolio, rigor: Rigor, out: &mut Vec<Violation>) {
+pub(super) fn walk(folio: &S2Folio, rigor: Rigor, out: &mut Vec<Violation>) {
     for op in &folio.ops {
         visit_op(op, None, rigor, out);
     }

--- a/crates/vize_s2/tests/stage_name_alias.rs
+++ b/crates/vize_s2/tests/stage_name_alias.rs
@@ -1,0 +1,20 @@
+use vize_davinci::folio::{Folio, FolioMode};
+use vize_s2::folio::{DisegnoFolio, S2Folio};
+
+const EMPTY: &str = "[disegno]\nops=0\n\n";
+
+#[test]
+fn s2_folio_is_the_physical_stage_name() {
+    let folio = S2Folio::parse(EMPTY).expect("empty S2 folio parses");
+
+    assert_eq!(folio, S2Folio::default());
+    assert_eq!(folio.print_to_string(FolioMode::Full).as_str(), EMPTY);
+}
+
+#[test]
+fn disegno_folio_remains_a_compatibility_alias() {
+    let folio: DisegnoFolio = S2Folio::default();
+    let stage_named: S2Folio = DisegnoFolio::parse(EMPTY).expect("compat alias parses");
+
+    assert_eq!(folio, stage_named);
+}


### PR DESCRIPTION
## Summary
- introduce `S2Folio` as the physical S2 folio type
- keep `DisegnoFolio` as a compatibility alias for existing callers
- update internal S2 folio/verifier surfaces to use the physical stage name

## Tests
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_s2 --test stage_name_alias -- --nocapture`
- `cargo test -p vize_s2`
- `node --test tests/tooling/davinci-stage-dependencies.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo clippy -p vize_s2 --all-targets -- -D warnings`
- `cargo doc -p vize_s2 --no-deps`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790726698&installation_model_id=422833&pr_number=5447&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5447&signature=6fc938b8a8c26b4c4218c1b8cae2cb18b9b418307d96dccdc16be3a668f78ad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **API Updates**
  - Renamed the S2 folio type to `S2Folio`.
  - Retained `DisegnoFolio` as a compatibility alias.
  - Updated parsing, printing, verification, and observer APIs to use the new name.

- **Compatibility**
  - Existing code using `DisegnoFolio` remains supported.
  - Added coverage confirming both names are interchangeable and preserve round-trip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->