### PR TITLE
fix(davinci): close final DOM corpus residuals

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_corpus_residuals.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_corpus_residuals.rs
@@ -1,0 +1,33 @@
+//! DOM corpus residuals promoted to focused byte-for-byte pins.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "foreign_svg_static_bind_root_splits_props_and_child_hoist",
+        r#"<Handle><svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" :width="10" :height="10"><circle cx="8" cy="8" r="7" fill="hotpink" /></svg></Handle>"#,
+    ),
+    (
+        "component_slot_static_global_constant_prop_is_patchless",
+        r#"<md-tabs><md-tab :id="NaN" md-label="Tab id=NaN">NaN</md-tab></md-tabs>"#,
+    ),
+    (
+        "transition_slot_props_fallback_keeps_static_props_inline",
+        r#"<transition name="sw-update-popup"><slot :reload="reload"><br /></slot></transition>"#,
+    ),
+    (
+        "v_else_with_value_uses_legacy_else_if_condition",
+        r#"<div v-if="disabled">disabled</div><span v-else="enabled">enabled</span>"#,
+    ),
+];
+
+#[test]
+fn s2_dom_corpus_residuals_match_the_shipped_lane() {
+    support::assert_s2_matches_shipped(BATTERY);
+}

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -288,9 +288,29 @@ fn component_has_static_bind_props(component: &ComponentOp<'_>) -> Result<bool, 
 pub(super) fn transition_props_slot_hoist(component: &ComponentOp<'_>, has_slots: bool) -> bool {
     matches!(component.name, "Transition" | "transition")
         && has_slots
-        && (children_are_forwarded_slot_outlets_only(&component.children)
+        && (children_are_bare_forwarded_slot_outlets_only(&component.children)
             || (!has_direct_slot_outlet(&component.children)
                 && has_element_with_direct_slot_outlet(&component.children)))
+}
+
+fn children_are_bare_forwarded_slot_outlets_only(region: &Region<'_>) -> bool {
+    let mut found = false;
+    for op in region.ops.iter() {
+        if slots::is_whitespace_text(op) {
+            continue;
+        }
+        match op {
+            Op::Slot(slot)
+                if slot.attributes.is_empty()
+                    && slot.bindings.is_empty()
+                    && slot.fallback.ops.iter().all(slots::is_whitespace_text) =>
+            {
+                found = true;
+            }
+            _ => return false,
+        }
+    }
+    found
 }
 
 fn has_direct_slot_outlet(region: &Region<'_>) -> bool {

--- a/crates/vize_s1_to_s2/src/emit/props.rs
+++ b/crates/vize_s1_to_s2/src/emit/props.rs
@@ -14,7 +14,8 @@ use super::buf::Buf;
 use super::on::{admit_on, event_key_for, needs_hydration};
 use static_expr::{
     bind_value_uses_legacy_patchless_bounded_string_concat,
-    bind_value_uses_legacy_patchless_runtime_expr, is_static_bound_expr,
+    bind_value_uses_legacy_patchless_runtime_expr, is_legacy_static_global_constant,
+    is_static_bound_expr,
 };
 
 pub(super) use super::props_bind::{
@@ -242,7 +243,9 @@ pub(super) fn prune_legacy_patchless_dynamic_props(
 
 pub(super) fn bind_value_is_static_patchless(bind: &vize_s2::op::BindOp<'_>) -> bool {
     match bind_value(bind) {
-        Ok(value) => value.js().is_some_and(|js| is_static_bound_expr(js.ast)),
+        Ok(value) => value.js().is_some_and(|js| {
+            is_static_bound_expr(js.ast) || is_legacy_static_global_constant(js.ast)
+        }),
         Err(_) => false,
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/props/static_expr.rs
+++ b/crates/vize_s1_to_s2/src/emit/props/static_expr.rs
@@ -53,6 +53,13 @@ pub(super) fn is_static_bound_expr(expr: &Expression<'_>) -> bool {
     }
 }
 
+pub(super) fn is_legacy_static_global_constant(expr: &Expression<'_>) -> bool {
+    matches!(
+        unwrap_expr(expr),
+        Expression::Identifier(ident) if matches!(ident.name.as_str(), "NaN" | "Infinity")
+    )
+}
+
 fn is_legacy_patchless_runtime_expr(expr: &Expression<'_>) -> bool {
     is_legacy_bounded_string_concat(expr) || is_legacy_in_conditional(expr)
 }

--- a/crates/vize_s1_to_s2/src/emit/vnode_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_static.rs
@@ -1,7 +1,7 @@
 //! Static child vnode hoist gates for native element emission.
 
 use vize_davinci::id::NodeId;
-use vize_s2::op::{ElementOp, Op};
+use vize_s2::op::{ElementOp, Namespace, Op};
 
 use super::EmitCx;
 use crate::pass::StaticLevel;
@@ -52,6 +52,16 @@ fn has_direct_component_child(element: &ElementOp<'_>) -> bool {
 }
 
 pub(super) fn can_whole_hoist_static_element(element: &ElementOp<'_>) -> bool {
+    if element.namespace != Namespace::Html
+        && !element.bindings.is_empty()
+        && element
+            .children
+            .ops
+            .iter()
+            .any(|op| matches!(op, Op::Element(_)))
+    {
+        return false;
+    }
     super::props_static::static_vnode_surface_can_hoist(&element.attributes, &element.bindings)
         && element
             .children

--- a/crates/vize_s1_to_s2/src/lower/structural.rs
+++ b/crates/vize_s1_to_s2/src/lower/structural.rs
@@ -201,7 +201,8 @@ fn lower_if_group<'a>(
             None => BranchKind::If,
         };
         let condition = match kind {
-            BranchKind::Else => None,
+            BranchKind::Else => attr_value_text(element, attr_idx)
+                .and_then(|text| (!text.trim().is_empty()).then(|| expr_at(cx, text))),
             BranchKind::If | BranchKind::ElseIf => {
                 let text = attr_value_text(element, attr_idx);
                 if text.map(str::trim).is_none_or(str::is_empty) {


### PR DESCRIPTION
## Summary
- align S2 DOM emission with the shipped lane for the last corpus residuals after PR #5583
- preserve patchless top-level NaN/Infinity props while keeping nested global constants dynamic
- match legacy Transition slot prop hoisting, foreign SVG hoist splitting, and valued v-else branch conditions
- add focused byte-for-byte residual coverage

## Verification
- cargo fmt --all --check
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --max-lines 350 --limit 20 --base-ref origin/main
- node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_atelier_dom --test davinci_s2_corpus_residuals --test davinci_s2_slots --test davinci_s2_dom --test davinci_s2_static_vnode_hoist --test davinci_s2_patch_flags -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_static_hoist --test emit_merge --test emit_comp --test emit_dynamic_bind_keys --test emit_on --test emit_static -- --nocapture
- rust-script --force /tmp/vize_compare_corpus.rs tests/_fixtures/_git/vue-flow tests/_fixtures/_git/vue-material tests/_fixtures/_git/vuepress tests/_fixtures/_git/vux tests/_fixtures/_git/directus tests/_fixtures/_git/douyin tests/_fixtures/_git/inspira-ui tests/_fixtures/_git/motion-vue tests/_fixtures/_git/naive-ui tests/_fixtures/_git/portal-vue tests/_fixtures/_git/vue-charts tests/_fixtures/_git/vue-data-ui tests/_fixtures/_git/shadcn-vue

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790870695&installation_model_id=422833&pr_number=5585&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5585&signature=4036b4523fed5d1bbfc6efb9d572c386e3cddcfc0b5f550952b30c789ccf879f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of conditional branches so non-empty branch values are now respected.
  * Made slot forwarding stricter, preventing unsupported slot content from being treated as valid.
  * Expanded static detection so more constant values are treated as non-dynamic, reducing unnecessary updates.
  * Tightened static hoisting rules for certain non-HTML elements to avoid incorrect optimization.

* **Tests**
  * Added coverage to confirm shipped DOM snippets still match the expected output exactly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->