### PR TITLE
fix(release): bump qs audit floor

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,7 +382,7 @@ overrides:
   node-forge: 1.4.0
   postcss@>=8.0.0 <8.5.26: 8.5.26
   nuxt: 4.5.1
-  qs: 6.15.2
+  qs: 6.16.0
   readdir-glob>minimatch: 10.2.5
   shell-quote: 1.9.0
   simple-git: 3.36.0
@@ -10139,8 +10139,8 @@ packages:
     engines: {node: '>=22.12.0'}
     hasBin: true
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -17638,7 +17638,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -18946,7 +18946,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.2
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0(supports-color@10.2.2)
       send: 1.2.1(supports-color@10.2.2)
@@ -21333,7 +21333,7 @@ snapshots:
       - utf-8-validate
       - yauzl
 
-  qs@6.15.2:
+  qs@6.16.0:
     dependencies:
       side-channel: 1.1.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,7 +55,7 @@ overrides:
   node-forge: "1.4.0"
   "postcss@>=8.0.0 <8.5.26": "8.5.26"
   nuxt: "4.5.1"
-  qs: "6.15.2"
+  qs: "6.16.0"
   "readdir-glob>minimatch": "10.2.5"
   shell-quote: "1.9.0"
   simple-git: "3.36.0"


### PR DESCRIPTION
## Summary
- bump the workspace qs override from 6.15.2 to 6.16.0
- update the lockfile qs package and express/body-parser snapshots only
- unblock release security-audit after the v0.390.0 publish attempt rolled back the unpublished tag

## Verification
- rtk vp install --workspace-root --frozen-lockfile --prefer-offline
- rtk vp exec pnpm audit --prod --audit-level moderate
- rtk node --test tests/tooling/release-package-versions.test.ts tests/tooling/github-workflows-release-publish.test.ts tests/tooling/release-preflight-workflow.test.ts
- rtk node --test tests/tooling/package-manifests.test.ts
- rtk git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790957194&installation_model_id=422833&pr_number=5611&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5611&signature=775b9ba4efaa476468d611912409d37d2394c71435e0312802f9705c6ca45ebe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the workspace override for the `qs` package to version 6.16.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->