### PR TITLE
fix(davinci): preserve dynamic-component directive patch flags

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dirs.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dirs.rs
@@ -22,6 +22,14 @@ const BATTERY: &[(&str, &str)] = &[
     ("mods_value", r#"<div v-example.foo.bar="val"></div>"#),
     ("dyn_arg", r#"<div v-example:[dyn]="val"></div>"#),
     ("two", r#"<div v-pin v-foo></div>"#),
+    (
+        "dynamic_component_custom_directive_keeps_need_patch",
+        r#"<component :is="view" v-example />"#,
+    ),
+    (
+        "dynamic_component_custom_directive_static_props_keeps_need_patch",
+        r#"<component :is="copied ? 'CheckOutlined' : 'SnippetsOutlined'" key="copy" class="code-action" v-clipboard:copy="sourceCode" v-clipboard:success="handleCodeCopied" />"#,
+    ),
     ("kebab", r#"<div v-my-dir></div>"#),
     ("id", r#"<div id="x" v-example></div>"#),
     ("bind_id", r#"<div :id="id" v-example></div>"#),

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -255,6 +255,9 @@ fn emit_call(
         if patch.dynamic_props.is_empty() {
             patch.flag &= !8;
         }
+        if directive::has_runtime(&component.bindings) && patch.flag & (2 | 4 | 8 | 16) == 0 {
+            patch.flag |= 512;
+        }
     }
     let mut flag = patch.flag;
     if array && children_need_text_flag(&component.children) {

--- a/crates/vize_s1_to_s2/tests/emit_dirs.rs
+++ b/crates/vize_s1_to_s2/tests/emit_dirs.rs
@@ -248,6 +248,23 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+fn a_dynamic_component_directive_keeps_need_patch() {
+    assert_eq!(
+        assembled(r#"<component :is="view" v-example />"#),
+        pin("\
+const { resolveDirective: _resolveDirective, resolveDynamicComponent: _resolveDynamicComponent, withDirectives: _withDirectives, openBlock: _openBlock, createBlock: _createBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective(\"example\")
+
+  return _withDirectives((_openBlock(), _createBlock(_resolveDynamicComponent(view), null, null, 512 /* NEED_PATCH */)), [
+    [_directive_example]
+  ])
+}")
+    );
+}
+
+#[test]
 fn native_v_model_keeps_the_model_entry_first() {
     assert_eq!(
         assembled(r#"<input v-example v-model="x">"#),


### PR DESCRIPTION
Summary:
- preserve NEED_PATCH when dynamic component is only dynamic because of :is plus runtime directives
- add Davinci DOM parity witnesses for dynamic component custom directives

Validation:
- cargo test -q -p vize_atelier_dom --test davinci_s2_dirs -- --nocapture
- cargo test -q -p vize_s1_to_s2 --test emit_comp --test emit_dirs -- --nocapture
- node --test tests/tooling/davinci-storage-policy.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-module-layout.test.ts
- cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5536"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790791436&installation_model_id=422833&pr_number=5536&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5536&signature=87765e633789d1423600c9858bb249e5d078bdf4da5dd9cd42779330c3264a8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic component updates when custom directives are used.
  * Ensured directive-driven changes are correctly applied alongside static properties, classes, and other component attributes.

* **Tests**
  * Added coverage for dynamic components using custom directives and directive arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->