### PR TITLE
test(davinci): pin unfused build traversal boundary

### DIFF
--- a/crates/vize_s1_to_s2/tests/emit_budget_observer.rs
+++ b/crates/vize_s1_to_s2/tests/emit_budget_observer.rs
@@ -27,6 +27,7 @@ const S2_DOM_EMIT_COUNTS: [(&str, u32, u32); 6] = [
 
 #[test]
 fn observed_dom_emit_keeps_output_and_walk_budget() {
+    let fused_walk_target = phase_2_dom_walk_target();
     for fixture in &LADDER {
         let template =
             template_block(fixture.source).expect("every ladder fixture has a template block");
@@ -94,13 +95,22 @@ fn observed_dom_emit_keeps_output_and_walk_budget() {
             observed.budget.emit_visits,
             baseline.visits
         );
+        assert!(
+            observed.budget.total_walks() > fused_walk_target,
+            "{} total walks {} already meet the phase-2 fused DOM target {} before the build path has switched",
+            fixture.name,
+            observed.budget.total_walks(),
+            fused_walk_target
+        );
         println!(
-            "davinci.s2_dom.walk {} emit_walks={} emit_visits={} transform_walks={} transform_passes={} baseline_walks={} baseline_visits={}",
+            "davinci.s2_dom.walk {} emit_walks={} emit_visits={} transform_walks={} transform_passes={} total_walks={} fused_walk_target={} baseline_walks={} baseline_visits={}",
             fixture.name,
             observed.budget.emit_walks,
             observed.budget.emit_visits,
             observed.budget.transform.walks,
             observed.budget.transform.passes,
+            observed.budget.total_walks(),
+            fused_walk_target,
             baseline.walks,
             baseline.visits
         );
@@ -136,6 +146,22 @@ fn traversal_budget(fixture: &str) -> TraversalBudget {
         walks: required_u32(entry, &id, "walks"),
         visits: required_u32(entry, &id, "visits"),
     }
+}
+
+fn phase_2_dom_walk_target() -> u32 {
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate directory")
+        .parent()
+        .expect("repo root");
+    let text = std::fs::read_to_string(repo.join("davinci-road/plan/budgets.toml"))
+        .expect("budgets.toml reads");
+    let value: toml::Value = toml::from_str(&text).expect("budgets.toml parses");
+    let entry = value
+        .get("target")
+        .and_then(|target| target.get("phase-2"))
+        .expect("budgets.toml has [target.phase-2]");
+    required_u32(entry, "target.phase-2", "dom_walks_max")
 }
 
 fn required_u32(entry: &toml::Value, id: &str, field: &str) -> u32 {


### PR DESCRIPTION
## Summary
- pin that observed S2 DOM emit still exceeds the phase-2 fused DOM walk target when transform walks are included
- keep the boundary explicit before any production build path switch

## Tests
- cargo test -p vize_s1_to_s2 --test emit_budget_observer
- cargo test -p vize --test build_profile_cli
- cargo fmt --all --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/davinci-traversal-budgets.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5607"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790951167&installation_model_id=422833&pr_number=5607&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5607&signature=cd9f8eb3a0198e2c9e1590615cf836e7af9231a94b1c27236baa091daa042039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated budget validation to compare observed Phase 2 DOM walks against the configured target for each fixture.
  * Enhanced diagnostics to report both observed totals and configured targets when validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->