### PR TITLE
fix(davinci): preserve scoped component prop order

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -65,6 +65,10 @@ const BATTERY: &[(&str, &str)] = &[
         "for_component_child_hoists_keep_avatar_props_order",
         r#"<div v-for="(author, index) of authors" :key="index"><AvatarRoot class="size-10 inline-flex select-none items-center justify-center overflow-hidden rounded-full bg-neutral-100 align-middle dark:bg-neutral-800"><AvatarImage class="h-full w-full rounded-[inherit] object-cover" :src="author.avatar || author.avatarFallback" :alt="`${author.displayName}'s avatar`" /><AvatarFallback class="h-full w-full flex items-center justify-center bg-white text-sm text-primary font-medium leading-1 dark:bg-neutral-800 dark:text-neutral-300" :delay-ms="600" as-child>{{ [author.displayName.charAt(0).toUpperCase(), author.displayName.charAt(1).toUpperCase()].join('') }}</AvatarFallback></AvatarRoot></div>"#,
     ),
+    (
+        "scoped_slot_component_child_hoists_keep_parent_props_inline",
+        r#"<CursorMomentum v-slot="{ currentValue }"><Volumed :perspective="800" transform="rotateX(45deg) translateY(3px)"><TestDummyMarkerFlat :style="{ transform: `rotate(${currentValue}deg)` }" /></Volumed></CursorMomentum>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -215,9 +215,14 @@ fn emit_call(
             || hoistable_static_props
                 .as_ref()
                 .is_some_and(|props| props.all_static_binds));
+    let hoist_static_props_in_scoped_slot_context = cx.slot_param_depth > 0
+        && (slots::has_text_only_implicit_default(&component.children)
+            || hoistable_static_props
+                .as_ref()
+                .is_some_and(|props| props.all_static_binds));
     let static_props_hoist_context = hoist_static_props_in_static_vnode_context
         || hoist_static_props_in_loop_context
-        || cx.slot_param_depth > 0;
+        || hoist_static_props_in_scoped_slot_context;
     let can_hoist_static_props = !has_custom
         && !for_item
         && if_key.is_none()

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -208,21 +208,14 @@ fn emit_call(
     {
         cx.buf.push_hoist(props.source.clone());
     }
-    let hoist_static_props_in_static_vnode_context =
-        cx.hoist_static_vnodes && slots::has_text_only_implicit_default(&component.children);
-    let hoist_static_props_in_loop_context = cx.in_v_for
-        && (slots::has_text_only_implicit_default(&component.children)
+    let text_only_default = slots::has_text_only_implicit_default(&component.children);
+    let loop_or_scoped_slot_hoist = (cx.in_v_for || cx.slot_param_depth > 0)
+        && (text_only_default
             || hoistable_static_props
                 .as_ref()
                 .is_some_and(|props| props.all_static_binds));
-    let hoist_static_props_in_scoped_slot_context = cx.slot_param_depth > 0
-        && (slots::has_text_only_implicit_default(&component.children)
-            || hoistable_static_props
-                .as_ref()
-                .is_some_and(|props| props.all_static_binds));
-    let static_props_hoist_context = hoist_static_props_in_static_vnode_context
-        || hoist_static_props_in_loop_context
-        || hoist_static_props_in_scoped_slot_context;
+    let static_props_hoist_context =
+        (cx.hoist_static_vnodes && text_only_default) || loop_or_scoped_slot_hoist;
     let can_hoist_static_props = !has_custom
         && !for_item
         && if_key.is_none()


### PR DESCRIPTION
## Summary
- avoid treating scoped-slot emission as an unconditional component static-props hoist context
- keep scoped-slot hoisting for text-only defaults and all-static-bind props
- add a CursorMomentum/Volumed Davinci DOM regression from the current corpus residuals

## Validation
- cargo test -q -p vize_atelier_dom --test davinci_s2_hoist_order --test davinci_s2_template_wrapper_component_props --test davinci_s2_root_hoist -- --nocapture
- cargo test -q -p vize_s1_to_s2 --test emit_comp --test emit_static_hoist --test emit_merge --test emit_dynamic_bind_keys -- --nocapture
- node --test tests/tooling/davinci-storage-policy.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-module-layout.test.ts
- cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- git -c submodule.recurse=false diff --check -- crates/vize_s1_to_s2/src/emit/component.rs crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of static component properties within scoped slots.
  * Prevented eligible properties from being hoisted in cases where this could alter rendered output.
  * Added coverage for scoped-slot rendering with parent properties preserved inline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->