### PR TITLE
fix(release): allow VS Code vsce dlx builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,10 @@ jobs:
     timeout-minutes: 30
     environment: vscode-marketplace
     permissions: { contents: read }
-    env: { PUBLISH_RESOLUTION_RETRY_LIMIT: "90", VSCE_PAT: "${{ secrets.VSCE_PAT }}" }
+    env:
+      PUBLISH_RESOLUTION_RETRY_LIMIT: "90"
+      VSCE_DLX_BIN: pnpm
+      VSCE_PAT: "${{ secrets.VSCE_PAT }}"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Setup Vite+ and Node.js

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -273,6 +273,7 @@ test("release workflow requires VS Code Marketplace publication", () => {
   assert.ok(publishJobContract);
   assert.equal(publishJobContract["timeout-minutes"], 30);
   assert.equal(publishJobContract.env?.PUBLISH_RESOLUTION_RETRY_LIMIT, "90");
+  assert.equal(publishJobContract.env?.VSCE_DLX_BIN, "pnpm");
   assert.equal(parsed.env?.PUBLISH_RESOLUTION_RETRY_DELAY, 10);
 
   assert.match(publishJob, /environment:\s*vscode-marketplace/);

--- a/tests/tooling/moonbit-publish-vscode-dlx.test.ts
+++ b/tests/tooling/moonbit-publish-vscode-dlx.test.ts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { runMoonScript } from "./_helpers/moonbit.ts";
+import { writeFakeCommand } from "./support/fake-command.ts";
+
+test("publish_vscode_extension allows pnpm dlx builds for vsce signing dependencies", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "moonbit-publish-vsix-pnpm-"));
+  const binDir = path.join(tempDir, "bin");
+  const argsLogPath = path.join(tempDir, "pnpm-args.log");
+  const vsixPath = path.join(tempDir, "vize.vsix");
+  const packageJsonPath = path.join(tempDir, "package.json");
+
+  try {
+    fs.mkdirSync(binDir, { recursive: true });
+    writeFileSync(vsixPath, "placeholder");
+    writeFileSync(
+      packageJsonPath,
+      `${JSON.stringify({ publisher: "ubugeeei", name: "vize", version: "0.57.0" }, null, 2)}\n`,
+    );
+    writeFakeCommand(
+      binDir,
+      "pnpm",
+      [
+        "const fs = require('node:fs');",
+        "const args = process.argv.slice(2);",
+        "if (args[0] === 'dlx' && args[7] === 'vsce' && args[8] === 'show') {",
+        "  if (fs.existsSync(process.env.PNPM_ARGS_LOG)) {",
+        "    process.stdout.write(JSON.stringify({ versions: [{ version: '0.57.0' }] }));",
+        "    process.exit(0);",
+        "  }",
+        "  process.exit(1);",
+        "}",
+        "fs.writeFileSync(process.env.PNPM_ARGS_LOG, args.join('\\n'));",
+        "process.exit(0);",
+      ].join("\n"),
+    );
+
+    const result = runMoonScript("publish_vscode_extension", [vsixPath, packageJsonPath], {
+      env: {
+        NPM_TAG: "rc",
+        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        PNPM_ARGS_LOG: argsLogPath,
+        VSCE_DLX_BIN: "pnpm",
+      },
+    });
+
+    assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
+    assert.deepEqual(fs.readFileSync(argsLogPath, "utf8").trim().split("\n"), [
+      "dlx",
+      "--allow-build",
+      "@vscode/vsce-sign",
+      "--allow-build",
+      "keytar",
+      "--package",
+      "@vscode/vsce@^3.3.2",
+      "vsce",
+      "publish",
+      "--no-dependencies",
+      "--packagePath",
+      vsixPath,
+      "--pre-release",
+    ]);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/tools/config/vite-plus/tasks/release.ts
+++ b/tools/config/vite-plus/tasks/release.ts
@@ -39,7 +39,7 @@ export const releaseTasks = defineTasks({
   ),
   "publish:crates": noCacheTask(moonScript("publish_crates")),
   "publish:vscode-extension": noCacheTask(
-    `${installVscodeExtensionDependencies} && ${moonScript("publish_vscode_extension", "editors/vscode/dist/vize.vsix")}`,
+    `${installVscodeExtensionDependencies} && VSCE_DLX_BIN=pnpm ${moonScript("publish_vscode_extension", "editors/vscode/dist/vize.vsix")}`,
   ),
   publish: noCacheTask(runTasks("publish:npm", "publish:crates")),
 });

--- a/tools/moon/cmd/publish_vscode_extension/main.mbt
+++ b/tools/moon/cmd/publish_vscode_extension/main.mbt
@@ -45,6 +45,43 @@ fn read_package_json(path : String) -> Json? {
 }
 
 ///|
+fn configured_vsce_dlx_bin() -> String {
+  match @env.get_env_var("VSCE_DLX_BIN") {
+    Some(value) if value != "" => value
+    _ =>
+      match @env.get_env_var("VP_BIN") {
+        Some(value) if value != "" => value
+        _ => "vp"
+      }
+  }
+}
+
+///|
+fn vsce_dlx_args(
+  dlx_bin : String,
+  command : String,
+  extra_args : Array[String],
+) -> Array[String] {
+  let args = ["dlx"]
+  if dlx_bin == "pnpm" {
+    args.push("--allow-build")
+    args.push("@vscode/vsce-sign")
+    args.push("--allow-build")
+    args.push("keytar")
+    args.push("--package")
+  } else {
+    args.push("-p")
+  }
+  args.push("@vscode/vsce@^3.3.2")
+  args.push("vsce")
+  args.push(command)
+  for arg in extra_args {
+    args.push(arg)
+  }
+  args
+}
+
+///|
 fn extension_info_from_package_json(value : Json) -> ExtensionInfo? {
   guard value is Object(obj) else { return None }
   guard obj.get("publisher") is Some(String(publisher)) else { return None }
@@ -70,13 +107,14 @@ fn json_has_extension_version(value : Json, expected : String) -> Bool {
 
 ///|
 async fn extension_version_is_visible(
-  vp_bin : String,
+  dlx_bin : String,
   extension_id : String,
   version : String,
 ) -> Bool {
-  let (exit_code, stdout, _) = @process.collect_output(vp_bin, [
-    "dlx", "-p", "@vscode/vsce@^3.3.2", "vsce", "show", extension_id, "--json",
-  ])
+  let (exit_code, stdout, _) = @process.collect_output(
+    dlx_bin,
+    vsce_dlx_args(dlx_bin, "show", [extension_id, "--json"]),
+  )
   if exit_code != 0 {
     return false
   }
@@ -90,7 +128,7 @@ async fn extension_version_is_visible(
 
 ///|
 async fn wait_for_extension_visibility(
-  vp_bin : String,
+  dlx_bin : String,
   extension_id : String,
   version : String,
   max_attempts : Int,
@@ -98,7 +136,7 @@ async fn wait_for_extension_visibility(
 ) -> Bool {
   let mut attempt = 1
   while attempt <= max_attempts {
-    if extension_version_is_visible(vp_bin, extension_id, version) {
+    if extension_version_is_visible(dlx_bin, extension_id, version) {
       println(
         "\{extension_id} \{version} is visible in the VS Code Marketplace.",
       )
@@ -146,10 +184,7 @@ async fn run_app() -> Int {
       return 1
     }
   }
-  let vp_bin = match @env.get_env_var("VP_BIN") {
-    Some(value) if value != "" => value
-    _ => "vp"
-  }
+  let dlx_bin = configured_vsce_dlx_bin()
   let resolution_attempts = env_int_at_least(
     "PUBLISH_RESOLUTION_RETRY_LIMIT", 1, 24,
   )
@@ -157,7 +192,7 @@ async fn run_app() -> Int {
     "PUBLISH_RESOLUTION_RETRY_DELAY", 0, 10,
   )
   if extension_version_is_visible(
-      vp_bin,
+      dlx_bin,
       extension_info.extension_id,
       extension_info.version,
     ) {
@@ -172,11 +207,6 @@ async fn run_app() -> Int {
     _ => "latest"
   }
   let publish_args = [
-    "dlx",
-    "-p",
-    "@vscode/vsce@^3.3.2",
-    "vsce",
-    "publish",
     "--no-dependencies",
     "--packagePath",
     @tool.resolve_path(args[0]),
@@ -184,9 +214,9 @@ async fn run_app() -> Int {
   if tag != "latest" {
     publish_args.push("--pre-release")
   }
-  let exit_code = @process.run(vp_bin, publish_args)
+  let exit_code = @process.run(dlx_bin, vsce_dlx_args(dlx_bin, "publish", publish_args))
   if wait_for_extension_visibility(
-      vp_bin,
+      dlx_bin,
       extension_info.extension_id,
       extension_info.version,
       resolution_attempts,


### PR DESCRIPTION
## Summary
- run VS Code Marketplace vsce tooling through pnpm dlx when release automation publishes the extension
- allow the vsce signing dependencies that pnpm v12 blocks by default during dlx installs
- pin the release workflow env and add regression coverage for the pnpm dlx argument contract

## Verification
- rtk node --test --test-concurrency=1 tests/tooling/moonbit-publish-vscode-dlx.test.ts tests/tooling/moonbit-publish.test.ts tests/tooling/github-workflows-release-publish.test.ts
- rtk vp check --fix tools/moon/cmd/publish_vscode_extension/main.mbt tests/tooling/moonbit-publish-vscode-dlx.test.ts tests/tooling/github-workflows-release-publish.test.ts tools/config/vite-plus/tasks/release.ts .github/workflows/release.yml
- rtk rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20
- rtk git diff --cached --check
- rtk cargo fmt --all --check
- rtk pnpm dlx --allow-build @vscode/vsce-sign --allow-build keytar --package @vscode/vsce@^3.3.2 vsce --version

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790853504&installation_model_id=422833&pr_number=5579&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5579&signature=42b04c96c4ea935ccf215311653463f644ab6c4028f85f8f500736a26525f6b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated VS Code extension publishing to support pnpm-based package execution.
  * Added required build approvals for signing and keychain packages during publication.
  * Preserved compatibility with existing package-manager configurations.

* **Tests**
  * Added coverage verifying pnpm commands and publishing arguments are configured correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->