### PR TITLE
fix(davinci): preserve directive helper priority

### DIFF
--- a/crates/vize_s1_to_s2/src/emit/buf/helper_order.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/helper_order.rs
@@ -36,12 +36,23 @@ impl Buf {
     fn order_same_rank_helper(&self, left: Helper, right: Helper) -> Ordering {
         match (
             left.rank(),
+            self.preferred_position(left),
+            self.preferred_position(right),
             self.first_alias_position(left),
             self.first_alias_position(right),
         ) {
-            (2 | 5, Some(left_pos), Some(right_pos)) => left_pos.cmp(&right_pos),
+            (2, Some(left_pos), Some(right_pos), _, _) => left_pos.cmp(&right_pos),
+            (2, Some(_), None, _, _) => Ordering::Less,
+            (2, None, Some(_), _, _) => Ordering::Greater,
+            (5, _, _, Some(left_pos), Some(right_pos)) => left_pos.cmp(&right_pos),
             _ => Ordering::Equal,
         }
+    }
+
+    fn preferred_position(&self, helper: Helper) -> Option<usize> {
+        self.preferred
+            .iter()
+            .position(|candidate| candidate.bit() == helper.bit())
     }
 
     fn first_alias_position(&self, helper: Helper) -> Option<usize> {

--- a/crates/vize_s1_to_s2/src/emit/buf/tests.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/tests.rs
@@ -76,6 +76,33 @@ fn helper_preamble_keeps_preferred_before_body_order() {
 
     assert_eq!(
         buf.preamble(),
-        "const { withDirectives: _withDirectives, withModifiers: _withModifiers, withKeys: _withKeys } = Vue\n"
+        "const { withDirectives: _withDirectives, withKeys: _withKeys, withModifiers: _withModifiers } = Vue\n"
+    );
+}
+
+#[test]
+fn helper_preamble_keeps_preferred_directives_before_modifier_body_order() {
+    let mut buf = Buf::new();
+    buf.prefer(Helper::WithDirectives);
+    buf.use_helper(Helper::WithModifiers);
+    buf.use_helper(Helper::WithDirectives);
+    buf.push("_withModifiers(handler, [\"stop\"]); _withDirectives(node, [])");
+
+    assert_eq!(
+        buf.preamble(),
+        "const { withDirectives: _withDirectives, withModifiers: _withModifiers } = Vue\n"
+    );
+}
+
+#[test]
+fn helper_preamble_keeps_unpreferred_rank_two_in_first_use_order() {
+    let mut buf = Buf::new();
+    buf.use_helper(Helper::WithKeys);
+    buf.use_helper(Helper::WithModifiers);
+    buf.push("_withModifiers(handler, [\"stop\"]); _withKeys(handler, [\"enter\"])");
+
+    assert_eq!(
+        buf.preamble(),
+        "const { withKeys: _withKeys, withModifiers: _withModifiers } = Vue\n"
     );
 }

--- a/crates/vize_s1_to_s2/tests/emit_dirs.rs
+++ b/crates/vize_s1_to_s2/tests/emit_dirs.rs
@@ -114,6 +114,11 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+fn a_custom_dir_with_event_modifier_keeps_shipped_helper_order() {
+    assert_shipped_parity(r#"<div v-example @click.stop="handler"></div>"#);
+}
+
+#[test]
 fn a_kebab_name_becomes_an_underscore_ident() {
     assert_eq!(
         assembled(r#"<div v-my-dir></div>"#),

--- a/tests/tooling/davinci-v-on-storage.test.ts
+++ b/tests/tooling/davinci-v-on-storage.test.ts
@@ -180,7 +180,7 @@ test("the natural committed v-on corpus fits the two-entry inline buckets", () =
     "the Mealie-shaped dynamic slot fixture keeps its natural modified v-on spelling",
   );
   assert.deepEqual(classify("@click.prevent"), { options: 0, event: 1, keys: 0 });
-  assert.equal(spellings.length, 199, "update the measured corpus evidence intentionally");
+  assert.equal(spellings.length, 200, "update the measured corpus evidence intentionally");
   assert.deepEqual(maxima, { options: 2, event: 2, keys: 2 });
 });
 


### PR DESCRIPTION
## Summary
- keep preferred rank-2 helpers ahead of body-order-only helpers when ordering the Vue helper preamble
- pin custom directive plus event modifier parity against the shipped DOM emitter
- update the measured natural v-on corpus count for the added fixture

## Verification
- rtk cargo fmt --all --check
- rtk cargo test -p vize_s1_to_s2 --lib emit::buf::tests -- --nocapture
- rtk cargo test -p vize_s1_to_s2 --test emit_dirs -- --nocapture
- rtk cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture
- rtk cargo test -p vize_s1_to_s2 -- --nocapture
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20
- node --test tests/tooling/davinci-v-on-storage.test.ts tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
- rtk cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected helper ordering for directives and modifiers in generated output.
  - Preserved expected ordering when custom directives are combined with event modifiers.
  - Improved compatibility with the shipped reference compiler.

- **Tests**
  - Added regression coverage for preferred and unpreferred helper ordering.
  - Added coverage for custom directives with event modifiers.
  - Updated coverage for the expanded `v-on` syntax corpus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->