### PR TITLE
fix(glyph): stabilize charset comment formatting

### DIFF
--- a/crates/vize_glyph/src/style.rs
+++ b/crates/vize_glyph/src/style.rs
@@ -49,6 +49,9 @@ fn format_with_preserved_top_level_comments(
                     .as_str()
                     .trim_end_matches('\n')
                     .trim_end_matches('\r');
+                if formatted.is_empty() {
+                    continue;
+                }
                 if emitted_any {
                     output.push_str(newline);
                 }
@@ -324,5 +327,22 @@ mod tests {
         // lightningcss emits a clean single-rule output.
         assert!(result.contains(".x"));
         assert!(result.contains("\"/* not a comment */\""));
+    }
+
+    #[test]
+    fn test_format_charset_before_top_level_comment_reaches_fixed_point() {
+        let source = concat!(
+            "@charset \"UTF-8\";\n",
+            "/* comment */\n",
+            ".a {\n",
+            "  color: red;\n",
+            "}",
+        );
+        let options = FormatOptions::default();
+        let result = format_style_content(source, &options).unwrap();
+        let again = format_style_content(result.as_str(), &options).unwrap();
+
+        assert_eq!(result, again);
+        assert!(result.as_str().starts_with("/* comment */\n.a {"));
     }
 }


### PR DESCRIPTION
Closes #5471

## Summary
- skip code segments that become empty after lightningcss drops @charset
- add a fixed-point regression for @charset followed by a top-level comment

## Tests
- cargo test -p vize_glyph style::tests::test_format_charset_before_top_level_comment_reaches_fixed_point -- --exact
- cargo test -p vize_glyph
- cargo fmt --all -- --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790758916&installation_model_id=422833&pr_number=5485&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5485&signature=f4114713e630e2d240508c63a68d6073968d73bb3627751377cd473f4c5dc2d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->