### PR TITLE
fix(davinci): keep component static props inline

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -101,6 +101,14 @@ const BATTERY: &[(&str, &str)] = &[
         "table_column_static_props_stay_inline_after_static_vnode",
         r#"<b-table :data="data" :loading="loading" paginated backend-pagination :total="total" :per-page="perPage" @page-change="onPageChange" backend-sorting :default-sort="[sortField, sortOrder]" @sort="onSort"><b-table-column field="original_title" label="Title" sortable v-slot="props">{{ props.row.original_title }}</b-table-column><b-table-column field="vote_average" label="Vote Average" numeric sortable v-slot="props"><span class="tag" :class="type(props.row.vote_average)">{{ props.row.vote_average }}</span></b-table-column><b-table-column field="vote_count" label="Vote Count" numeric sortable v-slot="props">{{ props.row.vote_count }}</b-table-column></b-table>"#,
     ),
+    (
+        "for_component_root_slot_static_props_stay_inline",
+        r#"<ListItem v-for="entry in entries" label="fixed" v-slot="{ value }">{{ value }}</ListItem>"#,
+    ),
+    (
+        "if_branch_component_root_slot_static_props_stay_inline",
+        r#"<Panel v-if="open" label="fixed" v-slot="{ value }"><span class="value">{{ value }}</span></Panel>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -89,6 +89,18 @@ const BATTERY: &[(&str, &str)] = &[
         "nested_component_responsive_props_wait_before_parent_static_bind",
         r#"<section class="markdown"><template v-for="group in menuItems" :key="group.title"><div class="components-overview"><h2 class="ant-typography components-overview-group-title"><a-space align="center">{{ isZhCN ? group.title : group.enTitle }}<a-tag style="display: block">{{ group.children.length }}</a-tag></a-space></h2><a-row :gutter="[24, 24]"><template v-for="component in group.children" :key="component.title"><a-col :xs="24" :sm="12" :lg="8" :xl="6"><component :is="component.target ? 'a' : 'router-link'" v-bind="component.target ? { href: component.path, target: component.target } : { to: getLocalizedPathname(component.path, isZhCN) }"><a-card size="small" class="components-overview-card"><template #title><div class="components-overview-title">{{ component.title }}{{ isZhCN ? component.subtitle : '' }}</div></template><div class="components-overview-img"><img :src="isDark && component.coverDark ? component.coverDark : component.cover" :alt="component.title" /></div></a-card></component></a-col></template></a-row></div></template></section>"#,
     ),
+    (
+        "slot_component_static_attrs_stay_inline_after_prior_hoist",
+        r#"<a-menu><a-menu-item-group v-if="isZhCN" key="advanced" title="advanced"><a-menu-item key="surely-table"><a href="https://www.surelyvue.com" target="_blank" rel="noopener noreferrer" style="position: relative">Surely Table</a></a-menu-item></a-menu-item-group><template v-for="m in menus"><template v-if="m.children"><a-menu-item-group :key="m.order" :title="m.title"><template v-for="n in m.children"><a-menu-item v-if="n.path" :key="n.path"><router-link :to="n.path"><span>{{ n.title }}</span><span v-if="isZhCN" class="chinese">{{ n.subtitle }}</span></router-link><a-tag v-if="n.tag" color="green" style="margin-left: auto">{{ n.tag }}</a-tag></a-menu-item></template></a-menu-item-group></template></template></a-menu>"#,
+    ),
+    (
+        "slot_component_static_bind_props_stay_inline_after_prior_hoist",
+        r#"<a-row class="list-row" :gutter="24"><a-col v-for="item in renderData" :key="item.id" class="list-col" :xs="12" :sm="12" :md="12" :lg="6" :xl="6" :xxl="6"><CardWrap :loading="loading" :title="item.title" :description="item.description"><template #skeleton><a-skeleton :animation="true"><a-skeleton-line :widths="['50%', '100%']" :rows="4" /></a-skeleton></template></CardWrap></a-col></a-row>"#,
+    ),
+    (
+        "table_column_static_props_stay_inline_after_static_vnode",
+        r#"<b-table :data="data" :loading="loading" paginated backend-pagination :total="total" :per-page="perPage" @page-change="onPageChange" backend-sorting :default-sort="[sortField, sortOrder]" @sort="onSort"><b-table-column field="original_title" label="Title" sortable v-slot="props">{{ props.row.original_title }}</b-table-column><b-table-column field="vote_average" label="Vote Average" numeric sortable v-slot="props"><span class="tag" :class="type(props.row.vote_average)">{{ props.row.vote_average }}</span></b-table-column><b-table-column field="vote_count" label="Vote Count" numeric sortable v-slot="props">{{ props.row.vote_count }}</b-table-column></b-table>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -193,7 +193,8 @@ fn emit_call(
     {
         cx.buf.push_hoist(props.source.clone());
     }
-    let static_props_hoist_blocked = has_custom || for_item || if_key.is_some();
+    let static_props_hoist_blocked =
+        has_custom || for_item || if_key.is_some() || has_component_root_slot;
     let can_hoist_static_props = call_props::can_hoist_static_props(
         cx,
         component,
@@ -226,6 +227,7 @@ fn emit_call(
     };
     let branch_unused_hoist = !has_custom
         && !for_item
+        && !cx.in_v_for
         && if_key.is_some()
         && cx.template_if_branch_root
         && hoistable_static_props.is_some()

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -183,6 +183,7 @@ fn emit_call(
     let hoistable_static_props =
         call_props::hoistable_static_props(component, skip_is, &hoist_attrs)?;
     if for_item
+        && !has_component_root_slot
         && !has_custom
         && !has_runtime
         && cx.slot_param_depth == 0
@@ -225,7 +226,8 @@ fn emit_call(
     } else {
         None
     };
-    let branch_unused_hoist = !has_custom
+    let branch_unused_hoist = !has_component_root_slot
+        && !has_custom
         && !for_item
         && !cx.in_v_for
         && if_key.is_some()

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -101,6 +101,7 @@ pub(super) fn can_hoist_static_props(
             }))
         || (!props.dynamic_values
             && props.valued_prop
+            && !props.all_static_binds
             && !has_runtime_directive
             && (hoist_context || transition_props_slot_hoist))
         || (props.dynamic_values


### PR DESCRIPTION
## Summary
- keep component-root v-slot carrier props inline to match the shipped DOM lane
- stop emitting unused branch prop hoists inside v-for loops
- avoid hoisting all-static component bind props through the broad slot hoist path
- add corpus-derived hoist-order regressions for Ant Design, Arco, and Buefy cases

## Tests
- rtk test node --test tests/tooling/source-file-lengths.test.ts
- rtk cargo test -q -p vize_atelier_dom --test davinci_s2_hoist_order --test davinci_s2_template_wrapper_component_props --test davinci_s2_slots --test davinci_s2_builtins --test davinci_s2_static_vnode_hoist --test davinci_s2_root_hoist -- --nocapture
- rtk cargo test -q -p vize_s1_to_s2 --test emit_comp --test emit_static_hoist --test emit_create_slots --test emit_vslots --test emit_merge -- --nocapture
- rtk cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- cargo fmt --all -- --check
- git -c submodule.recurse=false diff --check -- crates/vize_s1_to_s2/src/emit/component.rs crates/vize_s1_to_s2/src/emit/component/call_props.rs crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved component rendering to keep static attributes and bound properties in their correct inline positions.
  - Prevented incorrect property hoisting for components containing root slot content.
  - Corrected hoisting behavior inside loop-rendered components.
  - Preserved static table-column properties after preceding static content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->