### PR TITLE
fix(davinci): wrap typed arrow event handlers

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_handler_parity.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_handler_parity.rs
@@ -1,0 +1,29 @@
+//! Reduced real-project handler parity witnesses.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "untyped_arrow_component_handler_stays_direct",
+        r#"<FieldKeyValues @add="(key, value) => addKeyValue(headers, key, value)" />"#,
+    ),
+    (
+        "typed_arrow_component_handler",
+        r#"<FieldKeyValues @add="(key: string, value: string) => addKeyValue(headers, key, value)" />"#,
+    ),
+    (
+        "typed_arrow_component_handler_with_static_props",
+        r#"<FieldKeyValues label="Headers" @remove="(index: number) => removeKeyValue(index, headers)" />"#,
+    ),
+];
+
+#[test]
+fn s2_real_project_handler_parity_matches_the_shipped_dom_lane() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -62,6 +62,7 @@ mod namespace;
 mod on;
 mod on_body;
 mod on_dynamic;
+mod on_typed;
 mod once;
 mod outlet;
 mod outlet_props;

--- a/crates/vize_s1_to_s2/src/emit/on.rs
+++ b/crates/vize_s1_to_s2/src/emit/on.rs
@@ -202,7 +202,9 @@ fn emit_mod_array(cx: &mut EmitCx<'_>, mods: &[&str]) {
 }
 
 pub(super) fn emit_handler(cx: &mut EmitCx<'_>, js: &JsExpr<'_>) {
-    if is_handler_reference(js.ast) || is_function(js.ast) {
+    if is_handler_reference(js.ast)
+        || (is_function(js.ast) && !super::on_typed::is_typed_arrow(js.ast))
+    {
         cx.buf.push(js.source);
         return;
     }

--- a/crates/vize_s1_to_s2/src/emit/on_typed.rs
+++ b/crates/vize_s1_to_s2/src/emit/on_typed.rs
@@ -1,0 +1,21 @@
+//! TypeScript-specific `v-on` handler detection.
+
+use oxc_ast::ast::Expression;
+
+pub(super) fn is_typed_arrow(expr: &Expression<'_>) -> bool {
+    let Expression::ArrowFunctionExpression(arrow) = expr else {
+        return false;
+    };
+    arrow.type_parameters.is_some()
+        || arrow.return_type.is_some()
+        || arrow
+            .params
+            .items
+            .iter()
+            .any(|param| param.type_annotation.is_some())
+        || arrow
+            .params
+            .rest
+            .as_ref()
+            .is_some_and(|rest| rest.type_annotation.is_some())
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           928 |                   487 |               441 |             140 |     371 |             941 |      498 |           488 |           602 |
+| Compiler                   |           928 |                   487 |               441 |             140 |     371 |             941 |      498 |           488 |           603 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   238 |               641 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |


### PR DESCRIPTION
## Summary
- keep TypeScript-annotated arrow event handlers on the legacy wrapper path
- preserve direct emission for untyped arrow handlers
- add reduced component-handler parity witnesses from the real-project corpus

## Verification
- cargo test -p vize_atelier_dom --test davinci_s2_handler_parity -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_on -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_von -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_dynamic_von_keys -- --nocapture
- cargo clippy -p vize_s1_to_s2 --test emit_on -- -D warnings
- cargo clippy -p vize_atelier_dom --test davinci_s2_handler_parity -- -D warnings
- cargo fmt --all -- --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790745591&installation_model_id=422833&pr_number=5464&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5464&signature=793ae5c1f4e8126c924b26eb1fd5154ef8f799e25ac0568d4c72ad54643231de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->