### PR TITLE
fix(davinci): preserve transition prop hoist order

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -81,6 +81,10 @@ const BATTERY: &[(&str, &str)] = &[
         "scoped_slot_component_static_bind_props_wait_for_keyed_children",
         r#"<a-tree><template #title="{ key }"><a-dropdown :trigger="['contextmenu']"><template #overlay><a-menu><a-menu-item key="1">one</a-menu-item><a-menu-item key="2">two</a-menu-item></a-menu></template><span>{{ key }}</span></a-dropdown></template></a-tree>"#,
     ),
+    (
+        "transition_forwarded_slot_static_props_wait_for_fallback_hoists",
+        r#"<div class="container"><svg><path d="M0 0z" /></svg><Transition name="fade"><div v-if="open" class="content"><slot /></div></Transition></div>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -152,8 +152,7 @@ fn emit_call(
         !array && !has_slots && slots::filler_default_needs_props_placeholder(&component.children);
     let dynamic_names = create || facts.is_some_and(slots::has_dynamic_names) || spread.is_some();
     let transition_slot_root = builtin::transition_slot_root(component.name);
-    let transition_props_slot_hoist =
-        matches!(component.name, "Transition" | "transition") && has_slots && forwards_slot;
+    let transition_props_slot_hoist = call_props::transition_props_slot_hoist(component, has_slots);
     let alias = if block {
         Buf::create_block_alias()
     } else {

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -7,7 +7,7 @@ use vize_s2::op::{Attribute, BindingOp, ComponentOp, DynamicName, Op, Region};
 use super::super::EmitCx;
 use super::super::hoist::compact_props_object;
 use super::super::props_static::ComponentHoistProps;
-use super::super::{EmitError, builtin, directive, outlet, props_static, slots};
+use super::super::{EmitError, builtin, directive, props_static, slots};
 
 pub(super) fn has_rendered_binds(component: &ComponentOp<'_>, skip_is: bool) -> bool {
     component.bindings.iter().any(|binding| {
@@ -82,9 +82,7 @@ pub(super) fn can_hoist_static_props(
     let hoist_context = (cx.hoist_static_vnodes && text_only_default) || loop_or_scoped_slot_hoist;
     let is_template_for_root = id.is_some_and(|id| cx.template_for_item_root_id == Some(id));
     let dynamic_props_hoistable = !props.dynamic_values || !has_slots || text_only_default;
-    let transition_props_slot_hoist = matches!(component.name, "Transition" | "transition")
-        && has_slots
-        && outlet::has_forwarded_outlet(&component.children);
+    let transition_props_slot_hoist = transition_props_slot_hoist(component, has_slots);
     (!is_template_for_root
         && dynamic_props_hoistable
         && props_static::should_hoist(cx, id, props_static::PropHoistPosition::Nested))
@@ -129,6 +127,16 @@ fn has_component_key(component: &ComponentOp<'_>) -> bool {
                 BindingOp::Bind(bind) if matches!(bind.name, Some(DynamicName::Static("key")))
             )
         })
+}
+
+pub(super) fn transition_props_slot_hoist(component: &ComponentOp<'_>, has_slots: bool) -> bool {
+    matches!(component.name, "Transition" | "transition")
+        && has_slots
+        && has_direct_slot_outlet(&component.children)
+}
+
+fn has_direct_slot_outlet(region: &Region<'_>) -> bool {
+    region.ops.iter().any(|op| matches!(op, Op::Slot(_)))
 }
 
 pub(super) fn emit_dynamic_props(cx: &mut EmitCx<'_>, names: &[String]) {


### PR DESCRIPTION
Summary:
- keep Transition/transition static props inline unless the slot outlet is direct
- add a transition props hoist-order regression to the S2 DOM battery

Validation:
- rtk cargo test -q -p vize_atelier_dom --test davinci_s2_hoist_order --test davinci_s2_static_vnode_hoist --test davinci_s2_root_hoist -- --nocapture
- rtk cargo test -q -p vize_s1_to_s2 --test emit_comp --test emit_static_hoist --test emit_merge --test emit_dynamic_bind_keys -- --nocapture
- rtk test node --test tests/tooling/davinci-storage-policy.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-module-layout.test.ts
- rtk cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- git -c submodule.recurse=false diff --check -- crates/vize_s1_to_s2/src/emit/component.rs crates/vize_s1_to_s2/src/emit/component/call_props.rs crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of static properties for transition components with forwarded slots.
  - Ensured slot content using conditional rendering waits correctly for fallback content.
  - Updated hoisting behavior to recognize direct slot outlets more accurately.

- **Tests**
  - Added coverage for transition components with forwarded slots, static properties, and fallback rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->