### PR TITLE
fix(davinci): detect TS-only model syntax structurally

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_model.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_model.rs
@@ -38,6 +38,12 @@ const BATTERY: &[(&str, &str)] = &[
     ("class_bind", r#"<input :class="c" v-model="msg">"#),
     ("style_bind", r#"<input :style="s" v-model="msg">"#),
     ("input_ts_cast", r#"<input v-model="voice as any">"#),
+    (
+        "input_ts_cast_comment",
+        r#"<input v-model="voice/*x*/as any">"#,
+    ),
+    ("input_ts_non_null", r#"<input v-model="voice!">"#),
+    ("input_string_as", r#"<input v-model="form[' as ']">"#),
     ("spread_then", r#"<input v-bind="obj" v-model="msg">"#),
     ("then_spread", r#"<input v-model="msg" v-bind="obj">"#),
     ("vif", r#"<input v-if="ok" v-model="msg">"#),
@@ -53,6 +59,7 @@ const BATTERY: &[(&str, &str)] = &[
         "comp_arg_ts_cast",
         r#"<Foo v-model:voice="voice as any" />"#,
     ),
+    ("comp_arg_ts_non_null", r#"<Foo v-model:voice="voice!" />"#),
     (
         "comp_kebab_arg",
         r#"<Foo v-model:auto-send="autoSendEnabled" />"#,

--- a/crates/vize_s1_to_s2/src/emit/model_key.rs
+++ b/crates/vize_s1_to_s2/src/emit/model_key.rs
@@ -1,7 +1,9 @@
 //! Object key spelling for component `ui.model` product props.
 
+use oxc_ast::ast as js;
+use oxc_ast_visit::Visit;
 use vize_s0::{String, camelize};
-use vize_s2::expr::JsExpr;
+use vize_s2::expr::{ExprRef, JsExpr};
 
 use super::EmitCx;
 use super::js::push_ident_key;
@@ -28,10 +30,15 @@ pub(super) fn emit_value(cx: &mut EmitCx<'_>, name: ModelName<'_>, source: &str)
     cx.buf.push(source);
 }
 
-pub(super) fn emit_update(cx: &mut EmitCx<'_>, key: &ModelUpdateKey<'_>, source: &str) {
+pub(super) fn emit_update(
+    cx: &mut EmitCx<'_>,
+    key: &ModelUpdateKey<'_>,
+    read: &ExprRef<'_>,
+    source: &str,
+) {
     emit_update_key(cx, key);
     cx.buf.push(": ");
-    emit_assignment(cx, source);
+    emit_assignment(cx, read, source);
 }
 
 pub(super) fn emit_modifiers(
@@ -113,8 +120,8 @@ fn emit_modifiers_key(cx: &mut EmitCx<'_>, key: &ModelModifiersKey<'_>) {
     }
 }
 
-pub(super) fn emit_assignment(cx: &mut EmitCx<'_>, source: &str) {
-    if is_ts_as_assignment_target(source) {
+pub(super) fn emit_assignment(cx: &mut EmitCx<'_>, read: &ExprRef<'_>, source: &str) {
+    if contains_ts_only_syntax(read) {
         cx.buf.push("$event => ($event => ($event => ((");
         cx.buf.push(source);
         cx.buf.push(") = $event)))");
@@ -125,6 +132,37 @@ pub(super) fn emit_assignment(cx: &mut EmitCx<'_>, source: &str) {
     cx.buf.push(") = $event)");
 }
 
-fn is_ts_as_assignment_target(source: &str) -> bool {
-    source.contains(" as ")
+fn contains_ts_only_syntax(read: &ExprRef<'_>) -> bool {
+    let ExprRef::Js(js) = read else {
+        return false;
+    };
+    let mut scan = TsOnlySyntaxScan { seen: false };
+    scan.visit_expression(js.ast);
+    scan.seen
+}
+
+struct TsOnlySyntaxScan {
+    seen: bool,
+}
+
+impl<'a> Visit<'a> for TsOnlySyntaxScan {
+    fn visit_ts_as_expression(&mut self, _expr: &js::TSAsExpression<'a>) {
+        self.seen = true;
+    }
+
+    fn visit_ts_satisfies_expression(&mut self, _expr: &js::TSSatisfiesExpression<'a>) {
+        self.seen = true;
+    }
+
+    fn visit_ts_type_assertion(&mut self, _expr: &js::TSTypeAssertion<'a>) {
+        self.seen = true;
+    }
+
+    fn visit_ts_non_null_expression(&mut self, _expr: &js::TSNonNullExpression<'a>) {
+        self.seen = true;
+    }
+
+    fn visit_ts_instantiation_expression(&mut self, _expr: &js::TSInstantiationExpression<'a>) {
+        self.seen = true;
+    }
 }

--- a/crates/vize_s1_to_s2/src/emit/props_object.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_object.rs
@@ -113,7 +113,7 @@ pub(super) fn emit_props_object(
             }
             Piece::ModelUpdate { key, model, .. } => {
                 let source = super::model::js_source(model)?;
-                super::model_key::emit_update(cx, key, source.as_str())
+                super::model_key::emit_update(cx, key, &model.contract.read, source.as_str())
             }
             Piece::ModelModifiers {
                 name, modifiers, ..

--- a/crates/vize_s1_to_s2/src/emit/props_object_merge.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_object_merge.rs
@@ -46,7 +46,7 @@ pub(super) fn emit_handlers(
             Piece::On(event) => on::emit_on_value(cx, event)?,
             Piece::ModelUpdate { model, .. } => {
                 let source = super::model::js_source(model)?;
-                super::model_key::emit_assignment(cx, source.as_str());
+                super::model_key::emit_assignment(cx, &model.contract.read, source.as_str());
             }
             _ => {}
         }


### PR DESCRIPTION
## Summary
- replace string scanning for TS-only v-model targets with an AST walk over retained S2 expressions
- keep JS expressions containing the text ` as ` from taking the TS fallback path
- add model parity regressions for commented casts, non-null assertions, and string-literal ` as ` member keys

## Tests
- cargo test -q -p vize_atelier_dom --test davinci_s2_model s2_v_model_matches_the_shipped_dom_lane_byte_for_byte -- --exact --nocapture
- cargo test -q -p vize_s1_to_s2
- cargo test -q -p vize_s1_to_s2 --test emit_model
- cargo fmt --all -- --check
- cargo clippy -q -p vize_s1_to_s2 --all-targets -- -D warnings -D clippy::wildcard_imports
- cargo clippy -q -p vize_atelier_dom --test davinci_s2_model -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790763923&installation_model_id=422833&pr_number=5498&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5498&signature=20712d64890e4f0510a29bda1eead3a3540997c6853929742b7ba194e1f136f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->