### PR TITLE
fix(davinci): recover nested interactive end tags

### DIFF
--- a/crates/vize_armature/src/parser/element/tags.rs
+++ b/crates/vize_armature/src/parser/element/tags.rs
@@ -237,6 +237,18 @@ impl<'a> Parser<'a> {
             return;
         }
 
+        let loc = self.create_loc(start.saturating_sub(2), end + 1); // Include </ and >
+        // HTML tree construction closed these nodes before their authored end
+        // tags. They are still inner to the current open-element stack, so they
+        // must claim matching end tags before an unrelated same-named ancestor.
+        if self.consume_implicitly_closed_tag(tag.as_str()) {
+            self.report_tree_construction_recovery(
+                &loc,
+                "HTML tree construction ignored this end tag because the element was already closed before a nested start tag.",
+            );
+            return;
+        }
+
         // Find matching open tag
         if let Some(i) = self.find_open_element_index(tag.as_str()) {
             self.close_stack_element_at(i, true);
@@ -244,15 +256,6 @@ impl<'a> Parser<'a> {
         }
 
         if self.template_syntax.is_quirks() && (self.options.is_void_tag)(tag.as_str()) {
-            return;
-        }
-
-        let loc = self.create_loc(start.saturating_sub(2), end + 1); // Include </ and >
-        if self.consume_implicitly_closed_tag(tag.as_str()) {
-            self.report_tree_construction_recovery(
-                &loc,
-                "HTML tree construction ignored this end tag because the element was already closed before a nested start tag.",
-            );
             return;
         }
 

--- a/crates/vize_armature/tests/nested_interactive_recovery.rs
+++ b/crates/vize_armature/tests/nested_interactive_recovery.rs
@@ -75,6 +75,26 @@ fn nested_interactive_recovery_consumes_descendant_end_tags() {
 }
 
 #[test]
+fn nested_interactive_recovery_does_not_close_same_named_ancestors() {
+    let allocator = Allocator::new();
+    for source in [
+        r#"<div><a href="/"><div><a href="/foo">inner</a></div></a></div>"#,
+        "<div><button><div><button>bbb</button></div></button></div>",
+    ] {
+        let (root, errors) = parse(&allocator, source);
+        assert!(
+            errors.iter().all(CompilerError::is_recoverable),
+            "{source}: redundant descendant end tags from nested interactive-content recovery must not pop same-named ancestors: {errors:?}"
+        );
+        assert_eq!(
+            root.children.len(),
+            1,
+            "{source}: the outer ancestor should stay open until its authored end tag"
+        );
+    }
+}
+
+#[test]
 fn nested_interactive_recovery_keeps_extra_end_tag_hard() {
     let allocator = Allocator::new();
     let (_, errors) = parse(

--- a/crates/vize_atelier_dom/tests/nested_interactive_recovery.rs
+++ b/crates/vize_atelier_dom/tests/nested_interactive_recovery.rs
@@ -20,6 +20,25 @@ fn standard_compile_emits_nested_anchor_and_button_recoveries() {
 }
 
 #[test]
+fn standard_compile_keeps_same_named_ancestors_after_nested_interactive_recovery() {
+    let allocator = Allocator::new();
+    for source in [
+        r#"<div><a href="/"><div><a href="/foo">inner</a></div></a></div>"#,
+        "<div><button><div><button>bbb</button></div></button></div>",
+    ] {
+        let (_, errors, result) = compile_template(&allocator, source);
+        assert!(
+            errors.iter().all(|error| error.is_compatibility_notice()),
+            "{source}: nested interactive-content recovery must not turn same-named ancestor end tags fatal: {errors:?}"
+        );
+        assert!(
+            !result.code.is_empty(),
+            "{source}: compatibility notices must still emit code"
+        );
+    }
+}
+
+#[test]
 fn standard_compile_keeps_extra_invalid_anchor_end_tag_fatal() {
     let allocator = Allocator::new();
     let (_, errors, result) = compile_template(

--- a/crates/vize_s1/src/build.rs
+++ b/crates/vize_s1/src/build.rs
@@ -15,6 +15,7 @@
 mod attr;
 mod tag;
 
+use vize_relief::Namespace;
 use vize_s0::{Allocator, Box, Vec};
 
 use crate::event::{Event, EventKind};
@@ -38,6 +39,7 @@ enum RawKind {
 struct Frame<'a> {
     open: OpenTag<'a>,
     children: Vec<'a, SurfaceChild<'a>>,
+    ns: Namespace,
 }
 
 impl<'a> Frame<'a> {
@@ -60,6 +62,7 @@ pub(crate) fn build<'a>(
         cursor: 0,
         root: Vec::new_in(&allocator),
         stack: Vec::new_in(&allocator),
+        implicitly_closed_tags: Vec::new_in(&allocator),
     };
     b.run();
     // EOF: bytes the tokenizer consumed without reporting structure
@@ -89,6 +92,7 @@ struct Builder<'a, 'e> {
     cursor: usize,
     root: Vec<'a, SurfaceChild<'a>>,
     stack: Vec<'a, Frame<'a>>,
+    implicitly_closed_tags: Vec<'a, &'a str>,
 }
 
 impl<'a> Builder<'a, '_> {

--- a/crates/vize_s1/src/build/tag.rs
+++ b/crates/vize_s1/src/build/tag.rs
@@ -1,6 +1,7 @@
 //! Open and close tags: the element half of the builder.
 
-use vize_s0::{Vec, is_void_tag};
+use vize_relief::Namespace;
+use vize_s0::{Box, Vec, is_math_ml_tag, is_svg_tag, is_void_tag};
 
 use super::{Builder, Frame};
 use crate::event::{Event, EventKind};
@@ -51,12 +52,17 @@ impl<'a> Builder<'a, '_> {
             }
         }
         let self_closing = slash.is_some();
+        let ns = self.enter_ns(tag);
         let open = OpenTag {
             lt_name,
             attrs,
             slash,
             gt,
         };
+        if !self_closing {
+            self.handle_nested_interactive_start_tag(tag, ns);
+        }
+
         if self_closing || is_void_tag(tag) {
             let element = Element {
                 open,
@@ -68,6 +74,7 @@ impl<'a> Builder<'a, '_> {
             self.stack.push(Frame {
                 open,
                 children: Vec::new_in(&self.allocator),
+                ns,
             });
         }
     }
@@ -99,15 +106,18 @@ impl<'a> Builder<'a, '_> {
         let gt_pos = self.find_byte(b'>', e, self.src.len());
         let name = &self.src[s..e];
         self.flush_gap(lt_start);
+        if self.consume_implicitly_closed_tag(name) {
+            self.unexpected_close_tag(lt_start, gt_pos);
+            return;
+        }
+
         let matched = self
             .stack
             .iter()
             .rposition(|frame| frame.tag().eq_ignore_ascii_case(name));
         let Some(depth) = matched else {
             // Stray end tag: a typed `Unexpected` hole, whole extent.
-            let end = gt_pos.map_or(self.src.len(), |g| g + 1);
-            let token = self.token_at(lt_start, end);
-            self.push_child(SurfaceChild::Unexpected(token));
+            self.unexpected_close_tag(lt_start, gt_pos);
             return;
         };
         // Elements left open above the match get node-level holes.
@@ -152,5 +162,85 @@ impl<'a> Builder<'a, '_> {
         } else {
             self.cursor
         }
+    }
+
+    fn unexpected_close_tag(&mut self, lt_start: usize, gt_pos: Option<usize>) {
+        let end = gt_pos.map_or(self.src.len(), |g| g + 1);
+        let token = self.token_at(lt_start, end);
+        self.push_child(SurfaceChild::Unexpected(token));
+    }
+
+    fn enter_ns(&self, tag: &str) -> Namespace {
+        if is_svg_tag(tag) {
+            Namespace::Svg
+        } else if is_math_ml_tag(tag) {
+            Namespace::MathMl
+        } else {
+            self.stack
+                .last()
+                .map_or(Namespace::Html, |frame| children_ns(frame.ns, frame.tag()))
+        }
+    }
+
+    fn handle_nested_interactive_start_tag(&mut self, tag: &'a str, ns: Namespace) {
+        if ns != Namespace::Html {
+            return;
+        }
+        if !matches!(tag, "a" | "button") {
+            return;
+        }
+        let Some(depth) = self
+            .stack
+            .iter()
+            .rposition(|frame| frame.ns == Namespace::Html && frame.tag() == tag)
+        else {
+            return;
+        };
+        self.note_implicitly_closed_stack_entries_from(depth);
+        self.implicitly_close_stack_element_at(depth);
+    }
+
+    fn note_implicitly_closed_stack_entries_from(&mut self, depth: usize) {
+        for frame in self.stack.iter().skip(depth) {
+            self.implicitly_closed_tags.push(frame.tag());
+        }
+    }
+
+    fn consume_implicitly_closed_tag(&mut self, tag: &str) -> bool {
+        let Some(closed) = self.implicitly_closed_tags.last() else {
+            return false;
+        };
+        if !closed.eq_ignore_ascii_case(tag) {
+            return false;
+        }
+        self.implicitly_closed_tags.pop();
+        true
+    }
+
+    fn implicitly_close_stack_element_at(&mut self, depth: usize) {
+        let mut child = None;
+        while self.stack.len() > depth {
+            let frame = self.stack.pop().expect("stack holds depth frames");
+            let mut children = frame.children;
+            if let Some(element) = child.take() {
+                children.push(SurfaceChild::Element(Box::new_in(element, &self.allocator)));
+            }
+            child = Some(Element {
+                open: frame.open,
+                children,
+                close: ElementClose::Implicit,
+            });
+        }
+        if let Some(element) = child {
+            self.attach(element);
+        }
+    }
+}
+
+fn children_ns(ns: Namespace, tag: &str) -> Namespace {
+    match ns {
+        Namespace::Svg if matches!(tag, "foreignObject" | "desc" | "title") => Namespace::Html,
+        Namespace::MathMl if matches!(tag, "mi" | "mo" | "mn" | "ms" | "mtext") => Namespace::Html,
+        other => other,
     }
 }

--- a/crates/vize_s1/src/render.rs
+++ b/crates/vize_s1/src/render.rs
@@ -5,7 +5,8 @@
 //! token, `leading` then `text`; children in tree order; an element as
 //! open tag (`lt_name`, attributes as `name`/`eq`/`open_quote`/`content`/
 //! `close_quote`, `slash`, `gt`), then children, then its close tag.
-//! `Missing` tokens and `ElementClose::Missing` render zero bytes.
+//! `Missing` tokens, `ElementClose::Implicit`, and `ElementClose::Missing`
+//! render zero bytes.
 
 use crate::surface::{
     Attribute, CloseTag, Element, ElementClose, Interpolation, SurfaceChild, SurfaceTree, Token,
@@ -175,6 +176,6 @@ fn count_element(element: &Element<'_>, counts: &mut HoleCounts) {
             count_token(gt, counts);
         }
         ElementClose::Missing => counts.missing_close_tags += 1,
-        ElementClose::NotExpected => {}
+        ElementClose::Implicit | ElementClose::NotExpected => {}
     }
 }

--- a/crates/vize_s1/src/surface.rs
+++ b/crates/vize_s1/src/surface.rs
@@ -128,6 +128,12 @@ pub struct OpenTag<'a> {
 pub enum ElementClose<'a> {
     /// A real end tag.
     Present(CloseTag<'a>),
+    /// Closed by HTML tree construction before its authored end tag.
+    /// The later redundant end tag is retained as an [`Unexpected`] child so
+    /// rendering remains byte-for-byte faithful.
+    ///
+    /// [`Unexpected`]: SurfaceChild::Unexpected
+    Implicit,
     /// Required but absent: the element was still open when its parent
     /// closed or the input ended. A typed hole, zero-width.
     Missing,

--- a/crates/vize_s1/tests/surface_fidelity.rs
+++ b/crates/vize_s1/tests/surface_fidelity.rs
@@ -130,6 +130,46 @@ fn self_closing_and_void_elements_expect_no_close() {
 }
 
 #[test]
+fn nested_interactive_content_keeps_fidelity_without_missing_close_holes() {
+    for source in [
+        r#"<div><a href="/"><div><a href="/foo">inner</a></div></a></div>"#,
+        "<div><button><div><button>bbb</button></div></button></div>",
+    ] {
+        let allocator = Allocator::new();
+        let (tree, _errors) = parse(&allocator, source);
+        assert_eq!(rendered(&tree), source);
+        assert_eq!(check_fidelity(&tree), Ok(()));
+        assert_eq!(
+            hole_counts(&tree),
+            HoleCounts {
+                missing_tokens: 0,
+                missing_close_tags: 0,
+                unexpected_nodes: 2,
+            },
+            "{source}: the redundant descendant and interactive end tags are kept as surface holes"
+        );
+    }
+}
+
+#[test]
+fn nested_interactive_recovery_stays_in_html_namespace() {
+    for source in [
+        r#"<A><a href="/foo">inner</a></A>"#,
+        "<svg><a><a>x</a></a></svg>",
+    ] {
+        let allocator = Allocator::new();
+        let (tree, _errors) = parse(&allocator, source);
+        assert_eq!(rendered(&tree), source);
+        assert_eq!(check_fidelity(&tree), Ok(()));
+        assert_eq!(
+            hole_counts(&tree),
+            HoleCounts::default(),
+            "{source}: component-like or foreign anchors must keep authored nesting"
+        );
+    }
+}
+
+#[test]
 fn interpolation_tokens_are_delimited() {
     let allocator = Allocator::new();
     let (tree, _errors) = parse(&allocator, "a{{ msg }}b");

--- a/crates/vize_s1_to_s2/src/lower/cx.rs
+++ b/crates/vize_s1_to_s2/src/lower/cx.rs
@@ -265,7 +265,7 @@ pub(crate) fn element_end(cx: &Cx<'_>, element: &Element<'_>) -> u32 {
     match &element.close {
         ElementClose::Present(CloseTag { gt, .. }) => cx.token_span(gt).end,
         ElementClose::NotExpected => cx.token_span(&element.open.gt).end,
-        ElementClose::Missing => element
+        ElementClose::Implicit | ElementClose::Missing => element
             .children
             .last()
             .map(|child| child_end(cx, child))

--- a/crates/vize_s1_to_s2/tests/emit_nested_interactive.rs
+++ b/crates/vize_s1_to_s2/tests/emit_nested_interactive.rs
@@ -1,0 +1,48 @@
+//! Nested interactive-content recovery must match the shipped DOM lane once
+//! S1 lowers to S2. The AIRI DOM corpus exposed this with same-named ancestor
+//! wrappers around nested `<a>` and `<button>` elements.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use vize_s0::Allocator;
+use vize_s1_to_s2::emit_dom_source;
+
+fn shipped(source: &str) -> String {
+    let allocator = Allocator::new();
+    let (_, errors, old) = vize_atelier_dom::compile_template(&allocator, source);
+    assert!(
+        errors.iter().all(|error| error.is_compatibility_notice()),
+        "{source}: shipped lane should recover with compatibility notices only: {errors:?}"
+    );
+    format!("{}\n{}", old.preamble, old.code)
+}
+
+fn emitted(source: &str) -> String {
+    let allocator = Allocator::new();
+    emit_dom_source(&allocator, source)
+        .unwrap_or_else(|error| panic!("S2 DOM emit refused {source:?}: {error:?}"))
+        .assembled()
+        .to_string()
+}
+
+#[test]
+fn nested_anchor_with_same_named_ancestor_matches_shipped_dom() {
+    let source = r#"<div><a href="/"><div><a href="/foo">inner</a></div></a></div>"#;
+    assert_eq!(emitted(source), shipped(source));
+}
+
+#[test]
+fn nested_button_with_same_named_ancestor_matches_shipped_dom() {
+    let source = "<div><button><div><button>bbb</button></div></button></div>";
+    assert_eq!(emitted(source), shipped(source));
+}
+
+#[test]
+fn foreign_anchor_children_stay_nested_and_match_shipped_dom() {
+    let source = "<svg><a><a>x</a></a></svg>";
+    assert_eq!(emitted(source), shipped(source));
+}

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -64,7 +64,7 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s1       | `alloc::vec::Vec`       |     0 |            0 |          0 |
 | s1       | `alloc::string::String` |     0 |            0 |          0 |
 | s1       | `vize_s0::String`       |     0 |            0 |          0 |
-| s1       | `vize_s0::Vec`          |     5 |            5 |         19 |
+| s1       | `vize_s0::Vec`          |     5 |            5 |         21 |
 | s1       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
 | s2       | `alloc::vec::Vec`       |    10 |           22 |         43 |
 | s2       | `alloc::string::String` |     0 |            0 |          0 |

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -103,7 +103,7 @@ s1_to_s2	pass	crates/vize_s1_to_s2/src/pass/vslot.rs	1	2	1	4	0	0	0	0
 s1_to_s2	pass	crates/vize_s1_to_s2/src/pass/vslot/consume.rs	1	8	1	6	0	0	0	0
 s1_to_s2	pass	crates/vize_s1_to_s2/src/pass/vslot/group.rs	1	6	1	11	0	0	0	0
 s1_to_s2	pass	crates/vize_s1_to_s2/src/pass/vslot/spell.rs	1	1	1	10	0	0	0	0
-s1	-	crates/vize_s1/src/build.rs	0	0	0	0	1	5	0	0
+s1	-	crates/vize_s1/src/build.rs	0	0	0	0	1	7	0	0
 s1	-	crates/vize_s1/src/build/tag.rs	0	0	0	0	1	4	0	0
 s1	-	crates/vize_s1/src/event.rs	0	0	0	0	1	2	0	0
 s1	-	crates/vize_s1/src/parse.rs	0	0	0	0	1	5	0	0


### PR DESCRIPTION
## Summary
- recover old parser nested interactive tree-construction behavior before hard end-tag matching
- carry implicit nested interactive closes through Davinci S1/S2 lowering without reporting missing close errors
- add reduced parser, DOM compiler, S1 fidelity, and S2 emission parity regressions for same-named nested anchor/button ancestors

## Validation
- cargo fmt --all -- --check
- git diff --check HEAD
- cargo test -p vize_armature --test nested_interactive_recovery -- --nocapture
- cargo test -p vize_atelier_dom --test nested_interactive_recovery -- --nocapture
- cargo test -p vize_s1 -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_nested_interactive -- --nocapture
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=/Users/nishimura/Code/github.com/ubugeeei/vize--davinci-old-error-skip-20260831-1/tests/_fixtures/_git/airi cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus dom_emit_agrees_on_sfc_templates -- --exact --nocapture

AIRI smoke on current main plus this commit: files=624 unreadable=0 parsed=624 templates=624 compared=624 old_error_skips=0 s2_refusals=0 divergences=0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790773428&installation_model_id=422833&pr_number=5515&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5515&signature=d3e14ee01dc37916504d7e38a87a5b80e04a9489879f5f8ad238b3a2846e28f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for nested interactive elements such as `<a>` and `<button>`.
  * Preserved same-named ancestor elements instead of prematurely closing them.
  * Retained redundant end tags for source fidelity without creating missing-close errors.
  * Ensured compiled and emitted DOM remains consistent for recovered nested interactive content.
* **Compatibility**
  * Nested interactive markup now produces compatibility notices rather than fatal errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->