### PR TITLE
fix(maestro): point LSP typecheck guidance at TypeScript 7

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -23,6 +23,8 @@ mod editor_typecheck_tests;
 mod line_index;
 mod service;
 mod severity;
+#[cfg(all(test, feature = "native"))]
+mod typecheck_unavailable_tests;
 mod vize_sfc_type;
 // `insta`'s snapshot macros expand through the disallowed `std::format!`; the
 // expansion is inside `insta`, so only an allow at the test module can silence
@@ -42,6 +44,15 @@ pub(in crate::ide) use line_index::LineIndex;
 pub(in crate::ide) use line_index::offset_to_line_col;
 #[cfg(feature = "native")]
 pub(in crate::ide) use service::{SourceMapping, VirtualTsResult};
+
+#[cfg(feature = "native")]
+pub(crate) const TYPECHECK_UNAVAILABLE_HINT_MESSAGE: &str = "Type checking is unavailable in this workspace. Make sure `tsconfig.json` exists. \
+     Install `typescript@^7` or configure `typeChecker.corsaPath`; \
+     see https://vizejs.dev/guide/static-analysis.";
+
+#[cfg(feature = "native")]
+pub(crate) const TYPECHECK_UNAVAILABLE_NOTICE_MESSAGE: &str = "Vize: type checking is unavailable in this workspace. Make sure tsconfig.json exists. \
+     Install `typescript@^7` or configure `typeChecker.corsaPath`.";
 
 /// Diagnostic source identifiers.
 pub mod sources {

--- a/crates/vize_maestro/src/ide/diagnostics/service.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/service.rs
@@ -387,7 +387,7 @@ fn has_error_severity_diagnostic(diagnostics: &[Diagnostic]) -> bool {
 /// but the Corsa bridge is not available. Single point of truth so the
 /// wording stays consistent for tests and follow-up code-action work.
 #[cfg(feature = "native")]
-fn typecheck_unavailable_hint() -> Diagnostic {
+pub(super) fn typecheck_unavailable_hint() -> Diagnostic {
     Diagnostic {
         range: Range {
             start: tower_lsp::lsp_types::Position {
@@ -402,10 +402,7 @@ fn typecheck_unavailable_hint() -> Diagnostic {
         severity: Some(DiagnosticSeverity::HINT),
         code: Some(NumberOrString::String("typecheck-unavailable".to_string())),
         source: Some(super::sources::TYPE_CHECKER.to_string()),
-        message: "Type checking is unavailable in this workspace. \
-            Make sure `tsconfig.json` exists and the Corsa runtime is reachable; \
-            see https://vizejs.dev/guide/static-analysis."
-            .to_string(),
+        message: super::TYPECHECK_UNAVAILABLE_HINT_MESSAGE.to_string(),
         ..Default::default()
     }
 }

--- a/crates/vize_maestro/src/ide/diagnostics/typecheck_unavailable_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/typecheck_unavailable_tests.rs
@@ -1,0 +1,30 @@
+use super::{
+    TYPECHECK_UNAVAILABLE_HINT_MESSAGE, TYPECHECK_UNAVAILABLE_NOTICE_MESSAGE,
+    service::typecheck_unavailable_hint, sources,
+};
+use tower_lsp::lsp_types::{DiagnosticSeverity, NumberOrString};
+
+#[test]
+fn unavailable_typecheck_diagnostic_points_to_typescript_7() {
+    let hint = typecheck_unavailable_hint();
+
+    assert_eq!(hint.source.as_deref(), Some(sources::TYPE_CHECKER));
+    assert_eq!(hint.severity, Some(DiagnosticSeverity::HINT));
+    assert_eq!(
+        hint.code,
+        Some(NumberOrString::String("typecheck-unavailable".to_string()))
+    );
+    assert_eq!(hint.message, TYPECHECK_UNAVAILABLE_HINT_MESSAGE);
+    assert_ts7_guidance(&hint.message);
+}
+
+#[test]
+fn unavailable_typecheck_notice_points_to_typescript_7() {
+    assert_ts7_guidance(TYPECHECK_UNAVAILABLE_NOTICE_MESSAGE);
+}
+
+fn assert_ts7_guidance(message: &str) {
+    assert!(message.contains("typescript@^7"));
+    assert!(message.contains("typeChecker.corsaPath"));
+    assert!(!message.contains("@typescript/native-preview"));
+}

--- a/crates/vize_maestro/src/server/diagnostic_publishing.rs
+++ b/crates/vize_maestro/src/server/diagnostic_publishing.rs
@@ -124,8 +124,7 @@ impl MaestroServer {
             self.client
                 .show_message(
                     MessageType::WARNING,
-                    "Vize: type checking is unavailable in this workspace. \
-                     Make sure tsconfig.json exists and the Corsa runtime is reachable.",
+                    crate::ide::diagnostics::TYPECHECK_UNAVAILABLE_NOTICE_MESSAGE,
                 )
                 .await;
         }

--- a/tests/snapshots/check/vue-benchmarks-lsp-ref-unwrap-oracle.ts
+++ b/tests/snapshots/check/vue-benchmarks-lsp-ref-unwrap-oracle.ts
@@ -53,7 +53,7 @@ const heuristicMarkers = ["_Script binding_", "_Template binding from script_"];
 const typecheckUnavailableHint = {
   code: "typecheck-unavailable",
   message:
-    "Type checking is unavailable in this workspace. Make sure `tsconfig.json` exists and the Corsa runtime is reachable; see https://vizejs.dev/guide/static-analysis.",
+    "Type checking is unavailable in this workspace. Make sure `tsconfig.json` exists. Install `typescript@^7` or configure `typeChecker.corsaPath`; see https://vizejs.dev/guide/static-analysis.",
   range: {
     start: { line: 0, character: 0 },
     end: { line: 0, character: 0 },


### PR DESCRIPTION
## Summary
- move the LSP typecheck-unavailable hint and window notice to shared wording
- point that wording at `typescript@^7` / `typeChecker.corsaPath` instead of the generic Corsa runtime hint
- add native Maestro regression coverage plus the vue-benchmarks LSP oracle update that reject retired `@typescript/native-preview` guidance

## Verification
- `cargo test -p vize_maestro unavailable_typecheck`
- `node --test tests/tooling/package-manifests-corsa-runtime.test.ts tests/tooling/content-mapper-manifest.test.ts`
- `cargo fmt --check --package vize_maestro`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10`
- `git diff --check origin/main...HEAD`

No rollout or release change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved messaging when TypeScript type checking is unavailable.
  * Added clearer guidance for configuring the supported TypeScript version and type-checker path.
  * Standardized the hint and notice shown across diagnostics.

* **Tests**
  * Added coverage to verify diagnostic severity, source, code, and guidance content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->