### PR TITLE
fix(release): bump fast-uri audit floor

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -370,7 +370,7 @@ overrides:
   devalue: 5.8.1
   dompurify: 3.4.13
   esbuild: 0.28.1
-  fast-uri: 3.1.5
+  fast-uri: 3.1.6
   glob>minimatch: 10.2.5
   h3: 1.15.11
   hono: 4.12.34
@@ -8236,8 +8236,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -17452,7 +17452,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -18989,7 +18989,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,7 +43,7 @@ overrides:
   devalue: "5.8.1"
   dompurify: "3.4.13"
   esbuild: "0.28.1"
-  fast-uri: "3.1.5"
+  fast-uri: "3.1.6"
   "glob>minimatch": "10.2.5"
   h3: "1.15.11"
   hono: "4.12.34"


### PR DESCRIPTION
`pnpm audit --prod --audit-level moderate` fails on four high advisories against `fast-uri` < 3.1.6, reached through `ajv` under the webpack builder package:

- GHSA-5jgf-p345-68v8 — host confusion via skipped IDN canonicalization
- GHSA-f65p-4m7j-42xc — SSRF via malformed IPv6 normalization
- GHSA-fph4-wmhf-6fwf
- GHSA-jqff-g426-hqxp

The workspace already pins this resolution (`fast-uri: "3.1.5"`), so this raises the floor to `3.1.6` and edits only the four lockfile lines that name the resolution plus its integrity — the lockfile is otherwise byte-identical.

Why it matters beyond its own job: `security-audit` is listed in `test-report`'s `needs`, and `test-report` (a required check) runs `require-needs-success.rs`. The advisory therefore blocks the required aggregate check on **every** open pull request, not just this one.

Verified locally with the pinned pnpm 12.1.0:

- `pnpm install --frozen-lockfile --lockfile-only` — accepted, no drift
- `pnpm audit --prod --audit-level moderate` — "No known vulnerabilities found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791021327&installation_model_id=422833&pr_number=5619&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5619&signature=cff73b987f21edc7f19663123d7c84dd84fed159b9677a62730a1b8938d42520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying URI-handling component to a newer patch version, incorporating maintenance updates without changing the application’s public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->