### PR TITLE
fix(davinci): close residual DOM corpus gaps

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_format_residuals.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_format_residuals.rs
@@ -9,9 +9,10 @@
 
 mod support;
 
-const BATTERY: &[(&str, &str)] = &[(
-    "directus_image_editor_slots_before_show_helper",
-    r#"
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "directus_image_editor_slots_before_show_helper",
+        r#"
 <VDrawer v-model="internalActive" class="modal">
   <template #activator="activatorBinding">
     <slot name="activator" v-bind="activatorBinding" />
@@ -50,7 +51,51 @@ const BATTERY: &[(&str, &str)] = &[(
   </template>
 </VDrawer>
 "#,
-)];
+    ),
+    (
+        "keyed_v_for_with_v_show_keeps_multiline_key_props",
+        r#"
+<div v-for="f in fields" v-show="visible(f)" :key="f.fieldname">
+  <div v-if="f.fieldtype !== 'Check'">{{ f.label }}</div>
+  <FormControl v-model="model[f.fieldname]" />
+</div>
+"#,
+    ),
+    (
+        "keyed_v_for_with_conditional_native_models_has_no_trailing_fragment_comma",
+        r#"
+<section>
+  <div v-for="colorName in Object.keys(customColors)" :key="colorName">
+    <input
+      v-if="isColor(colorName)"
+      :id="`color-input-${colorName}`"
+      type="color"
+      :value="customColors[colorName]"
+      @input="customColors[colorName] = $event.target.value"
+    />
+    <input
+      v-else
+      :id="`color-input-${colorName}`"
+      v-model="customColors[colorName]"
+      @input="setVariable(colorName, customColors[colorName])"
+    />
+  </div> <!-- End of color list -->
+</section>
+"#,
+    ),
+    (
+        "filler_component_before_looped_component_slots_keeps_walk_in_sync",
+        r#"
+<TransitionGroup tag="ul">
+  <Item v-if="empty" key="empty">&nbsp;</Item>
+  <Item v-for="msg in messages" :key="msg.id" class="py-2">
+    <Badge :variant="msg.kind">{{ msg.kind }}</Badge>
+    <span :class="[`text-${msg.kind}`]">{{ msg.text }}</span>
+  </Item>
+</TransitionGroup>
+"#,
+    ),
+];
 
 #[test]
 fn s2_format_residuals_match_the_shipped_dom_lane_byte_for_byte() {

--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_order.rs
@@ -129,6 +129,34 @@ const BATTERY: &[(&str, &str)] = &[
         "if_branch_component_root_slot_static_props_stay_inline",
         r#"<Panel v-if="open" label="fixed" v-slot="{ value }"><span class="value">{{ value }}</span></Panel>"#,
     ),
+    (
+        "for_native_dynamic_text_props_keep_legacy_hoist_order",
+        r#"<div v-for="project in projects" :key="project.name" class="card"><div class="card-content"><div class="content"><p>{{ project.name }}</p><p>{{ project.status }}</p>{{ project.description }}</div></div><footer class="card-footer"><a class="card-footer-item">Open</a></footer></div>"#,
+    ),
+    (
+        "for_direct_dynamic_text_props_keep_legacy_hoist_order",
+        r#"<div v-for="exchange in exchangeRates" :key="exchange.currency" v-tooltip="tooltip(exchange)" class="exchange-rate-row"><p class="value"><span class="input-currency">{{ inputCurrency }} =</span>{{ exchange.value }}</p></div>"#,
+    ),
+    (
+        "for_component_sibling_dynamic_text_props_keep_legacy_hoist_order",
+        r#"<div v-for="disk in disks" :key="disk.id" class="disk-row"><PercentageChart :title="disk.name" /><p class="info"><b>{{ label }}</b>: {{ disk.free }} out of {{ disk.size }}</p><p class="info"><b>{{ mountLabel }}</b>: {{ disk.mount }}</p></div>"#,
+    ),
+    (
+        "conditional_for_static_text_sibling_stays_inline",
+        r#"<section><p v-if="loading">loading</p><div v-for="group in groups" v-else :key="group.id" class="card"><p><strong>Leader: </strong><a v-if="group.leader">{{ group.leader }}</a></p></div></section>"#,
+    ),
+    (
+        "conditional_for_branch_static_child_and_component_props_stay_inline",
+        r#"<div><div v-for="block in blocks" v-if="block.enabled" :key="block.key"><div v-if="selected === block.key"><div class="selected-corner"></div><div v-html="icons.check"></div></div><strike class="gray-200">$60</strike></div></div>"#,
+    ),
+    (
+        "conditional_for_static_tail_child_stays_inline",
+        r#"<div><div v-for="category in categories" v-if="category.visible" :key="category.identifier"><Row :category="category" /><div class="fill-height"></div></div></div>"#,
+    ),
+    (
+        "nested_conditional_for_slot_carrier_props_stay_inline",
+        r#"<div><div v-for="row in rows" v-if="row.show" :key="row.id"><div v-for="item in row.items" :key="item.id"><Mount><span slot="popoverContent"><h4>{{ item.name }}</h4></span></Mount></div></div></div>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_once.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_once.rs
@@ -80,6 +80,16 @@ const CASES: &[Case] = &[
         sites: &[],
     },
     Case {
+        name: "custom_directive_is_resolved_but_not_wrapped",
+        src: r#"<h3 v-once v-example="heading">{{ question }}</h3>"#,
+        sites: &["1 /* TEXT */"],
+    },
+    Case {
+        name: "component_custom_directive_is_resolved_but_not_wrapped",
+        src: r#"<Foo v-once v-example="heading" />"#,
+        sites: &[],
+    },
+    Case {
         name: "event_binding_is_omitted_from_cache_initializer",
         src: r###"<button v-once class="btn" @click="closeWithAction()">{{ $t("viewAchievements") }}</button>"###,
         sites: &["1 /* TEXT */"],

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -163,6 +163,9 @@ struct EmitCx<'facts> {
     once_element_depth: u32,
     /// Slot objects inside `v-for` carry `_: 2 /* DYNAMIC */`.
     in_v_for: bool,
+    /// Emission is inside a `v-for` render-list item that was lowered from
+    /// a `v-if` branch, where descendant hoists stay inline like the shipped lane.
+    conditional_v_for_item: bool,
     /// The next array child is the single component child of a lowered
     /// `<template v-for>` item; its root props inherit the old item-root hoist.
     template_for_item_single_root: bool,
@@ -171,6 +174,8 @@ struct EmitCx<'facts> {
     template_for_item_root_id: Option<NodeId>,
     /// The current branch root was unwrapped from `<template v-if>`.
     template_if_branch_root: bool,
+    /// The current `v-for` branch root came from an authored `<template v-if>`.
+    template_if_for_branch_root: bool,
     /// A native root unwrapped from `<template v-for>` drops an authored
     /// child key unless the key was authored on the template wrapper.
     suppress_template_for_child_key: bool,
@@ -243,9 +248,11 @@ pub fn emit_dom(lowered: &Lowered<'_>, facts: &S2Facts) -> Result<DomEmit, EmitE
         once_depth: 0,
         once_element_depth: 0,
         in_v_for: false,
+        conditional_v_for_item: false,
         template_for_item_single_root: false,
         template_for_item_root_id: None,
         template_if_branch_root: false,
+        template_if_for_branch_root: false,
         suppress_template_for_child_key: false,
         skip_memo: false,
         slot_param_depth: 0,

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -2,6 +2,7 @@
 
 mod call_props;
 mod checks;
+mod children_arg;
 mod preamble;
 
 use call_props::{
@@ -302,41 +303,20 @@ fn emit_call(
     } else if emit_flag || has_slots || has_array || filler_default_props_placeholder {
         cx.buf.push(", null");
     }
-    if array {
-        if has_array {
-            cx.buf.push(", ");
-            cx.with_static_vnode_hoist(true, |cx| {
-                builtin::emit_array_children(cx, &component.children, if_key.is_some())
-            })?;
-        } else if emit_flag {
-            cx.buf.push(", null");
-        }
-    } else if create {
-        cx.buf.push(", ");
-        cx.with_static_vnode_hoist(true, |cx| {
-            create_slots::emit_create_slots(cx, &component.children, spread.as_ref())
-        })?;
-    } else if let Some(facts) = facts {
-        cx.buf.push(", ");
-        cx.with_static_vnode_hoist(true, |cx| {
-            let previous = cx.transition_slot_root;
-            cx.transition_slot_root = previous || transition_slot_root;
-            let result = slots::emit_slots(
-                cx,
-                &component.children,
-                facts,
-                spread.as_ref(),
-                &component.bindings,
-            );
-            cx.transition_slot_root = previous;
-            result
-        })?;
-    } else if let Some(spread) = spread {
-        cx.buf.push(", ");
-        cx.buf.push(spread.as_str());
-    } else if emit_flag {
-        cx.buf.push(", null");
-    }
+    children_arg::emit(
+        cx,
+        component,
+        children_arg::Args {
+            array,
+            has_array,
+            create,
+            facts,
+            spread: spread.as_ref(),
+            emit_flag,
+            keyed_branch: if_key.is_some(),
+            transition_slot_root,
+        },
+    )?;
     if emit_flag {
         emit_patch_flag(cx, flag);
     }

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -77,6 +77,9 @@ pub(super) fn can_hoist_static_props(
     if blocked_by_context {
         return Ok(false);
     }
+    if cx.conditional_v_for_item {
+        return Ok(false);
+    }
     let text_only_default = slots::has_text_only_implicit_default(&component.children);
     let has_runtime_directive = directive::has_runtime(&component.bindings);
     let nested_slot_key = cx.slot_param_depth > 0

--- a/crates/vize_s1_to_s2/src/emit/component/children_arg.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/children_arg.rs
@@ -1,0 +1,73 @@
+use vize_s2::op::ComponentOp;
+
+use crate::pass::SlotFacts;
+
+use super::super::js::RawJs;
+use super::super::{EmitCx, EmitError, builtin, create_slots, create_slots_walk, slots};
+
+pub(super) struct Args<'a> {
+    pub(super) array: bool,
+    pub(super) has_array: bool,
+    pub(super) create: bool,
+    pub(super) facts: Option<&'a SlotFacts>,
+    pub(super) spread: Option<&'a RawJs<'a>>,
+    pub(super) emit_flag: bool,
+    pub(super) keyed_branch: bool,
+    pub(super) transition_slot_root: bool,
+}
+
+pub(super) fn emit(
+    cx: &mut EmitCx<'_>,
+    component: &ComponentOp<'_>,
+    args: Args<'_>,
+) -> Result<(), EmitError> {
+    let emitted = if args.array {
+        if args.has_array {
+            cx.buf.push(", ");
+            cx.with_static_vnode_hoist(true, |cx| {
+                builtin::emit_array_children(cx, &component.children, args.keyed_branch)
+            })?;
+            true
+        } else if args.emit_flag {
+            cx.buf.push(", null");
+            false
+        } else {
+            false
+        }
+    } else if args.create {
+        cx.buf.push(", ");
+        cx.with_static_vnode_hoist(true, |cx| {
+            create_slots::emit_create_slots(cx, &component.children, args.spread)
+        })?;
+        true
+    } else if let Some(facts) = args.facts {
+        cx.buf.push(", ");
+        cx.with_static_vnode_hoist(true, |cx| {
+            let previous = cx.transition_slot_root;
+            cx.transition_slot_root = previous || args.transition_slot_root;
+            let result = slots::emit_slots(
+                cx,
+                &component.children,
+                facts,
+                args.spread,
+                &component.bindings,
+            );
+            cx.transition_slot_root = previous;
+            result
+        })?;
+        true
+    } else if let Some(spread) = args.spread {
+        cx.buf.push(", ");
+        cx.buf.push(spread.as_str());
+        false
+    } else if args.emit_flag {
+        cx.buf.push(", null");
+        false
+    } else {
+        false
+    };
+    if !emitted {
+        create_slots_walk::skip_ops(cx, &component.children.ops);
+    }
+    Ok(())
+}

--- a/crates/vize_s1_to_s2/src/emit/once.rs
+++ b/crates/vize_s1_to_s2/src/emit/once.rs
@@ -6,7 +6,6 @@ use vize_s2::op::{BindingOp, ComponentOp, ElementOp, Op};
 
 use super::buf::Buf;
 use super::builtin;
-use super::directive;
 use super::hoist::is_hoistable;
 use super::js::asset_ident;
 use super::vnode;
@@ -27,24 +26,22 @@ pub(super) fn emit_element(
     for_item: bool,
 ) -> Result<(), EmitError> {
     emit_cached(cx, |cx| {
-        directive::wrap_element(cx, element, |cx| {
-            cx.buf.use_create_element_vnode();
-            let previous_once_element_depth = cx.once_element_depth;
-            cx.once_element_depth = 0;
-            cx.once_depth += 1;
-            let result = vnode::emit_call(
-                cx,
-                element,
-                /* block */ false,
-                key,
-                /* hoist */ (false, None, super::props_static::PropHoistPosition::Nested),
-                for_item,
-                /* once */ true,
-            );
-            cx.once_depth -= 1;
-            cx.once_element_depth = previous_once_element_depth;
-            result
-        })
+        cx.buf.use_create_element_vnode();
+        let previous_once_element_depth = cx.once_element_depth;
+        cx.once_element_depth = 0;
+        cx.once_depth += 1;
+        let result = vnode::emit_call(
+            cx,
+            element,
+            /* block */ false,
+            key,
+            /* hoist */ (false, None, super::props_static::PropHoistPosition::Nested),
+            for_item,
+            /* once */ true,
+        );
+        cx.once_depth -= 1;
+        cx.once_element_depth = previous_once_element_depth;
+        result
     })
 }
 
@@ -57,14 +54,12 @@ pub(super) fn emit_component(
 ) -> Result<(), EmitError> {
     skip_or_hoist_component_children(cx, component);
     emit_cached(cx, |cx| {
-        directive::wrap_component(cx, component, |cx| {
-            cx.buf.use_create_vnode();
-            cx.buf.push(Buf::create_vnode_alias());
-            cx.buf.push("(");
-            emit_component_target(cx, component)?;
-            cx.buf.push(")");
-            Ok(())
-        })
+        cx.buf.use_create_vnode();
+        cx.buf.push(Buf::create_vnode_alias());
+        cx.buf.push("(");
+        emit_component_target(cx, component)?;
+        cx.buf.push(")");
+        Ok(())
     })
 }
 

--- a/crates/vize_s1_to_s2/src/emit/props.rs
+++ b/crates/vize_s1_to_s2/src/emit/props.rs
@@ -288,7 +288,7 @@ pub(super) fn emit_bind_props(
             if_key,
             skip_normalize: false,
             empty_key_multiline: for_item
-                && (super::directive::has_custom(bindings) || once_layout || force_multiline),
+                && (super::directive::has_runtime(bindings) || once_layout || force_multiline),
             is_plain_element,
             for_item,
             suppress_once_cache_dynamic: once_cache_initializer,

--- a/crates/vize_s1_to_s2/src/emit/tpl.rs
+++ b/crates/vize_s1_to_s2/src/emit/tpl.rs
@@ -97,7 +97,11 @@ fn unwrap_if(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<()
         }
         [Op::For(for_op)] => {
             let id = cx.walk.mint();
-            super::emit_for_op(cx, for_op, id, Some(key))
+            let previous = cx.template_if_for_branch_root;
+            cx.template_if_for_branch_root = true;
+            let result = super::emit_for_op(cx, for_op, id, Some(key));
+            cx.template_if_for_branch_root = previous;
+            result
         }
         _ => Err(EmitError::unsupported_at(
             Reason::TemplateUnwrapShape,

--- a/crates/vize_s1_to_s2/src/emit/vfor.rs
+++ b/crates/vize_s1_to_s2/src/emit/vfor.rs
@@ -134,8 +134,12 @@ pub(super) fn emit_for(
     }
     cx.buf.push("return ");
     let prev_in_v_for = cx.in_v_for;
+    let prev_conditional_v_for_item = cx.conditional_v_for_item;
+    let from_template_if_branch = cx.template_if_for_branch_root;
     let scope_mark = cx.push_scope(id);
     cx.in_v_for = true;
+    cx.conditional_v_for_item =
+        prev_conditional_v_for_item || (fragment_key.is_some() && !from_template_if_branch);
     let item = if from_template {
         super::tpl::emit_for_template_item(
             cx,
@@ -148,6 +152,7 @@ pub(super) fn emit_for(
     } else {
         emit_plain_item(cx, for_op, bind_len, stable)
     };
+    cx.conditional_v_for_item = prev_conditional_v_for_item;
     cx.in_v_for = prev_in_v_for;
     cx.pop_scope(scope_mark);
     item?;
@@ -188,12 +193,15 @@ fn emit_memo_body(
     cx.buf.newline();
     cx.buf.push("const _item = ");
     let prev_in_v_for = cx.in_v_for;
+    let prev_conditional_v_for_item = cx.conditional_v_for_item;
     let prev_skip_memo = cx.skip_memo;
     let scope_mark = cx.push_scope(id);
     cx.in_v_for = true;
+    cx.conditional_v_for_item = prev_conditional_v_for_item;
     cx.skip_memo = true;
     let item = emit_plain_item(cx, for_op, bind_len, stable);
     cx.skip_memo = prev_skip_memo;
+    cx.conditional_v_for_item = prev_conditional_v_for_item;
     cx.in_v_for = prev_in_v_for;
     cx.pop_scope(scope_mark);
     item?;

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -19,8 +19,9 @@ use super::props_static::PropHoistPosition;
 use super::vnode_children::emit_children;
 use super::{EmitCx, EmitError};
 use checks::{
-    direct_static_children_hoisted, has_cloak, has_direct_interpolation_child,
-    has_dynamic_key_binding, has_prop_bindings, template_if_branch_root_has_direct_interpolation,
+    direct_static_children_hoisted, has_cloak, has_dynamic_key_binding,
+    has_interpolation_descendant, has_prop_bindings,
+    template_if_branch_root_has_direct_interpolation,
 };
 
 pub(super) fn emit_unique_element(
@@ -214,12 +215,12 @@ pub(super) fn emit_call(
         && cx.slot_param_depth == 0
         && !template_if_branch_root_has_direct_interpolation(cx, element, if_key);
     let has_binds = has_prop_bindings(&element.bindings);
-    let nested_v_for_direct_text = cx.in_v_for
+    let conditional_v_for_dynamic_text = cx.conditional_v_for_item
         && matches!(prop_hoist, PropHoistPosition::Nested)
-        && has_direct_interpolation_child(element);
+        && has_interpolation_descendant(element);
     let hoisted_props = if allow_hoist
         && if_key.is_none()
-        && !nested_v_for_direct_text
+        && !conditional_v_for_dynamic_text
         && super::props_static::should_hoist(cx, id, prop_hoist)
     {
         super::props_static::root_hoist_props(&element.attributes, &element.bindings)?

--- a/crates/vize_s1_to_s2/src/emit/vnode/checks.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode/checks.rs
@@ -41,6 +41,29 @@ pub(super) fn has_direct_interpolation_child(element: &ElementOp<'_>) -> bool {
         .any(|op| matches!(op, Op::Interpolation(_)))
 }
 
+pub(super) fn has_interpolation_descendant(element: &ElementOp<'_>) -> bool {
+    region_has_interpolation_descendant(&element.children.ops)
+}
+
+fn op_has_interpolation_descendant(op: &Op<'_>) -> bool {
+    match op {
+        Op::Interpolation(_) => true,
+        Op::Element(element) => has_interpolation_descendant(element),
+        Op::Component(component) => region_has_interpolation_descendant(&component.children.ops),
+        Op::If(if_op) => if_op
+            .branches
+            .iter()
+            .any(|branch| region_has_interpolation_descendant(&branch.region.ops)),
+        Op::For(for_op) => region_has_interpolation_descendant(&for_op.region.ops),
+        Op::Slot(slot) => region_has_interpolation_descendant(&slot.fallback.ops),
+        Op::Text(_) => false,
+    }
+}
+
+fn region_has_interpolation_descendant(ops: &[Op<'_>]) -> bool {
+    ops.iter().any(op_has_interpolation_descendant)
+}
+
 pub(super) fn has_dynamic_key_binding(element: &ElementOp<'_>) -> bool {
     element.bindings.iter().any(|binding| {
         matches!(

--- a/crates/vize_s1_to_s2/src/emit/vnode_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_static.rs
@@ -14,6 +14,9 @@ pub(super) fn should_hoist_static_children(
     branch_root: bool,
     for_item: bool,
 ) -> bool {
+    if cx.conditional_v_for_item {
+        return false;
+    }
     if branch_root && cx.template_if_branch_root && has_direct_interpolation_child(element) {
         return false;
     }

--- a/crates/vize_s1_to_s2/src/lower/text/condense/boundary.rs
+++ b/crates/vize_s1_to_s2/src/lower/text/condense/boundary.rs
@@ -50,7 +50,7 @@ pub(super) fn comment_separated_element_gap_with_newline(
     }
     let mut has_newline = false;
     let mut saw_whitespace = false;
-    while index < hi {
+    while index < children.len() {
         match children.get(index) {
             Some(SurfaceChild::Text(token)) if token.text.chars().all(super::is_vue_ws) => {
                 saw_whitespace = true;


### PR DESCRIPTION
## Summary
- align remaining S2 DOM hoist behavior for conditional v-for branches and nested slot carriers
- keep v-once runtime directives resolved without wrapping cache initializers
- advance skipped component-slot walks so later slots keep the shipped render order

## Verification
- cargo fmt --all --check
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10
- cargo test -p vize_atelier_dom --test davinci_s2_hoist_order -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_once -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_format_residuals -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_static_hoist -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_vslots -- --nocapture
- cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture dom_emit_agrees_on_sfc_templates
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git/{airi,bootstrap-vue,buefy,cube-ui,dbx,dashy,element,frappe-builder,frappe-crm,frpc-desktop,habitica,hoppscotch} cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture dom_emit_agrees_on_sfc_templates

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790858187&installation_model_id=422833&pr_number=5582&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5582&signature=34e57e1150f60230f7e3a8ce2637b91247ef49ddae8d8b3864f317d1f4a14512"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering for conditional loops, keyed content, dynamic text, slots, and nested interpolations.
  * Corrected static content and property handling in conditional loop items.
  * Fixed whitespace and newline detection across separated text and comment regions.
  * Improved `v-once` behavior with custom directives.

* **Tests**
  * Added extensive regression coverage for loop ordering, DOM output, slots, conditional models, and `v-once` scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->