### PR TITLE
fix(davinci): carry static vnode hoist context

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_static_cache.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_static_cache.rs
@@ -22,6 +22,14 @@ const BATTERY: &[(&str, &str)] = &[
         "cached_static_child_before_dynamic_sibling",
         r#"<div class="root"><button><span>x</span></button><i :id="foo"></i></div>"#,
     ),
+    (
+        "airi_loading_component_formats_nested_static_props_inside_for",
+        r#"<div flex flex-col gap-2><div v-for="file in files" :key="file.filename" max-w-full flex flex-col gap="1 sm:2"><div grid="~ cols-[85%_15%]" justify-between text="xs sm:sm neutral-600 dark:neutral-400"><div flex items-center gap-1>{{ file.filename }}</div></div></div></div>"#,
+    ),
+    (
+        "airi_loading_modules_formats_static_slot_child_props_inside_for",
+        r#"<ul><li v-for="[moduleName, module] in resources" :key="moduleName"><WindowRouterLink :to="`/settings/modules/${moduleName}`" label="settings"><div flex items-center gap-1><div flex items-center gap-1><span>{{ moduleName }}</span></div></div></WindowRouterLink></li></ul>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_static_vnode_hoist.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_static_vnode_hoist.rs
@@ -25,6 +25,18 @@ const BATTERY: &[(&str, &str)] = &[
         "nested_v_show_static_child",
         r#"<div><span v-show="ok"><b>Downloading update</b></span></div>"#,
     ),
+    (
+        "airi_titlebar_dynamic_native_ancestor_hoists_static_grandchild",
+        r#"<div :class="root"><div flex drag-region><button @click="run"><span>{{ title }}</span></button><div w-full drag-region></div></div></div>"#,
+    ),
+    (
+        "airi_screen_capture_component_slot_hoists_static_break",
+        r#"<DialogDescription>{{ summary }}<ol><li>{{ step }}<br><span>{{ note }}</span></li></ol></DialogDescription>"#,
+    ),
+    (
+        "v_for_item_root_hoists_static_child_vnodes",
+        r#"<div v-for="item in items" :key="item.id"><span class="icon"></span>{{ item.name }}</div>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -45,6 +45,7 @@ mod children;
 mod component;
 mod create_slots;
 mod create_slots_walk;
+mod cx;
 mod directive;
 mod entity;
 mod error;
@@ -206,6 +207,9 @@ struct EmitCx<'facts> {
     /// Nested components inside a scoped `withCtx` treat forwarded
     /// outlets as `_: 2` + `DYNAMIC_SLOTS` (Vue `has_slot_params`).
     slot_param_depth: u32,
+    /// Legacy `hoist_static_vnodes` recursion state. Directive/component/branch
+    /// roots stay inline, but descendants may still become hoisted static VNodes.
+    hoist_static_vnodes: bool,
     /// The shipped lane caches static child vnodes only after transform
     /// produced at least one root hoist.
     static_cache: bool,
@@ -213,30 +217,6 @@ struct EmitCx<'facts> {
     /// depends on SVG/MathML boundaries staying block-local while same-namespace
     /// descendants remain inline VNodes.
     parent_ns: Namespace,
-}
-
-impl EmitCx<'_> {
-    fn scope_mark(&self) -> usize {
-        self.scope_names.len()
-    }
-
-    fn push_scope(&mut self, id: Option<NodeId>) -> usize {
-        let mark = self.scope_mark();
-        if let Some(facts) = id.and_then(|id| self.scopes.get(id)) {
-            for binding in facts.bindings.iter() {
-                self.scope_names.push(binding.name.clone());
-            }
-        }
-        mark
-    }
-
-    fn pop_scope(&mut self, mark: usize) {
-        self.scope_names.truncate(mark);
-    }
-
-    fn is_scope_name(&self, source: &str) -> bool {
-        self.scope_names.iter().any(|name| name.as_str() == source)
-    }
 }
 
 /// One DOM render module, split the way the shipped codegen splits it
@@ -288,6 +268,7 @@ pub fn emit_dom(lowered: &Lowered<'_>, facts: &S2Facts) -> Result<DomEmit, EmitE
         in_v_for: false,
         skip_memo: false,
         slot_param_depth: 0,
+        hoist_static_vnodes: false,
         static_cache,
         parent_ns: Namespace::Html,
     };

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -5,10 +5,12 @@
 //! spread, Vue builtins, and `<component :is>`
 //! (`resolveDynamicComponent`).
 
+mod preamble;
+
 use alloc::vec::Vec as StdVec;
 
 use vize_davinci::id::NodeId;
-use vize_s2::op::{BindingOp, ComponentOp, Op, Region};
+use vize_s2::op::{BindingOp, ComponentOp};
 
 use super::EmitCx;
 use super::EmitError;
@@ -26,25 +28,7 @@ use super::props_static;
 use super::props_static::PropHoistPosition;
 use super::slots;
 
-pub(super) fn collect_names<'a>(root: &Region<'a>) -> StdVec<&'a str> {
-    let mut names = StdVec::new();
-    collect_from(root, &mut names);
-    names
-}
-
-pub(super) fn emit_resolves(cx: &mut EmitCx<'_>, names: &[&str]) {
-    cx.buf.use_resolve_component();
-    for name in names {
-        cx.buf.push("const ");
-        cx.buf.push(asset_ident("component", name).as_str());
-        cx.buf.push(" = ");
-        cx.buf.push(Buf::resolve_component_alias());
-        cx.buf.push("(\"");
-        cx.buf.push(name);
-        cx.buf.push("\")");
-        cx.buf.newline();
-    }
-}
+pub(super) use preamble::{collect_names, emit_resolves};
 
 pub(super) fn emit_root(
     cx: &mut EmitCx<'_>,
@@ -142,30 +126,6 @@ pub(super) fn emit_for_item(
         });
     }
     emit_block(cx, component, key, true, id)
-}
-
-fn collect_from<'a>(region: &Region<'a>, names: &mut StdVec<&'a str>) {
-    for op in region.ops.iter() {
-        match op {
-            Op::Element(element) => collect_from(&element.children, names),
-            Op::Component(component) => {
-                collect_from(&component.children, names);
-                if !builtin::is_reserved_name(component.name)
-                    && !builtin::is_dynamic_component(component)
-                    && !names.contains(&component.name)
-                {
-                    names.push(component.name);
-                }
-            }
-            Op::If(if_op) => {
-                for branch in if_op.branches.iter() {
-                    collect_from(&branch.region, names);
-                }
-            }
-            Op::For(for_op) => collect_from(&for_op.region, names),
-            _ => {}
-        }
-    }
 }
 
 fn emit_call(
@@ -304,16 +264,22 @@ fn emit_call(
     if array {
         if has_array {
             cx.buf.push(", ");
-            builtin::emit_array_children(cx, &component.children, if_key.is_some())?;
+            cx.with_static_vnode_hoist(true, |cx| {
+                builtin::emit_array_children(cx, &component.children, if_key.is_some())
+            })?;
         } else if emit_flag {
             cx.buf.push(", null");
         }
     } else if create {
         cx.buf.push(", ");
-        create_slots::emit_create_slots(cx, &component.children, spread)?;
+        cx.with_static_vnode_hoist(true, |cx| {
+            create_slots::emit_create_slots(cx, &component.children, spread)
+        })?;
     } else if let Some(facts) = facts {
         cx.buf.push(", ");
-        slots::emit_slots(cx, &component.children, facts, spread)?;
+        cx.with_static_vnode_hoist(true, |cx| {
+            slots::emit_slots(cx, &component.children, facts, spread)
+        })?;
     } else if let Some(spread) = spread {
         cx.buf.push(", ");
         cx.buf.push(spread);

--- a/crates/vize_s1_to_s2/src/emit/component/preamble.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/preamble.rs
@@ -1,0 +1,51 @@
+//! Component asset preamble collection and emission.
+
+use alloc::vec::Vec as StdVec;
+
+use vize_s2::op::{Op, Region};
+
+use super::{Buf, EmitCx, asset_ident, builtin};
+
+pub(in crate::emit) fn collect_names<'a>(root: &Region<'a>) -> StdVec<&'a str> {
+    let mut names = StdVec::new();
+    collect_from(root, &mut names);
+    names
+}
+
+pub(in crate::emit) fn emit_resolves(cx: &mut EmitCx<'_>, names: &[&str]) {
+    cx.buf.use_resolve_component();
+    for name in names {
+        cx.buf.push("const ");
+        cx.buf.push(asset_ident("component", name).as_str());
+        cx.buf.push(" = ");
+        cx.buf.push(Buf::resolve_component_alias());
+        cx.buf.push("(\"");
+        cx.buf.push(name);
+        cx.buf.push("\")");
+        cx.buf.newline();
+    }
+}
+
+fn collect_from<'a>(region: &Region<'a>, names: &mut StdVec<&'a str>) {
+    for op in region.ops.iter() {
+        match op {
+            Op::Element(element) => collect_from(&element.children, names),
+            Op::Component(component) => {
+                collect_from(&component.children, names);
+                if !builtin::is_reserved_name(component.name)
+                    && !builtin::is_dynamic_component(component)
+                    && !names.contains(&component.name)
+                {
+                    names.push(component.name);
+                }
+            }
+            Op::If(if_op) => {
+                for branch in if_op.branches.iter() {
+                    collect_from(&branch.region, names);
+                }
+            }
+            Op::For(for_op) => collect_from(&for_op.region, names),
+            _ => {}
+        }
+    }
+}

--- a/crates/vize_s1_to_s2/src/emit/cx.rs
+++ b/crates/vize_s1_to_s2/src/emit/cx.rs
@@ -1,0 +1,41 @@
+//! Shared emitter context helpers kept out of `emit.rs` for the source budget.
+
+use vize_davinci::id::NodeId;
+
+use super::{EmitCx, EmitError};
+
+impl EmitCx<'_> {
+    pub(super) fn scope_mark(&self) -> usize {
+        self.scope_names.len()
+    }
+
+    pub(super) fn push_scope(&mut self, id: Option<NodeId>) -> usize {
+        let mark = self.scope_mark();
+        if let Some(facts) = id.and_then(|id| self.scopes.get(id)) {
+            for binding in facts.bindings.iter() {
+                self.scope_names.push(binding.name.clone());
+            }
+        }
+        mark
+    }
+
+    pub(super) fn pop_scope(&mut self, mark: usize) {
+        self.scope_names.truncate(mark);
+    }
+
+    pub(super) fn is_scope_name(&self, source: &str) -> bool {
+        self.scope_names.iter().any(|name| name.as_str() == source)
+    }
+
+    pub(super) fn with_static_vnode_hoist<T>(
+        &mut self,
+        enabled: bool,
+        write: impl FnOnce(&mut Self) -> Result<T, EmitError>,
+    ) -> Result<T, EmitError> {
+        let previous = self.hoist_static_vnodes;
+        self.hoist_static_vnodes = previous || enabled;
+        let result = write(self);
+        self.hoist_static_vnodes = previous;
+        result
+    }
+}

--- a/crates/vize_s1_to_s2/src/emit/props_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static.rs
@@ -183,7 +183,7 @@ pub(super) fn emit_inline<'a>(
     attributes: impl Iterator<Item = &'a Attribute<'a>>,
 ) {
     let unique = unique_attrs(attributes);
-    let multiline = unique.len() > 1 && !cx.in_v_for;
+    let multiline = unique.len() > 1;
     if multiline {
         cx.buf.push("{");
         cx.buf.indent();

--- a/crates/vize_s1_to_s2/src/emit/vfor_item.rs
+++ b/crates/vize_s1_to_s2/src/emit/vfor_item.rs
@@ -22,15 +22,17 @@ pub(super) fn emit_element(
         if stable {
             return directive::wrap_element(cx, element, |cx| {
                 cx.buf.use_create_element_vnode();
-                vnode::emit_call(
-                    cx,
-                    element,
-                    false,
-                    key,
-                    (false, None, PropHoistPosition::Nested),
-                    true,
-                    false,
-                )
+                cx.with_static_vnode_hoist(true, |cx| {
+                    vnode::emit_call(
+                        cx,
+                        element,
+                        false,
+                        key,
+                        (false, None, PropHoistPosition::Nested),
+                        true,
+                        false,
+                    )
+                })
             });
         }
         emit_block(cx, element, key)
@@ -48,15 +50,17 @@ fn emit_block(
         cx.buf.push("(");
         cx.buf.push(Buf::open_block_alias());
         cx.buf.push("(), ");
-        vnode::emit_call(
-            cx,
-            element,
-            true,
-            key,
-            (false, None, PropHoistPosition::Nested),
-            true,
-            false,
-        )?;
+        cx.with_static_vnode_hoist(true, |cx| {
+            vnode::emit_call(
+                cx,
+                element,
+                true,
+                key,
+                (false, None, PropHoistPosition::Nested),
+                true,
+                false,
+            )
+        })?;
         cx.buf.push(")");
         Ok(())
     })

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -168,7 +168,8 @@ pub(super) fn emit_call(
     cx.buf.push(element.tag);
     cx.buf.push("\"");
     let has_children = !element.children.ops.is_empty();
-    let hoist_static_children = allow_hoist && (if_key.is_some() || !element.bindings.is_empty());
+    let hoist_static_children = cx.hoist_static_vnodes
+        || (allow_hoist && (if_key.is_some() || !element.bindings.is_empty()));
     let has_memo = super::memo::has(&element.bindings);
     let memo_block = block && has_memo && !(if_key.is_some() && !for_item);
     let force_array_children = once
@@ -297,6 +298,7 @@ pub(super) fn emit_array_child(
     hoist_static_children: bool,
     cache_static_children: bool,
 ) -> Result<(), EmitError> {
+    let hoist_static_children = hoist_static_children || cx.hoist_static_vnodes;
     if hoist_static_children
         && let Op::Element(element) = op
         && super::hoist::is_hoistable(element)
@@ -310,30 +312,32 @@ pub(super) fn emit_array_child(
         return super::hoist::emit_cached_element(cx, element);
     }
     let id = cx.walk.mint();
-    ensure_sufficient_stack(|| match op {
-        Op::Element(element) if super::slots::is_slot_template(element) => {
-            cx.walk.skip(element.bindings.len());
-            super::tpl::emit_inline(cx, &element.children.ops)
-        }
-        Op::Element(element) => {
-            cx.walk.skip(element.bindings.len());
-            if super::once::emit_hoisted_child(cx, element)? {
-                return Ok(());
+    cx.with_static_vnode_hoist(hoist_static_children, |cx| {
+        ensure_sufficient_stack(|| match op {
+            Op::Element(element) if super::slots::is_slot_template(element) => {
+                cx.walk.skip(element.bindings.len());
+                super::tpl::emit_inline(cx, &element.children.ops)
             }
-            emit_nested(cx, element, id)
-        }
-        Op::Component(component) => {
-            cx.walk.skip(component.bindings.len());
-            super::component::emit_nested(cx, component, id)
-        }
-        Op::If(if_op) => super::emit_if_op(cx, if_op, id),
-        Op::For(for_op) => super::emit_for_op(cx, for_op, id, None),
-        Op::Slot(slot) => {
-            cx.walk.skip(slot.bindings.len());
-            super::outlet::emit_outlet(cx, slot, None, false)
-        }
-        Op::Text(_) | Op::Interpolation(_) => {
-            Err(EmitError::unsupported_op(Reason::ArrayChildTextRun, op))
-        }
+            Op::Element(element) => {
+                cx.walk.skip(element.bindings.len());
+                if super::once::emit_hoisted_child(cx, element)? {
+                    return Ok(());
+                }
+                emit_nested(cx, element, id)
+            }
+            Op::Component(component) => {
+                cx.walk.skip(component.bindings.len());
+                super::component::emit_nested(cx, component, id)
+            }
+            Op::If(if_op) => super::emit_if_op(cx, if_op, id),
+            Op::For(for_op) => super::emit_for_op(cx, for_op, id, None),
+            Op::Slot(slot) => {
+                cx.walk.skip(slot.bindings.len());
+                super::outlet::emit_outlet(cx, slot, None, false)
+            }
+            Op::Text(_) | Op::Interpolation(_) => {
+                Err(EmitError::unsupported_op(Reason::ArrayChildTextRun, op))
+            }
+        })
     })
 }

--- a/crates/vize_s1_to_s2/src/emit/vnode_children.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_children.rs
@@ -12,6 +12,25 @@ pub(super) fn emit_children(
     hoist_static_children: bool,
     cache_static_children: bool,
 ) -> Result<(), EmitError> {
+    let hoist_static_children = hoist_static_children || cx.hoist_static_vnodes;
+    cx.with_static_vnode_hoist(hoist_static_children, |cx| {
+        emit_children_inner(
+            cx,
+            children,
+            force_array,
+            hoist_static_children,
+            cache_static_children,
+        )
+    })
+}
+
+fn emit_children_inner(
+    cx: &mut EmitCx<'_>,
+    children: &Region<'_>,
+    force_array: bool,
+    hoist_static_children: bool,
+    cache_static_children: bool,
+) -> Result<(), EmitError> {
     let ops = &children.ops;
     if !force_array
         && ops
@@ -20,7 +39,11 @@ pub(super) fn emit_children(
     {
         return emit_text_like(cx, ops);
     }
-    if !force_array && cache_static_children && super::hoist::cacheable_elements_array(ops) {
+    if !force_array
+        && !hoist_static_children
+        && cache_static_children
+        && super::hoist::cacheable_elements_array(ops)
+    {
         return super::hoist::emit_cached_elements_array(cx, ops);
     }
     cx.buf.push("[");

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -21,8 +21,8 @@ or `collections` modules does not bypass the boundary.
 
 ## Retained `alloc::vec::Vec` inventory
 
-The four library trees in the reviewed inventory contain 57 production files,
-69 direct `alloc::vec::Vec` paths, and 238 bound `Vec`/`StdVec` uses. "Direct"
+The four library trees in the reviewed inventory contain 58 production files,
+70 direct `alloc::vec::Vec` paths, and 238 bound `Vec`/`StdVec` uses. "Direct"
 counts imports and fully-qualified paths; "bound" counts every type,
 constructor, and method path reached through a direct `Vec` import or alias.
 The executable ledger requires strict equality, so both growth and reduction
@@ -34,7 +34,7 @@ must update the file row and aggregate evidence in the same change.
 | analysis |     7 |            8 |         18 | Diagnostics, side tables, filters, and verifier results grow with the input; no inline bound is established.       |
 | lower    |    11 |           11 |         39 | Lowering worklists and owned results grow with source-tree shape. Bounded substructures may migrate independently. |
 | pass     |    13 |           13 |         51 | Facts, provenance, and traversal worklists grow with the number of operations.                                     |
-| emit     |    13 |           13 |         66 | Ordered output buffers and collected emission inputs grow with the document.                                       |
+| emit     |    14 |           14 |         66 | Ordered output buffers and collected emission inputs grow with the document.                                       |
 
 This is not an endorsement of every retained allocation. A focused change may
 replace a site with `SmallVec` after measuring a bound; that change lowers the
@@ -71,7 +71,7 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::String`       |    11 |           11 |         53 |
 | s2       | `vize_s0::Vec`          |     9 |            9 |         17 |
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
-| s1_to_s2 | `alloc::vec::Vec`       |    37 |           37 |        156 |
+| s1_to_s2 | `alloc::vec::Vec`       |    38 |           38 |        156 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
 | s1_to_s2 | `vize_s0::String`       |    53 |           55 |        237 |
 | s1_to_s2 | `vize_s0::Vec`          |    14 |           14 |         56 |

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -37,7 +37,8 @@ s2	-	crates/vize_s2/src/verify/observer.rs	0	0	1	1	0	0	0	0
 s2	analysis	crates/vize_s2/src/verify/walk.rs	1	5	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit.rs	1	2	1	4	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/buf.rs	1	8	1	11	0	0	0	0
-s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/component.rs	1	4	0	0	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/component.rs	1	1	0	0	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/component/preamble.rs	1	3	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/create_slots.rs	1	6	1	6	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/directive.rs	1	6	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/filter.rs	0	0	1	1	0	0	0	0

--- a/tests/tooling/davinci-storage-inventory.ts
+++ b/tests/tooling/davinci-storage-inventory.ts
@@ -42,8 +42,8 @@ export const categoryReasons: Record<VecCategory, string> = {
 };
 
 export const expectedProductionAllocVec: StorageSummary = {
-  files: 57,
-  directPaths: 69,
+  files: 58,
+  directPaths: 70,
   boundUses: 238,
 };
 


### PR DESCRIPTION
## Summary
- carry legacy static vnode hoist context through nested S2 DOM children
- preserve nested static vnode hoisting inside component slots and v-for item children
- add atelier DOM regression coverage for AIRI-style static descendants

## Corpus evidence
Focused AIRI stage-tamagotchi components corpus after this change:
- files=21
- parsed=21
- templates=21
- compared=21
- old_error_skips=0
- s2_refusals=0
- divergences=2

Representative residuals fixed from the previous sample:
- Window/TitleBar.vue
- WithScreenCapture.vue
- stage-islands/controls-island/indicator-mic-volume.vue

Remaining residuals in the focused subtree are separate nested static formatting/cache cases:
- stage-islands/resource-status-island/loading-component.vue
- stage-islands/resource-status-island/loading-modules.vue

## Verification
- cargo test -p vize_atelier_dom --test davinci_s2_static_vnode_hoist -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_static_hoist -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_for -- --nocapture
- cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- cargo fmt --all -- --check
- cargo clippy -p vize_s1_to_s2 --all-targets --features davinci-differential -- -D warnings
- git diff --check HEAD~1..HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790755069&installation_model_id=422833&pr_number=5480&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5480&signature=625c334298b0ddd6c75cfb3b51fecf4ed5d509ddbc31d68e4ca13c31c2e0bed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->