### PR TITLE
test(davinci): compare compatibility-notice corpus inputs

### DIFF
--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
@@ -8,6 +8,8 @@
 //! closed unless its gitlink inventory reconciles (see
 //! `davinci_test_support::corpus`).
 
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
 use std::{collections::BTreeMap, fs};
 
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
@@ -26,6 +28,10 @@ const BATTERY: &[(&str, &str)] = &[
     (
         "slot_template",
         r#"<template><Foo><template #default="{ item }"><span>{{ item }}</span></template></Foo></template>"#,
+    ),
+    (
+        "self_closing_non_void_html",
+        r#"<template><div /><span class="x" /></template>"#,
     ),
 ];
 
@@ -133,12 +139,16 @@ fn compare_sfc_template(name: &str, source: &str, report: &mut Report) {
 
     let old_allocator = Allocator::new();
     let (_, errors, old) = vize_atelier_dom::compile_template(&old_allocator, &template.content);
-    if !errors.is_empty() {
+    let blocking_errors: Vec<_> = errors
+        .iter()
+        .filter(|error| !error.is_compatibility_notice())
+        .collect();
+    if !blocking_errors.is_empty() {
         report.old_error_skips += 1;
         if report.old_error_samples.len() < 20 {
             report.old_error_samples.push(format!(
-                "{name}: {} old-lane errors: {errors:?}",
-                errors.len()
+                "{name}: {} old-lane blocking errors: {blocking_errors:?}",
+                blocking_errors.len()
             ));
         }
         return;


### PR DESCRIPTION
## Summary
- keep DOM corpus inputs comparable when the old lane only reports Vue-compatible self-closing HTML rewrite notices
- add a committed battery case for self-closing non-void HTML parity
- allow this corpus test binary to use existing diagnostic `String`/`format!` reporting under targeted clippy

## Verification
- cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture
- cargo clippy -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- -D warnings
- cargo fmt --all -- --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts tests/tooling/davinci-budgets.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790744388&installation_model_id=422833&pr_number=5461&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5461&signature=631b4b74807f365f94bdd0f225269d84f7f1f9bbb83beebd67eae452f035f0c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->