### PR TITLE
fix(release): invoke VS Code vsce through corepack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
     permissions: { contents: read }
     env:
       PUBLISH_RESOLUTION_RETRY_LIMIT: "90"
-      VSCE_DLX_BIN: pnpm
+      VSCE_DLX_BIN: corepack
       VSCE_PAT: "${{ secrets.VSCE_PAT }}"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/tests/tooling/github-workflows-release-publish.test.ts
+++ b/tests/tooling/github-workflows-release-publish.test.ts
@@ -273,7 +273,7 @@ test("release workflow requires VS Code Marketplace publication", () => {
   assert.ok(publishJobContract);
   assert.equal(publishJobContract["timeout-minutes"], 30);
   assert.equal(publishJobContract.env?.PUBLISH_RESOLUTION_RETRY_LIMIT, "90");
-  assert.equal(publishJobContract.env?.VSCE_DLX_BIN, "pnpm");
+  assert.equal(publishJobContract.env?.VSCE_DLX_BIN, "corepack");
   assert.equal(parsed.env?.PUBLISH_RESOLUTION_RETRY_DELAY, 10);
 
   assert.match(publishJob, /environment:\s*vscode-marketplace/);

--- a/tests/tooling/moonbit-publish-vscode-dlx.test.ts
+++ b/tests/tooling/moonbit-publish-vscode-dlx.test.ts
@@ -8,10 +8,10 @@ import { test } from "node:test";
 import { runMoonScript } from "./_helpers/moonbit.ts";
 import { writeFakeCommand } from "./support/fake-command.ts";
 
-test("publish_vscode_extension allows pnpm dlx builds for vsce signing dependencies", () => {
-  const tempDir = mkdtempSync(path.join(tmpdir(), "moonbit-publish-vsix-pnpm-"));
+test("publish_vscode_extension allows corepack pnpm dlx builds for vsce signing dependencies", () => {
+  const tempDir = mkdtempSync(path.join(tmpdir(), "moonbit-publish-vsix-corepack-"));
   const binDir = path.join(tempDir, "bin");
-  const argsLogPath = path.join(tempDir, "pnpm-args.log");
+  const argsLogPath = path.join(tempDir, "corepack-args.log");
   const vsixPath = path.join(tempDir, "vize.vsix");
   const packageJsonPath = path.join(tempDir, "package.json");
 
@@ -24,18 +24,18 @@ test("publish_vscode_extension allows pnpm dlx builds for vsce signing dependenc
     );
     writeFakeCommand(
       binDir,
-      "pnpm",
+      "corepack",
       [
         "const fs = require('node:fs');",
         "const args = process.argv.slice(2);",
-        "if (args[0] === 'dlx' && args[7] === 'vsce' && args[8] === 'show') {",
-        "  if (fs.existsSync(process.env.PNPM_ARGS_LOG)) {",
+        "if (args[0] === 'pnpm' && args[1] === 'dlx' && args[8] === 'vsce' && args[9] === 'show') {",
+        "  if (fs.existsSync(process.env.COREPACK_ARGS_LOG)) {",
         "    process.stdout.write(JSON.stringify({ versions: [{ version: '0.57.0' }] }));",
         "    process.exit(0);",
         "  }",
         "  process.exit(1);",
         "}",
-        "fs.writeFileSync(process.env.PNPM_ARGS_LOG, args.join('\\n'));",
+        "fs.writeFileSync(process.env.COREPACK_ARGS_LOG, args.join('\\n'));",
         "process.exit(0);",
       ].join("\n"),
     );
@@ -44,13 +44,14 @@ test("publish_vscode_extension allows pnpm dlx builds for vsce signing dependenc
       env: {
         NPM_TAG: "rc",
         PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
-        PNPM_ARGS_LOG: argsLogPath,
-        VSCE_DLX_BIN: "pnpm",
+        COREPACK_ARGS_LOG: argsLogPath,
+        VSCE_DLX_BIN: "corepack",
       },
     });
 
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
     assert.deepEqual(fs.readFileSync(argsLogPath, "utf8").trim().split("\n"), [
+      "pnpm",
       "dlx",
       "--allow-build",
       "@vscode/vsce-sign",

--- a/tools/config/vite-plus/tasks/release.ts
+++ b/tools/config/vite-plus/tasks/release.ts
@@ -39,7 +39,7 @@ export const releaseTasks = defineTasks({
   ),
   "publish:crates": noCacheTask(moonScript("publish_crates")),
   "publish:vscode-extension": noCacheTask(
-    `${installVscodeExtensionDependencies} && VSCE_DLX_BIN=pnpm ${moonScript("publish_vscode_extension", "editors/vscode/dist/vize.vsix")}`,
+    `${installVscodeExtensionDependencies} && VSCE_DLX_BIN=corepack ${moonScript("publish_vscode_extension", "editors/vscode/dist/vize.vsix")}`,
   ),
   publish: noCacheTask(runTasks("publish:npm", "publish:crates")),
 });

--- a/tools/moon/cmd/publish_vscode_extension/main.mbt
+++ b/tools/moon/cmd/publish_vscode_extension/main.mbt
@@ -62,8 +62,12 @@ fn vsce_dlx_args(
   command : String,
   extra_args : Array[String],
 ) -> Array[String] {
-  let args = ["dlx"]
-  if dlx_bin == "pnpm" {
+  let args = []
+  if dlx_bin == "corepack" {
+    args.push("pnpm")
+  }
+  args.push("dlx")
+  if dlx_bin == "pnpm" || dlx_bin == "corepack" {
     args.push("--allow-build")
     args.push("@vscode/vsce-sign")
     args.push("--allow-build")


### PR DESCRIPTION
## Summary
- run VS Code Marketplace vsce tooling as corepack pnpm dlx in release automation
- keep pnpm dlx build approvals for @vscode/vsce-sign and keytar
- pin workflow/local release tasks to the corepack launcher and update regression coverage

## Verification
- rtk corepack pnpm dlx --allow-build @vscode/vsce-sign --allow-build keytar --package @vscode/vsce@^3.3.2 vsce --version
- rtk node --test --test-concurrency=1 tests/tooling/moonbit-publish-vscode-dlx.test.ts tests/tooling/moonbit-publish.test.ts tests/tooling/github-workflows-release-publish.test.ts
- rtk vp check --fix tools/moon/cmd/publish_vscode_extension/main.mbt tests/tooling/moonbit-publish-vscode-dlx.test.ts tests/tooling/github-workflows-release-publish.test.ts tools/config/vite-plus/tasks/release.ts .github/workflows/release.yml
- rtk rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20
- rtk cargo fmt --all --check
- rtk git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790855451&installation_model_id=422833&pr_number=5581&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5581&signature=55dd3b05854e6eb1cd3372fce9c16cccbb71df1bdcf8b5fff614ccac41a5d185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VS Code extension publishing reliability by routing package execution through Corepack.
  * Preserved support for required native dependencies during extension signing and publishing.

* **Tests**
  * Updated publishing checks to validate Corepack-based commands and argument handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->