### PR TITLE
refactor(atelier): import empty component S0 through stage alias

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/empty_component.rs
+++ b/crates/vize_atelier_sfc/src/compile/empty_component.rs
@@ -1,6 +1,6 @@
 use crate::types::{SfcCompileOptions, SfcCompileResult, SfcError, SfcMacroArtifact};
 use vize_atelier_core::CodegenOptions;
-use vize_carton::String;
+use vize_s0::String;
 
 use super::output_module::{append_css_modules_assignment, finalize_output_mode};
 use super::styles::CompiledStyles;

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           928 |                   484 |               444 |             140 |     371 |             941 |      498 |           488 |           602 |
+| Compiler                   |           928 |                   485 |               443 |             140 |     371 |             941 |      498 |           488 |           602 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   233 |               646 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -606,7 +606,7 @@ compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	raw_o
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	raw_oxc	raw OXC	raw	oxc_parser	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/diagnostics.rs	3	s0	S0	stage	vize_carton	compat	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/empty_component.rs	3	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/empty_component.rs	3	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/helpers.rs	3	s0	S0	stage	vize_carton	compat	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/helpers.rs	3	croquis	Croquis analysis	old	vize_croquis	legacy	2
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/helpers.rs	3	raw_oxc	raw OXC	raw	oxc_allocator	raw	1

--- a/tests/tooling/davinci-atelier-sfc-stage-alias.test.mjs
+++ b/tests/tooling/davinci-atelier-sfc-stage-alias.test.mjs
@@ -14,6 +14,7 @@ const sfcPreferredS0Rows = [
   ["crates/vize_atelier_sfc/src/bundler/blocks.rs", "source", 2],
   ["crates/vize_atelier_sfc/src/bundler/css.rs", "source", 1],
   ["crates/vize_atelier_sfc/src/bundler/scope.rs", "source", 1],
+  ["crates/vize_atelier_sfc/src/compile/empty_component.rs", "source", 1],
   ["crates/vize_atelier_sfc/src/compile_template.rs", "source", 1],
   ["crates/vize_atelier_sfc/src/compile_template.rs", "test", 1],
   ["crates/vize_atelier_sfc/src/compile_template/extraction.rs", "source", 1],


### PR DESCRIPTION
## Summary
- import the empty SFC component compile path through the physical S0 alias
- pin the SFC stage-alias guard for `compile/empty_component.rs`
- refresh the Davinci consumer migration surface inventory

## Verification
- `cargo fmt --all -- --check`
- `node --test tests/tooling/davinci-atelier-sfc-stage-alias.test.mjs`
- `rust-script tools/commands/davinci/consumer-migration-surfaces.rs --check`
- `node --test tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `cargo test -p vize_atelier_sfc --test empty_component`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo metadata --no-deps --format-version 1 --locked > /tmp/vize-atelier-empty-component-s0-metadata.json`
- `git diff --check`
- `cargo clippy -p vize_atelier_sfc --lib -- -D warnings`
- `node --test tests/tooling/davinci-matrices.test.ts`
- `cargo test -p vize_atelier_sfc`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790737720&installation_model_id=422833&pr_number=5455&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5455&signature=82a24e5c29f0859fe500da2fcc68d87ef497a61f5b655bc0d07edaf7c15c3793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated compiler internals to use the preferred S0 dependency for empty component handling.
* **Documentation**
  * Updated consumer migration tracking to reflect the latest preferred and compatibility stage counts.
* **Tests**
  * Added coverage verifying the empty component implementation uses the preferred dependency exactly once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->