### PR TITLE
fix(davinci): preserve raw handler expressions

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_handler_parity.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_handler_parity.rs
@@ -18,6 +18,14 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<button @contextmenu="event => openContextMenu(event, image)">open</button>"#,
     ),
     (
+        "native_no_param_arrow_handler_stays_direct",
+        r#"<button @click="() => toggleDark()">toggle</button>"#,
+    ),
+    (
+        "native_null_handler_stays_direct",
+        r#"<Select @change="null" />"#,
+    ),
+    (
         "multiline_component_update_handler_keeps_authored_padding",
         r#"<AppCheck @update:model-value="
   value => {

--- a/crates/vize_s1_to_s2/src/emit/on/wrapped.rs
+++ b/crates/vize_s1_to_s2/src/emit/on/wrapped.rs
@@ -66,7 +66,7 @@ fn emit_handler(cx: &mut EmitCx<'_>, on: &OnOp<'_>, js: &JsExpr<'_>, is_plain_el
         emit_raw_handler(cx, on, js);
         return;
     }
-    if is_raw_function_handler(js.ast, is_plain_element)
+    if is_raw_handler_expression(js.ast, js.source, is_plain_element)
         && !super::super::on_typed::is_typed_arrow(js.ast)
     {
         super::super::js::push_js_expr(cx, js);
@@ -145,14 +145,23 @@ fn is_handler_reference(expr: &Expression<'_>) -> bool {
     }
 }
 
-fn is_raw_function_handler(expr: &Expression<'_>, is_plain_element: bool) -> bool {
+fn is_raw_handler_expression(expr: &Expression<'_>, source: &str, is_plain_element: bool) -> bool {
+    if matches!(expr, Expression::NullLiteral(_)) {
+        return true;
+    }
     if matches!(expr, Expression::FunctionExpression(_)) {
         return true;
     }
     match expr {
         Expression::ArrowFunctionExpression(arrow) => {
-            !is_plain_element || !arrow.params.items.is_empty()
+            !is_plain_element
+                || !arrow.params.items.is_empty()
+                || (arrow.expression && !source_uses_ts_expression_syntax(source))
         }
         _ => false,
     }
+}
+
+fn source_uses_ts_expression_syntax(source: &str) -> bool {
+    source.contains(" as ") || source.contains(" satisfies ")
 }


### PR DESCRIPTION
## Summary
- keep S2 DOM event handlers raw for no-parameter expression arrows that the shipped DOM lane treats as handlers
- keep literal null handlers raw
- add real-project reduced parity witnesses for the remaining DOM corpus handler class

## Validation
- cargo test -q -p vize_atelier_dom --test davinci_s2_handler_parity -- --nocapture
- cargo test -q -p vize_s1_to_s2 --test emit_on -- --nocapture
- node --test tests/tooling/davinci-storage-policy.test.ts tests/tooling/source-file-lengths.test.ts
- cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- git diff --check

Note: broader local clippy including vize_atelier_dom --tests is blocked by pre-existing lints in davinci_walk_baseline.rs and davinci_teardown_without_stack_guard.rs on this local toolchain.