### PR TITLE
fix(davinci): format nested cached static arrays

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_static_cache.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_static_cache.rs
@@ -9,10 +9,20 @@
 
 mod support;
 
-const BATTERY: &[(&str, &str)] = &[(
-    "hoisted_root_caches_static_children_array",
-    r#"<div class="root"><span>a</span><span>b</span></div>"#,
-)];
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "hoisted_root_caches_static_children_array",
+        r#"<div class="root"><span>a</span><span>b</span></div>"#,
+    ),
+    (
+        "cached_static_child_keeps_nested_element_array_shape",
+        r#"<div class="root"><button><span>x</span></button></div>"#,
+    ),
+    (
+        "cached_static_child_before_dynamic_sibling",
+        r#"<div class="root"><button><span>x</span></button><i :id="foo"></i></div>"#,
+    ),
+];
 
 #[test]
 fn s2_static_child_cache_matches_the_shipped_dom_lane_byte_for_byte() {

--- a/crates/vize_s1_to_s2/src/emit/buf.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf.rs
@@ -45,6 +45,10 @@ impl Buf {
         }
     }
 
+    pub(super) fn indent_width(&self) -> usize {
+        self.indent as usize * 2
+    }
+
     pub(super) fn indent(&mut self) {
         self.indent += 1;
     }

--- a/crates/vize_s1_to_s2/src/emit/hoist.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist.rs
@@ -45,7 +45,8 @@ pub(super) fn emit_cached_element(
     cx.buf.push("] || (_cache[");
     cx.buf.push(cache_index.as_str());
     cx.buf.push("] = ");
-    cx.buf.push(cached_element_rhs(element, true).as_str());
+    cx.buf
+        .push(cached_element_rhs(element, true, cx.buf.indent_width()).as_str());
     cx.buf.push(")");
     Ok(())
 }
@@ -87,7 +88,8 @@ pub(super) fn emit_cached_elements_array(
         if hoist_needs_create_text(element) {
             cx.buf.use_create_text();
         }
-        cx.buf.push(cached_element_rhs(element, true).as_str());
+        cx.buf
+            .push(cached_element_rhs(element, true, cx.buf.indent_width()).as_str());
     }
 
     cx.buf.deindent();
@@ -176,8 +178,18 @@ fn hoist_element_rhs(element: &ElementOp<'_>, pure: bool) -> String {
     out
 }
 
-fn cached_element_rhs(element: &ElementOp<'_>, cached: bool) -> String {
+fn cached_element_rhs(element: &ElementOp<'_>, cached: bool, line_indent: usize) -> String {
     let mut out = String::default();
+    append_cached_element_rhs(&mut out, element, cached, line_indent);
+    out
+}
+
+fn append_cached_element_rhs(
+    out: &mut String,
+    element: &ElementOp<'_>,
+    cached: bool,
+    line_indent: usize,
+) {
     out.push_str(Buf::create_element_vnode_alias());
     out.push('(');
     out.push('"');
@@ -194,13 +206,12 @@ fn cached_element_rhs(element: &ElementOp<'_>, cached: bool) -> String {
     if kids.is_empty() {
         out.push_str("null");
     } else {
-        append_cached_kids(&mut out, &kids);
+        append_cached_kids(out, &kids, line_indent);
     }
     if cached {
         out.push_str(", -1 /* CACHED */");
     }
     out.push(')');
-    out
 }
 
 fn append_hoist_kids(out: &mut String, kids: &[&Op<'_>]) {
@@ -237,7 +248,7 @@ fn append_hoist_kids(out: &mut String, kids: &[&Op<'_>]) {
     out.push(']');
 }
 
-fn append_cached_kids(out: &mut String, kids: &[&Op<'_>]) {
+fn append_cached_kids(out: &mut String, kids: &[&Op<'_>], line_indent: usize) {
     if kids.iter().all(|op| matches!(op, Op::Text(_))) {
         out.push('"');
         for op in kids.iter() {
@@ -251,8 +262,10 @@ fn append_cached_kids(out: &mut String, kids: &[&Op<'_>]) {
     out.push('[');
     for (i, op) in kids.iter().enumerate() {
         if i > 0 {
-            out.push_str(", ");
+            out.push(',');
         }
+        out.push('\n');
+        push_spaces(out, line_indent + 2);
         match op {
             Op::Text(text) => {
                 out.push_str(Buf::create_text_alias());
@@ -263,12 +276,18 @@ fn append_cached_kids(out: &mut String, kids: &[&Op<'_>]) {
                 out.push(')');
             }
             Op::Element(element) => {
-                out.push_str(cached_element_rhs(element, false).as_str());
+                append_cached_element_rhs(out, element, false, line_indent + 2);
             }
             _ => {}
         }
     }
+    out.push('\n');
+    push_spaces(out, line_indent);
     out.push(']');
+}
+
+fn push_spaces(out: &mut String, width: usize) {
+    out.extend(core::iter::repeat_n(' ', width));
 }
 
 fn meaningful<'a>(children: &'a Region<'a>) -> StdVec<&'a Op<'a>> {

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           928 |                   487 |               441 |             140 |     371 |             941 |      498 |           488 |           603 |
+| Compiler                   |           928 |                   487 |               441 |             140 |     371 |             941 |      498 |           488 |           604 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   238 |               641 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -73,7 +73,7 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
 | s1_to_s2 | `alloc::vec::Vec`       |    37 |           37 |        156 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    52 |           54 |        236 |
+| s1_to_s2 | `vize_s0::String`       |    52 |           54 |        238 |
 | s1_to_s2 | `vize_s0::Vec`          |    14 |           14 |         56 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     2 |            2 |          4 |
 

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -41,7 +41,7 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/component.rs	1	4	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/create_slots.rs	1	6	1	6	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/directive.rs	1	6	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/filter.rs	0	0	1	1	0	0	0	0
-s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/hoist.rs	1	4	1	10	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/hoist.rs	1	4	1	12	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/js.rs	0	0	1	13	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/merge.rs	1	8	1	3	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/model.rs	1	6	1	4	0	0	0	0


### PR DESCRIPTION
## Summary
- preserve shipped DOM byte layout for nested cached static child arrays
- add Davinci static-cache reductions for nested static element children before dynamic siblings
- refresh generated migration and reviewed owned-storage inventory after rebasing on current main

## Tests
- `cargo test -p vize_atelier_dom --test davinci_s2_static_cache -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_static_vnode_hoist -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_root_hoist -- --nocapture`
- `cargo test -p vize_s1_to_s2 --test emit_static -- --nocapture`
- `cargo clippy -p vize_s1_to_s2 --test emit_static -- -D warnings`
- `cargo clippy -p vize_atelier_dom --test davinci_s2_static_cache -- -D warnings`
- `cargo fmt --all -- --check`
- `node --test tests/tooling/davinci-storage-policy.test.ts`
- `node --test tests/tooling/davinci-matrices.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`
