### PR TITLE
fix(patina): preserve scoped rule options

### DIFF
--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -55,16 +55,15 @@ pub fn run(args: LintArgs) {
     let (loaded_config, linter_plan, linter_features) = if args.no_config {
         (
             crate::config::LoadedConfigWithFeatures::default(),
-            crate::config::LinterConfigPlan::default(),
+            crate::config::LinterConfigPlanWithRuleOptions::default(),
             crate::config::LinterFeatureFlags::default(),
         )
     } else {
-        crate::config::load_config_and_linter_plan_with_lint_features_and_source(
+        crate::config::load_config_and_linter_plan_with_rule_options_and_lint_features_and_source(
             args.config.as_deref(),
         )
     };
-    let linter_enabled = linter_plan.base.enabled;
-    let rule_options = linter_plan.rule_options.clone();
+    let linter_enabled = linter_plan.plan.base.enabled;
     let config_dir = loaded_config
         .source_path
         .as_deref()
@@ -79,7 +78,7 @@ pub fn run(args: LintArgs) {
         .type_checker
         .runtime_path()
         .map(|path| resolve_lint_config_path(config_dir, path));
-    let ignore_set = LintIgnoreSet::new(&linter_plan.global_ignores, config_dir);
+    let ignore_set = LintIgnoreSet::new(&linter_plan.plan.global_ignores, config_dir);
     let collect_start = Instant::now();
     let files = collect_lint_files(&args.patterns, ignore_set.as_ref());
     let collect_time = collect_start.elapsed();
@@ -96,7 +95,7 @@ pub fn run(args: LintArgs) {
     let preset_name: String = args
         .preset
         .as_deref()
-        .or(linter_plan.base.preset.as_deref())
+        .or(linter_plan.plan.base.preset.as_deref())
         .unwrap_or("ecosystem")
         .into();
     let preset = LintPreset::parse(preset_name.as_str()).unwrap_or_default();
@@ -107,7 +106,6 @@ pub fn run(args: LintArgs) {
         help_level,
         &args,
         linter_features,
-        &rule_options,
         configured_corsa_path,
     );
     let write_failures = AtomicUsize::new(0);

--- a/crates/vize/src/commands/lint/entry_rules.rs
+++ b/crates/vize/src/commands/lint/entry_rules.rs
@@ -4,7 +4,9 @@ use std::path::{Path, PathBuf};
 use vize_patina::{HelpLevel, LintPreset, Linter, Severity};
 use vize_s0::{
     FxHashMap, String,
-    config::{LintRuleOptions, LintRuleSeverity, LinterConfigPlan, LinterFeatureFlags},
+    config::{
+        LintRuleOptions, LintRuleSeverity, LinterConfigPlanWithRuleOptions, LinterFeatureFlags,
+    },
 };
 
 use super::LintArgs;
@@ -17,6 +19,7 @@ const SCRIPT_NO_RESTRICTED_MEMBERS: &str = "script/no-restricted-members";
 
 pub(super) struct ResolvedLinterRuleGroups {
     pub(super) configs: Vec<crate::config::LinterConfig>,
+    rule_options: Vec<LintRuleOptions>,
     pub(super) file_config_indices: Vec<usize>,
     pinia_available: Vec<bool>,
 }
@@ -28,13 +31,13 @@ impl ResolvedLinterRuleGroups {
         help_level: HelpLevel,
         args: &LintArgs,
         features: LinterFeatureFlags,
-        rule_options: &LintRuleOptions,
         configured_corsa_path: Option<PathBuf>,
     ) -> Vec<Linter> {
         self.configs
             .iter()
             .zip(&self.pinia_available)
-            .map(|(config, pinia_available)| {
+            .zip(&self.rule_options)
+            .map(|((config, pinia_available), rule_options)| {
                 let type_aware =
                     args.type_aware || args.strict_reactivity || config.type_aware_lint_enabled();
                 let mut additional_rules = config.enabled_rules();
@@ -95,14 +98,20 @@ fn severity_overrides(entries: Vec<(String, LintRuleSeverity)>) -> Vec<(String, 
 }
 
 pub(super) struct LinterRuleResolver {
-    plan: LinterConfigPlan,
+    plan: LinterConfigPlanWithRuleOptions,
     scopes: Vec<LintPlanScope>,
 }
 
 impl LinterRuleResolver {
-    pub(super) fn new(plan: LinterConfigPlan, config_dir: &Path, cwd: &Path) -> Self {
+    pub(super) fn new(
+        plan: impl Into<LinterConfigPlanWithRuleOptions>,
+        config_dir: &Path,
+        cwd: &Path,
+    ) -> Self {
+        let plan = plan.into();
         let config_dir = absolute_path(config_dir, cwd);
         let scopes = plan
+            .plan
             .entries
             .iter()
             .map(|entry| {
@@ -123,6 +132,7 @@ impl LinterRuleResolver {
         let mut signatures = FxHashMap::<(Vec<usize>, bool), usize>::default();
         let mut dependency_cache = FxHashMap::default();
         let mut configs = Vec::new();
+        let mut rule_options = Vec::new();
         let mut pinia_available = Vec::new();
         let mut file_config_indices = Vec::with_capacity(files.len());
         for file in files {
@@ -134,7 +144,9 @@ impl LinterRuleResolver {
                 Some(index) => *index,
                 None => {
                     let index = configs.len();
-                    configs.push(self.plan.resolve_matching_entries(&signature.0));
+                    let resolved = self.plan.resolve_matching_entries(&signature.0);
+                    configs.push(resolved.config);
+                    rule_options.push(resolved.rule_options);
                     pinia_available.push(signature.1);
                     signatures.insert(signature, index);
                     index
@@ -144,6 +156,7 @@ impl LinterRuleResolver {
         }
         ResolvedLinterRuleGroups {
             configs,
+            rule_options,
             file_config_indices,
             pinia_available,
         }

--- a/crates/vize/tests/lint_entry_rule_options_cli.rs
+++ b/crates/vize/tests/lint_entry_rule_options_cli.rs
@@ -1,0 +1,109 @@
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use std::{fs, path::Path, process::Command};
+
+fn write_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+fn output_details(output: &std::process::Output) -> String {
+    format!(
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn write_session_storage_sfc(root: &Path, path: &str) {
+    write_file(
+        root,
+        path,
+        r#"<script setup lang="ts">
+const token = window.sessionStorage.getItem("auth.token")
+</script>
+"#,
+    );
+}
+
+#[test]
+fn entry_rule_options_enable_project_local_rules_for_matching_files() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_file(
+        project_root.path(),
+        "vize.config.json",
+        r#"{
+  "linter": {
+    "preset": "incremental"
+  },
+  "entries": [
+    {
+      "files": ["src/admin/**/*.vue"],
+      "linter": {
+        "ruleOptions": {
+          "script/no-restricted-members": {
+            "members": [
+              {
+                "object": "window",
+                "property": "sessionStorage",
+                "message": "Use adminStorage."
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}"#,
+    );
+    write_session_storage_sfc(project_root.path(), "src/admin/App.vue");
+    write_session_storage_sfc(project_root.path(), "src/public/App.vue");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "src/admin/App.vue",
+            "src/public/App.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1), "{}", output_details(&output));
+    let actual = serde_json::from_slice::<serde_json::Value>(&output.stdout).unwrap();
+    assert_eq!(
+        actual,
+        serde_json::json!([
+          {
+            "file": "src/admin/App.vue",
+            "messages": [{
+              "ruleId": "script/no-restricted-members",
+              "ruleDocsPath": "docs/content/rules/type-and-script.md",
+              "severity": 2,
+              "message": "[vize:script/no-restricted-members] Use adminStorage.",
+              "line": 2,
+              "column": 15,
+              "endLine": 2,
+              "endColumn": 36
+            }],
+            "errorCount": 1,
+            "warningCount": 0
+          },
+          {
+            "file": "src/public/App.vue",
+            "messages": [],
+            "errorCount": 0,
+            "warningCount": 0
+          }
+        ]),
+        "{}",
+        output_details(&output),
+    );
+}

--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -10,6 +10,7 @@ pub use loader::{
     load_compiler_jsx_mode, load_compiler_template_syntax, load_compiler_vapor,
     load_compiler_vue_version, load_config,
     load_config_and_linter_plan_with_lint_features_and_source,
+    load_config_and_linter_plan_with_rule_options_and_lint_features_and_source,
     load_config_and_linter_with_features_and_source,
     load_config_and_linter_with_lint_features_and_source, load_config_and_linter_with_source,
     load_config_entry_files_with_source, load_config_entry_ignores_with_source,
@@ -21,9 +22,10 @@ pub use model::{
     ArrowParens, AttributeSortOrder, ConfigEntryFiles, ConfigEntryIgnore, ConfigFeatureFlags,
     EndOfLine, FormatterConfig, GlobalTypeDeclaration, GlobalTypesConfig, JsxCompat, JsxMode,
     LanguageServerConfig, LanguageServerUnstableFlags, LintRuleOptions, LintRuleSeverity,
-    LinterConfig, LinterConfigEntry, LinterConfigPlan, LinterFeatureFlags, LspConfig,
-    NoRestrictedGlobalsOptions, NoRestrictedMembersOptions, ParseVueVersionError, QuoteProps,
-    RestrictedGlobal, RestrictedMember, TrailingComma, TypeCheckerConfig, VizeConfig, VueVersion,
+    LinterConfig, LinterConfigEntry, LinterConfigPlan, LinterConfigPlanWithRuleOptions,
+    LinterFeatureFlags, LspConfig, NoRestrictedGlobalsOptions, NoRestrictedMembersOptions,
+    ParseVueVersionError, QuoteProps, ResolvedLinterConfig, RestrictedGlobal, RestrictedMember,
+    TrailingComma, TypeCheckerConfig, VizeConfig, VueVersion,
 };
 pub use normalize::normalize_public_config_value;
 

--- a/crates/vize_carton/src/config/loader/lint_features.rs
+++ b/crates/vize_carton/src/config/loader/lint_features.rs
@@ -5,7 +5,8 @@ use super::{
     load_raw_config_with_source,
 };
 use crate::config::{
-    ConfigEntryIgnore, LinterConfig, LinterConfigEntry, LinterConfigPlan, LinterFeatureFlags,
+    ConfigEntryIgnore, LinterConfig, LinterConfigEntry, LinterConfigPlan,
+    LinterConfigPlanWithRuleOptions, LinterFeatureFlags,
 };
 
 fn load_linter_plan_from_raw_config(config: &RawVizeConfig) -> LinterConfigPlan {
@@ -24,7 +25,46 @@ fn load_linter_plan_from_raw_config(config: &RawVizeConfig) -> LinterConfigPlan 
             })
         })
         .collect();
-    let global_ignores = config
+    LinterConfigPlan {
+        base: load_linter_from_raw_config(config),
+        entries,
+        global_ignores: global_ignores_from_raw_config(config),
+        rule_options: config.linter.rule_options().clone(),
+    }
+}
+
+fn load_linter_plan_with_rule_options_from_raw_config(
+    config: &RawVizeConfig,
+) -> LinterConfigPlanWithRuleOptions {
+    let mut entries = Vec::new();
+    let mut entry_rule_options = Vec::new();
+    for entry in config.entries.as_deref().unwrap_or_default() {
+        let rule_options = entry.linter.rule_options().clone();
+        let linter = LinterConfig::from(entry.linter.clone());
+        if linter.rules.is_empty() && rule_options.is_empty() {
+            continue;
+        }
+        entries.push(LinterConfigEntry {
+            base_path: entry.base_path.clone(),
+            files: entry.files.clone(),
+            ignores: entry.ignores.clone().unwrap_or_default(),
+            rules: linter.rules,
+        });
+        entry_rule_options.push(rule_options);
+    }
+    LinterConfigPlanWithRuleOptions {
+        plan: LinterConfigPlan {
+            base: load_linter_from_raw_config(config),
+            entries,
+            global_ignores: global_ignores_from_raw_config(config),
+            rule_options: config.linter.rule_options().clone(),
+        },
+        entry_rule_options,
+    }
+}
+
+fn global_ignores_from_raw_config(config: &RawVizeConfig) -> Vec<ConfigEntryIgnore> {
+    config
         .ignores
         .as_deref()
         .unwrap_or_default()
@@ -36,13 +76,7 @@ fn load_linter_plan_from_raw_config(config: &RawVizeConfig) -> LinterConfigPlan 
             base_path: None,
             pattern,
         })
-        .collect();
-    LinterConfigPlan {
-        base: load_linter_from_raw_config(config),
-        entries,
-        global_ignores,
-        rule_options: config.linter.rule_options().clone(),
-    }
+        .collect()
 }
 
 /// Load configuration, feature flags, linter settings, and lint-only compatibility in one pass.
@@ -91,6 +125,40 @@ pub fn load_config_and_linter_plan_with_lint_features_and_source(
         .vapor
         .or_else(|| loaded.config.experimentals.vapor_enabled().then_some(true));
     let linter = load_linter_plan_from_raw_config(&loaded.config);
+    let (config, features) = loaded.config.into_config_and_features();
+    let linter_features = LinterFeatureFlags::from_config_features(
+        features,
+        compiler_compatibility_vue_version,
+        compiler_vapor,
+    );
+
+    (
+        LoadedConfigWithFeatures {
+            config,
+            source_path: loaded.source_path,
+            features,
+        },
+        linter,
+        linter_features,
+    )
+}
+
+/// Load the declaration-ordered linter plan with entry-local rule options.
+pub fn load_config_and_linter_plan_with_rule_options_and_lint_features_and_source(
+    path: Option<&Path>,
+) -> (
+    LoadedConfigWithFeatures,
+    LinterConfigPlanWithRuleOptions,
+    LinterFeatureFlags,
+) {
+    let loaded = load_raw_config_with_source(path);
+    let compiler_compatibility_vue_version = loaded.config.compiler.compatibility.vue_version;
+    let compiler_vapor = loaded
+        .config
+        .compiler
+        .vapor
+        .or_else(|| loaded.config.experimentals.vapor_enabled().then_some(true));
+    let linter = load_linter_plan_with_rule_options_from_raw_config(&loaded.config);
     let (config, features) = loaded.config.into_config_and_features();
     let linter_features = LinterFeatureFlags::from_config_features(
         features,

--- a/crates/vize_carton/src/config/loader/tests/linter_plan_tests.rs
+++ b/crates/vize_carton/src/config/loader/tests/linter_plan_tests.rs
@@ -1,5 +1,7 @@
 //! Linter-plan configuration regressions.
 
+use crate::config::load_config_and_linter_plan_with_rule_options_and_lint_features_and_source;
+
 use super::*;
 
 #[test]
@@ -51,4 +53,72 @@ fn preserves_scopes_and_resolves_rules_in_declaration_order() {
     assert_eq!(plan.global_ignores.len(), 1);
     assert_eq!(plan.global_ignores[0].base_path, None);
     assert_eq!(plan.global_ignores[0].pattern.as_str(), "generated/**");
+}
+
+#[test]
+fn preserves_scoped_rule_options_for_options_only_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(
+        &config_path,
+        r#"{
+  "linter": {
+    "ruleOptions": {
+      "script/no-restricted-members": {
+        "members": [
+          {
+            "object": "window",
+            "property": "localStorage",
+            "message": "Use shared storage."
+          }
+        ]
+      }
+    }
+  },
+  "entries": [
+    {
+      "files": ["src/admin/**/*.vue"],
+      "linter": {
+        "ruleOptions": {
+          "script/no-restricted-members": {
+            "members": [
+              {
+                "object": "window",
+                "property": "sessionStorage",
+                "message": "Use admin storage."
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let (_, plan, _) = load_config_and_linter_plan_with_rule_options_and_lint_features_and_source(
+        Some(&config_path),
+    );
+    let base = plan.resolve_matching_entries(&[]);
+    let admin = plan.resolve_matching_entries(&[0]);
+
+    assert_eq!(plan.plan.entries.len(), 1);
+    assert_eq!(plan.entry_rule_options.len(), 1);
+    assert_eq!(
+        base.rule_options.restricted_members(),
+        [(
+            "window".into(),
+            "localStorage".into(),
+            Some("Use shared storage.".into())
+        )]
+    );
+    assert_eq!(
+        admin.rule_options.restricted_members(),
+        [(
+            "window".into(),
+            "sessionStorage".into(),
+            Some("Use admin storage.".into())
+        )]
+    );
 }

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -19,7 +19,10 @@ use vue::RawVueConfig;
 
 pub use compiler::{JsxCompat, JsxMode};
 pub(crate) use entries::RawConfigEntry;
-pub use entries::{ConfigEntryFiles, ConfigEntryIgnore, LinterConfigEntry, LinterConfigPlan};
+pub use entries::{
+    ConfigEntryFiles, ConfigEntryIgnore, LinterConfigEntry, LinterConfigPlan,
+    LinterConfigPlanWithRuleOptions, ResolvedLinterConfig,
+};
 
 use crate::String;
 use crate::dialect::VueDialect;

--- a/crates/vize_carton/src/config/model/entries.rs
+++ b/crates/vize_carton/src/config/model/entries.rs
@@ -45,6 +45,30 @@ pub struct LinterConfigPlan {
     pub rule_options: LintRuleOptions,
 }
 
+/// A linter config resolved with the scoped `ruleOptions` that apply to it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResolvedLinterConfig {
+    pub config: LinterConfig,
+    pub rule_options: LintRuleOptions,
+}
+
+/// Linter settings plus entry-local rule options for CLI lint execution.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LinterConfigPlanWithRuleOptions {
+    pub plan: LinterConfigPlan,
+    pub entry_rule_options: Vec<LintRuleOptions>,
+}
+
+impl From<LinterConfigPlan> for LinterConfigPlanWithRuleOptions {
+    fn from(plan: LinterConfigPlan) -> Self {
+        let entry_rule_options = vec![LintRuleOptions::default(); plan.entries.len()];
+        Self {
+            plan,
+            entry_rule_options,
+        }
+    }
+}
+
 impl LinterConfigPlan {
     /// Merge a set of matching entries in declaration order, with later rules winning.
     pub fn resolve_matching_entries(&self, matching_entries: &[usize]) -> LinterConfig {
@@ -61,5 +85,27 @@ impl LinterConfigPlan {
             }
         }
         resolved
+    }
+}
+
+impl LinterConfigPlanWithRuleOptions {
+    /// Merge matching linter rules and rule options in declaration order.
+    pub fn resolve_matching_entries(&self, matching_entries: &[usize]) -> ResolvedLinterConfig {
+        let mut rule_options = self.plan.rule_options.clone();
+        let mut matches = vec![false; self.plan.entries.len()];
+        for index in matching_entries {
+            if let Some(value) = matches.get_mut(*index) {
+                *value = true;
+            }
+        }
+        for (index, matches) in matches.into_iter().enumerate() {
+            if matches && let Some(options) = self.entry_rule_options.get(index) {
+                rule_options.merge_from(options);
+            }
+        }
+        ResolvedLinterConfig {
+            config: self.plan.resolve_matching_entries(matching_entries),
+            rule_options,
+        }
     }
 }

--- a/crates/vize_carton/src/config/model/linter_rule_options.rs
+++ b/crates/vize_carton/src/config/model/linter_rule_options.rs
@@ -71,6 +71,16 @@ impl LintRuleOptions {
             })
             .unwrap_or_default()
     }
+
+    /// Apply a later config layer to this option set.
+    pub fn merge_from(&mut self, overlay: &Self) {
+        if let Some(options) = &overlay.no_restricted_globals {
+            self.no_restricted_globals = Some(options.clone());
+        }
+        if let Some(options) = &overlay.no_restricted_members {
+            self.no_restricted_members = Some(options.clone());
+        }
+    }
 }
 
 /// Options for `script/no-restricted-globals`.


### PR DESCRIPTION
## Summary
- preserve entries[].linter.ruleOptions while building the CLI linter plan
- resolve rule options per matching entry group before constructing linters
- add CLI regression for an options-only scoped entry that previously exited 0 with empty messages

## Tests
- cargo test -p vize --test lint_entry_rule_options_cli
- cargo test -p vize_carton linter_plan
- cargo test -p vize --test lint_restricted_members_cli
- cargo test -p vize --test lint_config_cli
- cargo test -p vize --test lint_rule_severity_cli
- cargo test -p vize --test lint_entry_css_scope_cli
- cargo fmt --all --check
- env SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790953288&installation_model_id=422833&pr_number=5609&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5609&signature=89754b759d5787b4235601ff2d8b375abca3d385e7c9a6d4276b016f7d5c6d6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->