### PR TITLE
fix(davinci): close remaining DOM corpus residuals

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_corpus_residuals.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_corpus_residuals.rs
@@ -22,8 +22,16 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<transition name="sw-update-popup"><slot :reload="reload"><br /></slot></transition>"#,
     ),
     (
+        "transition_named_slot_fallback_hoists_static_props",
+        r#"<transition name="multiselect__loading"><slot name="loading"><div v-show="loading" class="multiselect__spinner"></div></slot></transition>"#,
+    ),
+    (
         "v_else_with_value_uses_legacy_else_if_condition",
         r#"<div v-if="disabled">disabled</div><span v-else="enabled">enabled</span>"#,
+    ),
+    (
+        "foreign_defs_with_static_bound_gradient_caches_as_legacy",
+        r##"<svg class="va-icon-vuestic"><defs><linearGradient :id="'ORIGINAL'" x1="0%" y1="50%" y2="50%"><stop offset="0%" stop-color="#4AE387" /><stop offset="100%" stop-color="#C8EA13" /></linearGradient></defs><path :fill="textColor" /></svg>"##,
     ),
 ];
 

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -300,11 +300,7 @@ fn children_are_bare_forwarded_slot_outlets_only(region: &Region<'_>) -> bool {
             continue;
         }
         match op {
-            Op::Slot(slot)
-                if slot.attributes.is_empty()
-                    && slot.bindings.is_empty()
-                    && slot.fallback.ops.iter().all(slots::is_whitespace_text) =>
-            {
+            Op::Slot(slot) if slot.attributes.is_empty() && slot.bindings.is_empty() => {
                 found = true;
             }
             _ => return false,

--- a/crates/vize_s1_to_s2/src/emit/vnode_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_static.rs
@@ -53,6 +53,7 @@ fn has_direct_component_child(element: &ElementOp<'_>) -> bool {
 
 pub(super) fn can_whole_hoist_static_element(element: &ElementOp<'_>) -> bool {
     if element.namespace != Namespace::Html
+        && element.tag == "svg"
         && !element.bindings.is_empty()
         && element
             .children


### PR DESCRIPTION
## Summary
- hoist Transition props for props-free named slot outlets with fallback content
- keep bound root svg vnode splitting while allowing static bound nested foreign children to cache
- add residual parity pins for vue-multiselect and vuestic-admin shapes

## Verification
- rust-script --force /tmp/vize_compare_corpus.rs tests/_fixtures/_git/vue-flow tests/_fixtures/_git/vue-material tests/_fixtures/_git/vuepress tests/_fixtures/_git/vux tests/_fixtures/_git/directus tests/_fixtures/_git/douyin tests/_fixtures/_git/inspira-ui tests/_fixtures/_git/motion-vue tests/_fixtures/_git/naive-ui tests/_fixtures/_git/portal-vue tests/_fixtures/_git/vue-charts tests/_fixtures/_git/vue-data-ui tests/_fixtures/_git/shadcn-vue tests/_fixtures/_git/vue-multiselect tests/_fixtures/_git/vuestic-admin
- cargo fmt --all --check
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --max-lines 350 --limit 20 --base-ref origin/main
- node --test tests/tooling/source-file-lengths.test.ts
- cargo test -p vize_atelier_dom --test davinci_s2_corpus_residuals --test davinci_s2_slots --test davinci_s2_dom --test davinci_s2_static_vnode_hoist --test davinci_s2_patch_flags -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_static_hoist --test emit_merge --test emit_comp --test emit_dynamic_bind_keys --test emit_on --test emit_static -- --nocapture
- cargo test -p vize_s1_to_s2 -- --nocapture
- cargo test -p vize_atelier_dom -- --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5586"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790871603&installation_model_id=422833&pr_number=5586&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5586&signature=ba560cf7064088e79c849af16c862116df9942915b03901a49aee542131b4059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of forwarded slot content, including slots without fallback text.
  - Improved static rendering behavior for non-HTML elements while preserving special handling for SVG.
  - Added coverage for slot fallback and gradient-related rendering scenarios.
- **Refactor**
  - Updated template compilation behavior to produce more consistent output for supported elements and slot patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->