### PR TITLE
fix(davinci): retry DOM corpus hydrate serially

### DIFF
--- a/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
+++ b/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
@@ -9,6 +9,7 @@ import {
   corpusEvidenceLines,
   expectedDomOutputComparisons,
   expectedGitlinks,
+  hydrateCorpus,
   parseCorpusEvidence,
   parseFixtureGitlinks,
   validateCorpusEvidence,
@@ -46,6 +47,7 @@ test("real-project workflow carries a full-canonical S2 DOM corpus job", () => {
     /artifactDir = "real-project-davinci-dom-corpus"/,
     /selected-gitlinks\.txt/,
     /"submodule",\s+"update",\s+"--init",\s+"--checkout",\s+"--depth",\s+"1",\s+"--jobs",\s+"8"/,
+    /"submodule",\s+"update",\s+"--init",\s+"--checkout",\s+"--force"/,
     /"submodule", "status", "--", corpusRoot/,
   ]) {
     assert.match(helperSource, pattern);
@@ -114,6 +116,64 @@ test("S2 DOM corpus workflow gitlink constant matches the checkout index", () =>
   );
 
   assert.equal(indexed.length, expectedGitlinks);
+});
+
+test("S2 DOM corpus hydrate falls back from bulk shallow failures", () => {
+  const artifact = mkdtempSync(join(tmpdir(), "vize-dom-corpus-"));
+  const fixturePaths = Array.from(
+    { length: expectedGitlinks },
+    (_, index) => `tests/_fixtures/_git/project-${index}`,
+  );
+  const calls = [];
+  const jobCount = (args) => {
+    const index = args.indexOf("--jobs");
+    return index === -1 ? undefined : args[index + 1];
+  };
+  const runCommand = (command, args) => {
+    calls.push([command, args]);
+    if (args[0] === "ls-files") {
+      return fixturePaths
+        .map((fixturePath, index) => `160000 ${String(index).padStart(40, "0")} 0\t${fixturePath}`)
+        .join("\n");
+    }
+    if (args[0] === "submodule" && args[1] === "update" && args.includes("--jobs")) {
+      if (args.includes("8")) throw new Error("bulk shallow failed");
+      if (args.includes("tests/_fixtures/_git/project-7")) {
+        throw new Error("single shallow failed");
+      }
+      return "";
+    }
+    if (args[0] === "submodule" && args[1] === "update" && args.includes("--force")) {
+      return "";
+    }
+    if (args[0] === "submodule" && args[1] === "status") {
+      return fixturePaths
+        .map((fixturePath, index) => ` ${String(index).padStart(40, "0")} ${fixturePath}`)
+        .join("\n");
+    }
+    throw new Error(`unexpected command: ${command} ${args.join(" ")}`);
+  };
+  try {
+    assert.equal(hydrateCorpus({ artifact, runCommand }), 0);
+    assert.ok(calls.some(([, args]) => jobCount(args) === "8"));
+    assert.equal(calls.filter(([, args]) => jobCount(args) === "1").length, expectedGitlinks);
+    assert.deepEqual(
+      calls.filter(([, args]) => args.includes("--force")).map(([, args]) => args.at(-1)),
+      ["tests/_fixtures/_git/project-7"],
+    );
+    assert.equal(
+      readFileSync(join(artifact, "selected-gitlinks.txt"), "utf8").split(/\r?\n/).filter(Boolean)
+        .length,
+      expectedGitlinks,
+    );
+    assert.equal(
+      readFileSync(join(artifact, "submodule-status.txt"), "utf8").split(/\r?\n/).filter(Boolean)
+        .length,
+      expectedGitlinks,
+    );
+  } finally {
+    rmSync(artifact, { recursive: true, force: true });
+  }
 });
 
 test("S2 DOM corpus workflow validates closure evidence artifacts", () => {

--- a/tools/fixtures/davinci-dom-corpus-workflow.mjs
+++ b/tools/fixtures/davinci-dom-corpus-workflow.mjs
@@ -31,6 +31,11 @@ function run(command, args, options = {}) {
   return result.stdout ?? "";
 }
 
+function errorMessage(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.replace(/\s+/g, " ").trim();
+}
+
 export function parseFixtureGitlinks(indexOutput) {
   return indexOutput
     .split(/\r?\n/)
@@ -41,8 +46,8 @@ export function parseFixtureGitlinks(indexOutput) {
     .sort((left, right) => left.localeCompare(right));
 }
 
-function selectedGitlinks() {
-  return parseFixtureGitlinks(run("git", ["ls-files", "--stage", "--", corpusRoot]));
+function selectedGitlinks(runCommand) {
+  return parseFixtureGitlinks(runCommand("git", ["ls-files", "--stage", "--", corpusRoot]));
 }
 
 export function verdictFor(outcome, mode) {
@@ -148,30 +153,69 @@ export function validateCorpusEvidence(artifact = artifactDir) {
   };
 }
 
-export function hydrateCorpus() {
-  mkdirSync(artifactDir, { recursive: true });
-  const fixturePaths = selectedGitlinks();
+function hydrateFixtureSerially(fixturePath, runCommand) {
+  try {
+    runCommand("git", [
+      "submodule",
+      "update",
+      "--init",
+      "--checkout",
+      "--depth",
+      "1",
+      "--jobs",
+      "1",
+      "--",
+      fixturePath,
+    ]);
+  } catch (error) {
+    console.warn(
+      `::warning title=Davinci corpus hydrate full fallback::${fixturePath}: ${errorMessage(
+        error,
+      )}`,
+    );
+    runCommand("git", [
+      "submodule",
+      "update",
+      "--init",
+      "--checkout",
+      "--force",
+      "--",
+      fixturePath,
+    ]);
+  }
+}
+
+export function hydrateCorpus({ artifact = artifactDir, runCommand = run } = {}) {
+  mkdirSync(artifact, { recursive: true });
+  const fixturePaths = selectedGitlinks(runCommand);
   if (fixturePaths.length !== expectedGitlinks) {
     console.error(
       `::error title=Unexpected fixture gitlinks::expected ${expectedGitlinks}, got ${fixturePaths.length}`,
     );
     return 1;
   }
-  writeFileSync(`${artifactDir}/selected-gitlinks.txt`, `${fixturePaths.join("\n")}\n`);
-  run("git", [
-    "submodule",
-    "update",
-    "--init",
-    "--checkout",
-    "--depth",
-    "1",
-    "--jobs",
-    "8",
-    "--",
-    ...fixturePaths,
-  ]);
-  const status = run("git", ["submodule", "status", "--", corpusRoot]);
-  writeFileSync(`${artifactDir}/submodule-status.txt`, status);
+  writeFileSync(`${artifact}/selected-gitlinks.txt`, `${fixturePaths.join("\n")}\n`);
+  try {
+    runCommand("git", [
+      "submodule",
+      "update",
+      "--init",
+      "--checkout",
+      "--depth",
+      "1",
+      "--jobs",
+      "8",
+      "--",
+      ...fixturePaths,
+    ]);
+  } catch (error) {
+    console.warn(`::warning title=Davinci corpus hydrate serial fallback::${errorMessage(error)}`);
+    for (const fixturePath of fixturePaths) {
+      hydrateFixtureSerially(fixturePath, runCommand);
+    }
+  }
+  const status = runCommand("git", ["submodule", "status", "--", corpusRoot]);
+  writeFileSync(`${artifact}/submodule-status.txt`, status);
   return 0;
 }
 


### PR DESCRIPTION
## Summary
- retry full Davinci DOM corpus hydration serially when the bulk shallow submodule update fails
- fall back to a force checkout without shallow depth for the individual fixture that still cannot be fetched shallowly
- add workflow-helper coverage for the bulk-to-serial-to-full fallback sequence

## Tests
- node --test tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
- vp check tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts tools/fixtures/davinci-dom-corpus-workflow.mjs
- vp run --workspace-root check:ci
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790743860&installation_model_id=422833&pr_number=5459&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5459&signature=d1d96693f08d8cde0a75555a6bb7383512a31fd0675f4f8bebbd8b5e3e7c884b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->