### PR TITLE
fix(davinci): compare nested interactive recovery

### DIFF
--- a/crates/vize_armature/src/parser.rs
+++ b/crates/vize_armature/src/parser.rs
@@ -16,6 +16,8 @@ mod entry;
 #[cfg(test)]
 mod experimental_tests;
 mod expression;
+#[cfg(test)]
+mod interactive_recovery_tests;
 mod pending_text;
 mod whitespace;
 
@@ -62,6 +64,10 @@ pub struct Parser<'a> {
     /// onto `stack`, so without this their end tags would find nothing to close
     /// and be reported as `InvalidEndTag` even though the source is correct.
     flattened_tags: Vec<'a, &'a str>,
+    /// Tags closed by HTML tree construction before their authored end tag was
+    /// reached. Their later end tags are redundant recovery fallout, not a new
+    /// parser failure.
+    implicitly_closed_tags: Vec<'a, &'a str>,
     /// Root node
     root: Option<RootNode<'a>>,
     /// Current element being parsed

--- a/crates/vize_armature/src/parser/constructor.rs
+++ b/crates/vize_armature/src/parser/constructor.rs
@@ -70,6 +70,7 @@ impl<'a> Parser<'a> {
             pending_text: None,
             stack: Vec::new_in(&allocator),
             flattened_tags: Vec::new_in(&allocator),
+            implicitly_closed_tags: Vec::new_in(&allocator),
             root: None,
             current_element: None,
             current_attr: None,

--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -34,6 +34,26 @@ impl<'a> Parser<'a> {
             .iter()
             .any(|candidate| tag.eq_ignore_ascii_case(candidate))
     }
+
+    pub(super) fn note_implicitly_closed_stack_entries_from(&mut self, index: usize) {
+        for entry in self.stack.iter().skip(index) {
+            if !entry.implicit && is_html_tree_element(&entry.element) {
+                self.implicitly_closed_tags.push(entry.element.tag);
+            }
+        }
+    }
+
+    pub(super) fn consume_implicitly_closed_tag(&mut self, tag: &str) -> bool {
+        let Some(index) = self
+            .implicitly_closed_tags
+            .iter()
+            .rposition(|closed| closed.eq_ignore_ascii_case(tag))
+        else {
+            return false;
+        };
+        self.implicitly_closed_tags.remove(index);
+        true
+    }
 }
 
 pub(super) fn is_html_tree_element(element: &ElementNode<'_>) -> bool {

--- a/crates/vize_armature/src/parser/element/scope.rs
+++ b/crates/vize_armature/src/parser/element/scope.rs
@@ -32,6 +32,7 @@ impl<'a> Parser<'a> {
                     &self.stack[index].element.loc.clone(),
                     "Nested anchor start tag closed the previous anchor before inserting the new one.",
                 );
+                self.note_implicitly_closed_stack_entries_from(index);
                 self.close_stack_element_at(index, false);
             }
             return;
@@ -45,6 +46,7 @@ impl<'a> Parser<'a> {
                     &self.stack[index].element.loc.clone(),
                     "Nested button start tag closed the previous button before inserting the new one.",
                 );
+                self.note_implicitly_closed_stack_entries_from(index);
                 self.close_stack_element_at(index, false);
             }
             return;

--- a/crates/vize_armature/src/parser/element/tags.rs
+++ b/crates/vize_armature/src/parser/element/tags.rs
@@ -248,6 +248,14 @@ impl<'a> Parser<'a> {
         }
 
         let loc = self.create_loc(start.saturating_sub(2), end + 1); // Include </ and >
+        if self.consume_implicitly_closed_tag(tag.as_str()) {
+            self.report_tree_construction_recovery(
+                &loc,
+                "HTML tree construction ignored this end tag because the element was already closed before a nested start tag.",
+            );
+            return;
+        }
+
         self.errors
             .push(CompilerError::new(ErrorCode::InvalidEndTag, Some(loc)));
     }

--- a/crates/vize_armature/src/parser/interactive_recovery_tests.rs
+++ b/crates/vize_armature/src/parser/interactive_recovery_tests.rs
@@ -1,0 +1,74 @@
+use super::parse;
+use vize_relief::{
+    TemplateChildNode,
+    errors::{CompilerError, ErrorCode},
+};
+use vize_s0::Allocator;
+
+#[test]
+fn nested_anchor_and_button_recovery_stays_recoverable() {
+    let allocator = Allocator::new();
+    let (anchor_root, anchor_errors) = parse(
+        &allocator,
+        r#"<a href="/">outer<a href="/foo">inner</a></a>"#,
+    );
+    assert_redundant_end_tag_notice(&anchor_errors, "a");
+    assert!(anchor_errors.iter().all(CompilerError::is_recoverable));
+    assert_eq!(anchor_root.children.len(), 2);
+    assert!(matches!(&anchor_root.children[0], TemplateChildNode::Element(a) if a.tag == "a"));
+    assert!(matches!(&anchor_root.children[1], TemplateChildNode::Element(a) if a.tag == "a"));
+
+    let (button_root, button_errors) =
+        parse(&allocator, "<button>aaa<button>bbb</button></button>");
+    assert_redundant_end_tag_notice(&button_errors, "button");
+    assert!(button_errors.iter().all(CompilerError::is_recoverable));
+    assert_eq!(button_root.children.len(), 2);
+    assert!(
+        matches!(&button_root.children[0], TemplateChildNode::Element(button) if button.tag == "button")
+    );
+    assert!(
+        matches!(&button_root.children[1], TemplateChildNode::Element(button) if button.tag == "button")
+    );
+}
+
+#[test]
+fn nested_anchor_recovery_consumes_only_matching_redundant_end_tag() {
+    let allocator = Allocator::new();
+    let (_, errors) = parse(
+        &allocator,
+        r#"<a href="/"><div><a href="/foo">inner</a></div></a></a>"#,
+    );
+
+    let invalid_end_tags = errors
+        .iter()
+        .filter(|error| error.code == ErrorCode::InvalidEndTag)
+        .count();
+    assert_eq!(
+        invalid_end_tags, 1,
+        "only the recovery-matched outer </a> is downgraded; an extra stray </a> stays hard: {errors:?}"
+    );
+}
+
+#[test]
+fn nested_interactive_recovery_consumes_descendant_end_tags() {
+    let allocator = Allocator::new();
+    for source in [
+        r#"<a href="/"><div><a href="/foo">inner</a></div></a>"#,
+        "<button><div><button>bbb</button></div></button>",
+    ] {
+        let (_, errors) = parse(&allocator, source);
+        assert!(
+            errors.iter().all(CompilerError::is_recoverable),
+            "{source}: descendant end tags popped by the nested interactive-content recovery must not stay hard: {errors:?}"
+        );
+    }
+}
+
+fn assert_redundant_end_tag_notice(errors: &[CompilerError], tag: &str) {
+    assert!(
+        errors.iter().any(|error| {
+            error.code == ErrorCode::ExtendPoint && error.message.contains("ignored this end tag")
+        }),
+        "the outer </{tag}> is redundant fallout from nested interactive-content recovery: {errors:?}"
+    );
+}

--- a/crates/vize_atelier_dom/src/interactive_recovery_tests.rs
+++ b/crates/vize_atelier_dom/src/interactive_recovery_tests.rs
@@ -1,0 +1,36 @@
+use super::compile_template;
+use vize_s0::Allocator;
+
+#[test]
+fn compile_standard_emits_nested_anchor_and_button_recoveries() {
+    let allocator = Allocator::new();
+    for source in [
+        r#"<a href="/"><div><a href="/foo">inner</a></div></a>"#,
+        "<button><div><button>bbb</button></div></button>",
+    ] {
+        let (_, errors, result) = compile_template(&allocator, source);
+        assert!(
+            errors.iter().all(|error| error.is_compatibility_notice()),
+            "{source}: nested interactive-content recovery must stay non-fatal without downgrading unrelated errors: {errors:?}"
+        );
+        assert!(
+            !result.code.is_empty(),
+            "{source}: compatibility notices must still emit code"
+        );
+    }
+}
+
+#[test]
+fn compile_standard_keeps_extra_invalid_anchor_end_tag_fatal() {
+    let allocator = Allocator::new();
+    let (_, errors, result) = compile_template(
+        &allocator,
+        r#"<a href="/">outer<a href="/foo">inner</a></a></a>"#,
+    );
+
+    assert!(
+        errors.iter().any(|error| !error.is_recoverable()),
+        "the extra stray </a> must remain a hard parse error: {errors:?}"
+    );
+    assert!(result.code.is_empty());
+}

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -16,6 +16,8 @@
 mod compile;
 #[cfg(test)]
 mod experimental_tests;
+#[cfg(test)]
+mod interactive_recovery_tests;
 mod namespace;
 pub mod options;
 pub mod steps;

--- a/crates/vize_relief/src/errors/compatibility.rs
+++ b/crates/vize_relief/src/errors/compatibility.rs
@@ -7,10 +7,20 @@ impl CompilerError {
     /// so the standard-mode rewrite must stay silent outside compilation.
     #[must_use]
     pub fn is_compatibility_notice(&self) -> bool {
-        self.code == ErrorCode::ExtendPoint
-            && self
+        if self.code != ErrorCode::ExtendPoint {
+            return false;
+        }
+        self.message
+            .starts_with("Invalid self-closing syntax on non-void HTML element")
+            || self
                 .message
-                .starts_with("Invalid self-closing syntax on non-void HTML element")
+                .starts_with("Nested anchor start tag closed the previous anchor")
+            || self
+                .message
+                .starts_with("Nested button start tag closed the previous button")
+            || self
+                .message
+                .starts_with("HTML tree construction ignored this end tag because the element was already closed before a nested start tag")
     }
 }
 
@@ -38,5 +48,33 @@ mod tests {
         assert!(!duplicate.is_compatibility_notice());
         assert!(!strict.is_recoverable());
         assert!(!strict.is_compatibility_notice());
+    }
+
+    #[test]
+    fn nested_anchor_and_button_tree_recovery_are_compatibility_notices() {
+        for message in [
+            "Nested anchor start tag closed the previous anchor before inserting the new one.",
+            "Nested button start tag closed the previous button before inserting the new one.",
+            "HTML tree construction ignored this end tag because the element was already closed before a nested start tag.",
+        ] {
+            let notice = CompilerError::with_message(ErrorCode::ExtendPoint, message, None);
+            assert!(notice.is_recoverable(), "{message}");
+            assert!(notice.is_compatibility_notice(), "{message}");
+        }
+    }
+
+    #[test]
+    fn unrelated_tree_recovery_is_not_a_compatibility_notice() {
+        let deep = CompilerError::with_message(
+            ErrorCode::ExtendPoint,
+            "Element nesting is too deep.",
+            None,
+        );
+        let invalid = CompilerError::new(ErrorCode::InvalidEndTag, None);
+
+        assert!(!deep.is_recoverable());
+        assert!(!deep.is_compatibility_notice());
+        assert!(!invalid.is_recoverable());
+        assert!(!invalid.is_compatibility_notice());
     }
 }

--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
@@ -248,3 +248,55 @@ fn assert_clean_corpus(report: &Report) {
         report.divergences.join("\n"),
     );
 }
+
+#[test]
+fn nested_anchor_and_button_recoveries_are_compared_not_skipped() {
+    let mut report = Report::default();
+    for (name, source) in [
+        (
+            "nested_anchor",
+            r#"<template><a href="/"><div><a href="/foo">inner</a></div></a></template>"#,
+        ),
+        (
+            "nested_button",
+            "<template><button><div><button>bbb</button></div></button></template>",
+        ),
+    ] {
+        compare_sfc_template(name, source, &mut report);
+    }
+
+    assert_eq!(report.templates, 2);
+    assert_eq!(
+        report.old_error_skips, 0,
+        "nested interactive-content recoveries should reach the DOM comparison lane: {:?}",
+        report.old_error_samples
+    );
+    assert_eq!(
+        report.s2_refusal_count, 0,
+        "S2 should emit so any remaining mismatch is counted as a divergence: {:?}",
+        report.s2_refusals
+    );
+    assert_eq!(report.compared, 2);
+}
+
+#[test]
+fn unrelated_invalid_end_tag_still_blocks_old_lane_comparison() {
+    let mut report = Report::default();
+    compare_sfc_template(
+        "stray_span_end",
+        "<template><div></span></div></template>",
+        &mut report,
+    );
+
+    assert_eq!(report.templates, 1);
+    assert_eq!(report.compared, 0);
+    assert_eq!(report.old_error_skips, 1);
+    assert!(
+        report
+            .old_error_samples
+            .iter()
+            .any(|sample| sample.contains("InvalidEndTag")),
+        "the hard invalid end tag must remain visible in skip evidence: {:?}",
+        report.old_error_samples
+    );
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           928 |                   487 |               441 |             140 |     371 |             941 |      498 |           488 |           603 |
+| Compiler                   |           929 |                   488 |               441 |             140 |     371 |             941 |      499 |           489 |           605 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   238 |               641 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
@@ -61,7 +61,7 @@ Scope: build command plus atelier compiler crates. This is a lexical inventory, 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
 | Davinci          |          21 |               4 |       17 |
-| S0               |         847 |             479 |      368 |
+| S0               |         848 |             479 |      369 |
 | S1               |           5 |               1 |        4 |
 | S2               |          15 |               1 |       14 |
 | S1->S2           |          40 |               2 |       38 |
@@ -91,7 +91,7 @@ Additional source/manifest rows are in the TSV: 309 omitted.
 | `crates/vize_atelier_sfc/src/compile_script/props/tests.rs:4` | test/dev | S0 15                                         |    15 |
 | `crates/vize_atelier_core/tests/s2_support/compare.rs:10`     | test/dev | Davinci 2<br>S0 4<br>S1 1<br>S2 1<br>S1->S2 3 |    11 |
 
-Additional test/dev rows are in the TSV: 205 omitted.
+Additional test/dev rows are in the TSV: 206 omitted.
 
 ### Linter
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -266,6 +266,7 @@ compiler	Compiler	source	crates/vize_atelier_dom/src/compile.rs	13	croquis	Croqu
 compiler	Compiler	source	crates/vize_atelier_dom/src/compile/custom_elements.rs	8	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_dom/src/compile/stage_options.rs	14	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_dom/src/experimental_tests.rs	2	s0	S0	stage	vize_s0	preferred	1
+compiler	Compiler	test/dev	crates/vize_atelier_dom/src/interactive_recovery_tests.rs	2	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	source	crates/vize_atelier_dom/src/namespace.rs	12	s0	S0	stage	vize_s0	preferred	4
 compiler	Compiler	source	crates/vize_atelier_dom/src/options.rs	5	s0	S0	stage	vize_s0	preferred	2
 compiler	Compiler	source	crates/vize_atelier_dom/src/options.rs	5	croquis	Croquis analysis	old	vize_croquis	legacy	1


### PR DESCRIPTION
## Summary
- track tags implicitly closed by nested anchor/button HTML tree recovery
- downgrade only the matching redundant end tags to compatibility notices
- keep unrelated stray end tags fatal and add Davinci corpus regressions

## Tests
- `cargo test -p vize_armature nested_interactive_recovery -- --nocapture`
- `cargo test -p vize_relief`
- `cargo test -p vize_armature`
- `cargo test -p vize_atelier_dom`
- `cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture`
- `cargo clippy -p vize_relief --tests -- -D warnings`
- `cargo clippy -p vize_armature --tests -- -D warnings`
- `cargo clippy -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- -D warnings`
- `cargo clippy -p vize_atelier_dom --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `node --test tests/tooling/davinci-matrices.test.ts`
- `git diff --check`

## Notes
- A broader local `cargo clippy -p vize_relief -p vize_armature -p vize_atelier_dom -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings` run stops on existing `vize_atelier_dom` test lints outside this PR's touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for nested `<a>` and `<button>` elements.
  * Redundant end tags caused by automatic HTML corrections are now treated as recoverable notices instead of parser failures.
  * Genuine stray end tags continue to produce errors and prevent code generation.

* **Tests**
  * Added coverage across parsing, compilation, DOM comparison, and compatibility reporting for interactive-content recovery.

* **Documentation**
  * Refreshed consumer migration surface counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->