### PR TITLE
test(davinci): pin s1 record stage alias

### DIFF
--- a/davinci-road/plan/phase-2-records/p2-7.md
+++ b/davinci-road/plan/phase-2-records/p2-7.md
@@ -7,7 +7,7 @@ corpus-widened TS-19 run recorded as deferred (below), not skipped.**
 ## The shape that landed: a new crate, driven by armature's tokenizer
 
 The contract offered "emitted by `vize_armature`, or a thin layer over
-relief". What landed is **`crates/vize_sinopia`** (the sinopia is the
+relief". What landed is **`crates/vize_s1`** (codename Sinopia, the
 preparatory underdrawing that survives when a fresco is detached — the
 byte-faithful record of what was drawn), a `publish = false` experimental
 crate whose `parse` drives **armature's tokenizer** through its public
@@ -18,7 +18,7 @@ measurement, not taste:
 - **Not a module inside `vize_armature`:** armature is published, and an
   experimental S1 surface inside it would enter the release graph P2-11's
   publish-gate finding warns about. A separate unpublished crate also
-  makes the additive claim mechanical: `cargo tree -i vize_sinopia
+  makes the additive claim mechanical: `cargo tree -i vize_s1
 --workspace` lists nothing, so no compile path can observe S1.
 - **Not a layer over the relief AST:** relief is the _compiler's_ tree —
   it drops bytes by design (whitespace condensing, entity decoding,
@@ -100,16 +100,16 @@ scope ran in both lanes; the recipe is in the lane's module docs:
 
 ```sh
 VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git \
-  cargo test -p vize_sinopia --features davinci-differential \
+  cargo test -p vize_s1 --features davinci-differential \
   --test davinci_surface_corpus -- --nocapture
 ```
 
 ## Acceptance
 
-- `cargo test -p vize_sinopia` green: 10 tests (TS-19 battery + census,
+- `cargo test -p vize_s1` green: 10 tests (TS-19 battery + census,
   truncation property, eight structural hole/token pins); the
   `davinci-differential` lane green in battery scope.
-- **TS-11 empty, proved mechanically**: `cargo tree -i vize_sinopia
+- **TS-11 empty, proved mechanically**: `cargo tree -i vize_s1
 --workspace` lists no reverse dependency — S1 is additive, nothing
   consumes it, no output byte can move.
 - Guarded size asserts compile — eleven 64-bit figures pinned

--- a/tests/tooling/davinci-s1-stage-alias.test.ts
+++ b/tests/tooling/davinci-s1-stage-alias.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readRepoFile(...parts: string[]): string {
+  return fs.readFileSync(path.join(repoRoot, ...parts), "utf8");
+}
+
+test("Davinci S1 uses the physical crate package and directory", () => {
+  const workspaceManifest = readRepoFile("Cargo.toml");
+  assert.match(workspaceManifest, /^\s*"crates\/vize_s1",$/m);
+  assert.match(workspaceManifest, /^vize_s1 = \{ path = "crates\/vize_s1" \}$/m);
+  assert.doesNotMatch(workspaceManifest, /crates\/vize_sinopia/u);
+  assert.doesNotMatch(workspaceManifest, /^vize_sinopia = /m);
+
+  const surfaceManifest = readRepoFile("crates", "vize_s1", "Cargo.toml");
+  assert.match(surfaceManifest, /^name = "vize_s1"$/m);
+
+  const lockfile = readRepoFile("Cargo.lock");
+  assert.match(lockfile, /^name = "vize_s1"$/m);
+});
+
+test("P2-7 lossless S1 recipes use the physical crate package", () => {
+  const record = readRepoFile("davinci-road", "plan", "phase-2-records", "p2-7.md");
+  assert.match(record, /cargo test -p vize_s1 --features davinci-differential/u);
+  assert.match(record, /cargo tree -i vize_s1\s+--workspace/u);
+  assert.doesNotMatch(record, /cargo (?:test -p|tree -i) vize_sinopia/u);
+  assert.doesNotMatch(record, /crates\/vize_sinopia/u);
+});


### PR DESCRIPTION
## Summary
- update the P2-7 lossless S1 record to point operational recipes at the physical `vize_s1` crate name
- add a tooling regression that pins the S1 workspace package/directory and P2-7 command recipes away from stale `vize_sinopia` paths

## Tests
- `node --test tests/tooling/davinci-s1-stage-alias.test.ts tests/tooling/davinci-stage-dependencies.test.ts`
- `node --test tests/tooling/davinci-phase2-ledger.test.ts`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`