### PR TITLE
test(glyph): pin S0 alias usage

### DIFF
--- a/tests/tooling/davinci-glyph-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-glyph-stage-dependencies.test.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+import { test } from "node:test";
+
+import { assertS0AliasConsumer, repoRoot } from "./support/davinci-stage-dependencies.ts";
+
+test("Glyph formatter imports S0 storage through the stage alias", () => {
+  assertS0AliasConsumer({
+    packageName: "vize_glyph",
+    label: "Glyph formatter",
+    directory: path.join(repoRoot, "crates", "vize_glyph"),
+  });
+});


### PR DESCRIPTION
## Summary
- add a dedicated Davinci stage dependency test for vize_glyph's S0 alias usage
- keep the existing stage dependency test below the source-length ceiling by using a small sibling test file

## Tests
- node --test tests/tooling/davinci-glyph-stage-dependencies.test.ts tests/tooling/davinci-stage-dependencies.test.ts
- node --test tests/tooling/davinci-assertion-lint.test.ts
- env SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790947809&installation_model_id=422833&pr_number=5602&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5602&signature=2a89c3285c11f1b10c0369e6c8fc05e6b2470ac3459506153fde98f1b5601c0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated coverage to validate stage-based storage dependency configuration.
  - Helps detect configuration regressions earlier and supports more reliable future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->