### PR TITLE
fix(sfc): resolve setup directives in separate render

### DIFF
--- a/crates/vize_atelier_core/src/codegen/root.rs
+++ b/crates/vize_atelier_core/src/codegen/root.rs
@@ -7,7 +7,7 @@ use crate::{RootNode, RuntimeHelper, TemplateChildNode};
 
 use super::context::CodegenContext;
 use super::element::helpers::is_dynamic_component_tag;
-use super::helpers::to_valid_asset_identifier;
+use super::helpers::{escape_js_string, to_valid_asset_identifier};
 use vize_s0::{String, camelize, capitalize};
 
 /// Check if a root-level text node is ignorable whitespace.
@@ -157,13 +157,21 @@ pub(super) fn generate_assets(ctx: &mut CodegenContext, root: &RootNode<'_>) {
         ctx.push(&to_valid_asset_identifier("directive", directive));
         ctx.push(" = ");
         let binding_name = imported_directive_binding_name(directive);
-        let uses_imported_binding = ctx
+        let imported_binding_type = ctx
             .options
             .binding_metadata
             .as_ref()
-            .is_some_and(|m| m.bindings.contains_key(binding_name.as_str()));
-        if uses_imported_binding {
-            ctx.push(&binding_name);
+            .and_then(|m| m.bindings.get(binding_name.as_str()).copied());
+        if let Some(binding_type) = imported_binding_type {
+            if ctx.options.inline {
+                ctx.push(&binding_name);
+            } else {
+                let prefix = binding_type.non_inline_template_prefix();
+                ctx.push(prefix.trim_end_matches('.'));
+                ctx.push("[\"");
+                ctx.push(&escape_js_string(&binding_name));
+                ctx.push("\"]");
+            }
         } else {
             ctx.use_helper(RuntimeHelper::ResolveDirective);
             ctx.push(ctx.helper(RuntimeHelper::ResolveDirective));

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/render.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/render.rs
@@ -242,6 +242,14 @@ fn template_references_setup_binding(template_code: &str, name: &str) -> bool {
         return true;
     }
 
+    let mut setup_bracket_access = String::with_capacity(name.len() + 11);
+    setup_bracket_access.push_str("$setup[\"");
+    setup_bracket_access.push_str(name);
+    setup_bracket_access.push_str("\"]");
+    if template_code.contains(setup_bracket_access.as_str()) {
+        return true;
+    }
+
     let mut ctx_access = String::with_capacity(name.len() + 5);
     ctx_access.push_str("_ctx.");
     ctx_access.push_str(name);

--- a/crates/vize_atelier_sfc/src/template_tests.rs
+++ b/crates/vize_atelier_sfc/src/template_tests.rs
@@ -4,8 +4,11 @@
 //! Split out of `lib.rs` so that module stays inside the per-file
 //! source-length budget.
 
-use super::{SfcCompileOptions, compile_sfc, compile_sfc_with_template_syntax, parse_sfc};
-use vize_atelier_core::TemplateSyntaxMode;
+use super::{
+    SfcCompileOptions, SfcScriptOutputMode, compile_sfc, compile_sfc_for_adapter,
+    compile_sfc_with_template_syntax, parse_sfc,
+};
+use vize_atelier_core::{CodegenOptions, TemplateSyntaxMode, options::CustomElementMatcher};
 use vize_carton::config::VueVersion;
 
 #[test]
@@ -200,6 +203,77 @@ const touches = ref(0)
         result.code.contains(r#""onUpdate:modelValue":"#)
             && result.code.contains("local.value = $event"),
         "unexpected code:\n{}",
+        result.code
+    );
+}
+
+#[test]
+fn test_compile_sfc_separate_template_uses_setup_local_directive_binding() {
+    let local_source = r#"
+<template>
+  <div v-flip>{{ message }}</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const message = ref('hello')
+const vFlip = {
+  mounted() {},
+}
+</script>
+"#;
+    assert_separate_template_local_directive_output(local_source);
+
+    let imported_source = r#"
+<template>
+  <div v-flip>{{ message }}</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { vFlip } from './directives'
+
+const message = ref('hello')
+</script>
+"#;
+    assert_separate_template_local_directive_output(imported_source);
+}
+
+fn assert_separate_template_local_directive_output(source: &str) {
+    let descriptor = parse_sfc(source, Default::default()).unwrap();
+    let result = compile_sfc_for_adapter(
+        &descriptor,
+        SfcCompileOptions::default(),
+        TemplateSyntaxMode::Standard,
+        CustomElementMatcher::default(),
+        CodegenOptions::default(),
+        SfcScriptOutputMode::SeparateTemplate,
+    )
+    .unwrap();
+
+    assert!(
+        result
+            .code
+            .contains(r#"const _directive_flip = $setup["vFlip"]"#),
+        "local script-setup directives must resolve from the setup state in separate-template mode:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("const _directive_flip = vFlip"),
+        "separate-template render functions cannot close over setup locals:\n{}",
+        result.code
+    );
+
+    let returned = result
+        .code
+        .split("const __returned__ = {")
+        .nth(1)
+        .and_then(|tail| tail.split("Object.defineProperty").next())
+        .unwrap_or("");
+    assert!(
+        returned.contains("vFlip"),
+        "local directive binding must be returned to $setup:\n{}",
         result.code
     );
 }

--- a/tests/app/vrt/misskey.spec.ts
+++ b/tests/app/vrt/misskey.spec.ts
@@ -161,7 +161,16 @@ const accountRoutes: VisualRoute[] = [
   { name: "timeline-antenna", path: "/timeline/antenna/9testantenna001", account: true },
   { name: "clicker", path: "/clicker", account: true },
   { name: "bubble-game", path: "/bubble-game", account: true },
-  { name: "qr", path: "/qr", account: true },
+  {
+    name: "qr",
+    path: "/qr",
+    account: true,
+    ready: async (page) => {
+      await expect(page.getByText("@alice@localhost:3000", { exact: true })).toBeVisible({
+        timeout: 15_000,
+      });
+    },
+  },
   { name: "admin", path: "/admin", account: true },
   { name: "admin-overview", path: "/admin/overview", account: true },
   { name: "admin-users", path: "/admin/users", account: true },


### PR DESCRIPTION
## Summary
- resolve script-setup local directive assets from `$setup[...]` in separate-template render mode
- keep imported local directives returned when the template uses bracket setup access
- wait for Misskey QR profile text before the VRT snapshot so runtime failures surface clearly

## Validation
- `rtk cargo fmt --all -- --check`
- `rtk git diff --check`
- `rtk cargo test -p vize_atelier_sfc template_tests`
- `rtk cargo test -p vize_atelier_core codegen`
- `rtk cargo clippy -p vize_atelier_core -p vize_atelier_sfc --lib -- -D warnings`
- `rtk vp run --filter ./npm/native build:ci`
- `rtk bash -lc 'rm -rf tests/_fixtures/_projects/_git-worktrees/local-misskey-qr-ready-fixed && export PATH=/Users/nishimura/.local/share/mise/installs/node/24.15.0/bin:$PWD/node_modules/.bin:$PATH && cd tests && node -v && VIZE_TEST_WORKTREE_ID=local-misskey-qr-ready-fixed ./node_modules/.bin/playwright test --config app/playwright.vrt.config.ts app/vrt/misskey.spec.ts --grep "misskey visual parity.*qr$"'`\n\n## Note\n- `rtk cargo clippy -p vize_atelier_core -p vize_atelier_sfc --all-targets -- -D warnings` currently reports existing test-target clippy violations in unrelated files (`std::String`, `format!`, `to_string`, etc.); this PR does not touch those files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5595"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790931445&installation_model_id=422833&pr_number=5595&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5595&signature=6752377e1cb4603f16ad4c7bcdacd7894e84e29b36427f3ca2cf38032ffbf36c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed directive bindings in separate-template mode so they correctly resolve through component setup state.
  - Improved handling of non-inline directive bindings, including bindings accessed with bracket notation.
  - Ensured setup bindings referenced in templates are recognized as runtime-used.
- **Tests**
  - Improved visual comparison stability by waiting for expected account text to appear before capturing the route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->