### PR TITLE
fix(davinci): align slot branch key reservations

### DIFF
--- a/crates/vize_s1_to_s2/src/emit/create_slots/branch_keys.rs
+++ b/crates/vize_s1_to_s2/src/emit/create_slots/branch_keys.rs
@@ -1,10 +1,11 @@
-use vize_s2::op::{ForOp, Op, Region};
+use vize_s2::op::{ForOp, IfOp, Op, Region};
 
 use crate::emit::create_slots_walk::{
-    advance_after_op, is_slot_for, is_slot_if, slot_template_content,
+    advance_after_op, first_slot_template, is_slot_for, is_slot_if, slot_template_content,
 };
 use crate::emit::slots::is_whitespace_text;
 use crate::emit::{EmitCx, EmitError};
+use crate::pass::walk::PageWalk;
 
 pub(super) fn is_template_for_slot_outlet_entry(
     cx: &EmitCx<'_>,
@@ -40,7 +41,8 @@ pub(super) fn default_branch_key_count(cx: &EmitCx<'_>, children: &Region<'_>) -
         .iter()
         .any(|op| !matches!(op, Op::Text(_) | Op::Interpolation(_)));
     children.ops.iter().fold(0u32, |count, op| {
-        let Some(id) = walk.mint() else {
+        let mut probe = walk.clone();
+        let Some(id) = probe.mint() else {
             return count;
         };
         let is_entry = match op {
@@ -53,24 +55,63 @@ pub(super) fn default_branch_key_count(cx: &EmitCx<'_>, children: &Region<'_>) -
         if (skip_ws && is_whitespace_text(op)) || is_entry {
             count
         } else {
-            count.saturating_add(op_branch_key_count(op))
+            let mut nested = walk.clone();
+            count.saturating_add(op_branch_key_count(cx, op, &mut nested))
         }
     })
 }
 
-fn region_branch_key_count(region: &Region<'_>) -> u32 {
+fn region_branch_key_count(cx: &EmitCx<'_>, region: &Region<'_>, walk: &mut PageWalk) -> u32 {
     region.ops.iter().fold(0u32, |count, op| {
-        count.saturating_add(op_branch_key_count(op))
+        count.saturating_add(op_branch_key_count(cx, op, walk))
     })
 }
 
-fn op_branch_key_count(op: &Op<'_>) -> u32 {
+fn op_branch_key_count(cx: &EmitCx<'_>, op: &Op<'_>, walk: &mut PageWalk) -> u32 {
+    let id = walk.mint();
     match op {
-        Op::Element(element) => region_branch_key_count(&element.children),
-        Op::Component(component) => region_branch_key_count(&component.children),
-        Op::If(if_op) => u32::try_from(if_op.branches.len()).unwrap_or(u32::MAX),
-        Op::For(for_op) => region_branch_key_count(&for_op.region),
-        Op::Slot(slot) => region_branch_key_count(&slot.fallback),
+        Op::Element(element) => {
+            walk.skip(element.bindings.len());
+            region_branch_key_count(cx, &element.children, walk)
+        }
+        Op::Component(component) => {
+            walk.skip(component.bindings.len());
+            region_branch_key_count(cx, &component.children, walk)
+        }
+        Op::If(if_op) if is_slot_if(cx, id, if_op) => slot_if_branch_key_count(cx, if_op, walk),
+        Op::If(if_op) => {
+            for branch in if_op.branches.iter() {
+                skip_ops_for_count(walk, &branch.region.ops);
+            }
+            u32::try_from(if_op.branches.len()).unwrap_or(u32::MAX)
+        }
+        Op::For(for_op) => region_branch_key_count(cx, &for_op.region, walk),
+        Op::Slot(slot) => {
+            walk.skip(slot.bindings.len());
+            region_branch_key_count(cx, &slot.fallback, walk)
+        }
         Op::Text(_) | Op::Interpolation(_) => 0,
+    }
+}
+
+fn slot_if_branch_key_count(cx: &EmitCx<'_>, if_op: &IfOp<'_>, walk: &mut PageWalk) -> u32 {
+    if_op.branches.iter().fold(0u32, |count, branch| {
+        let Some((idx, element, _content)) = first_slot_template(&branch.region) else {
+            skip_ops_for_count(walk, &branch.region.ops);
+            return count;
+        };
+        skip_ops_for_count(walk, &branch.region.ops[..idx]);
+        let _id = walk.mint();
+        walk.skip(element.bindings.len());
+        let count = count.saturating_add(region_branch_key_count(cx, &element.children, walk));
+        skip_ops_for_count(walk, &branch.region.ops[idx + 1..]);
+        count
+    })
+}
+
+fn skip_ops_for_count(walk: &mut PageWalk, ops: &[Op<'_>]) {
+    for op in ops {
+        let _id = walk.mint();
+        advance_after_op(walk, op);
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/slots/group.rs
+++ b/crates/vize_s1_to_s2/src/emit/slots/group.rs
@@ -1,9 +1,10 @@
 use alloc::vec::Vec as StdVec;
 
 use vize_s0::String;
-use vize_s2::op::{Op, Region};
+use vize_s2::op::{IfOp, Op, Region};
 
 use super::{capture_child, emit_template_pieces, is_slot_template};
+use crate::emit::create_slots_walk::{advance_after_op, first_slot_template};
 use crate::emit::{EmitCx, EmitError, UnsupportedReason as Reason};
 use crate::pass::walk::PageWalk;
 use crate::pass::{SlotCarrier, SlotFacts, SlotParams};
@@ -163,13 +164,42 @@ fn op_branch_key_count(cx: &EmitCx<'_>, op: &Op<'_>, walk: &mut PageWalk) -> u32
             walk.skip(component.bindings.len());
             region_branch_key_count(cx, &component.children, walk)
         }
-        Op::If(if_op) if crate::emit::create_slots_walk::is_slot_if(cx, id, if_op) => 0,
-        Op::If(if_op) => u32::try_from(if_op.branches.len()).unwrap_or(u32::MAX),
+        Op::If(if_op) if crate::emit::create_slots_walk::is_slot_if(cx, id, if_op) => {
+            slot_if_branch_key_count(cx, if_op, walk)
+        }
+        Op::If(if_op) => {
+            for branch in if_op.branches.iter() {
+                skip_ops_for_count(walk, &branch.region.ops);
+            }
+            u32::try_from(if_op.branches.len()).unwrap_or(u32::MAX)
+        }
         Op::For(for_op) => region_branch_key_count(cx, &for_op.region, walk),
         Op::Slot(slot) => {
             walk.skip(slot.bindings.len());
             region_branch_key_count(cx, &slot.fallback, walk)
         }
         Op::Text(_) | Op::Interpolation(_) => 0,
+    }
+}
+
+fn slot_if_branch_key_count(cx: &EmitCx<'_>, if_op: &IfOp<'_>, walk: &mut PageWalk) -> u32 {
+    if_op.branches.iter().fold(0u32, |count, branch| {
+        let Some((idx, element, _content)) = first_slot_template(&branch.region) else {
+            skip_ops_for_count(walk, &branch.region.ops);
+            return count;
+        };
+        skip_ops_for_count(walk, &branch.region.ops[..idx]);
+        let _id = walk.mint();
+        walk.skip(element.bindings.len());
+        let count = count.saturating_add(region_branch_key_count(cx, &element.children, walk));
+        skip_ops_for_count(walk, &branch.region.ops[idx + 1..]);
+        count
+    })
+}
+
+fn skip_ops_for_count(walk: &mut PageWalk, ops: &[Op<'_>]) {
+    for op in ops {
+        let _id = walk.mint();
+        advance_after_op(walk, op);
     }
 }

--- a/crates/vize_s1_to_s2/tests/emit_create_slots/dynamic_entries.rs
+++ b/crates/vize_s1_to_s2/tests/emit_create_slots/dynamic_entries.rs
@@ -92,6 +92,20 @@ fn create_slots_default_branch_keys_are_allocated_before_named_entries() {
 }
 
 #[test]
+fn branch_keys_inside_conditional_slot_entries_count_before_later_default_branches() {
+    assert_shipped_parity(
+        r#"<Foo><template #header><Bar><template v-if="meta" #meta><a v-if="downloadable">Download</a><a v-if="offline">Offline</a></template><template #controls><Qux v-if="controls" /></template></Bar></template><Loading v-if="loading" /></Foo>"#,
+    );
+}
+
+#[test]
+fn conditional_slot_entry_key_does_not_shift_nested_static_slot_branches() {
+    assert_shipped_parity(
+        r#"<Foo v-if="page"><Header><template #title><Badge v-if="badge" /></template><template #description><Mdc v-if="description" /></template><template #links><Button v-for="link in links" :key="link.label"><template v-if="link.avatar" #leading><Avatar /></template></Button></template></Header><Body><Content v-if="body" /><Separator v-if="surround" /></Body><template v-if="toc" #right><Toc><template #bottom><Separator v-if="toc" /><Links /><template v-if="prod"><Separator /><Ads /></template></template></Toc></template></Foo>"#,
+    );
+}
+
+#[test]
 fn dynamic_slot_template_branch_keys_do_not_leak_to_parent_slots() {
     assert_shipped_parity(
         r#"<Comp><template #a><Inner><template v-if="x" #input><div /></template></Inner></template><div v-if="y" /></Comp>"#,


### PR DESCRIPTION
## Summary
- Keep conditional slot template keys from shifting branch-key allocation in the parent slot context.
- Count only branch keys emitted inside the slot function so Koel and Nuxt UI parity fixtures keep legacy key numbering.

## Verification
- cargo fmt --all --check
- git diff --check
- cargo test -p vize_s1_to_s2 --test emit_create_slots --test emit_if --test vif_pass_keys -- --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790846800&installation_model_id=422833&pr_number=5572&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5572&signature=e72256d77760816f70a0d45aeba7c2d58a9c7277bef0263a4560ebff783a4888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected branch-key handling for nested conditional slots.
  - Fixed rendering behavior when conditional and default slot branches are combined.
  - Prevented nested static slot branches from receiving shifted keys in complex slot layouts.
  - Improved consistency for slot content involving nested conditionals and loops.
- **Tests**
  - Added coverage for complex dynamic slot scenarios to verify compiled output matches expected Vue behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->