### PR TITLE
fix(davinci): preserve s2 helper order parity

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_helper_composition.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_helper_composition.rs
@@ -45,6 +45,22 @@ const BATTERY: &[(&str, &str)] = &[
         "component_if_component_then_text",
         r#"<Foo><Bar v-if="ok">x</Bar>hello</Foo>"#,
     ),
+    (
+        "text_slot_before_v_if_fallback",
+        r#"<Foo>hello<template v-if="ok"><span>x</span></template></Foo>"#,
+    ),
+    (
+        "v_show_sibling_before_v_for",
+        r#"<section><div v-show="visible"></div><p v-for="item in items">{{ item }}</p></section>"#,
+    ),
+    (
+        "v_show_component_slot",
+        r#"<Dialog v-show="open"><span>Body</span></Dialog>"#,
+    ),
+    (
+        "nested_trigger_icon_resolves_in_child_before_parent_order",
+        r#"<DropdownMenu><DropdownMenuTrigger><Icon /></DropdownMenuTrigger></DropdownMenu>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -146,7 +146,8 @@ fn prefer_transform_helpers(buf: &mut Buf, region: &Region<'_>) {
                 buf.prefer(Helper::Fragment);
                 prefer_transform_helpers(buf, &for_op.region);
             }
-            Op::Text(_) | Op::Interpolation(_) => {}
+            Op::Text(_) => {}
+            Op::Interpolation(_) => buf.prefer(Helper::ToDisplayString),
         }
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/directive.rs
+++ b/crates/vize_s1_to_s2/src/emit/directive.rs
@@ -35,17 +35,9 @@ pub(super) fn has_runtime(bindings: &[BindingOp<'_>]) -> bool {
 }
 
 pub(super) fn prefer_helpers(buf: &mut Buf, bindings: &[BindingOp<'_>]) {
-    if has_runtime(bindings) {
-        buf.prefer(Helper::WithDirectives);
-    }
     if has_custom(bindings) {
+        buf.prefer(Helper::WithDirectives);
         buf.prefer(Helper::ResolveDirective);
-    }
-    if bindings
-        .iter()
-        .any(|binding| matches!(binding, BindingOp::VueShow(_)))
-    {
-        buf.prefer(Helper::VShow);
     }
 }
 
@@ -120,6 +112,9 @@ fn wrap(
     emit: impl FnOnce(&mut EmitCx<'_>) -> Result<(), EmitError>,
 ) -> Result<(), EmitError> {
     cx.buf.use_with_directives();
+    if native.is_none() && matches!(runtime, [RuntimeDirective::Show(_)]) {
+        cx.buf.use_v_show();
+    }
     cx.buf.push(Buf::with_directives_alias());
     cx.buf.push("(");
     emit(cx)?;


### PR DESCRIPTION
## Summary
- keep S2 DOM helper pre-scan aligned with helpers the shipped transform actually parks on root.helpers
- register plain v-show helpers at wrapper-open time so withCtx/vShow ties match shipped codegen
- add byte-for-byte DOM parity regressions for text/comment, renderList/vShow, withCtx/vShow, and nested component resolve order

## Tests
- rtk cargo test -p vize_atelier_dom --test davinci_s2_helper_composition
- rtk cargo test -p vize_atelier_dom --test davinci_s2_helper_composition --test davinci_s2_show --test davinci_s2_slots --test davinci_s2_dom
- rtk cargo test -p vize_s1_to_s2 --test emit_comp --test emit_dirs --test emit_slots --test emit_model --test emit_for --test emit_create_slots_wrappers
- rtk cargo test -p vize_atelier_dom --test davinci_s2_dirs --test davinci_s2_model --test davinci_s2_for --test davinci_s2_if_for
- rtk cargo fmt --all -- --check
- rtk cargo clippy -p vize_s1_to_s2 --lib -- -D warnings
- rtk cargo clippy -p vize_atelier_dom --test davinci_s2_helper_composition -- -D warnings
- rtk git diff --check

Note: a broader rtk cargo clippy -p vize_s1_to_s2 -p vize_atelier_dom --tests -- -D warnings still hits pre-existing unrelated failures in davinci_walk_baseline.rs and davinci_teardown_without_stack_guard.rs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790758741&installation_model_id=422833&pr_number=5484&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5484&signature=315cd6ae6b39ad22b5657ba6a158e42466f68b766f542acb917f9d0aaff984cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->