### PR TITLE
fix(davinci): keep component class binds inline

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -53,6 +53,10 @@ const BATTERY: &[(&str, &str)] = &[
   </template>
 </div>"#,
     ),
+    (
+        "component_static_class_array_props_stay_inline",
+        r#"<section><Menu><Content align="end" side="top" :side-offset="8" :class="['z-50', 'bg-white']"><Item /></Content></Menu><button><div class="i-stop"></div></button><button><div class="i-trash"></div></button></section>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/props_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static.rs
@@ -206,10 +206,7 @@ fn component_hoist_prop<'a>(
                 return Ok(None);
             };
             let dynamic_value = !bind_value_is_static_patchless(bind);
-            if key.as_str() == "ref" {
-                return Ok(None);
-            }
-            if key.as_str() == "class" && dynamic_value {
+            if matches!(key.as_str(), "ref" | "class") {
                 return Ok(None);
             }
             let value = bind_value(bind)?;


### PR DESCRIPTION
## Summary
- keep component `class` binds on the inline props path so `_normalizeClass` is preserved
- add a Davinci S2 parity witness for static class-array component props inside slots

## Validation
- cargo test -q -p vize_atelier_dom --test davinci_s2_hoist_order --test davinci_s2_template_wrapper_component_props --test davinci_s2_root_hoist -- --nocapture
- cargo test -q -p vize_s1_to_s2 --test emit_comp --test emit_static_hoist --test emit_merge --test emit_dynamic_bind_keys -- --nocapture
- node --test tests/tooling/davinci-storage-policy.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-module-layout.test.ts
- cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790800952&installation_model_id=422833&pr_number=5543&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5543&signature=bfd88bc8c38f5a239986cedce0cae7c0a63c5ab8e4e938ff148011bd182cd994"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component property handling so `class` bindings are treated consistently during component processing.
  * Added coverage for static class arrays used alongside menu content and icon buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->