### PR TITLE
fix(davinci): compare nested interactive recoveries

### DIFF
--- a/crates/vize_armature/src/parser.rs
+++ b/crates/vize_armature/src/parser.rs
@@ -62,6 +62,10 @@ pub struct Parser<'a> {
     /// onto `stack`, so without this their end tags would find nothing to close
     /// and be reported as `InvalidEndTag` even though the source is correct.
     flattened_tags: Vec<'a, &'a str>,
+    /// Tags closed by HTML tree construction before their authored end tag was
+    /// reached. Their later end tags are redundant recovery fallout, not a new
+    /// parser failure.
+    implicitly_closed_tags: Vec<'a, &'a str>,
     /// Root node
     root: Option<RootNode<'a>>,
     /// Current element being parsed

--- a/crates/vize_armature/src/parser/constructor.rs
+++ b/crates/vize_armature/src/parser/constructor.rs
@@ -70,6 +70,7 @@ impl<'a> Parser<'a> {
             pending_text: None,
             stack: Vec::new_in(&allocator),
             flattened_tags: Vec::new_in(&allocator),
+            implicitly_closed_tags: Vec::new_in(&allocator),
             root: None,
             current_element: None,
             current_attr: None,

--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -34,6 +34,25 @@ impl<'a> Parser<'a> {
             .iter()
             .any(|candidate| tag.eq_ignore_ascii_case(candidate))
     }
+
+    pub(super) fn note_implicitly_closed_stack_entries_from(&mut self, index: usize) {
+        for entry in self.stack.iter().skip(index) {
+            if !entry.implicit && is_html_tree_element(&entry.element) {
+                self.implicitly_closed_tags.push(entry.element.tag);
+            }
+        }
+    }
+
+    pub(super) fn consume_implicitly_closed_tag(&mut self, tag: &str) -> bool {
+        let Some(closed) = self.implicitly_closed_tags.last() else {
+            return false;
+        };
+        if !closed.eq_ignore_ascii_case(tag) {
+            return false;
+        }
+        self.implicitly_closed_tags.pop();
+        true
+    }
 }
 
 pub(super) fn is_html_tree_element(element: &ElementNode<'_>) -> bool {

--- a/crates/vize_armature/src/parser/element/scope.rs
+++ b/crates/vize_armature/src/parser/element/scope.rs
@@ -32,6 +32,7 @@ impl<'a> Parser<'a> {
                     &self.stack[index].element.loc.clone(),
                     "Nested anchor start tag closed the previous anchor before inserting the new one.",
                 );
+                self.note_implicitly_closed_stack_entries_from(index);
                 self.close_stack_element_at(index, false);
             }
             return;
@@ -45,6 +46,7 @@ impl<'a> Parser<'a> {
                     &self.stack[index].element.loc.clone(),
                     "Nested button start tag closed the previous button before inserting the new one.",
                 );
+                self.note_implicitly_closed_stack_entries_from(index);
                 self.close_stack_element_at(index, false);
             }
             return;

--- a/crates/vize_armature/src/parser/element/tags.rs
+++ b/crates/vize_armature/src/parser/element/tags.rs
@@ -248,6 +248,14 @@ impl<'a> Parser<'a> {
         }
 
         let loc = self.create_loc(start.saturating_sub(2), end + 1); // Include </ and >
+        if self.consume_implicitly_closed_tag(tag.as_str()) {
+            self.report_tree_construction_recovery(
+                &loc,
+                "HTML tree construction ignored this end tag because the element was already closed before a nested start tag.",
+            );
+            return;
+        }
+
         self.errors
             .push(CompilerError::new(ErrorCode::InvalidEndTag, Some(loc)));
     }

--- a/crates/vize_armature/tests/nested_interactive_recovery.rs
+++ b/crates/vize_armature/tests/nested_interactive_recovery.rs
@@ -1,0 +1,112 @@
+use vize_armature::{Allocator, CompilerError, ErrorCode, TemplateChildNode, parse};
+
+const NESTED_ANCHOR_RECOVERY: &str =
+    "Nested anchor start tag closed the previous anchor before inserting the new one.";
+const NESTED_BUTTON_RECOVERY: &str =
+    "Nested button start tag closed the previous button before inserting the new one.";
+const IGNORED_END_TAG_RECOVERY: &str = "HTML tree construction ignored this end tag because the element was already closed before a nested start tag.";
+
+#[test]
+fn nested_anchor_and_button_are_split_without_hard_errors() {
+    let allocator = Allocator::new();
+    let (anchor_root, anchor_errors) = parse(
+        &allocator,
+        r#"<a href="/">outer<a href="/foo">inner</a></a>"#,
+    );
+
+    assert!(
+        anchor_errors
+            .iter()
+            .any(|e| e.code == ErrorCode::ExtendPoint && e.message == NESTED_ANCHOR_RECOVERY)
+    );
+    assert!(
+        anchor_errors
+            .iter()
+            .any(|e| e.code == ErrorCode::ExtendPoint && e.message == IGNORED_END_TAG_RECOVERY),
+        "the outer </a> is redundant fallout from the nested-anchor recovery: {anchor_errors:?}"
+    );
+    assert!(
+        anchor_errors.iter().all(CompilerError::is_recoverable),
+        "nested anchor recovery must not leave a hard parser error: {anchor_errors:?}"
+    );
+    assert_eq!(anchor_root.children.len(), 2);
+    assert!(matches!(&anchor_root.children[0], TemplateChildNode::Element(a) if a.tag == "a"));
+    assert!(matches!(&anchor_root.children[1], TemplateChildNode::Element(a) if a.tag == "a"));
+
+    let (button_root, button_errors) =
+        parse(&allocator, "<button>aaa<button>bbb</button></button>");
+    assert!(
+        button_errors
+            .iter()
+            .any(|e| e.code == ErrorCode::ExtendPoint && e.message == NESTED_BUTTON_RECOVERY)
+    );
+    assert!(
+        button_errors
+            .iter()
+            .any(|e| e.code == ErrorCode::ExtendPoint && e.message == IGNORED_END_TAG_RECOVERY),
+        "the outer </button> is redundant fallout from the nested-button recovery: {button_errors:?}"
+    );
+    assert!(
+        button_errors.iter().all(CompilerError::is_recoverable),
+        "nested button recovery must not leave a hard parser error: {button_errors:?}"
+    );
+    assert_eq!(button_root.children.len(), 2);
+    assert!(
+        matches!(&button_root.children[0], TemplateChildNode::Element(button) if button.tag == "button")
+    );
+    assert!(
+        matches!(&button_root.children[1], TemplateChildNode::Element(button) if button.tag == "button")
+    );
+}
+
+#[test]
+fn nested_interactive_recovery_consumes_descendant_end_tags() {
+    let allocator = Allocator::new();
+    for source in [
+        r#"<a href="/"><div><a href="/foo">inner</a></div></a>"#,
+        "<button><div><button>bbb</button></div></button>",
+    ] {
+        let (_, errors) = parse(&allocator, source);
+        assert!(
+            errors.iter().all(CompilerError::is_recoverable),
+            "{source}: descendant end tags popped by the nested interactive-content recovery must not stay hard: {errors:?}"
+        );
+    }
+}
+
+#[test]
+fn nested_interactive_recovery_keeps_extra_end_tag_hard() {
+    let allocator = Allocator::new();
+    let (_, errors) = parse(
+        &allocator,
+        r#"<a href="/"><div><a href="/foo">inner</a></div></a></a>"#,
+    );
+
+    assert_eq!(
+        invalid_end_tag_count(&errors),
+        1,
+        "only the recovery-matched outer </a> is downgraded; an extra stray </a> stays hard: {errors:?}"
+    );
+}
+
+#[test]
+fn nested_interactive_recovery_keeps_out_of_order_end_tag_hard() {
+    let allocator = Allocator::new();
+    let (_, errors) = parse(
+        &allocator,
+        r#"<a href="/"><div><a href="/foo">inner</a></a></div>"#,
+    );
+
+    assert_eq!(
+        invalid_end_tag_count(&errors),
+        1,
+        "the redundant end-tag recovery must not consume out-of-order authored tags: {errors:?}"
+    );
+}
+
+fn invalid_end_tag_count(errors: &[CompilerError]) -> usize {
+    errors
+        .iter()
+        .filter(|error| error.code == ErrorCode::InvalidEndTag)
+        .count()
+}

--- a/crates/vize_atelier_dom/tests/nested_interactive_recovery.rs
+++ b/crates/vize_atelier_dom/tests/nested_interactive_recovery.rs
@@ -1,0 +1,35 @@
+use vize_atelier_dom::{Allocator, compile_template};
+
+#[test]
+fn standard_compile_emits_nested_anchor_and_button_recoveries() {
+    let allocator = Allocator::new();
+    for source in [
+        r#"<a href="/"><div><a href="/foo">inner</a></div></a>"#,
+        "<button><div><button>bbb</button></div></button>",
+    ] {
+        let (_, errors, result) = compile_template(&allocator, source);
+        assert!(
+            errors.iter().all(|error| error.is_compatibility_notice()),
+            "{source}: nested interactive-content recovery must stay non-fatal without downgrading unrelated errors: {errors:?}"
+        );
+        assert!(
+            !result.code.is_empty(),
+            "{source}: compatibility notices must still emit code"
+        );
+    }
+}
+
+#[test]
+fn standard_compile_keeps_extra_invalid_anchor_end_tag_fatal() {
+    let allocator = Allocator::new();
+    let (_, errors, result) = compile_template(
+        &allocator,
+        r#"<a href="/">outer<a href="/foo">inner</a></a></a>"#,
+    );
+
+    assert!(
+        errors.iter().any(|error| !error.is_recoverable()),
+        "the extra stray </a> must remain a hard parse error: {errors:?}"
+    );
+    assert!(result.code.is_empty());
+}

--- a/crates/vize_relief/src/errors/compatibility.rs
+++ b/crates/vize_relief/src/errors/compatibility.rs
@@ -7,10 +7,20 @@ impl CompilerError {
     /// so the standard-mode rewrite must stay silent outside compilation.
     #[must_use]
     pub fn is_compatibility_notice(&self) -> bool {
-        self.code == ErrorCode::ExtendPoint
-            && self
+        if self.code != ErrorCode::ExtendPoint {
+            return false;
+        }
+        self.message
+            .starts_with("Invalid self-closing syntax on non-void HTML element")
+            || self
                 .message
-                .starts_with("Invalid self-closing syntax on non-void HTML element")
+                .starts_with("Nested anchor start tag closed the previous anchor")
+            || self
+                .message
+                .starts_with("Nested button start tag closed the previous button")
+            || self
+                .message
+                .starts_with("HTML tree construction ignored this end tag because the element was already closed before a nested start tag")
     }
 }
 
@@ -38,5 +48,33 @@ mod tests {
         assert!(!duplicate.is_compatibility_notice());
         assert!(!strict.is_recoverable());
         assert!(!strict.is_compatibility_notice());
+    }
+
+    #[test]
+    fn nested_anchor_and_button_tree_recovery_are_compatibility_notices() {
+        for message in [
+            "Nested anchor start tag closed the previous anchor before inserting the new one.",
+            "Nested button start tag closed the previous button before inserting the new one.",
+            "HTML tree construction ignored this end tag because the element was already closed before a nested start tag.",
+        ] {
+            let notice = CompilerError::with_message(ErrorCode::ExtendPoint, message, None);
+            assert!(notice.is_recoverable(), "{message}");
+            assert!(notice.is_compatibility_notice(), "{message}");
+        }
+    }
+
+    #[test]
+    fn unrelated_tree_recovery_is_not_a_compatibility_notice() {
+        let deep = CompilerError::with_message(
+            ErrorCode::ExtendPoint,
+            "Element nesting is too deep.",
+            None,
+        );
+        let invalid = CompilerError::new(ErrorCode::InvalidEndTag, None);
+
+        assert!(!deep.is_recoverable());
+        assert!(!deep.is_compatibility_notice());
+        assert!(!invalid.is_recoverable());
+        assert!(!invalid.is_compatibility_notice());
     }
 }

--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
@@ -12,6 +12,7 @@
 
 use std::{collections::BTreeMap, fs};
 
+use vize_atelier_dom::errors::ErrorCode;
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 use vize_s0::Allocator;
 use vize_s1_to_s2::{EmitError, emit_dom_source};
@@ -45,6 +46,7 @@ struct Report {
     old_error_skips: u64,
     s2_refusal_count: u64,
     divergence_count: u64,
+    old_error_codes: Vec<ErrorCode>,
     unreadable: Vec<String>,
     old_error_samples: Vec<String>,
     s2_refusal_reasons: BTreeMap<&'static str, u64>,
@@ -145,6 +147,11 @@ fn compare_sfc_template(name: &str, source: &str, report: &mut Report) {
         .collect();
     if !blocking_errors.is_empty() {
         report.old_error_skips += 1;
+        if report.old_error_codes.len() < 20 {
+            report
+                .old_error_codes
+                .extend(blocking_errors.iter().map(|error| error.code));
+        }
         if report.old_error_samples.len() < 20 {
             report.old_error_samples.push(format!(
                 "{name}: {} old-lane blocking errors: {blocking_errors:?}",
@@ -246,5 +253,55 @@ fn assert_clean_corpus(report: &Report) {
         report.s2_refusals.join("\n"),
         report.divergence_count,
         report.divergences.join("\n"),
+    );
+}
+
+#[test]
+fn nested_anchor_and_button_recoveries_are_compared_not_skipped() {
+    let mut report = Report::default();
+    for (name, source) in [
+        (
+            "nested_anchor",
+            r#"<template><a href="/"><div><a href="/foo">inner</a></div></a></template>"#,
+        ),
+        (
+            "nested_button",
+            "<template><button><div><button>bbb</button></div></button></template>",
+        ),
+    ] {
+        compare_sfc_template(name, source, &mut report);
+    }
+
+    assert_eq!(report.templates, 2);
+    assert_eq!(
+        report.old_error_skips, 0,
+        "nested interactive-content recoveries should reach the DOM comparison lane: {:?}",
+        report.old_error_samples
+    );
+    assert_eq!(
+        report.s2_refusal_count, 0,
+        "S2 should emit so any remaining mismatch is counted as a divergence: {:?}",
+        report.s2_refusals
+    );
+    assert_eq!(report.compared, 2);
+}
+
+#[test]
+fn unrelated_invalid_end_tag_still_blocks_old_lane_comparison() {
+    let mut report = Report::default();
+    compare_sfc_template(
+        "stray_span_end",
+        "<template><div></span></div></template>",
+        &mut report,
+    );
+
+    assert_eq!(report.templates, 1);
+    assert_eq!(report.compared, 0);
+    assert_eq!(report.old_error_skips, 1);
+    assert_eq!(
+        report.old_error_codes,
+        vec![ErrorCode::InvalidEndTag],
+        "the hard invalid end tag must remain visible in skip evidence: {:?}",
+        report.old_error_samples
     );
 }

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           928 |                   487 |               441 |             140 |     371 |             941 |      498 |           488 |           604 |
+| Compiler                   |           928 |                   487 |               441 |             140 |     371 |             941 |      498 |           488 |           605 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   238 |               641 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |


### PR DESCRIPTION
## Summary
- record stack entries implicitly closed by nested `<a>` / `<button>` tree-construction recovery
- downgrade matching authored fallout end tags to recoverable compatibility notices
- move nested interactive recovery cases into parser, DOM compiler, and Davinci DOM corpus coverage while keeping unrelated invalid end tags fatal

## Tests
- `cargo test -p vize_armature --test nested_interactive_recovery`
- `cargo test -p vize_relief errors::compatibility::tests::nested_anchor_and_button_tree_recovery_are_compatibility_notices -- --exact`
- `cargo test -p vize_relief errors::compatibility::tests::unrelated_tree_recovery_is_not_a_compatibility_notice -- --exact`
- `cargo test -p vize_atelier_dom --test nested_interactive_recovery`
- `cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus nested_anchor_and_button_recoveries_are_compared_not_skipped -- --exact`
- `cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus unrelated_invalid_end_tag_still_blocks_old_lane_comparison -- --exact`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p vize_armature --test nested_interactive_recovery -- -D warnings`
- `cargo clippy -p vize_relief --lib -- -D warnings`
- `cargo clippy -p vize_atelier_dom --test nested_interactive_recovery -- -D warnings`
- `cargo clippy -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- -D warnings`

Note: broader local `cargo clippy -p vize_armature -p vize_relief -p vize_atelier_dom --all-targets -- -D warnings` reaches existing `crates/vize_atelier_dom/tests/davinci_teardown_without_stack_guard.rs` and fails on `clippy::drop_non_drop`; this PR does not touch that test. CI will verify the repository's configured clippy gate on the PR head.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790747859&installation_model_id=422833&pr_number=5467&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5467&signature=44fd91cbf1087889e34d6fde84ef3404854485bdd7c9b6f151b3db0ae48c8b5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery for nested `<a>` and `<button>` elements, producing the expected sibling structure.
  - Prevented redundant closing tags from generating erroneous fatal parse errors when elements were implicitly closed.
  - Preserved proper errors for extra or unrelated invalid closing tags.

- **Compatibility**
  - Nested interactive-element recovery is now reported as a non-fatal compatibility notice.
  - Improved consistency across compilation and DOM comparison workflows.

- **Tests**
  - Added regression coverage for nested anchors, buttons, redundant end tags, and invalid closing-tag scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->