### PR TITLE
fix(davinci): preserve nested component prop hoist order

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -85,6 +85,10 @@ const BATTERY: &[(&str, &str)] = &[
         "transition_forwarded_slot_static_props_wait_for_fallback_hoists",
         r#"<div class="container"><svg><path d="M0 0z" /></svg><Transition name="fade"><div v-if="open" class="content"><slot /></div></Transition></div>"#,
     ),
+    (
+        "nested_component_responsive_props_wait_before_parent_static_bind",
+        r#"<section class="markdown"><template v-for="group in menuItems" :key="group.title"><div class="components-overview"><h2 class="ant-typography components-overview-group-title"><a-space align="center">{{ isZhCN ? group.title : group.enTitle }}<a-tag style="display: block">{{ group.children.length }}</a-tag></a-space></h2><a-row :gutter="[24, 24]"><template v-for="component in group.children" :key="component.title"><a-col :xs="24" :sm="12" :lg="8" :xl="6"><component :is="component.target ? 'a' : 'router-link'" v-bind="component.target ? { href: component.path, target: component.target } : { to: getLocalizedPathname(component.path, isZhCN) }"><a-card size="small" class="components-overview-card"><template #title><div class="components-overview-title">{{ component.title }}{{ isZhCN ? component.subtitle : '' }}</div></template><div class="components-overview-img"><img :src="isDark && component.coverDark ? component.coverDark : component.cover" :alt="component.title" /></div></a-card></component></a-col></template></a-row></div></template></section>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -202,7 +202,7 @@ fn emit_call(
         has_slots,
         create,
         hoistable_static_props.as_ref(),
-    );
+    )?;
     let foreign_static_props = id
         .and_then(|id| cx.facts.static_facts.get(id))
         .is_some_and(|fact| fact.foreign && fact.props_hoistable);

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -64,26 +64,32 @@ pub(super) fn can_hoist_static_props(
     has_slots: bool,
     creates_slots: bool,
     props: Option<&ComponentHoistProps>,
-) -> bool {
+) -> Result<bool, EmitError> {
     let Some(props) = props else {
-        return false;
+        return Ok(false);
     };
     if blocked_by_context {
-        return false;
+        return Ok(false);
     }
     let text_only_default = slots::has_text_only_implicit_default(&component.children);
     let has_runtime_directive = directive::has_runtime(&component.bindings);
     let nested_slot_key = cx.slot_param_depth > 0
         && (has_slots || creates_slots)
         && has_nested_component_key(&component.children);
+    let nested_for_static_bind_props = (cx.in_v_for || cx.slot_param_depth > 0)
+        && (has_slots || creates_slots)
+        && has_nested_for_component_static_bind_props(&component.children)?;
     let loop_or_scoped_slot_hoist = (cx.in_v_for || cx.slot_param_depth > 0)
         && (text_only_default
-            || (props.all_static_binds && !has_runtime_directive && !nested_slot_key));
+            || (props.all_static_binds
+                && !has_runtime_directive
+                && !nested_slot_key
+                && !nested_for_static_bind_props));
     let hoist_context = (cx.hoist_static_vnodes && text_only_default) || loop_or_scoped_slot_hoist;
     let is_template_for_root = id.is_some_and(|id| cx.template_for_item_root_id == Some(id));
     let dynamic_props_hoistable = !props.dynamic_values || !has_slots || text_only_default;
     let transition_props_slot_hoist = transition_props_slot_hoist(component, has_slots);
-    (!is_template_for_root
+    Ok((!is_template_for_root
         && dynamic_props_hoistable
         && props_static::should_hoist(cx, id, props_static::PropHoistPosition::Nested))
         || (is_template_for_root
@@ -100,7 +106,7 @@ pub(super) fn can_hoist_static_props(
         || (props.dynamic_values
             && cx.slot_param_depth == 0
             && !cx.in_v_for
-            && dynamic_props_hoistable)
+            && dynamic_props_hoistable))
 }
 
 fn has_nested_component_key(region: &Region<'_>) -> bool {
@@ -127,6 +133,64 @@ fn has_component_key(component: &ComponentOp<'_>) -> bool {
                 BindingOp::Bind(bind) if matches!(bind.name, Some(DynamicName::Static("key")))
             )
         })
+}
+
+fn has_nested_for_component_static_bind_props(region: &Region<'_>) -> Result<bool, EmitError> {
+    for op in &region.ops {
+        let found = match op {
+            Op::Element(element) => has_nested_for_component_static_bind_props(&element.children)?,
+            Op::Component(component) => {
+                has_nested_for_component_static_bind_props(&component.children)?
+            }
+            Op::If(if_op) => {
+                let mut found = false;
+                for branch in &if_op.branches {
+                    found |= has_nested_for_component_static_bind_props(&branch.region)?;
+                }
+                found
+            }
+            Op::For(for_op) => region_has_component_static_bind_props(&for_op.region)?,
+            Op::Slot(slot) => has_nested_for_component_static_bind_props(&slot.fallback)?,
+            Op::Text(_) | Op::Interpolation(_) => false,
+        };
+        if found {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn region_has_component_static_bind_props(region: &Region<'_>) -> Result<bool, EmitError> {
+    for op in &region.ops {
+        let found = match op {
+            Op::Element(element) => region_has_component_static_bind_props(&element.children)?,
+            Op::Component(component) => {
+                component_has_static_bind_props(component)?
+                    || region_has_component_static_bind_props(&component.children)?
+            }
+            Op::If(if_op) => {
+                let mut found = false;
+                for branch in &if_op.branches {
+                    found |= region_has_component_static_bind_props(&branch.region)?;
+                }
+                found
+            }
+            Op::For(for_op) => region_has_component_static_bind_props(&for_op.region)?,
+            Op::Slot(slot) => region_has_component_static_bind_props(&slot.fallback)?,
+            Op::Text(_) | Op::Interpolation(_) => false,
+        };
+        if found {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn component_has_static_bind_props(component: &ComponentOp<'_>) -> Result<bool, EmitError> {
+    Ok(
+        props_static::component_hoist_props(&component.attributes, &component.bindings)?
+            .is_some_and(|props| props.all_static_binds && props.valued_prop),
+    )
 }
 
 pub(super) fn transition_props_slot_hoist(component: &ComponentOp<'_>, has_slots: bool) -> bool {


### PR DESCRIPTION
## Summary
- keep parent all-static component prop objects inline when nested component v-for props must stay before them
- make component static-prop hoistability checks fallible so nested component analysis can reuse emit context
- add a Davinci DOM regression for Ant Design row/column prop order

## Tests
- rtk test node --test tests/tooling/source-file-lengths.test.ts
- rtk cargo test -q -p vize_atelier_dom --test davinci_s2_hoist_order --test davinci_s2_static_vnode_hoist --test davinci_s2_root_hoist -- --nocapture
- rtk cargo test -q -p vize_s1_to_s2 --test emit_comp --test emit_static_hoist --test emit_merge --test emit_dynamic_bind_keys -- --nocapture
- rtk test node --test tests/tooling/davinci-storage-policy.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-module-layout.test.ts
- rtk cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- git -c submodule.recurse=false diff --check -- crates/vize_s1_to_s2/src/emit/component.rs crates/vize_s1_to_s2/src/emit/component/call_props.rs crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering order for nested components with responsive properties and parent static bindings.
  * Prevented static property optimization from incorrectly moving bindings ahead of nested loop content.
  * Improved handling of component property processing so rendering errors are surfaced reliably.

* **Tests**
  * Added coverage for nested component hoisting with responsive properties and verified the resulting DOM output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->