### PR TITLE
fix(glyph): align formatter changed-path hashing

### DIFF
--- a/legacy-tools/fixtures/tool-matrix-formatter.mjs
+++ b/legacy-tools/fixtures/tool-matrix-formatter.mjs
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import { globSync, readFileSync, statSync } from "node:fs";
 import { isAbsolute, resolve } from "node:path";
@@ -13,7 +14,7 @@ export function snapshotFormatterInputs(cwd, patterns) {
         globSync(pattern, { cwd, exclude: [".yarn/**", "**/node_modules/**"] }),
       ),
     ),
-  ].sort((left, right) => left.localeCompare(right));
+  ].sort(byteOrder);
   const digest = createHash("sha256");
   for (const inputPath of inputPaths) {
     const absolute = resolve(cwd, inputPath);
@@ -129,7 +130,7 @@ export function validateFormatterOutput(
 /** Build the canonical evidence shared by formatter check and write validation. */
 export function createFormatterChangeEvidence(checkedFileCount, changedPaths) {
   const digest = createHash("sha256");
-  for (const inputPath of [...changedPaths].sort((left, right) => left.localeCompare(right))) {
+  for (const inputPath of [...changedPaths].sort(byteOrder)) {
     digest.update(inputPath);
     digest.update("\0");
   }
@@ -163,6 +164,10 @@ export function validateFormatterChangeEvidence(evidence, label = "formatter cha
   if (!/^[0-9a-f]{64}$/.test(evidence.changedPathsSha256)) {
     throw new Error(`invalid ${label} changedPathsSha256`);
   }
+}
+
+function byteOrder(left, right) {
+  return Buffer.compare(Buffer.from(left), Buffer.from(right));
 }
 
 function parseCount(line, pattern, label) {

--- a/tests/tooling/fixture-tool-matrix-formatter-hash.test.ts
+++ b/tests/tooling/fixture-tool-matrix-formatter-hash.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createFormatterChangeEvidence } from "../../legacy-tools/fixtures/tool-matrix-formatter.mjs";
+
+test("formatter changed-path evidence is byte-ordered for Rust parity", () => {
+  assert.equal(
+    createFormatterChangeEvidence(3, ["src/ä.vue", "src/z.vue", "src/a.vue"]).changedPathsSha256,
+    "91ac181cb4e41902d4ba6c932b5a661be5cc0e3e535f633c6426e81d9d10685c",
+  );
+});


### PR DESCRIPTION
## Summary
- sort formatter matrix changed-path evidence by UTF-8 byte order, matching the Rust verifier
- apply the same byte order to formatter input snapshots
- add a non-ASCII path regression so locale ordering cannot reintroduce hash drift

## Tests
- rtk node --test tests/tooling/fixture-tool-matrix-formatter-hash.test.ts tests/tooling/fixture-tool-matrix-formatter.test.ts tests/tooling/glyph-corpus-idempotence.test.ts tests/tooling/davinci-corpus-formatter-contract.test.ts
- rtk node --test tests/tooling/fixture-tool-matrix-formatter.test.ts
- rtk node --test tests/tooling/glyph-corpus-idempotence.test.ts
- rtk env SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- rtk git diff --check

Note: rtk vp exec node --test ... failed before running tests because this worktree has no project-local vite-plus install and the Nix shim module was missing. The same test set passed under rtk node --test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5601"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790945845&installation_model_id=422833&pr_number=5601&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5601&signature=6cfb9ff99b96ab35ef84ab86ef25cf6926f99f3c7fb4edda9aa778e83e971217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured formatter snapshots and change evidence sort file paths consistently using byte-order comparison, including paths with non-ASCII characters.

* **Tests**
  * Added coverage verifying that generated change hashes remain consistent with byte-order sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->