### PR TITLE
ci: build native package before JS checks

### DIFF
--- a/.github/actions/setup-js-check-runtime/action.yml
+++ b/.github/actions/setup-js-check-runtime/action.yml
@@ -1,0 +1,15 @@
+name: Setup JS Check Runtime
+description: Install the MoonBit and Rust tools required by the JS check job
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup-moonbit
+    - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+    - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
+      with:
+        wild-version: "0.9.0"
+    - uses: ./.github/actions/setup-rust-sticky-cache
+      with:
+        key: check-js
+        cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,11 +63,11 @@ jobs:
           node-version-file: ".node-version"
           cache: true
           run-install: false
-      - uses: ./.github/actions/setup-moonbit
+      - uses: ./.github/actions/setup-js-check-runtime
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
       - name: Check JS/TS
-        run: vp run --workspace-root check:ci
+        run: vp run --filter './npm/native' build:debug && vp run --workspace-root check:ci
   semver-checks:
     name: cargo-semver-checks (${{ matrix.crate }})
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}


### PR DESCRIPTION
## Summary
- build the workspace native package before the JS/TS check job runs package checks
- give check-js the same Rust/wild-linker/cache setup needed for local native binding generation

## Verification
- vp install --frozen-lockfile --prefer-offline
- vp run --filter ./npm/native build:debug
- vp run --filter ./npm/ui/core lint:sfc
- git diff --check

Note: `vp check .github/workflows/check.yml` formatted the YAML but exited because there are no lintable files for that path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790770359&installation_model_id=422833&pr_number=5512&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5512&signature=4c62c08d8fb18359ee850e5f77fde67b404b54af809cdfa961ce9271dc253609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->