### PR TITLE
fix(davinci): seed namespace for bare svg tags

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_fragments.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_fragments.rs
@@ -48,6 +48,10 @@ const BATTERY: &[(&str, &str)] = &[
         "div_then_vfor",
         r#"<div></div><p v-for="i in n">{{ i }}</p>"#,
     ),
+    (
+        "root_dynamic_element_before_for_element",
+        r#"<feImage :href="parts.top" /><feComposite v-for="part in parts" :key="part" :in="part" />"#,
+    ),
     ("slot_then_div", "<slot></slot><div></div>"),
     (
         "teleport_then_div",

--- a/crates/vize_s1_to_s2/src/lower/element.rs
+++ b/crates/vize_s1_to_s2/src/lower/element.rs
@@ -3,16 +3,15 @@
 //!
 //! # Namespace, v1 scope (recorded in the P2-8 record)
 //!
-//! The namespace rule is tag inheritance: `<svg>` opens the SVG
-//! namespace, `<math>` opens MathML, and the SVG/MathML HTML integration
-//! points (`foreignObject`/`desc`/`title`; `mi`/`mo`/`mn`/`ms`/`mtext`)
-//! return their **children** to HTML. This approximates the HTML
-//! tree-construction namespace algorithm the way the shipped
-//! compiler-dom logic does; the full in-DOM rules are not replicated.
+//! The namespace rule is tag inheritance: SVG/MathML tags open their
+//! namespace, and the SVG/MathML HTML integration points
+//! (`foreignObject`/`desc`/`title`; `mi`/`mo`/`mn`/`ms`/`mtext`) return
+//! their **children** to HTML. This approximates the HTML tree-construction
+//! namespace algorithm the way the shipped compiler-dom logic does.
 
 use alloc::vec::Vec as StdVec;
 
-use vize_s0::{Box, Vec, cstr, is_native_tag};
+use vize_s0::{Box, Vec, cstr, is_math_ml_tag, is_native_tag, is_svg_tag};
 use vize_s1::Element;
 
 use vize_s2::op::{Attribute, BindingOp, ComponentOp, ElementOp, Namespace, Op, Region};
@@ -97,10 +96,12 @@ pub(crate) fn attr_value_text<'a>(element: &Element<'a>, index: usize) -> Option
 
 /// An element's own namespace, entered by tag.
 fn enter_ns(parent: Namespace, tag: &str) -> Namespace {
-    match tag {
-        "svg" => Namespace::Svg,
-        "math" => Namespace::MathMl,
-        _ => parent,
+    if is_svg_tag(tag) {
+        Namespace::Svg
+    } else if is_math_ml_tag(tag) {
+        Namespace::MathMl
+    } else {
+        parent
     }
 }
 

--- a/crates/vize_s1_to_s2/tests/lowering_elements.rs
+++ b/crates/vize_s1_to_s2/tests/lowering_elements.rs
@@ -40,6 +40,20 @@ fn the_svg_namespace_is_entered_by_tag_and_inherited() {
 }
 
 #[test]
+fn a_bare_svg_tag_enters_the_svg_namespace() {
+    let art = artifact("<feImage />");
+    assert_eq!(
+        art.folio,
+        "[disegno]\n\
+         ops=1\n\
+         \n\
+         [disegno.ops]\n\
+         ui.element feImage ns=svg @0:11\n\
+         \n"
+    );
+}
+
+#[test]
 fn v_model_lowers_to_the_contract_with_synthesized_attributes() {
     // Read and write share one authored payload; element kind and the
     // dialect modifiers ride as attributes carrying the binding's span,


### PR DESCRIPTION
## Summary
- seed SVG/MathML namespaces for bare foreign-element tags during S1 lowering
- add reduced lowering and DOM fragment regressions for bare SVG tag fragments

## Verification
- cargo test -p vize_s1_to_s2 --test lowering_elements a_bare_svg_tag_enters_the_svg_namespace -- --exact --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_fragments -- --nocapture
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check HEAD~1..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of SVG and MathML element namespaces, including standalone SVG filter elements such as `<feImage>`.
  - Ensured namespace inheritance works correctly for dynamic elements used before loop-rendered elements.

- **Tests**
  - Added coverage for SVG namespace lowering and dynamic SVG element scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->