### PR TITLE
fix(davinci): align modifier helper preamble order

### DIFF
--- a/crates/vize_s1_to_s2/src/emit/buf/helper_order.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/helper_order.rs
@@ -44,11 +44,7 @@ impl Buf {
             (2, Some(left_pos), Some(right_pos), _, _) => left_pos.cmp(&right_pos),
             (2, Some(_), None, _, _) => Ordering::Less,
             (2, None, Some(_), _, _) => Ordering::Greater,
-            (2, None, None, Some(left_pos), Some(right_pos))
-                if self.has_codegen_only_with_directives() =>
-            {
-                left_pos.cmp(&right_pos)
-            }
+            (2, None, None, Some(left_pos), Some(right_pos)) => left_pos.cmp(&right_pos),
             (5, _, _, Some(left_pos), Some(right_pos)) => left_pos.cmp(&right_pos),
             _ => Ordering::Equal,
         }
@@ -58,11 +54,6 @@ impl Buf {
         self.preferred
             .iter()
             .position(|candidate| candidate.bit() == helper.bit())
-    }
-
-    fn has_codegen_only_with_directives(&self) -> bool {
-        self.used & Helper::WithDirectives.bit() != 0
-            && self.preferred_position(Helper::WithDirectives).is_none()
     }
 
     fn first_alias_position(&self, helper: Helper) -> Option<usize> {

--- a/crates/vize_s1_to_s2/src/emit/buf/tests.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/tests.rs
@@ -76,7 +76,7 @@ fn helper_preamble_keeps_preferred_before_body_order() {
 
     assert_eq!(
         buf.preamble(),
-        "const { withDirectives: _withDirectives, withKeys: _withKeys, withModifiers: _withModifiers } = Vue\n"
+        "const { withDirectives: _withDirectives, withModifiers: _withModifiers, withKeys: _withKeys } = Vue\n"
     );
 }
 
@@ -103,7 +103,7 @@ fn helper_preamble_keeps_unpreferred_rank_two_in_first_use_order() {
 
     assert_eq!(
         buf.preamble(),
-        "const { withKeys: _withKeys, withModifiers: _withModifiers } = Vue\n"
+        "const { withModifiers: _withModifiers, withKeys: _withKeys } = Vue\n"
     );
 }
 

--- a/crates/vize_s1_to_s2/tests/emit_dirs.rs
+++ b/crates/vize_s1_to_s2/tests/emit_dirs.rs
@@ -341,3 +341,10 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }")
     );
 }
+
+#[test]
+fn custom_directive_with_native_model_and_event_modifiers_keeps_vue_helper_order() {
+    assert_shipped_parity(
+        r#"<div><input v-model="search" @keyup.enter="handleSubmit"><div v-markdown="label" @click.prevent.stop="selectItem(item)"></div></div>"#,
+    );
+}

--- a/tests/tooling/davinci-v-on-storage.test.ts
+++ b/tests/tooling/davinci-v-on-storage.test.ts
@@ -180,7 +180,7 @@ test("the natural committed v-on corpus fits the two-entry inline buckets", () =
     "the Mealie-shaped dynamic slot fixture keeps its natural modified v-on spelling",
   );
   assert.deepEqual(classify("@click.prevent"), { options: 0, event: 1, keys: 0 });
-  assert.equal(spellings.length, 203, "update the measured corpus evidence intentionally");
+  assert.equal(spellings.length, 205, "update the measured corpus evidence intentionally");
   assert.deepEqual(maxima, { options: 2, event: 2, keys: 2 });
 });
 


### PR DESCRIPTION
## Summary
- Order same-rank modifier helpers by final generated call position once preferred helpers are handled.
- Add focused parity coverage for directive/model/event modifier helper preamble ordering.

## Verification
- cargo fmt --all --check
- git diff --check
- cargo test -p vize_s1_to_s2 --lib emit::buf::tests -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_dirs -- --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790846802&installation_model_id=422833&pr_number=5573&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5573&signature=874670073a84f8c3f698d0046c8c89be1e1b218fd7b885531eafbb8d46ca3955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected helper ordering in generated output when multiple helpers share the same rank.
  * Preserved consistent ordering for modifier-related helpers and templates combining native model bindings with event modifiers and custom directives.

* **Tests**
  * Added coverage for these directive and modifier combinations.
  * Updated output expectations and validation counts to reflect the corrected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->