### PR TITLE
fix(davinci): close next DOM corpus residuals

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_format_residuals.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_format_residuals.rs
@@ -1,0 +1,58 @@
+//! P2-11 residual formatter/helper-order witnesses reduced from the S2 DOM
+//! corpus tail.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[(
+    "directus_image_editor_slots_before_show_helper",
+    r#"
+<VDrawer v-model="internalActive" class="modal">
+  <template #activator="activatorBinding">
+    <slot name="activator" v-bind="activatorBinding" />
+  </template>
+  <template #title-outer:append>
+    <VIcon v-tooltip.bottom="$t('changes_are_permanent')" name="error" />
+  </template>
+  <VMenu>
+    <template #activator="{ toggle }">
+      <VIcon :name="aspectRatioIcon" clickable @click="toggle" />
+    </template>
+    <VList>
+      <template v-if="customAspectRatios">
+        <VListItem
+          v-for="customAspectRatio in customAspectRatios"
+          :key="customAspectRatio.text"
+          clickable
+          :active="aspectRatio === customAspectRatio.value"
+        >
+          {{ customAspectRatio.text }}
+        </VListItem>
+      </template>
+    </VList>
+  </VMenu>
+  <button v-show="cropping" type="button" @click="cropping = false">
+    {{ localDragMode === 'focal_point' ? $t('cancel_selection') : $t('cancel_crop') }}
+  </button>
+  <template #actions:primary>
+    <PrivateViewHeaderBarActionButton :loading="saving">
+      <template v-if="props.createAllowed" #split-menu>
+        <VList>
+          <VListItem clickable @click="saveAsNew" />
+        </VList>
+      </template>
+    </PrivateViewHeaderBarActionButton>
+  </template>
+</VDrawer>
+"#,
+)];
+
+#[test]
+fn s2_format_residuals_match_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -118,6 +118,10 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<Form v-if="show" action="/dump/post" method="post"><input type="text" name="name" id="name" value="John" /></Form>"#,
     ),
     (
+        "branch_child_component_static_props_follow_shipped_hoist_order",
+        r#"<div v-if="show"><BranchRatio :ratio="16 / 9"><img class="Image" src="x" alt="y"></BranchRatio></div>"#,
+    ),
+    (
         "for_component_root_slot_static_props_stay_inline",
         r#"<ListItem v-for="entry in entries" label="fixed" v-slot="{ value }">{{ value }}</ListItem>"#,
     ),

--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -102,6 +102,22 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<b-table :data="data" :loading="loading" paginated backend-pagination :total="total" :per-page="perPage" @page-change="onPageChange" backend-sorting :default-sort="[sortField, sortOrder]" @sort="onSort"><b-table-column field="original_title" label="Title" sortable v-slot="props">{{ props.row.original_title }}</b-table-column><b-table-column field="vote_average" label="Vote Average" numeric sortable v-slot="props"><span class="tag" :class="type(props.row.vote_average)">{{ props.row.vote_average }}</span></b-table-column><b-table-column field="vote_count" label="Vote Count" numeric sortable v-slot="props">{{ props.row.vote_count }}</b-table-column></b-table>"#,
     ),
     (
+        "component_static_attr_props_precede_direct_static_slot_vnodes",
+        r#"<Head title="Test Head Component"><meta name="viewport" content="width=device-width, initial-scale=1" /><meta name="undefined" :content="undefined" /><meta name="number" :content="0" /></Head><h1 :style="{ fontSize: '40px' }">Head Component</h1>"#,
+    ),
+    (
+        "component_static_bind_props_precede_direct_static_slot_vnode",
+        r#"<div><AspectRatio :ratio="16 / 9"><img class="Image" src="x" alt="y"></AspectRatio></div>"#,
+    ),
+    (
+        "component_mixed_props_precede_direct_static_slot_vnode",
+        r#"<DocSectionText v-bind="$attrs"><p>Intro</p><p>More <a href="x">link</a></p></DocSectionText><div class="card"><Panel header="Header" toggleable unstyled :pt="{ root: 'x', header: (options) => ({ id: 'myPanelHeader' }) }"><p class="m-0">Lorem ipsum</p></Panel></div><DocSectionCode :code="code" />"#,
+    ),
+    (
+        "branch_component_static_props_stay_inline_before_static_slot_vnode",
+        r#"<Form v-if="show" action="/dump/post" method="post"><input type="text" name="name" id="name" value="John" /></Form>"#,
+    ),
+    (
         "for_component_root_slot_static_props_stay_inline",
         r#"<ListItem v-for="entry in entries" label="fixed" v-slot="{ value }">{{ value }}</ListItem>"#,
     ),

--- a/crates/vize_s1_to_s2/src/emit/buf/helper_order.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/helper_order.rs
@@ -46,6 +46,13 @@ impl Buf {
             (2, None, Some(_), _, _) => Ordering::Greater,
             (2, None, None, Some(left_pos), Some(right_pos)) => left_pos.cmp(&right_pos),
             (5, _, _, Some(left_pos), Some(right_pos)) => left_pos.cmp(&right_pos),
+            (10, _, _, _, _)
+                if self.used & Helper::ResolveDirective.bit() != 0
+                    && self.used & Helper::CreateText.bit() != 0
+                    && create_slots_show_pair(left, right) =>
+            {
+                create_slots_before_v_show(left, right)
+            }
             _ => Ordering::Equal,
         }
     }
@@ -66,5 +73,20 @@ impl Buf {
             offset += hoist.len();
         }
         helper_call_position(self.code.as_str(), alias).map(|position| offset + position)
+    }
+}
+
+fn create_slots_show_pair(left: Helper, right: Helper) -> bool {
+    matches!(
+        (left, right),
+        (Helper::CreateSlots, Helper::VShow) | (Helper::VShow, Helper::CreateSlots)
+    )
+}
+
+fn create_slots_before_v_show(left: Helper, _right: Helper) -> Ordering {
+    if matches!(left, Helper::CreateSlots) {
+        Ordering::Less
+    } else {
+        Ordering::Greater
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/buf/tests.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/tests.rs
@@ -120,3 +120,28 @@ fn helper_preamble_orders_codegen_only_directives_by_final_rank_two_use() {
         "const { withDirectives: _withDirectives, withModifiers: _withModifiers, withKeys: _withKeys } = Vue\n"
     );
 }
+
+#[test]
+fn helper_preamble_orders_create_slots_before_v_show_for_textful_directive_slots() {
+    let mut buf = Buf::new();
+    buf.use_helper(Helper::ResolveDirective);
+    buf.use_helper(Helper::CreateText);
+    buf.use_helper(Helper::VShow);
+    buf.use_helper(Helper::CreateSlots);
+    buf.push("_createSlots(slots, []); [_vShow, visible]");
+
+    assert_eq!(
+        buf.preamble(),
+        "const { resolveDirective: _resolveDirective, createTextVNode: _createTextVNode, createSlots: _createSlots, vShow: _vShow } = Vue\n"
+    );
+
+    let mut buf = Buf::new();
+    buf.use_helper(Helper::VShow);
+    buf.use_helper(Helper::CreateSlots);
+    buf.push("[_vShow, visible]; _createSlots(slots, [])");
+
+    assert_eq!(
+        buf.preamble(),
+        "const { vShow: _vShow, createSlots: _createSlots } = Vue\n"
+    );
+}

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -10,7 +10,7 @@ use call_props::{
 use checks::{admit, has_dynamic_key_binding};
 
 use vize_davinci::id::NodeId;
-use vize_s2::op::{BindingOp, ComponentOp};
+use vize_s2::op::ComponentOp;
 
 use super::EmitCx;
 use super::EmitError;
@@ -173,17 +173,12 @@ fn emit_call(
     let has_attrs = has_rendered_attrs(component, skip_is);
     let has_custom = directive::has_custom(&component.bindings);
     let has_runtime = directive::has_runtime(&component.bindings);
-    let has_component_root_slot = component
-        .bindings
-        .iter()
-        .any(|binding| matches!(binding, BindingOp::SlotContent(_)));
+    let has_component_root_slot = call_props::has_component_root_slot(&component.bindings);
     let hoist_attrs = rendered_hoist_attrs(component, skip_is);
     let static_nested = builtin::has_static_nested(&component.children);
     let builtin_helper = builtin::helper(component.name).is_some();
     let hoistable_static_props =
         call_props::hoistable_static_props(component, skip_is, &hoist_attrs)?;
-    let direct_static_slot_vnodes =
-        call_props::children_are_direct_static_vnode_hoists(&component.children);
     if for_item
         && !has_component_root_slot
         && !has_custom
@@ -215,7 +210,7 @@ fn emit_call(
             && (facts.is_some() || create || foreign_static_props)
             && (!builtin_helper
                 || static_nested
-                || direct_static_slot_vnodes
+                || call_props::children_are_direct_static_vnode_hoists(&component.children)
                 || transition_props_slot_hoist
                 || foreign_static_props))
             || (array && static_nested))

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -182,6 +182,8 @@ fn emit_call(
     let builtin_helper = builtin::helper(component.name).is_some();
     let hoistable_static_props =
         call_props::hoistable_static_props(component, skip_is, &hoist_attrs)?;
+    let direct_static_slot_vnodes =
+        call_props::children_are_direct_static_vnode_hoists(&component.children);
     if for_item
         && !has_component_root_slot
         && !has_custom
@@ -213,6 +215,7 @@ fn emit_call(
             && (facts.is_some() || create || foreign_static_props)
             && (!builtin_helper
                 || static_nested
+                || direct_static_slot_vnodes
                 || transition_props_slot_hoist
                 || foreign_static_props))
             || (array && static_nested))

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -28,6 +28,12 @@ pub(super) fn has_rendered_attrs(component: &ComponentOp<'_>, skip_is: bool) -> 
         .any(|attr| !skip_is || attr.name != "is")
 }
 
+pub(super) fn has_component_root_slot(bindings: &[BindingOp<'_>]) -> bool {
+    bindings
+        .iter()
+        .any(|binding| matches!(binding, BindingOp::SlotContent(_)))
+}
+
 pub(super) fn rendered_hoist_attrs<'a, 'b>(
     component: &'b ComponentOp<'a>,
     skip_is: bool,

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -81,8 +81,15 @@ pub(super) fn can_hoist_static_props(
         && has_nested_for_component_static_bind_props(&component.children)?;
     let forwarded_slot_only =
         has_slots && children_are_forwarded_slot_outlets_only(&component.children);
+    let direct_static_slot_vnodes =
+        has_slots && children_are_direct_static_vnode_hoists(&component.children);
     let dynamic_forwarded_slot_hoist = props.dynamic_values
         && forwarded_slot_only
+        && !has_runtime_directive
+        && !cx.in_v_for
+        && cx.slot_param_depth == 0;
+    let dynamic_direct_static_slot_hoist = props.dynamic_values
+        && direct_static_slot_vnodes
         && !has_runtime_directive
         && !cx.in_v_for
         && cx.slot_param_depth == 0;
@@ -94,8 +101,11 @@ pub(super) fn can_hoist_static_props(
                 && !nested_for_static_bind_props));
     let hoist_context = (cx.hoist_static_vnodes && text_only_default) || loop_or_scoped_slot_hoist;
     let is_template_for_root = id.is_some_and(|id| cx.template_for_item_root_id == Some(id));
-    let dynamic_props_hoistable =
-        !props.dynamic_values || !has_slots || text_only_default || dynamic_forwarded_slot_hoist;
+    let dynamic_props_hoistable = !props.dynamic_values
+        || !has_slots
+        || text_only_default
+        || dynamic_forwarded_slot_hoist
+        || dynamic_direct_static_slot_hoist;
     let transition_props_slot_hoist = transition_props_slot_hoist(component, has_slots);
     Ok((!is_template_for_root
         && dynamic_props_hoistable
@@ -115,7 +125,12 @@ pub(super) fn can_hoist_static_props(
         || (props.dynamic_values
             && cx.slot_param_depth == 0
             && !cx.in_v_for
-            && dynamic_props_hoistable))
+            && dynamic_props_hoistable)
+        || (!props.all_static_binds
+            && direct_static_slot_vnodes
+            && !has_runtime_directive
+            && cx.slot_param_depth == 0
+            && !cx.in_v_for))
 }
 
 fn has_nested_component_key(region: &Region<'_>) -> bool {
@@ -142,6 +157,20 @@ fn children_are_forwarded_slot_outlets_only(region: &Region<'_>) -> bool {
         }
         match op {
             Op::Slot(_) => found = true,
+            _ => return false,
+        }
+    }
+    found
+}
+
+pub(super) fn children_are_direct_static_vnode_hoists(region: &Region<'_>) -> bool {
+    let mut found = false;
+    for op in region.ops.iter() {
+        if slots::is_whitespace_text(op) {
+            continue;
+        }
+        match op {
+            Op::Element(element) if super::super::hoist::is_hoistable(element) => found = true,
             _ => return false,
         }
     }

--- a/crates/vize_s1_to_s2/src/emit/slots.rs
+++ b/crates/vize_s1_to_s2/src/emit/slots.rs
@@ -204,7 +204,7 @@ pub(super) fn emit_slots(
         cx.buf.push(spread.as_str());
     } else {
         let forwarded = super::outlet::has_forwarded_outlet(children);
-        if forwarded && cx.slot_param_depth == 0 && !cx.in_v_for && !has_dynamic_names(facts) {
+        if forwarded && cx.slot_param_depth == 0 && !cx.in_v_for {
             cx.buf.push("_: 3 /* FORWARDED */");
         } else if cx.in_v_for || has_dynamic_names(facts) || (forwarded && cx.slot_param_depth > 0)
         {

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -19,8 +19,8 @@ use super::props_static::PropHoistPosition;
 use super::vnode_children::emit_children;
 use super::{EmitCx, EmitError};
 use checks::{
-    direct_static_children_hoisted, has_cloak, has_dynamic_key_binding, has_prop_bindings,
-    template_if_branch_root_has_direct_interpolation,
+    direct_static_children_hoisted, has_cloak, has_direct_interpolation_child,
+    has_dynamic_key_binding, has_prop_bindings, template_if_branch_root_has_direct_interpolation,
 };
 
 pub(super) fn emit_unique_element(
@@ -214,13 +214,18 @@ pub(super) fn emit_call(
         && cx.slot_param_depth == 0
         && !template_if_branch_root_has_direct_interpolation(cx, element, if_key);
     let has_binds = has_prop_bindings(&element.bindings);
-    let hoisted_props =
-        if allow_hoist && if_key.is_none() && super::props_static::should_hoist(cx, id, prop_hoist)
-        {
-            super::props_static::root_hoist_props(&element.attributes, &element.bindings)?
-        } else {
-            None
-        };
+    let nested_v_for_direct_text = cx.in_v_for
+        && matches!(prop_hoist, PropHoistPosition::Nested)
+        && has_direct_interpolation_child(element);
+    let hoisted_props = if allow_hoist
+        && if_key.is_none()
+        && !nested_v_for_direct_text
+        && super::props_static::should_hoist(cx, id, prop_hoist)
+    {
+        super::props_static::root_hoist_props(&element.attributes, &element.bindings)?
+    } else {
+        None
+    };
     let hoist = hoisted_props.is_some();
     let patch = bind_patch(&element.bindings, false, if_key, for_item);
     let text_flag = !once && !memo_block && children_need_text_flag(&element.children);

--- a/crates/vize_s1_to_s2/src/emit/vnode/checks.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode/checks.rs
@@ -30,6 +30,10 @@ pub(super) fn template_if_branch_root_has_direct_interpolation(
     if if_key.is_none() || !cx.template_if_branch_root {
         return false;
     }
+    has_direct_interpolation_child(element)
+}
+
+pub(super) fn has_direct_interpolation_child(element: &ElementOp<'_>) -> bool {
     element
         .children
         .ops

--- a/crates/vize_s1_to_s2/tests/emit_outlets.rs
+++ b/crates/vize_s1_to_s2/tests/emit_outlets.rs
@@ -102,6 +102,13 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+fn dynamic_slot_name_with_forwarded_outlet_keeps_forwarded_flag() {
+    assert_shipped_parity(
+        r#"<Foo><template #[target]><Bar><slot name="selectors" /></Bar></template></Foo>"#,
+    );
+}
+
+#[test]
 fn fallback_interp_expands_the_compound_into_sibling_children() {
     assert_eq!(
         assembled("<slot>hello {{ msg }}</slot>"),

--- a/crates/vize_s1_to_s2/tests/emit_static_hoist.rs
+++ b/crates/vize_s1_to_s2/tests/emit_static_hoist.rs
@@ -340,3 +340,10 @@ fn v_for_item_v_once_stays_in_the_legacy_plain_item_path() {
         r#"<span v-for="item in list" v-once :key="item.id">{{ item.name }}</span>"#,
     );
 }
+
+#[test]
+fn v_for_descendant_dynamic_text_props_stay_inline() {
+    assert_shipped_parity(
+        r#"<div v-for="group in itemsGroups" v-if="visible" :key="group.key" :class="group.key"><h2 class="d-flex align-items-center mb-3">{{ group.label }}<span class="badge badge-pill badge-default ml-2">{{ items[group.key].length }}</span></h2></div>"#,
+    );
+}


### PR DESCRIPTION
## Summary
- reserve direct static slot prop hoists before direct static slot vnodes
- preserve forwarded slot flags with dynamic names and keep v-for direct-text props inline
- narrow createSlots/vShow helper ordering and cover branch-child static slot hoist behavior

## Verification
- cargo fmt --all --check
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10
- node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_s1_to_s2 --test emit_static_hoist --test emit_outlets -- --nocapture
- cargo test -p vize_s1_to_s2 --lib emit::buf::tests::helper_preamble -- --nocapture
- cargo test -p vize_s1_to_s2 --features davinci-differential -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_hoist_order --test davinci_s2_format_residuals --test davinci_s2_helper_order -- --nocapture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved rendering efficiency for components with static properties and statically hoisted slot content.
  - Expanded optimization coverage while preserving rendered content order and behavior.

- **Bug Fixes**
  - Corrected static property placement before hoisted slot elements across component and conditional scenarios.
  - Fixed forwarded-slot handling for dynamically named slots.
  - Preserved dynamic text and properties inline in nested loop and conditional rendering.
  - Stabilized helper ordering for slot and visibility directives.

- **Tests**
  - Added regression coverage for static properties, branch components, forwarded slots, helper ordering, and dynamic descendants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->