### PR TITLE
fix(davinci): preserve runtime directive prop order

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -73,6 +73,10 @@ const BATTERY: &[(&str, &str)] = &[
         "slot_if_branch_static_vnodes_keep_shipped_order",
         r#"<a-auto-complete><template #option="item"><template v-if="item.options"><span>{{ item.value }}<a style="float: right" href="https://www.google.com/search?q=antd" target="_blank" rel="noopener noreferrer">more</a></span></template><template v-else-if="item.value === 'all'"><a href="https://www.google.com/search?q=ant-design-vue" target="_blank" rel="noopener noreferrer">View all results</a></template></template></a-auto-complete>"#,
     ),
+    (
+        "template_for_component_bind_props_keep_shipped_order_before_later_static_props",
+        r#"<a-form><a-row :gutter="24"><template v-for="i in 10" :key="i"><a-col v-show="expand || i <= 6" :span="8"><a-form-item><a-input /></a-form-item></a-col></template></a-row><a-row><a-col :span="24" style="text-align: right"><a-button type="primary" html-type="submit">Search</a-button></a-col></a-row></a-form>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -179,6 +179,7 @@ fn emit_call(
         .iter()
         .any(|attr| !skip_is || attr.name != "is");
     let has_custom = directive::has_custom(&component.bindings);
+    let has_runtime = directive::has_runtime(&component.bindings);
     let hoist_attrs: StdVec<_> = component
         .attributes
         .iter()
@@ -200,6 +201,7 @@ fn emit_call(
     };
     if for_item
         && !has_custom
+        && !has_runtime
         && cx.slot_param_depth == 0
         && let Some(props) = hoistable_static_props.as_ref()
         && props.non_key
@@ -213,7 +215,7 @@ fn emit_call(
         && (text_only_default
             || hoistable_static_props
                 .as_ref()
-                .is_some_and(|props| props.all_static_binds));
+                .is_some_and(|props| props.all_static_binds && !has_runtime));
     let static_props_hoist_context =
         (cx.hoist_static_vnodes && text_only_default) || loop_or_scoped_slot_hoist;
     let can_hoist_static_props = !has_custom
@@ -260,7 +262,7 @@ fn emit_call(
         if patch.dynamic_props.is_empty() {
             patch.flag &= !8;
         }
-        if directive::has_runtime(&component.bindings) && patch.flag & (2 | 4 | 8 | 16) == 0 {
+        if has_runtime && patch.flag & (2 | 4 | 8 | 16) == 0 {
             patch.flag |= 512;
         }
     }


### PR DESCRIPTION
Summary:
- prevent loop/scoped-slot component props hoisting from moving runtime-directive props ahead of later static props
- add the Ant Design Vue advanced-search v-for/v-show regression to the S2 DOM hoist-order battery

Validation:
- rtk cargo test -q -p vize_atelier_dom --test davinci_s2_hoist_order --test davinci_s2_template_wrapper_component_props --test davinci_s2_root_hoist --test davinci_s2_static_vnode_hoist -- --nocapture
- rtk cargo test -q -p vize_s1_to_s2 --test emit_comp --test emit_static_hoist --test emit_merge --test emit_dynamic_bind_keys -- --nocapture
- rtk test node --test tests/tooling/davinci-storage-policy.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-module-layout.test.ts
- rtk cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- git -c submodule.recurse=false diff --check -- crates/vize_s1_to_s2/src/emit/component.rs crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5561"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the declared order of bound and static properties on components rendered inside `v-for` templates.
  - Improved handling of runtime directives so component properties are applied consistently without unintended reordering.
  - Maintained correct runtime updates while preventing static-property optimizations from changing rendered behavior.

- **Tests**
  - Added coverage validating property order for component bindings in loop-rendered templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->