### PR TITLE
fix(atelier): preserve non-ASCII attribute-binding template literals in v-for codegen

### DIFF
--- a/crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs
@@ -54,9 +54,40 @@ pub(crate) fn strip_scope_prefixes_for_slot_params(ctx: &CodegenContext, content
             continue;
         }
 
-        result.push(bytes[i] as char);
-        i += 1;
+        let ch = content[i..].chars().next().expect("valid UTF-8 boundary");
+        result.push(ch);
+        i += ch.len_utf8();
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_scope_prefixes_for_slot_params;
+    use crate::codegen::CodegenContext;
+    use crate::options::CodegenOptions;
+    use vize_s0::String;
+
+    // #5613: bytes outside a stripped prefix must be copied as UTF-8, not cast per byte.
+    #[test]
+    fn preserves_non_ascii_bytes_unrelated_to_the_stripped_scope_prefix() {
+        let mut ctx = CodegenContext::new(CodegenOptions::default());
+        ctx.add_slot_params(&[String::new("i")]);
+
+        let content = "`\u{2795} ${$setup.n}`";
+        let result = strip_scope_prefixes_for_slot_params(&ctx, content);
+
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn still_strips_the_scope_prefix_for_an_actual_slot_param() {
+        let mut ctx = CodegenContext::new(CodegenOptions::default());
+        ctx.add_slot_params(&[String::new("i")]);
+
+        let result = strip_scope_prefixes_for_slot_params(&ctx, "$setup.i");
+
+        assert_eq!(result, "i");
+    }
 }

--- a/crates/vize_atelier_dom/src/tests.rs
+++ b/crates/vize_atelier_dom/src/tests.rs
@@ -687,3 +687,72 @@ fn test_v_if_branch_component_dynamic_prop_keeps_props_patch_flag() {
     let full = full_output(&result.preamble, &result.code);
     insta::assert_snapshot!(full.as_str());
 }
+
+/// #5613: a scope-prefixed identifier (here `_ctx.n`) inside an attribute-bound
+/// template literal within a `v-for` used to come out mojibaked in the emitted
+/// `render()` source — the `v-for` alias is a codegen slot param, which routes the
+/// prefixed expression through the scope-prefix stripper, which cast raw UTF-8 bytes
+/// to Latin-1 `char`s.
+#[test]
+fn test_v_for_attribute_template_literal_preserves_non_ascii() {
+    let allocator = Allocator::new();
+    let options = DomCompilerOptions {
+        mode: CodegenMode::Function,
+        prefix_identifiers: true,
+        inline: false,
+        binding_metadata: None,
+        ..Default::default()
+    };
+
+    let (_, errors, result) = compile_template_with_options(
+        &allocator,
+        "<span v-for=\"i in 1\" :title=\"`\u{2795} ${n}`\"></span>",
+        options,
+    );
+
+    assert!(errors.is_empty(), "Errors: {:?}", errors);
+    let code = result.code.as_str();
+    assert!(
+        code.contains("`\u{2795} ${_ctx.n}`"),
+        "non-ASCII attribute-binding template literal must survive v-for codegen \
+         byte-for-byte:\n{code}"
+    );
+}
+
+/// #5613: same bug via the `<script setup>` binding path from the issue's repro —
+/// `n` is modeled as a setup const so it's `$setup.`-prefixed rather than `_ctx.`-prefixed,
+/// exercising the full script-setup → prefix → stripper pipeline end-to-end.
+#[test]
+fn test_v_for_script_setup_binding_template_literal_preserves_non_ascii() {
+    use vize_atelier_core::options::{BindingMetadata, BindingType};
+    use vize_s0::FxHashMap;
+
+    let allocator = Allocator::new();
+    let mut bindings = FxHashMap::default();
+    bindings.insert("n".into(), BindingType::SetupConst);
+    let options = DomCompilerOptions {
+        mode: CodegenMode::Function,
+        prefix_identifiers: true,
+        inline: false,
+        binding_metadata: Some(BindingMetadata {
+            bindings,
+            props_aliases: FxHashMap::default(),
+            is_script_setup: true,
+        }),
+        ..Default::default()
+    };
+
+    let (_, errors, result) = compile_template_with_options(
+        &allocator,
+        "<span v-for=\"i in 1\" :title=\"`\u{2795} ${n}`\"></span>",
+        options,
+    );
+
+    assert!(errors.is_empty(), "Errors: {:?}", errors);
+    let code = result.code.as_str();
+    assert!(
+        code.contains("`\u{2795} ${$setup.n}`"),
+        "non-ASCII attribute-binding template literal must survive v-for + script-setup \
+         codegen byte-for-byte:\n{code}"
+    );
+}


### PR DESCRIPTION
## Summary

Non-ASCII (multi-byte UTF-8) text in a JS template literal that is bound to an element attribute and sits inside a `v-for` came out mojibaked in the emitted `render()` source, whenever the literal also contained a scope-prefixed identifier (`_ctx.` / `$setup.` / …). Removing the `v-for` compiled the identical literal correctly.

## Root Cause

`strip_scope_prefixes_for_slot_params` in `crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs` walks an expression that has already been scope-prefixed, stripping prefixes that shadow a `v-for` alias (aliases are registered as codegen "slot params" via `ctx.add_slot_params(...)` in `codegen/v_for.rs`, so they aren't `_ctx.`-prefixed). For every byte outside a stripped prefix it did:

```rust
result.push(bytes[i] as char);
i += 1;
```

— reinterpreting each raw UTF-8 byte as a Latin-1 codepoint. This function only runs when slot params are in scope (inside a `v-for`) **and** the expression contains a scope prefix, which is why the bug needed the `v-for`. It does **not** need `<script setup>`: a plain outer/undeclared identifier is `_ctx.`-prefixed and triggers it just the same (the regression test uses exactly that, with `binding_metadata: None`).

Same bug class already fixed twice in adjacent paths — #1181 / PR #1244 (`vize_atelier_sfc` CSS collapser) and #2498 / PR #2527 (`vize_canon` virtual TS) — recurring here in the crate that emits the runtime `render()`.

## Fix

Same idiom as PR #2527: decode the actual codepoint and advance by its UTF-8 length.

```rust
let ch = content[i..].chars().next().expect("valid UTF-8 boundary");
result.push(ch);
i += ch.len_utf8();
```

(The ASCII-only `bytes[...]` scanning for prefix/identifier matching earlier in the function is left as-is — those bytes are always ASCII in UTF-8 and can't collide with a multi-byte continuation byte.)

## Regression tests

- `crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs`: two unit tests on `strip_scope_prefixes_for_slot_params` — non-ASCII bytes outside a stripped prefix survive untouched, and an actual slot-param prefix still gets stripped.
- `crates/vize_atelier_dom/src/tests.rs::test_v_for_attribute_template_literal_preserves_non_ascii`: end-to-end compile of `<span v-for="i in 1" :title="`➕ ${n}`"></span>`, asserting the output contains `` `➕ ${_ctx.n}` `` byte-for-byte. Verified it fails against pre-fix code with the exact reported mojibake (`` `â ${_ctx.n}` ``) and passes after.

## Validation

```
cargo test -p vize_atelier_core -p vize_atelier_dom --lib   # 231 + 71 passed, 0 failed
cargo clippy -p vize_atelier_core -p vize_atelier_dom -- -D warnings -D clippy::wildcard_imports   # clean
cargo fmt --all -- --check   # clean
```

`node --test tests/tooling/source-file-lengths.test.ts` fails **both before and after** this change in my sandbox (verified via `git stash`): its synthetic-git fixtures hit `gpg failed to sign the data: No secret key` because my local git forces commit signing. Environment/signing issue, unrelated to this diff — flagging in case it matters for CI (which presumably doesn't sign).

Closes #5613

## Note (out of scope for this PR)

This is the third recurrence of the `bytes[i] as char` byte→codepoint bug class (#1181, #2498, now #5613), each time in a different manual index-scanner. This PR keeps the minimal, same-idiom fix used by #2527/#3088. A more structural preventive would be to have these skip-ahead scanners iterate `char_indices()` (already the dominant idiom in the codebase — e.g. `crates/vize_croquis/src/sfc/css_transform/scanner.rs` drives a `char_indices().peekable()`), which makes a raw-byte cast impossible by construction. Left as a possible follow-up rather than folded in here, since converting the byte-level prefix matching in this function is a refactor beyond the fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790979052&installation_model_id=422833&pr_number=5614&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5614&signature=4b2ca4a163f815078a3295a47f8c43480da18b74cce846eba5b4253f301cd930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved non-ASCII characters in generated code for attribute-bound template literals.
  - Corrected scope-prefix handling for slot parameters within template literals.
  - Improved generated output for template literals used inside `v-for` bindings, including script-setup references.

- **Tests**
  - Added regression coverage for non-ASCII characters in template literals.
  - Added coverage for scope-prefix stripping and `v-for` code generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
