### PR TITLE
fix(davinci): keep static refs out of vnode hoists

### DIFF
--- a/crates/vize_s1_to_s2/src/emit/hoist.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist.rs
@@ -10,11 +10,9 @@ use alloc::vec::Vec as StdVec;
 use vize_s0::{String, ToCompactString};
 use vize_s2::op::{Attribute, ElementOp, Op, Region};
 
-use super::EmitCx;
-use super::EmitError;
-use super::UnsupportedReason as Reason;
 use super::buf::Buf;
 use super::js::{escape_js_string, is_valid_js_identifier};
+use super::{EmitCx, EmitError, UnsupportedReason as Reason};
 
 pub(super) fn emit_hoisted_element(
     cx: &mut EmitCx<'_>,
@@ -113,7 +111,9 @@ pub(super) fn is_hoistable(element: &ElementOp<'_>) -> bool {
 }
 
 pub(super) fn is_static_element_tree(element: &ElementOp<'_>) -> bool {
-    element.bindings.is_empty() && element.children.ops.iter().all(is_static_tree_child)
+    !element.attributes.iter().any(|attr| attr.name == "ref")
+        && element.bindings.is_empty()
+        && element.children.ops.iter().all(is_static_tree_child)
 }
 
 fn is_static_tree_child(op: &Op<'_>) -> bool {

--- a/crates/vize_s1_to_s2/tests/emit_static_hoist.rs
+++ b/crates/vize_s1_to_s2/tests/emit_static_hoist.rs
@@ -56,9 +56,23 @@ fn cached_static_child_formats_multikey_props_like_the_shipped_snapshot() {
 }
 
 #[test]
+fn static_ref_child_stays_inline_when_static_cache_is_enabled() {
+    assert_shipped_parity(
+        r#"<aside class="seed"></aside><main><div ref="canvasContainerRef"></div></main>"#,
+    );
+}
+
+#[test]
 fn cached_static_children_array_formats_multikey_props_like_the_shipped_snapshot() {
     assert_shipped_parity(
         r#"<div class="root"><span id="hero" class="title"></span><span data-panel="intro" aria-hidden="true"></span></div>"#,
+    );
+}
+
+#[test]
+fn static_ref_child_stays_inline_under_dynamic_parent_hoist() {
+    assert_shipped_parity(
+        r#"<section @mousemove="track"><div ref="silhouette" class="silhouette"></div></section>"#,
     );
 }
 


### PR DESCRIPTION
## Summary
- keep static template refs out of S2 static vnode hoist/cache eligibility
- add Davinci DOM parity regressions for ref-bearing static children in cache and hoist paths

## Tests
- rtk cargo test -p vize_s1_to_s2 --test emit_static_hoist -- --nocapture
- rtk cargo test -p vize_s1_to_s2 --test emit_static --test emit_static_hoist --test emit_tpl --test emit_slots --test emit_outlets --test emit_builtins --test hoist_pass
- rtk cargo fmt --all -- --check
- rtk cargo clippy -p vize_s1_to_s2 --tests -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790758448&installation_model_id=422833&pr_number=5481&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5481&signature=0a835440d452fdfbe8006d8db9df808519ae7f725307097f5fac970877e019be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of elements with template `ref` attributes so they remain inline instead of being incorrectly cached or hoisted.
  * Improved rendered output parity for static and dynamic parent scenarios involving referenced elements.

* **Tests**
  * Added coverage validating inline rendering and preventing incorrect static vnode caching or hoisting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->