### PR TITLE
fix(davinci): preserve spread style patch keys

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_recent_patch_flags.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_recent_patch_flags.rs
@@ -79,6 +79,16 @@ const CASES: &[Case] = &[
         src: r#"<Foo v-on.once.capture="handlers" />"#,
         sites: &["16 /* FULL_PROPS */"],
     },
+    Case {
+        name: "component_object_bind_dynamic_style",
+        src: r#"<Foo v-bind="obj" :style="style" />"#,
+        sites: &["16 /* FULL_PROPS */, [\"style\"]"],
+    },
+    Case {
+        name: "component_object_bind_dynamic_class",
+        src: r#"<Foo v-bind="obj" :class="klass" />"#,
+        sites: &["16 /* FULL_PROPS */, [\"class\"]"],
+    },
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/merge.rs
+++ b/crates/vize_s1_to_s2/src/emit/merge.rs
@@ -72,7 +72,8 @@ pub(super) fn object_patch(
                         flag |= 512;
                         continue;
                     }
-                    if matches!(raw_name, "class" | "style" | "key")
+                    if raw_name == "key"
+                        || (!is_component && matches!(raw_name, "class" | "style"))
                         || bind_value_is_static_patchless(bind)
                     {
                         continue;


### PR DESCRIPTION
## Summary
- keep component `class`/`style` dynamic prop keys when an object `v-bind` spread forces `FULL_PROPS`
- keep native element class/style special patch handling unchanged
- add recent Davinci patch-flag regressions for component spread + dynamic class/style

## Tests
- `rtk cargo test -p vize_atelier_dom --test davinci_s2_patch_flags -- --nocapture`
- `rtk cargo test -p vize_atelier_dom --test davinci_s2_patch_flags --test davinci_s2_recent_patch_flags --test davinci_s2_style_merge -- --nocapture`
- `rtk cargo test -p vize_s1_to_s2 --test emit_merge --test emit_dynamic_bind_keys --test emit_comp -- --nocapture`
- `rtk cargo test -q -p vize_s1_to_s2`
- `rtk cargo fmt --all -- --check`
- `rtk cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings`
- `rtk cargo clippy -p vize_atelier_dom --test davinci_s2_recent_patch_flags -- -D warnings`
- `rtk git diff --check`
- `SOURCE_LENGTH_BASE_REF=origin/main rtk node --test tests/tooling/source-file-lengths.test.ts`
- `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git/airi rtk cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture` (expected fail: residual corpus divergences 39 on this branch; unrelated model cast divergences are fixed separately in #5494)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790763297&installation_model_id=422833&pr_number=5496&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5496&signature=540ef4613e4031e151379731f2db07538023214666c84454da1ce6dba7a57f96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->