### PR TITLE
refactor(jsx): import S0 storage through stage alias

### DIFF
--- a/crates/vize_atelier_jsx/Cargo.toml
+++ b/crates/vize_atelier_jsx/Cargo.toml
@@ -10,7 +10,7 @@ metadata.vize.stability = "compatibility-preview"
 
 [dependencies]
 # Internal crates
-vize_carton = { workspace = true }
+vize_s0 = { workspace = true }
 vize_relief = { workspace = true }
 vize_croquis = { workspace = true }
 vize_atelier_core = { workspace = true }

--- a/crates/vize_atelier_jsx/benches/jsx_compile.rs
+++ b/crates/vize_atelier_jsx/benches/jsx_compile.rs
@@ -26,7 +26,7 @@ use vize_atelier_jsx::{
     JsxCompileConfig, JsxLang, VaporCompileOptions, VdomCompileOptions, analyze_jsx_program,
     compile_jsx, compile_to_vapor, compile_to_vdom, lower_source, parse_module,
 };
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 /// A minimal single-element component.
 const SMALL_JSX: &str = r#"const App = () => <div class="hero">{title}</div>;"#;

--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -10,8 +10,8 @@ mod render_exports;
 #[cfg(test)]
 mod tests;
 
-use vize_carton::{Allocator, String};
 use vize_croquis::Croquis;
+use vize_s0::{Allocator, String};
 
 use crate::compat::{JsxCompatMode, unsupported_with_vapor};
 use crate::diagnostics::JsxDiagnostic;

--- a/crates/vize_atelier_jsx/src/compile/babel.rs
+++ b/crates/vize_atelier_jsx/src/compile/babel.rs
@@ -1,4 +1,4 @@
-use vize_carton::{Allocator, String};
+use vize_s0::{Allocator, String};
 
 use super::{
     BabelJsxOptions, JsxCompileConfig, JsxCompileOutput,

--- a/crates/vize_atelier_jsx/src/compile/preamble.rs
+++ b/crates/vize_atelier_jsx/src/compile/preamble.rs
@@ -1,6 +1,6 @@
 //! Deduplicating the per-component runtime-helper preambles of one module.
 
-use vize_carton::{FxHashSet, String};
+use vize_s0::{FxHashSet, String};
 
 /// Merge a sequence of per-component preambles into one deduplicated preamble.
 ///

--- a/crates/vize_atelier_jsx/src/compile/render_exports.rs
+++ b/crates/vize_atelier_jsx/src/compile/render_exports.rs
@@ -1,4 +1,4 @@
-use vize_carton::{FxHashSet, String, ToCompactString};
+use vize_s0::{FxHashSet, String, ToCompactString};
 
 use super::JsxComponent;
 use crate::JsxOutputMode;

--- a/crates/vize_atelier_jsx/src/diagnostics.rs
+++ b/crates/vize_atelier_jsx/src/diagnostics.rs
@@ -3,8 +3,8 @@
 //! Every diagnostic carries a Vize byte range so it can be mapped back to the
 //! original `.jsx`/`.tsx` source by the compiler, type checker, and LSP.
 
-use vize_carton::String;
 use vize_relief::SourceLocation;
+use vize_s0::String;
 
 /// Severity of a JSX lowering diagnostic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/vize_atelier_jsx/src/finder.rs
+++ b/crates/vize_atelier_jsx/src/finder.rs
@@ -22,7 +22,7 @@ use oxc_ast::ast::{
 use oxc_ast_visit::{Visit, walk};
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::scope::ScopeFlags;
-use vize_carton::String;
+use vize_s0::String;
 
 use self::signature::{destructured_prop_names, formal_parameters_range, type_parameters_range};
 
@@ -179,7 +179,7 @@ impl RootLowerer<'_, '_, '_, '_> {
                         // statement (which includes the trailing `;`).
                         let loc = self.lowerer.mapper().location(directive.expression.span);
                         self.lowerer.report(JsxDiagnostic::error_at(
-                            vize_carton::cstr!(
+                            vize_s0::cstr!(
                                 "conflicting JSX mode directives: \"{}\" follows \"{}\" in the \
                                  same component; a component can select only one output mode",
                                 mode.directive(),
@@ -193,7 +193,7 @@ impl RootLowerer<'_, '_, '_, '_> {
                 DirectiveKind::MalformedVue => {
                     let loc = self.lowerer.mapper().location(directive.expression.span);
                     self.lowerer.report(JsxDiagnostic::error_at(
-                        vize_carton::cstr!(
+                        vize_s0::cstr!(
                             "unknown JSX mode directive \"{raw}\": expected \"{}\" or \"{}\"",
                             JsxOutputMode::Vdom.directive(),
                             JsxOutputMode::Vapor.directive()

--- a/crates/vize_atelier_jsx/src/finder/signature.rs
+++ b/crates/vize_atelier_jsx/src/finder/signature.rs
@@ -9,7 +9,7 @@
 
 use oxc_ast::ast::{BindingPattern, FormalParameters, PropertyKey, TSTypeParameterDeclaration};
 use oxc_span::GetSpan;
-use vize_carton::String;
+use vize_s0::String;
 
 /// Byte range covering the authored formal parameter list, parentheses excluded.
 ///

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! ```
 //! use vize_atelier_jsx::{lower_source, JsxLang};
-//! use vize_carton::Allocator;
+//! use vize_s0::Allocator;
 //!
 //! let allocator = Allocator::new();
 //! let out = lower_source(
@@ -53,10 +53,10 @@ mod forwarded_slots;
 pub use analyze::analyze_program as analyze_jsx_program;
 
 use oxc_semantic::SemanticBuilder;
-use vize_carton::{Allocator, String};
 use vize_croquis::Croquis;
 use vize_croquis::croquis::BindingMetadata;
 use vize_relief::RootNode;
+use vize_s0::{Allocator, String};
 
 pub use compat::JsxCompatMode;
 pub use compile::{

--- a/crates/vize_atelier_jsx/src/lower.rs
+++ b/crates/vize_atelier_jsx/src/lower.rs
@@ -26,8 +26,8 @@ pub(crate) use style::{RawScopedStyle, ScopedStyleExpr};
 use oxc_ast::ast::{JSXElement, JSXElementName, JSXFragment};
 use oxc_semantic::Scoping;
 use oxc_span::Span;
-use vize_carton::{Allocator, Box, String, ToCompactString, Vec};
 use vize_relief::{RootNode, TemplateChildNode};
+use vize_s0::{Allocator, Box, String, ToCompactString, Vec};
 
 use crate::BabelIsCustomElement;
 use crate::compat::JsxCompatMode;

--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -15,10 +15,10 @@ use oxc_ast::ast::{
     JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXSpreadAttribute,
 };
 use oxc_span::{GetSpan, Span};
-use vize_carton::{Box, Vec, is_builtin_directive};
 use vize_relief::{
     AttributeNode, DirectiveNode, PropNode, SimpleExpressionNode, SourceLocation, TextNode,
 };
+use vize_s0::{Box, Vec, is_builtin_directive};
 
 use super::Lowerer;
 use super::expr::container_expr_span;

--- a/crates/vize_atelier_jsx/src/lower/attr/compat.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr/compat.rs
@@ -2,8 +2,8 @@
 
 use oxc_ast::ast::{JSXAttribute, JSXAttributeName, JSXAttributeValue};
 use oxc_span::{GetSpan, Span};
-use vize_carton::String;
 use vize_relief::{DirectiveNode, PropNode, SourceLocation};
+use vize_s0::String;
 
 use crate::lower::Lowerer;
 

--- a/crates/vize_atelier_jsx/src/lower/babel_slot.rs
+++ b/crates/vize_atelier_jsx/src/lower/babel_slot.rs
@@ -17,8 +17,8 @@
 
 use oxc_ast::ast::{Expression, JSXChild, JSXExpressionContainer};
 use oxc_span::{GetSpan, Span};
-use vize_carton::{Box, String};
 use vize_relief::{ElementNode, ExpressionNode, SimpleExpressionNode};
+use vize_s0::{Box, String};
 
 use super::Lowerer;
 use super::slot::is_whitespace_child;

--- a/crates/vize_atelier_jsx/src/lower/child.rs
+++ b/crates/vize_atelier_jsx/src/lower/child.rs
@@ -2,11 +2,11 @@
 
 use oxc_ast::ast::{JSXChild, JSXExpression, JSXExpressionContainer, JSXSpreadChild};
 use oxc_span::GetSpan;
-use vize_carton::{Box, Vec};
 use vize_relief::{
     CompoundExpressionChild, CompoundExpressionNode, ExpressionNode, InterpolationNode,
     TemplateChildNode, TextNode,
 };
+use vize_s0::{Box, Vec};
 
 use super::Lowerer;
 

--- a/crates/vize_atelier_jsx/src/lower/element.rs
+++ b/crates/vize_atelier_jsx/src/lower/element.rs
@@ -2,8 +2,8 @@
 
 use oxc_ast::ast::{JSXAttributeItem, JSXElement, JSXElementName, JSXFragment};
 use oxc_span::{GetSpan, Span};
-use vize_carton::String;
 use vize_relief::{DirectiveNode, ElementNode, ElementType, PropNode};
+use vize_s0::String;
 
 use super::{Lowerer, name};
 
@@ -26,8 +26,8 @@ impl<'a, 'm, 's: 'a> Lowerer<'a, 'm, 's> {
         let custom_element_tag =
             name::identifier_name(&opening.name).filter(|tag| self.is_babel_custom_element(tag));
         let bound_custom_element = custom_element_tag.is_some_and(|tag| {
-            !vize_carton::is_html_tag(tag)
-                && !vize_carton::is_svg_tag(tag)
+            !vize_s0::is_html_tag(tag)
+                && !vize_s0::is_svg_tag(tag)
                 && self.is_bound_jsx_identifier(&opening.name)
         });
         // A member-expression or bound predicate match is a value, so it becomes

--- a/crates/vize_atelier_jsx/src/lower/expr.rs
+++ b/crates/vize_atelier_jsx/src/lower/expr.rs
@@ -2,8 +2,8 @@
 
 use oxc_ast::ast::{JSXExpression, JSXExpressionContainer};
 use oxc_span::{GetSpan, Span};
-use vize_carton::Box;
 use vize_relief::{ExpressionNode, SimpleExpressionNode};
+use vize_s0::Box;
 
 use super::Lowerer;
 

--- a/crates/vize_atelier_jsx/src/lower/name.rs
+++ b/crates/vize_atelier_jsx/src/lower/name.rs
@@ -2,7 +2,7 @@
 
 use oxc_ast::ast::JSXElementName;
 use oxc_span::Span;
-use vize_carton::String;
+use vize_s0::String;
 
 /// The XML namespace prefixes a JSX tag may legitimately carry.
 ///
@@ -71,7 +71,7 @@ pub(crate) fn is_component(name: &JSXElementName<'_>, babel_compat: bool) -> boo
 
 fn is_identifier_component(name: &str, babel_compat: bool) -> bool {
     if babel_compat {
-        !vize_carton::is_html_tag(name) && !vize_carton::is_svg_tag(name)
+        !vize_s0::is_html_tag(name) && !vize_s0::is_svg_tag(name)
     } else {
         !is_intrinsic(name)
     }

--- a/crates/vize_atelier_jsx/src/lower/slot.rs
+++ b/crates/vize_atelier_jsx/src/lower/slot.rs
@@ -18,9 +18,9 @@ use oxc_ast::ast::{
     Statement,
 };
 use oxc_span::{GetSpan, Span};
-use vize_carton::{Box, Vec};
 use vize_relief::ElementType;
 use vize_relief::{DirectiveNode, ElementNode, PropNode, TemplateChildNode, TextNode};
+use vize_s0::{Box, Vec};
 
 use super::Lowerer;
 use super::babel_slot::sole_expression_container;

--- a/crates/vize_atelier_jsx/src/lower/style.rs
+++ b/crates/vize_atelier_jsx/src/lower/style.rs
@@ -28,7 +28,7 @@ use oxc_ast::ast::{
 };
 use oxc_span::GetSpan;
 
-use vize_carton::String;
+use vize_s0::String;
 
 use super::Lowerer;
 

--- a/crates/vize_atelier_jsx/src/lower/text.rs
+++ b/crates/vize_atelier_jsx/src/lower/text.rs
@@ -7,8 +7,8 @@
 //! on the last line are preserved.
 
 use oxc_ast::ast::JSXText;
-use vize_carton::{Box, String};
 use vize_relief::{TemplateChildNode, TextNode};
+use vize_s0::{Box, String};
 
 use super::Lowerer;
 

--- a/crates/vize_atelier_jsx/src/lower/v_model.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_model.rs
@@ -14,9 +14,9 @@ use oxc_ast::ast::{
     ArrayExpressionElement, Expression, JSXAttribute, JSXAttributeName, JSXAttributeValue,
 };
 use oxc_span::GetSpan;
-use vize_carton::ToCompactString;
 use vize_relief::SourceLocation;
 use vize_relief::{DirectiveNode, PropNode, SimpleExpressionNode};
+use vize_s0::ToCompactString;
 
 use super::Lowerer;
 use crate::diagnostics::JsxDiagnostic;

--- a/crates/vize_atelier_jsx/src/lower/v_models.rs
+++ b/crates/vize_atelier_jsx/src/lower/v_models.rs
@@ -44,8 +44,8 @@
 
 use oxc_ast::ast::{ArrayExpression, Expression, JSXAttribute, JSXAttributeName};
 use oxc_span::{GetSpan, Span};
-use vize_carton::Vec;
 use vize_relief::PropNode;
+use vize_s0::Vec;
 
 use super::Lowerer;
 use super::v_model::{ModelArrayLowering, is_assignable_target};

--- a/crates/vize_atelier_jsx/src/parse.rs
+++ b/crates/vize_atelier_jsx/src/parse.rs
@@ -10,7 +10,7 @@ use oxc_parser::Parser;
 
 use std::borrow::Cow;
 
-use vize_carton::ToCompactString;
+use vize_s0::ToCompactString;
 
 use crate::diagnostics::JsxDiagnostic;
 use crate::lang::JsxLang;

--- a/crates/vize_atelier_jsx/src/scoped.rs
+++ b/crates/vize_atelier_jsx/src/scoped.rs
@@ -16,7 +16,7 @@
 //! Vapor backend (via post-generation template rewriting), mirroring the two SFC
 //! scope-injection paths.
 
-use vize_carton::String;
+use vize_s0::String;
 
 /// A JSX component's scoped style, after rewriting.
 #[derive(Debug, Clone)]

--- a/crates/vize_atelier_jsx/src/span.rs
+++ b/crates/vize_atelier_jsx/src/span.rs
@@ -5,7 +5,7 @@
 //! offsets and Vize's [`SourceLocation`] is a byte span too (Davinci P1-4
 //! retired the eager line/column fields), so the conversion is a direct
 //! offset carry-over; consumers that render line/column derive them from the
-//! offsets at their edge via `vize_carton::line_index`. This module is the
+//! offsets at their edge via `vize_s0::line_index`. This module is the
 //! single home for that conversion.
 
 use oxc_span::Span;

--- a/crates/vize_atelier_jsx/src/ssr.rs
+++ b/crates/vize_atelier_jsx/src/ssr.rs
@@ -7,8 +7,8 @@
 use vize_atelier_core::lane::transform_with_source_text;
 use vize_atelier_core::options::TransformOptions;
 use vize_atelier_ssr::{SsrCodegenContext, SsrCompilerOptions};
-use vize_carton::{Allocator, String};
 use vize_croquis::Croquis;
+use vize_s0::{Allocator, String};
 
 use crate::diagnostics::JsxDiagnostic;
 use crate::forwarded_slots::{SlotsForwardingBackend, reject_forwarded_slots};

--- a/crates/vize_atelier_jsx/src/vapor.rs
+++ b/crates/vize_atelier_jsx/src/vapor.rs
@@ -15,8 +15,8 @@
 use vize_atelier_core::lane::transform_with_source_text;
 use vize_atelier_core::options::TransformOptions;
 use vize_atelier_vapor::{VaporGenerateOptions, generate_vapor_with_options, transform_to_ir};
-use vize_carton::{Allocator, String};
 use vize_croquis::Croquis;
+use vize_s0::{Allocator, String};
 
 use crate::diagnostics::JsxDiagnostic;
 use crate::forwarded_slots::{SlotsForwardingBackend, reject_forwarded_slots};

--- a/crates/vize_atelier_jsx/src/vdom.rs
+++ b/crates/vize_atelier_jsx/src/vdom.rs
@@ -18,8 +18,8 @@ use vize_atelier_core::options::{CodegenMode, CodegenOptions, TransformOptions};
 // for bundlers, and the runtime `Function` (with-block) mode emits an empty
 // body under JSX's no-prefix closure model.
 use vize_atelier_core::CompilerError;
-use vize_carton::{Allocator, String};
 use vize_croquis::Croquis;
+use vize_s0::{Allocator, String};
 
 use crate::diagnostics::JsxDiagnostic;
 use crate::scoped::{ScopedStyle, build_scoped_style};

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -266,7 +266,7 @@ forwarded slots changed, with `_: 1` and the no-patch-flag variants both going
 stale — but that check is not committed and does not run in CI (#3391).
 
 `v-slots` is therefore a compiler built-in
-(`vize_carton::BUILTIN_DIRECTIVES`), not a user directive: a component-level
+(`vize_s0::BUILTIN_DIRECTIVES`), not a user directive: a component-level
 `v-slots` in a `.vue` template now spreads too, rather than compiling to the
 `resolveDirective("slots")` lookup #3418 removed. A user directive named `slots`
 collides with it exactly as one named `show` or `model` would.

--- a/crates/vize_atelier_jsx/tests/adversarial_snapshots.rs
+++ b/crates/vize_atelier_jsx/tests/adversarial_snapshots.rs
@@ -13,11 +13,11 @@ use vize_atelier_jsx::{
     LowerOutput, VaporCompileOptions, VaporOutput, VdomCompileOptions, VdomOutput, compile_jsx,
     compile_to_vapor, compile_to_vdom, lower_source,
 };
-use vize_carton::Allocator;
 use vize_relief::{
     ExpressionNode, PropNode, RootNode, TemplateChildNode, TextCallContent,
     expressions::CompoundExpressionChild,
 };
+use vize_s0::Allocator;
 
 const STATEFUL_DESTRUCTURED_TSX: &str = r#"
 import { computed, ref } from "vue";

--- a/crates/vize_atelier_jsx/tests/analysis.rs
+++ b/crates/vize_atelier_jsx/tests/analysis.rs
@@ -3,9 +3,9 @@
 mod common;
 
 use vize_atelier_jsx::{JsxLang, analyze_jsx_program, lower_source, parse_module};
-use vize_carton::Allocator;
 use vize_croquis::BindingMetadata;
 use vize_relief::BindingType;
+use vize_s0::Allocator;
 
 fn sorted_binding_entries(bindings: &BindingMetadata) -> Vec<(String, BindingType)> {
     let mut entries: Vec<_> = bindings

--- a/crates/vize_atelier_jsx/tests/attributes.rs
+++ b/crates/vize_atelier_jsx/tests/attributes.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use common::{as_attribute, as_directive, lower_one, lower_one_tsx, root_element, simple_content};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn static_string_attribute() {

--- a/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/mod.rs
@@ -16,7 +16,7 @@ use vize_atelier_jsx::{
     BabelIsCustomElement, BabelJsxCustomizations, BabelJsxOptions, JsxCompatMode, JsxCompileConfig,
     JsxLang, compile_jsx_with_babel_customizations,
 };
-use vize_carton::{Allocator, FxHashSet};
+use vize_s0::{Allocator, FxHashSet};
 
 /// The relationship between Vize's default output and babel's for one case.
 ///

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -33,7 +33,7 @@
 //! `tests/tooling/babel-jsx-oracle.test.ts`.
 
 // The oracle fixtures deserialize into plain `serde` structs, so std `String`
-// is intentional here rather than the workspace `vize_carton::String`.
+// is intentional here rather than the workspace `vize_s0::String`.
 #![allow(clippy::disallowed_types)]
 
 mod babel_compat;

--- a/crates/vize_atelier_jsx/tests/babel_is_custom_element.rs
+++ b/crates/vize_atelier_jsx/tests/babel_is_custom_element.rs
@@ -6,7 +6,7 @@ use vize_atelier_jsx::{
     BabelIsCustomElement, BabelJsxCustomizations, BabelJsxOptions, JsxCompatMode, JsxCompileConfig,
     JsxLang, JsxOutputMode, compile_jsx, compile_jsx_with_babel_customizations,
 };
-use vize_carton::{Allocator, FxHashSet, String};
+use vize_s0::{Allocator, FxHashSet, String};
 
 static PREDICATE_CALLS: AtomicUsize = AtomicUsize::new(0);
 

--- a/crates/vize_atelier_jsx/tests/babel_merge_props.rs
+++ b/crates/vize_atelier_jsx/tests/babel_merge_props.rs
@@ -8,7 +8,7 @@ use vize_atelier_jsx::{
 };
 
 fn compile_module(source: &str, compat: JsxCompatMode, mode: JsxOutputMode) -> String {
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let config = JsxCompileConfig {
         default_mode: mode,
         compat,
@@ -25,7 +25,7 @@ fn compile_with_merge_props(
     mode: JsxOutputMode,
     merge_props: bool,
 ) -> (String, Vec<String>) {
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let out = compile_jsx_with_babel_merge_props(
         &bump,
         source,
@@ -152,7 +152,7 @@ fn option_is_inert_by_default_in_native_vapor_and_ssr() {
     assert_eq!(vapor_false_diagnostics.len(), 1);
 
     let compile_ssr = |merge_props| {
-        let bump = vize_carton::Allocator::new();
+        let bump = vize_s0::Allocator::new();
         let out = compile_jsx_with_babel_merge_props(
             &bump,
             source,
@@ -178,7 +178,7 @@ fn option_is_inert_by_default_in_native_vapor_and_ssr() {
 
 #[test]
 fn false_composes_with_a_custom_pragma() {
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let out = compile_jsx_with_babel_pragma_and_merge_props(
         &bump,
         "const A = () => <div class=\"a\" {...p} class={c}/>;",

--- a/crates/vize_atelier_jsx/tests/babel_object_slots.rs
+++ b/crates/vize_atelier_jsx/tests/babel_object_slots.rs
@@ -9,7 +9,7 @@ use vize_atelier_jsx::{
     BabelJsxOptions, JsxCompatMode, JsxCompileConfig, JsxLang, JsxOutputMode, compile_jsx,
     compile_jsx_with_babel_object_slots,
 };
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 const LONE_IDENTIFIER_CHILD: &str = "const A = () => <B>{slots}</B>;";
 

--- a/crates/vize_atelier_jsx/tests/babel_spread_child.rs
+++ b/crates/vize_atelier_jsx/tests/babel_spread_child.rs
@@ -2,10 +2,10 @@
 
 use oxc_allocator::Allocator;
 use vize_atelier_jsx::{JsxCompatMode, JsxCompileConfig, JsxLang, compile_jsx, parse_module};
-use vize_carton::String;
+use vize_s0::String;
 
-fn compile(source: &str, compat: JsxCompatMode) -> (vize_carton::String, Vec<String>) {
-    let bump = vize_carton::Allocator::new();
+fn compile(source: &str, compat: JsxCompatMode) -> (vize_s0::String, Vec<String>) {
+    let bump = vize_s0::Allocator::new();
     let output = compile_jsx(
         &bump,
         source,

--- a/crates/vize_atelier_jsx/tests/babel_tag_classification.rs
+++ b/crates/vize_atelier_jsx/tests/babel_tag_classification.rs
@@ -1,9 +1,9 @@
 //! Lowercase tag classification in opt-in Babel compatibility mode (#3391).
 
 use vize_atelier_jsx::{JsxCompatMode, JsxCompileConfig, JsxLang, compile_jsx};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
-fn compile_module(source: &str, compat: JsxCompatMode) -> vize_carton::String {
+fn compile_module(source: &str, compat: JsxCompatMode) -> vize_s0::String {
     let bump = Allocator::new();
     compile_jsx(
         &bump,

--- a/crates/vize_atelier_jsx/tests/babel_v_slots.rs
+++ b/crates/vize_atelier_jsx/tests/babel_v_slots.rs
@@ -15,7 +15,7 @@
 //! malformed module.
 
 use vize_atelier_jsx::{JsxCompatMode, JsxCompileConfig, JsxLang, JsxOutputMode, compile_jsx};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 /// The diagnostic every non-slots-object `v-slots` value produces.
 fn not_a_slots_object(value: &str) -> String {

--- a/crates/vize_atelier_jsx/tests/children.rs
+++ b/crates/vize_atelier_jsx/tests/children.rs
@@ -3,8 +3,8 @@
 mod common;
 
 use common::{as_text, lower_one, root_element, simple_content};
-use vize_carton::Allocator;
 use vize_relief::TemplateChildNode;
+use vize_s0::Allocator;
 
 #[test]
 fn plain_text_child_is_lowered() {

--- a/crates/vize_atelier_jsx/tests/common/mod.rs
+++ b/crates/vize_atelier_jsx/tests/common/mod.rs
@@ -9,11 +9,11 @@ use vize_atelier_jsx::{
     JsxLang, LowerOutput, VaporCompileOptions, VdomCompileOptions, compile_to_vapor,
     compile_to_vdom, lower_source,
 };
-use vize_carton::Allocator;
 use vize_relief::{
     AttributeNode, DirectiveNode, ElementNode, ExpressionNode, PropNode, TemplateChildNode,
     TextNode,
 };
+use vize_s0::Allocator;
 
 /// Lower JSX source, asserting a single error-free render root, and return it.
 pub fn lower_one<'a>(allocator: &'a Allocator, source: &'a str) -> vize_relief::RootNode<'a> {
@@ -56,7 +56,7 @@ pub fn lower_all<'a>(allocator: &'a Allocator, source: &'a str) -> LowerOutput<'
 }
 
 /// Compile one component to VDOM render code.
-pub fn vdom_code(source: &str, lang: JsxLang) -> vize_carton::String {
+pub fn vdom_code(source: &str, lang: JsxLang) -> vize_s0::String {
     let bump = Allocator::new();
     let out = compile_to_vdom(&bump, source, lang, VdomCompileOptions::default());
     assert!(
@@ -69,7 +69,7 @@ pub fn vdom_code(source: &str, lang: JsxLang) -> vize_carton::String {
 }
 
 /// Compile one component to Vapor render code.
-pub fn vapor_code(source: &str, lang: JsxLang, ssr: bool) -> vize_carton::String {
+pub fn vapor_code(source: &str, lang: JsxLang, ssr: bool) -> vize_s0::String {
     let bump = Allocator::new();
     let out = compile_to_vapor(&bump, source, lang, VaporCompileOptions { ssr });
     assert!(
@@ -96,7 +96,7 @@ pub fn snapshot_text(source: &str) -> std::string::String {
 /// Render a named case matrix into a single deterministic snapshot body.
 pub fn snapshot_cases(
     cases: &[(&str, &str)],
-    mut compile: impl FnMut(&str) -> vize_carton::String,
+    mut compile: impl FnMut(&str) -> vize_s0::String,
 ) -> std::string::String {
     let mut snapshot = std::string::String::new();
     for (index, (name, source)) in cases.iter().enumerate() {
@@ -115,7 +115,7 @@ pub fn snapshot_cases(
 /// Render a named, language-aware case matrix into a snapshot body.
 pub fn snapshot_lang_cases(
     cases: &[(&str, JsxLang, &str)],
-    mut compile: impl FnMut(&str, JsxLang) -> vize_carton::String,
+    mut compile: impl FnMut(&str, JsxLang) -> vize_s0::String,
 ) -> std::string::String {
     let mut snapshot = std::string::String::new();
     for (index, (name, lang, source)) in cases.iter().enumerate() {

--- a/crates/vize_atelier_jsx/tests/compat_mode.rs
+++ b/crates/vize_atelier_jsx/tests/compat_mode.rs
@@ -28,7 +28,7 @@ fn module_code(compat: JsxCompatMode, mode: JsxOutputMode) -> String {
 }
 
 fn compile_module(source: &str, compat: JsxCompatMode, mode: JsxOutputMode) -> String {
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let config = JsxCompileConfig {
         default_mode: mode,
         compat,
@@ -39,7 +39,7 @@ fn compile_module(source: &str, compat: JsxCompatMode, mode: JsxOutputMode) -> S
 }
 
 fn diagnostics(compat: JsxCompatMode, mode: JsxOutputMode) -> Vec<String> {
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let config = JsxCompileConfig {
         default_mode: mode,
         compat,
@@ -53,7 +53,7 @@ fn diagnostics(compat: JsxCompatMode, mode: JsxOutputMode) -> Vec<String> {
 }
 
 fn compile_with_transform_on(source: &str, compat: JsxCompatMode, mode: JsxOutputMode) -> String {
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     compile_jsx_with_babel_options(
         &bump,
         source,
@@ -82,7 +82,7 @@ fn compat_is_off_by_default() {
 fn default_config_output_equals_explicit_native() {
     // The switch must be inert unless asked for: `Default::default()` and an
     // explicit `Native` must produce the same module, byte for byte.
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let implicit = compile_jsx(&bump, SOURCE, JsxLang::Jsx, &JsxCompileConfig::default());
     assert_eq!(
         implicit.module_code().to_string(),
@@ -102,7 +102,7 @@ fn babel_compat_vdom_remains_error_free() {
 #[test]
 fn babel_compat_emits_true_for_a_valueless_attribute_only_when_opted_in() {
     let compile = |compat| {
-        let bump = vize_carton::Allocator::new();
+        let bump = vize_s0::Allocator::new();
         compile_jsx(
             &bump,
             "const A = () => <input disabled/>;",
@@ -176,7 +176,7 @@ fn babel_compat_keeps_lone_element_expressions_raw_without_a_text_flag() {
         "const A = () => <div>{t}</div>;\n",
         "const B = () => <div class={c} id={i}>{t}</div>;",
     );
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let implicit_native = compile_jsx(&bump, source, JsxLang::Jsx, &JsxCompileConfig::default())
         .module_code()
         .to_string();

--- a/crates/vize_atelier_jsx/tests/compile.rs
+++ b/crates/vize_atelier_jsx/tests/compile.rs
@@ -5,7 +5,7 @@ use vize_atelier_jsx::{
     JsxCompileConfig, JsxCompileOutput, JsxComponent, JsxLang, JsxOutputMode, compile_jsx,
     resolve_mode,
 };
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 fn compile(src: &str, config: &JsxCompileConfig) -> JsxCompileOutput {
     let bump = Allocator::new();

--- a/crates/vize_atelier_jsx/tests/components.rs
+++ b/crates/vize_atelier_jsx/tests/components.rs
@@ -6,8 +6,8 @@ use common::{
     as_element, as_text, find_directive, is_static, lower_all, lower_one, root_element,
     simple_content,
 };
-use vize_carton::Allocator;
 use vize_relief::{ElementType, TemplateChildNode};
+use vize_s0::Allocator;
 
 #[test]
 fn multiple_top_level_roots_are_each_lowered() {

--- a/crates/vize_atelier_jsx/tests/diagnostics.rs
+++ b/crates/vize_atelier_jsx/tests/diagnostics.rs
@@ -4,7 +4,7 @@ mod common;
 
 use common::{lower_all, root_element};
 use vize_atelier_jsx::{JsxLang, lower_source};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn valid_source_has_no_diagnostics() {
@@ -68,11 +68,11 @@ fn line_and_column_derive_from_the_span_offset() {
     let bump = Allocator::new();
     // `<div/>` begins at column 1 of line 2 (0-indexed: line 1, column 0).
     // Nodes store byte offsets only; line/column are derived at the edges
-    // that render them, via `vize_carton::line_index` (Davinci P1-4).
+    // that render them, via `vize_s0::line_index` (Davinci P1-4).
     let src = "x;\n<div/>;";
     let out = lower_all(&bump, src);
     let loc = &root_element(&out.roots[0].root).loc;
-    let (line, column) = vize_carton::line_index::offset_to_line_col(src, loc.span.start as usize);
+    let (line, column) = vize_s0::line_index::offset_to_line_col(src, loc.span.start as usize);
     assert_eq!(line, 1);
     assert_eq!(column, 0);
 }

--- a/crates/vize_atelier_jsx/tests/directives.rs
+++ b/crates/vize_atelier_jsx/tests/directives.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use common::{find_directive, lower_one, root_element, simple_content};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn v_model_directive() {

--- a/crates/vize_atelier_jsx/tests/ecosystem_smoke.rs
+++ b/crates/vize_atelier_jsx/tests/ecosystem_smoke.rs
@@ -20,7 +20,7 @@
 
 // Std-only manual test harness: the manifest deserializes into plain structs, so
 // std `String` (what `serde` derives into) is intentional here rather than the
-// workspace `vize_carton::String`.
+// workspace `vize_s0::String`.
 #![allow(clippy::disallowed_types)]
 
 use std::fs;
@@ -30,7 +30,7 @@ use std::process::Command;
 
 use serde::Deserialize;
 use vize_atelier_jsx::{JsxLang, lower_source};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[derive(Deserialize)]
 struct Manifest {

--- a/crates/vize_atelier_jsx/tests/edge_cases.rs
+++ b/crates/vize_atelier_jsx/tests/edge_cases.rs
@@ -3,8 +3,8 @@
 mod common;
 
 use common::{as_attribute, as_directive, as_element, lower_one, lower_one_tsx, simple_content};
-use vize_carton::Allocator;
 use vize_relief::{ElementType, ExpressionNode, TemplateChildNode};
+use vize_s0::Allocator;
 
 fn expr_text<'a>(expr: &'a ExpressionNode<'a>) -> &'a str {
     simple_content(expr)

--- a/crates/vize_atelier_jsx/tests/elements.rs
+++ b/crates/vize_atelier_jsx/tests/elements.rs
@@ -4,8 +4,8 @@ mod common;
 
 use common::{as_directive, as_element, lower_one, root_element, simple_content, vdom_code};
 use vize_atelier_jsx::JsxLang;
-use vize_carton::Allocator;
 use vize_relief::ElementType;
+use vize_s0::Allocator;
 
 #[test]
 fn lowers_a_single_intrinsic_element() {

--- a/crates/vize_atelier_jsx/tests/events.rs
+++ b/crates/vize_atelier_jsx/tests/events.rs
@@ -10,7 +10,7 @@ mod common;
 
 use common::{as_directive, lower_one, root_element, simple_content, vdom_code};
 use vize_atelier_jsx::JsxLang;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn event_modifier_codegen_snapshot() {

--- a/crates/vize_atelier_jsx/tests/fragments.rs
+++ b/crates/vize_atelier_jsx/tests/fragments.rs
@@ -4,7 +4,7 @@ mod common;
 
 use common::{as_element, as_text, lower_all, lower_one, root_element, vapor_code, vdom_code};
 use vize_atelier_jsx::JsxLang;
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn top_level_fragment_lifts_children_to_root() {

--- a/crates/vize_atelier_jsx/tests/modes.rs
+++ b/crates/vize_atelier_jsx/tests/modes.rs
@@ -4,7 +4,7 @@ mod common;
 
 use common::lower_single;
 use vize_atelier_jsx::{JsxLang, JsxOutputMode, lower_source};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 fn jsx<'a>(bump: &'a Allocator, src: &'a str) -> vize_atelier_jsx::LoweredRoot<'a> {
     lower_single(bump, src, JsxLang::Jsx)

--- a/crates/vize_atelier_jsx/tests/module_code.rs
+++ b/crates/vize_atelier_jsx/tests/module_code.rs
@@ -5,7 +5,7 @@
 //! everything else falls back to plain render exports.
 
 use vize_atelier_jsx::{JsxCompileConfig, JsxLang, compile_jsx};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn module_code_renames_multiple_render_exports_to_component_names() {

--- a/crates/vize_atelier_jsx/tests/module_props.rs
+++ b/crates/vize_atelier_jsx/tests/module_props.rs
@@ -7,7 +7,7 @@
 //! while silently routing the rest to `attrs`.
 
 use vize_atelier_jsx::{JsxCompileConfig, JsxLang, compile_jsx};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 fn module_code(source: &str, lang: JsxLang) -> std::string::String {
     let bump = Allocator::new();

--- a/crates/vize_atelier_jsx/tests/parity_tsx.rs
+++ b/crates/vize_atelier_jsx/tests/parity_tsx.rs
@@ -7,7 +7,7 @@ use vize_atelier_jsx::{
     JsxLang, JsxOutputMode, VaporCompileOptions, VdomCompileOptions, compile_to_vapor,
     compile_to_vdom, lower_source,
 };
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn tsx_vdom_codegen_matrix() {

--- a/crates/vize_atelier_jsx/tests/parity_vapor.rs
+++ b/crates/vize_atelier_jsx/tests/parity_vapor.rs
@@ -4,7 +4,7 @@ mod common;
 
 use common::{snapshot_cases, vapor_code};
 use vize_atelier_jsx::{JsxLang, VaporCompileOptions, compile_to_vapor};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn vapor_parity_matrix_snapshot() {

--- a/crates/vize_atelier_jsx/tests/pragma.rs
+++ b/crates/vize_atelier_jsx/tests/pragma.rs
@@ -8,7 +8,7 @@ use vize_atelier_jsx::{
 };
 
 fn compile(
-    bump: &vize_carton::Allocator,
+    bump: &vize_s0::Allocator,
     source: &str,
     config: &JsxCompileConfig,
     pragma: Option<&str>,
@@ -39,7 +39,7 @@ fn pragma_is_empty_by_default_and_inert_outside_babel_vdom() {
             ..Default::default()
         },
     ] {
-        let bump = vize_carton::Allocator::new();
+        let bump = vize_s0::Allocator::new();
         let baseline = compile_jsx_with_babel_options(
             &bump,
             source,
@@ -56,7 +56,7 @@ fn pragma_is_empty_by_default_and_inert_outside_babel_vdom() {
         compat: JsxCompatMode::Babel,
         ..Default::default()
     };
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let baseline = compile(&bump, source, &config, None);
     for near_miss in [Some(""), Some("  \n")] {
         let output = compile(&bump, source, &config, near_miss);
@@ -71,7 +71,7 @@ fn babel_pragma_routes_every_vnode_shape_through_the_custom_factory() {
         "const A = () => <div><span/><Comp/></div>;",
         "const B = () => <>{ok ? <i/> : <b/>}</>;",
     );
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let output = compile(
         &bump,
         source,
@@ -121,7 +121,7 @@ fn babel_pragma_keeps_callee_precedence_for_non_identifier_expressions() {
             "(left || right // fallback\n)(",
         ),
     ] {
-        let bump = vize_carton::Allocator::new();
+        let bump = vize_s0::Allocator::new();
         let output = compile(
             &bump,
             "const A = () => <div>{ok ? <i/> : <b/>}</div>;",
@@ -147,7 +147,7 @@ fn babel_pragma_keeps_callee_precedence_for_non_identifier_expressions() {
 
 #[test]
 fn babel_pragma_removes_the_vue_import_when_no_other_helper_is_needed() {
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let output = compile(
         &bump,
         "const A = () => <div/>;",
@@ -165,7 +165,7 @@ fn babel_pragma_removes_the_vue_import_when_no_other_helper_is_needed() {
 
 #[test]
 fn babel_pragma_composes_with_transform_on_and_preserves_source_maps() {
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let output = compile_jsx_with_babel_pragma(
         &bump,
         "const A = () => <button on={{ click: handler }}/>;",
@@ -200,7 +200,7 @@ fn babel_pragma_composes_with_transform_on_and_preserves_source_maps() {
 
 #[test]
 fn babel_pragma_does_not_leak_into_a_vapor_component_override() {
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let output = compile(
         &bump,
         concat!(
@@ -222,7 +222,7 @@ fn babel_pragma_does_not_leak_into_a_vapor_component_override() {
 
 #[test]
 fn invalid_pragma_is_diagnosed_without_emitting_broken_javascript() {
-    let bump = vize_carton::Allocator::new();
+    let bump = vize_s0::Allocator::new();
     let output = compile(
         &bump,
         "const A = () => <div/>;",

--- a/crates/vize_atelier_jsx/tests/slots.rs
+++ b/crates/vize_atelier_jsx/tests/slots.rs
@@ -10,9 +10,9 @@
 mod common;
 
 use vize_atelier_jsx::{JsxLang, lower_source};
-use vize_carton::Allocator;
 use vize_relief::ElementType;
 use vize_relief::{ExpressionNode, PropNode, TemplateChildNode};
+use vize_s0::Allocator;
 
 #[test]
 fn slot_codegen_snapshot() {

--- a/crates/vize_atelier_jsx/tests/ssr.rs
+++ b/crates/vize_atelier_jsx/tests/ssr.rs
@@ -4,9 +4,9 @@ mod common;
 
 use common::{snapshot_cases, snapshot_lang_cases};
 use vize_atelier_jsx::{JsxLang, JsxOutputMode, SsrCompileOptions, compile_to_ssr};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
-fn ssr_code(source: &str, lang: JsxLang) -> vize_carton::String {
+fn ssr_code(source: &str, lang: JsxLang) -> vize_s0::String {
     let bump = Allocator::new();
     let out = compile_to_ssr(&bump, source, lang, SsrCompileOptions::default());
     assert!(

--- a/crates/vize_atelier_jsx/tests/style.rs
+++ b/crates/vize_atelier_jsx/tests/style.rs
@@ -5,7 +5,7 @@ use vize_atelier_jsx::{
     JsxLang, VaporCompileOptions, VdomCompileOptions, compile_to_vapor, compile_to_vdom,
     lower_source,
 };
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 const SCOPED: &str = r#"
 const Comp = () => (

--- a/crates/vize_atelier_jsx/tests/tsx.rs
+++ b/crates/vize_atelier_jsx/tests/tsx.rs
@@ -4,9 +4,9 @@ mod common;
 
 use common::{lower_one_tsx, root_element, simple_content};
 use vize_atelier_jsx::{JsxLang, lower_source};
-use vize_carton::Allocator;
 use vize_relief::ElementType;
 use vize_relief::TemplateChildNode;
+use vize_s0::Allocator;
 
 #[test]
 fn typed_arrow_component_lowers() {

--- a/crates/vize_atelier_jsx/tests/v_model_argument.rs
+++ b/crates/vize_atelier_jsx/tests/v_model_argument.rs
@@ -10,7 +10,7 @@ use vize_atelier_jsx::{
     JsxCompatMode, JsxCompileConfig, JsxLang, VdomCompileOptions, compile_jsx, compile_to_vdom,
     lower_source,
 };
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 const SOURCE: &str = "const A = () => <B v-model={[foo, bar]}/>;";
 const ELEMENT_ARG: &str = "const A = () => <input v-model:foo={val}/>;";

--- a/crates/vize_atelier_jsx/tests/v_model_target.rs
+++ b/crates/vize_atelier_jsx/tests/v_model_target.rs
@@ -10,7 +10,7 @@
 mod common;
 
 use vize_atelier_jsx::{JsxLang, VdomCompileOptions, compile_to_vdom, lower_source};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 fn errors(source: &str) -> Vec<String> {
     let bump = Allocator::new();

--- a/crates/vize_atelier_jsx/tests/v_models.rs
+++ b/crates/vize_atelier_jsx/tests/v_models.rs
@@ -15,7 +15,7 @@
 mod common;
 
 use vize_atelier_jsx::{JsxLang, VdomCompileOptions, compile_to_vdom, lower_source};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 use common::{find_directive, lower_one, root_element, simple_content};
 

--- a/crates/vize_atelier_jsx/tests/v_slots.rs
+++ b/crates/vize_atelier_jsx/tests/v_slots.rs
@@ -18,7 +18,7 @@
 mod common;
 
 use vize_atelier_jsx::{JsxLang, VdomCompileOptions, compile_to_vdom, lower_source};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 fn diagnostics(source: &str) -> Vec<String> {
     let bump = Allocator::new();

--- a/crates/vize_atelier_jsx/tests/v_slots_forwarding.rs
+++ b/crates/vize_atelier_jsx/tests/v_slots_forwarding.rs
@@ -36,7 +36,7 @@ use vize_atelier_jsx::{
     JsxLang, SsrCompileOptions, VaporCompileOptions, VdomCompileOptions, compile_to_ssr,
     compile_to_vapor, compile_to_vdom,
 };
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 fn render_code(source: &str) -> String {
     let bump = Allocator::new();

--- a/crates/vize_atelier_jsx/tests/vapor.rs
+++ b/crates/vize_atelier_jsx/tests/vapor.rs
@@ -4,7 +4,7 @@ mod common;
 
 use common::{snapshot_lang_cases, vapor_code};
 use vize_atelier_jsx::{JsxLang, JsxOutputMode, VaporCompileOptions, compile_to_vapor};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn vapor_codegen_matrix() {

--- a/crates/vize_atelier_jsx/tests/vapor_ssr.rs
+++ b/crates/vize_atelier_jsx/tests/vapor_ssr.rs
@@ -4,7 +4,7 @@ mod common;
 
 use common::{snapshot_cases, snapshot_lang_cases, vapor_code};
 use vize_atelier_jsx::{JsxLang, JsxOutputMode, VaporCompileOptions, compile_to_vapor};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn ssr_codegen_matrix() {

--- a/crates/vize_atelier_jsx/tests/vdom.rs
+++ b/crates/vize_atelier_jsx/tests/vdom.rs
@@ -8,7 +8,7 @@ mod common;
 
 use common::{snapshot_lang_cases, vdom_code};
 use vize_atelier_jsx::{JsxLang, JsxOutputMode, VdomCompileOptions, compile_to_vdom};
-use vize_carton::Allocator;
+use vize_s0::Allocator;
 
 #[test]
 fn vdom_codegen_matrix() {

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -312,6 +312,14 @@ test("Atelier DOM compiler imports S0 storage through the stage alias", () => {
   });
 });
 
+test("Atelier JSX compiler imports S0 storage through the stage alias", () => {
+  assertS0AliasConsumer({
+    packageName: "vize_atelier_jsx",
+    label: "Atelier JSX compiler",
+    directory: path.join(repoRoot, "crates", "vize_atelier_jsx"),
+  });
+});
+
 test("Atelier core compiler macros import S0 storage through the stage alias", () => {
   const manifest = readRepoFile("crates", "vize_atelier_core", "Cargo.toml");
   assert.match(manifest, /^vize_s0 = \{ workspace = true \}$/m);


### PR DESCRIPTION
## Summary
- switch `vize_atelier_jsx` from the physical `vize_carton` dependency/import name to the `vize_s0` stage alias
- extend the Davinci stage dependency gate so JSX compiler code cannot drift back to `vize_carton`
- keep runtime behavior, rollout/default lane selection, and P2-16 retargeting unchanged

## Validation
- `rtk cargo fmt --all -- --check`
- `rtk cargo test -p vize_atelier_jsx`
- `rtk cargo clippy -p vize_atelier_jsx -- -D warnings`
- `rtk run "node --test tests/tooling/davinci-stage-dependencies.test.ts"`
- `rtk cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `rtk git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5593"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790923753&installation_model_id=422833&pr_number=5593&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5593&signature=219536fae9b94ca5e14d925f4ce727048c3f74f16b5e0e8b9ba3ae847445afa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated JSX compilation and related tooling to use the standardized storage and allocation layer.
  * Preserved existing JSX, TSX, VDOM, Vapor, SSR, diagnostics, and compatibility behavior.

* **Tests**
  * Updated test utilities and suites to align with the standardized storage layer.
  * Added coverage verifying the JSX compiler’s storage-layer integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->