### PR TITLE
fix(davinci): suppress static spread patch keys

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs
@@ -1,7 +1,4 @@
-//! P2-11 patch-flag witness: the S2 DOM lane must compute the
-//! same per-node patch flags as the shipped lane, including dynamic
-//! prop arrays plus slot and fragment stability markers.
-
+//! P2-11 patch-flag witness for S2 DOM parity.
 #![allow(
     clippy::disallowed_macros,
     clippy::disallowed_types,
@@ -227,6 +224,11 @@ const CASES: &[Case] = &[
     Case {
         name: "component_object_bind",
         src: r#"<Foo v-bind="obj" />"#,
+        sites: &["16 /* FULL_PROPS */"],
+    },
+    Case {
+        name: "component_object_bind_static_literal_prop",
+        src: r#"<Foo v-bind="obj" :props-loading="true" />"#,
         sites: &["16 /* FULL_PROPS */"],
     },
     Case {

--- a/crates/vize_s1_to_s2/src/emit/merge.rs
+++ b/crates/vize_s1_to_s2/src/emit/merge.rs
@@ -17,8 +17,9 @@ use super::UnsupportedReason as Reason;
 use super::buf::Buf;
 use super::on::{event_key_for, needs_hydration};
 use super::props::{
-    BindName, Patch, Piece, StaticBindKeyCasing, bind_name, bind_value, emit_props_object,
-    has_prop_modifier, is_emitted_key_bind, pieces, static_bind_key,
+    BindName, Patch, Piece, StaticBindKeyCasing, bind_name, bind_value,
+    bind_value_is_static_patchless, emit_props_object, has_prop_modifier, is_emitted_key_bind,
+    pieces, static_bind_key,
 };
 
 pub(super) fn has_object_spread(bindings: &[BindingOp<'_>]) -> bool {
@@ -71,7 +72,9 @@ pub(super) fn object_patch(
                         flag |= 512;
                         continue;
                     }
-                    if matches!(raw_name, "class" | "style" | "key") {
+                    if matches!(raw_name, "class" | "style" | "key")
+                        || bind_value_is_static_patchless(bind)
+                    {
                         continue;
                     }
                     let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -298,8 +298,8 @@ compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_outlets.rs	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_outlets.rs	14	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags_static.rs	5	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags_static.rs	5	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s0	S0	stage	vize_s0	preferred	2
-compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	13	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	10	s0	S0	stage	vize_s0	preferred	2
+compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_patch_flags.rs	10	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	2
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_recent_patch_flags.rs	12	s0	S0	stage	vize_s0	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_recent_patch_flags.rs	12	s1_to_s2	S1->S2	stage	vize_s1_to_s2	preferred	1
 compiler	Compiler	test/dev	crates/vize_atelier_dom/tests/davinci_s2_show.rs	13	s0	S0	stage	vize_s0	preferred	1


### PR DESCRIPTION
## Summary
- stop adding static patchless binds to dynamic-props arrays when object spread already forces FULL_PROPS
- add a component object-spread regression for AIRI-style static literal binds
- refresh the consumer migration surface TSV line metadata

## Verification
- cargo test -p vize_atelier_dom --test davinci_s2_patch_flags -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_merge --test emit_comp --test emit_dynamic_bind_keys -- --nocapture
- cargo test -q -p vize_s1_to_s2
- cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/davinci-matrices.test.ts
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git/airi cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture (expected fail: AIRI subset still has 59 divergences, 0 S2 refusals)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790761298&installation_model_id=422833&pr_number=5489&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5489&signature=b70fcf53fc2732a26576be186cc44596d8fdd3410736d6a4440d6a848ccb22cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOM patch-flag handling for components combining object bindings with static literal props.
  * Prevented unnecessary full-props updates when statically bound values do not require patching.

* **Tests**
  * Added regression coverage for mixed object-binding and static-prop scenarios.
  * Updated module documentation for the related DOM parity case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->