### PR TITLE
fix(davinci): align static icon hoist order

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_static_vnode_hoist.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_static_vnode_hoist.rs
@@ -37,6 +37,18 @@ const BATTERY: &[(&str, &str)] = &[
         "v_for_item_root_hoists_static_child_vnodes",
         r#"<div v-for="item in items" :key="item.id"><span class="icon"></span>{{ item.name }}</div>"#,
     ),
+    (
+        "component_slot_dynamic_text_parent_keeps_icon_inline",
+        r#"<Panel><label :class="['flex', 'items-center', 'gap-2']"><div i-solar:magic-stick-bold-duotone></div>{{ t('settings.pages.modules.artistry.autonomous.title') }}</label><Checkbox></Checkbox></Panel>"#,
+    ),
+    (
+        "branch_child_dynamic_text_parent_keeps_icon_inline",
+        r#"<div v-if="isCorsError"><div class="flex items-center gap-2"><div i-solar:shield-warning-bold-duotone></div>{{ t('settings.pages.providers.provider.comfyui.settings.cors.title') }}</div></div>"#,
+    ),
+    (
+        "template_if_slot_keeps_upload_icon_hoist_after_parent_props",
+        r#"<InputFileCard><template #default="{ isDragging }"><template v-if="!isDragging"><div flex flex-col items-center><div i-solar:upload-square-line-duotone mb-4 text-5xl text="neutral-400 dark:neutral-500"></div><p font-medium text="neutral-600 dark:neutral-300">{{ t('settings.pages.card.upload') }}</p><p text="neutral-500 dark:neutral-400" mt-2 text-sm>{{ t('settings.pages.card.upload_desc') }}</p></div></template><template v-else><div flex flex-col items-center><div i-solar:upload-minimalistic-bold class="mb-2 text-5xl text-primary-500 dark:text-primary-400"></div><p font-medium text="primary-600 dark:primary-300">{{ t('settings.pages.card.drop_here') }}</p></div></template></template></InputFileCard>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -87,6 +87,7 @@ mod vfor_item;
 mod vif;
 mod vnode;
 mod vnode_children;
+mod vnode_static;
 mod vtext;
 
 use alloc::vec::Vec as StdVec;

--- a/crates/vize_s1_to_s2/src/emit/cx.rs
+++ b/crates/vize_s1_to_s2/src/emit/cx.rs
@@ -38,4 +38,16 @@ impl EmitCx<'_> {
         self.hoist_static_vnodes = previous;
         result
     }
+
+    pub(super) fn with_static_vnode_hoist_exact<T>(
+        &mut self,
+        enabled: bool,
+        write: impl FnOnce(&mut Self) -> Result<T, EmitError>,
+    ) -> Result<T, EmitError> {
+        let previous = self.hoist_static_vnodes;
+        self.hoist_static_vnodes = enabled;
+        let result = write(self);
+        self.hoist_static_vnodes = previous;
+        result
+    }
 }

--- a/crates/vize_s1_to_s2/src/emit/tpl.rs
+++ b/crates/vize_s1_to_s2/src/emit/tpl.rs
@@ -6,9 +6,10 @@
 //! static nodes, because a `v-for` item must keep block tracking); text /
 //! multi child stays a `STABLE_FRAGMENT`.
 
+use vize_davinci::id::NodeId;
 use vize_s0::String;
 use vize_s2::expr::{ExprRef, OpaqueReason};
-use vize_s2::op::{IfBranch, Op};
+use vize_s2::op::{Attribute, BindingOp, IfBranch, Op};
 
 use super::EmitCx;
 use super::EmitError;
@@ -75,8 +76,10 @@ fn unwrap_if(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<()
     match branch.region.ops.as_slice() {
         [Op::Element(element)] => {
             let id = cx.walk.mint();
-            cx.walk.skip(element.bindings.len());
-            register_unwrapped_if_child_props_hoist(cx, element, id)?;
+            let attributes = &element.attributes;
+            let bindings = &element.bindings;
+            cx.walk.skip(bindings.len());
+            register_unwrapped_if_child_props_hoist(cx, attributes, bindings, id)?;
             super::emit_if_branch_call(cx, element, key)
         }
         [Op::Component(component)] => {
@@ -102,15 +105,14 @@ fn unwrap_if(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<()
 
 fn register_unwrapped_if_child_props_hoist(
     cx: &mut EmitCx<'_>,
-    element: &vize_s2::op::ElementOp<'_>,
-    id: Option<vize_davinci::id::NodeId>,
+    attributes: &[Attribute<'_>],
+    bindings: &[BindingOp<'_>],
+    id: Option<NodeId>,
 ) -> Result<(), EmitError> {
     if !super::props_static::should_hoist(cx, id, PropHoistPosition::Nested) {
         return Ok(());
     }
-    if let Some(props) =
-        super::props_static::root_hoist_props(&element.attributes, &element.bindings)?
-    {
+    if let Some(props) = super::props_static::root_hoist_props(attributes, bindings)? {
         let _ = cx.buf.push_hoist(props);
     }
     Ok(())

--- a/crates/vize_s1_to_s2/src/emit/tpl.rs
+++ b/crates/vize_s1_to_s2/src/emit/tpl.rs
@@ -20,6 +20,7 @@ use super::children::{
 };
 use super::hoist::{emit_hoisted_element, is_hoistable};
 use super::js::escape_js_string;
+use super::props_static::PropHoistPosition;
 use super::vnode;
 use crate::lower::WrapperKey;
 
@@ -73,8 +74,9 @@ fn should_unwrap_if(ops: &[Op<'_>]) -> bool {
 fn unwrap_if(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<(), EmitError> {
     match branch.region.ops.as_slice() {
         [Op::Element(element)] => {
-            let _id = cx.walk.mint();
+            let id = cx.walk.mint();
             cx.walk.skip(element.bindings.len());
+            register_unwrapped_if_child_props_hoist(cx, element, id)?;
             super::emit_if_branch_call(cx, element, key)
         }
         [Op::Component(component)] => {
@@ -96,6 +98,22 @@ fn unwrap_if(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<()
             branch.span,
         )),
     }
+}
+
+fn register_unwrapped_if_child_props_hoist(
+    cx: &mut EmitCx<'_>,
+    element: &vize_s2::op::ElementOp<'_>,
+    id: Option<vize_davinci::id::NodeId>,
+) -> Result<(), EmitError> {
+    if !super::props_static::should_hoist(cx, id, PropHoistPosition::Nested) {
+        return Ok(());
+    }
+    if let Some(props) =
+        super::props_static::root_hoist_props(&element.attributes, &element.bindings)?
+    {
+        let _ = cx.buf.push_hoist(props);
+    }
+    Ok(())
 }
 
 pub(super) fn should_unwrap_for(ops: &[Op<'_>]) -> bool {

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -13,6 +13,7 @@ use super::props::{admit_element_bindings, apply_static_ref_patch, bind_patch, e
 use super::props_static::PropHoistPosition;
 use super::vnode_children::emit_children;
 use super::{EmitCx, EmitError, UnsupportedReason as Reason};
+use crate::pass::StaticLevel;
 
 pub(super) fn emit_unique_element(
     cx: &mut EmitCx<'_>,
@@ -168,8 +169,14 @@ pub(super) fn emit_call(
     cx.buf.push(element.tag);
     cx.buf.push("\"");
     let has_children = !element.children.ops.is_empty();
-    let hoist_static_children = cx.hoist_static_vnodes
-        || (allow_hoist && (if_key.is_some() || !element.bindings.is_empty()));
+    let hoist_static_children = should_hoist_static_children(
+        cx,
+        element,
+        id,
+        allow_hoist,
+        if_key.is_some() && !for_item,
+        for_item,
+    );
     let has_memo = super::memo::has(&element.bindings);
     let memo_block = block && has_memo && !(if_key.is_some() && !for_item);
     let force_array_children = once
@@ -271,6 +278,26 @@ pub(super) fn emit_call(
     }
     cx.buf.push(")");
     Ok(())
+}
+
+fn should_hoist_static_children(
+    cx: &EmitCx<'_>,
+    element: &ElementOp<'_>,
+    id: Option<NodeId>,
+    allow_hoist: bool,
+    branch_root: bool,
+    for_item: bool,
+) -> bool {
+    let requested =
+        cx.hoist_static_vnodes || (allow_hoist && (branch_root || !element.bindings.is_empty()));
+    if !requested {
+        return false;
+    }
+    if branch_root || for_item {
+        return true;
+    }
+    id.and_then(|id| cx.facts.static_facts.get(id))
+        .is_some_and(|fact| fact.level == StaticLevel::NotStatic)
 }
 
 fn has_prop_bindings(bindings: &[BindingOp<'_>]) -> bool {

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -13,7 +13,6 @@ use super::props::{admit_element_bindings, apply_static_ref_patch, bind_patch, e
 use super::props_static::PropHoistPosition;
 use super::vnode_children::emit_children;
 use super::{EmitCx, EmitError, UnsupportedReason as Reason};
-use crate::pass::StaticLevel;
 
 pub(super) fn emit_unique_element(
     cx: &mut EmitCx<'_>,
@@ -169,7 +168,7 @@ pub(super) fn emit_call(
     cx.buf.push(element.tag);
     cx.buf.push("\"");
     let has_children = !element.children.ops.is_empty();
-    let hoist_static_children = should_hoist_static_children(
+    let hoist_static_children = super::vnode_static::should_hoist_static_children(
         cx,
         element,
         id,
@@ -278,26 +277,6 @@ pub(super) fn emit_call(
     }
     cx.buf.push(")");
     Ok(())
-}
-
-fn should_hoist_static_children(
-    cx: &EmitCx<'_>,
-    element: &ElementOp<'_>,
-    id: Option<NodeId>,
-    allow_hoist: bool,
-    branch_root: bool,
-    for_item: bool,
-) -> bool {
-    let requested =
-        cx.hoist_static_vnodes || (allow_hoist && (branch_root || !element.bindings.is_empty()));
-    if !requested {
-        return false;
-    }
-    if branch_root || for_item {
-        return true;
-    }
-    id.and_then(|id| cx.facts.static_facts.get(id))
-        .is_some_and(|fact| fact.level == StaticLevel::NotStatic)
 }
 
 fn has_prop_bindings(bindings: &[BindingOp<'_>]) -> bool {

--- a/crates/vize_s1_to_s2/src/emit/vnode_children.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_children.rs
@@ -12,8 +12,7 @@ pub(super) fn emit_children(
     hoist_static_children: bool,
     cache_static_children: bool,
 ) -> Result<(), EmitError> {
-    let hoist_static_children = hoist_static_children || cx.hoist_static_vnodes;
-    cx.with_static_vnode_hoist(hoist_static_children, |cx| {
+    cx.with_static_vnode_hoist_exact(hoist_static_children, |cx| {
         emit_children_inner(
             cx,
             children,

--- a/crates/vize_s1_to_s2/src/emit/vnode_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_static.rs
@@ -1,0 +1,27 @@
+//! Static child vnode hoist gates for native element emission.
+
+use vize_davinci::id::NodeId;
+use vize_s2::op::ElementOp;
+
+use super::EmitCx;
+use crate::pass::StaticLevel;
+
+pub(super) fn should_hoist_static_children(
+    cx: &EmitCx<'_>,
+    element: &ElementOp<'_>,
+    id: Option<NodeId>,
+    allow_hoist: bool,
+    branch_root: bool,
+    for_item: bool,
+) -> bool {
+    let requested =
+        cx.hoist_static_vnodes || (allow_hoist && (branch_root || !element.bindings.is_empty()));
+    if !requested {
+        return false;
+    }
+    if branch_root || for_item {
+        return true;
+    }
+    id.and_then(|id| cx.facts.static_facts.get(id))
+        .is_some_and(|fact| fact.level == StaticLevel::NotStatic)
+}


### PR DESCRIPTION
## Summary
- align S2 static child vnode hoist propagation with the shipped DOM lane for dynamic-text parents
- register the shipped-lane template-v-if child props hoist before static icon vnode hoists
- add reduced AIRI-inspired parity cases for the icon hoist/order residuals

## Verification
- cargo fmt --all -- --check
- cargo check -p vize_s1_to_s2 -p vize_atelier_dom --tests
- cargo test -p vize_atelier_dom --test davinci_s2_static_vnode_hoist --test davinci_s2_hoist_order --test davinci_s2_root_hoist --test davinci_s2_static_cache --test davinci_s2_dom -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_static_hoist --test hoist_pass --test hoist_pass_snapshot -- --nocapture
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git/airi cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture (expected residual sweep failure: origin/main 14 divergences, this branch 10; static icon sample paths removed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790767629&installation_model_id=422833&pr_number=5506&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5506&signature=97cf22cfe0e1279289d5262093c026a0e7069cf0e7dc6e435062a3b613bb235a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static content handling in conditional templates, list items, and component slots.
  * Preserved inline icons and other static child elements alongside dynamic text or conditional content.
  * Improved hoisting of static properties and child elements for more accurate rendered output.

* **Tests**
  * Added coverage for static content preservation across panels, branches, conditional slots, and upload icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->