### PR TITLE
fix(davinci): preserve template slot helper order

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_helper_composition.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_helper_composition.rs
@@ -85,6 +85,26 @@ const BATTERY: &[(&str, &str)] = &[
         "slot_fallback_component_resolves_before_owner_component",
         r#"<DropdownMenuTrigger><slot name="trigger"><span>{{ label }}</span><Icon icon="x" /></slot></DropdownMenuTrigger><DropdownMenuItem><span>Item</span></DropdownMenuItem>"#,
     ),
+    (
+        "slot_outlet_and_static_child_keeps_root_element_vnode_before_slot",
+        r#"<div><slot /><span>{{ label }}</span></div>"#,
+    ),
+    (
+        "template_slot_carrier_imports_slot_before_element_vnode",
+        r#"<Collapsible :default="expand"><template #trigger="slotProps"><button :class="['w-full']"><slot name="title"><div>{{ title }}</div></slot></button></template><div :class="innerClass"><slot /></div></Collapsible>"#,
+    ),
+    (
+        "nested_template_slot_carrier_before_later_slot_outlet",
+        r#"<Section><FieldRange><template #label><div>{{ label }}</div></template></FieldRange><label><div><slot name="label">{{ fallback }}</slot></div><SelectTab /></label></Section>"#,
+    ),
+    (
+        "component_default_element_wraps_slot_outlet",
+        r#"<Section><label><div><slot name="label">{{ fallback }}</slot></div><SelectTab /></label></Section>"#,
+    ),
+    (
+        "earlier_root_component_template_slot_before_later_root_slot_outlet",
+        r#"<Section><FieldRange><template #label><div>{{ label }}</div></template></FieldRange></Section><Section><label><div><slot name="label">{{ fallback }}</slot></div><SelectTab /></label></Section>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -53,6 +53,7 @@ mod filter;
 mod flag;
 mod fragment;
 mod helper;
+mod helper_preference;
 mod hoist;
 mod html;
 pub(crate) mod js;
@@ -96,7 +97,7 @@ use vize_davinci::pass::BudgetObserver;
 use vize_davinci::side_table::SideTable;
 use vize_s0::{Allocator, String};
 use vize_s1::parse;
-use vize_s2::op::{ElementOp, ForOp, IfOp, Namespace, Op, Region};
+use vize_s2::op::{ElementOp, ForOp, IfOp, Namespace};
 use vize_s2::scope::ScopeFacts;
 
 use crate::lower::{ForWrapper, LegacyCaps, Lowered, WrapperKeys, lower_with_caps};
@@ -107,63 +108,6 @@ use self::buf::Buf;
 pub use self::error::{EmitError, UnsupportedReason, UnsupportedRefusal};
 use self::fragment::emit_root;
 use self::helper::Helper;
-
-fn prefer_helpers(buf: &mut Buf, facts: &S2Facts, walk: &mut PageWalk, region: &Region<'_>) {
-    for op in region.ops.iter() {
-        let id = walk.mint();
-        match op {
-            Op::Element(element) if sfc_style::is_carrier_element(element) => {
-                walk.skip(element.bindings.len())
-            }
-            Op::Element(element) => {
-                let bindings = &element.bindings;
-                directive::prefer_helpers(buf, bindings);
-                buf.prefer(Helper::CreateElementVNode);
-                walk.skip(bindings.len());
-                prefer_helpers(buf, facts, walk, &element.children);
-            }
-            Op::Component(component) => {
-                let bindings = &component.bindings;
-                directive::prefer_helpers(buf, bindings);
-                buf.prefer(Helper::ResolveComponent);
-                walk.skip(bindings.len());
-                prefer_helpers(buf, facts, walk, &component.children);
-            }
-            Op::Slot(slot) => {
-                buf.prefer(Helper::RenderSlot);
-                walk.skip(slot.bindings.len());
-                prefer_helpers(buf, facts, walk, &slot.fallback);
-            }
-            Op::If(if_op) => {
-                buf.prefer(Helper::OpenBlock);
-                buf.prefer(Helper::CreateBlock);
-                buf.prefer(Helper::CreateElementBlock);
-                buf.prefer(Helper::Fragment);
-                buf.prefer(Helper::CreateComment);
-                for branch in if_op.branches.iter() {
-                    prefer_helpers(buf, facts, walk, &branch.region);
-                }
-            }
-            Op::For(for_op) => {
-                buf.prefer(Helper::RenderList);
-                buf.prefer(Helper::OpenBlock);
-                buf.prefer(Helper::CreateBlock);
-                buf.prefer(Helper::Fragment);
-                prefer_helpers(buf, facts, walk, &for_op.region);
-            }
-            Op::Text(_) => buf.prefer(Helper::CreateText),
-            Op::Interpolation(_) => {
-                buf.prefer(Helper::ToDisplayString);
-                if id
-                    .and_then(|id| facts.text_facts.get(id))
-                    .is_some_and(|text| text.parts.iter().any(|part| !part.dynamic))
-                {
-                    buf.prefer(Helper::CreateText);
-                }
-            }
-        }
-    }
-}
 
 fn emit_if_op(cx: &mut EmitCx<'_>, if_op: &IfOp<'_>, id: Option<NodeId>) -> Result<(), EmitError> {
     vif::emit_if(cx, if_op, id)
@@ -295,7 +239,7 @@ pub fn emit_dom(lowered: &Lowered<'_>, facts: &S2Facts) -> Result<DomEmit, EmitE
         cx.buf.prefer(Helper::ResolveFilter);
     }
     let mut helper_walk = PageWalk::new();
-    prefer_helpers(&mut cx.buf, facts, &mut helper_walk, &lowered.root);
+    helper_preference::prefer_helpers(&mut cx.buf, facts, &mut helper_walk, &lowered.root);
     fragment::prefer_root_fragment(&mut cx.buf, &lowered.root);
     cx.buf
         .push("function render(_ctx, _cache, $props, $setup, $data, $options) {");

--- a/crates/vize_s1_to_s2/src/emit/helper_preference.rs
+++ b/crates/vize_s1_to_s2/src/emit/helper_preference.rs
@@ -1,0 +1,179 @@
+//! Transform-analogue helper pre-registration for the DOM emitter.
+
+use vize_s2::op::{Op, Region};
+
+use crate::pass::S2Facts;
+use crate::pass::walk::PageWalk;
+
+use super::buf::Buf;
+use super::helper::Helper;
+use super::{directive, sfc_style, slots};
+
+pub(super) fn prefer_helpers(
+    buf: &mut Buf,
+    facts: &S2Facts,
+    walk: &mut PageWalk,
+    region: &Region<'_>,
+) {
+    if component_slot_template_carrier_precedes_slot_outlet(region) {
+        buf.prefer(Helper::RenderSlot);
+    }
+    prefer_region_helpers(buf, facts, walk, region, false);
+}
+
+fn prefer_region_helpers(
+    buf: &mut Buf,
+    facts: &S2Facts,
+    walk: &mut PageWalk,
+    region: &Region<'_>,
+    template_slot_context: bool,
+) {
+    for op in region.ops.iter() {
+        let id = walk.mint();
+        match op {
+            Op::Element(element) if sfc_style::is_carrier_element(element) => {
+                walk.skip(element.bindings.len())
+            }
+            Op::Element(element) => {
+                let bindings = &element.bindings;
+                directive::prefer_helpers(buf, bindings);
+                if !template_slot_context {
+                    buf.prefer(Helper::CreateElementVNode);
+                }
+                walk.skip(bindings.len());
+                prefer_region_helpers(buf, facts, walk, &element.children, template_slot_context);
+                if template_slot_context {
+                    buf.prefer(Helper::CreateElementVNode);
+                }
+            }
+            Op::Component(component) => {
+                let bindings = &component.bindings;
+                directive::prefer_helpers(buf, bindings);
+                buf.prefer(Helper::ResolveComponent);
+                walk.skip(bindings.len());
+                let has_template_slot_carrier = has_slot_template_carrier(&component.children);
+                let template_slot_context = template_slot_context || has_template_slot_carrier;
+                if (has_template_slot_carrier && has_slot_outlet(&component.children))
+                    || component_slot_template_carrier_precedes_slot_outlet(&component.children)
+                {
+                    buf.prefer(Helper::RenderSlot);
+                }
+                prefer_region_helpers(buf, facts, walk, &component.children, template_slot_context);
+            }
+            Op::Slot(slot) => {
+                buf.prefer(Helper::RenderSlot);
+                walk.skip(slot.bindings.len());
+                prefer_region_helpers(buf, facts, walk, &slot.fallback, template_slot_context);
+            }
+            Op::If(if_op) => {
+                buf.prefer(Helper::OpenBlock);
+                buf.prefer(Helper::CreateBlock);
+                buf.prefer(Helper::CreateElementBlock);
+                buf.prefer(Helper::Fragment);
+                buf.prefer(Helper::CreateComment);
+                for branch in if_op.branches.iter() {
+                    prefer_region_helpers(buf, facts, walk, &branch.region, template_slot_context);
+                }
+            }
+            Op::For(for_op) => {
+                buf.prefer(Helper::RenderList);
+                buf.prefer(Helper::OpenBlock);
+                buf.prefer(Helper::CreateBlock);
+                buf.prefer(Helper::Fragment);
+                prefer_region_helpers(buf, facts, walk, &for_op.region, template_slot_context);
+            }
+            Op::Text(_) => buf.prefer(Helper::CreateText),
+            Op::Interpolation(_) => {
+                buf.prefer(Helper::ToDisplayString);
+                if id
+                    .and_then(|id| facts.text_facts.get(id))
+                    .is_some_and(|text| text.parts.iter().any(|part| !part.dynamic))
+                {
+                    buf.prefer(Helper::CreateText);
+                }
+            }
+        }
+    }
+}
+
+fn has_slot_template_carrier(region: &Region<'_>) -> bool {
+    region.ops.iter().any(|op| match op {
+        Op::Element(element) => slots::is_slot_template(element),
+        Op::If(if_op) => if_op
+            .branches
+            .iter()
+            .any(|branch| has_slot_template_carrier(&branch.region)),
+        Op::For(for_op) => has_slot_template_carrier(&for_op.region),
+        Op::Component(_) | Op::Text(_) | Op::Interpolation(_) | Op::Slot(_) => false,
+    })
+}
+
+fn has_slot_outlet(region: &Region<'_>) -> bool {
+    region.ops.iter().any(|op| match op {
+        Op::Element(element) => has_slot_outlet(&element.children),
+        Op::Component(component) => has_slot_outlet(&component.children),
+        Op::If(if_op) => if_op
+            .branches
+            .iter()
+            .any(|branch| has_slot_outlet(&branch.region)),
+        Op::For(for_op) => has_slot_outlet(&for_op.region),
+        Op::Slot(_) => true,
+        Op::Text(_) | Op::Interpolation(_) => false,
+    })
+}
+
+fn component_slot_template_carrier_precedes_slot_outlet(region: &Region<'_>) -> bool {
+    let mut saw_carrier = false;
+    for op in region.ops.iter() {
+        if saw_carrier && op_has_slot_outlet(op) {
+            return true;
+        }
+        saw_carrier |= op_has_component_slot_template_carrier(op);
+    }
+    false
+}
+
+fn op_has_component_slot_template_carrier(op: &Op<'_>) -> bool {
+    match op {
+        Op::Element(element) => element
+            .children
+            .ops
+            .iter()
+            .any(op_has_component_slot_template_carrier),
+        Op::Component(component) => {
+            has_slot_template_carrier(&component.children)
+                || component
+                    .children
+                    .ops
+                    .iter()
+                    .any(op_has_component_slot_template_carrier)
+        }
+        Op::If(if_op) => if_op.branches.iter().any(|branch| {
+            branch
+                .region
+                .ops
+                .iter()
+                .any(op_has_component_slot_template_carrier)
+        }),
+        Op::For(for_op) => for_op
+            .region
+            .ops
+            .iter()
+            .any(op_has_component_slot_template_carrier),
+        Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => false,
+    }
+}
+
+fn op_has_slot_outlet(op: &Op<'_>) -> bool {
+    match op {
+        Op::Element(element) => has_slot_outlet(&element.children),
+        Op::Component(component) => has_slot_outlet(&component.children),
+        Op::If(if_op) => if_op
+            .branches
+            .iter()
+            .any(|branch| has_slot_outlet(&branch.region)),
+        Op::For(for_op) => has_slot_outlet(&for_op.region),
+        Op::Slot(_) => true,
+        Op::Text(_) | Op::Interpolation(_) => false,
+    }
+}


### PR DESCRIPTION
## Summary
- move S2 DOM helper pre-registration into a focused helper_preference module
- keep top-level slot outlets on the shipped helper order while matching explicit `<template #...>` component slot carriers
- add reduced helper-order witnesses for both root slot outlet order and template-slot carrier order

## Validation
- `rtk cargo fmt --all -- --check`
- `rtk cargo test -p vize_atelier_dom --test davinci_s2_helper_composition -- --nocapture`
- `rtk cargo test -p vize_s1_to_s2 --test emit_outlets --test emit_static --test emit_slots -- --nocapture`
- `rtk cargo test -q -p vize_s1_to_s2`
- `rtk cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings`
- `rtk cargo clippy -p vize_atelier_dom --test davinci_s2_helper_composition -- -D warnings`
- `SOURCE_LENGTH_BASE_REF=origin/main rtk node --test tests/tooling/source-file-lengths.test.ts`
- `rtk node --test tests/tooling/davinci-matrices.test.ts`
- `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=/private/tmp/vize-davinci-template-slot-helper-order-20260831/tests/_fixtures/_git/airi rtk cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture` (expected residual failure; AIRI smoke reports `divergences=12`, `old_error_skips=2`, `s2_refusals=0`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790767320&installation_model_id=422833&pr_number=5504&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5504&signature=602b9fb5556cb29c7398548f742495af1caf1e02cee0e90db7e97ba88fe8a04a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->