### PR TITLE
test(davinci): pin fixture tool coverage surfaces

### DIFF
--- a/tests/tooling/vue-ecosystem-fixtures.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures.test.ts
@@ -299,6 +299,8 @@ test("new fixture licenses and read-only policy stay explicit", () => {
 
 test("every registry entry declares the requested tool coverage and diff mode", () => {
   const registry = readRegistry();
+  const requiredSurfaces = "compiler,linter,typechecker,formatter,syntax-highlighter,lsp";
+  assert.equal(registry.requiredToolCoverage.join(","), requiredSurfaces);
   const requiredCoverage = [...registry.requiredToolCoverage].sort();
 
   for (const project of registry.projects) {


### PR DESCRIPTION
## Summary
- pin the ecosystem fixture manifest required tool coverage set
- ensure compiler, linter, typechecker, formatter, syntax-highlighter, and LSP coverage cannot silently shrink

## Verification
- node --test tests/tooling/vue-ecosystem-fixtures.test.ts
- pnpm exec oxfmt --check tests/tooling/vue-ecosystem-fixtures.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790802476&installation_model_id=422833&pr_number=5546&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5546&signature=41319f3d2f6b8a7b05ec80aedccc6b305fbd74f8b86fdc99c51adde07f6092bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->