### PR TITLE
test(davinci): pin P2-8 lowering totality witnesses

### DIFF
--- a/crates/vize_s1_to_s2/tests/lowering_battery.rs
+++ b/crates/vize_s1_to_s2/tests/lowering_battery.rs
@@ -33,6 +33,23 @@ fn every_battery_fixture_lowers_soundly() {
 }
 
 #[test]
+fn plain_lowering_soundness_covers_every_lowering_side_table() {
+    let source = r#"<template v-if="ok" key="branch">hi {{ name }}</template><template v-for="item in items" :key="item.id"><span>{{ item }}</span></template>"#;
+    with_lowered(source, |lowered, _folio| {
+        assert_eq!(
+            (
+                lowered.texts.len(),
+                lowered.wrappers.len(),
+                lowered.for_wrappers.len()
+            ),
+            (1, 1, 1),
+            "the canary must exercise every lowering-owned side table"
+        );
+    });
+    assert_sound(source, "lowering-side-table-canary");
+}
+
+#[test]
 fn every_truncation_of_every_fixture_lowers_soundly() {
     // The EOF-adversarial lane: each fixture cut at every char boundary,
     // from both ends — the recovery paths TS-19 hammers, continued into

--- a/crates/vize_s1_to_s2/tests/support/mod.rs
+++ b/crates/vize_s1_to_s2/tests/support/mod.rs
@@ -190,8 +190,8 @@ pub fn assert_transformed_sound_caps(source: &str, caps: LegacyCaps, context: &s
 ///    so page-order ids resolve by construction.
 /// 2. **Verifier-clean at `Canonical` rigor** — the lowering builds
 ///    canonical `ui.if` shapes from birth and every span nests.
-/// 3. **Side tables resolve** — every scope key and every provenance
-///    node id names an op the artifact numbers.
+/// 3. **Side tables resolve** — every lowering side-table key and every
+///    provenance node id names an op the artifact numbers.
 /// 4. **Folio round-trip** — `parse(print(v)) == v` structurally and the
 ///    re-print is byte-identical (TS-16 applied to lowered output).
 pub fn assert_sound(source: &str, context: &str) {
@@ -217,6 +217,21 @@ pub fn assert_sound_caps(source: &str, caps: LegacyCaps, context: &str) {
             verify_table(folio, &lowered.scopes),
             Vec::<Violation>::new(),
             "a scope key dangles: {context}"
+        );
+        assert_eq!(
+            verify_table(folio, &lowered.texts),
+            Vec::<Violation>::new(),
+            "a recorded text-run key dangles: {context}"
+        );
+        assert_eq!(
+            verify_table(folio, &lowered.wrappers),
+            Vec::<Violation>::new(),
+            "a wrapper-key fact dangles: {context}"
+        );
+        assert_eq!(
+            verify_table(folio, &lowered.for_wrappers),
+            Vec::<Violation>::new(),
+            "a for-wrapper fact dangles: {context}"
         );
         let provenance_ids: SideTable<()> = lowered
             .provenance

--- a/tests/fuzz/fuzz_targets/s1_lowering.rs
+++ b/tests/fuzz/fuzz_targets/s1_lowering.rs
@@ -19,9 +19,9 @@
 use libfuzzer_sys::fuzz_target;
 use vize_davinci::folio::{Folio, FolioMode};
 use vize_davinci::side_table::SideTable;
-use vize_s0::Allocator;
+use vize_s0::{Allocator, SourceRoot, Span};
 use vize_s1::parse;
-use vize_s1_to_s2::lower;
+use vize_s1_to_s2::{Lowered, lower};
 use vize_s2::folio::DisegnoFolio;
 use vize_s2::verify::{Rigor, verify, verify_table};
 
@@ -37,6 +37,7 @@ fuzz_target!(|data: &[u8]| {
     let allocator = Allocator::new();
     let (tree, errors) = parse(&allocator, source);
     let lowered = lower(&allocator, &tree, &errors);
+    assert_fact_spans_resolve(source, &lowered);
     let folio = DisegnoFolio::of(&lowered.root.ops);
     assert_eq!(u64::from(lowered.op_count), folio.op_count());
     assert_eq!(verify(&folio, Rigor::Canonical), vec![]);
@@ -54,3 +55,22 @@ fuzz_target!(|data: &[u8]| {
     let reparsed = DisegnoFolio::parse(printed.as_str()).expect("canonical print must re-parse");
     assert_eq!(reparsed, folio);
 });
+
+fn assert_fact_spans_resolve(source: &str, lowered: &Lowered<'_>) {
+    let root = SourceRoot::new(source).expect("the fuzz target rejects u32-overflowing sources");
+    for diagnostic in &lowered.diagnostics {
+        assert_span_resolves(root, diagnostic.span, "diagnostic");
+    }
+    for record in &lowered.provenance {
+        assert_span_resolves(root, record.span, "provenance");
+    }
+}
+
+fn assert_span_resolves(root: SourceRoot<'_>, span: Span, label: &str) {
+    assert!(
+        root.contains_span(span),
+        "{label} span @{}:{} is not a valid authored UTF-8 range",
+        span.start,
+        span.end
+    );
+}


### PR DESCRIPTION
## Summary
- extend the S1 to S2 lowering soundness oracle across lowering-owned side tables
- add a canary for text and wrapper side table ownership
- assert fuzz diagnostic/provenance spans stay inside authored UTF-8 source

## Verification
- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- CARGO_TARGET_DIR=target/p2-8 cargo test -p vize_s1_to_s2 --test lowering_battery -- --nocapture
- CARGO_TARGET_DIR=target/p2-8 cargo check --manifest-path tests/fuzz/Cargo.toml --bin s1_lowering
- CARGO_TARGET_DIR=target/p2-8 cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus -- --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790792048&installation_model_id=422833&pr_number=5537&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5537&signature=3080e7a3861d99a73bafcb6c34e61a58fa17b03d96a337750c183ac736cb8872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->