### PR TITLE
refactor(musea): import S0 storage through stage alias

### DIFF
--- a/crates/vize_musea/Cargo.toml
+++ b/crates/vize_musea/Cargo.toml
@@ -9,7 +9,7 @@ description = "Musea - Component gallery and documentation for Vize Vue componen
 metadata.vize.stability = "experimental"
 
 [dependencies]
-vize_carton.workspace = true
+vize_s0.workspace = true
 vize_relief.workspace = true
 vize_atelier_sfc.workspace = true
 vize_croquis.workspace = true

--- a/crates/vize_musea/benches/art_parse.rs
+++ b/crates/vize_musea/benches/art_parse.rs
@@ -12,9 +12,9 @@
 )]
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
-use vize_carton::Allocator;
-use vize_carton::append;
 use vize_musea::{ArtParseOptions, parse_art, transform_to_csf, transform_to_vue};
+use vize_s0::Allocator;
+use vize_s0::append;
 
 // =============================================================================
 // Test Data

--- a/crates/vize_musea/src/autogen.rs
+++ b/crates/vize_musea/src/autogen.rs
@@ -13,7 +13,7 @@ pub use strategy::generate_variants;
 pub use types::{AutogenConfig, AutogenOutput, GeneratedVariant, PropDefinition};
 
 use std::path::Path;
-use vize_carton::{String, ToCompactString, append};
+use vize_s0::{String, ToCompactString, append};
 
 /// Generate an `.art.vue` file from prop definitions.
 pub fn generate_art_file(

--- a/crates/vize_musea/src/autogen/strategy.rs
+++ b/crates/vize_musea/src/autogen/strategy.rs
@@ -7,7 +7,7 @@
 
 use super::types::{AutogenConfig, GeneratedVariant, PropDefinition};
 use serde_json::{Map, Value, json};
-use vize_carton::{FxHashSet, String, ToCompactString, cstr};
+use vize_s0::{FxHashSet, String, ToCompactString, cstr};
 
 /// Generate variants from prop definitions using the configured strategy.
 pub fn generate_variants(
@@ -368,7 +368,7 @@ mod tests {
         let mut props = Vec::new();
         for i in 0..30 {
             props.push(PropDefinition {
-                name: vize_carton::cstr!("prop_{i}"),
+                name: vize_s0::cstr!("prop_{i}"),
                 prop_type: "boolean".into(),
                 required: false,
                 default_value: Some(json!(false)),

--- a/crates/vize_musea/src/autogen/types.rs
+++ b/crates/vize_musea/src/autogen/types.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::disallowed_types)]
 
 use serde::{Deserialize, Serialize};
-use vize_carton::String;
+use vize_s0::String;
 
 /// Configuration for variant auto-generation.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/vize_musea/src/docs.rs
+++ b/crates/vize_musea/src/docs.rs
@@ -6,7 +6,7 @@
 //! # Example
 //!
 //! ```rust
-//! use vize_carton::Allocator;
+//! use vize_s0::Allocator;
 //! use vize_musea::{parse_art, ArtParseOptions};
 //! use vize_musea::docs::{generate_component_doc, DocOptions};
 //!
@@ -31,7 +31,7 @@ pub use catalog::{CatalogEntry, generate_catalog, generate_category_index, gener
 pub use markdown::{generate_component_doc, generate_variant_doc};
 
 use serde::{Deserialize, Serialize};
-use vize_carton::String;
+use vize_s0::String;
 
 /// Options for documentation generation.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -122,7 +122,7 @@ pub struct CatalogOutput {
 mod tests {
     use super::{CatalogEntry, DocOptions, generate_catalog, generate_component_doc};
     use crate::{ArtParseOptions, parse_art};
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn test_generate_component_doc() {

--- a/crates/vize_musea/src/docs/catalog.rs
+++ b/crates/vize_musea/src/docs/catalog.rs
@@ -5,7 +5,7 @@
 use super::{CatalogOutput, DocOptions};
 use crate::types::{ArtDescriptor, ArtStatus};
 use serde::{Deserialize, Serialize};
-use vize_carton::{FxHashMap, String, ToCompactString, append, cstr};
+use vize_s0::{FxHashMap, String, ToCompactString, append, cstr};
 
 /// Entry in a component catalog.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -362,16 +362,16 @@ mod tests {
     fn make_entry(title: &str, category: Option<&str>, tags: &[&str]) -> CatalogEntry {
         CatalogEntry {
             title: title.into(),
-            description: Some(vize_carton::cstr!("{} description", title)),
+            description: Some(vize_s0::cstr!("{} description", title)),
             category: category.map(|s| s.into()),
             tags: tags
                 .iter()
-                .map(|s| vize_carton::CompactString::from(*s))
+                .map(|s| vize_s0::CompactString::from(*s))
                 .collect(),
             status: ArtStatus::Ready,
             variant_count: 2,
-            doc_path: vize_carton::cstr!("{}.md", slugify(title)),
-            source_path: vize_carton::cstr!("{}.art.vue", slugify(title)),
+            doc_path: vize_s0::cstr!("{}.md", slugify(title)),
+            source_path: vize_s0::cstr!("{}.art.vue", slugify(title)),
             order: None,
         }
     }

--- a/crates/vize_musea/src/docs/markdown.rs
+++ b/crates/vize_musea/src/docs/markdown.rs
@@ -4,7 +4,7 @@
 
 use super::{DocOptions, DocOutput};
 use crate::types::{ArtDescriptor, ArtStatus, ArtVariant};
-use vize_carton::{String, ToCompactString, append, cstr};
+use vize_s0::{String, ToCompactString, append, cstr};
 
 /// Generate Markdown documentation for a single Art component.
 ///

--- a/crates/vize_musea/src/lib.rs
+++ b/crates/vize_musea/src/lib.rs
@@ -25,14 +25,14 @@
 //!
 //! This crate is optimized for high performance:
 //! - **Zero-copy parsing**: All strings are borrowed from source
-//! - **Arena allocation**: Uses `vize_carton::Allocator` for fast allocation
+//! - **Arena allocation**: Uses `vize_s0::Allocator` for fast allocation
 //! - **Minimal allocations**: Only allocates when absolutely necessary
 //! - **Fast byte-level parsing**: Uses `memchr` and `memmem` for O(n) search
 //!
 //! ## Usage
 //!
 //! ```rust
-//! use vize_carton::Allocator;
+//! use vize_s0::Allocator;
 //! use vize_musea::{parse_art, transform_to_csf};
 //! use vize_musea::types::ArtParseOptions;
 //!
@@ -93,8 +93,8 @@ pub use types::{
     ArtStyleBlockOwned, ArtVariant, ArtVariantOwned, CsfOutput, SourceLocation, ViewportConfig,
 };
 
-// Re-export vize_carton::Allocator for convenience
-pub use vize_carton::Allocator;
+// Re-export vize_s0::Allocator for convenience
+pub use vize_s0::Allocator;
 
 /// Start the Musea component gallery server.
 ///

--- a/crates/vize_musea/src/palette.rs
+++ b/crates/vize_musea/src/palette.rs
@@ -6,7 +6,7 @@
 //! # Example
 //!
 //! ```rust
-//! use vize_carton::Allocator;
+//! use vize_s0::Allocator;
 //! use vize_musea::{parse_art, ArtParseOptions};
 //! use vize_musea::palette::{generate_palette, PaletteOptions};
 //!

--- a/crates/vize_musea/src/palette/codegen.rs
+++ b/crates/vize_musea/src/palette/codegen.rs
@@ -5,7 +5,7 @@
 use super::inference::infer_control_from_values;
 use super::{Palette, PaletteOptions, PaletteOutput, PropControl};
 use crate::types::ArtDescriptor;
-use vize_carton::{FxHashMap, String, ToCompactString, append, cstr};
+use vize_s0::{FxHashMap, String, ToCompactString, append, cstr};
 
 /// Generate palette configuration from an Art descriptor.
 ///

--- a/crates/vize_musea/src/palette/inference.rs
+++ b/crates/vize_musea/src/palette/inference.rs
@@ -6,7 +6,7 @@
 //! - Multiple values across variants (for select inference)
 
 use super::{ControlKind, PaletteOptions, RangeConfig, SelectOption};
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 /// Infer control type from a single value.
 #[inline]

--- a/crates/vize_musea/src/palette/types.rs
+++ b/crates/vize_musea/src/palette/types.rs
@@ -1,7 +1,7 @@
 //! Palette type definitions.
 
 use serde::{Deserialize, Serialize};
-use vize_carton::{FxHashMap, String};
+use vize_s0::{FxHashMap, String};
 
 /// Control type for a prop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/vize_musea/src/parse.rs
+++ b/crates/vize_musea/src/parse.rs
@@ -12,14 +12,14 @@ use crate::types::{
     SourceLocation,
 };
 use memchr::{memchr, memmem};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 /// Result type for parsing SFC blocks: (script_setup, script, styles)
 type SfcBlocksParseResult<'a> = Result<
     (
         Option<ArtScriptBlock<'a>>,
         Option<ArtScriptBlock<'a>>,
-        vize_carton::Vec<'a, ArtStyleBlock<'a>>,
+        vize_s0::Vec<'a, ArtStyleBlock<'a>>,
     ),
     ArtParseError,
 >;
@@ -32,7 +32,7 @@ type SfcBlocksParseResult<'a> = Result<
 /// # Example
 ///
 /// ```
-/// use vize_carton::Allocator;
+/// use vize_s0::Allocator;
 /// use vize_musea::parse::parse_art;
 /// use vize_musea::types::ArtParseOptions;
 ///
@@ -113,7 +113,7 @@ pub(crate) struct DefineArtMetadata<'a> {
     pub title: Option<&'a str>,
     pub description: Option<&'a str>,
     pub category: Option<&'a str>,
-    pub tags: vize_carton::Vec<'a, &'a str>,
+    pub tags: vize_s0::Vec<'a, &'a str>,
     pub status: Option<&'a str>,
     pub order: Option<u32>,
 }
@@ -126,7 +126,7 @@ impl<'a> DefineArtMetadata<'a> {
             title: None,
             description: None,
             category: None,
-            tags: vize_carton::Vec::new_in(&allocator),
+            tags: vize_s0::Vec::new_in(&allocator),
             status: None,
             order: None,
         }
@@ -139,7 +139,7 @@ fn parse_sfc_blocks<'a>(allocator: &'a Allocator, source: &'a str) -> SfcBlocksP
     let bytes = source.as_bytes();
     let mut script_setup: Option<ArtScriptBlock<'a>> = None;
     let mut script: Option<ArtScriptBlock<'a>> = None;
-    let mut styles = vize_carton::Vec::new_in(&allocator);
+    let mut styles = vize_s0::Vec::new_in(&allocator);
 
     // Use memmem finder for repeated searches (amortized O(n))
     let script_finder = memmem::Finder::new(b"<script");
@@ -451,7 +451,7 @@ pub(crate) fn calculate_location_fast(source: &str, start: u32, end: u32) -> Sou
 mod tests {
     use super::{extract_attr, has_attr, parse_art};
     use crate::types::{ArtParseError, ArtParseOptions};
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn test_parse_simple_art() {

--- a/crates/vize_musea/src/parse/art_block.rs
+++ b/crates/vize_musea/src/parse/art_block.rs
@@ -7,7 +7,7 @@ use super::status::{classify_status, is_unknown_status, unknown_status_warning};
 use super::{BlockInfo, extract_attr, has_attr};
 use crate::types::{ArtMetadata, ArtParseError, ArtStatus};
 use memchr::{memchr, memmem};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 /// Find the `<art>` block in the source.
 /// Returns the block info with attributes and content.
@@ -69,7 +69,7 @@ pub(crate) fn parse_metadata<'a>(
     block: &BlockInfo<'a>,
     define_art: Option<&DefineArtMetadata<'a>>,
     filename: &str,
-) -> Result<(ArtMetadata<'a>, vize_carton::Vec<'a, &'a str>), ArtParseError> {
+) -> Result<(ArtMetadata<'a>, vize_s0::Vec<'a, &'a str>), ArtParseError> {
     let attrs = block.attrs_str;
 
     let title = extract_attr(attrs, "title")
@@ -86,7 +86,7 @@ pub(crate) fn parse_metadata<'a>(
         .or_else(|| define_art.and_then(|metadata| metadata.category));
 
     // Parse tags (comma-separated) into arena-allocated vec
-    let mut tags = vize_carton::Vec::new_in(&allocator);
+    let mut tags = vize_s0::Vec::new_in(&allocator);
     if let Some(tags_str) = extract_attr(attrs, "tags") {
         // Split by comma, trim each tag - no allocations, just slices
         for tag in tags_str.split(',') {
@@ -104,7 +104,7 @@ pub(crate) fn parse_metadata<'a>(
         .or_else(|| define_art.and_then(|metadata| metadata.status.map(classify_status)))
         .unwrap_or_default();
 
-    let mut warnings = vize_carton::Vec::new_in(&allocator);
+    let mut warnings = vize_s0::Vec::new_in(&allocator);
     if let Some(value) = extract_attr(attrs, "status").filter(|value| is_unknown_status(value)) {
         warnings.push(unknown_status_warning(allocator, filename, value));
     } else if attr_status.is_none()
@@ -152,7 +152,7 @@ fn parse_status(attrs: &str) -> Option<ArtStatus> {
 mod tests {
     use super::{find_art_block, parse_metadata, parse_status};
     use crate::types::ArtStatus;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn test_find_art_block() {

--- a/crates/vize_musea/src/parse/status.rs
+++ b/crates/vize_musea/src/parse/status.rs
@@ -1,7 +1,7 @@
 //! Shared classification for `defineArt` / `<art status>` values.
 
 use crate::types::ArtStatus;
-use vize_carton::{Allocator, cstr};
+use vize_s0::{Allocator, cstr};
 
 #[inline]
 pub(crate) fn classify_status(value: &str) -> ArtStatus {
@@ -42,7 +42,7 @@ pub(crate) fn unknown_status_warning<'a>(
 mod tests {
     use super::{classify_status, is_unknown_status, unknown_status_warning};
     use crate::types::ArtStatus;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn classifies_known_and_unknown_status() {

--- a/crates/vize_musea/src/parse/variant.rs
+++ b/crates/vize_musea/src/parse/variant.rs
@@ -5,7 +5,7 @@
 use super::{calculate_location_fast, extract_attr, has_attr};
 use crate::types::{ArtParseError, ArtVariant, ViewportConfig};
 use memchr::{memchr, memmem};
-use vize_carton::{Allocator, FxHashMap, ToCompactString};
+use vize_s0::{Allocator, FxHashMap, ToCompactString};
 
 /// Parse all `<variant>` blocks from art content.
 ///
@@ -231,7 +231,7 @@ fn count_lines_fast(bytes: &[u8], pos: usize) -> u32 {
 mod tests {
     use super::{parse_variants, parse_viewport};
     use crate::types::ArtParseError;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn test_parse_single_variant() {

--- a/crates/vize_musea/src/status_warnings.rs
+++ b/crates/vize_musea/src/status_warnings.rs
@@ -4,7 +4,7 @@
 //! collected through a separate entry rather than a new descriptor field.
 
 use crate::parse::art_block::{find_art_block, parse_metadata};
-use vize_carton::{Allocator, Vec};
+use vize_s0::{Allocator, Vec};
 
 /// Return unknown-status warnings for `source`, or an empty list if the Art
 /// block is missing or metadata cannot be parsed.
@@ -25,7 +25,7 @@ pub fn parse_art_status_warnings<'a>(
 #[cfg(test)]
 mod tests {
     use super::parse_art_status_warnings;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn unknown_status_returns_the_shared_warning() {

--- a/crates/vize_musea/src/tokens/markdown.rs
+++ b/crates/vize_musea/src/tokens/markdown.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use vize_carton::{String, append, appends};
+use vize_s0::{String, append, appends};
 
 use super::types::TokenCategory;
 

--- a/crates/vize_musea/src/tokens/parse.rs
+++ b/crates/vize_musea/src/tokens/parse.rs
@@ -1,7 +1,7 @@
 use std::{fs, path::Path};
 
 use serde_json::{Map, Value};
-use vize_carton::{FxHashMap, String, ToCompactString};
+use vize_s0::{FxHashMap, String, ToCompactString};
 
 use super::types::{DesignToken, TokenCategory, TokenError, TokenResult};
 

--- a/crates/vize_musea/src/tokens/resolve.rs
+++ b/crates/vize_musea/src/tokens/resolve.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use vize_carton::{FxHashMap, FxHashSet, String, ToCompactString};
+use vize_s0::{FxHashMap, FxHashSet, String, ToCompactString};
 
 use super::types::{DesignToken, FlattenedToken, ResolvedTokens, TokenCategory, ValidationResult};
 
@@ -46,7 +46,7 @@ pub fn validate_reference(
     self_path: Option<&str>,
 ) -> ValidationResult {
     if !token_map.contains_key(reference) {
-        return invalid(vize_carton::cstr!(
+        return invalid(vize_s0::cstr!(
             "Reference target \"{reference}\" does not exist"
         ));
     }
@@ -60,7 +60,7 @@ pub fn validate_reference(
 
     while depth < MAX_RESOLVE_DEPTH {
         if !visited.insert(current.clone()) {
-            return invalid(vize_carton::cstr!(
+            return invalid(vize_s0::cstr!(
                 "Circular reference detected at \"{current}\""
             ));
         }

--- a/crates/vize_musea/src/tokens/types.rs
+++ b/crates/vize_musea/src/tokens/types.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use vize_carton::{FxHashMap, String};
+use vize_s0::{FxHashMap, String};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/vize_musea/src/transform/to_csf.rs
+++ b/crates/vize_musea/src/transform/to_csf.rs
@@ -7,7 +7,7 @@
 
 use super::to_csf_script::{ScriptSetupCsf, extract_script_setup_for_csf};
 use crate::types::{ArtDescriptor, ArtVariant, CsfOutput};
-use vize_carton::{String, ToCompactString, append, cstr};
+use vize_s0::{String, ToCompactString, append, cstr};
 
 const COMPONENT_BINDING: &str = "__museaComponent";
 const META_BINDING: &str = "__museaMeta";

--- a/crates/vize_musea/src/transform/to_csf/tests.rs
+++ b/crates/vize_musea/src/transform/to_csf/tests.rs
@@ -1,7 +1,7 @@
 use super::{escape_string, escape_template, to_pascal_case, transform_to_csf};
 use crate::parse::parse_art;
 use crate::types::ArtParseOptions;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn test_transform_simple() {

--- a/crates/vize_musea/src/transform/to_csf_script.rs
+++ b/crates/vize_musea/src/transform/to_csf_script.rs
@@ -1,7 +1,7 @@
 //! Script setup extraction for Storybook CSF output.
 
-use vize_carton::String;
 use vize_croquis::script_parser::parse_script_setup;
+use vize_s0::String;
 
 #[derive(Debug, Default)]
 pub(super) struct ScriptSetupCsf {

--- a/crates/vize_musea/src/transform/to_vue.rs
+++ b/crates/vize_musea/src/transform/to_vue.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::disallowed_macros)]
 
 use crate::types::ArtDescriptor;
-use vize_carton::{String, append, cstr};
+use vize_s0::{String, append, cstr};
 
 /// Output of Vue transformation.
 #[derive(Debug, Clone)]
@@ -316,7 +316,7 @@ mod tests {
     use super::{escape_template_literal, to_pascal_case, transform_to_vue};
     use crate::parse::parse_art;
     use crate::types::ArtParseOptions;
-    use vize_carton::Allocator;
+    use vize_s0::Allocator;
 
     #[test]
     fn test_transform_to_vue_basic() {

--- a/crates/vize_musea/src/types.rs
+++ b/crates/vize_musea/src/types.rs
@@ -6,7 +6,7 @@
 //! All types are designed for zero-copy parsing with arena allocation.
 
 use serde::{Deserialize, Serialize};
-use vize_carton::{Allocator, FxHashMap, String, ToCompactString, Vec as ArenaVec};
+use vize_s0::{Allocator, FxHashMap, String, ToCompactString, Vec as ArenaVec};
 
 /// Parsed Art file descriptor.
 ///

--- a/crates/vize_musea/src/vrt/config.rs
+++ b/crates/vize_musea/src/vrt/config.rs
@@ -1,7 +1,7 @@
 //! VRT configuration types.
 
 use serde::{Deserialize, Serialize};
-use vize_carton::{String, ToCompactString};
+use vize_s0::{String, ToCompactString};
 
 use super::preset::ViewportPreset;
 use crate::types::ViewportConfig;

--- a/crates/vize_musea/tests/art_types.rs
+++ b/crates/vize_musea/tests/art_types.rs
@@ -1,5 +1,5 @@
-use vize_carton::Allocator;
 use vize_musea::{ArtDescriptor, ArtStatus, ViewportConfig};
+use vize_s0::Allocator;
 
 #[test]
 fn art_descriptor_new_starts_empty() {

--- a/crates/vize_musea/tests/define_art_metadata.rs
+++ b/crates/vize_musea/tests/define_art_metadata.rs
@@ -1,5 +1,5 @@
-use vize_carton::Allocator;
 use vize_musea::{ArtParseOptions, ArtStatus, parse_art};
+use vize_s0::Allocator;
 
 fn parse<'a>(
     allocator: &'a Allocator,

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -244,6 +244,14 @@ test("Patina linter imports S0 storage through the stage alias", () => {
   });
 });
 
+test("Musea component gallery imports S0 storage through the stage alias", () => {
+  assertS0AliasConsumer({
+    packageName: "vize_musea",
+    label: "Musea component gallery",
+    directory: path.join(repoRoot, "crates", "vize_musea"),
+  });
+});
+
 test("Fresco TUI imports S0 storage through the stage alias", () => {
   assertS0AliasConsumer({
     packageName: "vize_fresco",


### PR DESCRIPTION
## Summary
- switch vize_musea from the retained vize_carton physical dependency key to the vize_s0 stage alias
- update Musea Rust imports, doc examples, tests, and bench helper imports to use vize_s0
- add a davinci-stage-dependencies gate so Musea cannot regress to the S0 compat name

## Validation
- rtk run "node --test tests/tooling/davinci-stage-dependencies.test.ts"
- rtk cargo test -p vize_musea --all-targets
- rtk cargo fmt --all -- --check
- rtk cargo clippy -p vize_musea --lib -- -D warnings
- rtk cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
- rtk run "node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-consumer-migration-surfaces.test.mjs tests/tooling/davinci-stage-release-firewall.test.ts tests/tooling/davinci-portability-lane.test.ts tests/tooling/source-file-lengths.test.ts"
- rtk git diff --check

## Local environment note
- rtk cargo test --workspace was attempted in this no-node_modules worktree and stopped on two vize CLI tests with workspace Vue package missing; required CI installs JS dependencies before running the workspace test lane.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790921792&installation_model_id=422833&pr_number=5592&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5592&signature=b7976889b90bf3cbd9edb8412270d13047c08b60d82fd6f4b86840f9f485abd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated Musea’s storage and utility integration to use the newer S0 storage layer.
  * Existing parsing, rendering, markdown generation, warning behavior, and public functionality remain unchanged.

* **Tests**
  * Added coverage confirming the Musea component gallery accesses S0 storage through the expected stage alias.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->