### PR TITLE
refactor(davinci): use S2 folio name in S1 lowering

### DIFF
--- a/crates/vize_s1_to_s2/src/lower.rs
+++ b/crates/vize_s1_to_s2/src/lower.rs
@@ -14,10 +14,11 @@
 //!
 //! Ops are numbered densely in page order as they are decided
 //! ([`lower::cx`]); [`Lowered::op_count`] equals
-//! `DisegnoFolio::of(&lowered.root.ops).op_count()` on every input —
+//! `S2Folio::of(&lowered.root.ops).op_count()` on every input —
 //! the law the side tables and the S2 verifier's `verify_table` key on.
 //!
 //! [`Diagnostic`]: vize_davinci::diagnostic::Diagnostic
+//! [`S2Folio`]: vize_s2::folio::S2Folio
 //! [`SurfaceError`]: vize_s1::SurfaceError
 
 use alloc::vec::Vec as StdVec;

--- a/crates/vize_s1_to_s2/src/lower/cx.rs
+++ b/crates/vize_s1_to_s2/src/lower/cx.rs
@@ -9,13 +9,15 @@
 //! references against exactly that numbering). [`Cx::mint_op`] therefore
 //! runs in **print order** during the walk: an op's id is minted when its
 //! line is decided, bindings as they attach, children after. The pinned
-//! law is `Cx::op_count == DisegnoFolio::of(root).op_count()`, tested per
+//! law is `Cx::op_count == S2Folio::of(root).op_count()`, tested per
 //! fixture.
 //!
 //! Exhaustion is a diagnostic, not a panic (the `NodeId::from_index`
 //! contract): past `u32::MAX - 1` ops the context reports once and stops
 //! minting; side tables simply stop gaining keys while the op tree stays
 //! total.
+//!
+//! [`S2Folio`]: vize_s2::folio::S2Folio
 
 use alloc::vec::Vec;
 

--- a/crates/vize_s1_to_s2/src/pass.rs
+++ b/crates/vize_s1_to_s2/src/pass.rs
@@ -194,7 +194,7 @@ pub fn run_transform<'a, O: PassObserver>(lowered: &mut Lowered<'a>, observer: &
         #[cfg(debug_assertions)]
         {
             verify.note(event);
-            let folio = vize_s2::folio::DisegnoFolio::of(&lowered.root.ops);
+            let folio = vize_s2::folio::S2Folio::of(&lowered.root.ops);
             verify.check(event, &folio);
             verify.check_table(event, &folio, &lowered.scopes);
             verify.check_table(event, &folio, &lowered.texts);

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -157,6 +157,18 @@ test("Davinci S1-to-S2 uses the physical crate package and directory", () => {
   assert.doesNotMatch(lockfile, /\bvize_ricalco\b/u);
 });
 
+test("Davinci S1-to-S2 source paths use the physical S2 folio type", () => {
+  const sourceDir = path.join(repoRoot, "crates", "vize_s1_to_s2", "src");
+  for (const fullPath of walkRustFiles(sourceDir)) {
+    const source = fs.readFileSync(fullPath, "utf8");
+    assert.doesNotMatch(
+      source,
+      /\bDisegnoFolio\b/u,
+      `${path.relative(sourceDir, fullPath)} must use S2Folio`,
+    );
+  }
+});
+
 test("Davinci DOM lane tests import lowering through the physical S1-to-S2 package", () => {
   const lowering = dependency(metadata, "vize_atelier_dom", "vize_s1_to_s2", "dev");
   assert.equal(lowering.rename, null);


### PR DESCRIPTION
## Summary
- use the physical `S2Folio` type name in S1-to-S2 transform verification
- update lowering documentation to name the S2 folio surface directly
- add a stage-dependency regression so `crates/vize_s1_to_s2/src` does not drift back to the `DisegnoFolio` compatibility alias

## Tests
- cargo fmt --all -- --check
- node --test tests/tooling/davinci-stage-dependencies.test.ts
- cargo test -p vize_s1_to_s2
- cargo test -p vize_s2 --test stage_name_alias
- cargo test -p vize_davinci stage
- cargo clippy -p vize_s1_to_s2 --all-targets -- -D warnings
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo metadata --no-deps --format-version 1 --locked
- rust-script tools/commands/davinci/consumer-migration-surfaces.rs --check
- node --test tests/tooling/davinci-consumer-migration-surfaces.test.mjs
- cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture
- node --test tests/tooling/davinci-matrices.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790733197&installation_model_id=422833&pr_number=5453&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5453&signature=d977e307976115359e7d836623770d56100303a0545487146a8e4e0b1ae64aa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated transformation documentation to consistently reference the current S2 folio terminology.
  * Improved documentation clarity around folio exhaustion behavior and related references.
  * Updated debug verification to use the current S2 folio representation.

* **Tests**
  * Added coverage to ensure outdated folio terminology is not reintroduced into the transformation source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->