### PR TITLE
fix(patina): ignore slot outlets for v-for key

### DIFF
--- a/crates/vize_patina/src/rules/vue/require_v_for_key.rs
+++ b/crates/vize_patina/src/rules/vue/require_v_for_key.rs
@@ -50,6 +50,9 @@ impl RequireVForKey {
         if element.is_tag("template") {
             return;
         }
+        if element.is_tag("slot") {
+            return;
+        }
         if element.has_key_binding() || has_object_bound_key(element) {
             return;
         }
@@ -211,6 +214,10 @@ impl Rule for RequireVForKey {
             return;
         }
 
+        if element.tag == "slot" {
+            return;
+        }
+
         // Check if element has :key or key attribute
         let has_key = element.props.iter().any(|prop| match prop {
             PropNode::Attribute(attr) => attr.name == "key",
@@ -276,6 +283,16 @@ mod tests {
         // Static key is unusual but technically valid
         let result = linter.lint_template(
             r#"<div v-for="item in items" key="static"></div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_valid_slot_outlet_v_for_without_key() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div><slot v-for="(item, index) in items" name="item" :item="item" :index="index" /></div>"#,
             "test.vue",
         );
         assert_eq!(result.error_count, 0);


### PR DESCRIPTION
Closes #5472

## Summary
- skip <slot v-for> outlets in vue/require-v-for-key across markup and legacy directive paths
- add a regression for keyless repeated named slot outlets

## Tests
- cargo test -p vize_patina rules::vue::require_v_for_key::tests::test_valid_slot_outlet_v_for_without_key -- --exact
- cargo test -p vize_patina
- cargo fmt --all -- --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790759367&installation_model_id=422833&pr_number=5486&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5486&signature=167f7e69534c5197426674977298522106cc7f66defc83094e3d60ba4758383e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->