### PR TITLE
fix(fixtures): classify lint rule location divergences

### DIFF
--- a/tests/tooling/_helpers/lint-divergence-fixture.ts
+++ b/tests/tooling/_helpers/lint-divergence-fixture.ts
@@ -25,6 +25,7 @@ export const ruleMap = {
   entries: {
     "vue/no-v-html": { status: "mapped", patinaRule: "vue/no-v-html" },
     "vue/require-v-for-key": { status: "mapped", patinaRule: "vue/require-v-for-key" },
+    "vue/no-unused-components": { status: "mapped", patinaRule: "vue/no-unused-components" },
     "vue/attributes-order": { status: "mapped", patinaRule: "vue/attribute-order" },
     "vue/no-undef-properties": { status: "unimplemented", issue: 3223 },
     "vue/max-attributes-per-line": {

--- a/tests/tooling/lint-divergence-ledger.test.ts
+++ b/tests/tooling/lint-divergence-ledger.test.ts
@@ -16,29 +16,29 @@ test("a ledger entry cancels exactly one false positive against one false negati
   const patina = [
     {
       file: "src/App.vue",
-      ruleId: "vue/require-v-for-key",
+      ruleId: "vue/no-v-html",
       severity: 2,
       ...span(4, 6, 4, 18),
-      message: "missing key",
+      message: "v-html",
     },
   ];
   const baseline = [
     eslintResult("src/App.vue", [
       {
-        ruleId: "vue/require-v-for-key",
+        ruleId: "vue/no-v-html",
         severity: 2,
         ...span(4, 6, 4, 30),
-        message: "Elements in iteration expect to have 'v-bind:key' directives.",
+        message: "`v-html` directive can lead to XSS attack.",
       },
     ]),
   ];
   const reason =
-    "patina highlights the v-for directive itself while eslint-plugin-vue highlights the whole start tag.";
+    "patina highlights the directive itself while eslint-plugin-vue highlights the whole attribute.";
   const ledger = [
     {
       project: "fixture",
       file: "src/App.vue",
-      ruleId: "vue/require-v-for-key",
+      ruleId: "vue/no-v-html",
       patina: { severity: "error", ...span(4, 6, 4, 18) },
       baseline: { severity: "error", ...span(4, 6, 4, 30) },
       issue: 3223,
@@ -56,7 +56,7 @@ test("a ledger entry cancels exactly one false positive against one false negati
   assert.deepEqual(documented.documentedDivergences, [
     {
       file: "src/App.vue",
-      ruleId: "vue/require-v-for-key",
+      ruleId: "vue/no-v-html",
       patina: { severity: "error", line: 4, column: 6, endLine: 4, endColumn: 18 },
       baseline: { severity: "error", line: 4, column: 6, endLine: 4, endColumn: 30 },
       issue: 3223,

--- a/tests/tooling/lint-divergence-report.test.ts
+++ b/tests/tooling/lint-divergence-report.test.ts
@@ -167,18 +167,23 @@ test("the markdown breaks findings down by upstream rule", () => {
       droppedConfigMessageCount: 4,
     },
     divergence: {
-      summary: { ...emptySummary(), falsePositiveCount: 2 },
+      summary: { ...emptySummary(), falsePositiveCount: 2, ruleLocationDivergenceCount: 1 },
       falsePositives: [
         { ruleId: "vue/no-v-html", upstreamRuleId: "vue/no-v-html" },
         { ruleId: "vue/no-v-html", upstreamRuleId: "vue/no-v-html" },
       ],
       falseNegatives: [{ ruleId: "vue/attribute-order", upstreamRuleId: "vue/attributes-order" }],
+      ruleLocationDivergences: [
+        { ruleId: "vue/require-v-for-key", upstreamRuleId: "vue/require-v-for-key" },
+      ],
       unimplemented: [],
     },
   });
 
   assert.match(markdown, /\| `vue\/no-v-html` \| 2 \|/u);
   assert.match(markdown, /\| `vue\/attributes-order` \| 1 \|/u);
+  assert.match(markdown, /\| `vue\/require-v-for-key` \| 1 \|/u);
+  assert.match(markdown, /Rule location divergences: 1/u);
   assert.match(markdown, /dropped as foreign-rule directives: 4/u);
 });
 
@@ -318,6 +323,7 @@ function emptySummary() {
     sharedCount: 0,
     messageDifferenceCount: 0,
     documentedDivergenceCount: 0,
+    ruleLocationDivergenceCount: 0,
     falsePositiveCount: 0,
     falseNegativeCount: 0,
     unimplementedCount: 0,

--- a/tests/tooling/lint-divergence-rule-location.test.ts
+++ b/tests/tooling/lint-divergence-rule-location.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { compare, eslintResult, span } from "./_helpers/lint-divergence-fixture.ts";
+
+test("known rule-owned location anchors are classified without hiding both ranges", () => {
+  const result = compare(
+    [
+      {
+        file: "src/List.vue",
+        ruleId: "vue/require-v-for-key",
+        severity: 2,
+        ...span(10, 7, 10, 41),
+        message:
+          "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <li>",
+      },
+    ],
+    [
+      eslintResult("src/List.vue", [
+        {
+          ruleId: "vue/require-v-for-key",
+          severity: 2,
+          ...span(10, 4, 10, 76),
+          message: "Elements in iteration expect to have 'v-bind:key' directives.",
+        },
+      ]),
+    ],
+  );
+
+  assert.deepEqual(result.falsePositives, []);
+  assert.deepEqual(result.falseNegatives, []);
+  assert.deepEqual(result.ruleLocationDivergences, [
+    {
+      file: "src/List.vue",
+      ruleId: "vue/require-v-for-key",
+      upstreamRuleId: "vue/require-v-for-key",
+      severity: "error",
+      subject: "missing-v-for-key",
+      reason:
+        "patina reports the v-for directive range while eslint-plugin-vue reports the owning element range.",
+      patina: {
+        line: 10,
+        column: 7,
+        endLine: 10,
+        endColumn: 41,
+        message:
+          "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <li>",
+      },
+      baseline: {
+        line: 10,
+        column: 4,
+        endLine: 10,
+        endColumn: 76,
+        message: "Elements in iteration expect to have 'v-bind:key' directives.",
+      },
+    },
+  ]);
+  assert.equal(result.summary.ruleLocationDivergenceCount, 1);
+  assert.equal(result.summary.falsePositiveRatio, 0);
+  assert.equal(result.summary.falseNegativeRatio, 0);
+});
+
+test("unused component location anchors are paired by component identity", () => {
+  const result = compare(
+    [
+      {
+        file: "src/Uploader.vue",
+        ruleId: "vue/no-unused-components",
+        severity: 2,
+        ...span(1, 11, 2, 12),
+        message:
+          "[vize:vue/no-unused-components] Component 'UploaderFile' is registered but never used in template",
+      },
+      {
+        file: "src/Uploader.vue",
+        ruleId: "vue/no-unused-components",
+        severity: 2,
+        ...span(1, 11, 2, 12),
+        message:
+          "[vize:vue/no-unused-components] Component 'UploaderFiles' is registered but never used in template",
+      },
+    ],
+    [
+      eslintResult("src/Uploader.vue", [
+        {
+          ruleId: "vue/no-unused-components",
+          severity: 2,
+          ...span(140, 7, 140, 20),
+          message: 'The "UploaderFiles" component has been registered but not used.',
+        },
+        {
+          ruleId: "vue/no-unused-components",
+          severity: 2,
+          ...span(141, 7, 141, 19),
+          message: 'The "UploaderFile" component has been registered but not used.',
+        },
+      ]),
+    ],
+  );
+
+  assert.deepEqual(result.falsePositives, []);
+  assert.deepEqual(result.falseNegatives, []);
+  assert.deepEqual(
+    result.ruleLocationDivergences.map((entry) => entry.subject),
+    ["component:UploaderFile", "component:UploaderFiles"],
+  );
+  assert.equal(result.summary.ruleLocationDivergenceCount, 2);
+});

--- a/tests/tooling/lint-divergence.test.ts
+++ b/tests/tooling/lint-divergence.test.ts
@@ -93,6 +93,7 @@ test("the divergence ledger keys on the full location tuple, not on counts", () 
     sharedCount: 1,
     messageDifferenceCount: 1,
     documentedDivergenceCount: 0,
+    ruleLocationDivergenceCount: 0,
     falsePositiveCount: 1,
     falseNegativeCount: 1,
     unimplementedCount: 0,

--- a/tools/fixtures/lint-divergence-markdown.mjs
+++ b/tools/fixtures/lint-divergence-markdown.mjs
@@ -30,6 +30,7 @@ export function renderMarkdown(artifact) {
     `Shared: ${summary.sharedCount}`,
     `Message differences: ${summary.messageDifferenceCount}`,
     `Documented divergences: ${summary.documentedDivergenceCount}`,
+    `Rule location divergences: ${summary.ruleLocationDivergenceCount ?? 0}`,
     `False positives: ${summary.falsePositiveCount} (${summary.falsePositiveRatio})`,
     `False negatives: ${summary.falseNegativeCount} (${summary.falseNegativeRatio})`,
     `Unimplemented upstream findings: ${summary.unimplementedCount}`,
@@ -46,6 +47,9 @@ export function renderMarkdown(artifact) {
   }
   lines.push(...ruleTable("False positives", artifact.divergence.falsePositives));
   lines.push(...ruleTable("False negatives", artifact.divergence.falseNegatives));
+  lines.push(
+    ...ruleTable("Rule location divergences", artifact.divergence.ruleLocationDivergences ?? []),
+  );
   lines.push(...ruleTable("Unimplemented upstream rules", artifact.divergence.unimplemented));
   return `${lines.join("\n")}\n`;
 }

--- a/tools/fixtures/lint-divergence-report.mjs
+++ b/tools/fixtures/lint-divergence-report.mjs
@@ -230,6 +230,7 @@ function sumTotals(artifacts) {
     "sharedCount",
     "messageDifferenceCount",
     "documentedDivergenceCount",
+    "ruleLocationDivergenceCount",
     "falsePositiveCount",
     "falseNegativeCount",
     "unimplementedCount",
@@ -240,7 +241,7 @@ function sumTotals(artifacts) {
   ];
   const totals = Object.fromEntries(keys.map((key) => [key, 0]));
   for (const artifact of artifacts) {
-    for (const key of keys) totals[key] += artifact.divergence.summary[key];
+    for (const key of keys) totals[key] += artifact.divergence.summary[key] ?? 0;
   }
   return totals;
 }

--- a/tools/fixtures/lint-divergence.mjs
+++ b/tools/fixtures/lint-divergence.mjs
@@ -16,13 +16,19 @@ import {
  * files and classify every finding, mirroring
  * [`compareTypecheckDiagnostics`](./typecheck-divergence.mjs) for the linter.
  *
- * Two linters agreeing on a *count* is not parity, so findings are matched on
- * the full location tuple — file, rule, severity and the whole
+ * Two linters agreeing on a *count* is not parity, so findings are normally
+ * matched on the full location tuple — file, rule, severity and the whole
  * `line`/`column`/`endLine`/`endColumn` range. Message wording is deliberately
  * excluded from that identity: the two implementations phrase the same finding
  * differently, and forcing byte equality there would bury real location
  * divergences under prose diffs. A matched pair whose wording differs is still
  * recorded, in `messageDifferences`, so the wording gap stays visible.
+ *
+ * A small set of mapped rules has a stable, rule-owned anchor difference where
+ * Patina and eslint-plugin-vue report the same semantic finding on different
+ * AST nodes. Those pairs are removed from false-positive/false-negative counts
+ * and recorded in `ruleLocationDivergences`, preserving both source ranges and
+ * messages so the location mismatch remains reviewable.
  *
  * Baseline findings are routed by the status their rule carries in the
  * checked-in rule map (`tests/_fixtures/patina-eslint-vue-rule-map.json`):
@@ -133,12 +139,14 @@ export function compareLintFindings({
     falsePositives,
     falseNegatives,
   );
+  const ruleLocationDivergences = pairRuleLocationDivergences(falsePositives, falseNegatives);
 
   const classified = {
     shared,
     messageDifferences,
     falsePositives,
     falseNegatives,
+    ruleLocationDivergences,
     unimplemented,
     intentionalDivergences,
     patinaOnlyRuleFindings,
@@ -151,6 +159,7 @@ export function compareLintFindings({
     sharedCount: shared.length,
     messageDifferenceCount: messageDifferences.length,
     documentedDivergenceCount: documented.length,
+    ruleLocationDivergenceCount: ruleLocationDivergences.length,
     falsePositiveCount: falsePositives.length,
     falseNegativeCount: falseNegatives.length,
     unimplementedCount: unimplemented.length,
@@ -255,6 +264,96 @@ function documentedSide(value, label) {
   return { severity: value.severity, ...span };
 }
 
+function pairRuleLocationDivergences(falsePositives, falseNegatives) {
+  const paired = [];
+  for (let positiveIndex = 0; positiveIndex < falsePositives.length;) {
+    const positive = falsePositives[positiveIndex];
+    const match = findRuleLocationDivergence(positive, falseNegatives);
+    if (match == null) {
+      positiveIndex += 1;
+      continue;
+    }
+    const [negative] = falseNegatives.splice(match.negativeIndex, 1);
+    falsePositives.splice(positiveIndex, 1);
+    paired.push(ruleLocationDivergence(positive, negative, match));
+  }
+  return paired.sort(compareRuleLocationDivergences);
+}
+
+function findRuleLocationDivergence(positive, falseNegatives) {
+  const rule = ruleLocationDivergenceRules[positive.ruleId];
+  if (rule == null) return null;
+  for (let negativeIndex = 0; negativeIndex < falseNegatives.length; negativeIndex += 1) {
+    const negative = falseNegatives[negativeIndex];
+    if (
+      positive.file !== negative.file ||
+      positive.ruleId !== negative.ruleId ||
+      positive.severity !== negative.severity
+    ) {
+      continue;
+    }
+    const subject = rule.subject(positive, negative);
+    if (subject == null) continue;
+    return { negativeIndex, reason: rule.reason, subject };
+  }
+  return null;
+}
+
+const ruleLocationDivergenceRules = {
+  "vue/no-unused-components": {
+    reason:
+      "patina reports the SFC/script anchor while eslint-plugin-vue reports the component registration property.",
+    subject(positive, negative) {
+      const positiveComponent = unusedComponentName(positive.message);
+      if (
+        positiveComponent == null ||
+        positiveComponent !== unusedComponentName(negative.message)
+      ) {
+        return null;
+      }
+      return `component:${positiveComponent}`;
+    },
+  },
+  "vue/require-v-for-key": {
+    reason:
+      "patina reports the v-for directive range while eslint-plugin-vue reports the owning element range.",
+    subject(positive, negative) {
+      return containsSpan(negative, positive) ? "missing-v-for-key" : null;
+    },
+  },
+};
+
+function ruleLocationDivergence(positive, negative, match) {
+  return {
+    file: positive.file,
+    ruleId: positive.ruleId,
+    upstreamRuleId: negative.upstreamRuleId,
+    severity: positive.severity,
+    subject: match.subject,
+    reason: match.reason,
+    patina: side(positive),
+    baseline: side(negative),
+  };
+}
+
+function side(value) {
+  return {
+    line: value.line,
+    column: value.column,
+    endLine: value.endLine,
+    endColumn: value.endColumn,
+    message: value.message,
+  };
+}
+
+function unusedComponentName(message) {
+  return (
+    message.match(/Component '([^']+)' is registered but never used(?: in template)?/u)?.[1] ??
+    message.match(/The "([^"]+)" component has been registered but not used\./u)?.[1] ??
+    null
+  );
+}
+
 function sameSpan(left, right) {
   return (
     left.line === right.line &&
@@ -262,6 +361,18 @@ function sameSpan(left, right) {
     left.endLine === right.endLine &&
     left.endColumn === right.endColumn
   );
+}
+
+function containsSpan(outer, inner) {
+  return compareSpanStart(outer, inner) <= 0 && compareSpanEnd(outer, inner) >= 0;
+}
+
+function compareSpanStart(left, right) {
+  return left.line - right.line || left.column - right.column;
+}
+
+function compareSpanEnd(left, right) {
+  return left.endLine - right.endLine || left.endColumn - right.endColumn;
 }
 
 function groupByIdentity(records) {
@@ -294,6 +405,20 @@ function compareShared(left, right) {
     byteOrder(left.ruleId, right.ruleId) ||
     byteOrder(left.patinaMessage, right.patinaMessage) ||
     byteOrder(left.baselineMessage, right.baselineMessage)
+  );
+}
+
+function compareRuleLocationDivergences(left, right) {
+  return (
+    byteOrder(left.file, right.file) ||
+    byteOrder(left.ruleId, right.ruleId) ||
+    byteOrder(left.subject, right.subject) ||
+    compareSpanStart(left.patina, right.patina) ||
+    compareSpanEnd(left.patina, right.patina) ||
+    compareSpanStart(left.baseline, right.baseline) ||
+    compareSpanEnd(left.baseline, right.baseline) ||
+    byteOrder(left.patina.message, right.patina.message) ||
+    byteOrder(left.baseline.message, right.baseline.message)
   );
 }
 


### PR DESCRIPTION
## Summary
- classify rule-owned lint location anchor differences separately from false positives/false negatives
- surface the new ruleLocationDivergences bucket in reports and markdown summaries
- add regressions for require-v-for-key and no-unused-components anchor-only differences

## Expected matrix impact
- reclassifies 32 lint divergence pairs from run 33364626129
- removes 64 FP/FN entries from lint divergence evidence without dropping Patina/ESLint ranges or messages

## Verification
- node --test tests/tooling/lint-divergence*.test.ts tests/tooling/real-project-matrix-summary.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/real-project-matrix-workflow.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790753463&installation_model_id=422833&pr_number=5470&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5470&signature=e0e937ccaea7a79db16a31accaefdeb20c95daa70b13a1b740315d397041aa8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lint comparison accuracy by recognizing equivalent findings reported at different code locations.
  * Prevented location differences from being incorrectly counted as false positives or false negatives.
  * Added reporting for the number and details of rule-location divergences.
* **Tests**
  * Expanded coverage for component-specific and rule-owned location mismatches.
  * Updated divergence fixtures and report-rendering expectations.
  * Added coverage for newly supported component and template lint rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->