### PR TITLE
fix(patina): apply categories to css rules

### DIFF
--- a/crates/vize/tests/lint_css_category_cli.rs
+++ b/crates/vize/tests/lint_css_category_cli.rs
@@ -1,0 +1,138 @@
+use std::{fs, path::Path, process::Command};
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+fn output_details(output: &std::process::Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn write_button_sfc(root: &Path) {
+    write_file(
+        root,
+        "src/Button.vue",
+        r#"<style scoped>
+.button { color: red !important; }
+</style>
+"#,
+    );
+}
+
+#[test]
+fn lint_config_style_category_disables_builtin_css_rules() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "opinionated",
+    "categories": {
+      "style": "off"
+    }
+  }
+}"#,
+    );
+    write_button_sfc(project_root.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "src/Button.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_details(&output));
+    let actual = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!([{
+          "file": "src/Button.vue",
+          "messages": [],
+          "errorCount": 0,
+          "warningCount": 0
+        }]),
+        "{}",
+        output_details(&output),
+    );
+}
+
+#[test]
+fn lint_config_style_category_severity_applies_to_builtin_css_rules() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "opinionated",
+    "categories": {
+      "style": "error"
+    }
+  }
+}"#,
+    );
+    write_button_sfc(project_root.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "src/Button.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let actual = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!([{
+          "file": "src/Button.vue",
+          "messages": [{
+            "ruleId": "css/no-hardcoded-values",
+            "ruleDocsPath": "docs/content/rules/musea-and-css.md",
+            "severity": 2,
+            "message": "[vize:css/no-hardcoded-values] Consider using a CSS variable for this color value",
+            "line": 1,
+            "column": 15,
+            "endLine": 2,
+            "endColumn": 10,
+            "help": "Use var(--color-name) for consistent theming"
+          }, {
+            "ruleId": "css/no-important",
+            "ruleDocsPath": "docs/content/rules/musea-and-css.md",
+            "severity": 2,
+            "message": "[vize:css/no-important] Avoid using !important as it makes styles harder to override",
+            "line": 2,
+            "column": 22,
+            "endLine": 2,
+            "endColumn": 32,
+            "help": "Use more specific selectors or reorganize CSS specificity instead"
+          }],
+          "errorCount": 2,
+          "warningCount": 0
+        }]),
+        "{}",
+        output_details(&output),
+    );
+}

--- a/crates/vize_patina/src/linter/category_config.rs
+++ b/crates/vize_patina/src/linter/category_config.rs
@@ -30,6 +30,14 @@ impl Linter {
                 .map(String::from);
             self.disabled_rules.extend(script_rules);
 
+            let css_rules = self
+                .css_rules
+                .iter()
+                .copied()
+                .filter(|rule_name| rule_name_matches_config_category(rule_name, &category))
+                .map(String::from);
+            self.disabled_rules.extend(css_rules);
+
             let musea_rules = self
                 .musea_rules
                 .iter()
@@ -62,6 +70,14 @@ impl Linter {
                 .filter(|rule_name| rule_name_matches_config_category(rule_name, &category))
                 .map(|rule_name| (String::from(rule_name), severity));
             self.severity_overrides.extend(script_rules);
+
+            let css_rules = self
+                .css_rules
+                .iter()
+                .copied()
+                .filter(|rule_name| rule_name_matches_config_category(rule_name, &category))
+                .map(|rule_name| (String::from(rule_name), severity));
+            self.severity_overrides.extend(css_rules);
 
             let musea_rules = self
                 .musea_rules

--- a/crates/vize_patina/src/linter/category_rules.rs
+++ b/crates/vize_patina/src/linter/category_rules.rs
@@ -69,6 +69,7 @@ fn is_style_rule_name(rule_name: &str) -> bool {
             | "vue/v-bind-style"
             | "vue/v-on-style"
             | "vue/v-slot-style"
+            | "css/no-hardcoded-values"
             | "css/no-id-selectors"
             | "css/no-important"
             | "css/no-utility-classes"
@@ -93,11 +94,54 @@ fn is_security_rule_name(rule_name: &str) -> bool {
 fn is_perf_rule_name(rule_name: &str) -> bool {
     matches!(
         rule_name,
-        "css/no-v-bind-performance"
+        "css/no-display-none"
+            | "css/no-v-bind-performance"
+            | "css/require-font-display"
             | "script/no-async-in-computed"
             | "script/no-next-tick"
             | "script/no-top-level-ref-in-script"
             | "type/no-floating-promises"
             | "type/no-reactivity-loss"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rule_name_matches_config_category;
+
+    #[test]
+    fn style_category_names_every_style_css_rule() {
+        let style_css_rules = [
+            "css/no-hardcoded-values",
+            "css/no-id-selectors",
+            "css/no-important",
+            "css/no-utility-classes",
+            "css/prefer-logical-properties",
+            "css/prefer-nested-selectors",
+            "css/prefer-slotted",
+        ];
+
+        for rule_name in style_css_rules {
+            assert!(
+                rule_name_matches_config_category(rule_name, "style"),
+                "{rule_name} must belong to the style category",
+            );
+        }
+    }
+
+    #[test]
+    fn perf_category_names_every_perf_css_rule() {
+        let perf_css_rules = [
+            "css/no-display-none",
+            "css/no-v-bind-performance",
+            "css/require-font-display",
+        ];
+
+        for rule_name in perf_css_rules {
+            assert!(
+                rule_name_matches_config_category(rule_name, "perf"),
+                "{rule_name} must belong to the perf category",
+            );
+        }
+    }
 }

--- a/crates/vize_patina/src/linter/tests/severity_overrides.rs
+++ b/crates/vize_patina/src/linter/tests/severity_overrides.rs
@@ -37,6 +37,38 @@ fn css_rule_severity_override_recounts_sfc_result() {
     assert_eq!(result.diagnostics[0].severity, Severity::Error);
 }
 
+#[test]
+fn css_rule_category_severity_override_recounts_sfc_result() {
+    let source = r#"<style>
+.button { color: red !important; }
+</style>
+"#;
+    let result = Linter::with_preset(LintPreset::Ecosystem)
+        .with_enabled_rules(Some(vec!["css/no-important".into()]))
+        .with_category_severity_overrides(vec![("style".into(), Severity::Error)])
+        .lint_sfc(source, "Button.vue");
+
+    assert_eq!(result.error_count, 1, "{:?}", result.diagnostics);
+    assert_eq!(result.warning_count, 0, "{:?}", result.diagnostics);
+    assert_eq!(result.diagnostics[0].severity, Severity::Error);
+}
+
+#[test]
+fn disabled_category_disables_classified_css_rule() {
+    let source = r#"<style>
+.button { color: red !important; }
+</style>
+"#;
+    let result = Linter::with_preset(LintPreset::Ecosystem)
+        .with_enabled_rules(Some(vec!["css/no-important".into()]))
+        .with_disabled_categories(vec!["style".into()])
+        .lint_sfc(source, "Button.vue");
+
+    assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+    assert_eq!(result.error_count, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
 const NUXT_CONFIG_ORDER_SOURCE: &str = "export default { ssr: true, modules: [] }";
 
 #[test]


### PR DESCRIPTION
## Summary
- apply disabled category and category severity config to the built-in css/* registry
- complete CSS rule category classification for style and perf rules
- add unit and CLI regressions for CSS category off/error behavior

## Tests
- cargo test -p vize_patina linter::category_rules
- cargo test -p vize_patina linter::tests::severity_overrides
- cargo test -p vize --test lint_css_category_cli
- cargo fmt --all --check
- env SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790948545&installation_model_id=422833&pr_number=5604&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5604&signature=f09d5f86bf62981fadb2adbdcb05382386970c3150f4863328aeea7d02b70e35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->