### PR TITLE
refactor(atelier): import SFC bindings S0 through stage alias

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/bindings.rs
+++ b/crates/vize_atelier_sfc/src/compile/bindings.rs
@@ -7,7 +7,7 @@ use oxc_ast::ast::{
     BindingPattern, Declaration, Expression, ImportDeclarationSpecifier, Statement,
     VariableDeclaration, VariableDeclarationKind,
 };
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 use crate::types::{BindingMetadata, BindingType};
 

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           928 |                   486 |               442 |             140 |     371 |             941 |      498 |           488 |           602 |
+| Compiler                   |           928 |                   487 |               441 |             140 |     371 |             941 |      498 |           488 |           602 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   238 |               641 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -600,7 +600,7 @@ compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile_tests.rs	8	s0	S0	
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile.rs	59	s0	S0	stage	vize_carton	compat	3
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile.rs	59	croquis	Croquis analysis	old	vize_croquis	legacy	2
 compiler	Compiler	test/dev	crates/vize_atelier_sfc/src/compile.rs	59	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
-compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	s0	S0	stage	vize_carton	compat	1
+compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	croquis	Croquis analysis	old	vize_croquis	legacy	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 compiler	Compiler	source	crates/vize_atelier_sfc/src/compile/bindings.rs	6	raw_oxc	raw OXC	raw	oxc_ast	raw	1

--- a/tests/tooling/davinci-atelier-sfc-stage-alias.test.mjs
+++ b/tests/tooling/davinci-atelier-sfc-stage-alias.test.mjs
@@ -14,6 +14,7 @@ const sfcPreferredS0Rows = [
   ["crates/vize_atelier_sfc/src/bundler/blocks.rs", "source", 2],
   ["crates/vize_atelier_sfc/src/bundler/css.rs", "source", 1],
   ["crates/vize_atelier_sfc/src/bundler/scope.rs", "source", 1],
+  ["crates/vize_atelier_sfc/src/compile/bindings.rs", "source", 1],
   ["crates/vize_atelier_sfc/src/compile/diagnostics.rs", "source", 1],
   ["crates/vize_atelier_sfc/src/compile/empty_component.rs", "source", 1],
   ["crates/vize_atelier_sfc/src/compile_template.rs", "source", 1],


### PR DESCRIPTION
## Summary
- move the Atelier SFC binding helper from the S0 compatibility crate name to the preferred `vize_s0` stage alias
- pin the row in the Atelier SFC stage-alias tooling guard
- regenerate Davinci consumer migration surface docs/TSV

## Tests
- `cargo test -p vize_atelier_sfc compile::tests::test_compile_both_script_blocks_exposes_normal_script_bindings_to_template -- --exact`
- `cargo test -p vize_atelier_sfc compile::tests::test_let_var_unref -- --exact`
- `cargo clippy -p vize_atelier_sfc -- -D warnings`
- `node --test tests/tooling/davinci-atelier-sfc-stage-alias.test.mjs tests/tooling/davinci-consumer-migration-surfaces.test.mjs`
- `rust-script tools/commands/davinci/consumer-migration-surfaces.rs --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `vp run --workspace-root check:ci`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790745510&installation_model_id=422833&pr_number=5463&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5463&signature=574a0e5be94cfdbc3de2b42489c26d921123095f2b1b6713c7741e793a4f6088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->