### PR TITLE
test(patina): pin standalone html script lint

### DIFF
--- a/crates/vize/tests/lint_html_script_cli.rs
+++ b/crates/vize/tests/lint_html_script_cli.rs
@@ -1,0 +1,98 @@
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use std::{fs, path::Path, process::Command};
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+fn output_details(output: &std::process::Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn configured_script_rules_reach_standalone_html_inline_scripts() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "incremental",
+    "rules": {
+      "script/no-next-tick": "error"
+    }
+  }
+}"#,
+    );
+    write_file(
+        project_root.path(),
+        "index.html",
+        r#"<!doctype html>
+<html>
+<body>
+  <div id="app"></div>
+  <script type="module">
+import { nextTick } from "vue"
+await nextTick()
+  </script>
+</body>
+</html>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "index.html",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let actual = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!([{
+          "file": "index.html",
+          "messages": [{
+            "ruleId": "script/no-next-tick",
+            "ruleDocsPath": "docs/content/rules/type-and-script.md",
+            "severity": 2,
+            "message": "[vize:script/no-next-tick] nextTick import is not supported in Vapor-oriented components",
+            "line": 6,
+            "column": 10,
+            "endLine": 6,
+            "endColumn": 18,
+            "help": "Remove nextTick() usage and rely on explicit lifecycle boundaries like onMounted() or direct reactive flow instead."
+          }, {
+            "ruleId": "script/no-next-tick",
+            "ruleDocsPath": "docs/content/rules/type-and-script.md",
+            "severity": 2,
+            "message": "[vize:script/no-next-tick] nextTick() is not supported in Vapor-oriented components",
+            "line": 7,
+            "column": 7,
+            "endLine": 7,
+            "endColumn": 15,
+            "help": "Avoid post-render scheduling with nextTick(). Prefer onMounted(), template refs, or a control flow that does not depend on a DOM flush boundary."
+          }],
+          "errorCount": 2,
+          "warningCount": 0
+        }]),
+        "{}",
+        output_details(&output),
+    );
+}


### PR DESCRIPTION
## Summary
- add a CLI regression proving configured script rules run inside standalone HTML inline scripts
- pin script/no-next-tick JSON output for an index.html fixture

## Tests
- cargo test -p vize --test lint_html_script_cli
- cargo test -p vize --test lint_rule_execution_cli
- cargo test -p vize --test lint_css_category_cli
- cargo fmt --all --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790950795&installation_model_id=422833&pr_number=5605&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5605&signature=632b4ef1175b70dada10f50c1cdbaa359ccb3eda05a58416ca0dde59031dde83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming lint rules detect `nextTick` imports and calls in standalone HTML inline module scripts.
  * Verified the CLI reports both diagnostics in JSON output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->