### PR TITLE
refactor(atelier): import SFC S0 storage through stage alias

### DIFF
--- a/crates/vize_atelier_sfc/Cargo.toml
+++ b/crates/vize_atelier_sfc/Cargo.toml
@@ -22,7 +22,7 @@ davinci-differential = [
 ]
 
 [dependencies]
-vize_carton = { workspace = true }
+vize_s0.workspace = true
 vize_croquis = { workspace = true }
 vize_atelier_core = { workspace = true }
 vize_atelier_dom = { workspace = true }

--- a/crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs
+++ b/crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs
@@ -15,7 +15,7 @@ use replacements::{
     AssetReferenceReplacement, apply_asset_replacements, asset_expression, join_expression_parts,
     push_string_part,
 };
-use vize_carton::{SmallVec, String};
+use vize_s0::{SmallVec, String};
 
 use super::assets::TemplateAssetUrl;
 

--- a/crates/vize_atelier_sfc/src/bundler/asset_rewrite/replacements.rs
+++ b/crates/vize_atelier_sfc/src/bundler/asset_rewrite/replacements.rs
@@ -1,4 +1,4 @@
-use vize_carton::{SmallVec, String};
+use vize_s0::{SmallVec, String};
 
 use crate::bundler::assets::TemplateAssetUrl;
 use crate::vite_plugin::js_string::push_js_string_literal;

--- a/crates/vize_atelier_sfc/src/bundler/assets.rs
+++ b/crates/vize_atelier_sfc/src/bundler/assets.rs
@@ -1,4 +1,4 @@
-use vize_carton::String;
+use vize_s0::String;
 
 use super::blocks::parse_descriptor;
 

--- a/crates/vize_atelier_sfc/src/bundler/blocks.rs
+++ b/crates/vize_atelier_sfc/src/bundler/blocks.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use vize_carton::String;
+use vize_s0::String;
 
 use crate::{SfcCustomBlock, SfcParseOptions, SfcStyleBlock, parse_sfc};
 
@@ -140,9 +140,7 @@ fn custom_block_to_bundler((index, block): (usize, &SfcCustomBlock<'_>)) -> Bund
     }
 }
 
-fn block_attrs(
-    attrs: &vize_carton::FxHashMap<Cow<'_, str>, Cow<'_, str>>,
-) -> Vec<SfcBlockAttribute> {
+fn block_attrs(attrs: &vize_s0::FxHashMap<Cow<'_, str>, Cow<'_, str>>) -> Vec<SfcBlockAttribute> {
     attrs
         .iter()
         .map(|(name, value)| SfcBlockAttribute {

--- a/crates/vize_atelier_sfc/src/bundler/css.rs
+++ b/crates/vize_atelier_sfc/src/bundler/css.rs
@@ -1,4 +1,4 @@
-use vize_carton::{SmallVec, String};
+use vize_s0::{SmallVec, String};
 
 pub fn strip_css_comments_for_scoped(css: &str) -> String {
     if !css.contains("/*") {

--- a/crates/vize_atelier_sfc/src/bundler/scope.rs
+++ b/crates/vize_atelier_sfc/src/bundler/scope.rs
@@ -1,7 +1,7 @@
 use std::path::{Component, Path};
 
 use sha2::{Digest, Sha256};
-use vize_carton::String;
+use vize_s0::String;
 
 pub fn generate_bundler_scope_id(
     filename: &str,

--- a/crates/vize_atelier_sfc/src/compile_template.rs
+++ b/crates/vize_atelier_sfc/src/compile_template.rs
@@ -3,7 +3,7 @@
 //! This module handles compilation of `<template>` blocks,
 //! supporting both DOM mode and Vapor mode.
 
-use vize_carton::{String, ToCompactString, profile};
+use vize_s0::{String, ToCompactString, profile};
 mod extraction;
 mod string_tracking;
 mod vapor;
@@ -18,7 +18,7 @@ pub(crate) use vapor::compile_template_block_vapor;
 
 use vize_atelier_core::CodegenOptions;
 use vize_atelier_core::TemplateSyntaxMode;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 use vize_atelier_core::CompilerErrorWithSource;
 

--- a/crates/vize_atelier_sfc/src/compile_template/extraction.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/extraction.rs
@@ -1,6 +1,6 @@
 //! Extraction of imports, hoisted consts, and render functions from compiled template code.
 
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use super::TemplateCodeSections;
 use super::string_tracking::{

--- a/crates/vize_atelier_sfc/src/compile_template/string_tracking.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/string_tracking.rs
@@ -4,7 +4,7 @@
 //! block comments, and `${...}` expressions when counting braces and
 //! parentheses in JavaScript/TypeScript code.
 
-use vize_carton::String;
+use vize_s0::String;
 
 /// State for tracking string/template literal/comment context across multiple lines.
 /// Required because template literals (backtick strings) and block comments can span

--- a/crates/vize_atelier_sfc/src/compile_template/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/tests.rs
@@ -368,7 +368,7 @@ fn test_slice_template_parts_matches_line_scanner() {
             attrs: Default::default(),
         };
         let bindings = BindingMetadata::default();
-        let template_allocator = vize_carton::Allocator::new();
+        let template_allocator = vize_s0::Allocator::new();
         let result = compile_template_block(
             &template_allocator,
             &template,

--- a/crates/vize_atelier_sfc/src/compile_template/vapor.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/vapor.rs
@@ -5,7 +5,7 @@ use vize_atelier_core::{CodegenOptions, TemplateSyntaxMode, options::CustomEleme
 use vize_atelier_vapor::{
     VaporCompilerOptions, compile_vapor_with_custom_elements_template_syntax_and_diagnostics,
 };
-use vize_carton::{Allocator, String, ToCompactString};
+use vize_s0::{Allocator, String, ToCompactString};
 
 use crate::{
     compile_template::{
@@ -124,16 +124,13 @@ pub(super) fn add_scope_id_to_template(template_line: &str, scope_id: &str) -> S
 
 fn rewrite_vapor_import(line: &str, runtime_module_name: &str) -> String {
     let (source, replacement) = if line.contains("'vue/vapor'") {
-        ("'vue/vapor'", vize_carton::cstr!("'{runtime_module_name}'"))
+        ("'vue/vapor'", vize_s0::cstr!("'{runtime_module_name}'"))
     } else if line.contains("\"vue/vapor\"") {
-        (
-            "\"vue/vapor\"",
-            vize_carton::cstr!("\"{runtime_module_name}\""),
-        )
+        ("\"vue/vapor\"", vize_s0::cstr!("\"{runtime_module_name}\""))
     } else if line.contains("'vue'") {
-        ("'vue'", vize_carton::cstr!("'{runtime_module_name}'"))
+        ("'vue'", vize_s0::cstr!("'{runtime_module_name}'"))
     } else if line.contains("\"vue\"") {
-        ("\"vue\"", vize_carton::cstr!("\"{runtime_module_name}\""))
+        ("\"vue\"", vize_s0::cstr!("\"{runtime_module_name}\""))
     } else {
         return line.to_compact_string();
     };

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -41,6 +41,8 @@
 )]
 #![cfg_attr(test, allow(clippy::disallowed_methods, clippy::needless_borrow))]
 
+extern crate vize_s0 as vize_carton;
+
 // Core modules - following Vue.js compiler-sfc structure
 pub mod bundler;
 pub mod compile;

--- a/crates/vize_atelier_sfc/tests/allocation_budget.rs
+++ b/crates/vize_atelier_sfc/tests/allocation_budget.rs
@@ -27,7 +27,7 @@
 use std::alloc::System;
 
 use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
-use vize_carton::profiler::{
+use vize_s0::profiler::{
     ProfilingAllocator, allocation_snapshot, reset_allocation_counters,
     set_allocation_tracking_enabled,
 };

--- a/crates/vize_atelier_sfc/tests/component_spread_props.rs
+++ b/crates/vize_atelier_sfc/tests/component_spread_props.rs
@@ -7,7 +7,7 @@
 //! `Missing required prop: "name"` followed by an SSR 500.
 
 use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
-use vize_carton::String;
+use vize_s0::String;
 
 const NUXT_UI_ICON_SFC: &str = r#"<script setup lang="ts">
 const props = defineProps<{ name: string }>()

--- a/crates/vize_atelier_sfc/tests/css_engine_panic_boundary.rs
+++ b/crates/vize_atelier_sfc/tests/css_engine_panic_boundary.rs
@@ -73,7 +73,7 @@ fn parse_css_ast_rejects_the_percentage_math_panic_matrix() {
         assert_eq!(result.errors, [GUARD_ERROR], "source {source:?}");
         assert_eq!(
             result.warnings,
-            Vec::<vize_carton::String>::new(),
+            Vec::<vize_s0::String>::new(),
             "source {source:?}"
         );
     }
@@ -169,7 +169,7 @@ fn parse_css_ast_survives_non_finite_hue() {
         } else {
             assert_eq!(
                 result.errors,
-                Vec::<vize_carton::String>::new(),
+                Vec::<vize_s0::String>::new(),
                 "source {source:?}"
             );
         }
@@ -230,7 +230,7 @@ fn parse_css_ast_keeps_accepting_resolvable_math_functions() {
         assert!(result.ast.is_some(), "expected clean parse for {source:?}");
         assert_eq!(
             result.errors,
-            Vec::<vize_carton::String>::new(),
+            Vec::<vize_s0::String>::new(),
             "source {source:?}"
         );
     }
@@ -259,7 +259,7 @@ fn parse_css_ast_survives_the_hue_assert_artifact() {
         assert!(
             !result
                 .errors
-                .contains(&vize_carton::String::from(PARSE_BOUNDARY_ERROR))
+                .contains(&vize_s0::String::from(PARSE_BOUNDARY_ERROR))
         );
     }
 
@@ -268,8 +268,5 @@ fn parse_css_ast_survives_the_hue_assert_artifact() {
     let negative_hue = "a{color:hsla(-842 5 2 / 1)}";
     let negative_hue_result = parse_css_ast(negative_hue, &CssCompileOptions::default());
     assert!(negative_hue_result.ast.is_some());
-    assert_eq!(
-        negative_hue_result.errors,
-        Vec::<vize_carton::String>::new()
-    );
+    assert_eq!(negative_hue_result.errors, Vec::<vize_s0::String>::new());
 }

--- a/crates/vize_atelier_sfc/tests/css_nesting_guard.rs
+++ b/crates/vize_atelier_sfc/tests/css_nesting_guard.rs
@@ -8,7 +8,7 @@
 #![cfg(feature = "native")]
 
 use vize_atelier_sfc::{CssCompileOptions, compile_css, parse_css_ast};
-use vize_carton::String;
+use vize_s0::String;
 
 /// One repetition of the dominant pattern in the fuzz reproducer; each
 /// repetition opens six brackets that are never closed.
@@ -33,7 +33,7 @@ fn parse_css_ast_rejects_the_fuzz_timeout_shape_without_backtracking() {
     let result = parse_css_ast(&reproducer(32), &CssCompileOptions::default());
     assert!(result.ast.is_none());
     assert_eq!(result.errors, [NESTING_DEPTH_ERROR]);
-    assert_eq!(result.warnings, Vec::<vize_carton::String>::new());
+    assert_eq!(result.warnings, Vec::<vize_s0::String>::new());
 
     // The smallest reproducer shape past the boundary is rejected the same way.
     let result = parse_css_ast(&reproducer(6), &CssCompileOptions::default());
@@ -57,7 +57,7 @@ fn parse_css_ast_keeps_accepting_the_documented_depth_boundary() {
     // `.a {` plus 31 function tokens sits exactly on the depth-32 boundary.
     let allowed = parse_css_ast(&nested(31), &CssCompileOptions::default());
     assert!(allowed.ast.is_some());
-    assert_eq!(allowed.errors, Vec::<vize_carton::String>::new());
+    assert_eq!(allowed.errors, Vec::<vize_s0::String>::new());
 
     let rejected = parse_css_ast(&nested(32), &CssCompileOptions::default());
     assert!(rejected.ast.is_none());
@@ -70,9 +70,9 @@ fn compile_css_rejects_over_deep_sources_and_passes_them_through() {
     let result = compile_css(&css, &CssCompileOptions::default());
     assert_eq!(result.code, css);
     assert!(result.map.is_none());
-    assert_eq!(result.css_vars, Vec::<vize_carton::String>::new());
+    assert_eq!(result.css_vars, Vec::<vize_s0::String>::new());
     assert_eq!(result.errors, [NESTING_DEPTH_ERROR]);
-    assert_eq!(result.warnings, Vec::<vize_carton::String>::new());
+    assert_eq!(result.warnings, Vec::<vize_s0::String>::new());
     assert!(result.exports.is_none());
 }
 
@@ -80,6 +80,6 @@ fn compile_css_rejects_over_deep_sources_and_passes_them_through() {
 fn compile_css_still_compiles_realistic_nesting() {
     let css = ".a { .b { .c { width: calc(1px + min(2px, max(3px, 4px))); } } }";
     let result = compile_css(css, &CssCompileOptions::default());
-    assert_eq!(result.errors, Vec::<vize_carton::String>::new());
+    assert_eq!(result.errors, Vec::<vize_s0::String>::new());
     assert!(!result.code.is_empty());
 }

--- a/crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs
+++ b/crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs
@@ -2,7 +2,7 @@
 
 use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
 
-fn compile(source: &str) -> vize_carton::String {
+fn compile(source: &str) -> vize_s0::String {
     let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("parse SFC");
     compile_sfc(&descriptor, SfcCompileOptions::default())
         .expect("compile SFC")

--- a/crates/vize_atelier_sfc/tests/davinci_arena_pool.rs
+++ b/crates/vize_atelier_sfc/tests/davinci_arena_pool.rs
@@ -24,7 +24,7 @@
 use vize_atelier_sfc::{
     SfcCompileOptions, SfcCompileResult, SfcParseOptions, compile_sfc, parse_sfc,
 };
-use vize_carton::{String, pool};
+use vize_s0::{String, pool};
 
 /// How many other files run between populating a cache and reading it back.
 ///

--- a/crates/vize_atelier_sfc/tests/emitter_javascript_output.rs
+++ b/crates/vize_atelier_sfc/tests/emitter_javascript_output.rs
@@ -16,7 +16,7 @@ use vize_atelier_sfc::{
 /// Compile an SFC exactly the way the Vite plugin does: `is_ts` is left at its
 /// default `false`, which is what makes the script pipeline strip TypeScript
 /// itself instead of deferring it to the bundler.
-fn compile_like_the_vite_plugin(source: &str) -> vize_carton::String {
+fn compile_like_the_vite_plugin(source: &str) -> vize_s0::String {
     let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("SFC should parse");
     compile_sfc(&descriptor, SfcCompileOptions::default())
         .expect("SFC should compile")
@@ -165,7 +165,7 @@ function greet(who: string): string {
 
 #[test]
 fn ensure_javascript_output_passes_javascript_through_untouched() {
-    let js: vize_carton::String = "import { ref } from \"vue\";\nexport default { ref };".into();
+    let js: vize_s0::String = "import { ref } from \"vue\";\nexport default { ref };".into();
     let out = ensure_javascript_output(js.clone());
     assert_eq!(
         out, js,
@@ -181,7 +181,7 @@ fn ensure_javascript_output_passes_javascript_through_untouched() {
 /// ran a semantic check at all.
 #[test]
 fn semantic_diagnostics_do_not_abort_the_emitter_strip() {
-    let redeclared: vize_carton::String =
+    let redeclared: vize_s0::String =
         "let a: number = 1;\nlet a: number = 2;\nexport { a };".into();
 
     assert!(

--- a/crates/vize_atelier_sfc/tests/imported_pick_intersection_props.rs
+++ b/crates/vize_atelier_sfc/tests/imported_pick_intersection_props.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 fn temp_project_dir() -> PathBuf {
     let nonce = std::time::SystemTime::now()

--- a/crates/vize_atelier_sfc/tests/imported_type_cache.rs
+++ b/crates/vize_atelier_sfc/tests/imported_type_cache.rs
@@ -5,14 +5,14 @@ use vize_atelier_sfc::{
     SfcCompileOptions, SfcCompileResult, SfcParseOptions, begin_type_resolution_batch, compile_sfc,
     parse_sfc,
 };
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 fn temp_project_dir() -> PathBuf {
     let nonce = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    let name = vize_carton::cstr!(
+    let name = vize_s0::cstr!(
         "vize-sfc-imported-type-cache-{}-{nonce}",
         std::process::id()
     );

--- a/crates/vize_atelier_sfc/tests/workspace_prop_types.rs
+++ b/crates/vize_atelier_sfc/tests/workspace_prop_types.rs
@@ -3,14 +3,14 @@
 use std::path::PathBuf;
 
 use vize_atelier_sfc::{SfcCompileOptions, SfcParseOptions, compile_sfc, parse_sfc};
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 fn temp_project_dir() -> PathBuf {
     let nonce = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_nanos();
-    let name = vize_carton::cstr!("vize-sfc-workspace-props-{}-{nonce}", std::process::id());
+    let name = vize_s0::cstr!("vize-sfc-workspace-props-{}-{nonce}", std::process::id());
     std::env::temp_dir().join(name.as_str())
 }
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           926 |                   442 |               484 |             140 |     371 |             939 |      498 |           488 |           602 |
+| Compiler                   |           928 |                   484 |               444 |             140 |     371 |             941 |      498 |           488 |           602 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   227 |               652 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
@@ -61,7 +61,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          21 |               4 |       17 |
-| S0               |         845 |             477 |      368 |
+| S0               |         847 |             479 |      368 |
 | S1               |           5 |               1 |        4 |
 | S2               |          15 |               1 |       14 |
 | S1->S2           |          40 |               2 |       38 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -468,7 +468,7 @@ compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/v_slots.rs	21	s0	S0	sta
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/vapor_ssr.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/vapor.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_jsx/tests/vdom.rs	11	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	raw_oxc	raw OXC	raw	oxc_ast	raw	1
@@ -477,18 +477,18 @@ compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	raw_oxc	raw OXC
 compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
 compiler	Compiler	manifest	crates/vize_atelier_sfc/Cargo.toml	25	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs	4	raw_oxc	raw OXC	raw	oxc_syntax	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite/predicates.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite/replacements.rs	1	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/assets.rs	1	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/blocks.rs	3	s0	S0	stage	vize_carton	compat	2
-compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/css.rs	1	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/scope.rs	4	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/asset_rewrite/replacements.rs	1	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/assets.rs	1	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/blocks.rs	3	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/css.rs	1	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/bundler/scope.rs	4	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_script.rs	38	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/artifacts.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/artifacts.rs	7	croquis	Croquis analysis	old	vize_croquis	legacy	1
@@ -589,13 +589,13 @@ compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/typescript.r
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/typescript.rs	5	raw_oxc	raw OXC	raw	oxc_codegen	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/typescript.rs	5	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_script/typescript.rs	5	raw_oxc	raw OXC	raw	oxc_semantic	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template.rs	6	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_template.rs	21	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template.rs	6	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_template.rs	21	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_template.rs	21	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template/extraction.rs	3	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template/string_tracking.rs	7	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_template/tests.rs	371	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template/vapor.rs	8	s0	S0	stage	vize_carton	compat	5
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template/extraction.rs	3	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template/string_tracking.rs	7	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_template/tests.rs	371	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile_template/vapor.rs	8	s0	S0	stage	vize_s0	preferred	5
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_tests.rs	8	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile.rs	59	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile.rs	59	croquis	Croquis analysis	old	vize_croquis	legacy	2
@@ -635,7 +635,9 @@ compiler	Compiler	source	crates/vize_atelier_sfc/src/css/parser/engine_boundary/
 compiler	Compiler	source	crates/vize_atelier_sfc/src/css/scoped.rs	6	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/css/tests.rs	7	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/css/transform.rs	4	croquis	Croquis analysis	old	vize_croquis	legacy	2
-compiler	Compiler	source	crates/vize_atelier_sfc/src/lib.rs	69	croquis	Croquis analysis	old	vize_croquis	legacy	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/lib.rs	44	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/lib.rs	44	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/lib.rs	44	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/module_shape.rs	43	s0	S0	stage	vize_carton	compat	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/module_shape.rs	43	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/module_shape.rs	43	raw_oxc	raw OXC	raw	oxc_ast	raw	2
@@ -738,25 +740,25 @@ compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/transform.rs	3	
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/transform.rs	3	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/transform.rs	3	raw_oxc	raw OXC	raw	oxc_ast_visit	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/vite_plugin/transform.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/allocation_budget.rs	30	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/component_spread_props.rs	10	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/allocation_budget.rs	30	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/component_spread_props.rs	10	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/component_tag_binding.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/component_tag_binding.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/css_engine_panic_boundary.rs	76	s0	S0	stage	vize_carton	compat	5
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/css_nesting_guard.rs	11	s0	S0	stage	vize_carton	compat	6
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs	5	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/davinci_arena_pool.rs	27	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/css_engine_panic_boundary.rs	76	s0	S0	stage	vize_s0	preferred	5
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/css_nesting_guard.rs	11	s0	S0	stage	vize_s0	preferred	6
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs	5	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/davinci_arena_pool.rs	27	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/dynamic_template_ref.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/dynamic_template_ref.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/emitter_javascript_output.rs	19	s0	S0	stage	vize_carton	compat	3
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/imported_pick_intersection_props.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/emitter_javascript_output.rs	19	s0	S0	stage	vize_s0	preferred	3
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/imported_pick_intersection_props.rs	6	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/imported_prop_defaults.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/imported_prop_defaults.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/imported_type_cache.rs	8	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/imported_type_cache.rs	8	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/module_mode_setup_bindings.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/module_mode_setup_bindings.rs	3	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/parse_facade.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1
-compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/workspace_prop_types.rs	6	s0	S0	stage	vize_carton	compat	2
+compiler	Compiler	test/dev	crates/vize_atelier_sfc/tests/workspace_prop_types.rs	6	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_ssr/benches/davinci.rs	22	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	davinci	Davinci	stage	vize_davinci	preferred	1
 compiler	Compiler	manifest	crates/vize_atelier_ssr/Cargo.toml	13	s0	S0	stage	vize_s0	preferred	1

--- a/tests/tooling/davinci-atelier-sfc-stage-alias.test.mjs
+++ b/tests/tooling/davinci-atelier-sfc-stage-alias.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { scanConsumerMigrationSurfaces } from "../../tools/davinci/lib/consumer-migration-scan.mjs";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const sfcPreferredS0Rows = [
+  ["crates/vize_atelier_sfc/src/bundler/asset_rewrite.rs", "source", 1],
+  ["crates/vize_atelier_sfc/src/bundler/asset_rewrite/replacements.rs", "source", 1],
+  ["crates/vize_atelier_sfc/src/bundler/assets.rs", "source", 1],
+  ["crates/vize_atelier_sfc/src/bundler/blocks.rs", "source", 2],
+  ["crates/vize_atelier_sfc/src/bundler/css.rs", "source", 1],
+  ["crates/vize_atelier_sfc/src/bundler/scope.rs", "source", 1],
+  ["crates/vize_atelier_sfc/src/compile_template.rs", "source", 1],
+  ["crates/vize_atelier_sfc/src/compile_template.rs", "test", 1],
+  ["crates/vize_atelier_sfc/src/compile_template/extraction.rs", "source", 1],
+  ["crates/vize_atelier_sfc/src/compile_template/string_tracking.rs", "source", 1],
+  ["crates/vize_atelier_sfc/src/compile_template/tests.rs", "test", 1],
+  ["crates/vize_atelier_sfc/src/compile_template/vapor.rs", "source", 5],
+  ["crates/vize_atelier_sfc/tests/allocation_budget.rs", "test", 1],
+  ["crates/vize_atelier_sfc/tests/component_spread_props.rs", "test", 1],
+  ["crates/vize_atelier_sfc/tests/css_engine_panic_boundary.rs", "test", 5],
+  ["crates/vize_atelier_sfc/tests/css_nesting_guard.rs", "test", 6],
+  ["crates/vize_atelier_sfc/tests/custom_directive_patch_flag.rs", "test", 1],
+  ["crates/vize_atelier_sfc/tests/davinci_arena_pool.rs", "test", 1],
+  ["crates/vize_atelier_sfc/tests/emitter_javascript_output.rs", "test", 3],
+  ["crates/vize_atelier_sfc/tests/imported_pick_intersection_props.rs", "test", 1],
+  ["crates/vize_atelier_sfc/tests/imported_type_cache.rs", "test", 2],
+  ["crates/vize_atelier_sfc/tests/workspace_prop_types.rs", "test", 2],
+];
+
+function compiler() {
+  const scan = scanConsumerMigrationSurfaces();
+  const consumer = scan.consumers.find((candidate) => candidate.id === "compiler");
+  assert.ok(consumer);
+  return consumer;
+}
+
+void test("Atelier SFC declares the S0 dependency through the preferred name", () => {
+  const cargoToml = fs.readFileSync(
+    path.join(repoRoot, "crates", "vize_atelier_sfc", "Cargo.toml"),
+    "utf8",
+  );
+
+  assert.match(cargoToml, /^vize_s0\.workspace = true$/m);
+  assert.doesNotMatch(cargoToml, /^vize_carton\.workspace = true$/m);
+});
+
+void test("Atelier SFC selected compiler and integration test slices import S0 through the preferred name", () => {
+  const rows = compiler().fileRows;
+
+  for (const [relPath, mode, sites] of sfcPreferredS0Rows) {
+    const row = rows.find((candidate) => candidate.relPath === relPath && candidate.mode === mode);
+    assert.ok(row, `${relPath} (${mode})`);
+    assert.equal(row.surfaceCounts.s0, sites, relPath);
+    assert.equal(row.surfaceNameCounts.s0.vize_s0, sites, relPath);
+    assert.equal(row.surfaceNameCounts.s0.vize_carton ?? 0, 0, relPath);
+
+    const source = fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+    assert.doesNotMatch(source, /\bvize_carton\b/u, relPath);
+  }
+});


### PR DESCRIPTION
## Summary
- switch selected Atelier SFC bundler/template and integration-test S0 imports to the preferred `vize_s0` stage alias
- keep the crate-local `vize_carton` alias so untouched internals retain behavior while the manifest now declares `vize_s0`
- add a migration-surface regression and refresh generated Davinci consumer inventory

## Tests
- cargo fmt --all -- --check
- node --test tests/tooling/davinci-atelier-sfc-stage-alias.test.mjs
- rust-script tools/commands/davinci/consumer-migration-surfaces.rs --check
- node --test tests/tooling/davinci-consumer-migration-surfaces.test.mjs
- node --test tests/tooling/davinci-matrices.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo metadata --no-deps --format-version 1 --locked
- cargo test -p vize_atelier_sfc
- cargo clippy -p vize_atelier_sfc --all-targets -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790730583&installation_model_id=422833&pr_number=5452&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5452&signature=c6f803865954b563ebddd61fa11b1865d03dfbcd41f5275bd2463fbbc918473e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated Atelier SFC’s compiler and bundling components to the preferred S0 foundation.
  * Updated allocation, string handling, and profiling integrations without changing user-visible behavior.

* **Tests**
  * Added coverage to verify preferred S0 dependency usage and prevent legacy references.
  * Updated regression and allocation tests to use the new foundation.

* **Documentation**
  * Refreshed the consumer migration inventory with updated compiler migration totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->