### PR TITLE
fix(davinci): align static prop hoist surfaces

### DIFF
--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -211,7 +211,10 @@ fn emit_call(
     let hoisted_static_props = if can_hoist_static_props
         && ((!array
             && (facts.is_some() || create || foreign_static_props)
-            && (!builtin_helper || static_nested || transition_props_slot_hoist))
+            && (!builtin_helper
+                || static_nested
+                || transition_props_slot_hoist
+                || foreign_static_props))
             || (array && static_nested))
     {
         Some(

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -79,6 +79,13 @@ pub(super) fn can_hoist_static_props(
     let nested_for_static_bind_props = (cx.in_v_for || cx.slot_param_depth > 0)
         && (has_slots || creates_slots)
         && has_nested_for_component_static_bind_props(&component.children)?;
+    let forwarded_slot_only =
+        has_slots && children_are_forwarded_slot_outlets_only(&component.children);
+    let dynamic_forwarded_slot_hoist = props.dynamic_values
+        && forwarded_slot_only
+        && !has_runtime_directive
+        && !cx.in_v_for
+        && cx.slot_param_depth == 0;
     let loop_or_scoped_slot_hoist = (cx.in_v_for || cx.slot_param_depth > 0)
         && (text_only_default
             || (props.all_static_binds
@@ -87,7 +94,8 @@ pub(super) fn can_hoist_static_props(
                 && !nested_for_static_bind_props));
     let hoist_context = (cx.hoist_static_vnodes && text_only_default) || loop_or_scoped_slot_hoist;
     let is_template_for_root = id.is_some_and(|id| cx.template_for_item_root_id == Some(id));
-    let dynamic_props_hoistable = !props.dynamic_values || !has_slots || text_only_default;
+    let dynamic_props_hoistable =
+        !props.dynamic_values || !has_slots || text_only_default || dynamic_forwarded_slot_hoist;
     let transition_props_slot_hoist = transition_props_slot_hoist(component, has_slots);
     Ok((!is_template_for_root
         && dynamic_props_hoistable
@@ -124,6 +132,20 @@ fn has_nested_component_key(region: &Region<'_>) -> bool {
         Op::Slot(slot) => has_nested_component_key(&slot.fallback),
         Op::Text(_) | Op::Interpolation(_) => false,
     })
+}
+
+fn children_are_forwarded_slot_outlets_only(region: &Region<'_>) -> bool {
+    let mut found = false;
+    for op in region.ops.iter() {
+        if slots::is_whitespace_text(op) {
+            continue;
+        }
+        match op {
+            Op::Slot(_) => found = true,
+            _ => return false,
+        }
+    }
+    found
 }
 
 fn has_component_key(component: &ComponentOp<'_>) -> bool {

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -81,7 +81,15 @@ pub(super) fn emit_fragment_element(
         return super::once::emit_element(cx, element, None, false);
     }
     if namespace::crosses_boundary(cx, element, direct_static_children_hoisted(cx, element, id)) {
-        return emit_nested_block(cx, element, id);
+        return super::memo::emit_cached(cx, &element.bindings, |cx| {
+            emit_block(
+                cx,
+                element,
+                None,
+                false,
+                (true, id, PropHoistPosition::Root),
+            )
+        });
     }
     if has_dynamic_key_binding(element) {
         return emit_nested_block(cx, element, id);

--- a/crates/vize_s1_to_s2/tests/emit_static_hoist.rs
+++ b/crates/vize_s1_to_s2/tests/emit_static_hoist.rs
@@ -171,6 +171,27 @@ fn foreign_namespace_component_props_hoist_without_static_children() {
 }
 
 #[test]
+fn foreign_namespace_builtin_component_props_hoist_without_static_children() {
+    assert_shipped_parity(
+        r#"<svg><TransitionGroup name="fade"><path v-for="arrow in arrows" :key="arrow.id" :class="{ [arrow.type]: true }" :d="arrow.d" stroke-linecap="round" /></TransitionGroup></svg>"#,
+    );
+}
+
+#[test]
+fn foreign_namespace_fragment_root_props_use_legacy_hoist() {
+    assert_shipped_parity(
+        r#"<Foo /><svg absolute op0 width="0" height="0"><defs><clipPath id="avatar-mask" clipPathUnits="objectBoundingBox"><path d="M 0,0.5 C 0,0 0,0 0.5,0 S 1,0 1,0.5 1,1 0.5,1 0,1 0,0.5" /></clipPath></defs></svg>"#,
+    );
+}
+
+#[test]
+fn forwarded_slot_component_global_constant_props_use_legacy_hoist() {
+    assert_shipped_parity(
+        r#"<MkCondensedLine :minScale="2 / 3"><slot name="label"></slot></MkCondensedLine>"#,
+    );
+}
+
+#[test]
 fn static_option_with_undefined_value_hoists_like_legacy_global_constant() {
     assert_shipped_parity(
         r#"<select v-model="locale"><option :value="undefined"></option><option :value="'de-DE'">de-DE</option></select>"#,


### PR DESCRIPTION
## Summary
- Hoist static props for foreign built-in components so SVG TransitionGroup output keeps legacy numbering.
- Treat namespace-crossing fragment roots as root prop-hoist candidates.
- Preserve legacy global-constant prop hoists for components that only forward slots.

## Verification
- cargo test -p vize_s1_to_s2 --test emit_static_hoist -- --nocapture
- cargo test -p vize_s1_to_s2 --lib emit::buf::tests -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_dirs --test emit_model --test emit_on -- --nocapture
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=/Users/ubugeeei/Source/github.com/ubugeeei/vize--davinci-residual/tests/_fixtures/_git cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture (expected residual corpus failure: 83 divergences, 0 S2 refusals)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790844572&installation_model_id=422833&pr_number=5569&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5569&signature=d58fc99e1cd39ae4d91004909a6984751055b9fb684f5a0d4e49e102cad546cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static property optimization for built-in components in foreign namespaces.
  * Improved optimization for components containing forwarded slots.
  * Corrected property handling for fragment roots crossing namespace boundaries.
  * Preserved proper behavior for components with forwarded slots and constant properties.

* **Tests**
  * Added coverage for foreign-namespace components, fragment roots, and forwarded-slot scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->