### PR TITLE
test(patina): pin lint rule execution families

### DIFF
--- a/crates/vize/tests/lint_rule_execution_cli.rs
+++ b/crates/vize/tests/lint_rule_execution_cli.rs
@@ -1,0 +1,122 @@
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use std::{collections::BTreeSet, fs, path::Path, process::Command};
+
+fn write_project_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+fn output_details(output: &std::process::Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn json_rule_ids(output: &std::process::Output) -> BTreeSet<String> {
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .unwrap_or_else(|_| panic!("lint must emit JSON: {}", output_details(output)));
+    let files = parsed.as_array().unwrap_or_else(|| {
+        panic!(
+            "lint JSON root must be an array: {}",
+            output_details(output)
+        )
+    });
+
+    files
+        .iter()
+        .flat_map(|file| {
+            file["messages"]
+                .as_array()
+                .unwrap_or_else(|| panic!("lint file entry must contain messages: {file:#?}"))
+        })
+        .map(|message| {
+            message["ruleId"]
+                .as_str()
+                .unwrap_or_else(|| panic!("lint message must contain ruleId: {message:#?}"))
+                .to_owned()
+        })
+        .collect()
+}
+
+#[test]
+fn configured_rules_reach_every_lint_execution_family() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_project_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "incremental",
+    "rules": {
+      "script/no-next-tick": "error",
+      "css/no-important": "warn",
+      "vue/a11y-img-alt": "warn",
+      "a11y/img-alt": "warn",
+      "musea/require-title": "error"
+    }
+  }
+}"#,
+    );
+    write_project_file(
+        project_root.path(),
+        "src/App.vue",
+        r#"<script setup lang="ts">
+import { nextTick } from 'vue'
+const raw = '<strong>unsafe</strong>'
+await nextTick()
+</script>
+
+<template>
+  <img src="/hero.png">
+</template>
+
+<style>
+.card { color: red !important; }
+</style>
+"#,
+    );
+    write_project_file(
+        project_root.path(),
+        "src/Button.art.vue",
+        r#"<art component="./Button.vue">
+  <variant name="default">Default</variant>
+</art>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "--max-warnings",
+            "0",
+            "src/App.vue",
+            "src/Button.art.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{}", output_details(&output));
+    assert_eq!(
+        json_rule_ids(&output),
+        BTreeSet::from([
+            "a11y/img-alt".to_owned(),
+            "css/no-important".to_owned(),
+            "musea/require-title".to_owned(),
+            "script/no-next-tick".to_owned(),
+            "vue/a11y-img-alt".to_owned(),
+        ]),
+        "{}",
+        output_details(&output)
+    );
+}


### PR DESCRIPTION
## Summary
- add a vize lint CLI integration test that config-enables representative script, css, legacy template, markup, and musea rules
- assert the exact emitted JSON rule-id set so implemented-but-unrouted rules fail in CI instead of passing silently

## Tests
- rtk cargo test -p vize --test lint_rule_execution_cli
- rtk cargo test -p vize --test lint_rule_execution_cli --test lint_config_cli --test lint_musea_cli
- rtk cargo test -p vize_patina preset::tests
- rtk cargo test -p vize_patina linter::tests::script
- rtk cargo test -p vize_patina linter::tests::sfc
- rtk cargo test -p vize_patina linter::tests::musea
- rtk node --test tests/tooling/cli-lint-contract.test.ts
- rtk node --test tests/tooling/davinci-assertion-lint.test.ts
- rtk env SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- rtk cargo fmt --all --check
- rtk git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for the CLI lint command across script, CSS, Vue, accessibility, and Musea rule families.
  * Verified JSON output includes all configured rule identifiers and that exceeding the warning limit causes the command to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->