### PR TITLE
fix(patina): enable configured restricted members

### DIFF
--- a/crates/vize/src/commands/lint/entry_rules.rs
+++ b/crates/vize/src/commands/lint/entry_rules.rs
@@ -13,6 +13,7 @@ use crate::lint_plan::matcher::GlobSequence;
 use crate::lint_plan::matcher::{LintPlanScope, absolute_path};
 
 const PINIA_PREFER_STORE_TO_REFS: &str = "ecosystem/pinia-prefer-store-to-refs";
+const SCRIPT_NO_RESTRICTED_MEMBERS: &str = "script/no-restricted-members";
 
 pub(super) struct ResolvedLinterRuleGroups {
     pub(super) configs: Vec<crate::config::LinterConfig>,
@@ -36,9 +37,23 @@ impl ResolvedLinterRuleGroups {
             .map(|(config, pinia_available)| {
                 let type_aware =
                     args.type_aware || args.strict_reactivity || config.type_aware_lint_enabled();
+                let mut additional_rules = config.enabled_rules();
+                let disabled_rules = resolved_disabled_rules(config, *pinia_available);
+                let restricted_globals = rule_options.restricted_globals();
+                let restricted_members = rule_options.restricted_members();
+                if !restricted_members.is_empty()
+                    && !disabled_rules
+                        .iter()
+                        .any(|rule| rule.as_str() == SCRIPT_NO_RESTRICTED_MEMBERS)
+                    && !additional_rules
+                        .iter()
+                        .any(|rule| rule.as_str() == SCRIPT_NO_RESTRICTED_MEMBERS)
+                {
+                    additional_rules.push(SCRIPT_NO_RESTRICTED_MEMBERS.into());
+                }
                 let mut linter = Linter::with_preset(preset)
-                    .with_additional_rules(config.enabled_rules())
-                    .with_disabled_rules(resolved_disabled_rules(config, *pinia_available))
+                    .with_additional_rules(additional_rules)
+                    .with_disabled_rules(disabled_rules)
                     .with_disabled_categories(config.disabled_categories())
                     .with_category_severity_overrides(severity_overrides(
                         config.category_severity_overrides(),
@@ -50,8 +65,8 @@ impl ResolvedLinterRuleGroups {
                     .with_type_aware_lint(type_aware)
                     .with_vue_version(features.vue_version)
                     .with_vapor_mode(features.vapor)
-                    .with_restricted_globals(rule_options.restricted_globals())
-                    .with_restricted_members(rule_options.restricted_members());
+                    .with_restricted_globals(restricted_globals)
+                    .with_restricted_members(restricted_members);
                 #[cfg(not(target_arch = "wasm32"))]
                 {
                     linter = linter.with_corsa_path(configured_corsa_path.clone());

--- a/crates/vize/tests/lint_restricted_members_cli.rs
+++ b/crates/vize/tests/lint_restricted_members_cli.rs
@@ -1,0 +1,148 @@
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use std::{fs, path::Path, process::Command};
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+fn output_details(output: &std::process::Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn write_restricted_member_sfc(root: &Path) {
+    write_file(
+        root,
+        "src/App.vue",
+        r#"<script setup lang="ts">
+const token = window.localStorage.getItem("auth.token")
+</script>
+"#,
+    );
+}
+
+#[test]
+fn configured_restricted_members_enable_the_project_local_rule() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "incremental",
+    "ruleOptions": {
+      "script/no-restricted-members": {
+        "members": [
+          {
+            "object": "window",
+            "property": "localStorage",
+            "message": "Use authStorage."
+          }
+        ]
+      }
+    }
+  }
+}"#,
+    );
+    write_restricted_member_sfc(project_root.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "src/App.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let actual = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!([{
+          "file": "src/App.vue",
+          "messages": [{
+            "ruleId": "script/no-restricted-members",
+            "ruleDocsPath": "docs/content/rules/type-and-script.md",
+            "severity": 2,
+            "message": "[vize:script/no-restricted-members] Use authStorage.",
+            "line": 2,
+            "column": 15,
+            "endLine": 2,
+            "endColumn": 34
+          }],
+          "errorCount": 1,
+          "warningCount": 0
+        }]),
+        "{}",
+        output_details(&output),
+    );
+}
+
+#[test]
+fn explicit_off_keeps_configured_restricted_members_disabled() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "incremental",
+    "rules": {
+      "script/no-restricted-members": "off"
+    },
+    "ruleOptions": {
+      "script/no-restricted-members": {
+        "members": [
+          {
+            "object": "window",
+            "property": "localStorage",
+            "message": "Use authStorage."
+          }
+        ]
+      }
+    }
+  }
+}"#,
+    );
+    write_restricted_member_sfc(project_root.path());
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "src/App.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "{}", output_details(&output));
+    let actual = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!([{
+          "file": "src/App.vue",
+          "messages": [],
+          "errorCount": 0,
+          "warningCount": 0
+        }]),
+        "{}",
+        output_details(&output),
+    );
+}


### PR DESCRIPTION
## Summary
- auto-enable script/no-restricted-members when linter.ruleOptions provides a non-empty members list
- keep explicit rules[script/no-restricted-members] = off authoritative
- add CLI regressions for the formerly silent ruleOptions-only case

## Tests
- cargo test -p vize --test lint_restricted_members_cli
- cargo test -p vize --test lint_rule_execution_cli
- cargo test -p vize --test lint_config_cli
- cargo test -p vize --test lint_rule_severity_cli
- cargo test -p vize_carton config::model::linter
- cargo test -p vize_patina linter::tests::script
- cargo fmt --all --check
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790951448&installation_model_id=422833&pr_number=5608&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5608&signature=a4f51a889ea0863d0604156a4fdf58c6c7eb4f09b54b10d49da8fc5693a32879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured restricted-member checks now automatically enable the corresponding lint rule when appropriate.
  * Lint results report configured restricted members with the specified message and source location.

* **Bug Fixes**
  * Explicitly disabling the restricted-member rule now correctly suppresses its diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->