### PR TITLE
fix(davinci): skip normalizeStyle for static style binds

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_static_style.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_static_style.rs
@@ -1,0 +1,58 @@
+//! Static object `:style` output, compared byte-for-byte against the
+//! shipped DOM lane.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "nested_native_static_object_style",
+        r#"<section><div :style="{ color: 'red' }"></div></section>"#,
+    ),
+    (
+        "branch_native_static_object_style",
+        r#"<section><div v-if="ok" :style="{ color: 'red' }"></div></section>"#,
+    ),
+    (
+        "native_dynamic_identifier_style",
+        r#"<section><div :style="s"></div></section>"#,
+    ),
+    (
+        "native_static_and_dynamic_style_merge",
+        r#"<section><div style="color: red" :style="s"></div></section>"#,
+    ),
+    (
+        "native_computed_key_style",
+        r#"<section><div :style="{ [prop]: 'red' }"></div></section>"#,
+    ),
+    (
+        "component_static_object_style",
+        r#"<section><Foo :style="{ color: 'red' }" /></section>"#,
+    ),
+    (
+        "component_dynamic_identifier_style",
+        r#"<section><Foo :style="s" /></section>"#,
+    ),
+    (
+        "component_computed_key_style",
+        r#"<section><Foo :style="{ [prop]: 'red' }" /></section>"#,
+    ),
+    (
+        "component_static_and_dynamic_style_merge",
+        r#"<section><Foo style="color: red" :style="s" /></section>"#,
+    ),
+    (
+        "component_static_and_static_object_style_merge",
+        r#"<section><Foo style="color: red" :style="{ top: '1px' }" /></section>"#,
+    ),
+];
+
+#[test]
+fn s2_static_object_style_matches_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_s1_to_s2/src/emit/props_object.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_object.rs
@@ -303,10 +303,9 @@ fn emit_bind_pair(
     let raw_name = props_bind::static_bind_name(bind)?;
     let key = props_bind::static_bind_key(bind, StaticBindKeyCasing::Preserve)?;
     let value = props_value::bind_value(bind)?;
+    let static_style = static_style_piece(pieces);
     let skip_normalize = skip_normalize
-        || (!is_plain_element
-            && raw_name == "style"
-            && super::props::bind_value_is_static_patchless(bind));
+        || style::bind_skips_normalize(raw_name, is_plain_element, static_style.is_some(), &value);
     emit_ref_for(cx, key.as_str());
     push_ident_key(cx, key.as_str());
     cx.buf.push(": ");
@@ -326,9 +325,7 @@ fn emit_bind_pair(
             }
         },
         "style" => match value.js() {
-            Some(js) => {
-                style::emit_style_value(cx, static_style_piece(pieces), bind, js, skip_normalize)
-            }
+            Some(js) => style::emit_style_value(cx, static_style, bind, js, skip_normalize),
             None => value.emit(cx),
         },
         _ => value.emit(cx),

--- a/crates/vize_s1_to_s2/src/emit/style.rs
+++ b/crates/vize_s1_to_s2/src/emit/style.rs
@@ -1,11 +1,73 @@
 //! Static style-attribute serialization used by dynamic `:style` merges.
 
+use oxc_ast::ast::{ArrayExpressionElement, Expression, ObjectPropertyKind};
 use vize_s2::expr::JsExpr;
 use vize_s2::op::{Attribute, BindOp};
 
 use super::EmitCx;
 use super::buf::Buf;
 use super::js::{escape_js_string, js_expr_source};
+use super::props_value::BindValue;
+
+pub(super) fn bind_skips_normalize(
+    raw_name: &str,
+    is_plain_element: bool,
+    has_static_style: bool,
+    value: &BindValue<'_>,
+) -> bool {
+    if raw_name != "style" {
+        return false;
+    }
+    if !is_plain_element {
+        return static_bind_value(value);
+    }
+    !has_static_style && static_bind_value(value)
+}
+
+fn static_bind_value(value: &BindValue<'_>) -> bool {
+    value.js().is_some_and(|js| static_expression(js.ast))
+}
+
+fn static_expression(expr: &Expression<'_>) -> bool {
+    match unwrap_static_expression(expr) {
+        Expression::StringLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::RegExpLiteral(_) => true,
+        Expression::TemplateLiteral(template) => template.expressions.is_empty(),
+        Expression::UnaryExpression(unary) => static_expression(&unary.argument),
+        Expression::ArrayExpression(array) => array.elements.iter().all(static_array_element),
+        Expression::ObjectExpression(object) => object.properties.iter().all(|property| {
+            let ObjectPropertyKind::ObjectProperty(property) = property else {
+                return false;
+            };
+            !property.computed && static_expression(&property.value)
+        }),
+        _ => false,
+    }
+}
+
+fn static_array_element(element: &ArrayExpressionElement<'_>) -> bool {
+    match element {
+        ArrayExpressionElement::SpreadElement(_) => false,
+        ArrayExpressionElement::Elision(_) => true,
+        _ => element.as_expression().is_some_and(static_expression),
+    }
+}
+
+fn unwrap_static_expression<'a>(mut expr: &'a Expression<'a>) -> &'a Expression<'a> {
+    loop {
+        match expr {
+            Expression::ParenthesizedExpression(paren) => expr = &paren.expression,
+            Expression::TSAsExpression(ts_as) => expr = &ts_as.expression,
+            Expression::TSNonNullExpression(ts_non_null) => expr = &ts_non_null.expression,
+            Expression::TSSatisfiesExpression(ts_satisfies) => expr = &ts_satisfies.expression,
+            _ => return expr,
+        }
+    }
+}
 
 pub(super) fn emit_style_value(
     cx: &mut EmitCx<'_>,

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -45,7 +45,7 @@ observational guard for planning only. It does not change rollout state.
 
 | consumer                   | stage/Davinci | preferred stage names | compat code names | old AST/Croquis | raw OXC | source/manifest | test/dev | surface files | scanned files |
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
-| Compiler                   |           928 |                   487 |               441 |             140 |     371 |             941 |      498 |           488 |           606 |
+| Compiler                   |           928 |                   487 |               441 |             140 |     371 |             941 |      498 |           488 |           607 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           879 |                   238 |               641 |             396 |     187 |             807 |      655 |           467 |           663 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |


### PR DESCRIPTION
## Summary
- add a byte-for-byte vize_atelier_dom regression for static object :style emission against the shipped DOM lane
- skip normalizeStyle in the S2 emitter only for static style values that the shipped lane emits raw, while preserving computed-key/spread normalization and static-style merge behavior

## Validation
- rtk cargo test -p vize_atelier_dom --test davinci_s2_static_style -- --nocapture
- rtk cargo test -p vize_atelier_dom --test davinci_s2_style_merge -- --nocapture
- rtk cargo test -p vize_atelier_dom --tests -- --nocapture
- rtk cargo test -p vize_s1_to_s2 --features davinci-differential --tests -- --nocapture
- rtk cargo clippy -p vize_s1_to_s2 --tests -- -D warnings
- rtk cargo clippy -p vize_atelier_dom --test davinci_s2_static_style -- -D warnings
- rtk cargo clippy -p vize_atelier_dom --lib -- -D warnings
- rtk cargo fmt --all -- --check
- git diff --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=/private/tmp/vize-airi-style-focus-1788170895 rtk cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture

AIRI full smoke: current origin/main d6d3f23dc had 28 divergences; this branch has 19. The remaining full-sweep failures are outside the requested style/props emission scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5497"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790763893&installation_model_id=422833&pr_number=5497&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5497&signature=6dd1d033cbdb12b58934fe0f483f38f9500551cecf15088bfed946e56be1c00b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->