### PR TITLE
fix(davinci): preserve static hoist text separators

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_static_cache.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_static_cache.rs
@@ -23,6 +23,10 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<div class="root"><button><span>x</span></button><i :id="foo"></i></div>"#,
     ),
     (
+        "static_slot_hoist_keeps_inline_space_text_child",
+        r#"<Variant><div><span>Project</span> <span>AIRI</span></div></Variant>"#,
+    ),
+    (
         "airi_loading_component_formats_nested_static_props_inside_for",
         r#"<div flex flex-col gap-2><div v-for="file in files" :key="file.filename" max-w-full flex flex-col gap="1 sm:2"><div grid="~ cols-[85%_15%]" justify-between text="xs sm:sm neutral-600 dark:neutral-400"><div flex items-center gap-1>{{ file.filename }}</div></div></div></div>"#,
     ),

--- a/crates/vize_s1_to_s2/src/emit/hoist.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist.rs
@@ -141,7 +141,7 @@ fn walk_hoisted(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) {
 }
 
 fn hoist_needs_create_text(element: &ElementOp<'_>) -> bool {
-    let kids = meaningful(&element.children);
+    let kids = renderable_children(&element.children);
     let has_text = kids.iter().any(|op| matches!(op, Op::Text(_)));
     let has_other = kids.iter().any(|op| !matches!(op, Op::Text(_)));
     (has_text && has_other)
@@ -161,7 +161,7 @@ fn hoist_element_rhs(element: &ElementOp<'_>, pure: bool) -> String {
     out.push('"');
     out.push_str(element.tag);
     out.push('"');
-    let kids = meaningful(&element.children);
+    let kids = renderable_children(&element.children);
     let has_attrs = !element.attributes.is_empty();
     if has_attrs || !kids.is_empty() {
         out.push_str(", ");
@@ -203,7 +203,7 @@ fn append_cached_element_rhs(
         cached_props::push_object(out, element.attributes.iter(), line_indent);
     }
     out.push_str(", ");
-    let kids = meaningful(&element.children);
+    let kids = renderable_children(&element.children);
     if kids.is_empty() {
         out.push_str("null");
     } else {
@@ -291,16 +291,10 @@ fn push_spaces(out: &mut String, width: usize) {
     out.extend(core::iter::repeat_n(' ', width));
 }
 
-fn meaningful<'a>(children: &'a Region<'a>) -> StdVec<&'a Op<'a>> {
-    children
-        .ops
-        .iter()
-        .filter(|op| !is_whitespace_text(op))
-        .collect()
-}
-
-fn is_whitespace_text(op: &Op<'_>) -> bool {
-    matches!(op, Op::Text(text) if text.content.chars().all(char::is_whitespace))
+fn renderable_children<'a>(children: &'a Region<'a>) -> StdVec<&'a Op<'a>> {
+    // S2 lowering has already applied legacy condense/drop decisions; every
+    // remaining text op is renderable, including a single-space separator.
+    children.ops.iter().collect()
 }
 
 /// First-occurrence static attrs as a single-line object, matching


### PR DESCRIPTION
## Summary
- preserve already-lowered text children when serializing static hoisted/cached S2 element subtrees
- add a reduced component-slot static hoist regression for a single-space separator between spans

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_static_cache s2_static_child_cache_matches_the_shipped_dom_lane_byte_for_byte -- --exact
- cargo test -p vize_atelier_dom --test davinci_s2_static_vnode_hoist
- cargo test -p vize_atelier_dom --test davinci_s2_dom s2_native_html_and_interpolations_match_the_shipped_dom_lane_byte_for_byte -- --exact
- cargo test -p vize_atelier_dom --test davinci_s2_slots
- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- cargo check -p vize_s1_to_s2 -p vize_atelier_dom --tests
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git/airi cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus dom_emit_agrees_on_sfc_templates -- --exact --nocapture (expected residual sweep failure: current origin/main 14 divergences; this branch 13; TypographySans.story.vue removed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790767365&installation_model_id=422833&pr_number=5505&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5505&signature=b568eee746ef40b81e69d9335deb55afd15f6d67ed7b660ffaaf91333fb6887f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->