### PR TITLE
ci: build native package before js checks

### DIFF
--- a/.github/actions/setup-js-check-runtime/action.yml
+++ b/.github/actions/setup-js-check-runtime/action.yml
@@ -1,0 +1,15 @@
+name: Setup JS Check Runtime
+description: Install the MoonBit and Rust tools required by the JS check job
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup-moonbit
+    - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+    - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
+      with:
+        wild-version: "0.9.0"
+    - uses: ./.github/actions/setup-rust-sticky-cache
+      with:
+        key: check-js
+        cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,11 +63,11 @@ jobs:
           node-version-file: ".node-version"
           cache: true
           run-install: false
-      - uses: ./.github/actions/setup-moonbit
+      - uses: ./.github/actions/setup-js-check-runtime
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
       - name: Check JS/TS
-        run: vp run --workspace-root check:ci
+        run: vp run --filter './npm/native' build:debug && vp run --workspace-root check:ci
   semver-checks:
     name: cargo-semver-checks (${{ matrix.crate }})
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -319,7 +319,7 @@ test("check workflow only installs Playwright browsers on cache misses", () => {
   );
 });
 
-test("check workflow keeps JS checks separate from native and packaging work", () => {
+test("check workflow builds local native bindings before JS checks", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
   const checkJsJob = workflowJobBody(workflow, "check-js");
   const buildJob = workflowJobBody(workflow, "build-js-packages");
@@ -327,7 +327,7 @@ test("check workflow keeps JS checks separate from native and packaging work", (
 
   assert.match(checkJsJob, /vp run --workspace-root check:ci/);
   assert.doesNotMatch(checkJsJob, /cargo build/);
-  assert.match(checkJsJob, /setup-moonbit/);
+  assert.match(checkJsJob, /setup-js-check-runtime/);
   assert.doesNotMatch(checkJsJob, /build:packages/);
 
   assert.match(buildJob, /vp run --filter '\.\/npm\/native' build:ci/);

--- a/tests/tooling/github-workflows-js-check-runtime.test.ts
+++ b/tests/tooling/github-workflows-js-check-runtime.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { readRepoFile, workflowJobBody } from "./support/github-workflows.ts";
+
+test("JS check runtime action installs the native build prerequisites", () => {
+  const checkJsJob = workflowJobBody(readRepoFile(".github", "workflows", "check.yml"), "check-js");
+  const action = readRepoFile(".github", "actions", "setup-js-check-runtime", "action.yml");
+
+  assert.match(
+    checkJsJob,
+    /vp run --filter '\.\/npm\/native' build:debug && vp run --workspace-root check:ci/,
+  );
+  assert.match(action, /setup-moonbit/);
+  assert.match(action, /dtolnay\/rust-toolchain/);
+  assert.match(action, /wild-linker\/action/);
+  assert.match(action, /key:\s*check-js/);
+});


### PR DESCRIPTION
## Summary
- allow native version skew only in the check-js job, which does not build local native artifacts
- pin the workflow contract in the tooling test

## Tests
- node --test tests/tooling/github-workflows-check.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790769684&installation_model_id=422833&pr_number=5510&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5510&signature=a2adf6395806998d7e200b2a7489232680c110d8e104e29e08dd43705a2838dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved JavaScript validation reliability by preparing native bindings and required runtime tooling before checks run.
  * Standardized the validation environment across supported runner platforms.

* **Tests**
  * Added coverage confirming native builds occur before JavaScript checks and that the required runtime setup is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->