### PR TITLE
test(davinci): report DOM corpus old-lane error reasons

### DIFF
--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
@@ -47,6 +47,7 @@ struct Report {
     s2_refusal_count: u64,
     divergence_count: u64,
     old_error_codes: Vec<ErrorCode>,
+    old_error_reasons: BTreeMap<String, u64>,
     unreadable: Vec<String>,
     old_error_samples: Vec<String>,
     s2_refusal_reasons: BTreeMap<&'static str, u64>,
@@ -118,6 +119,10 @@ fn dom_emit_agrees_on_sfc_templates_body() {
         corpus.s2_refusal_reasons
     );
     eprintln!(
+        "davinci DOM corpus old-lane error reasons: {:?}",
+        corpus.old_error_reasons
+    );
+    eprintln!(
         "davinci DOM corpus refusal samples: {:?}",
         corpus.s2_refusal_samples
     );
@@ -147,6 +152,12 @@ fn compare_sfc_template(name: &str, source: &str, report: &mut Report) {
         .collect();
     if !blocking_errors.is_empty() {
         report.old_error_skips += 1;
+        for error in &blocking_errors {
+            *report
+                .old_error_reasons
+                .entry(format!("{:?}", error.code))
+                .or_default() += 1;
+        }
         if report.old_error_codes.len() < 20 {
             report
                 .old_error_codes
@@ -243,10 +254,11 @@ fn assert_clean_corpus(report: &Report) {
             && report.old_error_skips == 0
             && report.s2_refusal_count == 0
             && report.divergence_count == 0,
-        "corpus unreadable files ({}):\n{}\n\ncorpus old-lane error skips ({}):\n{}\n\ncorpus S2 refusals ({}) by reason {:?}:\n{}\n\ncorpus divergences ({}):\n{}",
+        "corpus unreadable files ({}):\n{}\n\ncorpus old-lane error skips ({}) by reason {:?}:\n{}\n\ncorpus S2 refusals ({}) by reason {:?}:\n{}\n\ncorpus divergences ({}):\n{}",
         report.unreadable_count,
         report.unreadable.join("\n"),
         report.old_error_skips,
+        report.old_error_reasons,
         report.old_error_samples.join("\n"),
         report.s2_refusal_count,
         report.s2_refusal_reasons,
@@ -304,4 +316,5 @@ fn unrelated_invalid_end_tag_still_blocks_old_lane_comparison() {
         "the hard invalid end tag must remain visible in skip evidence: {:?}",
         report.old_error_samples
     );
+    assert_eq!(report.old_error_reasons.get("InvalidEndTag"), Some(&1));
 }

--- a/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
+++ b/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
@@ -12,6 +12,7 @@ import {
   hydrateCorpus,
   parseCorpusEvidence,
   parseFixtureGitlinks,
+  parseOldErrorReasons,
   validateCorpusEvidence,
   verdictFor,
 } from "../../tools/fixtures/davinci-dom-corpus-workflow.mjs";
@@ -74,6 +75,7 @@ test("real-project workflow carries a full-canonical S2 DOM corpus job", () => {
   assert.match(helperSource, /expectedDomOutputComparisons = 144/);
   assert.match(helperSource, /summary\.json/);
   assert.match(helperSource, /davinci-differential corpus scope\|davinci DOM corpus sweep/);
+  assert.match(helperSource, /davinci DOM corpus old-lane error reasons/);
   assert.match(helperSource, /Davinci S2 DOM corpus failed/);
 
   const upload = findStep(steps, "Upload S2 DOM corpus evidence");
@@ -106,6 +108,45 @@ test("S2 DOM corpus workflow helper extracts canonical evidence", () => {
   assert.equal(verdictFor("cancelled", "record-only"), "cancelled");
   assert.equal(expectedGitlinks, 146);
   assert.equal(expectedDomOutputComparisons, 144);
+});
+
+test("S2 DOM corpus workflow extracts old-lane skip reasons from corpus logs", () => {
+  const log = [
+    "davinci-differential corpus scope: root=tests/_fixtures/_git scope=canonical closure_evidence=true submodules=146",
+    "davinci DOM corpus sweep: files=3 unreadable=0 parsed=3 templates=3 compared=1 old_error_skips=2 s2_refusals=0 divergences=0",
+    "corpus old-lane error skips (2):",
+    '/repo/tests/_fixtures/_git/a.vue: 2 old-lane blocking errors: [CompilerError { code: InvalidEndTag, message: "Invalid end tag.", loc: None }, CompilerError { code: MissingEndTag, message: "Element is missing end tag.", loc: None }]',
+    '/repo/tests/_fixtures/_git/b.vue: 1 old-lane blocking errors: [CompilerError { code: DuplicateAttribute, message: "Duplicate attribute.", loc: None }]',
+    "",
+    "corpus S2 refusals (0) by reason {}:",
+  ].join("\n");
+
+  assert.deepEqual(parseOldErrorReasons(log), {
+    DuplicateAttribute: 1,
+    InvalidEndTag: 1,
+    MissingEndTag: 1,
+  });
+  assert.deepEqual(parseCorpusEvidence(log).oldErrorReasons, {
+    DuplicateAttribute: 1,
+    InvalidEndTag: 1,
+    MissingEndTag: 1,
+  });
+});
+
+test("S2 DOM corpus workflow prefers explicit old-lane reason counts", () => {
+  const log = [
+    "davinci DOM corpus sweep: files=3 unreadable=0 parsed=3 templates=3 compared=1 old_error_skips=2 s2_refusals=0 divergences=0",
+    'davinci DOM corpus old-lane error reasons: {"InvalidEndTag": 2, "VIfSameKey": 1}',
+  ].join("\n");
+
+  assert.deepEqual(parseOldErrorReasons(log), {
+    InvalidEndTag: 2,
+    VIfSameKey: 1,
+  });
+  assert.deepEqual(parseCorpusEvidence(log).oldErrorReasons, {
+    InvalidEndTag: 2,
+    VIfSameKey: 1,
+  });
 });
 
 test("S2 DOM corpus workflow gitlink constant matches the checkout index", () => {
@@ -218,6 +259,7 @@ test("S2 DOM corpus workflow validates closure evidence artifacts", () => {
       templates: 35000,
       compared: 35000,
       oldErrorSkips: 0,
+      oldErrorReasons: {},
       s2Refusals: 0,
       divergences: 0,
     });
@@ -241,6 +283,11 @@ test("S2 DOM corpus workflow rejects stale or dirty evidence artifacts", () => {
       [
         "davinci-differential corpus scope: root=/tmp/tests/_fixtures/_git scope=smoke closure_evidence=false",
         "davinci DOM corpus sweep: files=1 unreadable=3 parsed=1 templates=1 compared=0 old_error_skips=2 s2_refusals=1 divergences=1",
+        "corpus old-lane error skips (2):",
+        '/repo/tests/_fixtures/_git/a.vue: 1 old-lane blocking errors: [CompilerError { code: InvalidEndTag, message: "Invalid end tag.", loc: None }]',
+        '/repo/tests/_fixtures/_git/b.vue: 1 old-lane blocking errors: [CompilerError { code: VIfSameKey, message: "v-if/v-else-if branches must use unique keys.", loc: None }]',
+        "",
+        "corpus S2 refusals (1) by reason {}:",
       ].join("\n"),
     );
 
@@ -250,7 +297,7 @@ test("S2 DOM corpus workflow rejects stale or dirty evidence artifacts", () => {
       "corpus log is missing canonical closure evidence",
       "corpus log submodules 0 != 146",
       "corpus log proves no DOM-output comparisons",
-      "corpus log skipped inputs: unreadable=3 old_error_skips=2",
+      "corpus log skipped inputs: unreadable=3 old_error_skips=2 reasons=InvalidEndTag=1,VIfSameKey=1",
       "corpus log is not clean: s2_refusals=1 divergences=1",
     ]);
   } finally {

--- a/tools/fixtures/davinci-dom-corpus-workflow.mjs
+++ b/tools/fixtures/davinci-dom-corpus-workflow.mjs
@@ -58,8 +58,32 @@ export function corpusEvidenceLines(logText) {
   return logText
     .split(/\r?\n/)
     .filter((line) =>
-      /davinci-differential corpus scope|davinci DOM corpus sweep/.test(stripAnsi(line)),
+      /davinci-differential corpus scope|davinci DOM corpus sweep|davinci DOM corpus old-lane error reasons/.test(
+        stripAnsi(line),
+      ),
     );
+}
+
+export function parseOldErrorReasons(logText) {
+  for (const line of corpusEvidenceLines(logText).map(stripAnsi)) {
+    const match = /old-lane error reasons: (\{.*\})/.exec(line);
+    if (!match) continue;
+    try {
+      return sortReasonCounts(JSON.parse(match[1]));
+    } catch {
+      return {};
+    }
+  }
+  const block =
+    /corpus old-lane error skips \(\d+\)(?: by reason \{.*\})?:\n([\s\S]*?)\n\ncorpus S2 refusals/.exec(
+      stripAnsi(logText),
+    );
+  if (!block) return {};
+  const reasons = {};
+  for (const code of block[1].matchAll(/code: ([A-Za-z0-9_]+)/g)) {
+    reasons[code[1]] = (reasons[code[1]] ?? 0) + 1;
+  }
+  return sortReasonCounts(reasons);
 }
 
 export function parseCorpusEvidence(logText) {
@@ -73,6 +97,7 @@ export function parseCorpusEvidence(logText) {
     templates: 0,
     compared: 0,
     oldErrorSkips: 0,
+    oldErrorReasons: {},
     s2Refusals: 0,
     divergences: 0,
   };
@@ -97,7 +122,19 @@ export function parseCorpusEvidence(logText) {
       evidence.oldErrorSkips = Number(sweep[6]);
       evidence.s2Refusals = Number(sweep[7]);
       evidence.divergences = Number(sweep[8]);
+      continue;
     }
+    const oldErrorReasons = /old-lane error reasons: (\{.*\})/.exec(line);
+    if (oldErrorReasons) {
+      try {
+        evidence.oldErrorReasons = sortReasonCounts(JSON.parse(oldErrorReasons[1]));
+      } catch {
+        evidence.oldErrorReasons = {};
+      }
+    }
+  }
+  if (Object.keys(evidence.oldErrorReasons).length === 0) {
+    evidence.oldErrorReasons = parseOldErrorReasons(logText);
   }
   return evidence;
 }
@@ -135,8 +172,9 @@ export function validateCorpusEvidence(artifact = artifactDir) {
     failures.push("corpus log proves no DOM-output comparisons");
   }
   if (evidence.unreadable !== 0 || evidence.oldErrorSkips !== 0) {
+    const oldErrorReasons = formatReasonCounts(evidence.oldErrorReasons);
     failures.push(
-      `corpus log skipped inputs: unreadable=${evidence.unreadable} old_error_skips=${evidence.oldErrorSkips}`,
+      `corpus log skipped inputs: unreadable=${evidence.unreadable} old_error_skips=${evidence.oldErrorSkips}${oldErrorReasons ? ` reasons=${oldErrorReasons}` : ""}`,
     );
   }
   if (evidence.s2Refusals !== 0 || evidence.divergences !== 0) {
@@ -305,6 +343,7 @@ async function appendCorpusSummary(mode, outcome, verdict, summaryPath) {
       `- gitlinks: \`${validation.selectedGitlinks}\``,
       `- submodule status rows: \`${validation.submoduleStatusRows}\``,
       `- compared templates: \`${validation.evidence.compared}\``,
+      `- old-lane error reasons: \`${formatReasonCounts(validation.evidence.oldErrorReasons) || "none"}\``,
       "",
       ...evidence,
       "",
@@ -318,6 +357,20 @@ function readOptional(path) {
   } catch {
     return "";
   }
+}
+
+function sortReasonCounts(reasons) {
+  return Object.fromEntries(
+    Object.entries(reasons)
+      .filter(([, count]) => Number.isFinite(count) && count > 0)
+      .sort(([left], [right]) => left.localeCompare(right)),
+  );
+}
+
+function formatReasonCounts(reasons) {
+  return Object.entries(sortReasonCounts(reasons))
+    .map(([reason, count]) => `${reason}=${count}`)
+    .join(",");
 }
 
 async function main() {


### PR DESCRIPTION
## Summary
- include old-lane diagnostic reason counts in the Davinci DOM corpus report
- teach the real-project workflow summary parser to prefer explicit old-lane reason counts and fall back to log parsing
- add workflow helper regressions without changing compiler semantics

## Corpus evidence
Run 33366454581 canonical S2 DOM corpus artifact:
- files=42668
- templates=42295
- compared=42276
- old_error_skips=19
- s2_refusals=0

Old-lane diagnostics across the 19 skipped files:
- InvalidEndTag: 22
- MissingEndTag: 10
- MissingWhitespaceBetweenAttributes: 4
- VIfSameKey: 4
- DuplicateAttribute: 1
- ExtendPoint: 1
- VElseNoAdjacentIf: 1
- VSlotDuplicateSlotNames: 1

Classification from artifact review:
- 9 file-level skips are invalid corpus inputs where Vue also errors
- 10 file-level skips are old-lane recovery/compare candidates because Vue compiler accepts them

## Verification
- node --test --test-concurrency=1 tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture
- cargo fmt --all -- --check
- git diff --check HEAD~1..HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790754756&installation_model_id=422833&pr_number=5479&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5479&signature=f576f1687d53a52ea1b0ba6a43a9f3f1a4f93470c81e6e47c78d2a51cf5012e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->