### PR TITLE
fix(davinci): snap tokenizer diagnostics to UTF-8 boundaries

### DIFF
--- a/crates/vize_s1_to_s2/src/lower.rs
+++ b/crates/vize_s1_to_s2/src/lower.rs
@@ -172,10 +172,7 @@ pub fn lower_source_block_with_caps<'a>(
         cx.diagnostics.push(Diagnostic::new(
             Severity::Error,
             Stage::Surface,
-            Span::new(
-                block.start().saturating_add(error.offset),
-                block.start().saturating_add(error.offset),
-            ),
+            surface_error_span(block, error.offset),
             String::from(error.code.message()),
         ));
     }
@@ -193,6 +190,18 @@ pub fn lower_source_block_with_caps<'a>(
         for_wrappers: cx.for_wrappers,
         caps,
     }
+}
+
+fn surface_error_span(block: SourceBlock<'_>, offset: u32) -> Span {
+    let absolute = block.start().saturating_add(offset);
+    let hole = block.zero_width_at(absolute);
+    block.span_of(hole).unwrap_or_else(|| {
+        debug_assert!(
+            false,
+            "SourceBlock::zero_width_at returned a slice outside its block"
+        );
+        Span::new(block.start(), block.start())
+    })
 }
 
 impl fmt::Debug for Lowered<'_> {

--- a/crates/vize_s1_to_s2/tests/lowering_battery.rs
+++ b/crates/vize_s1_to_s2/tests/lowering_battery.rs
@@ -144,6 +144,35 @@ fn source_block_tokenizer_errors_are_file_absolute() {
 }
 
 #[test]
+fn tokenizer_error_diagnostics_snap_to_utf8_boundary() {
+    let source = std::str::from_utf8(
+        b"\n  <div>{{ props.title }}</div\x1d\"vm\xd7\xa3p=\n\xd7\xa3\0s_bme\">plate v-if=\"-vhow=\"\n  <te-plate v-if=\"vm\xd7\xa3p>\n",
+    )
+    .expect("reproducer is valid UTF-8");
+    let mid_char_offset = 40;
+    assert!(!source.is_char_boundary(mid_char_offset));
+
+    let allocator = Allocator::new();
+    let (tree, errors) = parse(&allocator, source);
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.offset == mid_char_offset as u32),
+        "the committed reproducer must keep covering a tokenizer error inside a UTF-8 scalar"
+    );
+
+    let lowered = vize_s1_to_s2::lower(&allocator, &tree, &errors);
+    assert_authored_artifact(source, &lowered);
+    assert!(
+        lowered
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.span == Span::new(39, 39)),
+        "the mid-scalar tokenizer offset should snap down to the preceding char boundary"
+    );
+}
+
+#[test]
 fn the_battery_aggregates_are_pinned() {
     // The decision-surface census over the whole battery: ops minted,
     // diagnostics raised, provenance records written, scopes tagged.


### PR DESCRIPTION
## Summary
- snap S1 tokenizer-error diagnostics through SourceBlock::zero_width_at before entering the unified diagnostic channel
- add the CI fuzz reproducer as a lowering regression for a tokenizer error inside a UTF-8 scalar

## Verification
- rtk cargo fmt --all --check
- rtk cargo test -p vize_s1_to_s2 --test lowering_battery tokenizer_error_diagnostics_snap_to_utf8_boundary -- --nocapture
- rtk cargo test -p vize_s1_to_s2 --test lowering_battery -- --nocapture
- rtk cargo test -p vize_s1_to_s2 -- --nocapture
- rtk cargo +nightly fuzz run --fuzz-dir tests/fuzz s1_lowering /tmp/vize-fuzz-repro-33491837154.DWoNq8/crash-4e3607dcc32779d1020ed1fed90a0b59a852a107 -- -runs=1 -max_len=65536 -timeout=25 -rss_limit_mb=4096 -malloc_limit_mb=2048
- rtk rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20
- rtk git diff --check
- rtk cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790848067&installation_model_id=422833&pr_number=5575&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5575&signature=ae0f9555577efd32b163052688994ae270292a488f1cae1207949013a5d06a64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->