### PR TITLE
fix(davinci): align mathml integration namespaces

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dom_namespace.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dom_namespace.rs
@@ -54,6 +54,18 @@ const BATTERY: &[(&str, &str)] = &[
         "v_if_static_mathml_child",
         r#"<div v-if="ok"><math><mi>x</mi></math></div>"#,
     ),
+    (
+        "mathml_same_namespace_dynamic_descendants",
+        r#"<div><math><mrow><msub :data-depth="depth"><mi>x</mi></msub></mrow></math></div>"#,
+    ),
+    (
+        "mathml_annotation_xml_html_boundary",
+        r#"<math><annotation-xml><div v-if="ok"><span>label</span></div></annotation-xml><mn>1</mn></math>"#,
+    ),
+    (
+        "component_slot_static_mathml_child",
+        r#"<Foo><math><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow></math></Foo>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/lower/element.rs
+++ b/crates/vize_s1_to_s2/src/lower/element.rs
@@ -110,7 +110,11 @@ fn enter_ns(parent: Namespace, tag: &str) -> Namespace {
 fn children_ns(own: Namespace, tag: &str) -> Namespace {
     match own {
         Namespace::Svg if matches!(tag, "foreignObject" | "desc" | "title") => Namespace::Html,
-        Namespace::MathMl if matches!(tag, "mi" | "mo" | "mn" | "ms" | "mtext") => Namespace::Html,
+        Namespace::MathMl
+            if matches!(tag, "annotation-xml" | "mi" | "mo" | "mn" | "ms" | "mtext") =>
+        {
+            Namespace::Html
+        }
         other => other,
     }
 }


### PR DESCRIPTION
## Summary
- align S1->S2 MathML child namespace inheritance with the documented/emitter integration-point list by adding `annotation-xml`
- add S2-vs-shipped DOM parity witnesses for MathML dynamic descendants, annotation-xml HTML boundary, and component slot MathML children

## Verification
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_atelier_dom --test davinci_s2_dom_namespace -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_s1_to_s2 --test lowering_elements -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo test -p vize_s1_to_s2 --features davinci-differential`
- `CARGO_TARGET_DIR=/Users/nishimura/Code/github.com/ubugeeei/vize/target cargo fmt --all -- --check && git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790780821&installation_model_id=422833&pr_number=5517&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5517&signature=57d7c4657d5aae85e79656e229022aa4a784f09c0e8abeb2d920b3d1d17fab3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected namespace handling for content inside MathML integration elements, including `annotation-xml` and common MathML text elements.
  - Ensures embedded HTML content is interpreted correctly instead of remaining in the MathML namespace.

- **Tests**
  - Expanded coverage for dynamic MathML descendants, HTML boundaries within `annotation-xml`, and MathML component slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->