### PR TITLE
fix(release): align npm smoke init flags

### DIFF
--- a/tests/tooling/release-smoke-install.test.ts
+++ b/tests/tooling/release-smoke-install.test.ts
@@ -210,6 +210,7 @@ test("release install smoke can run runtime checks for Vize packages", () => {
     "utf8",
   );
   const smokeSources = `${script}\n${runtimeScript}`;
+  const rustScript = fs.readFileSync(smokeCommand, "utf8");
   const initTypecheckScript = fs.readFileSync(
     path.join(root, "legacy-tools/npm/smoke-release-init-typecheck.mjs"),
     "utf8",
@@ -231,6 +232,8 @@ test("release install smoke can run runtime checks for Vize packages", () => {
   assert.match(smokeSources, /"check"[\s\S]*"src\/App\.vue"/);
   assert.match(smokeSources, /"lint"[\s\S]*"src\/App\.vue"/);
   assert.match(smokeSources, /runInitTypecheckChecks\([\s\S]*RUNTIME_PEER_DEPENDENCIES\)/);
+  assert.match(rustScript, /project\.join\("package\.json"\)/);
+  assert.doesNotMatch(rustScript, /"--language"/);
   assert.match(runtimeScript, /VIZE_TEST_CONTENT_MAPPER_TSGO/);
   assert.match(runtimeScript, /runInstalledContentMapperChecks/);
   assert.match(runtimeScript, /content mapper project with spaces/);
@@ -238,7 +241,12 @@ test("release install smoke can run runtime checks for Vize packages", () => {
   assert.match(runtimeScript, /tsconfig\.emit\.json/);
   assert.match(initTypecheckScript, /`init-smoke-\$\{language\}`/);
   assert.match(initTypecheckScript, /\["typescript", "javascript"\]/);
-  assert.match(initTypecheckScript, /"init"[\s\S]*"--typecheck"[\s\S]*"--no-install"/);
+  assert.match(initTypecheckScript, /devDependencies/);
+  assert.match(
+    initTypecheckScript,
+    /"init"[\s\S]*"--yes"[\s\S]*"--typecheck"[\s\S]*"--no-install"/,
+  );
+  assert.doesNotMatch(initTypecheckScript, /"--language"/);
   assert.match(initTypecheckScript, /"run", "--silent", "vize:check"/);
   for (const diagnostic of [
     "standalone source",

--- a/tools/commands/release/npm/smoke-release-install.rs
+++ b/tools/commands/release/npm/smoke-release-install.rs
@@ -667,15 +667,28 @@ fn run_init_typecheck_checks(install_dir: &Path, vize_bin: &Path) -> Result<(), 
         let project = install_dir.join(format!("init-smoke-{language}"));
         fs::create_dir_all(&project)
             .map_err(|error| format!("cannot create {}: {error}", project.display()))?;
+        let mut dev_dependencies = Map::new();
+        dev_dependencies.insert("vue".to_string(), json!("3.5.34"));
+        if language == "typescript" {
+            dev_dependencies.insert("typescript".to_string(), json!("6.0.3"));
+        }
+        common::write_json_pretty(
+            project.join("package.json"),
+            &json!({
+                "name": format!("vize-init-{language}-smoke"),
+                "private": true,
+                "type": "module",
+                "devDependencies": Value::Object(dev_dependencies),
+            }),
+        )?;
         run_command(
             env::var("NODE_BIN").unwrap_or_else(|_| "node".to_string()),
             &[
                 vize_bin.to_string_lossy().as_ref(),
                 "init",
+                "--yes",
                 "--typecheck",
                 "--no-install",
-                "--language",
-                language,
             ],
             None,
             &project,


### PR DESCRIPTION
## Summary
- update release npm install smoke to invoke the current vize init CLI contract
- create minimal TypeScript/JavaScript smoke projects so init can detect language without the removed --language option
- add regression coverage that the release smoke no longer passes --language

## Verification
- rtk node --test --test-concurrency=1 tests/tooling/release-smoke-install.test.ts
- rtk vp check --fix tools/commands/release/npm/smoke-release-install.rs tests/tooling/release-smoke-install.test.ts
- rtk rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20
- rtk cargo fmt --all --check
- rtk git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790868034&installation_model_id=422833&pr_number=5584&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5584&signature=9e924fe23a3ed5883a75a3e984cb637383a284dc5758e35b35c2d0b15a93c24f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release smoke checks for generated projects.
  * Initialization now uses the project manifest to determine language and dependencies.
  * Added required development dependencies before type-check validation.
  * Improved non-interactive initialization reliability with automatic confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->