### PR TITLE
fix(davinci): normalize bare object style binds

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_style_merge.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_style_merge.rs
@@ -24,6 +24,22 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<div style="color: red" :style="{ fontSize: x }"></div>"#,
     ),
     (
+        "bare_object_literal",
+        r#"<div :style="{ color: textColor }"></div>"#,
+    ),
+    (
+        "bare_object_static_value",
+        r#"<div :style="{ color: 'red' }"></div>"#,
+    ),
+    (
+        "bare_object_spread",
+        r#"<div :style="{ ...styles }"></div>"#,
+    ),
+    (
+        "bare_object_computed_key",
+        r#"<div :style="{ [prop]: 'red' }"></div>"#,
+    ),
+    (
         "css_function_semicolon",
         r#"<div style="background: url(a;b); color: red" :style="s"></div>"#,
     ),

--- a/crates/vize_s1_to_s2/src/emit/style.rs
+++ b/crates/vize_s1_to_s2/src/emit/style.rs
@@ -1,6 +1,5 @@
 //! Static style-attribute serialization used by dynamic `:style` merges.
 
-use oxc_ast::ast::Expression;
 use vize_s2::expr::JsExpr;
 use vize_s2::op::{Attribute, BindOp};
 
@@ -15,9 +14,7 @@ pub(super) fn emit_style_value(
     js: &JsExpr<'_>,
     skip_normalize: bool,
 ) {
-    let bare_object_literal =
-        static_style.is_none() && matches!(js.ast, Expression::ObjectExpression(_));
-    let wrap = !skip_normalize && !bare_object_literal;
+    let wrap = !skip_normalize;
     if wrap {
         cx.buf.use_normalize_style();
         cx.buf.push(Buf::normalize_style_alias());


### PR DESCRIPTION
## Summary
- route bare object style v-bind payloads through the same normalizeStyle lowering as other dynamic style forms
- add S2 DOM parity coverage for bare object style literals, static values, spreads, and computed keys

## Tests
- cargo test -p vize_atelier_dom --test davinci_s2_style_merge
- cargo test -p vize_atelier_dom --test davinci_s2_dom -- --nocapture
- cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture
- cargo clippy -p vize_atelier_dom --test davinci_s2_style_merge -- -D warnings
- cargo fmt --all -- --check
- node --test tests/tooling/davinci-assertion-lint.test.ts tests/tooling/davinci-budgets.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790743188&installation_model_id=422833&pr_number=5457&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5457&signature=4740536b5bd0c4a2b6b7e31120b834d8f934ba78ace28514e45c95d00ae2cbdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of object-based `:style` bindings, including dynamic values, static values, spread properties, and computed keys.
  * Ensured style values are consistently normalized for reliable rendering.
* **Tests**
  * Added coverage for additional object-style binding scenarios and verified output consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->