### PR TITLE
refactor(typechecker): remove content-mapper croquis naming dependency

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper.rs
@@ -5,11 +5,11 @@ use std::path::Path;
 
 use vize_atelier_core::TemplateSyntaxMode;
 use vize_atelier_sfc::{SfcError, SfcParseOptions, parse_sfc};
-use vize_s0::{String as CompactString, ToCompactString, config::VueVersion};
+use vize_s0::{ToCompactString, config::VueVersion};
 
 use crate::batch::Diagnostic;
 use crate::batch::error::CorsaResult;
-use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions, VizeMapping, to_safe_identifier};
+use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions, VizeMapping};
 
 #[path = "content_mapper_alias.rs"]
 mod alias;
@@ -28,6 +28,10 @@ pub use protocol::{
 #[path = "content_mapper_directives.rs"]
 mod directives;
 use directives::template_diagnostic_directives;
+
+#[path = "content_mapper_component_name.rs"]
+mod component_name;
+use component_name::content_mapper_component_name;
 
 use super::build::{
     descriptor_uses_jsx_script, prepend_vue_jsx_reference, virtual_ts_options_for_descriptor,
@@ -179,20 +183,6 @@ pub fn generate_vue_content_mapper_transform_with_options(
             .collect(),
         text: code,
     })
-}
-
-fn content_mapper_component_name(path: &Path) -> CompactString {
-    let stem = path
-        .file_stem()
-        .and_then(|stem| stem.to_str())
-        .unwrap_or("VueComponent");
-    let pascal = vize_croquis::naming::to_pascal_case(stem);
-    let name = to_safe_identifier(pascal.as_str());
-    if name.as_str().bytes().all(|byte| byte == b'_') {
-        CompactString::from("VueComponent")
-    } else {
-        name
-    }
 }
 
 fn sfc_parse_diagnostic(source: &str, error: &SfcError) -> ContentMapperDiagnostic {

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_component_export_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_component_export_tests.rs
@@ -8,6 +8,8 @@ fn names_the_default_export_from_the_sfc_filename() {
     for (file_name, component_name) in [
         ("Child.vue", "Child"),
         ("user-card.vue", "UserCard"),
+        ("user_card.vue", "UserCard"),
+        ("component.name.vue", "Component_name"),
         ("123-widget.vue", "_123Widget"),
         ("日本語.vue", "VueComponent"),
     ] {

--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_component_name.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_component_name.rs
@@ -1,0 +1,37 @@
+use std::path::Path;
+
+use vize_s0::String as CompactString;
+
+use crate::virtual_ts::to_safe_identifier;
+
+pub(super) fn content_mapper_component_name(path: &Path) -> CompactString {
+    let stem = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("VueComponent");
+    let pascal = content_mapper_pascal_case(stem);
+    let name = to_safe_identifier(pascal.as_str());
+    if name.as_str().bytes().all(|byte| byte == b'_') {
+        CompactString::from("VueComponent")
+    } else {
+        name
+    }
+}
+
+fn content_mapper_pascal_case(value: &str) -> CompactString {
+    let mut result = CompactString::with_capacity(value.len());
+    let mut capitalize_next = true;
+
+    for character in value.chars() {
+        if character == '-' || character == '_' {
+            capitalize_next = true;
+        } else if capitalize_next {
+            result.push(character.to_ascii_uppercase());
+            capitalize_next = false;
+        } else {
+            result.push(character);
+        }
+    }
+
+    result
+}

--- a/davinci-road/plan/consumer-migration-surfaces.md
+++ b/davinci-road/plan/consumer-migration-surfaces.md
@@ -48,7 +48,7 @@ observational guard for planning only. It does not change rollout state.
 | Compiler                   |           928 |                   487 |               441 |             140 |     371 |             941 |      498 |           488 |           609 |
 | Linter                     |           331 |                   331 |                 0 |             290 |     287 |             671 |      237 |           375 |           539 |
 | Typechecker                |           880 |                   238 |               642 |             396 |     187 |             808 |      655 |           468 |           666 |
-| Typechecker content-mapper |             8 |                     8 |                 0 |               1 |       0 |               9 |        0 |             7 |            19 |
+| Typechecker content-mapper |             9 |                     9 |                 0 |               0 |       0 |               9 |        0 |             8 |            20 |
 | Formatter                  |            38 |                    38 |                 0 |               0 |      21 |              40 |       19 |            30 |            65 |
 | LSP                        |           272 |                   272 |                 0 |             115 |      44 |             326 |      105 |           167 |           388 |
 
@@ -167,22 +167,21 @@ Additional test/dev rows are in the TSV: 185 omitted.
 
 Scope: content-mapper command plus Canon content-mapper protocol files. This is a lexical inventory, not a rollout gate.
 
-| surface          | total sites | source/manifest | test/dev |
-| ---------------- | ----------: | --------------: | -------: |
-| S0               |           8 |               8 |        0 |
-| Croquis analysis |           1 |               1 |        0 |
+| surface | total sites | source/manifest | test/dev |
+| ------- | ----------: | --------------: | -------: |
+| S0      |           9 |               9 |        0 |
 
 #### Top source and manifest files
 
-| file                                                                          | class  | surfaces                   | sites |
-| ----------------------------------------------------------------------------- | ------ | -------------------------- | ----: |
-| `crates/vize_canon/src/batch/virtual_project/content_mapper.rs:8`             | source | S0 2<br>Croquis analysis 1 |     3 |
-| `crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs:1`       | source | S0 1                       |     1 |
-| `crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs:12` | source | S0 1                       |     1 |
-| `crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs:4`    | source | S0 1                       |     1 |
-| `crates/vize/src/commands/content_mapper.rs:18`                               | source | S0 1                       |     1 |
+| file                                                                             | class  | surfaces | sites |
+| -------------------------------------------------------------------------------- | ------ | -------- | ----: |
+| `crates/vize_canon/src/batch/virtual_project/content_mapper.rs:8`                | source | S0 2     |     2 |
+| `crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs:1`          | source | S0 1     |     1 |
+| `crates/vize_canon/src/batch/virtual_project/content_mapper_component_name.rs:3` | source | S0 1     |     1 |
+| `crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs:12`    | source | S0 1     |     1 |
+| `crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs:4`       | source | S0 1     |     1 |
 
-Additional source/manifest rows are in the TSV: 2 omitted.
+Additional source/manifest rows are in the TSV: 3 omitted.
 
 #### Top test/dev files
 

--- a/davinci-road/plan/consumer-migration-surfaces.tsv
+++ b/davinci-road/plan/consumer-migration-surfaces.tsv
@@ -2439,10 +2439,10 @@ typechecker	Typechecker	test/dev	crates/vize/src/commands/check/tsconfig_inputs/
 typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/type_references.rs	9	s0	S0	stage	vize_s0	preferred	1
 typechecker	Typechecker	source	crates/vize/src/commands/check/tsconfig_inputs/type_references/tsconfig_types.rs	4	s0	S0	stage	vize_s0	preferred	2
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_alias.rs	1	s0	S0	stage	vize_s0	preferred	1
+typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_component_name.rs	3	s0	S0	stage	vize_s0	preferred	1
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_directives.rs	12	s0	S0	stage	vize_s0	preferred	1
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper_protocol.rs	4	s0	S0	stage	vize_s0	preferred	1
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper.rs	8	s0	S0	stage	vize_s0	preferred	2
-typechecker-content-mapper	Typechecker content-mapper	source	crates/vize_canon/src/batch/virtual_project/content_mapper.rs	8	croquis	Croquis analysis	old	vize_croquis	legacy	1
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper.rs	18	s0	S0	stage	vize_s0	preferred	1
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper/project.rs	13	s0	S0	stage	vize_s0	preferred	1
 typechecker-content-mapper	Typechecker content-mapper	source	crates/vize/src/commands/content_mapper/test_support.rs	6	s0	S0	stage	vize_s0	preferred	1

--- a/davinci-road/plan/croquis-consumption.md
+++ b/davinci-road/plan/croquis-consumption.md
@@ -340,7 +340,7 @@ Items consumers import from `vize_croquis` that are outside the product set abov
 | `runtime_erased_macro_names`                 | `vize_atelier_sfc`   |     3 |     5 |
 | `scoped_v_bind_name`                         | `vize_atelier_sfc`   |     1 |     1 |
 | `strip_js_comments`                          | `vize_canon`         |     3 |     4 |
-| `to_pascal_case`                             | `vize_canon`         |     2 |     2 |
+| `to_pascal_case`                             | `vize_canon`         |     1 |     1 |
 | `to_pascal_case`                             | `vize_patina`        |     2 |     3 |
 
 ## Cross-check: symbol-resolved vs naive grep

--- a/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
+++ b/tests/tooling/davinci-consumer-migration-surfaces.test.mjs
@@ -299,7 +299,7 @@ void test("consumer migration scan keeps every rollout consumer and surface clas
     ["compiler", { stage: true, old: true, raw: true }],
     ["linter", { stage: true, old: true, raw: true }],
     ["typechecker", { stage: true, old: true, raw: true }],
-    ["typechecker-content-mapper", { stage: true, old: true, raw: false }],
+    ["typechecker-content-mapper", { stage: true, old: false, raw: false }],
     ["formatter", { stage: true, old: false, raw: true }],
     ["lsp", { stage: true, old: true, raw: true }],
   ]);
@@ -326,9 +326,9 @@ void test("content-mapper S0 surface stays on the preferred physical name", () =
     (consumer) => consumer.id === "typechecker-content-mapper",
   );
   assert.ok(contentMapper);
-  assert.equal(contentMapper.surfaceCounts.s0, 8);
+  assert.equal(contentMapper.surfaceCounts.s0, 9);
   assert.equal(contentMapper.nameKindCounts.compat, 0);
-  assert.equal(contentMapper.nameKindCounts.preferred, 8);
+  assert.equal(contentMapper.nameKindCounts.preferred, 9);
   assert.ok(
     contentMapper.sites
       .filter((site) => site.surfaceId === "s0")


### PR DESCRIPTION
## Summary
- move content-mapper SFC export naming into a local S0-backed helper
- pin filename casing edge cases for generated default export names
- refresh davinci consumer migration surfaces so content-mapper has no Croquis surface

## Tests
- cargo test -p vize_canon component_exports -- --nocapture
- cargo test -p vize_canon content_mapper -- --nocapture
- cargo fmt --all -- --check
- rust-script tools/commands/davinci/consumer-migration-surfaces.rs --check
- node --test tests/tooling/davinci-consumer-migration-surfaces.test.mjs
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Component names are now derived more consistently from Vue single-file component filenames, including names with underscores and dots.
  * Files without a usable name automatically use a safe default component name.

* **Tests**
  * Added coverage for additional filename-to-component-name conversions.
  * Updated migration-surface checks to reflect the expanded content-mapping coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->