### PR TITLE
test(davinci): pin owned folio span contracts

### DIFF
--- a/crates/vize_davinci/src/folio/feed.rs
+++ b/crates/vize_davinci/src/folio/feed.rs
@@ -37,6 +37,15 @@ use crate::folio::dump::FolioDump;
 /// the committed schema's `const` together.
 pub const SPOLVERO_FEED_SCHEMA_VERSION: u32 = 1;
 
+/// A consumer-side schema negotiation failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SpolveroFeedSchemaMismatch {
+    /// The feed schema this crate knows how to consume.
+    pub expected: u32,
+    /// The feed schema presented by the payload.
+    pub found: u32,
+}
+
 /// One page of the feed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SpolveroPage {
@@ -68,6 +77,18 @@ pub struct SpolveroFeed {
 }
 
 impl SpolveroFeed {
+    /// Negotiate the feed schema before reading any shape-dependent field.
+    pub fn negotiate_schema_version(schema_version: u32) -> Result<(), SpolveroFeedSchemaMismatch> {
+        if schema_version == SPOLVERO_FEED_SCHEMA_VERSION {
+            Ok(())
+        } else {
+            Err(SpolveroFeedSchemaMismatch {
+                expected: SPOLVERO_FEED_SCHEMA_VERSION,
+                found: schema_version,
+            })
+        }
+    }
+
     /// An empty feed for `command`.
     #[must_use]
     pub fn new(command: &str) -> Self {

--- a/crates/vize_davinci/tests/spolvero_feed.rs
+++ b/crates/vize_davinci/tests/spolvero_feed.rs
@@ -11,7 +11,7 @@ use std::process::{Command, Output, Stdio};
 
 use davinci_test_support::schema as schema_check;
 use vize_davinci::folio::dump::FolioDump;
-use vize_davinci::folio::feed::SpolveroFeed;
+use vize_davinci::folio::feed::{SpolveroFeed, SpolveroFeedSchemaMismatch};
 use vize_davinci::pass::{Fusability, PassDesc, PassEvent, PassKind, Pipeline, Preserved};
 
 /// A canonical `[budget-observer]` page - the smallest committed-format
@@ -55,6 +55,25 @@ fn temp_dir(name: &str) -> PathBuf {
 fn read_feed(dir: &Path) -> serde_json::Value {
     let text = std::fs::read_to_string(dir.join("spolvero.json")).expect("feed reads");
     serde_json::from_str(&text).expect("feed is valid JSON")
+}
+
+fn negotiate_feed_schema(feed: &serde_json::Value) -> Result<(), SchemaGateError> {
+    let version = feed
+        .get("schema_version")
+        .ok_or(SchemaGateError::MissingVersion)?
+        .as_u64()
+        .ok_or(SchemaGateError::NonNumericVersion)?;
+    let Ok(version) = u32::try_from(version) else {
+        return Err(SchemaGateError::NonNumericVersion);
+    };
+    SpolveroFeed::negotiate_schema_version(version).map_err(SchemaGateError::VersionMismatch)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SchemaGateError {
+    MissingVersion,
+    NonNumericVersion,
+    VersionMismatch(SpolveroFeedSchemaMismatch),
 }
 
 /// Load the committed schema relative to this crate's manifest.
@@ -196,5 +215,40 @@ fn the_schema_refuses_version_and_shape_mismatches_loudly() {
         error.message().as_str(),
         "schema violation at `$.pages[0].stage`: string does not match pattern \
          `^[a-z][a-z0-9-]*$`"
+    );
+}
+
+#[test]
+fn consumers_negotiate_schema_version_before_reading_pages() {
+    let mut feed = serde_json::json!({
+        "schema_version": 1,
+        "command": "davinci-opt",
+        "pages": "not read until the version is accepted",
+    });
+    assert_eq!(negotiate_feed_schema(&feed), Ok(()));
+
+    feed.as_object_mut()
+        .expect("feed is an object")
+        .remove("schema_version");
+    assert_eq!(
+        negotiate_feed_schema(&feed),
+        Err(SchemaGateError::MissingVersion)
+    );
+
+    feed["schema_version"] = serde_json::Value::from("1");
+    assert_eq!(
+        negotiate_feed_schema(&feed),
+        Err(SchemaGateError::NonNumericVersion)
+    );
+
+    feed["schema_version"] = serde_json::Value::from(2);
+    assert_eq!(
+        negotiate_feed_schema(&feed),
+        Err(SchemaGateError::VersionMismatch(
+            SpolveroFeedSchemaMismatch {
+                expected: 1,
+                found: 2,
+            }
+        ))
     );
 }

--- a/crates/vize_s1_to_s2/tests/ir_contract_spans.rs
+++ b/crates/vize_s1_to_s2/tests/ir_contract_spans.rs
@@ -33,15 +33,21 @@ fn owned_folio_spans_resolve_for_optional_corpus() {
     );
     let mut checked = 0usize;
     for file in &sweep.files {
-        let Ok(source) = fs::read_to_string(file) else {
-            continue;
-        };
+        let source = fs::read_to_string(file).unwrap_or_else(|error| {
+            panic!("failed to read corpus file {}: {error}", file.display())
+        });
         let context = file.to_string_lossy();
         with_lowered(&source, |_lowered, folio| {
             assert_folio_spans_resolve(&source, folio, context.as_ref());
         });
         checked += 1;
     }
+    assert_eq!(
+        checked,
+        sweep.files.len(),
+        "corpus sweep did not check every .vue file under {}",
+        sweep.root.display()
+    );
     eprintln!(
         "davinci owned folio span corpus sweep: files={} checked={}",
         sweep.files.len(),

--- a/crates/vize_s1_to_s2/tests/ir_contract_spans.rs
+++ b/crates/vize_s1_to_s2/tests/ir_contract_spans.rs
@@ -1,0 +1,50 @@
+//! P2-17 mechanical span gate: the owned S2 folio carries no span that
+//! cannot be resolved against the authored source.
+
+mod support;
+
+use std::fs;
+
+use davinci_test_support::surface_fixture as battery;
+use support::{assert_folio_spans_resolve, with_lowered, with_transformed};
+
+#[test]
+fn owned_folio_spans_resolve_for_committed_battery() {
+    for fixture in battery::WELL_FORMED.iter().chain(battery::MALFORMED) {
+        with_lowered(fixture.source, |_lowered, folio| {
+            assert_folio_spans_resolve(fixture.source, folio, fixture.name);
+        });
+        with_transformed(fixture.source, |_lowered, folio, _facts, _budget| {
+            assert_folio_spans_resolve(fixture.source, folio, fixture.name);
+        });
+    }
+}
+
+#[test]
+fn owned_folio_spans_resolve_for_optional_corpus() {
+    let Some(sweep) = davinci_test_support::corpus::resolve_env_sweep() else {
+        eprintln!("VIZE_DAVINCI_DIFFERENTIAL_CORPUS unset: committed battery only");
+        return;
+    };
+    assert!(
+        !sweep.files.is_empty(),
+        "corpus sweep found no .vue files under {}",
+        sweep.root.display()
+    );
+    let mut checked = 0usize;
+    for file in &sweep.files {
+        let Ok(source) = fs::read_to_string(file) else {
+            continue;
+        };
+        let context = file.to_string_lossy();
+        with_lowered(&source, |_lowered, folio| {
+            assert_folio_spans_resolve(&source, folio, context.as_ref());
+        });
+        checked += 1;
+    }
+    eprintln!(
+        "davinci owned folio span corpus sweep: files={} checked={}",
+        sweep.files.len(),
+        checked
+    );
+}

--- a/crates/vize_s1_to_s2/tests/support/folio_spans.rs
+++ b/crates/vize_s1_to_s2/tests/support/folio_spans.rs
@@ -1,0 +1,204 @@
+//! Owned folio span oracle: every span that survives into the lifetime-free
+//! S2 folio must resolve against the authored source.
+
+use vize_s0::{SourceRoot, Span};
+use vize_s2::folio::{
+    DisegnoFolio, FolioAttribute, FolioBinding, FolioExpr, FolioForBinding, FolioName, FolioOp,
+};
+
+pub fn assert_folio_spans_resolve(source: &str, folio: &DisegnoFolio, context: &str) {
+    let root = SourceRoot::new(source).expect("authored source");
+    for op in &folio.ops {
+        assert_op(source, root, op, context);
+    }
+}
+
+fn assert_op(source: &str, root: SourceRoot<'_>, op: &FolioOp, context: &str) {
+    match op {
+        FolioOp::Element(element) => {
+            assert_span(source, root, element.span, "element", context);
+            assert_attributes(source, root, &element.attributes, context);
+            assert_bindings(source, root, &element.bindings, context);
+            assert_ops(source, root, &element.children, context);
+        }
+        FolioOp::Component(component) => {
+            assert_span(source, root, component.span, "component", context);
+            assert_attributes(source, root, &component.attributes, context);
+            assert_bindings(source, root, &component.bindings, context);
+            assert_ops(source, root, &component.children, context);
+        }
+        FolioOp::Text(text) => assert_span(source, root, text.span, "text", context),
+        FolioOp::Interpolation(interpolation) => {
+            assert_span(source, root, interpolation.span, "interpolation", context);
+            assert_expr(source, root, &interpolation.expression, context);
+        }
+        FolioOp::If(if_op) => {
+            assert_span(source, root, if_op.span, "if", context);
+            for branch in &if_op.branches {
+                assert_span(source, root, branch.span, "if branch", context);
+                if let Some(condition) = &branch.condition {
+                    assert_expr(source, root, condition, context);
+                }
+                assert_ops(source, root, &branch.ops, context);
+            }
+        }
+        FolioOp::For(for_op) => {
+            assert_span(source, root, for_op.span, "for", context);
+            assert_for_binding(source, root, &for_op.binding, context);
+            assert_ops(source, root, &for_op.ops, context);
+        }
+        FolioOp::Slot(slot) => {
+            assert_span(source, root, slot.span, "slot", context);
+            assert_name(source, root, &slot.name, context);
+            assert_attributes(source, root, &slot.attributes, context);
+            assert_bindings(source, root, &slot.bindings, context);
+            assert_ops(source, root, &slot.fallback, context);
+        }
+    }
+}
+
+fn assert_ops(source: &str, root: SourceRoot<'_>, ops: &[FolioOp], context: &str) {
+    for op in ops {
+        assert_op(source, root, op, context);
+    }
+}
+
+fn assert_attributes(source: &str, root: SourceRoot<'_>, attrs: &[FolioAttribute], context: &str) {
+    for attr in attrs {
+        assert_span(source, root, attr.span, "attribute", context);
+    }
+}
+
+fn assert_bindings(source: &str, root: SourceRoot<'_>, bindings: &[FolioBinding], context: &str) {
+    for binding in bindings {
+        match binding {
+            FolioBinding::Bind(bind) => {
+                assert_span(source, root, bind.span, "bind", context);
+                if let Some(name) = &bind.name {
+                    assert_name(source, root, name, context);
+                }
+                if let Some(value) = &bind.value {
+                    assert_expr(source, root, value, context);
+                }
+            }
+            FolioBinding::On(on) => {
+                assert_span(source, root, on.span, "on", context);
+                if let Some(name) = &on.name {
+                    assert_name(source, root, name, context);
+                }
+                if let Some(handler) = &on.handler {
+                    assert_expr(source, root, handler, context);
+                }
+            }
+            FolioBinding::Model(model) => {
+                assert_span(source, root, model.span, "model", context);
+                assert_expr(source, root, &model.contract.read, context);
+                assert_expr(source, root, &model.contract.write, context);
+                if let Some(argument) = &model.argument {
+                    assert_name(source, root, argument, context);
+                }
+                assert_attributes(source, root, &model.attributes, context);
+            }
+            FolioBinding::SlotContent(content) => {
+                assert_span(source, root, content.span, "slot content", context);
+                if let Some(name) = &content.name {
+                    assert_name(source, root, name, context);
+                }
+                if let Some(params) = &content.params {
+                    assert_expr(source, root, params, context);
+                }
+            }
+            FolioBinding::VueDirective(directive) => {
+                assert_span(source, root, directive.span, "vue directive", context);
+                if let Some(argument) = &directive.argument {
+                    assert_name(source, root, argument, context);
+                }
+                if let Some(value) = &directive.value {
+                    assert_expr(source, root, value, context);
+                }
+            }
+            FolioBinding::VueCssBind(css) => {
+                assert_span(source, root, css.span, "css bind", context);
+                assert_expr(source, root, &css.value, context);
+            }
+            FolioBinding::VueSync(sync) => {
+                assert_span(source, root, sync.span, "sync", context);
+                assert_expr(source, root, &sync.value, context);
+            }
+            FolioBinding::VueSlotScope(slot) => {
+                assert_span(source, root, slot.span, "slot scope", context);
+                if let Some(params) = &slot.params {
+                    assert_expr(source, root, params, context);
+                }
+            }
+            FolioBinding::VueOnce(once) => assert_span(source, root, once.span, "once", context),
+            FolioBinding::VueMemo(memo) => {
+                assert_span(source, root, memo.span, "memo", context);
+                assert_expr(source, root, &memo.value, context);
+            }
+            FolioBinding::VueShow(show) => {
+                assert_span(source, root, show.span, "show", context);
+                assert_expr(source, root, &show.value, context);
+            }
+            FolioBinding::VueHtml(html) => {
+                assert_span(source, root, html.span, "html", context);
+                if let Some(value) = &html.value {
+                    assert_expr(source, root, value, context);
+                }
+            }
+            FolioBinding::VueText(text) => {
+                assert_span(source, root, text.span, "text", context);
+                if let Some(value) = &text.value {
+                    assert_expr(source, root, value, context);
+                }
+            }
+            FolioBinding::VueCloak(cloak) => {
+                assert_span(source, root, cloak.span, "cloak", context);
+            }
+        }
+    }
+}
+
+fn assert_name(source: &str, root: SourceRoot<'_>, name: &FolioName, context: &str) {
+    match name {
+        FolioName::Static(_) => {}
+        FolioName::Dynamic(expr) => assert_expr(source, root, expr, context),
+    }
+}
+
+fn assert_for_binding(
+    source: &str,
+    root: SourceRoot<'_>,
+    binding: &FolioForBinding,
+    context: &str,
+) {
+    assert_expr(source, root, &binding.source, context);
+    assert_expr(source, root, &binding.value, context);
+    if let Some(key) = &binding.key {
+        assert_expr(source, root, key, context);
+    }
+    if let Some(index) = &binding.index {
+        assert_expr(source, root, index, context);
+    }
+}
+
+fn assert_expr(source: &str, root: SourceRoot<'_>, expr: &FolioExpr, context: &str) {
+    match expr {
+        FolioExpr::Js { span, .. }
+        | FolioExpr::Foreign { span, .. }
+        | FolioExpr::Opaque { span, .. }
+        | FolioExpr::Filter { span, .. } => {
+            assert_span(source, root, *span, "expression", context);
+        }
+    }
+}
+
+fn assert_span(source: &str, root: SourceRoot<'_>, span: Span, label: &str, context: &str) {
+    assert!(
+        root.contains_span(span),
+        "{label} owned-folio span @{}:{} is not a valid authored UTF-8 range in source length {}: {context}",
+        span.start,
+        span.end,
+        source.len()
+    );
+}

--- a/crates/vize_s1_to_s2/tests/support/mod.rs
+++ b/crates/vize_s1_to_s2/tests/support/mod.rs
@@ -6,6 +6,7 @@
 #![allow(dead_code)]
 
 mod authored;
+mod folio_spans;
 
 use vize_davinci::diagnostic::Diagnostic;
 use vize_davinci::folio::{Folio, FolioMode};
@@ -19,6 +20,7 @@ use vize_s2::scope::ScopeFacts;
 use vize_s2::verify::{Rigor, Violation, verify, verify_table};
 
 pub use authored::assert_authored_artifact;
+pub use folio_spans::assert_folio_spans_resolve;
 
 /// The owned snapshot of one lowering, for exact-equality pins.
 #[derive(Debug)]
@@ -120,6 +122,7 @@ pub fn assert_transformed_sound(source: &str, context: &str) {
 pub fn assert_transformed_sound_caps(source: &str, caps: LegacyCaps, context: &str) {
     with_transformed_caps(source, caps, |lowered, folio, facts, _budget| {
         assert_authored_artifact(source, lowered);
+        assert_folio_spans_resolve(source, folio, context);
         assert_eq!(
             u64::from(lowered.op_count),
             folio.op_count(),
@@ -199,6 +202,7 @@ pub fn assert_sound(source: &str, context: &str) {
 pub fn assert_sound_caps(source: &str, caps: LegacyCaps, context: &str) {
     with_lowered_caps(source, caps, |lowered, folio| {
         assert_authored_artifact(source, lowered);
+        assert_folio_spans_resolve(source, folio, context);
         assert_eq!(
             u64::from(lowered.op_count),
             folio.op_count(),


### PR DESCRIPTION
## Summary
- add consumer-side schema_version negotiation for the Spolvero feed before page-shape reads
- add an exhaustive owned S2 folio span walker and wire it into the lowering soundness helpers
- add a P2-17 mechanical span gate over committed fixtures, with optional corpus widening

## Tests
- cargo test -p vize_davinci --test spolvero_feed
- cargo test -p vize_s1_to_s2 --test ir_contract_spans
- cargo test -p vize_s1_to_s2 --test lowering_battery
- cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus -- --nocapture
- cargo clippy -p vize_davinci --test spolvero_feed -- -D warnings
- cargo clippy -p vize_s1_to_s2 --test ir_contract_spans -- -D warnings
- cargo fmt --all -- --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts tests/tooling/davinci-budgets.test.ts
- git diff --cached --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790743201&installation_model_id=422833&pr_number=5458&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5458&signature=c8f780a11d45e5d13637066c5c5b44ccc69e3714db46e8439cc457983470a4ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added feed schema-version negotiation to detect incompatible payloads before processing.
  - Clear mismatch details are provided when a feed uses an unsupported schema version.

- **Bug Fixes**
  - Improved reliability of source-span resolution across converted folios, including malformed inputs and complex template constructs.

- **Tests**
  - Added coverage for missing, invalid, and mismatched schema versions.
  - Expanded validation across fixture and optional corpus inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->