### PR TITLE
fix(patina): run configured musea design token lint

### DIFF
--- a/crates/vize/src/commands/lint/entry_rules.rs
+++ b/crates/vize/src/commands/lint/entry_rules.rs
@@ -16,6 +16,7 @@ use crate::lint_plan::matcher::GlobSequence;
 use crate::lint_plan::matcher::{LintPlanScope, absolute_path};
 
 const PINIA_PREFER_STORE_TO_REFS: &str = "ecosystem/pinia-prefer-store-to-refs";
+const MUSEA_PREFER_DESIGN_TOKENS: &str = "musea/prefer-design-tokens";
 const SCRIPT_NO_RESTRICTED_MEMBERS: &str = "script/no-restricted-members";
 
 pub(super) struct ResolvedLinterRuleGroups {
@@ -45,6 +46,17 @@ impl ResolvedLinterRuleGroups {
                 let disabled_rules = resolved_disabled_rules(config, *pinia_available);
                 let restricted_globals = rule_options.restricted_globals();
                 let restricted_members = rule_options.restricted_members();
+                let musea_design_tokens = rule_options.musea_design_tokens();
+                if !musea_design_tokens.is_empty()
+                    && !disabled_rules
+                        .iter()
+                        .any(|rule| rule.as_str() == MUSEA_PREFER_DESIGN_TOKENS)
+                    && !additional_rules
+                        .iter()
+                        .any(|rule| rule.as_str() == MUSEA_PREFER_DESIGN_TOKENS)
+                {
+                    additional_rules.push(MUSEA_PREFER_DESIGN_TOKENS.into());
+                }
                 if !restricted_members.is_empty()
                     && !disabled_rules
                         .iter()
@@ -70,7 +82,8 @@ impl ResolvedLinterRuleGroups {
                     .with_vue_version(features.vue_version)
                     .with_vapor_mode(features.vapor)
                     .with_restricted_globals(restricted_globals)
-                    .with_restricted_members(restricted_members);
+                    .with_restricted_members(restricted_members)
+                    .with_musea_design_tokens(musea_design_tokens);
                 if let Some(casing) = rule_options.component_name_in_template_casing() {
                     linter =
                         linter.with_component_name_in_template_casing(component_casing(casing));

--- a/crates/vize/tests/lint_musea_cli.rs
+++ b/crates/vize/tests/lint_musea_cli.rs
@@ -140,3 +140,86 @@ fn lint_runs_explicit_musea_rules_for_art_files() {
         output_details(&configured_output)
     );
 }
+
+#[test]
+fn lint_runs_configured_musea_design_token_rule_for_art_styles() {
+    let project_root = tempfile::tempdir().unwrap();
+    write_project_file(
+        project_root.path(),
+        "vize.config.json",
+        r##"{
+  "linter": {
+    "preset": "incremental",
+    "ruleOptions": {
+      "musea/prefer-design-tokens": {
+        "tokens": [
+          {
+            "path": "color.primary",
+            "value": "#3b82f6"
+          }
+        ]
+      }
+    }
+  }
+}"##,
+    );
+    write_project_file(
+        project_root.path(),
+        "src/Button.art.vue",
+        r##"<art title="Button" component="./Button.vue">
+  <variant name="default"><button class="button">Save</button></variant>
+</art>
+
+<style scoped>
+.button {
+  background: #3b82f6;
+}
+</style>
+"##,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project_root.path())
+        .args([
+            "lint",
+            "--config",
+            "vize.config.json",
+            "--format",
+            "json",
+            "--max-warnings",
+            "0",
+            "src/Button.art.vue",
+        ])
+        .output()
+        .unwrap();
+    assert!(!output.status.success(), "{}", output_details(&output));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
+        panic!(
+            "configured lint must emit JSON: {}",
+            output_details(&output)
+        )
+    });
+    assert_eq!(
+        json,
+        serde_json::json!([{
+            "file": "src/Button.art.vue",
+            "messages": [
+                {
+                    "ruleId": "musea/prefer-design-tokens",
+                    "ruleDocsPath": "docs/content/rules/musea-and-css.md",
+                    "severity": 1,
+                    "message": "[vize:musea/prefer-design-tokens] Hardcoded value '#3b82f6' matches primitive token 'color.primary' — use var(--color-primary)",
+                    "line": 7,
+                    "column": 1,
+                    "endLine": 7,
+                    "endColumn": 23,
+                    "help": "Use var(--color-primary) for consistent theming and maintainability"
+                }
+            ],
+            "errorCount": 0,
+            "warningCount": 1
+        }]),
+        "{}",
+        output_details(&output)
+    );
+}

--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -26,10 +26,10 @@ pub use model::{
     GlobalTypesConfig, JsxCompat, JsxMode, LanguageServerConfig, LanguageServerUnstableFlags,
     LintRuleOptions, LintRuleSeverity, LinterConfig, LinterConfigEntry, LinterConfigPlan,
     LinterConfigPlanWithConfigRuleOptions, LinterConfigPlanWithRuleOptions, LinterFeatureFlags,
-    LspConfig, NoRestrictedGlobalsOptions, NoRestrictedMembersOptions, ParseVueVersionError,
-    QuoteProps, ResolvedLinterConfig, ResolvedLinterConfigWithConfigRuleOptions, RestrictedGlobal,
-    RestrictedMember, TemplateComponentNameCasing, TrailingComma, TypeCheckerConfig, VizeConfig,
-    VueVersion,
+    LspConfig, MuseaDesignToken, MuseaPreferDesignTokensOptions, NoRestrictedGlobalsOptions,
+    NoRestrictedMembersOptions, ParseVueVersionError, QuoteProps, ResolvedLinterConfig,
+    ResolvedLinterConfigWithConfigRuleOptions, RestrictedGlobal, RestrictedMember,
+    TemplateComponentNameCasing, TrailingComma, TypeCheckerConfig, VizeConfig, VueVersion,
 };
 pub use normalize::normalize_public_config_value;
 

--- a/crates/vize_carton/src/config/loader/tests/linter_plan_tests.rs
+++ b/crates/vize_carton/src/config/loader/tests/linter_plan_tests.rs
@@ -1,6 +1,6 @@
 //! Linter-plan configuration regressions.
 
-use crate::config::load_config_and_linter_plan_with_rule_options_and_lint_features_and_source;
+use crate::config::load_config_and_linter_plan_with_config_rule_options_and_lint_features_and_source;
 
 use super::*;
 
@@ -10,7 +10,7 @@ fn preserves_scopes_and_resolves_rules_in_declaration_order() {
     let config_path = dir.path().join("vize.config.json");
     std::fs::write(
         &config_path,
-        r#"{
+        r##"{
   "basePath": "workspace",
   "ignores": ["generated/**"],
   "linter": { "rules": { "base": "error", "shared": "warn" } },
@@ -26,7 +26,7 @@ fn preserves_scopes_and_resolves_rules_in_declaration_order() {
       "linter": { "rules": { "last": "error", "shared": "off" } }
     }
   ]
-}"#,
+}"##,
     )
     .unwrap();
 
@@ -61,9 +61,14 @@ fn preserves_scoped_rule_options_for_options_only_entries() {
     let config_path = dir.path().join("vize.config.json");
     std::fs::write(
         &config_path,
-        r#"{
+        r##"{
   "linter": {
     "ruleOptions": {
+      "musea/prefer-design-tokens": {
+        "tokens": [
+          { "path": "color.primary", "value": "#3b82f6" }
+        ]
+      },
       "script/no-restricted-members": {
         "members": [
           {
@@ -80,6 +85,11 @@ fn preserves_scoped_rule_options_for_options_only_entries() {
       "files": ["src/admin/**/*.vue"],
       "linter": {
         "ruleOptions": {
+          "musea/prefer-design-tokens": {
+            "tokens": [
+              { "path": "color.admin", "value": "#2563eb", "tier": "semantic" }
+            ]
+          },
           "script/no-restricted-members": {
             "members": [
               {
@@ -93,13 +103,14 @@ fn preserves_scoped_rule_options_for_options_only_entries() {
       }
     }
   ]
-}"#,
+}"##,
     )
     .unwrap();
 
-    let (_, plan, _) = load_config_and_linter_plan_with_rule_options_and_lint_features_and_source(
-        Some(&config_path),
-    );
+    let (_, plan, _) =
+        load_config_and_linter_plan_with_config_rule_options_and_lint_features_and_source(Some(
+            &config_path,
+        ));
     let base = plan.resolve_matching_entries(&[]);
     let admin = plan.resolve_matching_entries(&[0]);
 
@@ -114,11 +125,19 @@ fn preserves_scoped_rule_options_for_options_only_entries() {
         )]
     );
     assert_eq!(
+        base.rule_options.musea_design_tokens(),
+        [("#3b82f6".into(), "color.primary".into(), "primitive".into())]
+    );
+    assert_eq!(
         admin.rule_options.restricted_members(),
         [(
             "window".into(),
             "sessionStorage".into(),
             Some("Use admin storage.".into())
         )]
+    );
+    assert_eq!(
+        admin.rule_options.musea_design_tokens(),
+        [("#2563eb".into(), "color.admin".into(), "semantic".into())]
     );
 }

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -18,6 +18,8 @@ use compiler::RawCompilerConfig;
 use experimentals::RawExperimentalsConfig;
 use vue::RawVueConfig;
 
+use crate::String;
+use crate::dialect::VueDialect;
 pub use compiler::{JsxCompat, JsxMode};
 pub(crate) use entries::RawConfigEntry;
 pub use entries::{
@@ -25,9 +27,6 @@ pub use entries::{
     LinterConfigPlanWithConfigRuleOptions, LinterConfigPlanWithRuleOptions, ResolvedLinterConfig,
     ResolvedLinterConfigWithConfigRuleOptions,
 };
-
-use crate::String;
-use crate::dialect::VueDialect;
 pub use formatter::{
     ArrowParens, AttributeSortOrder, EndOfLine, FormatterConfig, QuoteProps, TrailingComma,
 };

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -39,8 +39,9 @@ pub use linter::{LintRuleSeverity, LinterConfig};
 #[allow(unused_imports)]
 pub use linter_rule_options::{
     ComponentNameInTemplateCasingOptions, ConfigLintRuleOptions, CustomEventNameCasing,
-    CustomEventNameCasingOptions, LintRuleOptions, NoRestrictedGlobalsOptions,
-    NoRestrictedMembersOptions, RestrictedGlobal, RestrictedMember, TemplateComponentNameCasing,
+    CustomEventNameCasingOptions, LintRuleOptions, MuseaDesignToken,
+    MuseaPreferDesignTokensOptions, NoRestrictedGlobalsOptions, NoRestrictedMembersOptions,
+    RestrictedGlobal, RestrictedMember, TemplateComponentNameCasing,
 };
 pub use type_checker::TypeCheckerConfig;
 pub use vue::{ParseVueVersionError, VueVersion};

--- a/crates/vize_carton/src/config/model/linter_rule_options.rs
+++ b/crates/vize_carton/src/config/model/linter_rule_options.rs
@@ -1,11 +1,11 @@
 //! Typed per-rule lint options.
 //!
-//! A handful of script rules accept project-local configuration so teams can
-//! enforce their own architecture conventions (e.g. forbidding direct access to
-//! `process` or `window.localStorage`) through `vize lint` instead of running a
-//! sidecar ESLint. Options live under `linter.ruleOptions.<rule-name>` and are
-//! parsed into typed structs (no untyped `serde_json::Value`) so the schema is
-//! discoverable and option payload validation stays strict.
+//! A handful of lint rules accept project-local configuration so teams can
+//! enforce their own architecture and design-system conventions through
+//! `vize lint` instead of running a sidecar tool. Options live under
+//! `linter.ruleOptions.<rule-name>` and are parsed into typed structs (no
+//! untyped `serde_json::Value`) so the schema is discoverable and validation
+//! stays strict.
 
 use serde::{Deserialize, Serialize};
 
@@ -104,6 +104,9 @@ pub struct ConfigLintRuleOptions {
     /// Options for `script/custom-event-name-casing`.
     #[serde(rename = "script/custom-event-name-casing")]
     custom_event_name_casing: Option<CustomEventNameCasingOptions>,
+    /// Options for `musea/prefer-design-tokens`.
+    #[serde(rename = "musea/prefer-design-tokens")]
+    musea_prefer_design_tokens: Option<MuseaPreferDesignTokensOptions>,
 }
 
 impl ConfigLintRuleOptions {
@@ -128,6 +131,7 @@ impl ConfigLintRuleOptions {
         self.stable.is_empty()
             && self.component_name_in_template_casing.is_none()
             && self.custom_event_name_casing.is_none()
+            && self.musea_prefer_design_tokens.is_none()
     }
 
     /// Configured deny list for `script/no-restricted-globals`.
@@ -158,6 +162,22 @@ impl ConfigLintRuleOptions {
             .map(|options| options.casing)
     }
 
+    /// Configured design-token primitive values for
+    /// `musea/prefer-design-tokens` as `(value, path, tier)` tuples. Empty
+    /// when unconfigured.
+    pub fn musea_design_tokens(&self) -> Vec<(String, String, String)> {
+        self.musea_prefer_design_tokens
+            .as_ref()
+            .map(|options| {
+                options
+                    .tokens
+                    .iter()
+                    .map(|token| (token.value.clone(), token.path.clone(), token.tier.clone()))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     /// Apply a later config layer to this option set.
     pub fn merge_from(&mut self, overlay: &Self) {
         self.stable.merge_from(&overlay.stable);
@@ -166,6 +186,9 @@ impl ConfigLintRuleOptions {
         }
         if let Some(options) = &overlay.custom_event_name_casing {
             self.custom_event_name_casing = Some(*options);
+        }
+        if let Some(options) = &overlay.musea_prefer_design_tokens {
+            self.musea_prefer_design_tokens = Some(options.clone());
         }
     }
 }
@@ -218,132 +241,34 @@ pub struct RestrictedMember {
     pub message: Option<String>,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::{
-        ComponentNameInTemplateCasingOptions, ConfigLintRuleOptions, CustomEventNameCasing,
-        CustomEventNameCasingOptions, LintRuleOptions, RestrictedGlobal, RestrictedMember,
-        TemplateComponentNameCasing,
-    };
-
-    #[test]
-    fn empty_options_deserialize_to_default() {
-        let options = serde_json::from_str::<LintRuleOptions>("{}").unwrap();
-        assert_eq!(options, LintRuleOptions::default());
-        assert!(options.is_empty());
-    }
-
-    #[test]
-    fn deserializes_restricted_globals_with_and_without_message() {
-        let json = r#"{
-            "script/no-restricted-globals": {
-                "globals": [
-                    { "name": "process", "message": "Use a typed config helper." },
-                    { "name": "localStorage" }
-                ]
-            }
-        }"#;
-        let options = serde_json::from_str::<LintRuleOptions>(json).unwrap();
-        let globals = options.no_restricted_globals.unwrap().globals;
-        assert_eq!(
-            globals,
-            vec![
-                RestrictedGlobal {
-                    name: "process".into(),
-                    message: Some("Use a typed config helper.".into()),
-                },
-                RestrictedGlobal {
-                    name: "localStorage".into(),
-                    message: None,
-                },
-            ]
-        );
-        assert!(options.no_restricted_members.is_none());
-    }
-
-    #[test]
-    fn deserializes_restricted_members() {
-        let json = r#"{
-            "script/no-restricted-members": {
-                "members": [
-                    { "object": "window", "property": "localStorage", "message": "Use authStorage." },
-                    { "object": "globalThis", "property": "process" }
-                ]
-            }
-        }"#;
-        let options = serde_json::from_str::<LintRuleOptions>(json).unwrap();
-        let members = options.no_restricted_members.unwrap().members;
-        assert_eq!(
-            members,
-            vec![
-                RestrictedMember {
-                    object: "window".into(),
-                    property: "localStorage".into(),
-                    message: Some("Use authStorage.".into()),
-                },
-                RestrictedMember {
-                    object: "globalThis".into(),
-                    property: "process".into(),
-                    message: None,
-                },
-            ]
-        );
-        assert!(options.no_restricted_globals.is_none());
-    }
-
-    #[test]
-    fn deserializes_casing_options() {
-        let json = r#"{
-            "vue/component-name-in-template-casing": { "casing": "kebab-case" },
-            "script/custom-event-name-casing": { "casing": "camelCase" }
-        }"#;
-        let options = serde_json::from_str::<ConfigLintRuleOptions>(json).unwrap();
-        assert_eq!(
-            options.component_name_in_template_casing,
-            Some(ComponentNameInTemplateCasingOptions {
-                casing: TemplateComponentNameCasing::KebabCase
-            })
-        );
-        assert_eq!(
-            options.custom_event_name_casing,
-            Some(CustomEventNameCasingOptions {
-                casing: CustomEventNameCasing::CamelCase
-            })
-        );
-        assert_eq!(
-            options.component_name_in_template_casing(),
-            Some(TemplateComponentNameCasing::KebabCase)
-        );
-        assert_eq!(
-            options.custom_event_name_casing(),
-            Some(CustomEventNameCasing::CamelCase)
-        );
-    }
-
-    #[test]
-    fn stable_lint_rule_options_keep_legacy_shape() {
-        let json = r#"{
-            "script/no-restricted-globals": {
-                "globals": [{ "name": "process" }]
-            },
-            "vue/component-name-in-template-casing": { "casing": "kebab-case" }
-        }"#;
-        let options = serde_json::from_str::<ConfigLintRuleOptions>(json).unwrap();
-        assert_eq!(
-            options.stable_options().restricted_globals(),
-            [("process".into(), None)]
-        );
-        assert!(options.component_name_in_template_casing().is_some());
-    }
-
-    #[test]
-    fn unknown_fields_are_rejected() {
-        // Typed structs reject unknown keys inside an entry so config typos surface.
-        let json = r#"{
-            "script/no-restricted-globals": {
-                "globals": [{ "name": "process", "bogus": true }]
-            }
-        }"#;
-        assert!(serde_json::from_str::<LintRuleOptions>(json).is_err());
-    }
+/// Options for `musea/prefer-design-tokens`.
+///
+/// The rule is off unless tokens are configured and the rule is enabled by
+/// severity or implicitly by this non-empty token list. Each token maps one
+/// hardcoded CSS value to a design-token path.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+pub struct MuseaPreferDesignTokensOptions {
+    /// Design tokens that should replace matching hardcoded CSS values.
+    pub tokens: Vec<MuseaDesignToken>,
 }
+
+/// A design token recognized by `musea/prefer-design-tokens`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MuseaDesignToken {
+    /// Token path (e.g. `color.primary`).
+    pub path: String,
+    /// Primitive CSS value to match (e.g. `#3b82f6`).
+    pub value: String,
+    /// Token tier shown in diagnostics. Defaults to `primitive`.
+    #[serde(default = "default_musea_design_token_tier")]
+    pub tier: String,
+}
+
+fn default_musea_design_token_tier() -> String {
+    "primitive".into()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_carton/src/config/model/linter_rule_options/tests.rs
+++ b/crates/vize_carton/src/config/model/linter_rule_options/tests.rs
@@ -1,0 +1,166 @@
+use super::{
+    ComponentNameInTemplateCasingOptions, ConfigLintRuleOptions, CustomEventNameCasing,
+    CustomEventNameCasingOptions, LintRuleOptions, MuseaDesignToken, RestrictedGlobal,
+    RestrictedMember, TemplateComponentNameCasing,
+};
+
+#[test]
+fn empty_options_deserialize_to_default() {
+    let options = serde_json::from_str::<LintRuleOptions>("{}").unwrap();
+    assert_eq!(options, LintRuleOptions::default());
+    assert!(options.is_empty());
+}
+
+#[test]
+fn deserializes_restricted_globals_with_and_without_message() {
+    let json = r#"{
+        "script/no-restricted-globals": {
+            "globals": [
+                { "name": "process", "message": "Use a typed config helper." },
+                { "name": "localStorage" }
+            ]
+        }
+    }"#;
+    let options = serde_json::from_str::<LintRuleOptions>(json).unwrap();
+    let globals = options.no_restricted_globals.unwrap().globals;
+    assert_eq!(
+        globals,
+        vec![
+            RestrictedGlobal {
+                name: "process".into(),
+                message: Some("Use a typed config helper.".into()),
+            },
+            RestrictedGlobal {
+                name: "localStorage".into(),
+                message: None,
+            },
+        ]
+    );
+    assert!(options.no_restricted_members.is_none());
+}
+
+#[test]
+fn deserializes_restricted_members() {
+    let json = r#"{
+        "script/no-restricted-members": {
+            "members": [
+                { "object": "window", "property": "localStorage", "message": "Use authStorage." },
+                { "object": "globalThis", "property": "process" }
+            ]
+        }
+    }"#;
+    let options = serde_json::from_str::<LintRuleOptions>(json).unwrap();
+    let members = options.no_restricted_members.unwrap().members;
+    assert_eq!(
+        members,
+        vec![
+            RestrictedMember {
+                object: "window".into(),
+                property: "localStorage".into(),
+                message: Some("Use authStorage.".into()),
+            },
+            RestrictedMember {
+                object: "globalThis".into(),
+                property: "process".into(),
+                message: None,
+            },
+        ]
+    );
+    assert!(options.no_restricted_globals.is_none());
+}
+
+#[test]
+fn deserializes_casing_options() {
+    let json = r#"{
+        "vue/component-name-in-template-casing": { "casing": "kebab-case" },
+        "script/custom-event-name-casing": { "casing": "camelCase" }
+    }"#;
+    let options = serde_json::from_str::<ConfigLintRuleOptions>(json).unwrap();
+    assert_eq!(
+        options.component_name_in_template_casing,
+        Some(ComponentNameInTemplateCasingOptions {
+            casing: TemplateComponentNameCasing::KebabCase
+        })
+    );
+    assert_eq!(
+        options.custom_event_name_casing,
+        Some(CustomEventNameCasingOptions {
+            casing: CustomEventNameCasing::CamelCase
+        })
+    );
+    assert_eq!(
+        options.component_name_in_template_casing(),
+        Some(TemplateComponentNameCasing::KebabCase)
+    );
+    assert_eq!(
+        options.custom_event_name_casing(),
+        Some(CustomEventNameCasing::CamelCase)
+    );
+}
+
+#[test]
+fn deserializes_musea_design_tokens_with_default_tier() {
+    let json = r##"{
+        "musea/prefer-design-tokens": {
+            "tokens": [
+                { "path": "color.primary", "value": "#3b82f6" },
+                { "path": "color.danger", "value": "#ef4444", "tier": "semantic" }
+            ]
+        }
+    }"##;
+    let options = serde_json::from_str::<ConfigLintRuleOptions>(json).unwrap();
+    let tokens = options.musea_prefer_design_tokens.unwrap().tokens;
+    assert_eq!(
+        tokens,
+        vec![
+            MuseaDesignToken {
+                path: "color.primary".into(),
+                value: "#3b82f6".into(),
+                tier: "primitive".into(),
+            },
+            MuseaDesignToken {
+                path: "color.danger".into(),
+                value: "#ef4444".into(),
+                tier: "semantic".into(),
+            },
+        ]
+    );
+}
+
+#[test]
+fn stable_lint_rule_options_keep_legacy_shape() {
+    let json = r#"{
+        "script/no-restricted-globals": {
+            "globals": [{ "name": "process" }]
+        },
+        "vue/component-name-in-template-casing": { "casing": "kebab-case" }
+    }"#;
+    let options = serde_json::from_str::<ConfigLintRuleOptions>(json).unwrap();
+    assert_eq!(
+        options.stable_options().restricted_globals(),
+        [("process".into(), None)]
+    );
+    assert!(options.component_name_in_template_casing().is_some());
+}
+
+#[test]
+fn unknown_fields_are_rejected() {
+    let json = r#"{
+        "script/no-restricted-globals": {
+            "globals": [{ "name": "process", "bogus": true }]
+        }
+    }"#;
+    assert!(serde_json::from_str::<LintRuleOptions>(json).is_err());
+}
+
+#[test]
+fn unknown_musea_option_fields_are_rejected() {
+    let json = r##"{
+        "musea/prefer-design-tokens": {
+            "toknes": [
+                { "path": "color.primary", "value": "#3b82f6" }
+            ]
+        }
+    }"##;
+    assert!(serde_json::from_str::<ConfigLintRuleOptions>(json).is_err());
+}

--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -14,6 +14,8 @@ mod collectors;
 mod component_props;
 #[cfg(test)]
 mod component_props_tests;
+#[cfg(test)]
+mod configured_lint_tests;
 #[cfg(feature = "native")]
 pub(in crate::ide) mod corsa;
 #[cfg(all(test, feature = "native"))]

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -153,12 +153,10 @@ impl DiagnosticService {
                 continue;
             }
 
-            // Reconstruct the art block content including tags for the linter
-            // The linter expects a full art file, so we wrap the content
+            // The linter expects a full art file, so wrap the block content.
             #[allow(clippy::disallowed_macros)]
             let art_content = format!(
                 "<art{}>\n{}\n</art>",
-                // Reconstruct attributes
                 custom.attrs.iter().fold(String::new(), |mut acc, (k, v)| {
                     append!(acc, " {k}=\"{v}\"");
                     acc
@@ -168,17 +166,12 @@ impl DiagnosticService {
 
             let result = linter.lint(&art_content);
 
-            // Map diagnostics back to the original file positions
             let block_content_start = custom.loc.start;
 
             for lint_diag in result.diagnostics {
-                // The lint_diag offsets are relative to art_content
-                // We need to adjust: skip the reconstructed <art ...>\n prefix
                 let art_tag_prefix_len = art_content.find('\n').unwrap_or(0) + 1;
 
-                // Only process diagnostics that fall within the content area
                 if (lint_diag.start as usize) < art_tag_prefix_len {
-                    // Diagnostic is on the <art> tag itself - map to the original tag
                     let (start_line, start_col) = line_index.line_col(custom.loc.tag_start);
                     let (end_line, end_col) =
                         line_index.line_col(custom.loc.tag_end.min(content.len()));
@@ -215,7 +208,6 @@ impl DiagnosticService {
                         ..Default::default()
                     });
                 } else {
-                    // Diagnostic is in the content area - map offset to original file
                     let content_relative_start =
                         (lint_diag.start as usize).saturating_sub(art_tag_prefix_len);
                     let content_relative_end =
@@ -497,6 +489,8 @@ impl DiagnosticService {
         }
         .with_additional_rules(lint_options.additional_rules)
         .with_disabled_rules(lint_options.disabled_rules)
+        .with_category_severity_overrides(lint_options.category_severity_overrides)
+        .with_rule_severity_overrides(lint_options.rule_severity_overrides)
         .with_restricted_globals(lint_options.restricted_globals)
         .with_restricted_members(lint_options.restricted_members)
         .with_musea_design_tokens(lint_options.musea_design_tokens);

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -21,13 +21,14 @@ use vize_s0::append;
 impl DiagnosticService {
     /// Collect diagnostics for Art files (*.art.vue) using vize_patina's MuseaLinter.
     pub(super) fn collect_musea_diagnostics(
+        state: &crate::server::ServerState,
         uri: &Url,
         content: &str,
         line_index: &LineIndex<'_>,
     ) -> Vec<Diagnostic> {
-        use vize_patina::rules::musea::MuseaLinter;
-
-        let linter = MuseaLinter::new();
+        let Some(linter) = linter_options::musea_linter_for_uri(state, uri) else {
+            return Vec::new();
+        };
         let result = linter.lint(content);
 
         let mut diagnostics: Vec<_> = result
@@ -135,12 +136,15 @@ impl DiagnosticService {
 
     /// Collect diagnostics for inline <art> custom blocks in regular .vue files.
     pub(super) fn collect_inline_art_diagnostics(
-        _uri: &Url,
+        state: &crate::server::ServerState,
+        uri: &Url,
         content: &str,
         descriptor: &SfcDescriptor<'_>,
         line_index: &LineIndex<'_>,
     ) -> Vec<Diagnostic> {
-        use vize_patina::rules::musea::MuseaLinter;
+        let Some(linter) = linter_options::musea_linter_for_uri(state, uri) else {
+            return Vec::new();
+        };
 
         let mut diagnostics = Vec::new();
 
@@ -162,7 +166,6 @@ impl DiagnosticService {
                 custom.content
             );
 
-            let linter = MuseaLinter::new();
             let result = linter.lint(&art_content);
 
             // Map diagnostics back to the original file positions
@@ -485,15 +488,18 @@ impl DiagnosticService {
 
         let preset = linter_config.preset.as_deref();
         let preset = preset.and_then(LintPreset::parse).unwrap_or_default();
+        let lint_options = linter_options::resolve_patina_options(&linter_config, &rule_options);
+
         let mut linter = if ecosystem_enabled && linter_config.preset.is_none() {
             vize_patina::Linter::with_ecosystem()
         } else {
             vize_patina::Linter::with_preset(preset)
         }
-        .with_additional_rules(linter_config.enabled_rules())
-        .with_disabled_rules(linter_config.disabled_rules())
-        .with_restricted_globals(rule_options.restricted_globals())
-        .with_restricted_members(rule_options.restricted_members());
+        .with_additional_rules(lint_options.additional_rules)
+        .with_disabled_rules(lint_options.disabled_rules)
+        .with_restricted_globals(lint_options.restricted_globals)
+        .with_restricted_members(lint_options.restricted_members)
+        .with_musea_design_tokens(lint_options.musea_design_tokens);
         linter = linter_options::apply_rule_options(linter, &rule_options);
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vize_maestro/src/ide/diagnostics/configured_lint_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/configured_lint_tests.rs
@@ -1,0 +1,175 @@
+use tower_lsp::lsp_types::{Diagnostic, NumberOrString, Url};
+
+use super::DiagnosticService;
+use crate::server::ServerState;
+
+#[test]
+fn collect_lints_configured_project_local_rule_options() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(
+        dir.path().join("vize.config.json"),
+        r##"{
+            "lsp": { "lint": true },
+            "linter": {
+                "preset": "incremental",
+                "ruleOptions": {
+                    "script/no-restricted-members": {
+                        "members": [
+                            {
+                                "object": "window",
+                                "property": "localStorage",
+                                "message": "Use appStorage."
+                            }
+                        ]
+                    },
+                    "musea/prefer-design-tokens": {
+                        "tokens": [
+                            {
+                                "path": "color.primary",
+                                "value": "#3b82f6"
+                            }
+                        ]
+                    }
+                }
+            }
+        }"##,
+    )
+    .unwrap();
+
+    let state = ServerState::new();
+    state.load_lsp_config(dir.path());
+
+    let app_uri = Url::from_file_path(dir.path().join("src/App.vue")).unwrap();
+    let app_source = r#"<script setup lang="ts">
+window.localStorage.getItem("token")
+</script>
+<template><main></main></template>
+"#;
+    state.documents.open(
+        app_uri.clone(),
+        app_source.to_string(),
+        1,
+        "vue".to_string(),
+    );
+
+    let art_uri = Url::from_file_path(dir.path().join("src/Button.art.vue")).unwrap();
+    let art_source = r##"<art title="Button" component="./Button.vue">
+  <variant name="default"><button class="button">Save</button></variant>
+</art>
+
+<style scoped>
+.button {
+  background: #3b82f6;
+}
+</style>
+"##;
+    state.documents.open(
+        art_uri.clone(),
+        art_source.to_string(),
+        1,
+        "vue".to_string(),
+    );
+
+    let inline_art_uri = Url::from_file_path(dir.path().join("src/InlineArt.vue")).unwrap();
+    let inline_art_source = r##"<template><main></main></template>
+<art title="Inline" component="./Inline.vue">
+<style scoped>
+.button {
+  color: #3b82f6;
+}
+</style>
+</art>
+"##;
+    state.documents.open(
+        inline_art_uri.clone(),
+        inline_art_source.to_string(),
+        1,
+        "vue".to_string(),
+    );
+
+    let app_codes = diagnostic_codes(&DiagnosticService::collect_lint_only(&state, &app_uri));
+    let art_codes = diagnostic_codes(&DiagnosticService::collect_lint_only(&state, &art_uri));
+    let inline_art_codes = diagnostic_codes(&DiagnosticService::collect_lint_only(
+        &state,
+        &inline_art_uri,
+    ));
+
+    assert_eq!(
+        app_codes,
+        ["script/no-restricted-members"],
+        "configured restricted members must run through the LSP lint path"
+    );
+    assert_eq!(
+        art_codes,
+        ["musea/prefer-design-tokens"],
+        "configured Musea design tokens must run through the Art LSP lint path"
+    );
+    assert_eq!(
+        inline_art_codes,
+        ["musea/prefer-design-tokens"],
+        "configured Musea design tokens must run through inline <art> blocks"
+    );
+}
+
+#[test]
+fn collect_musea_lint_respects_disabled_linter_config() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("src")).unwrap();
+    std::fs::write(
+        dir.path().join("vize.config.json"),
+        r##"{
+            "languageServer": { "lint": true },
+            "linter": {
+                "enabled": false,
+                "ruleOptions": {
+                    "musea/prefer-design-tokens": {
+                        "tokens": [
+                            {
+                                "path": "color.primary",
+                                "value": "#3b82f6"
+                            }
+                        ]
+                    }
+                }
+            }
+        }"##,
+    )
+    .unwrap();
+
+    let state = ServerState::new();
+    state.load_lsp_config(dir.path());
+
+    let art_uri = Url::from_file_path(dir.path().join("src/Button.art.vue")).unwrap();
+    let art_source = r##"<art title="Button" component="./Button.vue">
+  <variant name="default"><button class="button">Save</button></variant>
+</art>
+
+<style scoped>
+.button {
+  background: #3b82f6;
+}
+</style>
+"##;
+    state.documents.open(
+        art_uri.clone(),
+        art_source.to_string(),
+        1,
+        "vue".to_string(),
+    );
+
+    assert_eq!(
+        diagnostic_codes(&DiagnosticService::collect_lint_only(&state, &art_uri)),
+        Vec::<String>::new()
+    );
+}
+
+fn diagnostic_codes(diagnostics: &[Diagnostic]) -> Vec<String> {
+    diagnostics
+        .iter()
+        .filter_map(|diagnostic| match diagnostic.code.as_ref() {
+            Some(NumberOrString::String(code)) => Some(code.clone()),
+            _ => None,
+        })
+        .collect()
+}

--- a/crates/vize_maestro/src/ide/diagnostics/configured_lint_tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/configured_lint_tests.rs
@@ -1,4 +1,4 @@
-use tower_lsp::lsp_types::{Diagnostic, NumberOrString, Url};
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Url};
 
 use super::DiagnosticService;
 use crate::server::ServerState;
@@ -13,6 +13,10 @@ fn collect_lints_configured_project_local_rule_options() {
             "lsp": { "lint": true },
             "linter": {
                 "preset": "incremental",
+                "rules": {
+                    "musea/prefer-design-tokens": "error",
+                    "script/no-restricted-members": "error"
+                },
                 "ruleOptions": {
                     "script/no-restricted-members": {
                         "members": [
@@ -88,27 +92,30 @@ window.localStorage.getItem("token")
         "vue".to_string(),
     );
 
-    let app_codes = diagnostic_codes(&DiagnosticService::collect_lint_only(&state, &app_uri));
-    let art_codes = diagnostic_codes(&DiagnosticService::collect_lint_only(&state, &art_uri));
-    let inline_art_codes = diagnostic_codes(&DiagnosticService::collect_lint_only(
-        &state,
-        &inline_art_uri,
-    ));
+    let app_diagnostics = DiagnosticService::collect_lint_only(&state, &app_uri);
+    let art_diagnostics = DiagnosticService::collect_lint_only(&state, &art_uri);
+    let inline_art_diagnostics = DiagnosticService::collect_lint_only(&state, &inline_art_uri);
 
     assert_eq!(
-        app_codes,
+        diagnostic_codes(&app_diagnostics),
         ["script/no-restricted-members"],
         "configured restricted members must run through the LSP lint path"
     );
     assert_eq!(
-        art_codes,
+        diagnostic_codes(&art_diagnostics),
         ["musea/prefer-design-tokens"],
         "configured Musea design tokens must run through the Art LSP lint path"
     );
     assert_eq!(
-        inline_art_codes,
+        diagnostic_codes(&inline_art_diagnostics),
         ["musea/prefer-design-tokens"],
         "configured Musea design tokens must run through inline <art> blocks"
+    );
+    assert_eq!(app_diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
+    assert_eq!(art_diagnostics[0].severity, Some(DiagnosticSeverity::ERROR));
+    assert_eq!(
+        inline_art_diagnostics[0].severity,
+        Some(DiagnosticSeverity::ERROR)
     );
 }
 

--- a/crates/vize_maestro/src/ide/diagnostics/linter_options.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/linter_options.rs
@@ -1,8 +1,11 @@
 use tower_lsp::lsp_types::Url;
-use vize_patina::rules::musea::{MuseaLinter, PreferDesignTokensConfig};
+use vize_patina::{
+    Severity,
+    rules::musea::{MuseaLintResult, MuseaLinter, PreferDesignTokensConfig},
+};
 use vize_s0::{
     String,
-    config::{ConfigLintRuleOptions, LinterConfig},
+    config::{ConfigLintRuleOptions, LintRuleSeverity, LinterConfig},
 };
 
 const MUSEA_PREFER_DESIGN_TOKENS: &str = "musea/prefer-design-tokens";
@@ -14,6 +17,43 @@ pub(super) struct PatinaLintOptions {
     pub(super) restricted_globals: Vec<(String, Option<String>)>,
     pub(super) restricted_members: Vec<(String, String, Option<String>)>,
     pub(super) musea_design_tokens: Vec<(String, String, String)>,
+    pub(super) category_severity_overrides: Vec<(String, Severity)>,
+    pub(super) rule_severity_overrides: Vec<(String, Severity)>,
+}
+
+pub(super) struct MuseaLintOptions {
+    linter: MuseaLinter,
+    rule_severity_overrides: Vec<(String, Severity)>,
+}
+
+impl MuseaLintOptions {
+    pub(super) fn lint(&self, source: &str) -> MuseaLintResult {
+        let mut result = self.linter.lint(source);
+        if self.rule_severity_overrides.is_empty() {
+            return result;
+        }
+
+        for diagnostic in &mut result.diagnostics {
+            if let Some((_, severity)) = self
+                .rule_severity_overrides
+                .iter()
+                .find(|(rule, _)| rule.as_str() == diagnostic.rule_name)
+            {
+                diagnostic.severity = *severity;
+            }
+        }
+        result.error_count = result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.severity == Severity::Error)
+            .count();
+        result.warning_count = result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.severity == Severity::Warning)
+            .count();
+        result
+    }
 }
 
 pub(super) fn resolve_patina_options(
@@ -44,18 +84,23 @@ pub(super) fn resolve_patina_options(
         restricted_globals: rule_options.restricted_globals(),
         restricted_members,
         musea_design_tokens,
+        category_severity_overrides: severity_overrides(
+            linter_config.category_severity_overrides(),
+        ),
+        rule_severity_overrides: severity_overrides(linter_config.rule_severity_overrides()),
     }
 }
 
 pub(super) fn musea_linter_for_uri(
     state: &crate::server::ServerState,
     uri: &Url,
-) -> Option<MuseaLinter> {
+) -> Option<MuseaLintOptions> {
     let (linter_config, rule_options) = state.linter_settings_for_uri(uri);
     if !linter_config.enabled {
         return None;
     }
 
+    let rule_severity_overrides = severity_overrides(linter_config.rule_severity_overrides());
     let tokens = rule_options.musea_design_tokens();
     if tokens.is_empty()
         || linter_config
@@ -63,14 +108,20 @@ pub(super) fn musea_linter_for_uri(
             .iter()
             .any(|rule| rule.as_str() == MUSEA_PREFER_DESIGN_TOKENS)
     {
-        return Some(MuseaLinter::new());
+        return Some(MuseaLintOptions {
+            linter: MuseaLinter::new(),
+            rule_severity_overrides,
+        });
     }
 
     let mut config = PreferDesignTokensConfig::default();
     for (value, path, tier) in tokens {
         config.add_token(&value, &path, &tier);
     }
-    Some(MuseaLinter::new().with_design_tokens(config))
+    Some(MuseaLintOptions {
+        linter: MuseaLinter::new().with_design_tokens(config),
+        rule_severity_overrides,
+    })
 }
 
 pub(super) fn apply_rule_options(
@@ -100,6 +151,17 @@ fn add_project_local_rule(
     {
         additional_rules.push(rule_name.into());
     }
+}
+
+fn severity_overrides(entries: Vec<(String, LintRuleSeverity)>) -> Vec<(String, Severity)> {
+    entries
+        .into_iter()
+        .filter_map(|(name, severity)| match severity {
+            LintRuleSeverity::Off => None,
+            LintRuleSeverity::Warn => Some((name, Severity::Warning)),
+            LintRuleSeverity::Error => Some((name, Severity::Error)),
+        })
+        .collect()
 }
 
 fn component_casing(

--- a/crates/vize_maestro/src/ide/diagnostics/linter_options.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/linter_options.rs
@@ -1,3 +1,78 @@
+use tower_lsp::lsp_types::Url;
+use vize_patina::rules::musea::{MuseaLinter, PreferDesignTokensConfig};
+use vize_s0::{
+    String,
+    config::{ConfigLintRuleOptions, LinterConfig},
+};
+
+const MUSEA_PREFER_DESIGN_TOKENS: &str = "musea/prefer-design-tokens";
+const SCRIPT_NO_RESTRICTED_MEMBERS: &str = "script/no-restricted-members";
+
+pub(super) struct PatinaLintOptions {
+    pub(super) additional_rules: Vec<String>,
+    pub(super) disabled_rules: Vec<String>,
+    pub(super) restricted_globals: Vec<(String, Option<String>)>,
+    pub(super) restricted_members: Vec<(String, String, Option<String>)>,
+    pub(super) musea_design_tokens: Vec<(String, String, String)>,
+}
+
+pub(super) fn resolve_patina_options(
+    linter_config: &LinterConfig,
+    rule_options: &ConfigLintRuleOptions,
+) -> PatinaLintOptions {
+    let mut additional_rules = linter_config.enabled_rules();
+    let disabled_rules = linter_config.disabled_rules();
+    let restricted_members = rule_options.restricted_members();
+    let musea_design_tokens = rule_options.musea_design_tokens();
+
+    add_project_local_rule(
+        &mut additional_rules,
+        &disabled_rules,
+        SCRIPT_NO_RESTRICTED_MEMBERS,
+        !restricted_members.is_empty(),
+    );
+    add_project_local_rule(
+        &mut additional_rules,
+        &disabled_rules,
+        MUSEA_PREFER_DESIGN_TOKENS,
+        !musea_design_tokens.is_empty(),
+    );
+
+    PatinaLintOptions {
+        additional_rules,
+        disabled_rules,
+        restricted_globals: rule_options.restricted_globals(),
+        restricted_members,
+        musea_design_tokens,
+    }
+}
+
+pub(super) fn musea_linter_for_uri(
+    state: &crate::server::ServerState,
+    uri: &Url,
+) -> Option<MuseaLinter> {
+    let (linter_config, rule_options) = state.linter_settings_for_uri(uri);
+    if !linter_config.enabled {
+        return None;
+    }
+
+    let tokens = rule_options.musea_design_tokens();
+    if tokens.is_empty()
+        || linter_config
+            .disabled_rules()
+            .iter()
+            .any(|rule| rule.as_str() == MUSEA_PREFER_DESIGN_TOKENS)
+    {
+        return Some(MuseaLinter::new());
+    }
+
+    let mut config = PreferDesignTokensConfig::default();
+    for (value, path, tier) in tokens {
+        config.add_token(&value, &path, &tier);
+    }
+    Some(MuseaLinter::new().with_design_tokens(config))
+}
+
 pub(super) fn apply_rule_options(
     mut linter: vize_patina::Linter,
     options: &vize_s0::config::ConfigLintRuleOptions,
@@ -9,6 +84,22 @@ pub(super) fn apply_rule_options(
         linter = linter.with_custom_event_name_casing(event_name_casing(casing));
     }
     linter
+}
+
+fn add_project_local_rule(
+    additional_rules: &mut Vec<String>,
+    disabled_rules: &[String],
+    rule_name: &str,
+    configured: bool,
+) {
+    if configured
+        && !disabled_rules.iter().any(|rule| rule.as_str() == rule_name)
+        && !additional_rules
+            .iter()
+            .any(|rule| rule.as_str() == rule_name)
+    {
+        additional_rules.push(rule_name.into());
+    }
 }
 
 fn component_casing(

--- a/crates/vize_maestro/src/ide/diagnostics/service.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/service.rs
@@ -7,38 +7,24 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Range
 
 use super::{LineIndex, Severity};
 
-/// Source position mapping from @vize-map comments.
 #[cfg(feature = "native")]
 #[derive(Debug, Clone)]
 pub(in crate::ide) struct SourceMapping {
-    /// Byte offset start in SFC
     pub(in crate::ide) start: u32,
-    /// Byte offset end in SFC
     pub(in crate::ide) end: u32,
 }
 
-/// Virtual TypeScript generation result with position mapping info.
 #[cfg(feature = "native")]
 pub(in crate::ide) struct VirtualTsResult {
-    /// Generated TypeScript code (post `.vue` → `.vue.ts` import rewrite).
     pub(in crate::ide) code: String,
-    /// Byte-range source mappings from generated TS back to the source SFC.
-    /// Offsets are in pre-rewrite generated TS coordinates; callers must
-    /// translate post-rewrite byte offsets via `import_source_map` first.
     pub(in crate::ide) source_mappings: Vec<vize_canon::virtual_ts::VizeMapping>,
-    /// Stable semantic links in post-rewrite generated TS coordinates.
     pub(in crate::ide) semantic_links: Vec<vize_canon::virtual_ts::VizeSemanticLink>,
     /// Byte-offset mapping from post-rewrite to pre-rewrite virtual TS.
     /// Empty when no `.vue` import specifiers were rewritten.
     pub(in crate::ide) import_source_map: vize_canon::ImportSourceMap,
-    /// Line number where user code starts in virtual TS (0-indexed)
     pub(in crate::ide) user_code_start_line: u32,
-    /// Line number where script starts in original SFC (1-indexed)
     pub(in crate::ide) sfc_script_start_line: u32,
-    /// Line number where template scope starts in virtual TS (0-indexed)
     pub(in crate::ide) template_scope_start_line: u32,
-    /// Line-to-source mappings from @vize-map comments
-    /// Index is virtual TS line number (0-indexed), value is source position in SFC
     pub(in crate::ide) line_mappings: Vec<Option<SourceMapping>>,
     pub(in crate::ide) skipped_import_lines: u32,
 }

--- a/crates/vize_maestro/src/ide/diagnostics/service.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/service.rs
@@ -65,7 +65,12 @@ impl DiagnosticService {
         let path = uri.path();
         if path.ends_with(".art.vue") {
             if features.lint {
-                diagnostics.extend(Self::collect_musea_diagnostics(uri, &content, &line_index));
+                diagnostics.extend(Self::collect_musea_diagnostics(
+                    state,
+                    uri,
+                    &content,
+                    &line_index,
+                ));
             }
             return diagnostics;
         }
@@ -193,8 +198,13 @@ impl DiagnosticService {
 
         // Also lint inline <art> blocks in regular .vue files
         if features.lint {
-            let inline_art_diags =
-                Self::collect_inline_art_diagnostics(uri, &content, &descriptor, &line_index);
+            let inline_art_diags = Self::collect_inline_art_diagnostics(
+                state,
+                uri,
+                &content,
+                &descriptor,
+                &line_index,
+            );
             tracing::info!(
                 "collect: inline art diagnostics: {}",
                 inline_art_diags.len()
@@ -213,9 +223,7 @@ impl DiagnosticService {
     /// `vize/musea`. It reproduces exactly the lint/musea diagnostics that the
     /// full pipeline would publish — including the parser-error short-circuit
     /// that gates them — while skipping the expensive SFC compile, ecosystem,
-    /// and (per-call, uncached) SFC type-check passes that hover discards. The
-    /// returned set is byte-for-byte the lint/musea subset of `collect`'s
-    /// output for every document shape (Art file, standalone HTML, SFC).
+    /// and uncached SFC type-check passes that hover discards.
     pub fn collect_lint_only(state: &ServerState, uri: &Url) -> Vec<Diagnostic> {
         let Some(content) = state.documents.text(uri) else {
             return vec![];
@@ -235,7 +243,12 @@ impl DiagnosticService {
         // Art files (*.art.vue): Musea-specific lint only.
         let path = uri.path();
         if path.ends_with(".art.vue") {
-            diagnostics.extend(Self::collect_musea_diagnostics(uri, &content, &line_index));
+            diagnostics.extend(Self::collect_musea_diagnostics(
+                state,
+                uri,
+                &content,
+                &line_index,
+            ));
             return diagnostics;
         }
 
@@ -275,6 +288,7 @@ impl DiagnosticService {
             &line_index,
         ));
         diagnostics.extend(Self::collect_inline_art_diagnostics(
+            state,
             uri,
             &content,
             &descriptor,

--- a/crates/vize_patina/src/linter.rs
+++ b/crates/vize_patina/src/linter.rs
@@ -13,6 +13,7 @@ mod config;
 mod corsa_session;
 pub(crate) mod css_rules;
 mod engine;
+mod musea_config;
 pub(crate) mod musea_rules;
 #[cfg(not(target_arch = "wasm32"))]
 mod native_type_aware;

--- a/crates/vize_patina/src/linter/config.rs
+++ b/crates/vize_patina/src/linter/config.rs
@@ -12,6 +12,7 @@ use crate::{
         ecosystem_builtin_script_rule_names,
     },
     rule::RuleRegistry,
+    rules::musea::PreferDesignTokensConfig,
 };
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::PathBuf;
@@ -80,6 +81,8 @@ pub struct Linter {
     pub(crate) css_rules: &'static [&'static str],
     /// Built-in `musea/*` rules enabled for this linter.
     pub(crate) musea_rules: &'static [&'static str],
+    /// Optional design-token data for `musea/prefer-design-tokens`.
+    pub(crate) musea_design_tokens: Option<PreferDesignTokensConfig>,
     /// Whether native type-aware lint rules may run.
     pub(crate) type_aware_enabled: bool,
     /// Lazily initialized native corsa session for type-aware lint.
@@ -110,6 +113,7 @@ impl Linter {
             script_rules: builtin_script_rule_names(preset),
             css_rules: builtin_css_rule_names(preset),
             musea_rules: &[],
+            musea_design_tokens: None,
             script_rule_overrides: FxHashMap::default(),
             type_aware_enabled: false,
             #[cfg(not(target_arch = "wasm32"))]
@@ -134,6 +138,7 @@ impl Linter {
             script_rules: builtin_script_rule_names(preset),
             css_rules: builtin_css_rule_names(preset),
             musea_rules: &[],
+            musea_design_tokens: None,
             script_rule_overrides: FxHashMap::default(),
             type_aware_enabled: false,
             #[cfg(not(target_arch = "wasm32"))]
@@ -158,6 +163,7 @@ impl Linter {
             script_rules: ecosystem_builtin_script_rule_names(),
             css_rules: builtin_css_rule_names(LintPreset::Ecosystem),
             musea_rules: &[],
+            musea_design_tokens: None,
             script_rule_overrides: FxHashMap::default(),
             type_aware_enabled: false,
             #[cfg(not(target_arch = "wasm32"))]
@@ -182,6 +188,7 @@ impl Linter {
             script_rules: &[],
             css_rules: &[],
             musea_rules: &[],
+            musea_design_tokens: None,
             script_rule_overrides: FxHashMap::default(),
             type_aware_enabled: false,
             #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vize_patina/src/linter/musea_config.rs
+++ b/crates/vize_patina/src/linter/musea_config.rs
@@ -1,0 +1,25 @@
+//! Builder methods for configurable built-in `musea/*` rules.
+
+use super::config::Linter;
+use crate::rules::musea::PreferDesignTokensConfig;
+use vize_s0::String;
+
+impl Linter {
+    /// Configure design tokens for `musea/prefer-design-tokens`.
+    ///
+    /// Each entry is `(value, path, tier)`. Enabling the rule itself is still
+    /// governed by the usual rule-enable configuration; this only supplies the
+    /// token data the rule needs to avoid becoming a silent no-op.
+    #[inline]
+    pub fn with_musea_design_tokens(mut self, tokens: Vec<(String, String, String)>) -> Self {
+        if tokens.is_empty() {
+            return self;
+        }
+        let mut config = PreferDesignTokensConfig::default();
+        for (value, path, tier) in tokens {
+            config.add_token(&value, &path, &tier);
+        }
+        self.musea_design_tokens = Some(config);
+        self
+    }
+}

--- a/crates/vize_patina/src/linter/musea_rules.rs
+++ b/crates/vize_patina/src/linter/musea_rules.rs
@@ -54,6 +54,11 @@ pub(crate) fn append_builtin_musea_diagnostics(
     musea_linter.check_valid_variant = rule_is_active(linter, RULE_VALID_VARIANT);
     musea_linter.check_unique_variant_names = rule_is_active(linter, RULE_UNIQUE_VARIANT_NAMES);
     musea_linter.check_no_empty_variant = rule_is_active(linter, RULE_NO_EMPTY_VARIANT);
+    if rule_is_active(linter, RULE_PREFER_DESIGN_TOKENS)
+        && let Some(config) = linter.musea_design_tokens.clone()
+    {
+        musea_linter = musea_linter.with_design_tokens(config);
+    }
 
     let musea_result = profile!("patina.musea_rule.lint_art_file", musea_linter.lint(source));
     let diagnostics = musea_result

--- a/npm/cli/pkl/LinterConfig.pkl
+++ b/npm/cli/pkl/LinterConfig.pkl
@@ -52,12 +52,30 @@ class CustomEventNameCasingOptions {
   casing: CustomEventNameCasing = "camelCase"
 }
 
+/// A design token recognized by `musea/prefer-design-tokens`.
+class MuseaDesignToken {
+  /// Token path (e.g. `color.primary`).
+  path: String
+
+  /// Primitive CSS value to match (e.g. `#3b82f6`).
+  value: String
+
+  /// Token tier shown in diagnostics.
+  tier: String = "primitive"
+}
+
+/// Options for `musea/prefer-design-tokens`.
+class MuseaPreferDesignTokensOptions {
+  tokens: Listing<MuseaDesignToken>? = null
+}
+
 /// Typed per-rule options for rules that accept project-local configuration.
 class LintRuleOptions {
   `script/no-restricted-globals`: NoRestrictedGlobalsOptions? = null
   `script/no-restricted-members`: NoRestrictedMembersOptions? = null
   `vue/component-name-in-template-casing`: ComponentNameInTemplateCasingOptions? = null
   `script/custom-event-name-casing`: CustomEventNameCasingOptions? = null
+  `musea/prefer-design-tokens`: MuseaPreferDesignTokensOptions? = null
 }
 
 class LinterConfig {

--- a/npm/cli/pkl/jsonschema/ConfigArtifactDefinitions.pkl
+++ b/npm/cli/pkl/jsonschema/ConfigArtifactDefinitions.pkl
@@ -223,6 +223,38 @@ customEventNameCasingOptionsDef: JsonSchema = new JsonSchema {
   additionalProperties = false
 }
 
+museaDesignTokenDef: JsonSchema = new JsonSchema {
+  type = "object"
+  properties {
+    ["path"] = new JsonSchema {
+      type = "string"
+      description = "Token path, for example color.primary"
+    }
+    ["value"] = new JsonSchema {
+      type = "string"
+      description = "Primitive CSS value to match, for example #3b82f6"
+    }
+    ["tier"] = new JsonSchema {
+      type = "string"
+      description = "Token tier shown in diagnostics"
+      default = "primitive"
+    }
+  }
+  required = new Listing { "path"; "value" }
+  additionalProperties = false
+}
+
+museaPreferDesignTokensOptionsDef: JsonSchema = new JsonSchema {
+  type = "object"
+  properties {
+    ["tokens"] = new JsonSchema {
+      type = "array"
+      items = new JsonSchema { `$ref` = "#/definitions/MuseaDesignToken" }
+    }
+  }
+  additionalProperties = false
+}
+
 lintRuleOptionsDef: JsonSchema = new JsonSchema {
   type = "object"
   properties {
@@ -234,6 +266,9 @@ lintRuleOptionsDef: JsonSchema = new JsonSchema {
     }
     ["vue/component-name-in-template-casing"] = componentNameInTemplateCasingOptionsDef
     ["script/custom-event-name-casing"] = customEventNameCasingOptionsDef
+    ["musea/prefer-design-tokens"] = new JsonSchema {
+      `$ref` = "#/definitions/MuseaPreferDesignTokensOptions"
+    }
   }
   additionalProperties = false
 }

--- a/npm/cli/pkl/jsonschema/generate.pkl
+++ b/npm/cli/pkl/jsonschema/generate.pkl
@@ -1,5 +1,4 @@
 /// Generates secondary JSON Schema compatibility output from the primary Pkl definitions.
-///
 /// Usage: pkl eval -f json pkl/jsonschema/generate.pkl
 module vize.jsonschema.generate
 import "@json_schema/JsonSchema.pkl"
@@ -486,7 +485,6 @@ local configEntryDef: JsonSchema = new JsonSchema {
   }
   additionalProperties = false
 }
-
 output {
   value = new JsonSchema {
     `$schema` = "http://json-schema.org/draft-07/schema#"
@@ -503,6 +501,8 @@ output {
       ["RestrictedMember"] = ConfigArtifactDefinitions.restrictedMemberDef
       ["NoRestrictedGlobalsOptions"] = ConfigArtifactDefinitions.noRestrictedGlobalsOptionsDef
       ["NoRestrictedMembersOptions"] = ConfigArtifactDefinitions.noRestrictedMembersOptionsDef
+      ["MuseaDesignToken"] = ConfigArtifactDefinitions.museaDesignTokenDef
+      ["MuseaPreferDesignTokensOptions"] = ConfigArtifactDefinitions.museaPreferDesignTokensOptionsDef
       ["LintRuleOptions"] = ConfigArtifactDefinitions.lintRuleOptionsDef
       ["TypeCheckerConfig"] = typeCheckerConfigDef
       ["FormatterConfig"] = formatterConfigDef

--- a/npm/cli/pkl/vize.pkl
+++ b/npm/cli/pkl/vize.pkl
@@ -96,11 +96,22 @@ class CustomEventNameCasingOptions {
   casing: CustomEventNameCasing = "camelCase"
 }
 
+class MuseaDesignToken {
+  path: String
+  value: String
+  tier: String? = null
+}
+
+class MuseaPreferDesignTokensOptions {
+  tokens: Listing<MuseaDesignToken>? = null
+}
+
 class LintRuleOptions {
   `script/no-restricted-globals`: NoRestrictedGlobalsOptions? = null
   `script/no-restricted-members`: NoRestrictedMembersOptions? = null
   `vue/component-name-in-template-casing`: ComponentNameInTemplateCasingOptions? = null
   `script/custom-event-name-casing`: CustomEventNameCasingOptions? = null
+  `musea/prefer-design-tokens`: MuseaPreferDesignTokensOptions? = null
 }
 
 class LinterConfig {

--- a/npm/cli/schemas/vize.config.schema.json
+++ b/npm/cli/schemas/vize.config.schema.json
@@ -301,6 +301,38 @@
       },
       "additionalProperties": false
     },
+    "MuseaDesignToken": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "Token path, for example color.primary",
+          "type": "string"
+        },
+        "value": {
+          "description": "Primitive CSS value to match, for example #3b82f6",
+          "type": "string"
+        },
+        "tier": {
+          "description": "Token tier shown in diagnostics",
+          "default": "primitive",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": ["path", "value"]
+    },
+    "MuseaPreferDesignTokensOptions": {
+      "type": "object",
+      "properties": {
+        "tokens": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MuseaDesignToken"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "LintRuleOptions": {
       "type": "object",
       "properties": {
@@ -331,6 +363,9 @@
             }
           },
           "additionalProperties": false
+        },
+        "musea/prefer-design-tokens": {
+          "$ref": "#/definitions/MuseaPreferDesignTokensOptions"
         }
       },
       "additionalProperties": false

--- a/npm/cli/src/types/generated.ts
+++ b/npm/cli/src/types/generated.ts
@@ -230,6 +230,7 @@ export interface LintRuleOptions {
   "script/custom-event-name-casing"?: {
     casing?: "camelCase" | "kebab-case";
   };
+  "musea/prefer-design-tokens"?: MuseaPreferDesignTokensOptions;
 }
 export interface NoRestrictedGlobalsOptions {
   globals?: RestrictedGlobal[];
@@ -245,6 +246,23 @@ export interface RestrictedMember {
   object: string;
   property: string;
   message?: string;
+}
+export interface MuseaPreferDesignTokensOptions {
+  tokens?: MuseaDesignToken[];
+}
+export interface MuseaDesignToken {
+  /**
+   * Token path, for example color.primary
+   */
+  path: string;
+  /**
+   * Primitive CSS value to match, for example #3b82f6
+   */
+  value: string;
+  /**
+   * Token tier shown in diagnostics
+   */
+  tier?: string;
 }
 export interface TypeCheckerConfig {
   /**


### PR DESCRIPTION
## Summary
- add typed execution config for `linter.ruleOptions["musea/prefer-design-tokens"].tokens` without changing the existing constructible `LintRuleOptions` public shape
- pass configured Musea design tokens into Patina from both CLI and LSP diagnostics
- auto-enable project-local Musea design-token lint when tokens are configured and the rule is not explicitly disabled
- add CLI, LSP, config loader, schema/type generation regressions for options-only rule execution
- bump the existing `fast-uri` override to 3.1.6 so the PR security gate stays green

## Verification
- `rtk cargo fmt --all`
- `rtk cargo test --locked -p vize_carton`
- `rtk cargo test --locked -p vize --test lint_musea_cli`
- `rtk cargo test --locked -p vize --test lint_rule_execution_cli`
- `rtk cargo test --locked -p vize --test lint_restricted_members_cli`
- `rtk cargo test --locked -p vize`
- `rtk cargo test --locked -p vize_maestro ide::diagnostics::tests`
- `rtk cargo test --locked -p vize_maestro`
- `rtk cargo +1.95.0 semver-checks check-release --package vize_carton --baseline-rev ba106e85ec7a1c9458d3a26a0ff7f2adba9162a5`
- `rtk env VIZE_ALLOW_NATIVE_VERSION_MISMATCH=1 node --test tests/tooling/config-generation.test.ts tests/tooling/config-json-shape.test.ts tests/tooling/moonbit-postprocess-types.test.ts tests/tooling/source-file-lengths.test.ts`
- `rtk pnpm install --frozen-lockfile`
- `rtk pnpm audit --prod --audit-level moderate`
- `rtk git diff --check`

## Local caveats
- A full `vize_patina` local run still has unrelated type-aware Corsa protocol failures on this checkout.
- A broad workspace local run was interrupted after hanging without useful progress; PR CI is the authoritative full gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the `musea/prefer-design-tokens` lint rule with primitive and semantic design tokens.
  * Hardcoded design-token values now produce lint warnings with suggested CSS variable replacements.
  * Project-specific lint settings are applied consistently to standalone and inline Art files in IDE diagnostics.
  * Added configuration schema and TypeScript types for design-token lint options.

* **Bug Fixes**
  * Disabled or unavailable project lint configurations no longer produce Musea diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->