### PR TITLE
fix(davinci): finish DOM corpus residual parity

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dom_namespace.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dom_namespace.rs
@@ -57,6 +57,14 @@ const BATTERY: &[(&str, &str)] = &[
         "component_slot_static_svg_child",
         r#"<Foo><svg><path d="M0 0h1v1z"/></svg></Foo>"#,
     ),
+    (
+        "nested_template_if_static_svg_keeps_parent_vnode",
+        r#"<button :class="x"><div><template v-if="ok"><svg><path /></svg></template></div></button>"#,
+    ),
+    (
+        "template_if_directive_button_static_svg_keeps_parent_vnode",
+        r#"<div v-if="root"><div><template v-if="ok"><button v-tip @click="go"><svg><path /></svg></button></template></div></div>"#,
+    ),
     ("mathml_static_tree", "<math><mi>x</mi></math>"),
     (
         "v_if_static_mathml_child",

--- a/crates/vize_atelier_dom/tests/davinci_s2_helper_order.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_helper_order.rs
@@ -41,6 +41,10 @@ const BATTERY: &[(&str, &str)] = &[
         "unicode_identifier_suffix_does_not_reorder_helpers",
         r#"<div :class="classes" :style="é_normalizeStyle() ? styles : fallback"></div>"#,
     ),
+    (
+        "normalize_props_guard_precedes_later_merge_props",
+        r#"<Foo v-bind="props"><template #default="{ item }"><Bar v-bind="item.props" :class="item.class" /></template></Foo>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_outlets.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_outlets.rs
@@ -133,6 +133,10 @@ const BATTERY: &[(&str, &str)] = &[
         "named_mixed_props",
         r#"<slot name="header" foo="1" :bar="b"></slot>"#,
     ),
+    (
+        "dynamic_style_prop_normalizes",
+        r#"<slot :style="{ color }"></slot>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_static_vnode_hoist.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_static_vnode_hoist.rs
@@ -61,6 +61,10 @@ const BATTERY: &[(&str, &str)] = &[
         "pure_static_vnode_hoist_drops_descendant_patchless_binds",
         r#"<Foo><button :style="{ transform: 'none' }"><span class="x" :style="{ color: 'red' }"></span></button></Foo>"#,
     ),
+    (
+        "template_if_component_slot_resets_branch_root_before_nested_if",
+        r#"<Foo><template v-if="show"><ClientOnly><template #fallback><span class="subtle">(-)</span></template><span v-if="pending">(<span class="spinner"></span>)</span><span v-else-if="total !== null"><span class="subtle">(</span>{{ total }}<span class="subtle">)</span></span><span v-else class="subtle">(-)</span></ClientOnly></template></Foo>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_v_for_child_props.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_v_for_child_props.rs
@@ -47,6 +47,10 @@ const BATTERY: &[(&str, &str)] = &[
 </div>
 "#,
     ),
+    (
+        "document_global_key_for_item_registers_unused_hoist",
+        r#"<div><div v-for="document in docs" :key="document.id" class="pill"><img v-if="document.logoUrl" :src="document.logoUrl" />{{ document.title }}</div></div>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_v_pre.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_v_pre.rs
@@ -1,0 +1,27 @@
+//! `v-pre` DOM parity witnesses.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "interpolation_renders_as_static_text",
+        r#"<div v-pre class="code">{{ variable }}</div>"#,
+    ),
+    (
+        "multiline_interpolation_condenses_as_static_text",
+        r#"<code v-pre class="font-code">
+  {{ variable }}
+</code>"#,
+    ),
+];
+
+#[test]
+fn s2_v_pre_matches_the_shipped_dom_lane_byte_for_byte() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_s1_to_s2/src/emit/buf/helper_order.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/helper_order.rs
@@ -45,7 +45,7 @@ impl Buf {
             (2, Some(_), None, _, _) => Ordering::Less,
             (2, None, Some(_), _, _) => Ordering::Greater,
             (2, None, None, Some(left_pos), Some(right_pos)) => left_pos.cmp(&right_pos),
-            (5, _, _, Some(left_pos), Some(right_pos)) => left_pos.cmp(&right_pos),
+            (5, _, _, _, _) => self.rank_five_key(left).cmp(&self.rank_five_key(right)),
             (10, _, _, _, _)
                 if self.used & Helper::ResolveDirective.bit() != 0
                     && self.used & Helper::CreateText.bit() != 0
@@ -73,6 +73,74 @@ impl Buf {
             offset += hoist.len();
         }
         helper_call_position(self.code.as_str(), alias).map(|position| offset + position)
+    }
+
+    fn rank_five_key(&self, helper: Helper) -> (usize, u8, u8) {
+        if let Some((position, order)) = self.normalize_props_guard_merge_order(helper) {
+            return (position, order, rank_five_all_order(helper));
+        }
+        let position = self
+            .first_alias_position(helper)
+            .map(alias_sort_position)
+            .or_else(|| self.virtual_alias_position(helper))
+            .unwrap_or_else(|| usize::MAX - 16 + usize::from(rank_five_all_order(helper)));
+        (position, 0, rank_five_all_order(helper))
+    }
+
+    fn normalize_props_guard_merge_order(&self, helper: Helper) -> Option<(usize, u8)> {
+        let normalize_pos = self.first_alias_position(Helper::NormalizeProps)?;
+        let merge_pos = self.first_alias_position(Helper::MergeProps)?;
+        if normalize_pos >= merge_pos {
+            return None;
+        }
+        let base = alias_sort_position(merge_pos);
+        match helper {
+            Helper::GuardReactiveProps
+                if self
+                    .first_alias_position(helper)
+                    .is_some_and(|position| position > merge_pos) =>
+            {
+                Some((base, 0))
+            }
+            Helper::MergeProps => Some((base, 1)),
+            _ => None,
+        }
+    }
+
+    fn virtual_alias_position(&self, helper: Helper) -> Option<usize> {
+        let index = self
+            .used_order
+            .iter()
+            .position(|candidate| candidate.bit() == helper.bit())?;
+        self.used_order[..index]
+            .iter()
+            .rev()
+            .find_map(|candidate| self.first_alias_position(*candidate))
+            .map(|position| alias_sort_position(position) + 1)
+            .or_else(|| {
+                self.used_order[index + 1..]
+                    .iter()
+                    .find_map(|candidate| self.first_alias_position(*candidate))
+                    .map(|position| alias_sort_position(position).saturating_sub(1))
+            })
+    }
+}
+
+fn alias_sort_position(position: usize) -> usize {
+    position.saturating_mul(2)
+}
+
+fn rank_five_all_order(helper: Helper) -> u8 {
+    match helper {
+        Helper::NormalizeClass => 0,
+        Helper::NormalizeStyle => 1,
+        Helper::NormalizeProps => 2,
+        Helper::GuardReactiveProps => 3,
+        Helper::MergeProps => 4,
+        Helper::ToHandlers => 5,
+        Helper::ToHandlerKey => 6,
+        Helper::Camelize => 7,
+        _ => 8,
     }
 }
 

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -231,11 +231,11 @@ fn emit_call(
     let branch_unused_hoist = !has_component_root_slot
         && !has_custom
         && !for_item
-        && !cx.in_v_for
         && if_key.is_some()
         && cx.template_if_branch_root
         && hoistable_static_props.is_some()
-        && static_nested;
+        && (static_nested
+            || call_props::children_are_direct_static_vnode_hoists(&component.children));
     let unused_hoist = hoisted_static_props.is_none()
         && ((can_hoist_static_props && static_nested) || branch_unused_hoist);
     if unused_hoist {
@@ -303,7 +303,11 @@ fn emit_call(
     } else if emit_flag || has_slots || has_array || filler_default_props_placeholder {
         cx.buf.push(", null");
     }
-    children_arg::emit(
+    let previous_template_if_branch_root = cx.template_if_branch_root;
+    if previous_template_if_branch_root {
+        cx.template_if_branch_root = false;
+    }
+    let children_result = children_arg::emit(
         cx,
         component,
         children_arg::Args {
@@ -316,7 +320,9 @@ fn emit_call(
             keyed_branch: if_key.is_some(),
             transition_slot_root,
         },
-    )?;
+    );
+    cx.template_if_branch_root = previous_template_if_branch_root;
+    children_result?;
     if emit_flag {
         emit_patch_flag(cx, flag);
     }

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -51,6 +51,9 @@ pub(super) fn hoistable_static_props(
     hoist_attrs: &[&Attribute<'_>],
 ) -> Result<Option<ComponentHoistProps>, EmitError> {
     if skip_is {
+        if has_rendered_binds(component, skip_is) {
+            return Ok(None);
+        }
         return Ok((!hoist_attrs.is_empty()).then(|| ComponentHoistProps {
             source: compact_props_object(hoist_attrs.iter().copied()),
             dynamic_values: false,
@@ -92,6 +95,8 @@ pub(super) fn can_hoist_static_props(
         has_slots && children_are_forwarded_slot_outlets_only(&component.children);
     let direct_static_slot_vnodes =
         has_slots && children_are_direct_static_vnode_hoists(&component.children);
+    let mixed_static_slot_vnode =
+        has_slots && children_are_mixed_text_and_static_vnode_hoists(&component.children);
     let dynamic_forwarded_slot_hoist = props.dynamic_values
         && forwarded_slot_only
         && !has_runtime_directive
@@ -99,6 +104,11 @@ pub(super) fn can_hoist_static_props(
         && cx.slot_param_depth == 0;
     let dynamic_direct_static_slot_hoist = props.dynamic_values
         && direct_static_slot_vnodes
+        && !has_runtime_directive
+        && !cx.in_v_for
+        && cx.slot_param_depth == 0;
+    let dynamic_mixed_static_slot_hoist = props.dynamic_values
+        && mixed_static_slot_vnode
         && !has_runtime_directive
         && !cx.in_v_for
         && cx.slot_param_depth == 0;
@@ -114,7 +124,8 @@ pub(super) fn can_hoist_static_props(
         || !has_slots
         || text_only_default
         || dynamic_forwarded_slot_hoist
-        || dynamic_direct_static_slot_hoist;
+        || dynamic_direct_static_slot_hoist
+        || dynamic_mixed_static_slot_hoist;
     let transition_props_slot_hoist = transition_props_slot_hoist(component, has_slots);
     Ok((!is_template_for_root
         && dynamic_props_hoistable
@@ -179,6 +190,21 @@ pub(super) fn children_are_direct_static_vnode_hoists(region: &Region<'_>) -> bo
             continue;
         }
         match op {
+            Op::Element(element) if super::super::hoist::is_hoistable(element) => found = true,
+            _ => return false,
+        }
+    }
+    found
+}
+
+fn children_are_mixed_text_and_static_vnode_hoists(region: &Region<'_>) -> bool {
+    let mut found = false;
+    for op in region.ops.iter() {
+        if slots::is_whitespace_text(op) {
+            continue;
+        }
+        match op {
+            Op::Text(_) => {}
             Op::Element(element) if super::super::hoist::is_hoistable(element) => found = true,
             _ => return false,
         }
@@ -257,11 +283,19 @@ fn component_has_static_bind_props(component: &ComponentOp<'_>) -> Result<bool, 
 pub(super) fn transition_props_slot_hoist(component: &ComponentOp<'_>, has_slots: bool) -> bool {
     matches!(component.name, "Transition" | "transition")
         && has_slots
-        && has_direct_slot_outlet(&component.children)
+        && !has_direct_slot_outlet(&component.children)
+        && has_element_with_direct_slot_outlet(&component.children)
 }
 
 fn has_direct_slot_outlet(region: &Region<'_>) -> bool {
     region.ops.iter().any(|op| matches!(op, Op::Slot(_)))
+}
+
+fn has_element_with_direct_slot_outlet(region: &Region<'_>) -> bool {
+    region
+        .ops
+        .iter()
+        .any(|op| matches!(op, Op::Element(element) if element.bindings.is_empty() && has_direct_slot_outlet(&element.children)))
 }
 
 pub(super) fn emit_dynamic_props(cx: &mut EmitCx<'_>, names: &[String]) {

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -126,8 +126,12 @@ pub(super) fn can_hoist_static_props(
         || dynamic_forwarded_slot_hoist
         || dynamic_direct_static_slot_hoist
         || dynamic_mixed_static_slot_hoist;
+    let transition_direct_slot_outlet = matches!(component.name, "Transition" | "transition")
+        && has_slots
+        && has_direct_slot_outlet(&component.children);
     let transition_props_slot_hoist = transition_props_slot_hoist(component, has_slots);
-    Ok((!is_template_for_root
+    Ok((!transition_direct_slot_outlet
+        && !is_template_for_root
         && dynamic_props_hoistable
         && props_static::should_hoist(cx, id, props_static::PropHoistPosition::Nested))
         || (is_template_for_root
@@ -143,6 +147,7 @@ pub(super) fn can_hoist_static_props(
             && !has_runtime_directive
             && (hoist_context || transition_props_slot_hoist))
         || (props.dynamic_values
+            && !transition_direct_slot_outlet
             && cx.slot_param_depth == 0
             && !cx.in_v_for
             && dynamic_props_hoistable)
@@ -283,8 +288,9 @@ fn component_has_static_bind_props(component: &ComponentOp<'_>) -> Result<bool, 
 pub(super) fn transition_props_slot_hoist(component: &ComponentOp<'_>, has_slots: bool) -> bool {
     matches!(component.name, "Transition" | "transition")
         && has_slots
-        && !has_direct_slot_outlet(&component.children)
-        && has_element_with_direct_slot_outlet(&component.children)
+        && (children_are_forwarded_slot_outlets_only(&component.children)
+            || (!has_direct_slot_outlet(&component.children)
+                && has_element_with_direct_slot_outlet(&component.children)))
 }
 
 fn has_direct_slot_outlet(region: &Region<'_>) -> bool {

--- a/crates/vize_s1_to_s2/src/emit/helper_preference/slot_order.rs
+++ b/crates/vize_s1_to_s2/src/emit/helper_preference/slot_order.rs
@@ -185,54 +185,43 @@ pub(super) fn op_is_direct_slot_carrier(op: &Op<'_>) -> bool {
 }
 
 fn op_precedes_slot_outlet_as_carrier(op: &Op<'_>) -> bool {
-    op_has_component_slot_template_carrier(op) && !op_has_slot_outlet(op)
+    op_has_direct_slot_carrier(op) && !op_has_slot_outlet(op)
 }
 
-fn has_slot_template_carrier(region: &Region<'_>) -> bool {
-    region.ops.iter().any(|op| match op {
+fn region_has_direct_slot_carrier(region: &Region<'_>) -> bool {
+    region.ops.iter().any(op_has_direct_slot_carrier)
+}
+
+fn op_has_direct_slot_carrier(op: &Op<'_>) -> bool {
+    match op {
         Op::Element(element) => slots::is_slot_template(element),
+        Op::Component(component) => {
+            component.bindings.iter().any(component_slot_content)
+                || component_tree_has_slot_carrier(&component.children)
+        }
         Op::If(if_op) => if_op
             .branches
             .iter()
-            .any(|branch| has_slot_template_carrier(&branch.region)),
-        Op::For(for_op) => has_slot_template_carrier(&for_op.region),
-        Op::Component(_) | Op::Text(_) | Op::Interpolation(_) | Op::Slot(_) => false,
-    })
-}
-
-fn op_has_component_slot_template_carrier(op: &Op<'_>) -> bool {
-    match op {
-        Op::Element(element) => {
-            slots::is_slot_template(element)
-                || element
-                    .children
-                    .ops
-                    .iter()
-                    .any(op_has_component_slot_template_carrier)
-        }
-        Op::Component(component) => {
-            component.bindings.iter().any(component_slot_content)
-                || has_slot_template_carrier(&component.children)
-                || component
-                    .children
-                    .ops
-                    .iter()
-                    .any(op_has_component_slot_template_carrier)
-        }
-        Op::If(if_op) => if_op.branches.iter().any(|branch| {
-            branch
-                .region
-                .ops
-                .iter()
-                .any(op_has_component_slot_template_carrier)
-        }),
-        Op::For(for_op) => for_op
-            .region
-            .ops
-            .iter()
-            .any(op_has_component_slot_template_carrier),
+            .any(|branch| region_has_direct_slot_carrier(&branch.region)),
+        Op::For(for_op) => region_has_direct_slot_carrier(&for_op.region),
         Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => false,
     }
+}
+
+fn component_tree_has_slot_carrier(region: &Region<'_>) -> bool {
+    region.ops.iter().any(|op| match op {
+        Op::Element(element) => slots::is_slot_template(element),
+        Op::Component(component) => {
+            component.bindings.iter().any(component_slot_content)
+                || component_tree_has_slot_carrier(&component.children)
+        }
+        Op::If(if_op) => if_op
+            .branches
+            .iter()
+            .any(|branch| component_tree_has_slot_carrier(&branch.region)),
+        Op::For(for_op) => component_tree_has_slot_carrier(&for_op.region),
+        Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => false,
+    })
 }
 
 pub(super) fn has_slot_outlet(region: &Region<'_>) -> bool {

--- a/crates/vize_s1_to_s2/src/emit/hoist.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist.rs
@@ -115,16 +115,7 @@ pub(super) fn is_hoistable(element: &ElementOp<'_>) -> bool {
 }
 
 pub(super) fn is_static_element_tree(element: &ElementOp<'_>) -> bool {
-    super::props_static::static_vnode_surface_can_hoist(&element.attributes, &element.bindings)
-        && element.children.ops.iter().all(is_static_tree_child)
-}
-
-fn is_static_tree_child(op: &Op<'_>) -> bool {
-    match op {
-        Op::Text(_) => true,
-        Op::Element(element) => is_static_element_tree(element),
-        _ => false,
-    }
+    super::vnode_static::can_whole_hoist_static_element(element)
 }
 
 fn walk_hoisted(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) {

--- a/crates/vize_s1_to_s2/src/emit/merge/args.rs
+++ b/crates/vize_s1_to_s2/src/emit/merge/args.rs
@@ -41,6 +41,7 @@ pub(super) fn key_and_bind_spread(args: &[Arg<'_>]) -> bool {
             Arg::Object {
                 if_key: Some(_),
                 pieces,
+                suppressed_authored_key: false,
                 ..
             },
             Arg::BindSpread(_),

--- a/crates/vize_s1_to_s2/src/emit/namespace.rs
+++ b/crates/vize_s1_to_s2/src/emit/namespace.rs
@@ -34,6 +34,7 @@ pub(super) fn crosses_boundary(
     element.namespace != cx.parent_ns
         || child_namespace_crosses(element)
         || structural_children_cross_boundary(
+            cx.source,
             element.namespace,
             &element.children,
             direct_static_children_hoisted,
@@ -41,16 +42,19 @@ pub(super) fn crosses_boundary(
 }
 
 fn structural_children_cross_boundary(
+    source: &str,
     ns: Namespace,
     children: &Region<'_>,
     direct_static_children_hoisted: bool,
 ) -> bool {
     children.ops.iter().any(|child| match child {
         Op::Element(element) => child_crosses_direct(ns, element, direct_static_children_hoisted),
-        Op::If(if_op) => if_op
-            .branches
-            .iter()
-            .any(|branch| ensure_sufficient_stack(|| children_cross_boundary(ns, &branch.region))),
+        Op::If(if_op) => if_op.branches.iter().any(|branch| {
+            ensure_sufficient_stack(|| {
+                !authored_template_branch(source, branch)
+                    && children_cross_boundary(ns, &branch.region)
+            })
+        }),
         Op::For(for_op) => ensure_sufficient_stack(|| children_cross_boundary(ns, &for_op.region)),
         Op::Component(_) | Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => false,
     })
@@ -90,6 +94,18 @@ fn child_namespace_crosses(element: &ElementOp<'_>) -> bool {
             .ops
             .iter()
             .any(|op| matches!(op, Op::Element(_) | Op::If(_) | Op::For(_)))
+}
+
+fn authored_template_branch(source: &str, branch: &vize_s2::op::IfBranch<'_>) -> bool {
+    let Ok(start) = usize::try_from(branch.span.start) else {
+        return false;
+    };
+    let Ok(end) = usize::try_from(branch.span.end) else {
+        return false;
+    };
+    source
+        .get(start..end)
+        .is_some_and(|source| source.trim_start().starts_with("<template"))
 }
 
 pub(super) fn with_child<T>(

--- a/crates/vize_s1_to_s2/src/emit/on/wrapped.rs
+++ b/crates/vize_s1_to_s2/src/emit/on/wrapped.rs
@@ -138,6 +138,11 @@ fn handler_expr_source<'a>(js: &JsExpr<'a>) -> super::super::js::RawJs<'a> {
         Expression::FunctionExpression(function) if function.body.is_some() => {
             super::super::js::RawJs::Borrowed(js.source)
         }
+        _ if js.source.contains("//")
+            && !super::super::on_body::ends_in_line_comment(js.source) =>
+        {
+            super::super::js::RawJs::Borrowed(js.source)
+        }
         _ => super::super::js::js_expr_source(js),
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/once.rs
+++ b/crates/vize_s1_to_s2/src/emit/once.rs
@@ -86,6 +86,29 @@ fn skip_or_hoist_component_children(cx: &mut EmitCx<'_>, component: &ComponentOp
                 cx.walk.skip(element.bindings.len());
                 let _alias = super::hoist::hoist_static_element(cx, element);
             }
+            Op::Element(element) if has(&element.bindings) => {
+                let _id = cx.walk.mint();
+                cx.walk.skip(element.bindings.len());
+                skip_or_hoist_once_element_children(cx, element);
+            }
+            _ => super::create_slots_walk::skip_ops(cx, core::slice::from_ref(op)),
+        }
+    }
+}
+
+fn skip_or_hoist_once_element_children(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) {
+    for op in element.children.ops.iter() {
+        match op {
+            Op::Element(child) if super::hoist::is_hoistable(child) => {
+                let _id = cx.walk.mint();
+                cx.walk.skip(child.bindings.len());
+                let _alias = super::hoist::hoist_static_element(cx, child);
+            }
+            Op::Element(child) => {
+                let _id = cx.walk.mint();
+                cx.walk.skip(child.bindings.len());
+                skip_or_hoist_once_element_children(cx, child);
+            }
             _ => super::create_slots_walk::skip_ops(cx, core::slice::from_ref(op)),
         }
     }

--- a/crates/vize_s1_to_s2/src/emit/outlet_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/outlet_props.rs
@@ -4,7 +4,7 @@
 //! first object `v-bind`, then first object `v-on`, then entry props.
 
 use vize_s0::camelize;
-use vize_s2::op::{BindOp, BindingOp, DynamicName, OnOp, SlotOp};
+use vize_s2::op::{BindOp, BindingOp, OnOp, SlotOp};
 
 use super::buf::Buf;
 use super::js::{escape_js_string, is_valid_js_identifier};
@@ -13,7 +13,7 @@ use super::props::{
 };
 use super::props_bind::is_emitted_key_bind;
 use super::{EmitCx, EmitError};
-use super::{UnsupportedReason as Reason, merge};
+use super::{UnsupportedReason as Reason, merge, style};
 
 pub(super) fn emit_props(
     cx: &mut EmitCx<'_>,
@@ -160,9 +160,17 @@ fn emit_props_object(
                     let key = static_bind_key(bind, StaticBindKeyCasing::Camelize)?;
                     push_key(cx, key.as_str());
                     cx.buf.push(": ");
-                    if matches!(bind.name, Some(DynamicName::Static("class"))) {
+                    if key.as_str() == "class" {
                         cx.buf.use_normalize_class();
                         cx.buf.push(Buf::normalize_class_alias());
+                        cx.buf.push("(");
+                        value.emit_authored(cx, bind);
+                        cx.buf.push(")");
+                    } else if key.as_str() == "style"
+                        && !style::bind_skips_normalize("style", false, false, &value)
+                    {
+                        cx.buf.use_normalize_style();
+                        cx.buf.push(Buf::normalize_style_alias());
                         cx.buf.push("(");
                         value.emit_authored(cx, bind);
                         cx.buf.push(")");

--- a/crates/vize_s1_to_s2/src/emit/props.rs
+++ b/crates/vize_s1_to_s2/src/emit/props.rs
@@ -148,8 +148,7 @@ pub(super) fn bind_patch(
                     "key" => {}
                     key if key.ends_with("Modifiers")
                         || bind_value_is_static_patchless(bind)
-                        || (!is_component
-                            && bind_value_uses_legacy_patchless_bounded_string_concat(bind)) => {}
+                        || bind_value_uses_legacy_patchless_bounded_string_concat(bind) => {}
                     _ => {
                         flag |= 8;
                         let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {

--- a/crates/vize_s1_to_s2/src/emit/props/static_expr.rs
+++ b/crates/vize_s1_to_s2/src/emit/props/static_expr.rs
@@ -31,6 +31,7 @@ pub(super) fn is_static_bound_expr(expr: &Expression<'_>) -> bool {
         | Expression::NumericLiteral(_)
         | Expression::BigIntLiteral(_)
         | Expression::RegExpLiteral(_) => true,
+        Expression::Identifier(ident) => matches!(ident.name.as_str(), "NaN" | "Infinity"),
         Expression::TemplateLiteral(template) => template.expressions.is_empty(),
         Expression::UnaryExpression(unary) => is_static_bound_expr(&unary.argument),
         Expression::ArrayExpression(array) => array.elements.iter().all(static_array_element),

--- a/crates/vize_s1_to_s2/src/emit/props/static_expr.rs
+++ b/crates/vize_s1_to_s2/src/emit/props/static_expr.rs
@@ -31,7 +31,6 @@ pub(super) fn is_static_bound_expr(expr: &Expression<'_>) -> bool {
         | Expression::NumericLiteral(_)
         | Expression::BigIntLiteral(_)
         | Expression::RegExpLiteral(_) => true,
-        Expression::Identifier(ident) => matches!(ident.name.as_str(), "NaN" | "Infinity"),
         Expression::TemplateLiteral(template) => template.expressions.is_empty(),
         Expression::UnaryExpression(unary) => is_static_bound_expr(&unary.argument),
         Expression::ArrayExpression(array) => array.elements.iter().all(static_array_element),

--- a/crates/vize_s1_to_s2/src/emit/props_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static.rs
@@ -16,7 +16,8 @@ use super::hoist::{push_attr_pair, unique_attrs};
 use super::props::{Piece, pieces, static_bind_key};
 use super::props_bind::StaticBindKeyCasing;
 use hoist_pair::{
-    bind_value_is_legacy_static_prop, component_hoist_prop, has_prior_component_hoist_key,
+    bind_value_is_legacy_static_prop, component_hoist_prop, for_item_hoist_prop,
+    has_for_item_legacy_global_key, has_prior_component_hoist_key, has_prior_for_item_hoist_key,
     has_prior_hoist_key, multiline_props_object, static_hoist_prop,
 };
 
@@ -53,6 +54,10 @@ pub(super) fn should_hoist(
 pub(super) fn props_hoistable(cx: &EmitCx<'_>, id: Option<NodeId>) -> bool {
     id.and_then(|id| cx.facts.static_facts.get(id))
         .is_some_and(|fact| fact.props_hoistable)
+}
+
+pub(super) fn has_legacy_global_for_item_key(bindings: &[BindingOp<'_>]) -> bool {
+    bindings.iter().any(has_for_item_legacy_global_key)
 }
 
 pub(super) fn root_hoist_props(
@@ -162,6 +167,34 @@ pub(super) fn component_hoist_props(
         valued_prop,
         all_static_binds,
     }))
+}
+
+pub(super) fn for_item_hoist_props(
+    attributes: &[Attribute<'_>],
+    bindings: &[BindingOp<'_>],
+) -> Result<Option<String>, EmitError> {
+    let pieces = pieces(attributes, bindings, false)?;
+    let mut out = String::from("{ ");
+    let mut emitted = 0usize;
+    for (index, piece) in pieces.iter().enumerate() {
+        let mut prop = String::default();
+        let Some(key) = for_item_hoist_prop(&mut prop, piece)? else {
+            return Ok(None);
+        };
+        if has_prior_for_item_hoist_key(&pieces[..index], key.as_str())? {
+            continue;
+        }
+        if emitted > 0 {
+            out.push_str(", ");
+        }
+        out.push_str(prop.as_str());
+        emitted += 1;
+    }
+    if emitted == 0 {
+        return Ok(None);
+    }
+    out.push_str(" }");
+    Ok(Some(out))
 }
 
 pub(super) fn static_vnode_surface_can_hoist(

--- a/crates/vize_s1_to_s2/src/emit/props_static/hoist_pair.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static/hoist_pair.rs
@@ -1,5 +1,5 @@
 use vize_s0::String;
-use vize_s2::op::BindOp;
+use vize_s2::op::{BindOp, BindingOp};
 
 use super::super::EmitError;
 use super::super::hoist::push_attr_pair;
@@ -67,6 +67,39 @@ pub(super) fn component_hoist_prop<'a>(
     }
 }
 
+pub(super) fn for_item_hoist_prop<'a>(
+    out: &mut String,
+    piece: &Piece<'a>,
+) -> Result<Option<HoistKey<'a>>, EmitError> {
+    match piece {
+        Piece::Attr(attr) if attr.name != "ref" => {
+            push_attr_pair(out, attr);
+            Ok(Some(HoistKey::Borrowed(attr.name)))
+        }
+        Piece::Bind(bind) => {
+            let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
+                return Ok(None);
+            };
+            if matches!(key.as_str(), "ref" | "class") {
+                return Ok(None);
+            }
+            if key.as_str() != "key" && !bind_value_is_legacy_static_prop(bind) {
+                return Ok(None);
+            }
+            let value = bind_value(bind)?;
+            let Some(js) = value.js() else {
+                return Ok(None);
+            };
+            push_key(out, key.as_str());
+            out.push_str(": ");
+            let source = js_expr_source(js);
+            out.push_str(source.as_str());
+            Ok(Some(HoistKey::StaticBind(key)))
+        }
+        _ => Ok(None),
+    }
+}
+
 pub(super) fn has_prior_hoist_key(pieces: &[Piece<'_>], key: &str) -> Result<bool, EmitError> {
     for piece in pieces {
         if hoist_key(piece)?.is_some_and(|prior| prior.as_str() == key) {
@@ -86,6 +119,37 @@ pub(super) fn has_prior_component_hoist_key(
         }
     }
     Ok(false)
+}
+
+pub(super) fn has_prior_for_item_hoist_key(
+    pieces: &[Piece<'_>],
+    key: &str,
+) -> Result<bool, EmitError> {
+    for piece in pieces {
+        if for_item_hoist_key(piece)?.is_some_and(|prior| prior.as_str() == key) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+pub(super) fn has_for_item_legacy_global_key(piece: &BindingOp<'_>) -> bool {
+    let BindingOp::Bind(bind) = piece else {
+        return false;
+    };
+    let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
+        return false;
+    };
+    if key.as_str() != "key" {
+        return false;
+    }
+    let Ok(value) = bind_value(bind) else {
+        return false;
+    };
+    let Some(js) = value.js() else {
+        return false;
+    };
+    legacy_global_constant_expr(js.ast, js.source)
 }
 
 pub(super) fn bind_value_is_legacy_static_prop(bind: &BindOp<'_>) -> bool {
@@ -140,6 +204,25 @@ fn component_hoist_key<'a>(piece: &Piece<'a>) -> Result<Option<HoistKey<'a>>, Em
             if key.as_str() == "ref"
                 || (key.as_str() == "class" && !bind_value_is_static_patchless(bind))
             {
+                return Ok(None);
+            }
+            Ok(Some(HoistKey::StaticBind(key)))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn for_item_hoist_key<'a>(piece: &Piece<'a>) -> Result<Option<HoistKey<'a>>, EmitError> {
+    match piece {
+        Piece::Attr(attr) if attr.name != "ref" => Ok(Some(HoistKey::Borrowed(attr.name))),
+        Piece::Bind(bind) => {
+            let Ok(key) = static_bind_key(bind, StaticBindKeyCasing::Preserve) else {
+                return Ok(None);
+            };
+            if matches!(key.as_str(), "ref" | "class") {
+                return Ok(None);
+            }
+            if key.as_str() != "key" && !bind_value_is_legacy_static_prop(bind) {
                 return Ok(None);
             }
             Ok(Some(HoistKey::StaticBind(key)))

--- a/crates/vize_s1_to_s2/src/emit/static_cache.rs
+++ b/crates/vize_s1_to_s2/src/emit/static_cache.rs
@@ -19,7 +19,102 @@ pub(super) fn enabled(
     wrappers: &SideTable<WrapperKeys>,
 ) -> bool {
     let mut walk = PageWalk::new();
-    region_has_legacy_hoist(&mut walk, &root.ops, facts, wrappers, true, false)
+    region_has_legacy_hoist(&mut walk, &root.ops, facts, wrappers, true, false) || {
+        let mut walk = PageWalk::new();
+        region_has_non_branch_foreign_props_hoist(&mut walk, &root.ops, facts, false)
+    }
+}
+
+fn region_has_non_branch_foreign_props_hoist(
+    walk: &mut PageWalk,
+    ops: &[Op<'_>],
+    facts: &S2Facts,
+    branch_root: bool,
+) -> bool {
+    for op in ops {
+        let id = walk.mint();
+        match op {
+            Op::Element(element) => {
+                walk.skip(element.bindings.len());
+                if !branch_root
+                    && id
+                        .and_then(|id| facts.static_facts.get(id))
+                        .is_some_and(|fact| {
+                            fact.props_hoistable
+                                && fact.foreign
+                                && fact.level == StaticLevel::NotStatic
+                        })
+                {
+                    skip_region(walk, &element.children.ops);
+                    return true;
+                }
+                if ensure_sufficient_stack(|| {
+                    region_has_non_branch_foreign_props_hoist(
+                        walk,
+                        &element.children.ops,
+                        facts,
+                        false,
+                    )
+                }) {
+                    return true;
+                }
+            }
+            Op::Component(component) => {
+                walk.skip(component.bindings.len());
+                if ensure_sufficient_stack(|| {
+                    region_has_non_branch_foreign_props_hoist(
+                        walk,
+                        &component.children.ops,
+                        facts,
+                        false,
+                    )
+                }) {
+                    return true;
+                }
+            }
+            Op::If(if_op) => {
+                for branch in if_op.branches.iter() {
+                    if ensure_sufficient_stack(|| {
+                        region_has_non_branch_foreign_props_hoist(
+                            walk,
+                            &branch.region.ops,
+                            facts,
+                            true,
+                        )
+                    }) {
+                        return true;
+                    }
+                }
+            }
+            Op::For(for_op) => {
+                if ensure_sufficient_stack(|| {
+                    region_has_non_branch_foreign_props_hoist(
+                        walk,
+                        &for_op.region.ops,
+                        facts,
+                        false,
+                    )
+                }) {
+                    return true;
+                }
+            }
+            Op::Slot(slot) => {
+                walk.skip(slot.bindings.len());
+                if ensure_sufficient_stack(|| {
+                    region_has_non_branch_foreign_props_hoist(
+                        walk,
+                        &slot.fallback.ops,
+                        facts,
+                        false,
+                    )
+                }) {
+                    return true;
+                }
+            }
+            Op::Text(_) | Op::Interpolation(_) => {}
+        }
+    }
+    false
 }
 
 fn region_has_legacy_hoist(

--- a/crates/vize_s1_to_s2/src/emit/static_cache.rs
+++ b/crates/vize_s1_to_s2/src/emit/static_cache.rs
@@ -5,6 +5,8 @@
 //! so this pre-walk reconstructs the old `!root.hoists.is_empty()` gate from
 //! page-order ids plus `StaticFacts`.
 
+mod foreign_props;
+
 use vize_davinci::side_table::SideTable;
 use vize_s0::ensure_sufficient_stack;
 use vize_s2::op::{ComponentOp, ElementOp, Op, Region};
@@ -21,100 +23,8 @@ pub(super) fn enabled(
     let mut walk = PageWalk::new();
     region_has_legacy_hoist(&mut walk, &root.ops, facts, wrappers, true, false) || {
         let mut walk = PageWalk::new();
-        region_has_non_branch_foreign_props_hoist(&mut walk, &root.ops, facts, false)
+        foreign_props::region_has_non_branch_foreign_props_hoist(&mut walk, &root.ops, facts, false)
     }
-}
-
-fn region_has_non_branch_foreign_props_hoist(
-    walk: &mut PageWalk,
-    ops: &[Op<'_>],
-    facts: &S2Facts,
-    branch_root: bool,
-) -> bool {
-    for op in ops {
-        let id = walk.mint();
-        match op {
-            Op::Element(element) => {
-                walk.skip(element.bindings.len());
-                if !branch_root
-                    && id
-                        .and_then(|id| facts.static_facts.get(id))
-                        .is_some_and(|fact| {
-                            fact.props_hoistable
-                                && fact.foreign
-                                && fact.level == StaticLevel::NotStatic
-                        })
-                {
-                    skip_region(walk, &element.children.ops);
-                    return true;
-                }
-                if ensure_sufficient_stack(|| {
-                    region_has_non_branch_foreign_props_hoist(
-                        walk,
-                        &element.children.ops,
-                        facts,
-                        false,
-                    )
-                }) {
-                    return true;
-                }
-            }
-            Op::Component(component) => {
-                walk.skip(component.bindings.len());
-                if ensure_sufficient_stack(|| {
-                    region_has_non_branch_foreign_props_hoist(
-                        walk,
-                        &component.children.ops,
-                        facts,
-                        false,
-                    )
-                }) {
-                    return true;
-                }
-            }
-            Op::If(if_op) => {
-                for branch in if_op.branches.iter() {
-                    if ensure_sufficient_stack(|| {
-                        region_has_non_branch_foreign_props_hoist(
-                            walk,
-                            &branch.region.ops,
-                            facts,
-                            true,
-                        )
-                    }) {
-                        return true;
-                    }
-                }
-            }
-            Op::For(for_op) => {
-                if ensure_sufficient_stack(|| {
-                    region_has_non_branch_foreign_props_hoist(
-                        walk,
-                        &for_op.region.ops,
-                        facts,
-                        false,
-                    )
-                }) {
-                    return true;
-                }
-            }
-            Op::Slot(slot) => {
-                walk.skip(slot.bindings.len());
-                if ensure_sufficient_stack(|| {
-                    region_has_non_branch_foreign_props_hoist(
-                        walk,
-                        &slot.fallback.ops,
-                        facts,
-                        false,
-                    )
-                }) {
-                    return true;
-                }
-            }
-            Op::Text(_) | Op::Interpolation(_) => {}
-        }
-    }
-    false
 }
 
 fn region_has_legacy_hoist(

--- a/crates/vize_s1_to_s2/src/emit/static_cache/foreign_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/static_cache/foreign_props.rs
@@ -1,0 +1,97 @@
+use vize_s0::ensure_sufficient_stack;
+use vize_s2::op::Op;
+
+use crate::pass::walk::PageWalk;
+use crate::pass::{S2Facts, StaticLevel};
+
+pub(super) fn region_has_non_branch_foreign_props_hoist(
+    walk: &mut PageWalk,
+    ops: &[Op<'_>],
+    facts: &S2Facts,
+    branch_root: bool,
+) -> bool {
+    for op in ops {
+        let id = walk.mint();
+        match op {
+            Op::Element(element) => {
+                walk.skip(element.bindings.len());
+                if !branch_root
+                    && id
+                        .and_then(|id| facts.static_facts.get(id))
+                        .is_some_and(|fact| {
+                            fact.props_hoistable
+                                && fact.foreign
+                                && fact.level == StaticLevel::NotStatic
+                        })
+                {
+                    super::skip_region(walk, &element.children.ops);
+                    return true;
+                }
+                if ensure_sufficient_stack(|| {
+                    region_has_non_branch_foreign_props_hoist(
+                        walk,
+                        &element.children.ops,
+                        facts,
+                        false,
+                    )
+                }) {
+                    return true;
+                }
+            }
+            Op::Component(component) => {
+                walk.skip(component.bindings.len());
+                if ensure_sufficient_stack(|| {
+                    region_has_non_branch_foreign_props_hoist(
+                        walk,
+                        &component.children.ops,
+                        facts,
+                        false,
+                    )
+                }) {
+                    return true;
+                }
+            }
+            Op::If(if_op) => {
+                for branch in if_op.branches.iter() {
+                    if ensure_sufficient_stack(|| {
+                        region_has_non_branch_foreign_props_hoist(
+                            walk,
+                            &branch.region.ops,
+                            facts,
+                            true,
+                        )
+                    }) {
+                        return true;
+                    }
+                }
+            }
+            Op::For(for_op) => {
+                if ensure_sufficient_stack(|| {
+                    region_has_non_branch_foreign_props_hoist(
+                        walk,
+                        &for_op.region.ops,
+                        facts,
+                        false,
+                    )
+                }) {
+                    return true;
+                }
+            }
+            Op::Slot(slot) => {
+                walk.skip(slot.bindings.len());
+                if ensure_sufficient_stack(|| {
+                    region_has_non_branch_foreign_props_hoist(
+                        walk,
+                        &slot.fallback.ops,
+                        facts,
+                        false,
+                    )
+                }) {
+                    return true;
+                }
+            }
+            Op::Text(_) | Op::Interpolation(_) => {}
+        }
+    }
+    false
+}

--- a/crates/vize_s1_to_s2/src/emit/style.rs
+++ b/crates/vize_s1_to_s2/src/emit/style.rs
@@ -1,6 +1,8 @@
 //! Static style-attribute serialization used by dynamic `:style` merges.
 
-use oxc_ast::ast::{ArrayExpressionElement, Expression, IdentifierReference, ObjectPropertyKind};
+use oxc_ast::ast::{
+    ArrayExpressionElement, Expression, IdentifierReference, ObjectPropertyKind, PropertyKey,
+};
 use oxc_ast_visit::Visit;
 use vize_s2::expr::JsExpr;
 use vize_s2::op::{Attribute, BindOp};
@@ -44,7 +46,8 @@ fn legacy_static_style_object_expr(expr: &Expression<'_>, source: &str) -> bool 
         let ObjectPropertyKind::ObjectProperty(property) = property else {
             return false;
         };
-        !property.computed && legacy_static_style_value(&property.value, source)
+        legacy_static_style_key(&property.key, property.computed)
+            && legacy_static_style_value(&property.value, source)
     })
 }
 
@@ -92,8 +95,20 @@ fn static_expression(expr: &Expression<'_>) -> bool {
             let ObjectPropertyKind::ObjectProperty(property) = property else {
                 return false;
             };
-            !property.computed && static_expression(&property.value)
+            legacy_static_style_key(&property.key, property.computed)
+                && static_expression(&property.value)
         }),
+        _ => false,
+    }
+}
+
+fn legacy_static_style_key(key: &PropertyKey<'_>, computed: bool) -> bool {
+    if !computed {
+        return true;
+    }
+    match key {
+        PropertyKey::StringLiteral(_) => true,
+        PropertyKey::TemplateLiteral(template) => template.expressions.is_empty(),
         _ => false,
     }
 }
@@ -110,9 +125,6 @@ fn unwrap_static_expression<'a>(mut expr: &'a Expression<'a>) -> &'a Expression<
     loop {
         match expr {
             Expression::ParenthesizedExpression(paren) => expr = &paren.expression,
-            Expression::TSAsExpression(ts_as) => expr = &ts_as.expression,
-            Expression::TSNonNullExpression(ts_non_null) => expr = &ts_non_null.expression,
-            Expression::TSSatisfiesExpression(ts_satisfies) => expr = &ts_satisfies.expression,
             _ => return expr,
         }
     }

--- a/crates/vize_s1_to_s2/src/emit/vfor_item.rs
+++ b/crates/vize_s1_to_s2/src/emit/vfor_item.rs
@@ -68,11 +68,13 @@ fn register_props_hoist(
     element: &ElementOp<'_>,
     id: Option<NodeId>,
 ) -> Result<(), EmitError> {
-    if !super::props_static::should_hoist(cx, id, PropHoistPosition::ForItem) {
+    if !super::props_static::should_hoist(cx, id, PropHoistPosition::ForItem)
+        && !super::props_static::has_legacy_global_for_item_key(&element.bindings)
+    {
         return Ok(());
     }
     if let Some(props) =
-        super::props_static::root_hoist_props(&element.attributes, &element.bindings)?
+        super::props_static::for_item_hoist_props(&element.attributes, &element.bindings)?
     {
         let _ = cx.buf.push_hoist(props);
     }

--- a/crates/vize_s1_to_s2/src/emit/vif.rs
+++ b/crates/vize_s1_to_s2/src/emit/vif.rs
@@ -96,6 +96,13 @@ fn emit_condition(
             let source = super::js::js_expr_source(js);
             if let Some((leading, trailing)) =
                 authored_condition_padding(cx.source, branch_span, source.as_str(), js.span)
+                    .or_else(|| {
+                        authored_condition_quote_padding(cx.source, source.as_str(), js.span)
+                    })
+                    .or_else(|| {
+                        authored_condition_padding(cx.source, branch_span, js.source, js.span)
+                    })
+                    .or_else(|| authored_condition_quote_padding(cx.source, js.source, js.span))
             {
                 cx.buf.push(leading);
                 cx.buf.push(source.as_str());
@@ -161,6 +168,37 @@ fn authored_condition_padding<'a>(
         .iter()
         .position(|byte| *byte == quote)
         .unwrap_or(after.len());
+    let trailing = after.get(..trailing_end)?;
+    if leading.is_empty() && trailing.is_empty() {
+        return None;
+    }
+    (leading.bytes().all(|byte| byte.is_ascii_whitespace())
+        && trailing.bytes().all(|byte| byte.is_ascii_whitespace()))
+    .then_some((leading, trailing))
+}
+
+fn authored_condition_quote_padding<'a>(
+    source: &'a str,
+    value: &str,
+    value_span: Span,
+) -> Option<(&'a str, &'a str)> {
+    let value_start = usize::try_from(value_span.start).ok()?;
+    let value_end = usize::try_from(value_span.end).ok()?;
+    if value_start > value_end
+        || value_end > source.len()
+        || source.get(value_start..value_end)? != value
+    {
+        return None;
+    }
+    let before = source.get(..value_start)?;
+    let quote_pos = before
+        .as_bytes()
+        .iter()
+        .rposition(|byte| matches!(*byte, b'\'' | b'"'))?;
+    let quote = before.as_bytes()[quote_pos];
+    let leading = source.get(quote_pos + 1..value_start)?;
+    let after = source.get(value_end..)?;
+    let trailing_end = after.as_bytes().iter().position(|byte| *byte == quote)?;
     let trailing = after.get(..trailing_end)?;
     if leading.is_empty() && trailing.is_empty() {
         return None;

--- a/crates/vize_s1_to_s2/src/emit/vif.rs
+++ b/crates/vize_s1_to_s2/src/emit/vif.rs
@@ -204,7 +204,11 @@ fn emit_branch(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<
         [Op::Component(component)] => {
             let _id = cx.walk.mint();
             cx.walk.skip(component.bindings.len());
-            super::component::emit_if_branch(cx, component, key, _id)
+            let previous = cx.template_if_branch_root;
+            cx.template_if_branch_root = authored_template_branch(cx, branch);
+            let result = super::component::emit_if_branch(cx, component, key, _id);
+            cx.template_if_branch_root = previous;
+            result
         }
         [Op::Slot(slot)] => {
             let _id = cx.walk.mint();
@@ -220,4 +224,16 @@ fn emit_branch(cx: &mut EmitCx<'_>, branch: &IfBranch<'_>, key: &str) -> Result<
             branch.span,
         )),
     }
+}
+
+fn authored_template_branch(cx: &EmitCx<'_>, branch: &IfBranch<'_>) -> bool {
+    let Ok(start) = usize::try_from(branch.span.start) else {
+        return false;
+    };
+    let Ok(end) = usize::try_from(branch.span.end) else {
+        return false;
+    };
+    cx.source
+        .get(start..end)
+        .is_some_and(|source| source.trim_start().starts_with("<template"))
 }

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -5,7 +5,7 @@ mod checks;
 
 pub(super) use array_child::emit_array_child;
 use vize_davinci::id::NodeId;
-use vize_s2::op::ElementOp;
+use vize_s2::op::{BindingOp, ElementOp, Op};
 
 use super::buf::Buf;
 use super::children::children_need_text_flag;
@@ -218,15 +218,15 @@ pub(super) fn emit_call(
     let conditional_v_for_dynamic_text = cx.conditional_v_for_item
         && matches!(prop_hoist, PropHoistPosition::Nested)
         && has_interpolation_descendant(element);
-    let hoisted_props = if allow_hoist
-        && if_key.is_none()
-        && !conditional_v_for_dynamic_text
-        && super::props_static::should_hoist(cx, id, prop_hoist)
-    {
-        super::props_static::root_hoist_props(&element.attributes, &element.bindings)?
-    } else {
-        None
-    };
+    let should_hoist_props = super::props_static::should_hoist(cx, id, prop_hoist)
+        || scoped_for_slot_component_slot_child_props(cx, element, prop_hoist);
+    let hoisted_props =
+        if allow_hoist && if_key.is_none() && !conditional_v_for_dynamic_text && should_hoist_props
+        {
+            super::props_static::root_hoist_props(&element.attributes, &element.bindings)?
+        } else {
+            None
+        };
     let hoist = hoisted_props.is_some();
     let patch = bind_patch(&element.bindings, false, if_key, for_item);
     let text_flag = !once && !memo_block && children_need_text_flag(&element.children);
@@ -328,4 +328,22 @@ pub(super) fn emit_call(
     }
     cx.buf.push(")");
     Ok(())
+}
+
+fn scoped_for_slot_component_slot_child_props(
+    cx: &EmitCx<'_>,
+    element: &ElementOp<'_>,
+    prop_hoist: PropHoistPosition,
+) -> bool {
+    matches!(prop_hoist, PropHoistPosition::Nested)
+        && cx.slot_param_depth > 0
+        && element.bindings.is_empty()
+        && matches!(
+            element.children.ops.as_slice(),
+            [Op::Component(component)]
+                if component
+                    .bindings
+                    .iter()
+                    .any(|binding| matches!(binding, BindingOp::SlotContent(_)))
+        )
 }

--- a/crates/vize_s1_to_s2/src/emit/vnode_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_static.rs
@@ -1,7 +1,7 @@
 //! Static child vnode hoist gates for native element emission.
 
 use vize_davinci::id::NodeId;
-use vize_s2::op::{ElementOp, Namespace, Op};
+use vize_s2::op::{ElementOp, Op};
 
 use super::EmitCx;
 use crate::pass::StaticLevel;
@@ -52,9 +52,6 @@ fn has_direct_component_child(element: &ElementOp<'_>) -> bool {
 }
 
 pub(super) fn can_whole_hoist_static_element(element: &ElementOp<'_>) -> bool {
-    if element.namespace != Namespace::Html && !element.bindings.is_empty() {
-        return false;
-    }
     super::props_static::static_vnode_surface_can_hoist(&element.attributes, &element.bindings)
         && element
             .children

--- a/crates/vize_s1_to_s2/src/emit/vnode_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_static.rs
@@ -1,7 +1,7 @@
 //! Static child vnode hoist gates for native element emission.
 
 use vize_davinci::id::NodeId;
-use vize_s2::op::{ElementOp, Op};
+use vize_s2::op::{ElementOp, Namespace, Op};
 
 use super::EmitCx;
 use crate::pass::StaticLevel;
@@ -18,6 +18,9 @@ pub(super) fn should_hoist_static_children(
         return false;
     }
     if branch_root && cx.template_if_branch_root && has_direct_interpolation_child(element) {
+        if has_direct_component_child(element) {
+            return true;
+        }
         return false;
     }
     let requested =
@@ -38,4 +41,32 @@ fn has_direct_interpolation_child(element: &ElementOp<'_>) -> bool {
         .ops
         .iter()
         .any(|op| matches!(op, Op::Interpolation(_)))
+}
+
+fn has_direct_component_child(element: &ElementOp<'_>) -> bool {
+    element
+        .children
+        .ops
+        .iter()
+        .any(|op| matches!(op, Op::Component(_)))
+}
+
+pub(super) fn can_whole_hoist_static_element(element: &ElementOp<'_>) -> bool {
+    if element.namespace != Namespace::Html && !element.bindings.is_empty() {
+        return false;
+    }
+    super::props_static::static_vnode_surface_can_hoist(&element.attributes, &element.bindings)
+        && element
+            .children
+            .ops
+            .iter()
+            .all(can_whole_hoist_static_child)
+}
+
+fn can_whole_hoist_static_child(op: &Op<'_>) -> bool {
+    match op {
+        Op::Text(_) => true,
+        Op::Element(element) => can_whole_hoist_static_element(element),
+        _ => false,
+    }
 }

--- a/crates/vize_s1_to_s2/src/lower/cx.rs
+++ b/crates/vize_s1_to_s2/src/lower/cx.rs
@@ -40,6 +40,9 @@ pub(crate) struct Cx<'a> {
     /// How many `<pre>` ancestors the walk is inside; condensing is
     /// suppressed for those subtrees (`lower::text`).
     condense_depth: u32,
+    /// How many `v-pre` ancestors the walk is inside; interpolations are
+    /// inert authored text for those subtrees.
+    v_pre_depth: u32,
     pub diagnostics: Vec<Diagnostic>,
     pub provenance: Vec<ProvenanceRecord>,
     pub scopes: SideTable<ScopeFacts>,
@@ -63,6 +66,7 @@ impl<'a> Cx<'a> {
             exhausted: false,
             next_scope: 0,
             condense_depth: 0,
+            v_pre_depth: 0,
             diagnostics: Vec::new(),
             provenance: Vec::new(),
             scopes: SideTable::new(),
@@ -78,6 +82,11 @@ impl<'a> Cx<'a> {
         self.condense_depth > 0
     }
 
+    /// Whether the walk is inside a `v-pre` subtree.
+    pub(crate) fn v_pre_suppressed(&self) -> bool {
+        self.v_pre_depth > 0
+    }
+
     /// Enter/leave a condense-suppressing `<pre>` around its children.
     pub(crate) fn push_condense_suppression(&mut self) {
         self.condense_depth = self.condense_depth.saturating_add(1);
@@ -85,6 +94,15 @@ impl<'a> Cx<'a> {
 
     pub(crate) fn pop_condense_suppression(&mut self) {
         self.condense_depth = self.condense_depth.saturating_sub(1);
+    }
+
+    /// Enter/leave a `v-pre` subtree around its children.
+    pub(crate) fn push_v_pre_suppression(&mut self) {
+        self.v_pre_depth = self.v_pre_depth.saturating_add(1);
+    }
+
+    pub(crate) fn pop_v_pre_suppression(&mut self) {
+        self.v_pre_depth = self.v_pre_depth.saturating_sub(1);
     }
 
     /// Attach a merged run's recorded parts to its compound op, when the

--- a/crates/vize_s1_to_s2/src/lower/element.rs
+++ b/crates/vize_s1_to_s2/src/lower/element.rs
@@ -83,6 +83,13 @@ impl Analyzed<'_> {
             |form| matches!(form, AttrForm::Directive(directive) if directive.head == Head::Slot),
         )
     }
+
+    /// Whether the element carries a `v-pre` spelling.
+    pub(crate) fn has_v_pre(&self) -> bool {
+        self.forms.iter().any(
+            |form| matches!(form, AttrForm::Directive(directive) if directive.head == Head::Pre),
+        )
+    }
 }
 
 /// The authored value text of an attribute, when it has a value node
@@ -201,8 +208,12 @@ pub(crate) fn element_core<'a>(
     // `<pre>` keeps its bytes: condensing is suppressed for the whole
     // subtree (`lower::text`, the shipped `is_pre_tag` configuration).
     let suppress = super::text::suppresses_condense(tag);
+    let suppress_v_pre = analyzed.has_v_pre();
     if suppress {
         cx.push_condense_suppression();
+    }
+    if suppress_v_pre {
+        cx.push_v_pre_suppression();
     }
     let children = Region {
         ops: if component || own_ns != Namespace::Html {
@@ -211,6 +222,9 @@ pub(crate) fn element_core<'a>(
             super::table::lower_element_children(cx, tag, &element.children, child_ns)
         },
     };
+    if suppress_v_pre {
+        cx.pop_v_pre_suppression();
+    }
     if suppress {
         cx.pop_condense_suppression();
     }

--- a/crates/vize_s1_to_s2/src/lower/structural.rs
+++ b/crates/vize_s1_to_s2/src/lower/structural.rs
@@ -89,7 +89,11 @@ pub(crate) fn lower_children<'a>(
                 }
             }
             SurfaceChild::Text(_) | SurfaceChild::Interpolation(_) => {
-                i = text::lower_text_run(cx, children, &plan, i, &mut out);
+                i = if cx.v_pre_suppressed() {
+                    text::lower_v_pre_text_run(cx, children, i, &mut out)
+                } else {
+                    text::lower_text_run(cx, children, &plan, i, &mut out)
+                };
                 continue;
             }
             other => lower_leaf(cx, other, &mut out),

--- a/crates/vize_s1_to_s2/src/lower/text.rs
+++ b/crates/vize_s1_to_s2/src/lower/text.rs
@@ -67,7 +67,7 @@ mod run;
 
 pub(crate) use condense::{TextAction, plan_whitespace, suppresses_condense};
 use condense::{collapse_fused, extends_run};
-pub(crate) use run::lower_text_run;
+pub(crate) use run::{lower_text_run, lower_v_pre_text_run};
 
 /// One part of a merged run, owned (the fact crosses compile boundaries
 /// with its artifact, P1-11).

--- a/crates/vize_s1_to_s2/src/lower/text/run.rs
+++ b/crates/vize_s1_to_s2/src/lower/text/run.rs
@@ -212,3 +212,70 @@ pub(crate) fn lower_text_run<'a>(
     }
     i
 }
+
+/// Lower a contiguous text/interpolation run under `v-pre`.
+/// Interpolation delimiters render as authored text, while Vue's normal
+/// whitespace condense still applies unless an enclosing `<pre>` disabled it.
+pub(crate) fn lower_v_pre_text_run<'a>(
+    cx: &mut Cx<'a>,
+    children: &[SurfaceChild<'a>],
+    start: usize,
+    out: &mut vize_s0::Vec<'a, Op<'a>>,
+) -> usize {
+    let Some(mut end) = text_family_end(cx, &children[start]) else {
+        return start + 1;
+    };
+    let start_offset = text_family_start(cx, &children[start]).unwrap_or(end);
+    let mut i = start + 1;
+    while i < children.len() {
+        let Some(next_start) = text_family_start(cx, &children[i]) else {
+            break;
+        };
+        if next_start != end {
+            break;
+        }
+        let Some(next_end) = text_family_end(cx, &children[i]) else {
+            break;
+        };
+        end = next_end;
+        i += 1;
+    }
+
+    let span = Span::new(start_offset, end);
+    let raw = cx
+        .source
+        .get(span.start as usize..span.end as usize)
+        .unwrap_or_default();
+    let mut content = String::from(raw);
+    if !cx.condense_suppressed() {
+        collapse_fused(&mut content);
+    }
+    let mut interned = StringBuilder::with_capacity_in(content.len(), cx.allocator);
+    interned.push_str(content.as_str());
+    let node = cx.mint_op();
+    cx.record("lower.v-pre-text", node, raw, String::from("ui.text"), span);
+    out.push(Op::Text(Box::new_in(
+        TextOp {
+            content: interned.into_str(),
+            span,
+        },
+        &cx.allocator,
+    )));
+    i
+}
+
+fn text_family_start(cx: &Cx<'_>, child: &SurfaceChild<'_>) -> Option<u32> {
+    match child {
+        SurfaceChild::Text(token) => Some(cx.offset(token.text)),
+        SurfaceChild::Interpolation(node) => Some(cx.offset(node.open.text)),
+        _ => None,
+    }
+}
+
+fn text_family_end(cx: &Cx<'_>, child: &SurfaceChild<'_>) -> Option<u32> {
+    match child {
+        SurfaceChild::Text(token) => Some(cx.token_span(token).end),
+        SurfaceChild::Interpolation(node) => Some(cx.token_span(&node.close).end),
+        _ => None,
+    }
+}

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -73,8 +73,8 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
 | s1_to_s2 | `alloc::vec::Vec`       |    47 |           47 |        167 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    63 |           65 |        264 |
-| s1_to_s2 | `vize_s0::Vec`          |    15 |           15 |         67 |
+| s1_to_s2 | `vize_s0::String`       |    63 |           65 |        270 |
+| s1_to_s2 | `vize_s0::Vec`          |    15 |           16 |         67 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     2 |            2 |          4 |
 
 `tests/tooling/davinci-storage-policy.test.ts` masks comments, literals, and

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -63,8 +63,8 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_bind.rs	1	5	1	2	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_object.rs	1	2	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_object/pieces.rs	1	3	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props_object_merge.rs	0	0	1	1	0	0	0	0
-s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_static.rs	1	1	1	9	0	0	0	0
-s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props_static/hoist_pair.rs	0	0	1	7	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_static.rs	1	1	1	12	0	0	0	0
+s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props_static/hoist_pair.rs	0	0	1	8	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/slots.rs	1	3	1	1	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/slots/capture.rs	1	1	1	4	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/slots/group.rs	1	3	1	1	0	0	0	0
@@ -92,7 +92,7 @@ s1_to_s2	-	crates/vize_s1_to_s2/src/lower/table.rs	0	0	0	0	1	11	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/sugar.rs	1	1	1	2	0	0	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/text.rs	1	1	1	3	0	0	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/text/condense.rs	1	5	1	2	0	0	0	0
-s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/text/run.rs	1	3	1	5	1	0	0	0
+s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/text/run.rs	1	3	1	7	2	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/vfor.rs	0	0	0	0	0	0	1	1
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/vtext.rs	0	0	1	2	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/pass/hoist/consts.rs	0	0	2	0	0	0	0	0


### PR DESCRIPTION
## Summary
- close the residual Davinci DOM corpus divergences left by the post-merge Real Project Matrix run for #5582
- add S2 lowering and emission parity fixes for v-pre inert text, template-if namespace/block shape, slot outlet style normalization, helper ordering, and v-for child hoists
- cover each residual class with focused atelier DOM parity fixtures

## Verification
- cargo fmt --all --check
- cargo test -p vize_atelier_dom --test davinci_s2_v_pre --test davinci_s2_dom_namespace --test davinci_s2_helper_order --test davinci_s2_outlets --test davinci_s2_static_vnode_hoist --test davinci_s2_v_for_child_props --test davinci_s2_helper_composition -- --nocapture
- cargo test -p vize_s1_to_s2 --test lowering_elements --test emit_static_hoist --test emit_outlets -- --nocapture
- cargo test -p vize_s1_to_s2 emit::buf --lib -- --nocapture
- rust-script /tmp/vize_compare_corpus.rs tests/_fixtures/_git (files=17688 parsed=17688 templates=17519 compared=17516 old_skips=3 s2_refusals=0 divergences=0)
- VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus dom_emit_agrees_on_sfc_templates -- --nocapture (local partial fixture inventory rejected: 126 of 146 indexed fixture submodules are unhydrated; Actions runs the full corpus inventory)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790863349&installation_model_id=422833&pr_number=5583&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5583&signature=0d9c4af0103829a3d6c0fccc44fa9ac5d44f1999769f8bb9ee639b8e6ce2f612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved interpolation text literally inside `v-pre` content.
  - Improved SVG namespace handling in conditional templates.
  - Corrected dynamic `style` normalization for slot content.
  - Fixed helper ordering for combined prop bindings and scoped slots.
  - Improved static prop handling and global keys inside `v-for` items.
  - Corrected component slot branching and nested conditional rendering.
- **Tests**
  - Added regression coverage for the updated rendering and compilation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->