### PR TITLE
fix(davinci): close DOM corpus parity gaps

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -320,6 +320,7 @@ jobs:
           persist-credentials: false
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: ./.github/actions/setup-rust-script
       - name: Setup Wild linker
         uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:

--- a/crates/vize_atelier_dom/tests/davinci_s2_handler_parity.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_handler_parity.rs
@@ -10,6 +10,25 @@ mod support;
 
 const BATTERY: &[(&str, &str)] = &[
     (
+        "native_expression_arrow_handler_is_wrapped",
+        r#"<span @click="() => deleteResource(cell?.data as Node)">delete</span>"#,
+    ),
+    (
+        "native_param_arrow_handler_stays_direct",
+        r#"<button @contextmenu="event => openContextMenu(event, image)">open</button>"#,
+    ),
+    (
+        "multiline_component_update_handler_keeps_authored_padding",
+        r#"<AppCheck @update:model-value="
+  value => {
+    p(opt.key).value = {
+      ...p(opt.key).value,
+      [key]: value,
+    };
+  }
+" />"#,
+    ),
+    (
         "untyped_arrow_component_handler_stays_direct",
         r#"<FieldKeyValues @add="(key, value) => addKeyValue(headers, key, value)" />"#,
     ),

--- a/crates/vize_atelier_dom/tests/davinci_s2_static_vnode_hoist.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_static_vnode_hoist.rs
@@ -14,6 +14,10 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<div><select v-model="msg"><option value=""> Select </option><option v-for="item in items" :value="item">{{ item }}</option></select></div>"#,
     ),
     (
+        "nested_select_patchless_bound_options_hoist",
+        r#"<div><select v-model="user.role"><option :value="1">User</option><option :value="2">Admin</option></select></div>"#,
+    ),
+    (
         "v_if_static_child_and_text",
         r#"<div v-if="ok"><span></span> x</div>"#,
     ),

--- a/crates/vize_atelier_dom/tests/davinci_s2_whitespace_text_vnode.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_whitespace_text_vnode.rs
@@ -1,0 +1,49 @@
+//! P2-11 DOM corpus parity pins for whitespace-only text vnode spelling.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "inline_element_space_uses_empty_create_text_call",
+        r#"<p><sup>text</sup> <code>^text^</code></p>"#,
+    ),
+    (
+        "inline_element_space_before_br_uses_empty_create_text_call",
+        r#"<p><em>does this help the user think better?</em> <br><br></p>"#,
+    ),
+    (
+        "keyboard_shortcut_space_uses_empty_create_text_call",
+        r#"<p><kbd>Ctrl</kbd> <kbd>K</kbd></p>"#,
+    ),
+    (
+        "hoisted_static_child_space_keeps_shipped_explicit_create_text_call",
+        r#"<div :id="id"><span><sup>text</sup> <code>^text^</code></span></div>"#,
+    ),
+    (
+        "cached_static_child_space_uses_empty_create_text_call",
+        r#"<div class="root">{{ msg }}<span><kbd>Ctrl</kbd> <kbd>K</kbd></span></div>"#,
+    ),
+    (
+        "conditional_component_space_before_icon_matches_shipped",
+        r#"<div><Icon v-if="item.enabled" :name="item.enabledIcon" /> <Icon :name="item.icon" />{{ item.label }}</div>"#,
+    ),
+    (
+        "implicit_slot_element_if_space_before_component_matches_shipped",
+        r#"<NuxtLink><span v-if="mark.hasMark(item.newId)" class="bubble"></span> <Icon :name="item.icon" />{{ item.label }}</NuxtLink>"#,
+    ),
+    (
+        "named_slot_element_if_space_before_component_matches_shipped",
+        r#"<Foo><template #default><span v-if="ok" class="bubble"></span> <Icon :name="item.icon" />{{ item.label }}</template></Foo>"#,
+    ),
+];
+
+#[test]
+fn s2_whitespace_text_vnodes_match_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_s1_to_s2/src/emit/children.rs
+++ b/crates/vize_s1_to_s2/src/emit/children.rs
@@ -1,5 +1,8 @@
 //! Text and interpolation children.
 
+mod slot_compound;
+
+use slot_compound::emit_slot_compound_parts;
 use vize_davinci::id::NodeId;
 use vize_s0::Span;
 use vize_s2::expr::{ExprRef, JsExpr, OpaqueReason};
@@ -325,31 +328,4 @@ pub(super) fn emit_raw_interpolation_or_refuse(
             expression.span(),
         ))
     }
-}
-
-fn emit_slot_compound_parts(
-    cx: &mut EmitCx<'_>,
-    parts: &[TextPart],
-    span: Span,
-) -> Result<(), EmitError> {
-    if parts.is_empty() {
-        return Err(EmitError::unsupported_at(Reason::EmptyCompoundText, span));
-    }
-    for (i, part) in parts.iter().enumerate() {
-        if i > 0 {
-            cx.buf.push(",");
-            cx.buf.newline();
-        }
-        cx.buf.use_create_text();
-        cx.buf.push(Buf::create_text_alias());
-        cx.buf.push("(");
-        if part.dynamic {
-            emit_to_display_string(cx, part.text.as_str());
-            cx.buf.push(", 1 /* TEXT */");
-        } else {
-            emit_quoted_text(cx, part.text.as_str());
-        }
-        cx.buf.push(")");
-    }
-    Ok(())
 }

--- a/crates/vize_s1_to_s2/src/emit/children.rs
+++ b/crates/vize_s1_to_s2/src/emit/children.rs
@@ -167,6 +167,10 @@ pub(super) fn emit_create_text_vnode(cx: &mut EmitCx<'_>, ops: &[Op<'_>]) -> Res
 /// Slot default children emit one or more `_createTextVNode`s.
 pub(super) fn emit_slot_text_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> {
     let Op::Interpolation(interp) = op else {
+        if let Op::Text(text) = op {
+            emit_slot_plain_text_vnode(cx, text.content);
+            return Ok(());
+        }
         return emit_create_text_vnode(cx, core::slice::from_ref(op));
     };
     match interp.expression {
@@ -212,15 +216,8 @@ pub(super) fn emit_slot_text_run(cx: &mut EmitCx<'_>, ops: &[Op<'_>]) -> Result<
         return Err(EmitError::unsupported(Reason::EmptyTextRun));
     }
     let has_interp = ops.iter().any(|op| matches!(op, Op::Interpolation(_)));
-    let is_single_space =
-        !has_interp && ops.len() == 1 && matches!(&ops[0], Op::Text(text) if text.content == " ");
     cx.buf.use_create_text();
     cx.buf.push(Buf::create_text_alias());
-    if is_single_space {
-        let _id = cx.walk.mint();
-        cx.buf.push("()");
-        return Ok(());
-    }
     cx.buf.push("(");
     emit_slot_text_like(cx, ops)?;
     if has_interp {
@@ -228,6 +225,15 @@ pub(super) fn emit_slot_text_run(cx: &mut EmitCx<'_>, ops: &[Op<'_>]) -> Result<
     }
     cx.buf.push(")");
     Ok(())
+}
+
+fn emit_slot_plain_text_vnode(cx: &mut EmitCx<'_>, content: &str) {
+    let _id = cx.walk.mint();
+    cx.buf.use_create_text();
+    cx.buf.push(Buf::create_text_alias());
+    cx.buf.push("(\"");
+    cx.buf.push(escape_js_string(content).as_str());
+    cx.buf.push("\")");
 }
 
 fn emit_slot_text_like(cx: &mut EmitCx<'_>, ops: &[Op<'_>]) -> Result<(), EmitError> {

--- a/crates/vize_s1_to_s2/src/emit/children/slot_compound.rs
+++ b/crates/vize_s1_to_s2/src/emit/children/slot_compound.rs
@@ -1,0 +1,33 @@
+use vize_s0::Span;
+
+use crate::lower::TextPart;
+
+use super::{EmitCx, EmitError, Reason, emit_quoted_text, emit_to_display_string};
+use crate::emit::buf::Buf;
+
+pub(super) fn emit_slot_compound_parts(
+    cx: &mut EmitCx<'_>,
+    parts: &[TextPart],
+    span: Span,
+) -> Result<(), EmitError> {
+    if parts.is_empty() {
+        return Err(EmitError::unsupported_at(Reason::EmptyCompoundText, span));
+    }
+    for (i, part) in parts.iter().enumerate() {
+        if i > 0 {
+            cx.buf.push(",");
+            cx.buf.newline();
+        }
+        cx.buf.use_create_text();
+        cx.buf.push(Buf::create_text_alias());
+        cx.buf.push("(");
+        if part.dynamic {
+            emit_to_display_string(cx, part.text.as_str());
+            cx.buf.push(", 1 /* TEXT */");
+        } else {
+            emit_quoted_text(cx, part.text.as_str());
+        }
+        cx.buf.push(")");
+    }
+    Ok(())
+}

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -25,7 +25,6 @@ use super::hoist::compact_props_object;
 use super::js::asset_ident;
 use super::props::{admit_bindings, apply_static_ref_patch, bind_patch, emit_bind_props};
 use super::props_static;
-use super::props_static::PropHoistPosition;
 use super::slots;
 
 pub(super) use preamble::{collect_names, emit_resolves};
@@ -193,26 +192,36 @@ fn emit_call(
     let static_nested = builtin::has_static_nested(&component.children);
     let builtin_helper = builtin::helper(component.name).is_some();
     let hoistable_static_props = if skip_is {
-        has_hoist_attrs.then(|| compact_props_object(hoist_attrs.iter().copied()))
+        has_hoist_attrs.then(|| props_static::ComponentHoistProps {
+            source: compact_props_object(hoist_attrs.iter().copied()),
+            dynamic_values: false,
+            non_key: hoist_attrs.iter().any(|attr| attr.name != "key"),
+        })
     } else {
-        props_static::root_hoist_props(&component.attributes, &component.bindings)?
+        props_static::component_hoist_props(&component.attributes, &component.bindings)?
     };
-    if for_item
-        && !has_custom
-        && hoistable_static_props.is_some()
-        && props_static::should_hoist(cx, id, PropHoistPosition::ForItem)
-    {
-        cx.buf.push_hoist(
-            hoistable_static_props
-                .clone()
-                .expect("checked hoisted props"),
-        );
+    if for_item && !has_custom && cx.slot_param_depth == 0 {
+        if let Some(props) = hoistable_static_props.as_ref()
+            && props.non_key
+            && (props_static::should_hoist(cx, id, props_static::PropHoistPosition::ForItem)
+                || (props.dynamic_values && !has_slots && !has_array))
+        {
+            cx.buf.push_hoist(props.source.clone());
+        }
     }
     let can_hoist_static_props = !has_custom
         && !for_item
         && if_key.is_none()
         && hoistable_static_props.is_some()
-        && props_static::should_hoist(cx, id, PropHoistPosition::Nested);
+        && cx.slot_param_depth == 0
+        && hoistable_static_props.as_ref().is_some_and(|props| {
+            props_static::should_hoist(cx, id, props_static::PropHoistPosition::Nested)
+                || (props.dynamic_values
+                    && !cx.in_v_for
+                    && (!cx.hoist_static_vnodes
+                        || !has_slots
+                        || slots::has_text_only_implicit_default(&component.children)))
+        });
     let hoisted_static_props = if can_hoist_static_props
         && ((!array && (facts.is_some() || create) && (!builtin_helper || static_nested))
             || (array && static_nested))
@@ -220,8 +229,10 @@ fn emit_call(
         Some(
             cx.buf.push_hoist(
                 hoistable_static_props
-                    .clone()
-                    .expect("checked hoisted props"),
+                    .as_ref()
+                    .expect("checked hoisted props")
+                    .source
+                    .clone(),
             ),
         )
     } else {
@@ -229,8 +240,11 @@ fn emit_call(
     };
     let unused_hoist = hoisted_static_props.is_none() && can_hoist_static_props && static_nested;
     if unused_hoist {
-        cx.buf
-            .push_hoist(hoistable_static_props.expect("checked hoisted props"));
+        cx.buf.push_hoist(
+            hoistable_static_props
+                .expect("checked hoisted props")
+                .source,
+        );
     }
     let mut patch = bind_patch(&component.bindings, true, if_key, for_item);
     if skip_is {

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -200,14 +200,15 @@ fn emit_call(
     } else {
         props_static::component_hoist_props(&component.attributes, &component.bindings)?
     };
-    if for_item && !has_custom && cx.slot_param_depth == 0 {
-        if let Some(props) = hoistable_static_props.as_ref()
-            && props.non_key
-            && (props_static::should_hoist(cx, id, props_static::PropHoistPosition::ForItem)
-                || (props.dynamic_values && !has_slots && !has_array))
-        {
-            cx.buf.push_hoist(props.source.clone());
-        }
+    if for_item
+        && !has_custom
+        && cx.slot_param_depth == 0
+        && let Some(props) = hoistable_static_props.as_ref()
+        && props.non_key
+        && (props_static::should_hoist(cx, id, props_static::PropHoistPosition::ForItem)
+            || (props.dynamic_values && !has_slots && !has_array))
+    {
+        cx.buf.push_hoist(props.source.clone());
     }
     let can_hoist_static_props = !has_custom
         && !for_item

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -5,12 +5,14 @@
 //! spread, Vue builtins, and `<component :is>`
 //! (`resolveDynamicComponent`).
 
+mod checks;
 mod preamble;
 
 use alloc::vec::Vec as StdVec;
+use checks::{admit, has_dynamic_key_binding};
 
 use vize_davinci::id::NodeId;
-use vize_s2::op::{BindingOp, ComponentOp, DynamicName};
+use vize_s2::op::{BindingOp, ComponentOp};
 
 use super::EmitCx;
 use super::EmitError;
@@ -23,7 +25,7 @@ use super::directive;
 use super::flag::emit_patch_flag;
 use super::hoist::compact_props_object;
 use super::js::asset_ident;
-use super::props::{admit_bindings, apply_static_ref_patch, bind_patch, emit_bind_props};
+use super::props::{apply_static_ref_patch, bind_patch, emit_bind_props};
 use super::props_static;
 use super::slots;
 
@@ -335,24 +337,4 @@ fn emit_call(
     }
     cx.buf.push(")");
     Ok(())
-}
-
-fn admit(cx: &EmitCx<'_>, component: &ComponentOp<'_>) -> Result<(), EmitError> {
-    if create_slots::needs_create_slots(cx, &component.children)
-        || slots::has_implicit_default(&component.children)
-    {
-        slots::admit_default(&component.children)?;
-    }
-    admit_bindings(&component.attributes, &component.bindings)
-}
-
-fn has_dynamic_key_binding(component: &ComponentOp<'_>) -> bool {
-    component.bindings.iter().any(|binding| {
-        matches!(
-            binding,
-            BindingOp::Bind(bind)
-                if bind.value.is_some()
-                    && matches!(bind.name, Some(DynamicName::Static("key")))
-        )
-    })
 }

--- a/crates/vize_s1_to_s2/src/emit/component/checks.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/checks.rs
@@ -1,0 +1,23 @@
+use vize_s2::op::{BindingOp, ComponentOp, DynamicName};
+
+use super::super::{EmitCx, EmitError, create_slots, slots};
+
+pub(super) fn admit(cx: &EmitCx<'_>, component: &ComponentOp<'_>) -> Result<(), EmitError> {
+    if create_slots::needs_create_slots(cx, &component.children)
+        || slots::has_implicit_default(&component.children)
+    {
+        slots::admit_default(&component.children)?;
+    }
+    super::super::props::admit_bindings(&component.attributes, &component.bindings)
+}
+
+pub(super) fn has_dynamic_key_binding(component: &ComponentOp<'_>) -> bool {
+    component.bindings.iter().any(|binding| {
+        matches!(
+            binding,
+            BindingOp::Bind(bind)
+                if bind.value.is_some()
+                    && matches!(bind.name, Some(DynamicName::Static("key")))
+        )
+    })
+}

--- a/crates/vize_s1_to_s2/src/emit/hoist.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist.rs
@@ -111,8 +111,7 @@ pub(super) fn is_hoistable(element: &ElementOp<'_>) -> bool {
 }
 
 pub(super) fn is_static_element_tree(element: &ElementOp<'_>) -> bool {
-    !element.attributes.iter().any(|attr| attr.name == "ref")
-        && element.bindings.is_empty()
+    super::props_static::static_vnode_surface_can_hoist(&element.attributes, &element.bindings)
         && element.children.ops.iter().all(is_static_tree_child)
 }
 
@@ -162,11 +161,11 @@ fn hoist_element_rhs(element: &ElementOp<'_>, pure: bool) -> String {
     out.push_str(element.tag);
     out.push('"');
     let kids = renderable_children(&element.children);
-    let has_attrs = !element.attributes.is_empty();
-    if has_attrs || !kids.is_empty() {
+    let props = static_vnode_props(element);
+    if props.is_some() || !kids.is_empty() {
         out.push_str(", ");
-        if has_attrs {
-            out.push_str(compact_props_object(element.attributes.iter()).as_str());
+        if let Some(props) = props {
+            out.push_str(props.as_str());
         } else {
             out.push_str("null");
         }
@@ -197,10 +196,12 @@ fn append_cached_element_rhs(
     out.push_str(element.tag);
     out.push('"');
     out.push_str(", ");
-    if element.attributes.is_empty() {
-        out.push_str("null");
-    } else {
+    if element.bindings.is_empty() && !element.attributes.is_empty() {
         cached_props::push_object(out, element.attributes.iter(), line_indent);
+    } else if let Some(props) = static_vnode_props(element) {
+        out.push_str(props.as_str());
+    } else {
+        out.push_str("null");
     }
     out.push_str(", ");
     let kids = renderable_children(&element.children);
@@ -213,6 +214,12 @@ fn append_cached_element_rhs(
         out.push_str(", -1 /* CACHED */");
     }
     out.push(')');
+}
+
+fn static_vnode_props(element: &ElementOp<'_>) -> Option<String> {
+    super::props_static::root_hoist_props(&element.attributes, &element.bindings)
+        .ok()
+        .flatten()
 }
 
 fn append_hoist_kids(out: &mut String, kids: &[&Op<'_>]) {
@@ -269,12 +276,7 @@ fn append_cached_kids(out: &mut String, kids: &[&Op<'_>], line_indent: usize) {
         push_spaces(out, line_indent + 2);
         match op {
             Op::Text(text) => {
-                out.push_str(Buf::create_text_alias());
-                out.push('(');
-                out.push('"');
-                out.push_str(escape_js_string(text.content).as_str());
-                out.push('"');
-                out.push(')');
+                push_cached_create_text_call(out, text.content);
             }
             Op::Element(element) => {
                 append_cached_element_rhs(out, element, false, line_indent + 2);
@@ -285,6 +287,19 @@ fn append_cached_kids(out: &mut String, kids: &[&Op<'_>], line_indent: usize) {
     out.push('\n');
     push_spaces(out, line_indent);
     out.push(']');
+}
+
+fn push_cached_create_text_call(out: &mut String, content: &str) {
+    out.push_str(Buf::create_text_alias());
+    if content == " " {
+        out.push_str("()");
+        return;
+    }
+    out.push('(');
+    out.push('"');
+    out.push_str(escape_js_string(content).as_str());
+    out.push('"');
+    out.push(')');
 }
 
 fn push_spaces(out: &mut String, width: usize) {

--- a/crates/vize_s1_to_s2/src/emit/hoist.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist.rs
@@ -5,13 +5,16 @@
 //! with later installments.
 
 mod cached_props;
+mod props;
+
 use alloc::vec::Vec as StdVec;
+pub(super) use props::{compact_props_object, push_attr_pair, unique_attrs};
 
 use vize_s0::{String, ToCompactString};
-use vize_s2::op::{Attribute, ElementOp, Op, Region};
+use vize_s2::op::{ElementOp, Op, Region};
 
 use super::buf::Buf;
-use super::js::{escape_js_string, is_valid_js_identifier};
+use super::js::escape_js_string;
 use super::{EmitCx, EmitError, UnsupportedReason as Reason};
 
 pub(super) fn emit_hoisted_element(
@@ -310,50 +313,4 @@ fn renderable_children<'a>(children: &'a Region<'a>) -> StdVec<&'a Op<'a>> {
     // S2 lowering has already applied legacy condense/drop decisions; every
     // remaining text op is renderable, including a single-space separator.
     children.ops.iter().collect()
-}
-
-/// First-occurrence static attrs as a single-line object, matching
-/// hoisted `JsChildNode::Object` emission.
-pub(super) fn compact_props_object<'a>(
-    attributes: impl Iterator<Item = &'a Attribute<'a>>,
-) -> String {
-    let unique = unique_attrs(attributes);
-    let mut out = String::from("{ ");
-    for (i, attr) in unique.iter().enumerate() {
-        if i > 0 {
-            out.push_str(", ");
-        }
-        push_attr_pair(&mut out, attr);
-    }
-    out.push_str(" }");
-    out
-}
-
-pub(super) fn unique_attrs<'a>(
-    attributes: impl Iterator<Item = &'a Attribute<'a>>,
-) -> StdVec<&'a Attribute<'a>> {
-    let mut unique: StdVec<&Attribute<'_>> = StdVec::new();
-    for attr in attributes {
-        if unique.iter().any(|seen| seen.name == attr.name) {
-            continue;
-        }
-        unique.push(attr);
-    }
-    unique
-}
-
-pub(super) fn push_attr_pair(out: &mut String, attr: &Attribute<'_>) {
-    let quoted = !is_valid_js_identifier(attr.name);
-    if quoted {
-        out.push('"');
-    }
-    out.push_str(attr.name);
-    if quoted {
-        out.push('"');
-    }
-    out.push_str(": \"");
-    if let Some(value) = attr.value {
-        out.push_str(escape_js_string(value).as_str());
-    }
-    out.push('"');
 }

--- a/crates/vize_s1_to_s2/src/emit/hoist/props.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist/props.rs
@@ -1,0 +1,52 @@
+use alloc::vec::Vec as StdVec;
+
+use vize_s0::String;
+use vize_s2::op::Attribute;
+
+use super::super::js::{escape_js_string, is_valid_js_identifier};
+
+/// First-occurrence static attrs as a single-line object, matching
+/// hoisted `JsChildNode::Object` emission.
+pub(in crate::emit) fn compact_props_object<'a>(
+    attributes: impl Iterator<Item = &'a Attribute<'a>>,
+) -> String {
+    let unique = unique_attrs(attributes);
+    let mut out = String::from("{ ");
+    for (i, attr) in unique.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        push_attr_pair(&mut out, attr);
+    }
+    out.push_str(" }");
+    out
+}
+
+pub(in crate::emit) fn unique_attrs<'a>(
+    attributes: impl Iterator<Item = &'a Attribute<'a>>,
+) -> StdVec<&'a Attribute<'a>> {
+    let mut unique: StdVec<&Attribute<'_>> = StdVec::new();
+    for attr in attributes {
+        if unique.iter().any(|seen| seen.name == attr.name) {
+            continue;
+        }
+        unique.push(attr);
+    }
+    unique
+}
+
+pub(in crate::emit) fn push_attr_pair(out: &mut String, attr: &Attribute<'_>) {
+    let quoted = !is_valid_js_identifier(attr.name);
+    if quoted {
+        out.push('"');
+    }
+    out.push_str(attr.name);
+    if quoted {
+        out.push('"');
+    }
+    out.push_str(": \"");
+    if let Some(value) = attr.value {
+        out.push_str(escape_js_string(value).as_str());
+    }
+    out.push('"');
+}

--- a/crates/vize_s1_to_s2/src/emit/namespace.rs
+++ b/crates/vize_s1_to_s2/src/emit/namespace.rs
@@ -26,9 +26,45 @@ pub(super) fn child_namespace(element: &ElementOp<'_>) -> Namespace {
     }
 }
 
-pub(super) fn crosses_boundary(cx: &EmitCx<'_>, element: &ElementOp<'_>) -> bool {
+pub(super) fn crosses_boundary(
+    cx: &EmitCx<'_>,
+    element: &ElementOp<'_>,
+    direct_static_children_hoisted: bool,
+) -> bool {
     element.namespace != cx.parent_ns
-        || children_cross_boundary(element.namespace, &element.children)
+        || child_namespace_crosses(element)
+        || structural_children_cross_boundary(
+            element.namespace,
+            &element.children,
+            direct_static_children_hoisted,
+        )
+}
+
+fn structural_children_cross_boundary(
+    ns: Namespace,
+    children: &Region<'_>,
+    direct_static_children_hoisted: bool,
+) -> bool {
+    children.ops.iter().any(|child| match child {
+        Op::Element(element) => child_crosses_direct(ns, element, direct_static_children_hoisted),
+        Op::If(if_op) => if_op
+            .branches
+            .iter()
+            .any(|branch| ensure_sufficient_stack(|| children_cross_boundary(ns, &branch.region))),
+        Op::For(for_op) => ensure_sufficient_stack(|| children_cross_boundary(ns, &for_op.region)),
+        Op::Component(_) | Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => false,
+    })
+}
+
+fn child_crosses_direct(
+    ns: Namespace,
+    element: &ElementOp<'_>,
+    direct_static_children_hoisted: bool,
+) -> bool {
+    if element.namespace != ns {
+        return !(direct_static_children_hoisted && super::hoist::is_hoistable(element));
+    }
+    child_namespace_crosses(element)
 }
 
 fn children_cross_boundary(ns: Namespace, children: &Region<'_>) -> bool {
@@ -37,7 +73,7 @@ fn children_cross_boundary(ns: Namespace, children: &Region<'_>) -> bool {
 
 fn child_crosses(ns: Namespace, child: &Op<'_>) -> bool {
     match child {
-        Op::Element(element) => element.namespace != ns,
+        Op::Element(element) => element.namespace != ns || child_namespace_crosses(element),
         Op::If(if_op) => if_op
             .branches
             .iter()
@@ -45,6 +81,15 @@ fn child_crosses(ns: Namespace, child: &Op<'_>) -> bool {
         Op::For(for_op) => ensure_sufficient_stack(|| children_cross_boundary(ns, &for_op.region)),
         Op::Component(_) | Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => false,
     }
+}
+
+fn child_namespace_crosses(element: &ElementOp<'_>) -> bool {
+    child_namespace(element) != element.namespace
+        && element
+            .children
+            .ops
+            .iter()
+            .any(|op| !matches!(op, Op::Text(_) | Op::Interpolation(_)))
 }
 
 pub(super) fn with_child<T>(

--- a/crates/vize_s1_to_s2/src/emit/on.rs
+++ b/crates/vize_s1_to_s2/src/emit/on.rs
@@ -3,7 +3,7 @@
 //! Object `v-on` lives in [`super::merge`].
 
 use oxc_ast::ast::{ChainElement, Expression};
-use vize_s0::{SmallVec, String, camelize, capitalize};
+use vize_s0::{SmallVec, Span, String, camelize, capitalize};
 use vize_s2::expr::{ExprRef, JsExpr, OpaqueReason};
 use vize_s2::op::{DynamicName, OnOp};
 
@@ -132,25 +132,30 @@ pub(super) fn emit_on_pair(
     is_plain_element: bool,
 ) -> Result<(), EmitError> {
     if super::on_dynamic::is_dynamic_on_name(on) {
-        return super::on_dynamic::emit_pair(cx, on);
+        return super::on_dynamic::emit_pair(cx, on, is_plain_element);
     }
     super::js::push_ident_key(cx, event_key_for(on, is_plain_element)?.as_str());
     cx.buf.push(": ");
-    emit_on_value(cx, on)
+    emit_on_value(cx, on, is_plain_element)
 }
 
-pub(super) fn emit_on_value(cx: &mut EmitCx<'_>, on: &OnOp<'_>) -> Result<(), EmitError> {
+pub(super) fn emit_on_value(
+    cx: &mut EmitCx<'_>,
+    on: &OnOp<'_>,
+    is_plain_element: bool,
+) -> Result<(), EmitError> {
     if super::on_dynamic::is_dynamic_on_name(on) {
-        return super::on_dynamic::emit_value(cx, on);
+        return super::on_dynamic::emit_value(cx, on, is_plain_element);
     }
     let classified = classify(on)?;
-    emit_wrapped_handler(cx, on, &classified)
+    emit_wrapped_handler(cx, on, &classified, is_plain_element)
 }
 
 pub(super) fn emit_wrapped_handler(
     cx: &mut EmitCx<'_>,
     on: &OnOp<'_>,
     classified: &Classified<'_>,
+    is_plain_element: bool,
 ) -> Result<(), EmitError> {
     if !classified.keys.is_empty() {
         cx.buf.use_with_keys();
@@ -163,7 +168,7 @@ pub(super) fn emit_wrapped_handler(
         cx.buf.push("(");
     }
     match on.handler {
-        Some(ExprRef::Js(js)) => emit_handler(cx, js),
+        Some(ExprRef::Js(js)) => emit_handler(cx, on, js, is_plain_element),
         Some(ExprRef::Opaque(opaque)) if opaque.reason == OpaqueReason::MultiStatement => {
             super::on_body::emit(cx, opaque.source);
         }
@@ -201,12 +206,18 @@ fn emit_mod_array(cx: &mut EmitCx<'_>, mods: &[&str]) {
     cx.buf.push("]");
 }
 
-pub(super) fn emit_handler(cx: &mut EmitCx<'_>, js: &JsExpr<'_>) {
+pub(super) fn emit_handler(
+    cx: &mut EmitCx<'_>,
+    on: &OnOp<'_>,
+    js: &JsExpr<'_>,
+    is_plain_element: bool,
+) {
     if is_handler_reference(js.ast) || super::on_body::preserves_raw_function_handler(js) {
-        cx.buf.push(js.source);
+        emit_raw_handler(cx, on, js);
         return;
     }
-    if is_function(js.ast) && !super::on_typed::is_typed_arrow(js.ast) {
+    if is_raw_function_handler(js.ast, is_plain_element) && !super::on_typed::is_typed_arrow(js.ast)
+    {
         super::js::push_js_expr(cx, js);
         return;
     }
@@ -217,6 +228,56 @@ pub(super) fn emit_handler(cx: &mut EmitCx<'_>, js: &JsExpr<'_>) {
         super::js::push_js_expr(cx, js);
         cx.buf.push(")");
     }
+}
+
+fn emit_raw_handler(cx: &mut EmitCx<'_>, on: &OnOp<'_>, js: &JsExpr<'_>) {
+    if let Some((leading, trailing)) = authored_handler_padding(cx.source, on, js.source, js.span) {
+        cx.buf.push(leading);
+        cx.buf.push(js.source);
+        cx.buf.push(trailing);
+    } else {
+        cx.buf.push(js.source);
+    }
+}
+
+fn authored_handler_padding<'a>(
+    source: &'a str,
+    on: &OnOp<'_>,
+    value: &str,
+    value_span: Span,
+) -> Option<(&'a str, &'a str)> {
+    let attr_start = usize::try_from(on.span.start).ok()?;
+    let attr_end = usize::try_from(on.span.end).ok()?;
+    let value_start = usize::try_from(value_span.start).ok()?;
+    let value_end = usize::try_from(value_span.end).ok()?;
+    if attr_start > value_start
+        || value_start > value_end
+        || value_end > attr_end
+        || attr_end > source.len()
+        || source.get(value_start..value_end)? != value
+    {
+        return None;
+    }
+    let before = source.get(attr_start..value_start)?;
+    let quote_pos = before
+        .as_bytes()
+        .iter()
+        .rposition(|byte| matches!(*byte, b'\'' | b'"'))?;
+    let quote = before.as_bytes()[quote_pos];
+    let leading = before.get(quote_pos + 1..)?;
+    let after = source.get(value_end..attr_end)?;
+    let trailing_end = after
+        .as_bytes()
+        .iter()
+        .position(|byte| *byte == quote)
+        .unwrap_or(after.len());
+    let trailing = after.get(..trailing_end)?;
+    if leading.is_empty() && trailing.is_empty() {
+        return None;
+    }
+    (leading.bytes().all(|byte| byte.is_ascii_whitespace())
+        && trailing.bytes().all(|byte| byte.is_ascii_whitespace()))
+    .then_some((leading, trailing))
 }
 
 fn classify<'a>(on: &'a OnOp<'a>) -> Result<Classified<'a>, EmitError> {
@@ -296,11 +357,16 @@ fn is_handler_reference(expr: &Expression<'_>) -> bool {
     }
 }
 
-fn is_function(expr: &Expression<'_>) -> bool {
-    matches!(
-        expr,
-        Expression::ArrowFunctionExpression(_) | Expression::FunctionExpression(_)
-    )
+fn is_raw_function_handler(expr: &Expression<'_>, is_plain_element: bool) -> bool {
+    if matches!(expr, Expression::FunctionExpression(_)) {
+        return true;
+    }
+    match expr {
+        Expression::ArrowFunctionExpression(arrow) => {
+            !is_plain_element || !arrow.params.items.is_empty()
+        }
+        _ => false,
+    }
 }
 
 #[cfg(test)]

--- a/crates/vize_s1_to_s2/src/emit/on.rs
+++ b/crates/vize_s1_to_s2/src/emit/on.rs
@@ -2,12 +2,17 @@
 //! key, and option modifiers (`withModifiers`, `withKeys`, `onClickOnce`, …).
 //! Object `v-on` lives in [`super::merge`].
 
-use oxc_ast::ast::{ChainElement, Expression};
-use vize_s0::{SmallVec, Span, String, camelize, capitalize};
-use vize_s2::expr::{ExprRef, JsExpr, OpaqueReason};
-use vize_s2::op::{DynamicName, OnOp};
+mod wrapped;
 
-use super::{EmitCx, EmitError, UnsupportedReason as Reason, buf::Buf};
+#[cfg(test)]
+mod tests;
+
+use vize_s0::{SmallVec, String, camelize, capitalize};
+use vize_s2::expr::{ExprRef, OpaqueReason};
+use vize_s2::op::{DynamicName, OnOp};
+pub(super) use wrapped::emit_wrapped_handler;
+
+use super::{EmitCx, EmitError, UnsupportedReason as Reason};
 
 // The checked modifier inventory in `tests/tooling/davinci-v-on-storage.test.ts`
 // selects two inline entries per classifier bucket. Authored directives remain
@@ -151,135 +156,6 @@ pub(super) fn emit_on_value(
     emit_wrapped_handler(cx, on, &classified, is_plain_element)
 }
 
-pub(super) fn emit_wrapped_handler(
-    cx: &mut EmitCx<'_>,
-    on: &OnOp<'_>,
-    classified: &Classified<'_>,
-    is_plain_element: bool,
-) -> Result<(), EmitError> {
-    if !classified.keys.is_empty() {
-        cx.buf.use_with_keys();
-        cx.buf.push(Buf::with_keys_alias());
-        cx.buf.push("(");
-    }
-    if !classified.event.is_empty() {
-        cx.buf.use_with_modifiers();
-        cx.buf.push(Buf::with_modifiers_alias());
-        cx.buf.push("(");
-    }
-    match on.handler {
-        Some(ExprRef::Js(js)) => emit_handler(cx, on, js, is_plain_element),
-        Some(ExprRef::Opaque(opaque)) if opaque.reason == OpaqueReason::MultiStatement => {
-            super::on_body::emit(cx, opaque.source);
-        }
-        None => cx.buf.push("() => {}"),
-        Some(expr) => {
-            return Err(EmitError::unsupported_at(
-                Reason::OnHandlerNotJs,
-                expr.span(),
-            ));
-        }
-    }
-    if !classified.event.is_empty() {
-        cx.buf.push(", ");
-        emit_mod_array(cx, &classified.event);
-        cx.buf.push(")");
-    }
-    if !classified.keys.is_empty() {
-        cx.buf.push(", ");
-        emit_mod_array(cx, &classified.keys);
-        cx.buf.push(")");
-    }
-    Ok(())
-}
-
-fn emit_mod_array(cx: &mut EmitCx<'_>, mods: &[&str]) {
-    cx.buf.push("[");
-    for (i, modifier) in mods.iter().enumerate() {
-        if i > 0 {
-            cx.buf.push(",");
-        }
-        cx.buf.push("\"");
-        cx.buf.push(modifier);
-        cx.buf.push("\"");
-    }
-    cx.buf.push("]");
-}
-
-pub(super) fn emit_handler(
-    cx: &mut EmitCx<'_>,
-    on: &OnOp<'_>,
-    js: &JsExpr<'_>,
-    is_plain_element: bool,
-) {
-    if is_handler_reference(js.ast) || super::on_body::preserves_raw_function_handler(js) {
-        emit_raw_handler(cx, on, js);
-        return;
-    }
-    if is_raw_function_handler(js.ast, is_plain_element) && !super::on_typed::is_typed_arrow(js.ast)
-    {
-        super::js::push_js_expr(cx, js);
-        return;
-    }
-    if js.source.contains(';') {
-        super::on_body::emit(cx, js.source);
-    } else {
-        cx.buf.push("$event => (");
-        super::js::push_js_expr(cx, js);
-        cx.buf.push(")");
-    }
-}
-
-fn emit_raw_handler(cx: &mut EmitCx<'_>, on: &OnOp<'_>, js: &JsExpr<'_>) {
-    if let Some((leading, trailing)) = authored_handler_padding(cx.source, on, js.source, js.span) {
-        cx.buf.push(leading);
-        cx.buf.push(js.source);
-        cx.buf.push(trailing);
-    } else {
-        cx.buf.push(js.source);
-    }
-}
-
-fn authored_handler_padding<'a>(
-    source: &'a str,
-    on: &OnOp<'_>,
-    value: &str,
-    value_span: Span,
-) -> Option<(&'a str, &'a str)> {
-    let attr_start = usize::try_from(on.span.start).ok()?;
-    let attr_end = usize::try_from(on.span.end).ok()?;
-    let value_start = usize::try_from(value_span.start).ok()?;
-    let value_end = usize::try_from(value_span.end).ok()?;
-    if attr_start > value_start
-        || value_start > value_end
-        || value_end > attr_end
-        || attr_end > source.len()
-        || source.get(value_start..value_end)? != value
-    {
-        return None;
-    }
-    let before = source.get(attr_start..value_start)?;
-    let quote_pos = before
-        .as_bytes()
-        .iter()
-        .rposition(|byte| matches!(*byte, b'\'' | b'"'))?;
-    let quote = before.as_bytes()[quote_pos];
-    let leading = before.get(quote_pos + 1..)?;
-    let after = source.get(value_end..attr_end)?;
-    let trailing_end = after
-        .as_bytes()
-        .iter()
-        .position(|byte| *byte == quote)
-        .unwrap_or(after.len());
-    let trailing = after.get(..trailing_end)?;
-    if leading.is_empty() && trailing.is_empty() {
-        return None;
-    }
-    (leading.bytes().all(|byte| byte.is_ascii_whitespace())
-        && trailing.bytes().all(|byte| byte.is_ascii_whitespace()))
-    .then_some((leading, trailing))
-}
-
 fn classify<'a>(on: &'a OnOp<'a>) -> Result<Classified<'a>, EmitError> {
     let name = static_on_name(on)?;
     Ok(classify_modifiers(name, on.modifiers.iter().copied()))
@@ -340,75 +216,5 @@ fn remapped_name<'a>(raw: &'a str, event: &[&str]) -> &'a str {
         "mouseup"
     } else {
         raw
-    }
-}
-
-fn is_handler_reference(expr: &Expression<'_>) -> bool {
-    match expr {
-        Expression::Identifier(_)
-        | Expression::StaticMemberExpression(_)
-        | Expression::ComputedMemberExpression(_)
-        | Expression::PrivateFieldExpression(_) => true,
-        Expression::ChainExpression(chain) => matches!(
-            chain.expression,
-            ChainElement::StaticMemberExpression(_) | ChainElement::ComputedMemberExpression(_)
-        ),
-        _ => false,
-    }
-}
-
-fn is_raw_function_handler(expr: &Expression<'_>, is_plain_element: bool) -> bool {
-    if matches!(expr, Expression::FunctionExpression(_)) {
-        return true;
-    }
-    match expr {
-        Expression::ArrowFunctionExpression(arrow) => {
-            !is_plain_element || !arrow.params.items.is_empty()
-        }
-        _ => false,
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::classify_modifiers;
-
-    #[test]
-    fn common_two_modifier_buckets_stay_inline() {
-        let classified = classify_modifiers(
-            "keyup",
-            ["capture", "once", "stop", "prevent", "enter", "escape"],
-        );
-
-        assert!(!classified.options.spilled());
-        assert!(!classified.event.spilled());
-        assert!(!classified.keys.spilled());
-    }
-
-    #[test]
-    fn authored_modifiers_spill_without_a_length_ceiling() {
-        let classified = classify_modifiers(
-            "keyup",
-            [
-                "capture", "once", "passive", "stop", "prevent", "self", "enter", "escape", "space",
-            ],
-        );
-
-        assert!(classified.options.spilled());
-        assert!(classified.event.spilled());
-        assert!(classified.keys.spilled());
-        assert_eq!(
-            classified.options.as_slice(),
-            ["capture", "once", "passive"]
-        );
-        assert_eq!(classified.event.as_slice(), ["stop", "prevent", "self"]);
-        assert_eq!(classified.keys.as_slice(), ["enter", "escape", "space"]);
-    }
-
-    #[cfg(target_pointer_width = "64")]
-    #[test]
-    fn inline_storage_stack_tradeoff_is_pinned() {
-        assert_eq!(core::mem::size_of::<super::Classified<'_>>(), 120);
-        assert_eq!(core::mem::size_of::<alloc::vec::Vec<&str>>() * 3, 72);
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/on/tests.rs
+++ b/crates/vize_s1_to_s2/src/emit/on/tests.rs
@@ -1,0 +1,40 @@
+use super::classify_modifiers;
+
+#[test]
+fn common_two_modifier_buckets_stay_inline() {
+    let classified = classify_modifiers(
+        "keyup",
+        ["capture", "once", "stop", "prevent", "enter", "escape"],
+    );
+
+    assert!(!classified.options.spilled());
+    assert!(!classified.event.spilled());
+    assert!(!classified.keys.spilled());
+}
+
+#[test]
+fn authored_modifiers_spill_without_a_length_ceiling() {
+    let classified = classify_modifiers(
+        "keyup",
+        [
+            "capture", "once", "passive", "stop", "prevent", "self", "enter", "escape", "space",
+        ],
+    );
+
+    assert!(classified.options.spilled());
+    assert!(classified.event.spilled());
+    assert!(classified.keys.spilled());
+    assert_eq!(
+        classified.options.as_slice(),
+        ["capture", "once", "passive"]
+    );
+    assert_eq!(classified.event.as_slice(), ["stop", "prevent", "self"]);
+    assert_eq!(classified.keys.as_slice(), ["enter", "escape", "space"]);
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn inline_storage_stack_tradeoff_is_pinned() {
+    assert_eq!(core::mem::size_of::<super::Classified<'_>>(), 120);
+    assert_eq!(core::mem::size_of::<super::OptionModifiers<'_>>() * 3, 120);
+}

--- a/crates/vize_s1_to_s2/src/emit/on/wrapped.rs
+++ b/crates/vize_s1_to_s2/src/emit/on/wrapped.rs
@@ -1,0 +1,158 @@
+use oxc_ast::ast::{ChainElement, Expression};
+use vize_s0::Span;
+use vize_s2::expr::{ExprRef, JsExpr, OpaqueReason};
+use vize_s2::op::OnOp;
+
+use super::super::{EmitCx, EmitError, UnsupportedReason as Reason, buf::Buf};
+use super::Classified;
+
+pub(in crate::emit) fn emit_wrapped_handler(
+    cx: &mut EmitCx<'_>,
+    on: &OnOp<'_>,
+    classified: &Classified<'_>,
+    is_plain_element: bool,
+) -> Result<(), EmitError> {
+    if !classified.keys.is_empty() {
+        cx.buf.use_with_keys();
+        cx.buf.push(Buf::with_keys_alias());
+        cx.buf.push("(");
+    }
+    if !classified.event.is_empty() {
+        cx.buf.use_with_modifiers();
+        cx.buf.push(Buf::with_modifiers_alias());
+        cx.buf.push("(");
+    }
+    match on.handler {
+        Some(ExprRef::Js(js)) => emit_handler(cx, on, js, is_plain_element),
+        Some(ExprRef::Opaque(opaque)) if opaque.reason == OpaqueReason::MultiStatement => {
+            super::super::on_body::emit(cx, opaque.source);
+        }
+        None => cx.buf.push("() => {}"),
+        Some(expr) => {
+            return Err(EmitError::unsupported_at(
+                Reason::OnHandlerNotJs,
+                expr.span(),
+            ));
+        }
+    }
+    if !classified.event.is_empty() {
+        cx.buf.push(", ");
+        emit_mod_array(cx, &classified.event);
+        cx.buf.push(")");
+    }
+    if !classified.keys.is_empty() {
+        cx.buf.push(", ");
+        emit_mod_array(cx, &classified.keys);
+        cx.buf.push(")");
+    }
+    Ok(())
+}
+
+fn emit_mod_array(cx: &mut EmitCx<'_>, mods: &[&str]) {
+    cx.buf.push("[");
+    for (i, modifier) in mods.iter().enumerate() {
+        if i > 0 {
+            cx.buf.push(",");
+        }
+        cx.buf.push("\"");
+        cx.buf.push(modifier);
+        cx.buf.push("\"");
+    }
+    cx.buf.push("]");
+}
+
+fn emit_handler(cx: &mut EmitCx<'_>, on: &OnOp<'_>, js: &JsExpr<'_>, is_plain_element: bool) {
+    if is_handler_reference(js.ast) || super::super::on_body::preserves_raw_function_handler(js) {
+        emit_raw_handler(cx, on, js);
+        return;
+    }
+    if is_raw_function_handler(js.ast, is_plain_element)
+        && !super::super::on_typed::is_typed_arrow(js.ast)
+    {
+        super::super::js::push_js_expr(cx, js);
+        return;
+    }
+    if js.source.contains(';') {
+        super::super::on_body::emit(cx, js.source);
+    } else {
+        cx.buf.push("$event => (");
+        super::super::js::push_js_expr(cx, js);
+        cx.buf.push(")");
+    }
+}
+
+fn emit_raw_handler(cx: &mut EmitCx<'_>, on: &OnOp<'_>, js: &JsExpr<'_>) {
+    if let Some((leading, trailing)) = authored_handler_padding(cx.source, on, js.source, js.span) {
+        cx.buf.push(leading);
+        cx.buf.push(js.source);
+        cx.buf.push(trailing);
+    } else {
+        cx.buf.push(js.source);
+    }
+}
+
+fn authored_handler_padding<'a>(
+    source: &'a str,
+    on: &OnOp<'_>,
+    value: &str,
+    value_span: Span,
+) -> Option<(&'a str, &'a str)> {
+    let attr_start = usize::try_from(on.span.start).ok()?;
+    let attr_end = usize::try_from(on.span.end).ok()?;
+    let value_start = usize::try_from(value_span.start).ok()?;
+    let value_end = usize::try_from(value_span.end).ok()?;
+    if attr_start > value_start
+        || value_start > value_end
+        || value_end > attr_end
+        || attr_end > source.len()
+        || source.get(value_start..value_end)? != value
+    {
+        return None;
+    }
+    let before = source.get(attr_start..value_start)?;
+    let quote_pos = before
+        .as_bytes()
+        .iter()
+        .rposition(|byte| matches!(*byte, b'\'' | b'"'))?;
+    let quote = before.as_bytes()[quote_pos];
+    let leading = before.get(quote_pos + 1..)?;
+    let after = source.get(value_end..attr_end)?;
+    let trailing_end = after
+        .as_bytes()
+        .iter()
+        .position(|byte| *byte == quote)
+        .unwrap_or(after.len());
+    let trailing = after.get(..trailing_end)?;
+    if leading.is_empty() && trailing.is_empty() {
+        return None;
+    }
+    (leading.bytes().all(|byte| byte.is_ascii_whitespace())
+        && trailing.bytes().all(|byte| byte.is_ascii_whitespace()))
+    .then_some((leading, trailing))
+}
+
+fn is_handler_reference(expr: &Expression<'_>) -> bool {
+    match expr {
+        Expression::Identifier(_)
+        | Expression::StaticMemberExpression(_)
+        | Expression::ComputedMemberExpression(_)
+        | Expression::PrivateFieldExpression(_) => true,
+        Expression::ChainExpression(chain) => matches!(
+            chain.expression,
+            ChainElement::StaticMemberExpression(_) | ChainElement::ComputedMemberExpression(_)
+        ),
+        _ => false,
+    }
+}
+
+fn is_raw_function_handler(expr: &Expression<'_>, is_plain_element: bool) -> bool {
+    if matches!(expr, Expression::FunctionExpression(_)) {
+        return true;
+    }
+    match expr {
+        Expression::ArrowFunctionExpression(arrow) => {
+            !is_plain_element || !arrow.params.items.is_empty()
+        }
+        _ => false,
+    }
+}

--- a/crates/vize_s1_to_s2/src/emit/on_dynamic.rs
+++ b/crates/vize_s1_to_s2/src/emit/on_dynamic.rs
@@ -28,7 +28,11 @@ pub(super) fn admit(on: &OnOp<'_>) -> Result<(), EmitError> {
     }
 }
 
-pub(super) fn emit_pair(cx: &mut EmitCx<'_>, on: &OnOp<'_>) -> Result<(), EmitError> {
+pub(super) fn emit_pair(
+    cx: &mut EmitCx<'_>,
+    on: &OnOp<'_>,
+    is_plain_element: bool,
+) -> Result<(), EmitError> {
     let js = dynamic_name(on)?;
     cx.buf.use_to_handler_key();
     cx.buf.push("[");
@@ -36,12 +40,16 @@ pub(super) fn emit_pair(cx: &mut EmitCx<'_>, on: &OnOp<'_>) -> Result<(), EmitEr
     cx.buf.push("(");
     emit_key_source(cx, js);
     cx.buf.push(")]: ");
-    emit_value(cx, on)
+    emit_value(cx, on, is_plain_element)
 }
 
-pub(super) fn emit_value(cx: &mut EmitCx<'_>, on: &OnOp<'_>) -> Result<(), EmitError> {
+pub(super) fn emit_value(
+    cx: &mut EmitCx<'_>,
+    on: &OnOp<'_>,
+    is_plain_element: bool,
+) -> Result<(), EmitError> {
     let classified = super::on::classify_dynamic_modifiers(on.modifiers.iter().copied());
-    super::on::emit_wrapped_handler(cx, on, &classified)
+    super::on::emit_wrapped_handler(cx, on, &classified, is_plain_element)
 }
 
 pub(super) fn forces_inline(on: &OnOp<'_>) -> bool {

--- a/crates/vize_s1_to_s2/src/emit/props_bind.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_bind.rs
@@ -230,7 +230,7 @@ fn emit_template_literal_prefixes(
     cx.buf.push(&source[cursor..]);
 }
 
-fn is_global_key_name(name: &str) -> bool {
+pub(super) fn is_global_key_name(name: &str) -> bool {
     matches!(
         name,
         "Infinity"

--- a/crates/vize_s1_to_s2/src/emit/props_object_merge.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_object_merge.rs
@@ -43,7 +43,7 @@ pub(super) fn emit_handlers(
         }
         first = false;
         match piece {
-            Piece::On(event) => on::emit_on_value(cx, event)?,
+            Piece::On(event) => on::emit_on_value(cx, event, is_plain_element)?,
             Piece::ModelUpdate { model, .. } => {
                 let source = super::model::js_source(model)?;
                 super::model_key::emit_assignment(cx, &model.contract.read, source.as_str());

--- a/crates/vize_s1_to_s2/src/emit/props_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static.rs
@@ -1,7 +1,8 @@
 //! Inline static props for native element calls.
 
-use oxc_ast::ast::{Expression, IdentifierReference};
-use oxc_ast_visit::Visit;
+mod legacy_constant;
+
+use legacy_constant::legacy_global_constant_expr;
 use vize_davinci::id::NodeId;
 use vize_s0::String;
 use vize_s2::op::{Attribute, BindingOp, DynamicName};
@@ -217,31 +218,6 @@ fn component_hoist_prop<'a>(
             Ok(Some((HoistKey::StaticBind(key), dynamic_value)))
         }
         _ => Ok(None),
-    }
-}
-
-fn legacy_global_constant_expr(expr: &Expression<'_>, source: &str) -> bool {
-    if source.contains("_ctx.")
-        || source.contains("$setup.")
-        || source.contains("__props.")
-        || source.contains("$props.")
-    {
-        return false;
-    }
-    let mut walk = LegacyGlobalConstWalk { dynamic: false };
-    walk.visit_expression(expr);
-    !walk.dynamic
-}
-
-struct LegacyGlobalConstWalk {
-    dynamic: bool,
-}
-
-impl<'a> Visit<'a> for LegacyGlobalConstWalk {
-    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
-        if !super::props_bind::is_global_key_name(ident.name.as_str()) {
-            self.dynamic = true;
-        }
     }
 }
 

--- a/crates/vize_s1_to_s2/src/emit/props_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static.rs
@@ -1,5 +1,7 @@
 //! Inline static props for native element calls.
 
+use oxc_ast::ast::{Expression, IdentifierReference};
+use oxc_ast_visit::Visit;
 use vize_davinci::id::NodeId;
 use vize_s0::String;
 use vize_s2::op::{Attribute, BindingOp, DynamicName};
@@ -76,6 +78,55 @@ pub(super) fn root_hoist_props(
     Ok(Some(out))
 }
 
+pub(super) struct ComponentHoistProps {
+    pub(super) source: String,
+    pub(super) dynamic_values: bool,
+    pub(super) non_key: bool,
+}
+
+pub(super) fn component_hoist_props(
+    attributes: &[Attribute<'_>],
+    bindings: &[BindingOp<'_>],
+) -> Result<Option<ComponentHoistProps>, EmitError> {
+    let pieces = pieces(attributes, bindings, false)?;
+    let mut out = String::from("{ ");
+    let mut emitted = 0usize;
+    let mut dynamic_values = false;
+    let mut non_key = false;
+    for (index, piece) in pieces.iter().enumerate() {
+        let mut prop = String::default();
+        let Some((key, dynamic_value)) = component_hoist_prop(&mut prop, piece)? else {
+            return Ok(None);
+        };
+        if has_prior_component_hoist_key(&pieces[..index], key.as_str())? {
+            continue;
+        }
+        dynamic_values |= dynamic_value;
+        non_key |= key.as_str() != "key";
+        if emitted > 0 {
+            out.push_str(", ");
+        }
+        out.push_str(prop.as_str());
+        emitted += 1;
+    }
+    if emitted == 0 {
+        return Ok(None);
+    }
+    out.push_str(" }");
+    Ok(Some(ComponentHoistProps {
+        source: out,
+        dynamic_values,
+        non_key,
+    }))
+}
+
+pub(super) fn static_vnode_surface_can_hoist(
+    attributes: &[Attribute<'_>],
+    bindings: &[BindingOp<'_>],
+) -> bool {
+    attributes.iter().all(|attr| attr.name != "ref") && bindings.iter().all(root_binding_can_hoist)
+}
+
 fn can_root_hoist_props(attributes: &[Attribute<'_>], bindings: &[BindingOp<'_>]) -> bool {
     if attributes.is_empty() && bindings.is_empty() {
         return false;
@@ -132,9 +183,80 @@ fn static_hoist_prop<'a>(
     Ok(Some(key))
 }
 
+fn component_hoist_prop<'a>(
+    out: &mut String,
+    piece: &Piece<'a>,
+) -> Result<Option<(HoistKey<'a>, bool)>, EmitError> {
+    match piece {
+        Piece::Attr(attr) if attr.name != "ref" => {
+            push_attr_pair(out, attr);
+            Ok(Some((HoistKey::Borrowed(attr.name), false)))
+        }
+        Piece::Bind(bind) => {
+            let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
+                return Ok(None);
+            };
+            let dynamic_value = !bind_value_is_static_patchless(bind);
+            if key.as_str() == "ref" {
+                return Ok(None);
+            }
+            if key.as_str() == "class" && dynamic_value {
+                return Ok(None);
+            }
+            let value = bind_value(bind)?;
+            let Some(js) = value.js() else {
+                return Ok(None);
+            };
+            if dynamic_value && !legacy_global_constant_expr(js.ast, js.source) {
+                return Ok(None);
+            }
+            push_key(out, key.as_str());
+            out.push_str(": ");
+            let source = js_expr_source(js);
+            out.push_str(source.as_str());
+            Ok(Some((HoistKey::StaticBind(key), dynamic_value)))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn legacy_global_constant_expr(expr: &Expression<'_>, source: &str) -> bool {
+    if source.contains("_ctx.")
+        || source.contains("$setup.")
+        || source.contains("__props.")
+        || source.contains("$props.")
+    {
+        return false;
+    }
+    let mut walk = LegacyGlobalConstWalk { dynamic: false };
+    walk.visit_expression(expr);
+    !walk.dynamic
+}
+
+struct LegacyGlobalConstWalk {
+    dynamic: bool,
+}
+
+impl<'a> Visit<'a> for LegacyGlobalConstWalk {
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
+        if !super::props_bind::is_global_key_name(ident.name.as_str()) {
+            self.dynamic = true;
+        }
+    }
+}
+
 fn has_prior_hoist_key(pieces: &[Piece<'_>], key: &str) -> Result<bool, EmitError> {
     for piece in pieces {
         if hoist_key(piece)?.is_some_and(|prior| prior.as_str() == key) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn has_prior_component_hoist_key(pieces: &[Piece<'_>], key: &str) -> Result<bool, EmitError> {
+    for piece in pieces {
+        if component_hoist_key(piece)?.is_some_and(|prior| prior.as_str() == key) {
             return Ok(true);
         }
     }
@@ -147,6 +269,24 @@ fn hoist_key<'a>(piece: &Piece<'a>) -> Result<Option<HoistKey<'a>>, EmitError> {
         Piece::Bind(bind) if bind_value_is_static_patchless(bind) => {
             let key = static_bind_key(bind, StaticBindKeyCasing::Preserve)?;
             if matches!(key.as_str(), "ref" | "class") {
+                return Ok(None);
+            }
+            Ok(Some(HoistKey::StaticBind(key)))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn component_hoist_key<'a>(piece: &Piece<'a>) -> Result<Option<HoistKey<'a>>, EmitError> {
+    match piece {
+        Piece::Attr(attr) if attr.name != "ref" => Ok(Some(HoistKey::Borrowed(attr.name))),
+        Piece::Bind(bind) => {
+            let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
+                return Ok(None);
+            };
+            if key.as_str() == "ref"
+                || (key.as_str() == "class" && !bind_value_is_static_patchless(bind))
+            {
                 return Ok(None);
             }
             Ok(Some(HoistKey::StaticBind(key)))

--- a/crates/vize_s1_to_s2/src/emit/props_static/legacy_constant.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static/legacy_constant.rs
@@ -1,0 +1,27 @@
+use oxc_ast::ast::{Expression, IdentifierReference};
+use oxc_ast_visit::Visit;
+
+pub(super) fn legacy_global_constant_expr(expr: &Expression<'_>, source: &str) -> bool {
+    if source.contains("_ctx.")
+        || source.contains("$setup.")
+        || source.contains("__props.")
+        || source.contains("$props.")
+    {
+        return false;
+    }
+    let mut walk = LegacyGlobalConstWalk { dynamic: false };
+    walk.visit_expression(expr);
+    !walk.dynamic
+}
+
+struct LegacyGlobalConstWalk {
+    dynamic: bool,
+}
+
+impl<'a> Visit<'a> for LegacyGlobalConstWalk {
+    fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
+        if !super::super::props_bind::is_global_key_name(ident.name.as_str()) {
+            self.dynamic = true;
+        }
+    }
+}

--- a/crates/vize_s1_to_s2/src/emit/slots.rs
+++ b/crates/vize_s1_to_s2/src/emit/slots.rs
@@ -62,6 +62,20 @@ pub(super) fn has_implicit_default(children: &Region<'_>) -> bool {
     children.ops.iter().any(|op| !is_whitespace_text(op))
 }
 
+pub(super) fn has_text_only_implicit_default(children: &Region<'_>) -> bool {
+    let mut has_content = false;
+    for op in children.ops.iter() {
+        if is_whitespace_text(op) {
+            continue;
+        }
+        has_content = true;
+        if !matches!(op, Op::Text(_) | Op::Interpolation(_)) {
+            return false;
+        }
+    }
+    has_content
+}
+
 pub(super) fn has_dynamic_names(facts: &SlotFacts) -> bool {
     facts
         .groups
@@ -189,15 +203,7 @@ fn collect_pieces(
     facts: &SlotFacts,
     buckets: &mut [StdVec<String>],
 ) -> Result<(), EmitError> {
-    let skip_ws = children
-        .ops
-        .iter()
-        .any(|op| !matches!(op, Op::Text(_) | Op::Interpolation(_)));
     for op in children.ops.iter() {
-        if skip_ws && is_whitespace_text(op) {
-            let _id = cx.walk.mint();
-            continue;
-        }
         match op {
             Op::Element(element) if is_slot_template(element) => {
                 let id = cx.walk.mint();
@@ -258,15 +264,7 @@ pub(super) fn emit_template_pieces(
         })?);
         return Ok(());
     }
-    let skip_ws = children
-        .ops
-        .iter()
-        .any(|op| !matches!(op, Op::Text(_) | Op::Interpolation(_)));
     for op in children.ops.iter() {
-        if skip_ws && is_whitespace_text(op) {
-            let _id = cx.walk.mint();
-            continue;
-        }
         bucket.push(capture_child(cx, op)?);
     }
     Ok(())

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -1,8 +1,10 @@
 //! Static native HTML element / children emission.
 
+mod array_child;
+
+pub(super) use array_child::emit_array_child;
 use vize_davinci::id::NodeId;
-use vize_s0::ensure_sufficient_stack;
-use vize_s2::op::{BindingOp, ElementOp, Op};
+use vize_s2::op::{BindingOp, ElementOp};
 
 use super::buf::Buf;
 use super::children::children_need_text_flag;
@@ -12,7 +14,7 @@ use super::namespace;
 use super::props::{admit_element_bindings, apply_static_ref_patch, bind_patch, emit_bind_props};
 use super::props_static::PropHoistPosition;
 use super::vnode_children::emit_children;
-use super::{EmitCx, EmitError, UnsupportedReason as Reason};
+use super::{EmitCx, EmitError};
 
 pub(super) fn emit_unique_element(
     cx: &mut EmitCx<'_>,
@@ -319,54 +321,4 @@ fn direct_static_children_hoisted(
     id: Option<NodeId>,
 ) -> bool {
     super::vnode_static::should_hoist_static_children(cx, element, id, true, false, false)
-}
-
-pub(super) fn emit_array_child(
-    cx: &mut EmitCx<'_>,
-    op: &Op<'_>,
-    hoist_static_children: bool,
-    cache_static_children: bool,
-) -> Result<(), EmitError> {
-    let hoist_static_children = hoist_static_children || cx.hoist_static_vnodes;
-    if hoist_static_children
-        && let Op::Element(element) = op
-        && super::hoist::is_hoistable(element)
-    {
-        return super::hoist::emit_hoisted_element(cx, element);
-    }
-    if cache_static_children
-        && let Op::Element(element) = op
-        && super::hoist::is_hoistable(element)
-    {
-        return super::hoist::emit_cached_element(cx, element);
-    }
-    let id = cx.walk.mint();
-    cx.with_static_vnode_hoist(hoist_static_children, |cx| {
-        ensure_sufficient_stack(|| match op {
-            Op::Element(element) if super::slots::is_slot_template(element) => {
-                cx.walk.skip(element.bindings.len());
-                super::tpl::emit_inline(cx, &element.children.ops)
-            }
-            Op::Element(element) => {
-                cx.walk.skip(element.bindings.len());
-                if super::once::emit_hoisted_child(cx, element)? {
-                    return Ok(());
-                }
-                emit_nested(cx, element, id)
-            }
-            Op::Component(component) => {
-                cx.walk.skip(component.bindings.len());
-                super::component::emit_nested(cx, component, id)
-            }
-            Op::If(if_op) => super::emit_if_op(cx, if_op, id),
-            Op::For(for_op) => super::emit_for_op(cx, for_op, id, None),
-            Op::Slot(slot) => {
-                cx.walk.skip(slot.bindings.len());
-                super::outlet::emit_outlet(cx, slot, None, false)
-            }
-            Op::Text(_) | Op::Interpolation(_) => {
-                Err(EmitError::unsupported_op(Reason::ArrayChildTextRun, op))
-            }
-        })
-    })
 }

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -71,7 +71,10 @@ pub(super) fn emit_fragment_element(
     if super::once::has(&element.bindings) {
         return super::once::emit_element(cx, element, None, false);
     }
-    if namespace::crosses_boundary(cx, element) {
+    if namespace::crosses_boundary(cx, element, direct_static_children_hoisted(cx, element, id)) {
+        return emit_nested_block(cx, element, id);
+    }
+    if has_dynamic_key_binding(element) {
         return emit_nested_block(cx, element, id);
     }
     super::memo::emit_cached(cx, &element.bindings, |cx| {
@@ -98,7 +101,10 @@ fn emit_nested(
     if super::once::has(&element.bindings) {
         return super::once::emit_element(cx, element, None, false);
     }
-    if namespace::crosses_boundary(cx, element) {
+    if namespace::crosses_boundary(cx, element, direct_static_children_hoisted(cx, element, id)) {
+        return emit_nested_block(cx, element, id);
+    }
+    if has_dynamic_key_binding(element) {
         return emit_nested_block(cx, element, id);
     }
     super::memo::emit_cached(cx, &element.bindings, |cx| {
@@ -296,6 +302,23 @@ fn has_cloak(bindings: &[BindingOp<'_>]) -> bool {
     bindings
         .iter()
         .any(|binding| matches!(binding, BindingOp::VueCloak(_)))
+}
+
+fn has_dynamic_key_binding(element: &ElementOp<'_>) -> bool {
+    element.bindings.iter().any(|binding| {
+        matches!(
+            binding,
+            BindingOp::Bind(bind) if super::props_bind::is_key_bind_name(bind)
+        )
+    })
+}
+
+fn direct_static_children_hoisted(
+    cx: &EmitCx<'_>,
+    element: &ElementOp<'_>,
+    id: Option<NodeId>,
+) -> bool {
+    super::vnode_static::should_hoist_static_children(cx, element, id, true, false, false)
 }
 
 pub(super) fn emit_array_child(

--- a/crates/vize_s1_to_s2/src/emit/vnode/array_child.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode/array_child.rs
@@ -1,0 +1,54 @@
+use vize_s0::ensure_sufficient_stack;
+use vize_s2::op::Op;
+
+use super::super::{EmitCx, EmitError, UnsupportedReason as Reason};
+
+pub(in crate::emit) fn emit_array_child(
+    cx: &mut EmitCx<'_>,
+    op: &Op<'_>,
+    hoist_static_children: bool,
+    cache_static_children: bool,
+) -> Result<(), EmitError> {
+    let hoist_static_children = hoist_static_children || cx.hoist_static_vnodes;
+    if hoist_static_children
+        && let Op::Element(element) = op
+        && super::super::hoist::is_hoistable(element)
+    {
+        return super::super::hoist::emit_hoisted_element(cx, element);
+    }
+    if cache_static_children
+        && let Op::Element(element) = op
+        && super::super::hoist::is_hoistable(element)
+    {
+        return super::super::hoist::emit_cached_element(cx, element);
+    }
+    let id = cx.walk.mint();
+    cx.with_static_vnode_hoist(hoist_static_children, |cx| {
+        ensure_sufficient_stack(|| match op {
+            Op::Element(element) if super::super::slots::is_slot_template(element) => {
+                cx.walk.skip(element.bindings.len());
+                super::super::tpl::emit_inline(cx, &element.children.ops)
+            }
+            Op::Element(element) => {
+                cx.walk.skip(element.bindings.len());
+                if super::super::once::emit_hoisted_child(cx, element)? {
+                    return Ok(());
+                }
+                super::emit_nested(cx, element, id)
+            }
+            Op::Component(component) => {
+                cx.walk.skip(component.bindings.len());
+                super::super::component::emit_nested(cx, component, id)
+            }
+            Op::If(if_op) => super::super::emit_if_op(cx, if_op, id),
+            Op::For(for_op) => super::super::emit_for_op(cx, for_op, id, None),
+            Op::Slot(slot) => {
+                cx.walk.skip(slot.bindings.len());
+                super::super::outlet::emit_outlet(cx, slot, None, false)
+            }
+            Op::Text(_) | Op::Interpolation(_) => {
+                Err(EmitError::unsupported_op(Reason::ArrayChildTextRun, op))
+            }
+        })
+    })
+}

--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
@@ -50,11 +50,105 @@ struct Report {
     old_error_reasons: BTreeMap<String, u64>,
     unreadable: Vec<String>,
     old_error_samples: Vec<String>,
+    unexpected_old_error_skips: u64,
+    unexpected_old_error_samples: Vec<String>,
     s2_refusal_reasons: BTreeMap<&'static str, u64>,
     s2_refusal_samples: BTreeMap<&'static str, Vec<String>>,
     s2_refusals: Vec<String>,
     divergences: Vec<String>,
 }
+
+const OLD_LANE_INVALID_FIXTURES: &[(&str, &[&str])] = &[
+    (
+        "crater/resources/scripts/admin/views/settings/PreferencesSetting.vue",
+        &[
+            "ExtendPoint",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+        ],
+    ),
+    (
+        "dashy/src/components/Widgets/MvgConnection.vue",
+        &["VIfSameKey"],
+    ),
+    (
+        "gogocode/packages/gogocode-vue-playground/packages/vue3/src/components/slots-unification/Comp-out.vue",
+        &["VSlotDuplicateSlotNames"],
+    ),
+    (
+        "habitica/website/client/src/components/modifyInventory.vue",
+        &[
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+        ],
+    ),
+    (
+        "habitica/website/client/src/components/static/privacy.vue",
+        &["InvalidEndTag"],
+    ),
+    (
+        "heyui/src/components/carousel/carousel.vue",
+        &["VIfSameKey"],
+    ),
+    (
+        "heyui/src/components/table/table.vue",
+        &["VElseNoAdjacentIf"],
+    ),
+    ("tdesign/site/src/pages/design/fonts.vue", &["VIfSameKey"]),
+    (
+        "tdesign/site/src/pages/design/fonts_zh-CN.vue",
+        &["VIfSameKey"],
+    ),
+    (
+        "vue-manage-system/src/views/table/basetable.vue",
+        &["InvalidEndTag"],
+    ),
+    (
+        "vue2-elm/src/page/shop/shop.vue",
+        &["MissingWhitespaceBetweenAttributes"],
+    ),
+    (
+        "vuesax/docs/.vuepress/theme/Home.vue",
+        &["InvalidEndTag", "InvalidEndTag"],
+    ),
+    (
+        "vuesax/docs/.vuepress/theme/homePatreons.vue",
+        &["InvalidEndTag"],
+    ),
+    (
+        "vux/src/components/inline-x-number/index.vue",
+        &["MissingWhitespaceBetweenAttributes"],
+    ),
+    (
+        "vux/src/components/x-number/index.vue",
+        &["MissingWhitespaceBetweenAttributes"],
+    ),
+    (
+        "vux/src/demos/PopupPicker.vue",
+        &["MissingWhitespaceBetweenAttributes"],
+    ),
+];
 
 #[test]
 fn dom_emit_agrees_on_sfc_templates() {
@@ -148,7 +242,7 @@ fn compare_sfc_template(name: &str, source: &str, report: &mut Report) {
     let (_, errors, old) = vize_atelier_dom::compile_template(&old_allocator, &template.content);
     let blocking_errors: Vec<_> = errors
         .iter()
-        .filter(|error| !error.is_compatibility_notice())
+        .filter(|error| !error.is_recoverable())
         .collect();
     if !blocking_errors.is_empty() {
         report.old_error_skips += 1;
@@ -168,6 +262,18 @@ fn compare_sfc_template(name: &str, source: &str, report: &mut Report) {
                 "{name}: {} old-lane blocking errors: {blocking_errors:?}",
                 blocking_errors.len()
             ));
+        }
+        let actual_codes = blocking_errors
+            .iter()
+            .map(|error| format!("{:?}", error.code))
+            .collect::<Vec<_>>();
+        if !old_lane_skip_is_allowed(name, &actual_codes) {
+            report.unexpected_old_error_skips += 1;
+            if report.unexpected_old_error_samples.len() < 20 {
+                report.unexpected_old_error_samples.push(format!(
+                    "{name}: unexpected old-lane blocking errors: {blocking_errors:?}"
+                ));
+            }
         }
         return;
     }
@@ -251,21 +357,45 @@ fn assert_empty(label: &str, values: &[String]) {
 fn assert_clean_corpus(report: &Report) {
     assert!(
         report.unreadable_count == 0
-            && report.old_error_skips == 0
+            && report.unexpected_old_error_skips == 0
             && report.s2_refusal_count == 0
             && report.divergence_count == 0,
-        "corpus unreadable files ({}):\n{}\n\ncorpus old-lane error skips ({}) by reason {:?}:\n{}\n\ncorpus S2 refusals ({}) by reason {:?}:\n{}\n\ncorpus divergences ({}):\n{}",
+        "corpus unreadable files ({}):\n{}\n\ncorpus old-lane error skips ({}) by reason {:?}:\n{}\n\nunexpected old-lane error skips ({}):\n{}\n\ncorpus S2 refusals ({}) by reason {:?}:\n{}\n\ncorpus divergences ({}):\n{}",
         report.unreadable_count,
         report.unreadable.join("\n"),
         report.old_error_skips,
         report.old_error_reasons,
         report.old_error_samples.join("\n"),
+        report.unexpected_old_error_skips,
+        report.unexpected_old_error_samples.join("\n"),
         report.s2_refusal_count,
         report.s2_refusal_reasons,
         report.s2_refusals.join("\n"),
         report.divergence_count,
         report.divergences.join("\n"),
     );
+}
+
+fn old_lane_skip_is_allowed(name: &str, actual_codes: &[String]) -> bool {
+    let Some(path) = fixture_path(name) else {
+        return false;
+    };
+    let Some((_, expected_codes)) = OLD_LANE_INVALID_FIXTURES
+        .iter()
+        .find(|(allowed_path, _)| *allowed_path == path)
+    else {
+        return false;
+    };
+    let mut actual = actual_codes.iter().map(String::as_str).collect::<Vec<_>>();
+    actual.sort_unstable();
+    let mut expected = expected_codes.to_vec();
+    expected.sort_unstable();
+    actual == expected
+}
+
+fn fixture_path(name: &str) -> Option<&str> {
+    name.split_once("tests/_fixtures/_git/")
+        .map(|(_, path)| path)
 }
 
 #[test]
@@ -280,14 +410,18 @@ fn nested_anchor_and_button_recoveries_are_compared_not_skipped() {
             "nested_button",
             "<template><button><div><button>bbb</button></div></button></template>",
         ),
+        (
+            "duplicate_attribute",
+            r#"<template><div class="a" class="b">duplicate</div></template>"#,
+        ),
     ] {
         compare_sfc_template(name, source, &mut report);
     }
 
-    assert_eq!(report.templates, 2);
+    assert_eq!(report.templates, 3);
     assert_eq!(
         report.old_error_skips, 0,
-        "nested interactive-content recoveries should reach the DOM comparison lane: {:?}",
+        "recoverable old-lane diagnostics should reach the DOM comparison lane: {:?}",
         report.old_error_samples
     );
     assert_eq!(
@@ -295,7 +429,7 @@ fn nested_anchor_and_button_recoveries_are_compared_not_skipped() {
         "S2 should emit so any remaining mismatch is counted as a divergence: {:?}",
         report.s2_refusals
     );
-    assert_eq!(report.compared, 2);
+    assert_eq!(report.compared, 3);
 }
 
 #[test]
@@ -310,6 +444,7 @@ fn unrelated_invalid_end_tag_still_blocks_old_lane_comparison() {
     assert_eq!(report.templates, 1);
     assert_eq!(report.compared, 0);
     assert_eq!(report.old_error_skips, 1);
+    assert_eq!(report.unexpected_old_error_skips, 1);
     assert_eq!(
         report.old_error_codes,
         vec![ErrorCode::InvalidEndTag],
@@ -317,4 +452,20 @@ fn unrelated_invalid_end_tag_still_blocks_old_lane_comparison() {
         report.old_error_samples
     );
     assert_eq!(report.old_error_reasons.get("InvalidEndTag"), Some(&1));
+}
+
+#[test]
+fn canonical_invalid_fixture_allowlist_is_exact() {
+    assert!(old_lane_skip_is_allowed(
+        "/repo/tests/_fixtures/_git/vue-manage-system/src/views/table/basetable.vue",
+        &[String::from("InvalidEndTag")],
+    ));
+    assert!(!old_lane_skip_is_allowed(
+        "/repo/tests/_fixtures/_git/vue-manage-system/src/views/table/basetable.vue",
+        &[String::from("MissingEndTag")],
+    ));
+    assert!(!old_lane_skip_is_allowed(
+        "/repo/tests/_fixtures/_git/vue-manage-system/src/views/table/other.vue",
+        &[String::from("InvalidEndTag")],
+    ));
 }

--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus.rs
@@ -10,12 +10,13 @@
 
 #![allow(clippy::disallowed_macros, clippy::disallowed_types)]
 
-use std::{collections::BTreeMap, fs};
+mod davinci_dom_corpus_support;
 
+use davinci_dom_corpus_support::{
+    Report, assert_clean_corpus, assert_empty, compare_sfc_template, compare_sweep,
+    old_lane_skip_is_allowed,
+};
 use vize_atelier_dom::errors::ErrorCode;
-use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-use vize_s0::Allocator;
-use vize_s1_to_s2::{EmitError, emit_dom_source};
 
 const BATTERY: &[(&str, &str)] = &[
     (
@@ -33,120 +34,6 @@ const BATTERY: &[(&str, &str)] = &[
     (
         "self_closing_non_void_html",
         r#"<template><div /><span class="x" /></template>"#,
-    ),
-];
-
-#[derive(Default)]
-struct Report {
-    files: u64,
-    unreadable_count: u64,
-    parsed: u64,
-    templates: u64,
-    compared: u64,
-    old_error_skips: u64,
-    s2_refusal_count: u64,
-    divergence_count: u64,
-    old_error_codes: Vec<ErrorCode>,
-    old_error_reasons: BTreeMap<String, u64>,
-    unreadable: Vec<String>,
-    old_error_samples: Vec<String>,
-    unexpected_old_error_skips: u64,
-    unexpected_old_error_samples: Vec<String>,
-    s2_refusal_reasons: BTreeMap<&'static str, u64>,
-    s2_refusal_samples: BTreeMap<&'static str, Vec<String>>,
-    s2_refusals: Vec<String>,
-    divergences: Vec<String>,
-}
-
-const OLD_LANE_INVALID_FIXTURES: &[(&str, &[&str])] = &[
-    (
-        "crater/resources/scripts/admin/views/settings/PreferencesSetting.vue",
-        &[
-            "ExtendPoint",
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "MissingEndTag",
-            "MissingEndTag",
-        ],
-    ),
-    (
-        "dashy/src/components/Widgets/MvgConnection.vue",
-        &["VIfSameKey"],
-    ),
-    (
-        "gogocode/packages/gogocode-vue-playground/packages/vue3/src/components/slots-unification/Comp-out.vue",
-        &["VSlotDuplicateSlotNames"],
-    ),
-    (
-        "habitica/website/client/src/components/modifyInventory.vue",
-        &[
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "InvalidEndTag",
-            "MissingEndTag",
-            "MissingEndTag",
-            "MissingEndTag",
-            "MissingEndTag",
-            "MissingEndTag",
-            "MissingEndTag",
-            "MissingEndTag",
-            "MissingEndTag",
-        ],
-    ),
-    (
-        "habitica/website/client/src/components/static/privacy.vue",
-        &["InvalidEndTag"],
-    ),
-    (
-        "heyui/src/components/carousel/carousel.vue",
-        &["VIfSameKey"],
-    ),
-    (
-        "heyui/src/components/table/table.vue",
-        &["VElseNoAdjacentIf"],
-    ),
-    ("tdesign/site/src/pages/design/fonts.vue", &["VIfSameKey"]),
-    (
-        "tdesign/site/src/pages/design/fonts_zh-CN.vue",
-        &["VIfSameKey"],
-    ),
-    (
-        "vue-manage-system/src/views/table/basetable.vue",
-        &["InvalidEndTag"],
-    ),
-    (
-        "vue2-elm/src/page/shop/shop.vue",
-        &["MissingWhitespaceBetweenAttributes"],
-    ),
-    (
-        "vuesax/docs/.vuepress/theme/Home.vue",
-        &["InvalidEndTag", "InvalidEndTag"],
-    ),
-    (
-        "vuesax/docs/.vuepress/theme/homePatreons.vue",
-        &["InvalidEndTag"],
-    ),
-    (
-        "vux/src/components/inline-x-number/index.vue",
-        &["MissingWhitespaceBetweenAttributes"],
-    ),
-    (
-        "vux/src/components/x-number/index.vue",
-        &["MissingWhitespaceBetweenAttributes"],
-    ),
-    (
-        "vux/src/demos/PopupPicker.vue",
-        &["MissingWhitespaceBetweenAttributes"],
     ),
 ];
 
@@ -180,23 +67,7 @@ fn dom_emit_agrees_on_sfc_templates_body() {
         sweep.root.display()
     );
 
-    let mut corpus = Report::default();
-    for file in &sweep.files {
-        let source = match fs::read_to_string(file) {
-            Ok(source) => source,
-            Err(error) => {
-                corpus.unreadable_count += 1;
-                if corpus.unreadable.len() < 20 {
-                    corpus
-                        .unreadable
-                        .push(format!("{}: {error}", file.display()));
-                }
-                continue;
-            }
-        };
-        let context = file.to_string_lossy();
-        compare_sfc_template(context.as_ref(), &source, &mut corpus);
-    }
+    let corpus = compare_sweep(&sweep);
     eprintln!(
         "davinci DOM corpus sweep: files={} unreadable={} parsed={} templates={} compared={} old_error_skips={} s2_refusals={} divergences={}",
         corpus.files,
@@ -225,177 +96,6 @@ fn dom_emit_agrees_on_sfc_templates_body() {
         "a corpus sweep that compares nothing proves nothing"
     );
     assert_clean_corpus(&corpus);
-}
-
-fn compare_sfc_template(name: &str, source: &str, report: &mut Report) {
-    report.files += 1;
-    let Ok(descriptor) = parse_sfc(source, SfcParseOptions::default()) else {
-        return;
-    };
-    report.parsed += 1;
-    let Some(template) = descriptor.template.as_ref() else {
-        return;
-    };
-    report.templates += 1;
-
-    let old_allocator = Allocator::new();
-    let (_, errors, old) = vize_atelier_dom::compile_template(&old_allocator, &template.content);
-    let blocking_errors: Vec<_> = errors
-        .iter()
-        .filter(|error| !error.is_recoverable())
-        .collect();
-    if !blocking_errors.is_empty() {
-        report.old_error_skips += 1;
-        for error in &blocking_errors {
-            *report
-                .old_error_reasons
-                .entry(format!("{:?}", error.code))
-                .or_default() += 1;
-        }
-        if report.old_error_codes.len() < 20 {
-            report
-                .old_error_codes
-                .extend(blocking_errors.iter().map(|error| error.code));
-        }
-        if report.old_error_samples.len() < 20 {
-            report.old_error_samples.push(format!(
-                "{name}: {} old-lane blocking errors: {blocking_errors:?}",
-                blocking_errors.len()
-            ));
-        }
-        let actual_codes = blocking_errors
-            .iter()
-            .map(|error| format!("{:?}", error.code))
-            .collect::<Vec<_>>();
-        if !old_lane_skip_is_allowed(name, &actual_codes) {
-            report.unexpected_old_error_skips += 1;
-            if report.unexpected_old_error_samples.len() < 20 {
-                report.unexpected_old_error_samples.push(format!(
-                    "{name}: unexpected old-lane blocking errors: {blocking_errors:?}"
-                ));
-            }
-        }
-        return;
-    }
-    let old = format!("{}\n{}", old.preamble, old.code);
-
-    let new_allocator = Allocator::new();
-    let new = match emit_dom_source(&new_allocator, &template.content) {
-        Ok(emit) => emit.assembled(),
-        Err(error) => {
-            report.s2_refusal_count += 1;
-            let reason = refusal_reason(&error);
-            *report.s2_refusal_reasons.entry(reason).or_default() += 1;
-            let samples = report.s2_refusal_samples.entry(reason).or_default();
-            if samples.len() < 5 {
-                samples.push(format!("{name}: {error:?}"));
-            }
-            if report.s2_refusals.len() < 20 {
-                report.s2_refusals.push(format!("{name}: {error:?}"));
-            }
-            return;
-        }
-    };
-
-    report.compared += 1;
-    if old != new {
-        report.divergence_count += 1;
-        if report.divergences.len() < 20 {
-            report.divergences.push(format!(
-                "{name}: old_len={} new_len={} first_diff={} old_window={} new_window={}",
-                old.len(),
-                new.len(),
-                first_diff(&old, &new),
-                mismatch_window(&old, &new),
-                mismatch_window(&new, &old)
-            ));
-        }
-    }
-}
-
-fn refusal_reason(error: &EmitError) -> &'static str {
-    error.reason().map_or("diagnostics", |reason| reason.code())
-}
-
-fn preview(source: &str) -> String {
-    source
-        .lines()
-        .take(4)
-        .collect::<Vec<_>>()
-        .join("\\n")
-        .chars()
-        .take(320)
-        .collect()
-}
-
-fn first_diff(left: &str, right: &str) -> usize {
-    left.as_bytes()
-        .iter()
-        .zip(right.as_bytes())
-        .position(|(left, right)| left != right)
-        .unwrap_or_else(|| left.len().min(right.len()))
-}
-
-fn mismatch_window(source: &str, other: &str) -> String {
-    let diff = first_diff(source, other);
-    let start = source[..diff]
-        .char_indices()
-        .rev()
-        .nth(80)
-        .map_or(0, |(index, _)| index);
-    let end = source[diff..]
-        .char_indices()
-        .nth(180)
-        .map_or(source.len(), |(index, _)| diff + index);
-    preview(&source[start..end])
-}
-
-fn assert_empty(label: &str, values: &[String]) {
-    assert!(values.is_empty(), "{label}:\n{}", values.join("\n"));
-}
-
-fn assert_clean_corpus(report: &Report) {
-    assert!(
-        report.unreadable_count == 0
-            && report.unexpected_old_error_skips == 0
-            && report.s2_refusal_count == 0
-            && report.divergence_count == 0,
-        "corpus unreadable files ({}):\n{}\n\ncorpus old-lane error skips ({}) by reason {:?}:\n{}\n\nunexpected old-lane error skips ({}):\n{}\n\ncorpus S2 refusals ({}) by reason {:?}:\n{}\n\ncorpus divergences ({}):\n{}",
-        report.unreadable_count,
-        report.unreadable.join("\n"),
-        report.old_error_skips,
-        report.old_error_reasons,
-        report.old_error_samples.join("\n"),
-        report.unexpected_old_error_skips,
-        report.unexpected_old_error_samples.join("\n"),
-        report.s2_refusal_count,
-        report.s2_refusal_reasons,
-        report.s2_refusals.join("\n"),
-        report.divergence_count,
-        report.divergences.join("\n"),
-    );
-}
-
-fn old_lane_skip_is_allowed(name: &str, actual_codes: &[String]) -> bool {
-    let Some(path) = fixture_path(name) else {
-        return false;
-    };
-    let Some((_, expected_codes)) = OLD_LANE_INVALID_FIXTURES
-        .iter()
-        .find(|(allowed_path, _)| *allowed_path == path)
-    else {
-        return false;
-    };
-    let mut actual = actual_codes.iter().map(String::as_str).collect::<Vec<_>>();
-    actual.sort_unstable();
-    let mut expected = expected_codes.to_vec();
-    expected.sort_unstable();
-    actual == expected
-}
-
-fn fixture_path(name: &str) -> Option<&str> {
-    name.split_once("tests/_fixtures/_git/")
-        .map(|(_, path)| path)
 }
 
 #[test]

--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus_support/allowlist.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus_support/allowlist.rs
@@ -1,0 +1,113 @@
+const OLD_LANE_INVALID_FIXTURES: &[(&str, &[&str])] = &[
+    (
+        "crater/resources/scripts/admin/views/settings/PreferencesSetting.vue",
+        &[
+            "ExtendPoint",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+        ],
+    ),
+    (
+        "dashy/src/components/Widgets/MvgConnection.vue",
+        &["VIfSameKey"],
+    ),
+    (
+        "gogocode/packages/gogocode-vue-playground/packages/vue3/src/components/slots-unification/Comp-out.vue",
+        &["VSlotDuplicateSlotNames"],
+    ),
+    (
+        "habitica/website/client/src/components/modifyInventory.vue",
+        &[
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "InvalidEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+            "MissingEndTag",
+        ],
+    ),
+    (
+        "habitica/website/client/src/components/static/privacy.vue",
+        &["InvalidEndTag"],
+    ),
+    (
+        "heyui/src/components/carousel/carousel.vue",
+        &["VIfSameKey"],
+    ),
+    (
+        "heyui/src/components/table/table.vue",
+        &["VElseNoAdjacentIf"],
+    ),
+    ("tdesign/site/src/pages/design/fonts.vue", &["VIfSameKey"]),
+    (
+        "tdesign/site/src/pages/design/fonts_zh-CN.vue",
+        &["VIfSameKey"],
+    ),
+    (
+        "vue-manage-system/src/views/table/basetable.vue",
+        &["InvalidEndTag"],
+    ),
+    (
+        "vue2-elm/src/page/shop/shop.vue",
+        &["MissingWhitespaceBetweenAttributes"],
+    ),
+    (
+        "vuesax/docs/.vuepress/theme/Home.vue",
+        &["InvalidEndTag", "InvalidEndTag"],
+    ),
+    (
+        "vuesax/docs/.vuepress/theme/homePatreons.vue",
+        &["InvalidEndTag"],
+    ),
+    (
+        "vux/src/components/inline-x-number/index.vue",
+        &["MissingWhitespaceBetweenAttributes"],
+    ),
+    (
+        "vux/src/components/x-number/index.vue",
+        &["MissingWhitespaceBetweenAttributes"],
+    ),
+    (
+        "vux/src/demos/PopupPicker.vue",
+        &["MissingWhitespaceBetweenAttributes"],
+    ),
+];
+
+pub fn old_lane_skip_is_allowed(name: &str, actual_codes: &[String]) -> bool {
+    let Some(path) = fixture_path(name) else {
+        return false;
+    };
+    let Some((_, expected_codes)) = OLD_LANE_INVALID_FIXTURES
+        .iter()
+        .find(|(allowed_path, _)| *allowed_path == path)
+    else {
+        return false;
+    };
+    let mut actual = actual_codes.iter().map(String::as_str).collect::<Vec<_>>();
+    actual.sort_unstable();
+    let mut expected = expected_codes.to_vec();
+    expected.sort_unstable();
+    actual == expected
+}
+
+fn fixture_path(name: &str) -> Option<&str> {
+    name.split_once("tests/_fixtures/_git/")
+        .map(|(_, path)| path)
+}

--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus_support/mod.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus_support/mod.rs
@@ -1,0 +1,203 @@
+mod allowlist;
+
+use std::{collections::BTreeMap, fs};
+
+use davinci_test_support::corpus::CorpusSweep;
+use vize_atelier_dom::errors::ErrorCode;
+use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
+use vize_s0::Allocator;
+use vize_s1_to_s2::{EmitError, emit_dom_source};
+
+pub use allowlist::old_lane_skip_is_allowed;
+
+#[derive(Default)]
+pub struct Report {
+    pub files: u64,
+    pub unreadable_count: u64,
+    pub parsed: u64,
+    pub templates: u64,
+    pub compared: u64,
+    pub old_error_skips: u64,
+    pub s2_refusal_count: u64,
+    pub divergence_count: u64,
+    pub old_error_codes: Vec<ErrorCode>,
+    pub old_error_reasons: BTreeMap<String, u64>,
+    pub unreadable: Vec<String>,
+    pub old_error_samples: Vec<String>,
+    pub unexpected_old_error_skips: u64,
+    pub unexpected_old_error_samples: Vec<String>,
+    pub s2_refusal_reasons: BTreeMap<&'static str, u64>,
+    pub s2_refusal_samples: BTreeMap<&'static str, Vec<String>>,
+    pub s2_refusals: Vec<String>,
+    pub divergences: Vec<String>,
+}
+
+pub fn compare_sweep(sweep: &CorpusSweep) -> Report {
+    let mut report = Report::default();
+    for file in &sweep.files {
+        let source = match fs::read_to_string(file) {
+            Ok(source) => source,
+            Err(error) => {
+                report.unreadable_count += 1;
+                if report.unreadable.len() < 20 {
+                    report
+                        .unreadable
+                        .push(format!("{}: {error}", file.display()));
+                }
+                continue;
+            }
+        };
+        let context = file.to_string_lossy();
+        compare_sfc_template(context.as_ref(), &source, &mut report);
+    }
+    report
+}
+
+pub fn compare_sfc_template(name: &str, source: &str, report: &mut Report) {
+    report.files += 1;
+    let Ok(descriptor) = parse_sfc(source, SfcParseOptions::default()) else {
+        return;
+    };
+    report.parsed += 1;
+    let Some(template) = descriptor.template.as_ref() else {
+        return;
+    };
+    report.templates += 1;
+
+    let old_allocator = Allocator::new();
+    let (_, errors, old) = vize_atelier_dom::compile_template(&old_allocator, &template.content);
+    let blocking_errors: Vec<_> = errors
+        .iter()
+        .filter(|error| !error.is_recoverable())
+        .collect();
+    if !blocking_errors.is_empty() {
+        report.old_error_skips += 1;
+        for error in &blocking_errors {
+            *report
+                .old_error_reasons
+                .entry(format!("{:?}", error.code))
+                .or_default() += 1;
+        }
+        if report.old_error_codes.len() < 20 {
+            report
+                .old_error_codes
+                .extend(blocking_errors.iter().map(|error| error.code));
+        }
+        if report.old_error_samples.len() < 20 {
+            report.old_error_samples.push(format!(
+                "{name}: {} old-lane blocking errors: {blocking_errors:?}",
+                blocking_errors.len()
+            ));
+        }
+        let actual_codes = blocking_errors
+            .iter()
+            .map(|error| format!("{:?}", error.code))
+            .collect::<Vec<_>>();
+        if !old_lane_skip_is_allowed(name, &actual_codes) {
+            report.unexpected_old_error_skips += 1;
+            if report.unexpected_old_error_samples.len() < 20 {
+                report.unexpected_old_error_samples.push(format!(
+                    "{name}: unexpected old-lane blocking errors: {blocking_errors:?}"
+                ));
+            }
+        }
+        return;
+    }
+    let old = format!("{}\n{}", old.preamble, old.code);
+
+    let new_allocator = Allocator::new();
+    let new = match emit_dom_source(&new_allocator, &template.content) {
+        Ok(emit) => emit.assembled(),
+        Err(error) => {
+            report.s2_refusal_count += 1;
+            let reason = refusal_reason(&error);
+            *report.s2_refusal_reasons.entry(reason).or_default() += 1;
+            let samples = report.s2_refusal_samples.entry(reason).or_default();
+            if samples.len() < 5 {
+                samples.push(format!("{name}: {error:?}"));
+            }
+            if report.s2_refusals.len() < 20 {
+                report.s2_refusals.push(format!("{name}: {error:?}"));
+            }
+            return;
+        }
+    };
+
+    report.compared += 1;
+    if old != new {
+        report.divergence_count += 1;
+        if report.divergences.len() < 20 {
+            report.divergences.push(format!(
+                "{name}: old_len={} new_len={} first_diff={} old_window={} new_window={}",
+                old.len(),
+                new.len(),
+                first_diff(&old, &new),
+                mismatch_window(&old, &new),
+                mismatch_window(&new, &old)
+            ));
+        }
+    }
+}
+
+fn refusal_reason(error: &EmitError) -> &'static str {
+    error.reason().map_or("diagnostics", |reason| reason.code())
+}
+
+fn preview(source: &str) -> String {
+    source
+        .lines()
+        .take(4)
+        .collect::<Vec<_>>()
+        .join("\\n")
+        .chars()
+        .take(320)
+        .collect()
+}
+
+fn first_diff(left: &str, right: &str) -> usize {
+    left.as_bytes()
+        .iter()
+        .zip(right.as_bytes())
+        .position(|(left, right)| left != right)
+        .unwrap_or_else(|| left.len().min(right.len()))
+}
+
+fn mismatch_window(source: &str, other: &str) -> String {
+    let diff = first_diff(source, other);
+    let start = source[..diff]
+        .char_indices()
+        .rev()
+        .nth(80)
+        .map_or(0, |(index, _)| index);
+    let end = source[diff..]
+        .char_indices()
+        .nth(180)
+        .map_or(source.len(), |(index, _)| diff + index);
+    preview(&source[start..end])
+}
+
+pub fn assert_empty(label: &str, values: &[String]) {
+    assert!(values.is_empty(), "{label}:\n{}", values.join("\n"));
+}
+
+pub fn assert_clean_corpus(report: &Report) {
+    assert!(
+        report.unreadable_count == 0
+            && report.unexpected_old_error_skips == 0
+            && report.s2_refusal_count == 0
+            && report.divergence_count == 0,
+        "corpus unreadable files ({}):\n{}\n\ncorpus old-lane error skips ({}) by reason {:?}:\n{}\n\nunexpected old-lane error skips ({}):\n{}\n\ncorpus S2 refusals ({}) by reason {:?}:\n{}\n\ncorpus divergences ({}):\n{}",
+        report.unreadable_count,
+        report.unreadable.join("\n"),
+        report.old_error_skips,
+        report.old_error_reasons,
+        report.old_error_samples.join("\n"),
+        report.unexpected_old_error_skips,
+        report.unexpected_old_error_samples.join("\n"),
+        report.s2_refusal_count,
+        report.s2_refusal_reasons,
+        report.s2_refusals.join("\n"),
+        report.divergence_count,
+        report.divergences.join("\n"),
+    );
+}

--- a/crates/vize_s1_to_s2/tests/emit_static_hoist.rs
+++ b/crates/vize_s1_to_s2/tests/emit_static_hoist.rs
@@ -84,6 +84,37 @@ fn static_bind_props_hoist_with_nested_dynamic_descendants() {
 }
 
 #[test]
+fn nested_event_and_model_children_match_legacy_block_shape() {
+    assert_shipped_parity(r#"<div><button @click="run">Run</button></div>"#);
+    assert_shipped_parity(
+        r#"<div class="password-input"><input v-model="password" :key="`password-${showPassword}`" /></div>"#,
+    );
+}
+
+#[test]
+fn html_parent_with_svg_child_keeps_legacy_parent_vnode_shape() {
+    assert_shipped_parity(
+        r#"<div><span class="menu-button" aria-label="Menu" @click="toggleMenu"><svg viewBox="0 0 24 24"><path d="M0 0h1" /></svg></span></div>"#,
+    );
+    assert_shipped_parity(
+        r#"<label><span class="mark"><svg v-if="checked" viewBox="0 0 24 24"><path d="M0 0h1" /></svg></span></label>"#,
+    );
+    assert_shipped_parity(
+        r#"<section><article class="chart-card"><h2>{{ title }}</h2><svg viewBox="0 0 100 40"><polyline :points="points" /></svg></article></section>"#,
+    );
+}
+
+#[test]
+fn cached_static_child_with_dynamic_text_uses_legacy_parent_block() {
+    assert_shipped_parity(
+        r#"<section><div class="cta"><svg viewBox="0 0 24 24"><path d="M0 0h1" /></svg>{{ label }}</div></section>"#,
+    );
+    assert_shipped_parity(
+        r#"<section><a href="/docs" class="cta"><svg viewBox="0 0 24 24"><path d="M0 0h1" /></svg>{{ label }}</a></section>"#,
+    );
+}
+
+#[test]
 fn v_for_item_props_hoist_is_registered_but_not_used() {
     assert_shipped_parity(r#"<div v-for="item in list" class="row">{{ item }}</div>"#);
     assert_shipped_parity(
@@ -94,4 +125,29 @@ fn v_for_item_props_hoist_is_registered_but_not_used() {
 #[test]
 fn v_for_component_item_props_hoist_is_registered_but_not_used() {
     assert_shipped_parity(r#"<Foo v-for="item in list" class="row"><span>{{ item }}</span></Foo>"#);
+    assert_shipped_parity(
+        r#"<NodeListInline v-for="document of filteredNodes" :key="document.id" :document="document" class="line-item" />"#,
+    );
+    assert_shipped_parity(
+        r#"<NodeCard v-for="document in filteredNodes" :key="document.id" :node="document" />"#,
+    );
+}
+
+#[test]
+fn component_slot_dynamic_static_name_props_use_legacy_hoist() {
+    assert_shipped_parity(
+        r#"<NuxtLink :to="`/dashboard/docs/${document.id}`" class="name">{{ document.name }}</NuxtLink>"#,
+    );
+    assert_shipped_parity(
+        r#"<NuxtLink :to="`/dashboard/docs/${node.id}`" class="name">{{ node.name }}</NuxtLink>"#,
+    );
+    assert_shipped_parity(
+        r#"<footer v-if="document"><NuxtLink :to="`/dashboard/docs/edit/${document.id}`" class="edit-link">{{ document.name }}</NuxtLink></footer>"#,
+    );
+    assert_shipped_parity(
+        r#"<TooltipRoot v-for="{ name } of contributors" :key="name"><span>{{ name }}</span></TooltipRoot>"#,
+    );
+    assert_shipped_parity(
+        r#"<NodeResourceInline v-for="diagram in diagrams" :key="diagram.id" :node="diagram" class="line-item" />"#,
+    );
 }

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -21,8 +21,8 @@ or `collections` modules does not bypass the boundary.
 
 ## Retained `alloc::vec::Vec` inventory
 
-The four library trees in the reviewed inventory contain 58 production files,
-70 direct `alloc::vec::Vec` paths, and 238 bound `Vec`/`StdVec` uses. "Direct"
+The four library trees in the reviewed inventory contain 59 production files,
+71 direct `alloc::vec::Vec` paths, and 238 bound `Vec`/`StdVec` uses. "Direct"
 counts imports and fully-qualified paths; "bound" counts every type,
 constructor, and method path reached through a direct `Vec` import or alias.
 The executable ledger requires strict equality, so both growth and reduction
@@ -34,7 +34,7 @@ must update the file row and aggregate evidence in the same change.
 | analysis |     7 |            8 |         18 | Diagnostics, side tables, filters, and verifier results grow with the input; no inline bound is established.       |
 | lower    |    11 |           11 |         39 | Lowering worklists and owned results grow with source-tree shape. Bounded substructures may migrate independently. |
 | pass     |    13 |           13 |         51 | Facts, provenance, and traversal worklists grow with the number of operations.                                     |
-| emit     |    14 |           14 |         66 | Ordered output buffers and collected emission inputs grow with the document.                                       |
+| emit     |    15 |           15 |         66 | Ordered output buffers and collected emission inputs grow with the document.                                       |
 
 This is not an endorsement of every retained allocation. A focused change may
 replace a site with `SmallVec` after measuring a bound; that change lowers the
@@ -43,9 +43,9 @@ Mechanical conversion of source-sized buffers is not a goal because it can
 move large payloads onto the stack or add spill bookkeeping without reducing
 allocations.
 
-The `alloc::vec::Vec` import in `emit/on.rs` and the second import in
-`side_table.rs` are `#[cfg(test)]` size/test evidence. The scanner excludes the
-complete attributed item or module, so neither can inflate production totals.
+The second `alloc::vec::Vec` import in `side_table.rs` is `#[cfg(test)]`
+size/test evidence. The scanner excludes the complete attributed item or
+module, so it cannot inflate production totals.
 
 ## Exact owned-storage inventory by scope
 
@@ -71,9 +71,9 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::String`       |    11 |           11 |         53 |
 | s2       | `vize_s0::Vec`          |     9 |            9 |         17 |
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
-| s1_to_s2 | `alloc::vec::Vec`       |    38 |           38 |        156 |
+| s1_to_s2 | `alloc::vec::Vec`       |    39 |           39 |        156 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    55 |           57 |        238 |
+| s1_to_s2 | `vize_s0::String`       |    56 |           58 |        244 |
 | s1_to_s2 | `vize_s0::Vec`          |    14 |           14 |         56 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     2 |            2 |          4 |
 

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -42,8 +42,9 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/component/preamble.rs	1	3	0	0	0	0	0	
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/create_slots.rs	1	6	1	6	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/directive.rs	1	6	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/filter.rs	0	0	1	1	0	0	0	0
-s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/hoist.rs	1	4	1	12	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/hoist.rs	1	1	1	11	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/hoist/cached_props.rs	0	0	1	1	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/hoist/props.rs	1	3	1	3	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/entity.rs	0	0	1	3	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/js.rs	0	0	1	6	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/js_comment.rs	0	0	1	3	0	0	0	0
@@ -57,7 +58,7 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props.rs	1	2	1	4	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_bind.rs	1	5	1	2	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_object.rs	1	5	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props_object_merge.rs	0	0	1	1	0	0	0	0
-s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props_static.rs	0	0	1	6	0	0	0	0
+s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props_static.rs	0	0	1	10	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/slots.rs	1	5	1	6	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/tpl.rs	0	0	1	3	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/vfor.rs	0	0	1	4	0	0	0	0

--- a/legacy-tools/fixtures/davinci-dom-corpus-workflow.mjs
+++ b/legacy-tools/fixtures/davinci-dom-corpus-workflow.mjs
@@ -11,6 +11,16 @@ export const artifactDir = "real-project-davinci-dom-corpus";
 export const corpusRoot = "tests/_fixtures/_git";
 export const expectedGitlinks = 146;
 export const expectedDomOutputComparisons = 144;
+export const expectedOldErrorSkips = 16;
+export const expectedOldErrorReasons = {
+  ExtendPoint: 1,
+  InvalidEndTag: 20,
+  MissingEndTag: 10,
+  MissingWhitespaceBetweenAttributes: 4,
+  VElseNoAdjacentIf: 1,
+  VIfSameKey: 4,
+  VSlotDuplicateSlotNames: 1,
+};
 
 const ansiEscapePattern = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, "g");
 
@@ -171,10 +181,15 @@ export function validateCorpusEvidence(artifact = artifactDir) {
   if (evidence.files === 0 || evidence.templates === 0 || evidence.compared === 0) {
     failures.push("corpus log proves no DOM-output comparisons");
   }
-  if (evidence.unreadable !== 0 || evidence.oldErrorSkips !== 0) {
-    const oldErrorReasons = formatReasonCounts(evidence.oldErrorReasons);
+  if (evidence.unreadable !== 0) {
+    failures.push(`corpus log unreadable inputs: unreadable=${evidence.unreadable}`);
+  }
+  if (
+    evidence.oldErrorSkips !== expectedOldErrorSkips ||
+    !sameReasonCounts(evidence.oldErrorReasons, expectedOldErrorReasons)
+  ) {
     failures.push(
-      `corpus log skipped inputs: unreadable=${evidence.unreadable} old_error_skips=${evidence.oldErrorSkips}${oldErrorReasons ? ` reasons=${oldErrorReasons}` : ""}`,
+      `corpus old-lane skip allowlist drift: old_error_skips=${evidence.oldErrorSkips}/${expectedOldErrorSkips} reasons=${formatReasonCounts(evidence.oldErrorReasons) || "none"} expected_reasons=${formatReasonCounts(expectedOldErrorReasons)}`,
     );
   }
   if (evidence.s2Refusals !== 0 || evidence.divergences !== 0) {
@@ -371,6 +386,10 @@ function formatReasonCounts(reasons) {
   return Object.entries(sortReasonCounts(reasons))
     .map(([reason, count]) => `${reason}=${count}`)
     .join(",");
+}
+
+function sameReasonCounts(left, right) {
+  return JSON.stringify(sortReasonCounts(left)) === JSON.stringify(sortReasonCounts(right));
 }
 
 async function main() {

--- a/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
+++ b/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
@@ -9,6 +9,8 @@ import {
   corpusEvidenceLines,
   expectedDomOutputComparisons,
   expectedGitlinks,
+  expectedOldErrorReasons,
+  expectedOldErrorSkips,
   hydrateCorpus,
   parseCorpusEvidence,
   parseFixtureGitlinks,
@@ -118,6 +120,16 @@ test("S2 DOM corpus workflow helper extracts canonical evidence", () => {
   assert.equal(verdictFor("cancelled", "record-only"), "cancelled");
   assert.equal(expectedGitlinks, 146);
   assert.equal(expectedDomOutputComparisons, 144);
+  assert.equal(expectedOldErrorSkips, 16);
+  assert.deepEqual(expectedOldErrorReasons, {
+    ExtendPoint: 1,
+    InvalidEndTag: 20,
+    MissingEndTag: 10,
+    MissingWhitespaceBetweenAttributes: 4,
+    VElseNoAdjacentIf: 1,
+    VIfSameKey: 4,
+    VSlotDuplicateSlotNames: 1,
+  });
 });
 
 test("S2 DOM corpus workflow extracts old-lane skip reasons from corpus logs", () => {
@@ -250,7 +262,8 @@ test("S2 DOM corpus workflow validates closure evidence artifacts", () => {
       join(artifact, "dom-corpus.log"),
       [
         "\u001B[32mdavinci-differential corpus scope: root=tests/_fixtures/_git scope=canonical closure_evidence=true submodules=146\u001B[0m",
-        "davinci DOM corpus sweep: files=37448 unreadable=0 parsed=37448 templates=35000 compared=35000 old_error_skips=0 s2_refusals=0 divergences=0",
+        "davinci DOM corpus sweep: files=37448 unreadable=0 parsed=37448 templates=35000 compared=34984 old_error_skips=16 s2_refusals=0 divergences=0",
+        'davinci DOM corpus old-lane error reasons: {"ExtendPoint":1,"InvalidEndTag":20,"MissingEndTag":10,"MissingWhitespaceBetweenAttributes":4,"VElseNoAdjacentIf":1,"VIfSameKey":4,"VSlotDuplicateSlotNames":1}',
       ].join("\n"),
     );
 
@@ -267,9 +280,9 @@ test("S2 DOM corpus workflow validates closure evidence artifacts", () => {
       unreadable: 0,
       parsed: 37448,
       templates: 35000,
-      compared: 35000,
-      oldErrorSkips: 0,
-      oldErrorReasons: {},
+      compared: 34984,
+      oldErrorSkips: 16,
+      oldErrorReasons: expectedOldErrorReasons,
       s2Refusals: 0,
       divergences: 0,
     });
@@ -307,7 +320,8 @@ test("S2 DOM corpus workflow rejects stale or dirty evidence artifacts", () => {
       "corpus log is missing canonical closure evidence",
       "corpus log submodules 0 != 146",
       "corpus log proves no DOM-output comparisons",
-      "corpus log skipped inputs: unreadable=3 old_error_skips=2 reasons=InvalidEndTag=1,VIfSameKey=1",
+      "corpus log unreadable inputs: unreadable=3",
+      "corpus old-lane skip allowlist drift: old_error_skips=2/16 reasons=InvalidEndTag=1,VIfSameKey=1 expected_reasons=ExtendPoint=1,InvalidEndTag=20,MissingEndTag=10,MissingWhitespaceBetweenAttributes=4,VElseNoAdjacentIf=1,VIfSameKey=4,VSlotDuplicateSlotNames=1",
       "corpus log is not clean: s2_refusals=1 divergences=1",
     ]);
   } finally {

--- a/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
+++ b/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
@@ -40,6 +40,7 @@ test("real-project workflow carries a full-canonical S2 DOM corpus job", () => {
   assert.match(checkout?.uses ?? "", /de0fac2e4500dabe0009e67214ff5f5447ce83dd/);
   assert.deepEqual(checkout?.with, { "persist-credentials": false });
   assert.ok(steps.some((step) => step.uses?.startsWith("dtolnay/rust-toolchain@")));
+  assert.ok(steps.some((step) => step.uses === "./.github/actions/setup-rust-script"));
   assert.ok(steps.some((step) => step.uses === "./.github/actions/setup-rust-sticky-cache"));
 
   const hydrate = findStep(steps, "Select and hydrate full fixture corpus");
@@ -84,6 +85,10 @@ test("real-project workflow carries a full-canonical S2 DOM corpus job", () => {
   );
   assert.match(helperSource, /"record-only"/);
   assert.match(helperSource, /EXPECTED_DOM_OUTPUT_COMPARISONS: usize = 144/);
+  assert.match(helperSource, /EXPECTED_OLD_ERROR_SKIPS: usize = 16/);
+  assert.match(helperSource, /"ExtendPoint", 1/);
+  assert.match(helperSource, /"VSlotDuplicateSlotNames", 1/);
+  assert.match(helperSource, /corpus old-lane skip allowlist drift/);
   assert.match(helperSource, /summary\.json/);
   assert.match(helperSource, /line\.contains\("davinci-differential corpus scope"\)/);
   assert.match(helperSource, /line\.contains\("davinci DOM corpus sweep"\)/);

--- a/tests/tooling/davinci-storage-inventory.ts
+++ b/tests/tooling/davinci-storage-inventory.ts
@@ -42,8 +42,8 @@ export const categoryReasons: Record<VecCategory, string> = {
 };
 
 export const expectedProductionAllocVec: StorageSummary = {
-  files: 58,
-  directPaths: 70,
+  files: 59,
+  directPaths: 71,
   boundUses: 238,
 };
 

--- a/tools/commands/fixtures/davinci-dom-corpus-workflow.rs
+++ b/tools/commands/fixtures/davinci-dom-corpus-workflow.rs
@@ -29,6 +29,7 @@ const ARTIFACT_DIR: &str = "real-project-davinci-dom-corpus";
 const CORPUS_ROOT: &str = "tests/_fixtures/_git";
 const EXPECTED_GITLINKS: usize = 146;
 const EXPECTED_DOM_OUTPUT_COMPARISONS: usize = 144;
+const EXPECTED_OLD_ERROR_SKIPS: usize = 16;
 
 fn main() -> ExitCode {
     match run() {
@@ -271,17 +272,23 @@ fn validate_corpus_evidence(artifact: &str) -> Validation {
     if evidence.files == 0 || evidence.templates == 0 || evidence.compared == 0 {
         failures.push("corpus log proves no DOM-output comparisons".to_string());
     }
-    if evidence.unreadable != 0 || evidence.old_error_skips != 0 {
+    if evidence.unreadable != 0 {
+        failures.push(format!(
+            "corpus log unreadable inputs: unreadable={}",
+            evidence.unreadable
+        ));
+    }
+    let expected_old_error_reasons = expected_old_error_reasons();
+    if evidence.old_error_skips != EXPECTED_OLD_ERROR_SKIPS
+        || !same_reason_counts(&evidence.old_error_reasons, &expected_old_error_reasons)
+    {
         let reasons = format_reason_counts(&evidence.old_error_reasons);
         failures.push(format!(
-            "corpus log skipped inputs: unreadable={} old_error_skips={}{}",
-            evidence.unreadable,
+            "corpus old-lane skip allowlist drift: old_error_skips={}/{} reasons={} expected_reasons={}",
             evidence.old_error_skips,
-            if reasons.is_empty() {
-                String::new()
-            } else {
-                format!(" reasons={reasons}")
-            }
+            EXPECTED_OLD_ERROR_SKIPS,
+            if reasons.is_empty() { "none".to_string() } else { reasons },
+            format_reason_counts(&expected_old_error_reasons)
         ));
     }
     if evidence.s2_refusals != 0 || evidence.divergences != 0 {
@@ -427,6 +434,28 @@ fn format_reason_counts(reasons: &BTreeMap<String, usize>) -> String {
         .map(|(reason, count)| format!("{reason}={count}"))
         .collect::<Vec<_>>()
         .join(",")
+}
+
+fn expected_old_error_reasons() -> BTreeMap<String, usize> {
+    [
+        ("ExtendPoint", 1),
+        ("InvalidEndTag", 20),
+        ("MissingEndTag", 10),
+        ("MissingWhitespaceBetweenAttributes", 4),
+        ("VElseNoAdjacentIf", 1),
+        ("VIfSameKey", 4),
+        ("VSlotDuplicateSlotNames", 1),
+    ]
+    .into_iter()
+    .map(|(reason, count)| (reason.to_string(), count))
+    .collect()
+}
+
+fn same_reason_counts(
+    left: &BTreeMap<String, usize>,
+    right: &BTreeMap<String, usize>,
+) -> bool {
+    left == right
 }
 
 fn append_corpus_summary(


### PR DESCRIPTION
## Summary

- close residual S2 DOM parity gaps for nested blocks, namespaces, static vnode hoists, slot whitespace, and native handler arrows
- compare recoverable old-lane diagnostics and enforce an exact canonical invalid-template allowlist
- update the Real Project Matrix DOM corpus evidence validator for the allowlisted invalid inputs

## Verification

- cargo test -p vize_s1_to_s2 --test emit_comp --test emit_slots --test emit_on --test emit_static_hoist -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_hoist_order --test davinci_s2_static_vnode_hoist --test davinci_s2_dom_namespace --test davinci_s2_static_cache --test davinci_s2_handler_parity --test davinci_s2_whitespace_text_vnode -- --nocapture
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git/alexandrie cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture
- node --test --test-concurrency=1 tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790782976&installation_model_id=422833&pr_number=5519&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5519&signature=2197b3049428855f008c41bcae2e57746276562531acc5aa99c4d9672c01e7de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event-handler output for plain HTML elements, including modifier handling and authored formatting.
  * Corrected static vnode and component prop hoisting in nested, dynamic, and namespace-sensitive scenarios.
  * Preserved whitespace-only text and slot content more accurately.
* **Tests**
  * Expanded DOM parity coverage for handlers, bound options, whitespace, static hoisting, and corpus diagnostics.
* **Chores**
  * Strengthened corpus validation and workflow setup checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->