### PR TITLE
fix(davinci): preserve loop component prop order

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -61,6 +61,10 @@ const BATTERY: &[(&str, &str)] = &[
         "dialog_content_static_props_stay_inline_before_slot_child_hoists",
         r#"<slot v-bind="{ hasPermissions }" /><DialogRoot :open="showDialog"><DialogPortal><DialogOverlay class="fixed inset-0" /><DialogContent flex="~ col items-start gap-4" class="fixed left-1/2 top-1/2"><DialogTitle class="m-0 text-lg font-semibold">{{ title }}</DialogTitle><DialogDescription>{{ body }}<ol mt-4 list-decimal pl-5 text-sm><li>one</li></ol></DialogDescription></DialogContent></DialogPortal></DialogRoot>"#,
     ),
+    (
+        "for_component_child_hoists_keep_avatar_props_order",
+        r#"<div v-for="(author, index) of authors" :key="index"><AvatarRoot class="size-10 inline-flex select-none items-center justify-center overflow-hidden rounded-full bg-neutral-100 align-middle dark:bg-neutral-800"><AvatarImage class="h-full w-full rounded-[inherit] object-cover" :src="author.avatar || author.avatarFallback" :alt="`${author.displayName}'s avatar`" /><AvatarFallback class="h-full w-full flex items-center justify-center bg-white text-sm text-primary font-medium leading-1 dark:bg-neutral-800 dark:text-neutral-300" :delay-ms="600" as-child>{{ [author.displayName.charAt(0).toUpperCase(), author.displayName.charAt(1).toUpperCase()].join('') }}</AvatarFallback></AvatarRoot></div>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -1,5 +1,4 @@
 //! Component emission, including slots, builtins, and dynamic components.
-
 mod checks;
 mod preamble;
 

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -1,9 +1,4 @@
-//! Static-name component emission (`resolveComponent` / `createVNode` /
-//! `createBlock`) plus slot objects from [`SlotFacts`] (implicit
-//! default, named `<template>` groups, component-root `v-slot`) and
-//! `createSlots` for `v-if` / `v-for` slot templates, the `v-slots`
-//! spread, Vue builtins, and `<component :is>`
-//! (`resolveDynamicComponent`).
+//! Component emission, including slots, builtins, and dynamic components.
 
 mod checks;
 mod preamble;

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -199,6 +199,7 @@ fn emit_call(
             dynamic_values: false,
             non_key: hoist_attrs.iter().any(|attr| attr.name != "key"),
             valued_prop: hoist_attrs.iter().any(|attr| attr.value.is_some()),
+            all_static_binds: false,
         })
     } else {
         props_static::component_hoist_props(&component.attributes, &component.bindings)?
@@ -215,8 +216,14 @@ fn emit_call(
     }
     let hoist_static_props_in_static_vnode_context =
         cx.hoist_static_vnodes && slots::has_text_only_implicit_default(&component.children);
-    let static_props_hoist_context =
-        hoist_static_props_in_static_vnode_context || cx.slot_param_depth > 0 || cx.in_v_for;
+    let hoist_static_props_in_loop_context = cx.in_v_for
+        && (slots::has_text_only_implicit_default(&component.children)
+            || hoistable_static_props
+                .as_ref()
+                .is_some_and(|props| props.all_static_binds));
+    let static_props_hoist_context = hoist_static_props_in_static_vnode_context
+        || hoist_static_props_in_loop_context
+        || cx.slot_param_depth > 0;
     let can_hoist_static_props = !has_custom
         && !for_item
         && if_key.is_none()

--- a/crates/vize_s1_to_s2/src/emit/props_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static.rs
@@ -84,6 +84,7 @@ pub(super) struct ComponentHoistProps {
     pub(super) dynamic_values: bool,
     pub(super) non_key: bool,
     pub(super) valued_prop: bool,
+    pub(super) all_static_binds: bool,
 }
 
 pub(super) fn component_hoist_props(
@@ -96,6 +97,7 @@ pub(super) fn component_hoist_props(
     let mut dynamic_values = false;
     let mut non_key = false;
     let mut valued_prop = false;
+    let mut all_static_binds = true;
     for (index, piece) in pieces.iter().enumerate() {
         let mut prop = String::default();
         let Some((key, dynamic_value)) = component_hoist_prop(&mut prop, piece)? else {
@@ -111,6 +113,7 @@ pub(super) fn component_hoist_props(
             Piece::Bind(_) => true,
             _ => false,
         };
+        all_static_binds &= matches!(piece, Piece::Bind(_)) && !dynamic_value;
         if emitted > 0 {
             out.push_str(", ");
         }
@@ -126,6 +129,7 @@ pub(super) fn component_hoist_props(
         dynamic_values,
         non_key,
         valued_prop,
+        all_static_binds,
     }))
 }
 


### PR DESCRIPTION
## Summary
- avoid hoisting loop-nested component static attrs when component children must keep shipped hoist order
- keep text-only loop component defaults and all-static-bind loop props eligible for hoisting
- add an AvatarRoot/AvatarFallback Davinci DOM regression from the latest corpus residual bucket

## Validation
- cargo test -q -p vize_atelier_dom --test davinci_s2_hoist_order --test davinci_s2_template_wrapper_component_props --test davinci_s2_root_hoist -- --nocapture
- cargo test -q -p vize_s1_to_s2 --test emit_comp --test emit_static_hoist --test emit_merge --test emit_dynamic_bind_keys -- --nocapture
- node --test tests/tooling/davinci-storage-policy.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-module-layout.test.ts
- cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- git -c submodule.recurse=false diff --check -- crates/vize_s1_to_s2/src/emit/component.rs crates/vize_s1_to_s2/src/emit/props_static.rs crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component rendering in loops when passing avatar and other static properties.
  * Corrected handling of dynamic components so their bindings are not incorrectly treated as static.
  * Improved hoisting decisions for components with dynamic or mixed bindings, helping ensure updates render correctly.

* **Tests**
  * Added coverage for component property ordering in loop-rendered components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->