### PR TITLE
fix(maestro): resolve dotted basename imports

### DIFF
--- a/crates/vize/tests/lsp_dotted_basename_cli.rs
+++ b/crates/vize/tests/lsp_dotted_basename_cli.rs
@@ -1,0 +1,184 @@
+use std::path::Path;
+
+use serde_json::json;
+use vize_s0::{corsa_resolver::discover_corsa_in_ancestors, cstr};
+
+#[path = "support/lsp_process.rs"]
+mod lsp_process;
+
+use lsp_process::{LspProcess, file_uri};
+
+#[test]
+fn lsp_corsa_resolves_dotted_basename_relative_imports() {
+    let workspace_root = workspace_root();
+    let Some(corsa_path) = discover_corsa_in_ancestors(workspace_root) else {
+        eprintln!(
+            "skipping LSP Corsa dotted basename regression: TypeScript 7 Corsa runtime is unavailable"
+        );
+        return;
+    };
+    let project = create_project(workspace_root, &corsa_path);
+    let project_root = project.path();
+    let app_path = project_root.join("src/a.vue");
+    let source = std::fs::read_to_string(&app_path).unwrap();
+    let app_uri = file_uri(&app_path);
+    let mut lsp = LspProcess::spawn(project_root);
+
+    initialize(&mut lsp, project_root);
+    lsp.send(json!({
+        "jsonrpc": "2.0",
+        "method": "initialized",
+        "params": {}
+    }));
+    lsp.send(json!({
+        "jsonrpc": "2.0",
+        "method": "textDocument/didOpen",
+        "params": {
+            "textDocument": {
+                "uri": app_uri,
+                "languageId": "vue",
+                "version": 1,
+                "text": source
+            }
+        }
+    }));
+
+    let publication = lsp.recv_matching(|message| {
+        message["method"].as_str() == Some("textDocument/publishDiagnostics")
+            && message["params"]["uri"].as_str() == Some(app_uri.as_str())
+            && message["params"]["version"].as_i64() == Some(1)
+    });
+    let diagnostics = publication["params"]["diagnostics"]
+        .as_array()
+        .expect("diagnostics array");
+    if diagnostics.iter().any(|diagnostic| {
+        diagnostic["code"].as_i64() == Some(2307)
+            || diagnostic["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("Cannot find module './x.use'"))
+    }) || !diagnostics.is_empty()
+    {
+        lsp.fail(cstr!(
+            "LSP dotted basename import must not publish diagnostics:\n{publication:#}"
+        ));
+    }
+
+    lsp.send(json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "shutdown"
+    }));
+    let shutdown = lsp.recv_response(2);
+    assert!(shutdown["result"].is_null(), "{shutdown:#}");
+    lsp.send(json!({
+        "jsonrpc": "2.0",
+        "method": "exit"
+    }));
+    let status = lsp.wait_for_exit();
+    assert!(status.success(), "LSP exited with {status}");
+}
+
+fn initialize(lsp: &mut LspProcess, project_root: &Path) {
+    lsp.send(json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "processId": null,
+            "rootUri": file_uri(project_root),
+            "capabilities": {},
+            "initializationOptions": {
+                "lint": false,
+                "typecheck": true,
+                "ecosystem": false
+            }
+        }
+    }));
+    let initialize = lsp.recv_response(1);
+    assert!(initialize["result"].is_object(), "{initialize:#}");
+}
+
+fn create_project(workspace_root: &Path, corsa_path: &Path) -> tempfile::TempDir {
+    let cases_root = workspace_root.join("target/vize-tests/tests");
+    std::fs::create_dir_all(&cases_root).unwrap();
+    let project = tempfile::Builder::new()
+        .prefix("lsp-corsa-dotted-basename-")
+        .tempdir_in(cases_root)
+        .unwrap();
+    let project_root = project.path();
+    std::fs::create_dir_all(project_root.join("src")).unwrap();
+    write_vue_package(project_root);
+    write_project_config(project_root, corsa_path);
+    std::fs::write(
+        project_root.join("src/x.use.ts"),
+        r#"export type ValidationRule = (v: unknown) => true | string;
+export const useX = () => 1;
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("src/a.vue"),
+        r#"<script setup lang="ts">
+import { useX, type ValidationRule } from "./x.use";
+const r: ValidationRule = () => true;
+console.log(useX(), r);
+</script>
+
+<template><div /></template>
+"#,
+    )
+    .unwrap();
+    project
+}
+
+fn write_vue_package(project_root: &Path) {
+    let vue_dir = project_root.join("node_modules/vue");
+    std::fs::create_dir_all(&vue_dir).unwrap();
+    std::fs::write(
+        vue_dir.join("package.json"),
+        r#"{"name":"vue","version":"3.0.0","types":"index.d.ts"}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        vue_dir.join("index.d.ts"),
+        r#"export type DefineComponent<P = any> = { new(): { $props: P } };
+export interface ComponentPublicInstance {
+  $attrs: Record<string, unknown>;
+  $slots: Record<string, unknown>;
+  $refs: Record<string, unknown>;
+  $emit: (...args: unknown[]) => void;
+}
+"#,
+    )
+    .unwrap();
+}
+
+fn write_project_config(project_root: &Path, corsa_path: &Path) {
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{"compilerOptions":{"strict":true,"moduleResolution":"bundler","module":"ESNext","target":"ESNext","noEmit":true},"include":["src/**/*"]}"#,
+    )
+    .unwrap();
+    let config = json!({
+        "typeChecker": {
+            "corsaPath": corsa_path,
+        },
+        "lsp": {
+            "lint": false,
+            "typecheck": true,
+            "ecosystem": false,
+        },
+    });
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        serde_json::to_vec_pretty(&config).unwrap(),
+    )
+    .unwrap();
+}
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}

--- a/crates/vize_canon/src/corsa_bridge/vue_dependency_paths.rs
+++ b/crates/vize_canon/src/corsa_bridge/vue_dependency_paths.rs
@@ -2,16 +2,18 @@
 
 use std::path::{Path, PathBuf};
 
+use vize_carton::cstr;
+
 pub(super) fn resolve_relative_script_import(dir: &Path, specifier: &str) -> Option<PathBuf> {
     let base = dir.join(specifier);
-    if base.extension().is_some() {
+    if has_known_script_extension(&base) {
         return known_script_path(&base).then(|| normalize_path(&base));
     }
 
     for ext in [
         "ts", "tsx", "mts", "cts", "d.ts", "d.mts", "d.cts", "js", "jsx", "mjs", "cjs",
     ] {
-        let candidate = base.with_extension(ext);
+        let candidate = append_extension(&base, ext);
         if candidate.exists() {
             return Some(normalize_path(&candidate));
         }
@@ -37,6 +39,17 @@ pub(super) fn resolve_relative_script_import(dir: &Path, specifier: &str) -> Opt
     None
 }
 
+fn has_known_script_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            matches!(
+                extension,
+                "ts" | "tsx" | "mts" | "cts" | "js" | "jsx" | "mjs" | "cjs"
+            )
+        })
+}
+
 fn known_script_path(path: &Path) -> bool {
     let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
         return false;
@@ -50,6 +63,13 @@ fn known_script_path(path: &Path) -> bool {
             || name.ends_with(".jsx")
             || name.ends_with(".mjs")
             || name.ends_with(".cjs"))
+}
+
+fn append_extension(path: &Path, extension: &str) -> PathBuf {
+    path.file_name().and_then(|name| name.to_str()).map_or_else(
+        || path.to_path_buf(),
+        |name| path.with_file_name(cstr!("{name}.{extension}")),
+    )
 }
 
 pub(super) fn normalize_path(path: &Path) -> PathBuf {
@@ -97,6 +117,20 @@ mod tests {
         assert_eq!(
             resolve_relative_script_import(&src, "./schema").as_deref(),
             Some(schema.as_path())
+        );
+    }
+
+    #[test]
+    fn resolves_extensionless_imports_with_dotted_basenames() {
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        std::fs::create_dir_all(&src).expect("src dir");
+        let target = src.join("x.use.ts");
+        std::fs::write(&target, "export const useX = () => 1;\n").expect("dotted module");
+
+        assert_eq!(
+            resolve_relative_script_import(&src, "./x.use").as_deref(),
+            Some(target.as_path())
         );
     }
 }

--- a/crates/vize_maestro/src/ide/definition/module_specifier.rs
+++ b/crates/vize_maestro/src/ide/definition/module_specifier.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, Range, Url};
 use vize_canon::{PackageRouteResolver, PackageSourceOptions};
+use vize_s0::cstr;
 
 #[cfg(feature = "native")]
 use vize_canon::CorsaBridge;
@@ -181,10 +182,14 @@ fn resolve_file_candidate(candidate: &Path) -> Option<PathBuf> {
     if candidate.is_file() {
         return candidate.canonicalize().ok();
     }
+    let extension_mode = extension_mode(candidate);
     for extension in [
         "vue", "d.ts", "d.mts", "d.cts", "ts", "tsx", "mts", "cts", "js", "mjs", "cjs",
     ] {
-        let with_extension = candidate.with_extension(extension);
+        let with_extension = match extension_mode {
+            ExtensionMode::Replace => candidate.with_extension(extension),
+            ExtensionMode::Append => append_extension(candidate, extension),
+        };
         if with_extension.is_file() {
             return with_extension.canonicalize().ok();
         }
@@ -204,4 +209,35 @@ fn resolve_file_candidate(candidate: &Path) -> Option<PathBuf> {
         }
     }
     None
+}
+
+#[derive(Clone, Copy)]
+enum ExtensionMode {
+    Replace,
+    Append,
+}
+
+fn extension_mode(candidate: &Path) -> ExtensionMode {
+    let Some(extension) = candidate
+        .extension()
+        .and_then(|extension| extension.to_str())
+    else {
+        return ExtensionMode::Replace;
+    };
+    if [
+        "vue", "d.ts", "d.mts", "d.cts", "ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs",
+    ]
+    .contains(&extension)
+    {
+        ExtensionMode::Replace
+    } else {
+        ExtensionMode::Append
+    }
+}
+
+fn append_extension(path: &Path, extension: &str) -> PathBuf {
+    path.file_name().and_then(|name| name.to_str()).map_or_else(
+        || path.to_path_buf(),
+        |name| path.with_file_name(cstr!("{name}.{extension}")),
+    )
 }

--- a/crates/vize_maestro/src/ide/definition/module_specifier_tests.rs
+++ b/crates/vize_maestro/src/ide/definition/module_specifier_tests.rs
@@ -276,6 +276,20 @@ fn resolves_relative_declarations_and_rejects_package_escape() {
     );
 }
 
+#[test]
+fn resolves_relative_imports_with_dotted_basenames() {
+    let workspace = tempdir().unwrap();
+    let source = workspace.path().join("src/App.vue");
+    let target = workspace.path().join("src/x.use.ts");
+    write(&source, "<script setup lang=\"ts\"></script>");
+    write(&target, "export const useX = () => 1;\n");
+
+    assert_eq!(
+        resolve_specifier(&file_url(&source), "./x.use"),
+        Some(target.canonicalize().unwrap()),
+    );
+}
+
 /// Native TypeScript answers a module-specifier definition with the whole
 /// target file span. The editor contract is the module identity at its origin,
 /// so the mapped answer must collapse back to a zero-width range.

--- a/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/editor_typecheck_tests.rs
@@ -78,6 +78,59 @@ fn async_collect_resolves_relative_vue_imports_in_script_setup() {
 }
 
 #[test]
+fn async_collect_resolves_relative_ts_imports_with_dotted_basenames() {
+    let Some(corsa_path) = resolve_test_tsgo_binary() else {
+        return;
+    };
+    let project = tempfile::TempDir::new().expect("temp project");
+    let root = project.path();
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).expect("src dir");
+    super::editor_typecheck_fixture::write_vue_test_package(root);
+    std::fs::write(
+        root.join("tsconfig.json"),
+        r#"{"compilerOptions":{"strict":true,"moduleResolution":"bundler","module":"ESNext","target":"ESNext","noEmit":true},"include":["src/**/*"]}"#,
+    )
+    .expect("tsconfig");
+    std::fs::write(
+        src.join("x.use.ts"),
+        r#"export type ValidationRule = (v: unknown) => true | string;
+export const useX = () => 1;
+"#,
+    )
+    .expect("dotted module");
+    write_corsa_config(root, &corsa_path);
+
+    let vue_path = src.join("a.vue");
+    let source = r#"<script setup lang="ts">
+import { useX, type ValidationRule } from "./x.use";
+const r: ValidationRule = () => true;
+console.log(useX(), r);
+</script>
+
+<template><div /></template>
+"#;
+    std::fs::write(&vue_path, source).expect("vue source");
+    let uri = Url::from_file_path(&vue_path).expect("file uri");
+    let state = state_for_fixture(root, &uri, source);
+    state.load_workspace_config(root);
+
+    let diagnostics = crate::runtime::block_on(DiagnosticService::collect_async(&state, &uri));
+
+    assert!(
+        diagnostics.iter().all(|diagnostic| {
+            diagnostic.code != Some(tower_lsp::lsp_types::NumberOrString::Number(2307))
+                && !diagnostic.message.contains("Cannot find module './x.use'")
+        }),
+        "dotted basename imports must resolve in editor diagnostics: {diagnostics:#?}",
+    );
+    assert!(
+        diagnostics.is_empty(),
+        "expected clean editor diagnostics, got: {diagnostics:#?}",
+    );
+}
+
+#[test]
 #[cfg(unix)]
 fn async_collect_resolves_workspace_package_vue_exports() {
     assert_workspace_package_vue_export_resolves("./src/Widget.vue", None);

--- a/crates/vize_maestro/src/server/importers.rs
+++ b/crates/vize_maestro/src/server/importers.rs
@@ -12,7 +12,7 @@ use oxc_span::SourceType;
 use parking_lot::{Mutex, RwLock};
 use tower_lsp::lsp_types::Url;
 use vize_canon::{PackageRouteResolver, PackageSourceOptions};
-use vize_s0::{FxHashMap, FxHashSet};
+use vize_s0::{FxHashMap, FxHashSet, cstr};
 
 use super::ServerState;
 pub(super) use dependents::open_typecheck_dependents;
@@ -268,12 +268,12 @@ fn resolve_relative_import(importer_dir: &Path, specifier: &str) -> Option<PathB
             .find(|candidate| candidate.exists())
             .map(|candidate| comparable_path(&candidate));
     }
-    if Path::new(specifier).extension().is_some() {
+    if has_script_extension(Path::new(specifier)) {
         return Some(comparable_path(&joined));
     }
     SCRIPT_EXTENSIONS
         .iter()
-        .map(|extension| joined.with_extension(extension))
+        .map(|extension| append_extension(&joined, extension))
         .chain(
             SCRIPT_EXTENSIONS
                 .iter()
@@ -281,6 +281,19 @@ fn resolve_relative_import(importer_dir: &Path, specifier: &str) -> Option<PathB
         )
         .find(|candidate| candidate.exists())
         .map(|candidate| comparable_path(&candidate))
+}
+
+fn has_script_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| SCRIPT_EXTENSIONS.contains(&extension))
+}
+
+fn append_extension(path: &Path, extension: &str) -> PathBuf {
+    path.file_name().and_then(|name| name.to_str()).map_or_else(
+        || path.to_path_buf(),
+        |name| path.with_file_name(cstr!("{name}.{extension}")),
+    )
 }
 
 fn comparable_path(path: &Path) -> PathBuf {

--- a/crates/vize_maestro/src/server/importers_tests.rs
+++ b/crates/vize_maestro/src/server/importers_tests.rs
@@ -98,6 +98,23 @@ fn index_resolves_explicit_script_dependencies_and_query_suffixes() {
 }
 
 #[test]
+fn index_resolves_extensionless_imports_with_dotted_basenames() {
+    let dir = tempfile::tempdir().unwrap();
+    let dependency = dir.path().join("x.use.ts");
+    let parent = dir.path().join("Parent.vue");
+    std::fs::write(&dependency, "export const useX = () => 1").unwrap();
+    std::fs::write(&parent, "<template />").unwrap();
+    let dependency_uri = Url::from_file_path(&dependency).unwrap();
+    let parent_uri = Url::from_file_path(&parent).unwrap();
+    let state = ServerState::new();
+    let source = "<script setup lang=\"ts\">import { useX } from './x.use'; useX()</script>";
+
+    state.update_virtual_docs(&parent_uri, source);
+
+    assert_eq!(open_importers(&state, &dependency_uri), vec![parent_uri]);
+}
+
+#[test]
 fn index_resolves_package_export_declaration_variants() {
     let dir = tempfile::tempdir().unwrap();
     let package = dir.path().join("node_modules/vue-router");

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -47,10 +47,10 @@ observational guard for planning only. It does not change rollout state.
 | -------------------------- | ------------: | --------------------: | ----------------: | --------------: | ------: | --------------: | -------: | ------------: | ------------: |
 | Compiler                   |           928 |                   487 |               441 |             140 |     371 |             941 |      498 |           488 |           606 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
-| Typechecker                |           879 |                   238 |               641 |             396 |     187 |             807 |      655 |           467 |           664 |
+| Typechecker                |           880 |                   238 |               642 |             396 |     187 |             808 |      655 |           468 |           666 |
 | Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
-| LSP                        |           271 |                   271 |                 0 |             115 |      44 |             325 |      105 |           166 |           388 |
+| LSP                        |           272 |                   272 |                 0 |             115 |      44 |             326 |      105 |           167 |           388 |
 
 ## Consumer details
 
@@ -134,7 +134,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         879 |             503 |      376 |
+| S0               |         880 |             504 |      376 |
 | old AST/parser   |         160 |              35 |      125 |
 | Croquis analysis |         236 |             118 |      118 |
 | raw OXC          |         187 |             151 |       36 |
@@ -149,7 +149,7 @@ Scope: check command plus Canon, excluding dedicated content-mapper files. This 
 | `crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/cache.rs:7` | source   | S0 10                                                       |    10 |
 | `crates/vize_canon/src/virtual_ts/expressions/statements.rs:15`                | source   | S0 6<br>Croquis analysis 3                                  |     9 |
 
-Additional source/manifest rows are in the TSV: 309 omitted.
+Additional source/manifest rows are in the TSV: 310 omitted.
 
 #### Top test/dev files
 
@@ -227,7 +227,7 @@ Scope: lsp/ide commands plus Maestro editor/server crate. This is a lexical inve
 
 | surface          | total sites | source/manifest | test/dev |
 | ---------------- | ----------: | --------------: | -------: |
-| S0               |         271 |             187 |       84 |
+| S0               |         272 |             188 |       84 |
 | old AST/parser   |          61 |              48 |       13 |
 | Croquis analysis |          54 |              46 |        8 |
 | raw OXC          |          44 |              44 |        0 |
@@ -242,7 +242,7 @@ Scope: lsp/ide commands plus Maestro editor/server crate. This is a lexical inve
 | `crates/vize_maestro/Cargo.toml:44`                             | manifest | S0 1<br>old AST/parser 2<br>Croquis analysis 1<br>raw OXC 5 |     9 |
 | `crates/vize_maestro/src/ide/hover/declaration_keyword.rs:19`   | source   | S0 1<br>old AST/parser 1<br>Croquis analysis 3<br>raw OXC 3 |     8 |
 
-Additional source/manifest rows are in the TSV: 115 omitted.
+Additional source/manifest rows are in the TSV: 116 omitted.
 
 #### Top test/dev files
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -1824,6 +1824,7 @@ typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependenci
 typechecker	Typechecker	test/dev	crates/vize_canon/src/corsa_bridge/vue_dependencies_alias/context/routes.rs	177	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies_walk.rs	6	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependencies.rs	7	s0	S0	stage	vize_carton	compat	1
+typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependency_paths.rs	5	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs	1	s0	S0	stage	vize_carton	compat	1
 typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs	1	raw_oxc	raw OXC	raw	oxc_allocator	raw	1
 typechecker	Typechecker	source	crates/vize_canon/src/corsa_bridge/vue_dependency_specifiers.rs	1	raw_oxc	raw OXC	raw	oxc_ast	raw	1
@@ -2554,6 +2555,7 @@ lsp	LSP	test/dev	crates/vize_maestro/src/ide/corsa_support/workspace_edit.rs	159
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/art.rs	10	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	test/dev	crates/vize_maestro/src/ide/definition/corsa_tests.rs	32	s0	S0	stage	vize_s0	preferred	2
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/import_resolver.rs	6	s0	S0	stage	vize_s0	preferred	1
+lsp	LSP	source	crates/vize_maestro/src/ide/definition/module_specifier.rs	7	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/script.rs	14	s0	S0	stage	vize_s0	preferred	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/script.rs	14	croquis	Croquis analysis	old	vize_croquis	legacy	1
 lsp	LSP	source	crates/vize_maestro/src/ide/definition/slot.rs	2	s0	S0	stage	vize_s0	preferred	1


### PR DESCRIPTION
## Summary
- Treat unknown dotted basenames like ./x.use as extensionless candidates in editor dependency resolution
- Sync the CorsaBridge dependency scan with CLI-style extension appending so x.use.ts is materialized for LSP diagnostics
- Add unit, editor diagnostic, and LSP protocol regressions for the TS2307 case

## Verification
- cargo test -p vize --test lsp_dotted_basename_cli lsp_corsa_resolves_dotted_basename_relative_imports
- cargo test -p vize_canon resolves_extensionless_imports_with_dotted_basenames
- cargo test -p vize_maestro dotted_basenames
- cargo test -p vize_maestro async_collect_resolves_relative_ts_imports_with_dotted_basenames --features native
- cargo test -p vize_maestro
- cargo build -p vize --features maestro
- cargo clippy -p vize --test lsp_dotted_basename_cli --features maestro -- -D warnings
- cargo clippy -p vize_maestro --tests --features native -- -D warnings
- cargo clippy -p vize -p vize_maestro -p vize_canon --features vize/maestro -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- moon run --target native tools/moon/cmd/source_file_lengths -- --check --base-ref origin/main --limit 20
- node --test tests/tooling/davinci-matrices.test.ts

Note: cargo clippy -p vize_canon --tests -- -D warnings still fails on existing unrelated test-target disallowed type/macro findings.

Closes #5477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed TypeScript and Vue import resolution for modules with dotted filenames, such as `x.use.ts`.
  - Prevented incorrect “Cannot find module” diagnostics for valid relative imports.
  - Improved consistency across editor typechecking, language-server diagnostics, and module navigation.

- **Tests**
  - Added regression coverage for dotted-basename imports in typechecking and language-server workflows.

- **Documentation**
  - Updated migration-surface inventories to reflect current coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->