### PR TITLE
fix(davinci): preserve TS cast model updates

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_model.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_model.rs
@@ -37,6 +37,7 @@ const BATTERY: &[(&str, &str)] = &[
     ("model_then_id", r#"<input v-model="msg" id="x">"#),
     ("class_bind", r#"<input :class="c" v-model="msg">"#),
     ("style_bind", r#"<input :style="s" v-model="msg">"#),
+    ("input_ts_cast", r#"<input v-model="voice as any">"#),
     ("spread_then", r#"<input v-bind="obj" v-model="msg">"#),
     ("then_spread", r#"<input v-model="msg" v-bind="obj">"#),
     ("vif", r#"<input v-if="ok" v-model="msg">"#),
@@ -48,6 +49,10 @@ const BATTERY: &[(&str, &str)] = &[
     ("fragment", r#"<input v-model="a"><input v-model="b">"#),
     ("comp", r#"<Foo v-model="msg" />"#),
     ("comp_arg", r#"<Foo v-model:title="pageTitle" />"#),
+    (
+        "comp_arg_ts_cast",
+        r#"<Foo v-model:voice="voice as any" />"#,
+    ),
     (
         "comp_kebab_arg",
         r#"<Foo v-model:auto-send="autoSendEnabled" />"#,

--- a/crates/vize_s1_to_s2/src/emit/model_key.rs
+++ b/crates/vize_s1_to_s2/src/emit/model_key.rs
@@ -114,7 +114,17 @@ fn emit_modifiers_key(cx: &mut EmitCx<'_>, key: &ModelModifiersKey<'_>) {
 }
 
 pub(super) fn emit_assignment(cx: &mut EmitCx<'_>, source: &str) {
+    if is_ts_as_assignment_target(source) {
+        cx.buf.push("$event => ($event => ($event => ((");
+        cx.buf.push(source);
+        cx.buf.push(") = $event)))");
+        return;
+    }
     cx.buf.push("$event => ((");
     cx.buf.push(source);
     cx.buf.push(") = $event)");
+}
+
+fn is_ts_as_assignment_target(source: &str) -> bool {
+    source.contains(" as ")
 }


### PR DESCRIPTION
## Summary
- mirror shipped DOM lane spelling for TS `as` cast v-model assignment targets
- add Davinci byte-parity regressions for native and component model cast updates
- reduces latest AIRI subset divergences from 42 to 38 on top of origin/main eca05a96f

## Tests
- `rtk cargo test -p vize_atelier_dom --test davinci_s2_model -- --nocapture`
- `rtk cargo test -p vize_atelier_dom --test davinci_s2_model --test davinci_s2_colon --test davinci_s2_patch_flags -- --nocapture`
- `rtk cargo test -p vize_s1_to_s2 --test emit_model --test emit_merge --test emit_comp -- --nocapture`
- `rtk cargo test -q -p vize_s1_to_s2`
- `rtk cargo fmt --all -- --check`
- `rtk cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings`
- `rtk cargo clippy -p vize_atelier_dom --test davinci_s2_model -- -D warnings`
- `rtk git diff --check`
- `SOURCE_LENGTH_BASE_REF=origin/main rtk node --test tests/tooling/source-file-lengths.test.ts`
- `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git/airi rtk cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture` (expected fail: residual corpus divergences now 38; no S2 refusals)

## Notes
- `rtk cargo clippy -p vize_atelier_dom --tests -- -D warnings` still hits unrelated existing lints in `element_nesting_depth.rs` and `davinci_walk_baseline.rs`; targeted changed-test clippy passes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790762907&installation_model_id=422833&pr_number=5494&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5494&signature=8cba4cafd6b4706c57b582f50e171879d580844cef4cf56891e031e924eaff8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->