### PR TITLE
test(patina): pin entry css rule scopes

### DIFF
--- a/crates/vize/tests/lint_entry_css_scope_cli.rs
+++ b/crates/vize/tests/lint_entry_css_scope_cli.rs
@@ -1,0 +1,146 @@
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use std::{fs, path::Path, process::Command};
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+fn output_details(output: &std::process::Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn write_css_fixtures(root: &Path) {
+    let source = r#"<style>
+.a { color: red !important; }
+</style>
+"#;
+    write_file(root, "src/components/Card.vue", source);
+    write_file(root, "src/pages/Home.vue", source);
+}
+
+fn css_no_important_message(file: &str) -> serde_json::Value {
+    serde_json::json!({
+      "file": file,
+      "messages": [{
+        "ruleId": "css/no-important",
+        "ruleDocsPath": "docs/content/rules/musea-and-css.md",
+        "severity": 2,
+        "message": "[vize:css/no-important] Avoid using !important as it makes styles harder to override",
+        "line": 2,
+        "column": 17,
+        "endLine": 2,
+        "endColumn": 27,
+        "help": "Use more specific selectors or reorganize CSS specificity instead"
+      }],
+      "errorCount": 1,
+      "warningCount": 0
+    })
+}
+
+fn empty_file_result(file: &str) -> serde_json::Value {
+    serde_json::json!({
+      "file": file,
+      "messages": [],
+      "errorCount": 0,
+      "warningCount": 0
+    })
+}
+
+#[test]
+fn entry_linter_rules_disable_builtin_css_rules_for_matching_files() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "incremental",
+    "rules": { "css/no-important": "error" }
+  },
+  "entries": [{
+    "files": ["src/pages/**/*.vue"],
+    "linter": { "rules": { "css/no-important": "off" } }
+  }]
+}"#,
+    );
+    write_css_fixtures(project_root.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "src/**/*.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let actual = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!([
+            css_no_important_message("src/components/Card.vue"),
+            empty_file_result("src/pages/Home.vue")
+        ]),
+        "{}",
+        output_details(&output),
+    );
+}
+
+#[test]
+fn entry_linter_rules_enable_builtin_css_rules_for_matching_files() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "incremental",
+    "rules": { "css/no-important": "off" }
+  },
+  "entries": [{
+    "files": ["src/pages/**/*.vue"],
+    "linter": { "rules": { "css/no-important": "error" } }
+  }]
+}"#,
+    );
+    write_css_fixtures(project_root.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "src/**/*.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let actual = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!([
+            empty_file_result("src/components/Card.vue"),
+            css_no_important_message("src/pages/Home.vue")
+        ]),
+        "{}",
+        output_details(&output),
+    );
+}


### PR DESCRIPTION
## Summary
- add CLI regressions for entries[] scoped css/no-important behavior
- pin both global error + entry off and global off + entry error cases

## Tests
- cargo test -p vize --test lint_entry_css_scope_cli
- cargo test -p vize --test lint_rule_severity_cli
- cargo test -p vize --test lint_css_category_cli
- cargo fmt --all --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5606"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790950960&installation_model_id=422833&pr_number=5606&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5606&signature=75268a5dfe4d43b95ec44273c972992077a6f6bf0389b8df22cea080eb4bee6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage verifying that entry-level CSS lint rule overrides take precedence over preset-level settings.
  * Added coverage for both enabling and disabling the `css/no-important` rule on matching files, while preserving preset behavior for non-matching files.
  * Added validation of lint results returned in JSON format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->