### PR TITLE
ci: add zizmor workflow scanning

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,49 @@
+name: Zizmor
+
+on:
+  push:
+    branches: [main, davinci]
+    paths:
+      - ".github/**"
+  pull_request:
+    branches: [main, davinci]
+    paths:
+      - ".github/**"
+  schedule:
+    # Weekly workflow-security audit, offset from the heavier daily gates.
+    - cron: "17 2 * * 2"
+  workflow_dispatch:
+
+concurrency:
+  group: zizmor-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99 # v0.6.3
+        with:
+          advanced-security: true
+          inputs: ".github"
+          min-confidence: high
+          min-severity: high
+          online-audits: true
+          version: "1.30.0"

--- a/tests/tooling/github-workflows-zizmor.test.ts
+++ b/tests/tooling/github-workflows-zizmor.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { parse } from "yaml";
+
+import { readRepoFile } from "./support/github-workflows.ts";
+
+test("zizmor workflow audits GitHub Actions with pinned security scanning", () => {
+  const workflow = readRepoFile(".github", "workflows", "zizmor.yml");
+  const parsed = parse(workflow) as {
+    name?: string;
+    on?: {
+      push?: { branches?: string[]; paths?: string[] };
+      pull_request?: { branches?: string[]; paths?: string[] };
+      schedule?: Array<{ cron?: string }>;
+      workflow_dispatch?: unknown;
+    };
+    concurrency?: {
+      group?: string;
+      "cancel-in-progress"?: boolean;
+    };
+    permissions?: Record<string, never>;
+    env?: Record<string, unknown>;
+    jobs?: {
+      zizmor?: {
+        name?: string;
+        "runs-on"?: string;
+        "timeout-minutes"?: number;
+        "continue-on-error"?: boolean;
+        permissions?: Record<string, string>;
+        steps?: Array<{
+          name?: string;
+          uses?: string;
+          "continue-on-error"?: boolean;
+          with?: Record<string, unknown>;
+        }>;
+      };
+    };
+  };
+
+  assert.equal(parsed.name, "Zizmor");
+  assert.deepEqual(parsed.permissions, {});
+  assert.equal(parsed.env?.FORCE_JAVASCRIPT_ACTIONS_TO_NODE24, true);
+  assert.deepEqual(parsed.on?.push?.branches, ["main", "davinci"]);
+  assert.deepEqual(parsed.on?.push?.paths, [".github/**"]);
+  assert.deepEqual(parsed.on?.pull_request?.branches, ["main", "davinci"]);
+  assert.deepEqual(parsed.on?.pull_request?.paths, [".github/**"]);
+  assert.deepEqual(parsed.on?.schedule, [{ cron: "17 2 * * 2" }]);
+  assert.ok(Object.hasOwn(parsed.on ?? {}, "workflow_dispatch"));
+  assert.equal(Object.hasOwn(parsed.on ?? {}, "pull_request_target"), false);
+  assert.deepEqual(parsed.concurrency, {
+    "cancel-in-progress": true,
+    group: "zizmor-${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}",
+  });
+
+  const job = parsed.jobs?.zizmor;
+  assert.ok(job, "missing zizmor job");
+  assert.equal(job.name, "Run zizmor");
+  assert.equal(job["runs-on"], "blacksmith-32vcpu-ubuntu-2404");
+  assert.equal(job["timeout-minutes"], 10);
+  assert.notEqual(job["continue-on-error"], true);
+  assert.deepEqual(job.permissions, {
+    actions: "read",
+    contents: "read",
+    "security-events": "write",
+  });
+
+  const checkout = job.steps?.find((step) => step.uses?.startsWith("actions/checkout@"));
+  assert.ok(checkout, "missing checkout step");
+  assert.match(checkout.uses ?? "", /^actions\/checkout@[0-9a-f]{40}$/);
+  assert.equal(checkout.with?.["persist-credentials"], false);
+
+  const scan = job.steps?.find((step) => step.uses?.startsWith("zizmorcore/zizmor-action@"));
+  assert.ok(scan, "missing zizmor action step");
+  assert.equal(scan.uses, "zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99");
+  assert.deepEqual(scan.with, {
+    "advanced-security": true,
+    inputs: ".github",
+    "min-confidence": "high",
+    "min-severity": "high",
+    "online-audits": true,
+    version: "1.30.0",
+  });
+  for (const step of job.steps ?? []) {
+    assert.notEqual(step["continue-on-error"], true, `${step.name ?? step.uses} must fail closed`);
+  }
+});

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -28,6 +28,7 @@ test("GitHub workflows opt JavaScript actions into Node 24", () => {
     "release.yml",
     "title-policy.yml",
     "tool-benchmark.yml",
+    "zizmor.yml",
   ]) {
     const workflow = readRepoFile(".github", "workflows", workflowName);
     assert.match(workflow, /FORCE_JAVASCRIPT_ACTIONS_TO_NODE24:\s*true/);


### PR DESCRIPTION
## Summary

- Add a dedicated Zizmor workflow for GitHub Actions security scanning.
- Run it on `.github` changes, a weekly schedule, and manual dispatch.
- Pin `zizmorcore/zizmor-action` v0.6.3 by SHA and pin the analyzer to v1.30.0; upload high-confidence/high-severity SARIF to code scanning.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [x] Not language-facing

## Behavior Reference

- https://docs.zizmor.sh/integrations/
- https://github.com/zizmorcore/zizmor-action/releases/tag/v0.6.3

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [ ] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

Commands run:

- `node --test tests/tooling/github-workflows.test.ts` -> 12/12 pass
- `MOON_HOME=/tmp/vize-moonbit-zizmor/moonbit PATH=/tmp/vize-moonbit-zizmor/moonbit-shims:/tmp/vize-moonbit-zizmor/moonbit/bin:$PATH vp run --workspace-root check:repo` -> pass
- `actrun lint .github/workflows/zizmor.yml` -> clean
- `GH_TOKEN=... uvx --from zizmor==1.30.0 zizmor --format=sarif --min-severity=high --min-confidence=high .github > /tmp/vize-zizmor.sarif` -> exit 0, SARIF reports analyzer 1.30.0 and 61 existing high/high findings

## Risk

- The new workflow uses SARIF/code scanning mode so initial existing findings are reported without making this introduction PR a broad remediation.
- The workflow is path-filtered to `.github/**` plus a weekly scheduled run to keep routine PR load low.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790781137&installation_model_id=422833&pr_number=5518&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5518&signature=4c6470e08f4322e0600c9a79360a68f347da4c6e4bdba967e7cc83596e943541"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added automated security audits for GitHub Actions workflows when workflow changes are submitted, weekly, or on demand.
  * Configured high-confidence and high-severity checks with secure permissions, pinned actions, and protections against overlapping audit runs.
  * Audits cover workflow changes across supported primary development branches.

* **Quality Assurance**
  * Added validation to ensure the security workflow maintains its required triggers, permissions, action versions, and security settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->