### PR TITLE
fix(davinci): decode named entity text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4044,6 +4044,7 @@ dependencies = [
  "criterion",
  "davinci_harness",
  "davinci_test_support",
+ "htmlize",
  "insta",
  "oxc_ast",
  "oxc_ast_visit",

--- a/crates/vize_s1_to_s2/Cargo.toml
+++ b/crates/vize_s1_to_s2/Cargo.toml
@@ -28,6 +28,7 @@ metadata.vize.stability = "experimental"
 davinci-differential = []
 
 [dependencies]
+htmlize = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_parser = { workspace = true }

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -46,6 +46,7 @@ mod component;
 mod create_slots;
 mod create_slots_walk;
 mod directive;
+mod entity;
 mod error;
 mod filter;
 mod flag;

--- a/crates/vize_s1_to_s2/src/emit/entity.rs
+++ b/crates/vize_s1_to_s2/src/emit/entity.rs
@@ -1,0 +1,187 @@
+//! HTML entity decoding for JS string emission.
+//!
+//! This mirrors `vize_armature`'s tokenizer entity rules so S2 text and static
+//! prop emission see the same decoded content the shipped DOM lane lowers.
+
+use core::cmp::min;
+use core::num::IntErrorKind;
+
+use htmlize::{Context, ENTITIES, ENTITY_MAX_LENGTH, ENTITY_MIN_LENGTH};
+use vize_s0::String;
+
+pub(super) fn decode_html_entities(source: &str) -> String {
+    if !source.contains('&') {
+        return String::from(source);
+    }
+
+    let bytes = source.as_bytes();
+    let mut out = String::with_capacity(source.len());
+    let mut index = 0usize;
+    while index < bytes.len() {
+        if let Some((ch, consumed)) = try_decode_entity(&bytes[index..], Context::General) {
+            out.push(ch);
+            index += consumed;
+            continue;
+        }
+
+        let ch = source[index..].chars().next().unwrap_or('\u{FFFD}');
+        out.push(ch);
+        index += ch.len_utf8();
+    }
+    out
+}
+
+fn try_decode_entity(input: &[u8], context: Context) -> Option<(char, usize)> {
+    if input.first() != Some(&b'&') {
+        return None;
+    }
+    if input.get(1) == Some(&b'#') {
+        decode_numeric_entity(input)
+    } else {
+        decode_named_entity(input, context)
+    }
+}
+
+fn first_scalar(expansion: &[u8]) -> Option<char> {
+    core::str::from_utf8(expansion).ok()?.chars().next()
+}
+
+fn decode_named_entity(input: &[u8], context: Context) -> Option<(char, usize)> {
+    let mut index = 1usize;
+    let mut steps = 0usize;
+    while steps < ENTITY_MAX_LENGTH - 1 && index < input.len() {
+        if input[index].is_ascii_alphanumeric() {
+            index += 1;
+            steps += 1;
+        } else {
+            break;
+        }
+    }
+
+    let mut consumed_end = index;
+    match input.get(index).copied() {
+        Some(b';') => consumed_end = index + 1,
+        Some(b'=') if context == Context::Attribute => return None,
+        _ => {}
+    }
+
+    if context == Context::Attribute {
+        let candidate = &input[..consumed_end];
+        if candidate.len() < ENTITY_MIN_LENGTH {
+            return None;
+        }
+        let expansion = ENTITIES.get(candidate)?;
+        let ch = first_scalar(expansion)?;
+        return Some((ch, consumed_end));
+    }
+
+    let max_len = min(consumed_end, ENTITY_MAX_LENGTH);
+    for check_len in (ENTITY_MIN_LENGTH..=max_len).rev() {
+        if let Some(expansion) = ENTITIES.get(&input[..check_len]) {
+            let ch = first_scalar(expansion)?;
+            return Some((ch, check_len));
+        }
+    }
+    None
+}
+
+fn decode_numeric_entity(input: &[u8]) -> Option<(char, usize)> {
+    if input.len() < 3 || input[0] != b'&' || input[1] != b'#' {
+        return None;
+    }
+
+    let mut position = 2usize;
+    let number = match input.get(position).copied() {
+        Some(b'x' | b'X') => {
+            position += 1;
+            let start = position;
+            while position < input.len() && input[position].is_ascii_hexdigit() {
+                position += 1;
+            }
+            let hex = &input[start..position];
+            if hex.is_empty() {
+                return None;
+            }
+            u32::from_str_radix(core::str::from_utf8(hex).ok()?, 16)
+        }
+        Some(c) if c.is_ascii_digit() => {
+            let start = position;
+            while position < input.len() && input[position].is_ascii_digit() {
+                position += 1;
+            }
+            let dec = &input[start..position];
+            if dec.is_empty() {
+                return None;
+            }
+            core::str::from_utf8(dec).ok()?.parse::<u32>()
+        }
+        _ => return None,
+    };
+
+    let mut end = position;
+    if input.get(position) == Some(&b';') {
+        end = position + 1;
+    }
+
+    let ch = match number {
+        Ok(n) => correct_numeric_entity(n),
+        Err(error) if *error.kind() == IntErrorKind::PosOverflow => '\u{FFFD}',
+        Err(_) => return None,
+    };
+    Some((ch, end))
+}
+
+#[allow(clippy::match_same_arms)]
+fn correct_numeric_entity(number: u32) -> char {
+    match number {
+        0x00 => '\u{FFFD}',
+        0x11_0000.. => '\u{FFFD}',
+        0xD800..=0xDFFF => '\u{FFFD}',
+        0x80 => '\u{20AC}',
+        0x82 => '\u{201A}',
+        0x83 => '\u{0192}',
+        0x84 => '\u{201E}',
+        0x85 => '\u{2026}',
+        0x86 => '\u{2020}',
+        0x87 => '\u{2021}',
+        0x88 => '\u{02C6}',
+        0x89 => '\u{2030}',
+        0x8A => '\u{0160}',
+        0x8B => '\u{2039}',
+        0x8C => '\u{0152}',
+        0x8E => '\u{017D}',
+        0x91 => '\u{2018}',
+        0x92 => '\u{2019}',
+        0x93 => '\u{201C}',
+        0x94 => '\u{201D}',
+        0x95 => '\u{2022}',
+        0x96 => '\u{2013}',
+        0x97 => '\u{2014}',
+        0x98 => '\u{02DC}',
+        0x99 => '\u{2122}',
+        0x9A => '\u{0161}',
+        0x9B => '\u{203A}',
+        0x9C => '\u{0153}',
+        0x9E => '\u{017E}',
+        0x9F => '\u{0178}',
+        scalar => char::from_u32(scalar).unwrap_or('\u{FFFD}'),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_html_entities;
+
+    #[test]
+    fn decodes_named_entities_like_text_tokenization() {
+        assert_eq!(decode_html_entities("&times;"), "\u{00d7}");
+        assert_eq!(decode_html_entities("&timesX"), "\u{00d7}X");
+        assert_eq!(decode_html_entities("&&amp;"), "&&");
+    }
+
+    #[test]
+    fn applies_html_numeric_correction_table() {
+        assert_eq!(decode_html_entities("&#128;"), "\u{20ac}");
+        assert_eq!(decode_html_entities("&#55296;"), "\u{fffd}");
+    }
+}

--- a/crates/vize_s1_to_s2/src/emit/js.rs
+++ b/crates/vize_s1_to_s2/src/emit/js.rs
@@ -8,59 +8,7 @@ use vize_s0::expression_guard::scan::{
 use vize_s0::{Allocator, Span, String, ToCompactString};
 use vize_s2::expr::{ExprRef, JsExpr, OpaqueExpr, OpaqueReason};
 
-fn decode_html_entities(s: &str) -> String {
-    if !s.contains('&') {
-        return String::from(s);
-    }
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-    while let Some(c) = chars.next() {
-        if c == '&' && chars.peek() == Some(&'#') {
-            chars.next();
-            let is_hex = chars.peek() == Some(&'x') || chars.peek() == Some(&'X');
-            if is_hex {
-                chars.next();
-            }
-            let mut num_str = String::default();
-            while let Some(&ch) = chars.peek() {
-                if ch == ';' {
-                    chars.next();
-                    break;
-                }
-                let is_valid_char =
-                    (is_hex && ch.is_ascii_hexdigit()) || (!is_hex && ch.is_ascii_digit());
-                if is_valid_char {
-                    num_str.push(ch);
-                    chars.next();
-                } else {
-                    break;
-                }
-            }
-            if !num_str.is_empty() {
-                let codepoint = if is_hex {
-                    u32::from_str_radix(num_str.as_str(), 16).ok()
-                } else {
-                    num_str.as_str().parse::<u32>().ok()
-                };
-                if let Some(cp) = codepoint
-                    && let Some(decoded_char) = char::from_u32(cp)
-                {
-                    result.push(decoded_char);
-                    continue;
-                }
-            }
-            result.push('&');
-            result.push('#');
-            if is_hex {
-                result.push('x');
-            }
-            result.push_str(num_str.as_str());
-        } else {
-            result.push(c);
-        }
-    }
-    result
-}
+use super::entity::decode_html_entities;
 
 #[inline]
 fn byte_may_need_js_escaping(b: u8) -> bool {

--- a/crates/vize_s1_to_s2/tests/emit_named_entities.rs
+++ b/crates/vize_s1_to_s2/tests/emit_named_entities.rs
@@ -1,0 +1,49 @@
+//! Named HTML entity parity for S2 DOM text and static props.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use support::with_transformed;
+use vize_s1_to_s2::emit_dom;
+
+fn assembled(source: &str) -> String {
+    with_transformed(source, |lowered, _folio, facts, _budget| {
+        emit_dom(lowered, facts)
+            .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
+            .assembled()
+            .to_string()
+    })
+}
+
+#[test]
+fn named_entity_text_matches_the_shipped_snapshot() {
+    assert_eq!(
+        assembled("<button>&times;</button>"),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"button\", null, \"\u{00d7}\"))
+}"
+    );
+}
+
+#[test]
+fn named_entity_static_attr_matches_the_shipped_snapshot() {
+    assert_eq!(
+        assembled(r#"<button title="&times;">close</button>"#),
+        "\
+const { openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+const _hoisted_1 = { title: \"\u{00d7}\" }
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"button\", _hoisted_1, \"close\"))
+}"
+    );
+}

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -73,7 +73,7 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
 | s1_to_s2 | `alloc::vec::Vec`       |    37 |           37 |        156 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    52 |           54 |        238 |
+| s1_to_s2 | `vize_s0::String`       |    53 |           55 |        237 |
 | s1_to_s2 | `vize_s0::Vec`          |    14 |           14 |         56 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     2 |            2 |          4 |
 

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -42,7 +42,8 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/create_slots.rs	1	6	1	6	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/directive.rs	1	6	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/filter.rs	0	0	1	1	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/hoist.rs	1	4	1	12	0	0	0	0
-s1_to_s2	-	crates/vize_s1_to_s2/src/emit/js.rs	0	0	1	13	0	0	0	0
+s1_to_s2	-	crates/vize_s1_to_s2/src/emit/entity.rs	0	0	1	3	0	0	0	0
+s1_to_s2	-	crates/vize_s1_to_s2/src/emit/js.rs	0	0	1	9	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/merge.rs	1	8	1	3	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/model.rs	1	6	1	4	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/memo.rs	0	0	1	0	0	0	0	0


### PR DESCRIPTION
## Summary
- replace the S2 JS emission numeric-only HTML entity decoder with a tokenizer-compatible named/numeric decoder
- normalize text and static prop string emission for named entities such as &times;
- add exact DOM output regressions and storage inventory ratchet updates

## Corpus evidence
- isolated AIRI InteractiveArea.vue DOM corpus now passes with this change
- the larger stage-tamagotchi components subtree drops the sampled entity divergence and still has 5 existing static hoist/cache residual divergences outside this slice

## Verification
- cargo test -p vize_s1_to_s2 --test emit_named_entities --test emit_raw_comment_format
- cargo test -p vize_s1_to_s2 emit::entity::tests --lib
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=/tmp/vize-davinci-entity-corpus-20260831-2 cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture
- node --test tests/tooling/davinci-storage-policy.test.ts
- node --test tests/tooling/davinci-matrices.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/davinci-assertion-lint.test.ts
- cargo fmt --all -- --check
- cargo clippy -p vize_s1_to_s2 --all-targets --features davinci-differential -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790753741&installation_model_id=422833&pr_number=5474&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5474&signature=244d3547cf7ff005fbe149e40109c6eb5fb2e2baa51c38274225ca0a8cf28b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTML entity decoding for generated JavaScript strings, including named and numeric entities.
  * Added support for decoding entities in button text and static `title` attributes.

* **Bug Fixes**
  * Improved handling of special, invalid, and out-of-range numeric HTML entities.

* **Tests**
  * Added coverage for named entity decoding and numeric entity corrections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->