### PR TITLE
test(davinci): pin DOM production boundary

### DIFF
--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { metadata, readRepoFile, workspacePackage } from "./support/davinci-stage-dependencies.ts";
+
+const domStageDeps = new Set(["vize_davinci", "vize_s1_to_s2", "vize_s2"]);
+
+test("DOM compiler keeps Davinci S2 dependencies in test space only", () => {
+  const dependencies = workspacePackage(metadata, "vize_atelier_dom").dependencies;
+  const productionStageDeps = dependencies
+    .filter((dependency) => dependency.kind === null && domStageDeps.has(dependency.name))
+    .map((dependency) => dependency.name)
+    .sort();
+  assert.deepEqual(productionStageDeps, []);
+
+  const witnessDeps = dependencies
+    .filter((dependency) => dependency.kind === "dev" && domStageDeps.has(dependency.name))
+    .map((dependency) => dependency.name)
+    .sort();
+  assert.deepEqual(witnessDeps, ["vize_davinci", "vize_s1_to_s2"]);
+});
+
+test("DOM compile entry remains on the shipped transform and codegen lane", () => {
+  const source = readRepoFile("crates", "vize_atelier_dom", "src", "compile.rs");
+  assert.match(
+    source,
+    /transform_with_custom_elements_and_template_syntax_quirks_and_hoisted_scope_id\(/u,
+  );
+  assert.match(source, /generate_with_sections\(&root, codegen_opts\)/u);
+  assert.doesNotMatch(source, /\b(?:vize_s1_to_s2|vize_s2)::|use\s+vize_s(?:1_to_s2|2)\b/u);
+  assert.doesNotMatch(source, /\b(?:VIZE_DAVINCI_DOM|DOM_LANE_FLAG|DAVINCI_DOM)\b/u);
+});


### PR DESCRIPTION
## Summary
- add a static gate that keeps vize_atelier_dom's Davinci S2 dependencies in dev-dependency test space
- pin the production DOM compile entry to the shipped transform and codegen lane until rollout is explicitly chosen

## Tests
- node --test tests/tooling/davinci-dom-production-boundary.test.ts
- node --test tests/tooling/davinci-assertion-lint.test.ts
- env SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790948005&installation_model_id=422833&pr_number=5603&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5603&signature=d54bcaa2323ef08e36125561d29e0f17e64ac7fa404b5bd635db71c5661b3a55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->