### PR TITLE
fix(davinci): preserve transition slot edge parity

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_builtins.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_builtins.rs
@@ -86,6 +86,30 @@ const BATTERY: &[(&str, &str)] = &[
         "transition_article_dynamic_key",
         r#"<Transition :name="transitionName" mode="out-in"><article :key="path" class="docs-article"><h1>{{ pageTitle }}</h1><Content /></article></Transition>"#,
     ),
+    (
+        "base_transition_article_dynamic_key",
+        r#"<BaseTransition mode="out-in"><article :key="path" class="docs-article"><h1>{{ pageTitle }}</h1><Content /></article></BaseTransition>"#,
+    ),
+    (
+        "kebab_transition_article_dynamic_key",
+        r#"<transition mode="out-in"><article :key="path" class="docs-article"><h1>{{ pageTitle }}</h1><Content /></article></transition>"#,
+    ),
+    (
+        "transition_article_static_key",
+        r#"<Transition><article key="docs" class="docs-article"><h1>{{ pageTitle }}</h1></article></Transition>"#,
+    ),
+    (
+        "transition_article_without_key",
+        r#"<Transition><article class="docs-article"><h1>{{ pageTitle }}</h1></article></Transition>"#,
+    ),
+    (
+        "transition_article_dynamic_key_once",
+        r#"<Transition><article v-once :key="path" class="docs-article"><h1>{{ pageTitle }}</h1></article></Transition>"#,
+    ),
+    (
+        "transition_article_dynamic_key_memo",
+        r#"<Transition><article v-memo="[path]" :key="path" class="docs-article"><h1>{{ pageTitle }}</h1></article></Transition>"#,
+    ),
     ("teleport_ws", r##"<Teleport to="#app">  </Teleport>"##),
     ("keepalive_ws", "<KeepAlive>  </KeepAlive>"),
 ];

--- a/crates/vize_s1_to_s2/src/emit/slot_root.rs
+++ b/crates/vize_s1_to_s2/src/emit/slot_root.rs
@@ -11,41 +11,39 @@ pub(super) fn emit_transition_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<
     let Op::Element(element) = op else {
         return Ok(false);
     };
-    if !has_key(element)
-        || super::once::has(&element.bindings)
-        || super::memo::has(&element.bindings)
-    {
+    if !has_dynamic_key(element) || super::once::has(&element.bindings) {
         return Ok(false);
     }
     let id = cx.walk.mint();
     cx.walk.skip(element.bindings.len());
-    super::directive::wrap_element(cx, element, |cx| {
-        cx.buf.use_open_block();
-        cx.buf.use_create_element_block();
-        cx.buf.push("(");
-        cx.buf.push(Buf::open_block_alias());
-        cx.buf.push("(), ");
-        super::vnode::emit_call(
-            cx,
-            element,
-            true,
-            None,
-            (true, id, PropHoistPosition::Nested),
-            false,
-            false,
-        )?;
-        cx.buf.push(")");
-        Ok(())
+    super::memo::emit_cached(cx, &element.bindings, |cx| {
+        super::directive::wrap_element(cx, element, |cx| {
+            cx.buf.use_open_block();
+            cx.buf.use_create_element_block();
+            cx.buf.push("(");
+            cx.buf.push(Buf::open_block_alias());
+            cx.buf.push("(), ");
+            super::vnode::emit_call(
+                cx,
+                element,
+                true,
+                None,
+                (true, id, PropHoistPosition::Nested),
+                false,
+                false,
+            )?;
+            cx.buf.push(")");
+            Ok(())
+        })
     })?;
     Ok(true)
 }
 
-fn has_key(element: &ElementOp<'_>) -> bool {
-    element.attributes.iter().any(|attr| attr.name == "key")
-        || element.bindings.iter().any(|binding| {
-            matches!(
-                binding,
-                BindingOp::Bind(bind) if super::props_bind::is_key_bind_name(bind)
-            )
-        })
+fn has_dynamic_key(element: &ElementOp<'_>) -> bool {
+    element.bindings.iter().any(|binding| {
+        matches!(
+            binding,
+            BindingOp::Bind(bind) if super::props_bind::is_key_bind_name(bind)
+        )
+    })
 }


### PR DESCRIPTION
## Summary
- keep Transition slot root block emission limited to dynamic :key roots
- preserve v-memo wrapping while matching shipped createElementBlock output
- add S2 built-in differential fixtures for BaseTransition, kebab transition, static key, unkeyed, v-once, and v-memo roots

## Tests
- cargo test -q -p vize_atelier_dom --test davinci_s2_builtins -- --nocapture
- cargo test -q -p vize_s1_to_s2
- cargo fmt --all -- --check
- git diff --check
- cargo clippy -q -p vize_s1_to_s2 --all-targets -- -D warnings -D clippy::wildcard_imports