### PR TITLE
fix(davinci): preserve helper preamble order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4051,6 +4051,7 @@ dependencies = [
  "oxc_parser",
  "oxc_semantic",
  "oxc_span",
+ "oxc_syntax",
  "vize_atelier_dom",
  "vize_atelier_sfc",
  "vize_carton",

--- a/crates/vize_atelier_dom/tests/davinci_s2_helper_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_helper_order.rs
@@ -31,11 +31,11 @@ const BATTERY: &[(&str, &str)] = &[
     ),
     (
         "hoisted_style_helper_precedes_body_class_helper",
-        r#"<div><Foo :style="{ color: tone }" /><span :class="classes" /></div>"#,
+        r#"<div><Foo :style="{ color: tone }" /><span :class="classes"></span></div>"#,
     ),
     (
         "alias_shaped_expression_text_does_not_reorder_helpers",
-        r#"<div :class="classes" :style="value === '_normalizeStyle()' ? styles : fallback" />"#,
+        r#"<div :class="classes" :style="value === '_normalizeStyle()' ? styles : fallback"></div>"#,
     ),
 ];
 

--- a/crates/vize_atelier_dom/tests/davinci_s2_helper_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_helper_order.rs
@@ -31,7 +31,7 @@ const BATTERY: &[(&str, &str)] = &[
     ),
     (
         "hoisted_style_helper_precedes_body_class_helper",
-        r#"<div><Foo :style="{ color: tone }" /><span :class="classes"></span></div>"#,
+        r#"<div><Foo :style="{ color: tone }"></Foo><span :class="classes"></span></div>"#,
     ),
     (
         "alias_shaped_expression_text_does_not_reorder_helpers",
@@ -39,7 +39,7 @@ const BATTERY: &[(&str, &str)] = &[
     ),
     (
         "unicode_identifier_suffix_does_not_reorder_helpers",
-        r#"<div :class="classes" :style="é_normalizeStyle() ? styles : fallback" />"#,
+        r#"<div :class="classes" :style="é_normalizeStyle() ? styles : fallback"></div>"#,
     ),
 ];
 

--- a/crates/vize_atelier_dom/tests/davinci_s2_helper_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_helper_order.rs
@@ -37,6 +37,10 @@ const BATTERY: &[(&str, &str)] = &[
         "alias_shaped_expression_text_does_not_reorder_helpers",
         r#"<div :class="classes" :style="value === '_normalizeStyle()' ? styles : fallback"></div>"#,
     ),
+    (
+        "unicode_identifier_suffix_does_not_reorder_helpers",
+        r#"<div :class="classes" :style="é_normalizeStyle() ? styles : fallback" />"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_helper_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_helper_order.rs
@@ -1,0 +1,37 @@
+//! P2-11 helper preamble ordering witnesses reduced from the real DOM corpus.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "style_before_class_still_destructures_class_before_style",
+        r#"<div :style="{ opacity: disabled ? 0.5 : 1 }"></div><div :class="{ active: ok }"></div>"#,
+    ),
+    (
+        "directive_and_key_event_modifiers_keep_vue_helper_order",
+        r#"<input v-focus @keyup.enter.stop="handler">"#,
+    ),
+    (
+        "class_before_block_helpers_in_conditional_list",
+        r#"<div><button :class="buttonClass" v-if="ok">Play</button><span v-for="item in items">{{ item }}</span></div>"#,
+    ),
+    (
+        "array_template_literal_class_still_normalizes",
+        r##"<span :class="[`text-${msg[0]}`, 'text-monospace', 'small', 'd-block']" style="white-space: pre-wrap;">{{ msg[1] }}</span>"##,
+    ),
+    (
+        "transition_group_component_list_keeps_dynamic_class_helper",
+        r##"<transition-group tag="ul" name="flip-list"><b-list-group-item v-for="msg in messages" :key="`console-${msg[2]}`"><span :class="[`text-${msg[0]}`, 'text-monospace', 'small', 'd-block']" style="white-space: pre-wrap;">{{ msg[1] }}</span></b-list-group-item></transition-group>"##,
+    ),
+];
+
+#[test]
+fn s2_helper_order_matches_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_atelier_dom/tests/davinci_s2_helper_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_helper_order.rs
@@ -29,6 +29,14 @@ const BATTERY: &[(&str, &str)] = &[
         "transition_group_component_list_keeps_dynamic_class_helper",
         r##"<transition-group tag="ul" name="flip-list"><b-list-group-item v-for="msg in messages" :key="`console-${msg[2]}`"><span :class="[`text-${msg[0]}`, 'text-monospace', 'small', 'd-block']" style="white-space: pre-wrap;">{{ msg[1] }}</span></b-list-group-item></transition-group>"##,
     ),
+    (
+        "hoisted_style_helper_precedes_body_class_helper",
+        r#"<div><Foo :style="{ color: tone }" /><span :class="classes" /></div>"#,
+    ),
+    (
+        "alias_shaped_expression_text_does_not_reorder_helpers",
+        r#"<div :class="classes" :style="value === '_normalizeStyle()' ? styles : fallback" />"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/Cargo.toml
+++ b/crates/vize_s1_to_s2/Cargo.toml
@@ -34,6 +34,7 @@ oxc_ast_visit = { workspace = true }
 oxc_parser = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
+oxc_syntax = { workspace = true }
 vize_s0 = { workspace = true }
 vize_davinci = { workspace = true }
 vize_s1 = { workspace = true }

--- a/crates/vize_s1_to_s2/src/emit/buf.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf.rs
@@ -313,8 +313,36 @@ impl Buf {
         for helper in Helper::ALL {
             push(helper);
         }
-        listed.sort_by_key(|helper| helper.rank());
+        listed.sort_by(|left, right| {
+            left.rank().cmp(&right.rank()).then_with(|| {
+                match (
+                    left.rank(),
+                    self.first_alias_position(*left),
+                    self.first_alias_position(*right),
+                ) {
+                    (2 | 5, Some(left_pos), Some(right_pos)) => left_pos.cmp(&right_pos),
+                    _ => core::cmp::Ordering::Equal,
+                }
+            })
+        });
         listed
+    }
+
+    fn first_alias_position(&self, helper: Helper) -> Option<usize> {
+        let alias = helper.alias();
+        let mut first = self.code.find(alias);
+        let mut offset = self.code.len();
+        for hoist in self.hoists.iter() {
+            if let Some(position) = hoist.find(alias) {
+                let absolute = offset + position;
+                first = match first {
+                    Some(current) if current <= absolute => Some(current),
+                    _ => Some(absolute),
+                };
+            }
+            offset += hoist.len();
+        }
+        first
     }
 
     /// Function-mode preamble, helpers in import-rank order, then any
@@ -346,5 +374,38 @@ impl Buf {
             }
         }
         preamble
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Buf, Helper};
+
+    #[test]
+    fn helper_preamble_uses_final_body_order_within_one_rank() {
+        let mut buf = Buf::new();
+        buf.use_helper(Helper::NormalizeStyle);
+        buf.use_helper(Helper::NormalizeClass);
+        buf.push("_normalizeClass(cls); _normalizeStyle(style)");
+
+        assert!(buf.preamble().starts_with(
+            "const { normalizeClass: _normalizeClass, normalizeStyle: _normalizeStyle"
+        ));
+    }
+
+    #[test]
+    fn helper_preamble_keeps_preferred_before_body_order() {
+        let mut buf = Buf::new();
+        buf.prefer(Helper::WithDirectives);
+        buf.use_helper(Helper::WithKeys);
+        buf.use_helper(Helper::WithDirectives);
+        buf.use_helper(Helper::WithModifiers);
+        buf.push("_withDirectives(node, [_withModifiers(handler), _withKeys(handler)])");
+
+        assert!(
+            buf.preamble().starts_with(
+                "const { withDirectives: _withDirectives, withModifiers: _withModifiers, withKeys: _withKeys"
+            )
+        );
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/buf.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf.rs
@@ -13,10 +13,11 @@ pub(super) struct Buf {
     used: u64,
     /// Transform-analogue registration order (`root.helpers`).
     preferred: StdVec<Helper>,
-    /// First `use_*` order (`used_helpers`). Same-rank leftovers follow
-    /// this, not `Helper::ALL`, so a builtin tag used before `withCtx`
+    /// First `use_*` order (`used_helpers`). Same-rank leftovers usually
+    /// follow this, not `Helper::ALL`, so a builtin tag used before `withCtx`
     /// stays before it (`Transition` then `withCtx`; nested `KeepAlive`
-    /// after the parent's `withCtx`).
+    /// after the parent's `withCtx`). Modifier and normalize helpers are
+    /// ordered by final alias use to match shipped output.
     used_order: StdVec<Helper>,
     /// Compact static-props / vnode RHS values, `_hoisted_1` first.
     hoists: StdVec<String>,
@@ -387,6 +388,19 @@ mod tests {
         buf.use_helper(Helper::NormalizeStyle);
         buf.use_helper(Helper::NormalizeClass);
         buf.push("_normalizeClass(cls); _normalizeStyle(style)");
+
+        assert!(buf.preamble().starts_with(
+            "const { normalizeClass: _normalizeClass, normalizeStyle: _normalizeStyle"
+        ));
+    }
+
+    #[test]
+    fn helper_preamble_uses_final_hoist_order_within_one_rank() {
+        let mut buf = Buf::new();
+        buf.use_helper(Helper::NormalizeStyle);
+        buf.use_helper(Helper::NormalizeClass);
+        buf.push_hoist("_normalizeClass(cls)".into());
+        buf.push_hoist("_normalizeStyle(style)".into());
 
         assert!(buf.preamble().starts_with(
             "const { normalizeClass: _normalizeClass, normalizeStyle: _normalizeStyle"

--- a/crates/vize_s1_to_s2/src/emit/buf.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf.rs
@@ -4,10 +4,10 @@ use alloc::vec::Vec as StdVec;
 
 use vize_s0::{String, ToCompactString};
 
-use self::call_position::helper_call_position;
 use super::helper::Helper;
 
 mod call_position;
+mod helper_order;
 
 /// Growing JS text plus the helpers the body mentioned.
 pub(super) struct Buf {
@@ -293,52 +293,6 @@ impl Buf {
 
     pub(super) fn hoist_root_props(&mut self, object: String) -> String {
         self.push_hoist(object)
-    }
-
-    fn ordered_helpers(&self) -> StdVec<Helper> {
-        let mut listed = StdVec::new();
-        let mut bits = 0u64;
-        let mut push = |helper: Helper| {
-            if self.used & helper.bit() == 0 || bits & helper.bit() != 0 {
-                return;
-            }
-            bits |= helper.bit();
-            listed.push(helper);
-        };
-        for helper in self.preferred.iter().copied() {
-            push(helper);
-        }
-        for helper in self.used_order.iter().copied() {
-            push(helper);
-        }
-        for helper in Helper::ALL {
-            push(helper);
-        }
-        listed.sort_by(|left, right| {
-            left.rank().cmp(&right.rank()).then_with(|| {
-                match (
-                    left.rank(),
-                    self.first_alias_position(*left),
-                    self.first_alias_position(*right),
-                ) {
-                    (2 | 5, Some(left_pos), Some(right_pos)) => left_pos.cmp(&right_pos),
-                    _ => core::cmp::Ordering::Equal,
-                }
-            })
-        });
-        listed
-    }
-
-    fn first_alias_position(&self, helper: Helper) -> Option<usize> {
-        let alias = helper.alias();
-        let mut offset = 0;
-        for hoist in self.hoists.iter() {
-            if let Some(position) = helper_call_position(hoist, alias) {
-                return Some(offset + position);
-            }
-            offset += hoist.len();
-        }
-        helper_call_position(self.code.as_str(), alias).map(|position| offset + position)
     }
 
     /// Function-mode preamble, helpers in import-rank order, then any

--- a/crates/vize_s1_to_s2/src/emit/buf.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf.rs
@@ -13,11 +13,8 @@ pub(super) struct Buf {
     used: u64,
     /// Transform-analogue registration order (`root.helpers`).
     preferred: StdVec<Helper>,
-    /// First `use_*` order (`used_helpers`). Same-rank leftovers usually
-    /// follow this, not `Helper::ALL`, so a builtin tag used before `withCtx`
-    /// stays before it (`Transition` then `withCtx`; nested `KeepAlive`
-    /// after the parent's `withCtx`). Modifier and normalize helpers are
-    /// ordered by final alias use to match shipped output.
+    /// First `use_*` order (`used_helpers`), with modifier and normalize
+    /// helpers reordered by final alias use to match shipped output.
     used_order: StdVec<Helper>,
     /// Compact static-props / vnode RHS values, `_hoisted_1` first.
     hoists: StdVec<String>,
@@ -379,47 +376,4 @@ impl Buf {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{Buf, Helper};
-
-    #[test]
-    fn helper_preamble_uses_final_body_order_within_one_rank() {
-        let mut buf = Buf::new();
-        buf.use_helper(Helper::NormalizeStyle);
-        buf.use_helper(Helper::NormalizeClass);
-        buf.push("_normalizeClass(cls); _normalizeStyle(style)");
-
-        assert!(buf.preamble().starts_with(
-            "const { normalizeClass: _normalizeClass, normalizeStyle: _normalizeStyle"
-        ));
-    }
-
-    #[test]
-    fn helper_preamble_uses_final_hoist_order_within_one_rank() {
-        let mut buf = Buf::new();
-        buf.use_helper(Helper::NormalizeStyle);
-        buf.use_helper(Helper::NormalizeClass);
-        buf.push_hoist("_normalizeClass(cls)".into());
-        buf.push_hoist("_normalizeStyle(style)".into());
-
-        assert!(buf.preamble().starts_with(
-            "const { normalizeClass: _normalizeClass, normalizeStyle: _normalizeStyle"
-        ));
-    }
-
-    #[test]
-    fn helper_preamble_keeps_preferred_before_body_order() {
-        let mut buf = Buf::new();
-        buf.prefer(Helper::WithDirectives);
-        buf.use_helper(Helper::WithKeys);
-        buf.use_helper(Helper::WithDirectives);
-        buf.use_helper(Helper::WithModifiers);
-        buf.push("_withDirectives(node, [_withModifiers(handler), _withKeys(handler)])");
-
-        assert!(
-            buf.preamble().starts_with(
-                "const { withDirectives: _withDirectives, withModifiers: _withModifiers, withKeys: _withKeys"
-            )
-        );
-    }
-}
+mod tests;

--- a/crates/vize_s1_to_s2/src/emit/buf.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf.rs
@@ -4,7 +4,10 @@ use alloc::vec::Vec as StdVec;
 
 use vize_s0::{String, ToCompactString};
 
+use self::call_position::helper_call_position;
 use super::helper::Helper;
+
+mod call_position;
 
 /// Growing JS text plus the helpers the body mentioned.
 pub(super) struct Buf {
@@ -328,19 +331,14 @@ impl Buf {
 
     fn first_alias_position(&self, helper: Helper) -> Option<usize> {
         let alias = helper.alias();
-        let mut first = self.code.find(alias);
-        let mut offset = self.code.len();
+        let mut offset = 0;
         for hoist in self.hoists.iter() {
-            if let Some(position) = hoist.find(alias) {
-                let absolute = offset + position;
-                first = match first {
-                    Some(current) if current <= absolute => Some(current),
-                    _ => Some(absolute),
-                };
+            if let Some(position) = helper_call_position(hoist, alias) {
+                return Some(offset + position);
             }
             offset += hoist.len();
         }
-        first
+        helper_call_position(self.code.as_str(), alias).map(|position| offset + position)
     }
 
     /// Function-mode preamble, helpers in import-rank order, then any

--- a/crates/vize_s1_to_s2/src/emit/buf/call_position.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/call_position.rs
@@ -1,3 +1,5 @@
+use oxc_syntax::identifier::is_identifier_part;
+
 pub(super) fn helper_call_position(text: &str, alias: &str) -> Option<usize> {
     let bytes = text.as_bytes();
     let alias = alias.as_bytes();
@@ -18,10 +20,10 @@ pub(super) fn helper_call_position(text: &str, alias: &str) -> Option<usize> {
                     .map_or(bytes.len(), |end| position + 4 + end);
             }
             _ if bytes[position..].starts_with(alias)
-                && position
-                    .checked_sub(1)
-                    .and_then(|before| bytes.get(before))
-                    .is_none_or(|byte| !is_identifier(*byte) && *byte != b'.') =>
+                && text[..position]
+                    .chars()
+                    .next_back()
+                    .is_none_or(|ch| !is_identifier_part(ch) && ch != '.') =>
             {
                 let after = position + alias.len();
                 if bytes[after..]
@@ -50,8 +52,4 @@ fn quoted_end(bytes: &[u8], start: usize) -> usize {
         }
     }
     bytes.len()
-}
-
-fn is_identifier(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
 }

--- a/crates/vize_s1_to_s2/src/emit/buf/call_position.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/call_position.rs
@@ -1,0 +1,57 @@
+pub(super) fn helper_call_position(text: &str, alias: &str) -> Option<usize> {
+    let bytes = text.as_bytes();
+    let alias = alias.as_bytes();
+    let mut position = 0;
+    while position < bytes.len() {
+        match bytes[position] {
+            b'\'' | b'"' | b'`' => position = quoted_end(bytes, position),
+            b'/' if bytes.get(position + 1) == Some(&b'/') => {
+                position = bytes[position + 2..]
+                    .iter()
+                    .position(|byte| *byte == b'\n')
+                    .map_or(bytes.len(), |end| position + 2 + end);
+            }
+            b'/' if bytes.get(position + 1) == Some(&b'*') => {
+                position = bytes[position + 2..]
+                    .windows(2)
+                    .position(|pair| pair == b"*/")
+                    .map_or(bytes.len(), |end| position + 4 + end);
+            }
+            _ if bytes[position..].starts_with(alias)
+                && position
+                    .checked_sub(1)
+                    .and_then(|before| bytes.get(before))
+                    .is_none_or(|byte| !is_identifier(*byte) && *byte != b'.') =>
+            {
+                let after = position + alias.len();
+                if bytes[after..]
+                    .iter()
+                    .find(|byte| !byte.is_ascii_whitespace())
+                    == Some(&b'(')
+                {
+                    return Some(position);
+                }
+                position = after;
+            }
+            _ => position += 1,
+        }
+    }
+    None
+}
+
+fn quoted_end(bytes: &[u8], start: usize) -> usize {
+    let quote = bytes[start];
+    let mut position = start + 1;
+    while position < bytes.len() {
+        match bytes[position] {
+            b'\\' => position += 2,
+            byte if byte == quote => return position + 1,
+            _ => position += 1,
+        }
+    }
+    bytes.len()
+}
+
+fn is_identifier(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'$')
+}

--- a/crates/vize_s1_to_s2/src/emit/buf/helper_order.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/helper_order.rs
@@ -1,0 +1,58 @@
+use alloc::vec::Vec as StdVec;
+use core::cmp::Ordering;
+
+use super::super::helper::Helper;
+use super::Buf;
+use super::call_position::helper_call_position;
+
+impl Buf {
+    pub(super) fn ordered_helpers(&self) -> StdVec<Helper> {
+        let mut listed = StdVec::new();
+        let mut bits = 0u64;
+        let mut push = |helper: Helper| {
+            if self.used & helper.bit() == 0 || bits & helper.bit() != 0 {
+                return;
+            }
+            bits |= helper.bit();
+            listed.push(helper);
+        };
+        for helper in self.preferred.iter().copied() {
+            push(helper);
+        }
+        for helper in self.used_order.iter().copied() {
+            push(helper);
+        }
+        for helper in Helper::ALL {
+            push(helper);
+        }
+        listed.sort_by(|left, right| {
+            left.rank()
+                .cmp(&right.rank())
+                .then_with(|| self.order_same_rank_helper(*left, *right))
+        });
+        listed
+    }
+
+    fn order_same_rank_helper(&self, left: Helper, right: Helper) -> Ordering {
+        match (
+            left.rank(),
+            self.first_alias_position(left),
+            self.first_alias_position(right),
+        ) {
+            (2 | 5, Some(left_pos), Some(right_pos)) => left_pos.cmp(&right_pos),
+            _ => Ordering::Equal,
+        }
+    }
+
+    fn first_alias_position(&self, helper: Helper) -> Option<usize> {
+        let alias = helper.alias();
+        let mut offset = 0;
+        for hoist in self.hoists.iter() {
+            if let Some(position) = helper_call_position(hoist, alias) {
+                return Some(offset + position);
+            }
+            offset += hoist.len();
+        }
+        helper_call_position(self.code.as_str(), alias).map(|position| offset + position)
+    }
+}

--- a/crates/vize_s1_to_s2/src/emit/buf/tests.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/tests.rs
@@ -33,6 +33,39 @@ fn helper_preamble_uses_final_hoist_order_within_one_rank() {
 }
 
 #[test]
+fn helper_preamble_uses_hoists_before_the_body() {
+    let mut buf = Buf::new();
+    buf.use_helper(Helper::NormalizeClass);
+    buf.use_helper(Helper::NormalizeStyle);
+    buf.push("_normalizeClass(cls)");
+    buf.push_hoist("_normalizeStyle(style)".into());
+
+    assert_eq!(
+        buf.preamble(),
+        concat!(
+            "const { normalizeStyle: _normalizeStyle, normalizeClass: _normalizeClass } = Vue\n",
+            "\n",
+            "const _hoisted_1 = _normalizeStyle(style)\n"
+        )
+    );
+}
+
+#[test]
+fn helper_preamble_ignores_alias_shaped_authored_text() {
+    let mut buf = Buf::new();
+    buf.use_helper(Helper::NormalizeStyle);
+    buf.use_helper(Helper::NormalizeClass);
+    buf.push(
+        "['_normalizeStyle()', value._normalizeStyle(), /* _normalizeStyle() */ _normalizeClass(cls), _normalizeStyle(style)]",
+    );
+
+    assert_eq!(
+        buf.preamble(),
+        "const { normalizeClass: _normalizeClass, normalizeStyle: _normalizeStyle } = Vue\n"
+    );
+}
+
+#[test]
 fn helper_preamble_keeps_preferred_before_body_order() {
     let mut buf = Buf::new();
     buf.prefer(Helper::WithDirectives);

--- a/crates/vize_s1_to_s2/src/emit/buf/tests.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/tests.rs
@@ -1,0 +1,48 @@
+use super::{Buf, Helper};
+
+#[test]
+fn helper_preamble_uses_final_body_order_within_one_rank() {
+    let mut buf = Buf::new();
+    buf.use_helper(Helper::NormalizeStyle);
+    buf.use_helper(Helper::NormalizeClass);
+    buf.push("_normalizeClass(cls); _normalizeStyle(style)");
+
+    assert_eq!(
+        buf.preamble(),
+        "const { normalizeClass: _normalizeClass, normalizeStyle: _normalizeStyle } = Vue\n"
+    );
+}
+
+#[test]
+fn helper_preamble_uses_final_hoist_order_within_one_rank() {
+    let mut buf = Buf::new();
+    buf.use_helper(Helper::NormalizeStyle);
+    buf.use_helper(Helper::NormalizeClass);
+    buf.push_hoist("_normalizeClass(cls)".into());
+    buf.push_hoist("_normalizeStyle(style)".into());
+
+    assert_eq!(
+        buf.preamble(),
+        concat!(
+            "const { normalizeClass: _normalizeClass, normalizeStyle: _normalizeStyle } = Vue\n",
+            "\n",
+            "const _hoisted_1 = _normalizeClass(cls)\n",
+            "const _hoisted_2 = _normalizeStyle(style)\n"
+        )
+    );
+}
+
+#[test]
+fn helper_preamble_keeps_preferred_before_body_order() {
+    let mut buf = Buf::new();
+    buf.prefer(Helper::WithDirectives);
+    buf.use_helper(Helper::WithKeys);
+    buf.use_helper(Helper::WithDirectives);
+    buf.use_helper(Helper::WithModifiers);
+    buf.push("_withDirectives(node, [_withModifiers(handler), _withKeys(handler)])");
+
+    assert_eq!(
+        buf.preamble(),
+        "const { withDirectives: _withDirectives, withModifiers: _withModifiers, withKeys: _withKeys } = Vue\n"
+    );
+}

--- a/crates/vize_s1_to_s2/src/emit/buf/tests.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/tests.rs
@@ -56,7 +56,7 @@ fn helper_preamble_ignores_alias_shaped_authored_text() {
     buf.use_helper(Helper::NormalizeStyle);
     buf.use_helper(Helper::NormalizeClass);
     buf.push(
-        "['_normalizeStyle()', value._normalizeStyle(), /* _normalizeStyle() */ _normalizeClass(cls), _normalizeStyle(style)]",
+        "['_normalizeStyle()', value._normalizeStyle(), é_normalizeStyle(), /* _normalizeStyle() */ _normalizeClass(cls), _normalizeStyle(style)]",
     );
 
     assert_eq!(

--- a/crates/vize_s1_to_s2/src/emit/helper.rs
+++ b/crates/vize_s1_to_s2/src/emit/helper.rs
@@ -1,8 +1,9 @@
 //! Vue helpers this installment can mention, ranked the way
 //! `vue_helper_import_rank` orders the shipped preamble. Same-rank
-//! helpers follow transform-first registration, then emit order
+//! helpers mostly follow transform-first registration, then emit order
 //! (`Buf::prefer` then first `use_*`), matching `root.helpers`
-//! then `used_helpers`.
+//! then `used_helpers`; ranks whose shipped order is driven by emitted
+//! helper calls are sorted by final alias use.
 
 #[derive(Clone, Copy)]
 pub(super) enum Helper {

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -21,8 +21,8 @@ or `collections` modules does not bypass the boundary.
 
 ## Retained `alloc::vec::Vec` inventory
 
-The four library trees in the reviewed inventory contain 66 production files,
-78 direct `alloc::vec::Vec` paths, and 249 bound `Vec`/`StdVec` uses. "Direct"
+The four library trees in the reviewed inventory contain 67 production files,
+79 direct `alloc::vec::Vec` paths, and 249 bound `Vec`/`StdVec` uses. "Direct"
 counts imports and fully-qualified paths; "bound" counts every type,
 constructor, and method path reached through a direct `Vec` import or alias.
 The executable ledger requires strict equality, so both growth and reduction
@@ -34,7 +34,7 @@ must update the file row and aggregate evidence in the same change.
 | analysis |     7 |            8 |         18 | Diagnostics, side tables, filters, and verifier results grow with the input; no inline bound is established.       |
 | lower    |    12 |           12 |         46 | Lowering worklists and owned results grow with source-tree shape. Bounded substructures may migrate independently. |
 | pass     |    13 |           13 |         51 | Facts, provenance, and traversal worklists grow with the number of operations.                                     |
-| emit     |    21 |           21 |         70 | Ordered output buffers and collected emission inputs grow with the document.                                       |
+| emit     |    22 |           22 |         70 | Ordered output buffers and collected emission inputs grow with the document.                                       |
 
 This is not an endorsement of every retained allocation. A focused change may
 replace a site with `SmallVec` after measuring a bound; that change lowers the
@@ -71,7 +71,7 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::String`       |    11 |           11 |         53 |
 | s2       | `vize_s0::Vec`          |     9 |            9 |         17 |
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
-| s1_to_s2 | `alloc::vec::Vec`       |    46 |           46 |        167 |
+| s1_to_s2 | `alloc::vec::Vec`       |    47 |           47 |        167 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
 | s1_to_s2 | `vize_s0::String`       |    63 |           65 |        264 |
 | s1_to_s2 | `vize_s0::Vec`          |    15 |           15 |         67 |

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -36,7 +36,8 @@ s2	analysis	crates/vize_s2/src/verify.rs	1	4	1	1	0	0	0	0
 s2	-	crates/vize_s2/src/verify/observer.rs	0	0	1	1	0	0	0	0
 s2	analysis	crates/vize_s2/src/verify/walk.rs	1	5	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit.rs	1	2	1	4	0	0	0	0
-s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/buf.rs	1	8	1	11	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/buf.rs	1	6	1	11	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/buf/helper_order.rs	1	2	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/component/call_props.rs	1	1	1	1	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/component/preamble.rs	1	3	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/create_slots.rs	1	5	1	4	0	0	0	0

--- a/tests/tooling/davinci-storage-inventory.ts
+++ b/tests/tooling/davinci-storage-inventory.ts
@@ -42,8 +42,8 @@ export const categoryReasons: Record<VecCategory, string> = {
 };
 
 export const expectedProductionAllocVec: StorageSummary = {
-  files: 66,
-  directPaths: 78,
+  files: 67,
+  directPaths: 79,
   boundUses: 249,
 };
 

--- a/tests/tooling/davinci-v-on-storage.test.ts
+++ b/tests/tooling/davinci-v-on-storage.test.ts
@@ -180,7 +180,7 @@ test("the natural committed v-on corpus fits the two-entry inline buckets", () =
     "the Mealie-shaped dynamic slot fixture keeps its natural modified v-on spelling",
   );
   assert.deepEqual(classify("@click.prevent"), { options: 0, event: 1, keys: 0 });
-  assert.equal(spellings.length, 198, "update the measured corpus evidence intentionally");
+  assert.equal(spellings.length, 199, "update the measured corpus evidence intentionally");
   assert.deepEqual(maxima, { options: 2, event: 2, keys: 2 });
 });
 


### PR DESCRIPTION
## Summary
- preserve shipped Vue helper preamble order for normalize/modifier helper ranks by using final alias occurrence order
- keep existing preferred/helper registration fallback for other helper ranks
- add corpus-derived DOM helper-order regressions and Buf ordering unit coverage

## Tests
- rtk cargo test -q -p vize_atelier_dom --test davinci_s2_helper_order -- --nocapture
- rtk cargo test -q -p vize_s1_to_s2 emit::buf::tests -- --nocapture
- rtk cargo test -q -p vize_s1_to_s2 --test emit_on --test emit_dirs --test emit_model --test emit_merge --test emit_dynamic_bind_keys --test emit_static --test emit_static_hoist --test emit_comp -- --nocapture
- rtk test node --test tests/tooling/source-file-lengths.test.ts
- cargo fmt --all -- --check
- rtk cargo clippy -p vize_s1_to_s2 --features davinci-differential --tests -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated helper ordering to consistently follow usage order in rendered output and hoisted content.
  - Ensured preferred helpers remain correctly prioritized.
  - Prevented helper-like text in strings, comments, and invalid identifiers from affecting ordering.

- **Tests**
  - Added coverage across styles, classes, directives, key events, conditional lists, normalized array classes, transition-group lists, aliases, and Unicode identifiers.
  - Updated corpus validation for the latest directive-handling coverage.
  - Expanded storage inventory validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->