### PR TITLE
fix(davinci): skip static component style normalization

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_style_merge.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_style_merge.rs
@@ -40,6 +40,10 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<div :style="{ [prop]: 'red' }"></div>"#,
     ),
     (
+        "component_object_literal",
+        r#"<WindowRoot :style="{ left: '50%', top: '72px' }" />"#,
+    ),
+    (
         "css_function_semicolon",
         r#"<div style="background: url(a;b); color: red" :style="s"></div>"#,
     ),

--- a/crates/vize_s1_to_s2/src/emit/props_object.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_object.rs
@@ -1,18 +1,14 @@
-//! Object-literal emission for static attrs plus bind / on / model pieces.
-
 use alloc::vec::Vec as StdVec;
 use vize_s0::Span;
 use vize_s2::expr::{ExprRef, OpaqueReason};
 use vize_s2::op::{Attribute, BindOp, BindingOp, DynamicName, ModelOp, OnOp, VueHtmlOp, VueTextOp};
 
-use super::EmitCx;
-use super::EmitError;
 use super::error::UnsupportedReason as Reason;
 use super::js::{escape_js_string, push_ident_key};
 use super::model_key::{ModelModifiersKey, ModelName, ModelUpdateKey};
 use super::props_bind::{self, StaticBindKeyCasing};
-use super::props_value;
-use super::{on, style};
+use super::{EmitCx, EmitError};
+use super::{on, props_value, style};
 
 pub(super) fn emit_props_object(
     cx: &mut EmitCx<'_>,
@@ -105,7 +101,9 @@ pub(super) fn emit_props_object(
         }
         match piece {
             Piece::Attr(attr) => emit_static_pair(cx, attr),
-            Piece::Bind(bind) => emit_bind_pair(cx, pieces, bind, skip_normalize)?,
+            Piece::Bind(bind) => {
+                emit_bind_pair(cx, pieces, bind, skip_normalize, is_plain_element)?
+            }
             Piece::On(event) => on::emit_on_pair(cx, event, is_plain_element)?,
             Piece::VueHtml(html) => super::html::emit_pair(cx, html)?,
             Piece::VueText(text) => super::vtext::emit_pair(cx, text)?,
@@ -297,6 +295,7 @@ fn emit_bind_pair(
     pieces: &[Piece<'_>],
     bind: &BindOp<'_>,
     skip_normalize: bool,
+    is_plain_element: bool,
 ) -> Result<(), EmitError> {
     if props_bind::emit_dynamic_bind_pair(cx, bind)? {
         return Ok(());
@@ -304,6 +303,10 @@ fn emit_bind_pair(
     let raw_name = props_bind::static_bind_name(bind)?;
     let key = props_bind::static_bind_key(bind, StaticBindKeyCasing::Preserve)?;
     let value = props_value::bind_value(bind)?;
+    let skip_normalize = skip_normalize
+        || (!is_plain_element
+            && raw_name == "style"
+            && super::props::bind_value_is_static_patchless(bind));
     emit_ref_for(cx, key.as_str());
     push_ident_key(cx, key.as_str());
     cx.buf.push(": ");


### PR DESCRIPTION
## Summary
- preserve shipped DOM output for static object-literal style binds on components
- keep element style normalization behavior unchanged
- add an AIRI-derived component style regression

## Verification
- cargo test -p vize_atelier_dom --test davinci_s2_style_merge -- --nocapture
- cargo test -q -p vize_s1_to_s2
- cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/davinci-matrices.test.ts
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git/airi cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture (expected fail: AIRI subset still has 54 divergences, 0 S2 refusals on this branch)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790761440&installation_model_id=422833&pr_number=5491&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5491&signature=da25ce2c101d3373a1ace8558abb2e8a6930cf6974a9a557ef4b3b73c8e6fc22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->