### PR TITLE
fix(davinci): align nested component prop hoists

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -57,6 +57,10 @@ const BATTERY: &[(&str, &str)] = &[
         "component_static_class_array_props_stay_inline",
         r#"<section><Menu><Content align="end" side="top" :side-offset="8" :class="['z-50', 'bg-white']"><Item /></Content></Menu><button><div class="i-stop"></div></button><button><div class="i-trash"></div></button></section>"#,
     ),
+    (
+        "dialog_content_static_props_stay_inline_before_slot_child_hoists",
+        r#"<slot v-bind="{ hasPermissions }" /><DialogRoot :open="showDialog"><DialogPortal><DialogOverlay class="fixed inset-0" /><DialogContent flex="~ col items-start gap-4" class="fixed left-1/2 top-1/2"><DialogTitle class="m-0 text-lg font-semibold">{{ title }}</DialogTitle><DialogDescription>{{ body }}<ol mt-4 list-decimal pl-5 text-sm><li>one</li></ol></DialogDescription></DialogContent></DialogPortal></DialogRoot>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -213,8 +213,10 @@ fn emit_call(
     {
         cx.buf.push_hoist(props.source.clone());
     }
+    let hoist_static_props_in_static_vnode_context =
+        cx.hoist_static_vnodes && slots::has_text_only_implicit_default(&component.children);
     let static_props_hoist_context =
-        cx.hoist_static_vnodes || cx.slot_param_depth > 0 || cx.in_v_for;
+        hoist_static_props_in_static_vnode_context || cx.slot_param_depth > 0 || cx.in_v_for;
     let can_hoist_static_props = !has_custom
         && !for_item
         && if_key.is_none()


### PR DESCRIPTION
## Summary
- restrict nested component static props hoisting in static-vnode contexts to text-only implicit defaults
- keep component props inline when slot child hoists need to retain the shipped helper ordering
- add a Davinci DOM regression covering DialogContent with nested slot child hoists

## Validation
- cargo test -q -p vize_atelier_dom --test davinci_s2_hoist_order --test davinci_s2_template_wrapper_component_props --test davinci_s2_root_hoist -- --nocapture
- cargo test -q -p vize_s1_to_s2 --test emit_comp --test emit_static_hoist --test emit_merge --test emit_dynamic_bind_keys -- --nocapture
- node --test tests/tooling/davinci-storage-policy.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-module-layout.test.ts
- cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- git -c submodule.recurse=false diff --check -- crates/vize_s1_to_s2/src/emit/component.rs crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->