### PR TITLE
fix(davinci): match cached static prop formatting

### DIFF
--- a/crates/vize_s1_to_s2/src/emit/hoist.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist.rs
@@ -4,6 +4,7 @@
 //! Named / scoped slots and nested hoist-out-of-dynamic-parents stay
 //! with later installments.
 
+mod cached_props;
 use alloc::vec::Vec as StdVec;
 
 use vize_s0::{String, ToCompactString};
@@ -199,7 +200,7 @@ fn append_cached_element_rhs(
     if element.attributes.is_empty() {
         out.push_str("null");
     } else {
-        out.push_str(compact_props_object(element.attributes.iter()).as_str());
+        cached_props::push_object(out, element.attributes.iter(), line_indent);
     }
     out.push_str(", ");
     let kids = meaningful(&element.children);

--- a/crates/vize_s1_to_s2/src/emit/hoist/cached_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist/cached_props.rs
@@ -1,0 +1,34 @@
+//! Cached static-props object layout.
+
+use vize_s0::String;
+use vize_s2::op::Attribute;
+
+use super::{compact_props_object, push_attr_pair, push_spaces, unique_attrs};
+
+/// First-occurrence static attrs for cached vnode calls. The shipped transform
+/// keeps one attr inline, but prints multi-key static props over vnode-relative
+/// lines inside `_cache` initializers.
+pub(super) fn push_object<'a>(
+    out: &mut String,
+    attributes: impl Iterator<Item = &'a Attribute<'a>>,
+    line_indent: usize,
+) {
+    let unique = unique_attrs(attributes);
+    if unique.len() <= 1 {
+        out.push_str(compact_props_object(unique.iter().copied()).as_str());
+        return;
+    }
+
+    out.push('{');
+    for (i, attr) in unique.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('\n');
+        push_spaces(out, line_indent + 2);
+        push_attr_pair(out, attr);
+    }
+    out.push('\n');
+    push_spaces(out, line_indent);
+    out.push('}');
+}

--- a/crates/vize_s1_to_s2/tests/emit_static_hoist.rs
+++ b/crates/vize_s1_to_s2/tests/emit_static_hoist.rs
@@ -49,6 +49,20 @@ fn dynamic_parent_hoists_static_children_instead_of_render_cache() {
 }
 
 #[test]
+fn cached_static_child_formats_multikey_props_like_the_shipped_snapshot() {
+    assert_shipped_parity(
+        r#"<div class="root">{{ msg }}<span id="cta" class="pill"></span></div>"#,
+    );
+}
+
+#[test]
+fn cached_static_children_array_formats_multikey_props_like_the_shipped_snapshot() {
+    assert_shipped_parity(
+        r#"<div class="root"><span id="hero" class="title"></span><span data-panel="intro" aria-hidden="true"></span></div>"#,
+    );
+}
+
+#[test]
 fn static_bind_props_hoist_with_nested_dynamic_descendants() {
     assert_shipped_parity(
         r#"<div><section class="panel" :id="'fixed'"><span>{{ msg }}</span></section></div>"#,

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -73,7 +73,7 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
 | s1_to_s2 | `alloc::vec::Vec`       |    38 |           38 |        156 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    54 |           56 |        237 |
+| s1_to_s2 | `vize_s0::String`       |    55 |           57 |        238 |
 | s1_to_s2 | `vize_s0::Vec`          |    14 |           14 |         56 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     2 |            2 |          4 |
 

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -43,6 +43,7 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/create_slots.rs	1	6	1	6	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/directive.rs	1	6	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/filter.rs	0	0	1	1	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/hoist.rs	1	4	1	12	0	0	0	0
+s1_to_s2	-	crates/vize_s1_to_s2/src/emit/hoist/cached_props.rs	0	0	1	1	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/entity.rs	0	0	1	3	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/js.rs	0	0	1	6	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/js_comment.rs	0	0	1	3	0	0	0	0


### PR DESCRIPTION
## Summary

- Match the shipped DOM lane formatting for multi-key static attrs inside cached vnode `_cache` initializers.
- Keep root/static-props hoists compact; this only changes cached vnode RHS layout.
- Add focused S1->S2 parity pins for a cached static child and a cached static children array.

## Change Class

- [ ] Parser or AST
- [x] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

Davinci S1->S2 DOM output parity residuals from Real Project Matrix run 33373722661: multi-key static props under cached/static vnode contexts should use the shipped lane multiline layout without changing semantics.

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

Commands run:

- `rtk cargo test -p vize_s1_to_s2 --features davinci-differential --test emit_static_hoist --test emit_static --test emit_raw_comment_format --test davinci_dom_corpus`
- `rtk cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings`
- `rtk cargo fmt --all -- --check`
- `rtk git diff --check origin/main..HEAD`
- `rtk pnpm exec node --test tests/tooling/davinci-storage-policy.test.ts`
- `rtk pnpm exec node --test tests/tooling/source-file-lengths.test.ts`

Also tried `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/fixtures/davinci-matrix rtk cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus`; the sweep still reports unrelated slot/template divergences and one slot diagnostic outside this cached static-props formatting patch.

## Risk

Low semantic risk: this changes only emitted whitespace for multi-key static attrs in cached vnode calls. It does not change helper ordering, component ordering, hoist eligibility, patch flags, or cached array selection.