### PR TITLE
fix(davinci): preserve slot branch vnode order

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -69,6 +69,10 @@ const BATTERY: &[(&str, &str)] = &[
         "scoped_slot_component_child_hoists_keep_parent_props_inline",
         r#"<CursorMomentum v-slot="{ currentValue }"><Volumed :perspective="800" transform="rotateX(45deg) translateY(3px)"><TestDummyMarkerFlat :style="{ transform: `rotate(${currentValue}deg)` }" /></Volumed></CursorMomentum>"#,
     ),
+    (
+        "slot_if_branch_static_vnodes_keep_shipped_order",
+        r#"<a-auto-complete><template #option="item"><template v-if="item.options"><span>{{ item.value }}<a style="float: right" href="https://www.google.com/search?q=antd" target="_blank" rel="noopener noreferrer">more</a></span></template><template v-else-if="item.value === 'all'"><a href="https://www.google.com/search?q=ant-design-vue" target="_blank" rel="noopener noreferrer">View all results</a></template></template></a-auto-complete>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/vnode_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_static.rs
@@ -1,7 +1,7 @@
 //! Static child vnode hoist gates for native element emission.
 
 use vize_davinci::id::NodeId;
-use vize_s2::op::ElementOp;
+use vize_s2::op::{ElementOp, Op};
 
 use super::EmitCx;
 use crate::pass::StaticLevel;
@@ -19,9 +19,20 @@ pub(super) fn should_hoist_static_children(
     if !requested {
         return false;
     }
+    if has_direct_interpolation_child(element) {
+        return false;
+    }
     if branch_root || for_item {
         return true;
     }
     id.and_then(|id| cx.facts.static_facts.get(id))
         .is_some_and(|fact| fact.level == StaticLevel::NotStatic)
+}
+
+fn has_direct_interpolation_child(element: &ElementOp<'_>) -> bool {
+    element
+        .children
+        .ops
+        .iter()
+        .any(|op| matches!(op, Op::Interpolation(_)))
 }

--- a/crates/vize_s1_to_s2/src/emit/vnode_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_static.rs
@@ -19,7 +19,7 @@ pub(super) fn should_hoist_static_children(
     if !requested {
         return false;
     }
-    if has_direct_interpolation_child(element) {
+    if branch_root && has_direct_interpolation_child(element) {
         return false;
     }
     if branch_root || for_item {


### PR DESCRIPTION
Summary:
- stop inherited static vnode hoisting from reordering static children under direct interpolation parents
- add an Ant Design Vue option slot branch regression for byte-for-byte DOM parity

Validation:
- rtk cargo test -q -p vize_atelier_dom --test davinci_s2_hoist_order --test davinci_s2_template_wrapper_component_props --test davinci_s2_root_hoist -- --nocapture
- rtk cargo test -q -p vize_s1_to_s2 --test emit_comp --test emit_static_hoist --test emit_merge --test emit_dynamic_bind_keys -- --nocapture
- rtk test node --test tests/tooling/davinci-storage-policy.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-module-layout.test.ts
- rtk cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- git -c submodule.recurse=false diff --check -- crates/vize_s1_to_s2/src/emit/vnode_static.rs crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5560"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where static content could be incorrectly reordered when an element contained direct interpolated content.
  * Improved rendering consistency for autocomplete slots using conditional branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->