### PR TITLE
fix(patina): register legacy img alt rule opt-in

### DIFF
--- a/crates/vize_patina/src/preset/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/preset/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -544,6 +544,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "petite-vue/no-unsupported-directive",
     "petite-vue/valid-v-effect",
     "petite-vue/valid-v-scope",
+    "vue/a11y-img-alt",
     "vue/no-undefined-refs",
     "vue/no-multiple-template-root",
     "vue/no-use-v-else-with-v-for",

--- a/crates/vize_patina/src/rules/vue.rs
+++ b/crates/vize_patina/src/rules/vue.rs
@@ -238,6 +238,9 @@ pub(crate) fn register_security(registry: &mut crate::rule::RuleRegistry) {
 /// A documented rule still has to be instantiable here: config-enabling a
 /// name that no registry entry owns is a silent false negative (#4636).
 pub(crate) fn register_opt_in(registry: &mut crate::rule::RuleRegistry) {
+    if !registry.has_rule("vue/a11y-img-alt") {
+        registry.register(Box::new(A11yImgAlt));
+    }
     if !registry.has_rule("vue/no-undefined-refs") {
         registry.register(Box::new(NoUndefinedRefs));
     }

--- a/crates/vize_patina/src/rules/vue/a11y_img_alt.rs
+++ b/crates/vize_patina/src/rules/vue/a11y_img_alt.rs
@@ -81,12 +81,33 @@ impl Rule for A11yImgAlt {
 mod tests {
     use super::A11yImgAlt;
     use crate::linter::Linter;
+    use crate::preset::LintPreset;
     use crate::rule::RuleRegistry;
+
+    const RULE: &str = "vue/a11y-img-alt";
 
     fn create_linter() -> Linter {
         let mut registry = RuleRegistry::new();
         registry.register(Box::new(A11yImgAlt));
         Linter::with_registry(registry)
+    }
+
+    #[test]
+    fn opt_in_registry_owns_legacy_rule_and_default_presets_do_not() {
+        assert!(RuleRegistry::with_opt_in_rules().has_rule(RULE));
+        assert!(!RuleRegistry::with_preset(LintPreset::HappyPath).has_rule(RULE));
+        assert!(!RuleRegistry::with_preset(LintPreset::Ecosystem).has_rule(RULE));
+        assert!(!RuleRegistry::with_preset(LintPreset::Opinionated).has_rule(RULE));
+    }
+
+    #[test]
+    fn explicit_enablement_runs_legacy_rule() {
+        let result = Linter::new()
+            .with_enabled_rules(Some(vec![RULE.into()]))
+            .lint_template(r#"<img src="/photo.jpg" />"#, "test.vue");
+
+        assert_eq!(result.warning_count, 1);
+        assert_eq!(result.diagnostics[0].rule_name, RULE);
     }
 
     #[test]

--- a/npm/cli/src/types/rules.ts
+++ b/npm/cli/src/types/rules.ts
@@ -143,6 +143,7 @@ export const LINT_RULE_NAMES = [
   "vapor/no-vue-lifecycle-events",
   "vapor/prefer-static-class",
   "vapor/require-vapor-attribute",
+  "vue/a11y-img-alt",
   "vue/attribute-hyphenation",
   "vue/attribute-order",
   "vue/component-definition-name-casing",


### PR DESCRIPTION
## Summary
- register `vue/a11y-img-alt` as an explicit opt-in Vue rule
- add tests proving default presets stay silent while `with_enabled_rules(["vue/a11y-img-alt"])` runs the legacy rule
- update the preset membership snapshot and generated CLI rule types so the opt-in surface includes the legacy rule

## Validation
- rtk cargo fmt --all
- rtk cargo test -p vize_patina a11y_img_alt -- --nocapture
- rtk cargo test -p vize_patina preset_rule_membership_snapshot -- --nocapture
- rtk cargo test -p vize_patina --lib -- --skip native_type_aware
- rtk cargo clippy -p vize_patina --all-targets -- -D warnings
- rtk git diff --check
- rtk rust-script tools/commands/generate/rule-types.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `vue/a11y-img-alt` accessibility rule to the available lint rules and opt-in registry.
  - The rule can be explicitly enabled to check image alternative text in Vue code.
  - The rule remains excluded from standard presets unless opted in.

- **Tests**
  - Added coverage confirming the rule’s availability, opt-in behavior, and exclusion from standard presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->