### PR TITLE
fix(davinci): preserve codegen directive helper order

### DIFF
--- a/crates/vize_s1_to_s2/src/emit/buf/helper_order.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/helper_order.rs
@@ -44,6 +44,11 @@ impl Buf {
             (2, Some(left_pos), Some(right_pos), _, _) => left_pos.cmp(&right_pos),
             (2, Some(_), None, _, _) => Ordering::Less,
             (2, None, Some(_), _, _) => Ordering::Greater,
+            (2, None, None, Some(left_pos), Some(right_pos))
+                if self.has_codegen_only_with_directives() =>
+            {
+                left_pos.cmp(&right_pos)
+            }
             (5, _, _, Some(left_pos), Some(right_pos)) => left_pos.cmp(&right_pos),
             _ => Ordering::Equal,
         }
@@ -53,6 +58,11 @@ impl Buf {
         self.preferred
             .iter()
             .position(|candidate| candidate.bit() == helper.bit())
+    }
+
+    fn has_codegen_only_with_directives(&self) -> bool {
+        self.used & Helper::WithDirectives.bit() != 0
+            && self.preferred_position(Helper::WithDirectives).is_none()
     }
 
     fn first_alias_position(&self, helper: Helper) -> Option<usize> {

--- a/crates/vize_s1_to_s2/src/emit/buf/tests.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/tests.rs
@@ -106,3 +106,17 @@ fn helper_preamble_keeps_unpreferred_rank_two_in_first_use_order() {
         "const { withKeys: _withKeys, withModifiers: _withModifiers } = Vue\n"
     );
 }
+
+#[test]
+fn helper_preamble_orders_codegen_only_directives_by_final_rank_two_use() {
+    let mut buf = Buf::new();
+    buf.use_helper(Helper::WithKeys);
+    buf.use_helper(Helper::WithDirectives);
+    buf.use_helper(Helper::WithModifiers);
+    buf.push("_withDirectives(node, { onClick: _withModifiers(handler, [\"stop\"]), onKeydown: _withKeys(handler, [\"enter\"]) })");
+
+    assert_eq!(
+        buf.preamble(),
+        "const { withDirectives: _withDirectives, withModifiers: _withModifiers, withKeys: _withKeys } = Vue\n"
+    );
+}

--- a/crates/vize_s1_to_s2/tests/emit_dirs.rs
+++ b/crates/vize_s1_to_s2/tests/emit_dirs.rs
@@ -119,6 +119,13 @@ fn a_custom_dir_with_event_modifier_keeps_shipped_helper_order() {
 }
 
 #[test]
+fn component_slot_key_event_before_v_show_keeps_shipped_helper_order() {
+    assert_shipped_parity(
+        r#"<div><Dropdown><template #trigger="props" v-if="ready"><slot name="trigger" v-bind="props"><Input @keyup.enter="first" /></slot></template><a v-show="ok" @click.prevent="second" @keydown.enter.prevent="third"></a></Dropdown></div>"#,
+    );
+}
+
+#[test]
 fn a_kebab_name_becomes_an_underscore_ident() {
     assert_eq!(
         assembled(r#"<div v-my-dir></div>"#),

--- a/tests/tooling/davinci-v-on-storage.test.ts
+++ b/tests/tooling/davinci-v-on-storage.test.ts
@@ -180,7 +180,7 @@ test("the natural committed v-on corpus fits the two-entry inline buckets", () =
     "the Mealie-shaped dynamic slot fixture keeps its natural modified v-on spelling",
   );
   assert.deepEqual(classify("@click.prevent"), { options: 0, event: 1, keys: 0 });
-  assert.equal(spellings.length, 200, "update the measured corpus evidence intentionally");
+  assert.equal(spellings.length, 203, "update the measured corpus evidence intentionally");
   assert.deepEqual(maxima, { options: 2, event: 2, keys: 2 });
 });
 


### PR DESCRIPTION
## Summary
- preserve final rank-2 helper order for codegen-only withDirectives cases
- add a focused buffer-order regression
- add shipped-parity coverage for a createSlots default-vs-dynamic-slot v-show ordering case

## Verification
- rtk cargo fmt --all --check
- rtk cargo test -p vize_s1_to_s2 --lib emit::buf::tests -- --nocapture
- rtk cargo test -p vize_s1_to_s2 --test emit_dirs -- --nocapture
- rtk cargo test -p vize_s1_to_s2 --test emit_on -- --nocapture
- rtk cargo test -p vize_s1_to_s2 -- --nocapture
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git/buefy rtk cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture
- rtk rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20
- rtk cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790843478&installation_model_id=422833&pr_number=5568&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5568&signature=df1b31ad24ddd725da934c7df9e20c65b82a7c4703e2ce89f67006cf28d892ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected helper ordering in generated output for directive-related code.
  * Ensured generated helpers follow their final usage order in applicable cases.
  * Improved output consistency for slots combining conditional rendering, iteration, keyboard events, visibility directives, and event modifiers.

* **Tests**
  * Added regression coverage for helper ordering and component slot output parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->