### PR TITLE
fix(davinci): preserve scoped slot key prop order

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -77,6 +77,10 @@ const BATTERY: &[(&str, &str)] = &[
         "template_for_component_bind_props_keep_shipped_order_before_later_static_props",
         r#"<a-form><a-row :gutter="24"><template v-for="i in 10" :key="i"><a-col v-show="expand || i <= 6" :span="8"><a-form-item><a-input /></a-form-item></a-col></template></a-row><a-row><a-col :span="24" style="text-align: right"><a-button type="primary" html-type="submit">Search</a-button></a-col></a-row></a-form>"#,
     ),
+    (
+        "scoped_slot_component_static_bind_props_wait_for_keyed_children",
+        r#"<a-tree><template #title="{ key }"><a-dropdown :trigger="['contextmenu']"><template #overlay><a-menu><a-menu-item key="1">one</a-menu-item><a-menu-item key="2">two</a-menu-item></a-menu></template><span>{{ key }}</span></a-dropdown></template></a-tree>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -340,29 +340,3 @@ fn emit_call(
     cx.buf.push(")");
     Ok(())
 }
-
-fn has_nested_component_key_props(region: &Region<'_>) -> bool {
-    region.ops.iter().any(|op| match op {
-        Op::Element(element) => has_nested_component_key_props(&element.children),
-        Op::Component(component) => {
-            has_component_key_prop(component) || has_nested_component_key_props(&component.children)
-        }
-        Op::If(if_op) => if_op
-            .branches
-            .iter()
-            .any(|branch| has_nested_component_key_props(&branch.region)),
-        Op::For(for_op) => has_nested_component_key_props(&for_op.region),
-        Op::Slot(slot) => has_nested_component_key_props(&slot.fallback),
-        Op::Text(_) | Op::Interpolation(_) => false,
-    })
-}
-
-fn has_component_key_prop(component: &ComponentOp<'_>) -> bool {
-    component.attributes.iter().any(|attr| attr.name == "key")
-        || component.bindings.iter().any(|binding| {
-            matches!(
-                binding,
-                BindingOp::Bind(bind) if matches!(bind.name, Some(DynamicName::Static("key")))
-            )
-        })
-}

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -201,6 +201,7 @@ fn emit_call(
         id,
         static_props_hoist_blocked,
         has_slots,
+        create,
         hoistable_static_props.as_ref(),
     );
     let foreign_static_props = id
@@ -338,4 +339,30 @@ fn emit_call(
     emit_dynamic_props(cx, &patch.dynamic_props);
     cx.buf.push(")");
     Ok(())
+}
+
+fn has_nested_component_key_props(region: &Region<'_>) -> bool {
+    region.ops.iter().any(|op| match op {
+        Op::Element(element) => has_nested_component_key_props(&element.children),
+        Op::Component(component) => {
+            has_component_key_prop(component) || has_nested_component_key_props(&component.children)
+        }
+        Op::If(if_op) => if_op
+            .branches
+            .iter()
+            .any(|branch| has_nested_component_key_props(&branch.region)),
+        Op::For(for_op) => has_nested_component_key_props(&for_op.region),
+        Op::Slot(slot) => has_nested_component_key_props(&slot.fallback),
+        Op::Text(_) | Op::Interpolation(_) => false,
+    })
+}
+
+fn has_component_key_prop(component: &ComponentOp<'_>) -> bool {
+    component.attributes.iter().any(|attr| attr.name == "key")
+        || component.bindings.iter().any(|binding| {
+            matches!(
+                binding,
+                BindingOp::Bind(bind) if matches!(bind.name, Some(DynamicName::Static("key")))
+            )
+        })
 }

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -2,7 +2,7 @@ use alloc::vec::Vec as StdVec;
 
 use vize_davinci::id::NodeId;
 use vize_s0::String;
-use vize_s2::op::{Attribute, BindingOp, ComponentOp};
+use vize_s2::op::{Attribute, BindingOp, ComponentOp, DynamicName, Op, Region};
 
 use super::super::EmitCx;
 use super::super::hoist::compact_props_object;
@@ -62,6 +62,7 @@ pub(super) fn can_hoist_static_props(
     id: Option<NodeId>,
     blocked_by_context: bool,
     has_slots: bool,
+    creates_slots: bool,
     props: Option<&ComponentHoistProps>,
 ) -> bool {
     let Some(props) = props else {
@@ -72,8 +73,12 @@ pub(super) fn can_hoist_static_props(
     }
     let text_only_default = slots::has_text_only_implicit_default(&component.children);
     let has_runtime_directive = directive::has_runtime(&component.bindings);
+    let nested_slot_key = cx.slot_param_depth > 0
+        && (has_slots || creates_slots)
+        && has_nested_component_key(&component.children);
     let loop_or_scoped_slot_hoist = (cx.in_v_for || cx.slot_param_depth > 0)
-        && (text_only_default || (props.all_static_binds && !has_runtime_directive));
+        && (text_only_default
+            || (props.all_static_binds && !has_runtime_directive && !nested_slot_key));
     let hoist_context = (cx.hoist_static_vnodes && text_only_default) || loop_or_scoped_slot_hoist;
     let is_template_for_root = id.is_some_and(|id| cx.template_for_item_root_id == Some(id));
     let dynamic_props_hoistable = !props.dynamic_values || !has_slots || text_only_default;
@@ -98,6 +103,32 @@ pub(super) fn can_hoist_static_props(
             && cx.slot_param_depth == 0
             && !cx.in_v_for
             && dynamic_props_hoistable)
+}
+
+fn has_nested_component_key(region: &Region<'_>) -> bool {
+    region.ops.iter().any(|op| match op {
+        Op::Element(element) => has_nested_component_key(&element.children),
+        Op::Component(component) => {
+            has_component_key(component) || has_nested_component_key(&component.children)
+        }
+        Op::If(if_op) => if_op
+            .branches
+            .iter()
+            .any(|branch| has_nested_component_key(&branch.region)),
+        Op::For(for_op) => has_nested_component_key(&for_op.region),
+        Op::Slot(slot) => has_nested_component_key(&slot.fallback),
+        Op::Text(_) | Op::Interpolation(_) => false,
+    })
+}
+
+fn has_component_key(component: &ComponentOp<'_>) -> bool {
+    component.attributes.iter().any(|attr| attr.name == "key")
+        || component.bindings.iter().any(|binding| {
+            matches!(
+                binding,
+                BindingOp::Bind(bind) if matches!(bind.name, Some(DynamicName::Static("key")))
+            )
+        })
 }
 
 pub(super) fn emit_dynamic_props(cx: &mut EmitCx<'_>, names: &[String]) {


### PR DESCRIPTION
Summary:
- keep scoped-slot all-static-bind component props from moving ahead of nested keyed component props
- add the Ant Design Vue context-menu regression to the S2 DOM hoist-order battery

Validation:
- rtk cargo test -q -p vize_atelier_dom --test davinci_s2_hoist_order --test davinci_s2_template_wrapper_component_props --test davinci_s2_root_hoist --test davinci_s2_static_vnode_hoist -- --nocapture
- rtk cargo test -q -p vize_s1_to_s2 --test emit_comp --test emit_static_hoist --test emit_merge --test emit_dynamic_bind_keys -- --nocapture
- rtk test node --test tests/tooling/davinci-storage-policy.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-module-layout.test.ts
- rtk cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- git -c submodule.recurse=false diff --check -- crates/vize_s1_to_s2/src/emit/component.rs crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5562"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect hoisting of static component properties in scoped-slot and loop contexts.
  * Preserved correct rendering for nested keyed components and components that create slots.
  * Added regression coverage for keyed children and scoped-slot component bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->