### PR TITLE
fix(davinci): preserve block handler line comments

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_handler_parity.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_handler_parity.rs
@@ -21,6 +21,19 @@ const BATTERY: &[(&str, &str)] = &[
         "typed_arrow_component_handler_with_static_props",
         r#"<FieldKeyValues label="Headers" @remove="(index: number) => removeKeyValue(index, headers)" />"#,
     ),
+    (
+        "block_arrow_handler_preserves_line_comment",
+        r#"<button @click="() => {
+if (active) {
+  // keep active click note
+  next();
+}
+else {
+  // keep inactive click note
+  select();
+}
+}"></button>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/on.rs
+++ b/crates/vize_s1_to_s2/src/emit/on.rs
@@ -202,9 +202,11 @@ fn emit_mod_array(cx: &mut EmitCx<'_>, mods: &[&str]) {
 }
 
 pub(super) fn emit_handler(cx: &mut EmitCx<'_>, js: &JsExpr<'_>) {
-    if is_handler_reference(js.ast)
-        || (is_function(js.ast) && !super::on_typed::is_typed_arrow(js.ast))
-    {
+    if is_handler_reference(js.ast) || super::on_body::preserves_raw_function_handler(js) {
+        cx.buf.push(js.source);
+        return;
+    }
+    if is_function(js.ast) && !super::on_typed::is_typed_arrow(js.ast) {
         super::js::push_js_expr(cx, js);
         return;
     }

--- a/crates/vize_s1_to_s2/src/emit/on_body.rs
+++ b/crates/vize_s1_to_s2/src/emit/on_body.rs
@@ -1,5 +1,8 @@
 //! Block-body event handlers (`$event => { ... }`).
 
+use oxc_ast::ast::Expression;
+use vize_s2::expr::JsExpr;
+
 use super::EmitCx;
 
 pub(super) fn emit(cx: &mut EmitCx<'_>, source: &str) {
@@ -11,7 +14,16 @@ pub(super) fn emit(cx: &mut EmitCx<'_>, source: &str) {
     cx.buf.push("}");
 }
 
-fn ends_in_line_comment(source: &str) -> bool {
+pub(super) fn preserves_raw_function_handler(js: &JsExpr<'_>) -> bool {
+    let is_block_function = match js.ast {
+        Expression::ArrowFunctionExpression(arrow) => !arrow.expression,
+        Expression::FunctionExpression(function) => function.body.is_some(),
+        _ => false,
+    };
+    is_block_function && !ends_in_line_comment(js.source)
+}
+
+pub(super) fn ends_in_line_comment(source: &str) -> bool {
     let bytes = source.as_bytes();
     let mut index = 0usize;
     let mut state = ScanState::Code;


### PR DESCRIPTION
## Summary
- keep raw block-function handler source when it is self-contained, preserving `//` comments inside event handler block bodies
- retain line-comment-to-block safety for expression handler values that can comment out generated syntax
- add a shipped DOM lane regression for block arrow handler line comments

## Validation
- `rtk cargo test -p vize_atelier_dom --test davinci_s2_handler_parity -- --nocapture`
- `rtk cargo test -p vize_s1_to_s2 --test emit_on_handler_body --test emit_on --test emit_raw_comment_format -- --nocapture`
- `rtk cargo test -q -p vize_s1_to_s2`
- `rtk cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings`
- `rtk cargo clippy -p vize_atelier_dom --test davinci_s2_handler_parity -- -D warnings`
- `rtk cargo fmt --all -- --check`
- `rtk git diff --check`
- `SOURCE_LENGTH_BASE_REF=origin/main rtk node --test tests/tooling/source-file-lengths.test.ts`
- `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=/Users/nishimura/Code/github.com/ubugeeei/vize--davinci-static-style-20260831/tests/_fixtures/_git/airi rtk cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture` fails as expected with AIRI residuals at 24 divergences; `steps.story.vue` is no longer in the residual list. This branch does not include #5499 yet, so `ripple-grid/index.story.vue` remains until that PR lands.