### PR TITLE
feat(davinci): resolve S2 DOM identifiers through binding metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4053,6 +4053,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "toml",
+ "vize_atelier_core",
  "vize_atelier_dom",
  "vize_atelier_sfc",
  "vize_carton",

--- a/crates/vize_atelier_dom/tests/davinci_s2_binding_metadata.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_binding_metadata.rs
@@ -1,0 +1,307 @@
+//! P2-11 installment 86 witness: **binding metadata** in non-inline mode.
+//! With `prefix_identifiers` and a binding table, free identifiers resolve
+//! to `$setup.` / `$props.` / `$data.` / `$options.` (`_ctx.` for Vue
+//! globals and unknown names), components and directives that name a
+//! script binding read `$setup` members instead of runtime resolution,
+//! Options API method handlers are guarded references, destructured prop
+//! aliases project onto their keys, and module mode carries the
+//! six-argument render signature — all compared byte-for-byte with the
+//! shipped lane.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use vize_atelier_core::options::{BindingMetadata, BindingType, CodegenMode, CodegenOptions};
+use vize_atelier_dom::DomCompilerOptions;
+use vize_s0::FxHashMap;
+use vize_s1_to_s2::{BindingKind, BindingTable, DomEmitMode, DomEmitOptions};
+
+const BATTERY: &[(&str, &str)] = &[
+    ("setup_ref", "<div>{{ count }}</div>"),
+    ("setup_let", "<div>{{ msg }}</div>"),
+    ("setup_const", "<div>{{ handler }}</div>"),
+    ("setup_reactive", "<div>{{ state.value }}</div>"),
+    ("props", "<div>{{ title }}</div>"),
+    ("props_alias", "<div>{{ label }}</div>"),
+    ("data_option", "<div>{{ d }} {{ method }}</div>"),
+    ("literal_const", "<div>{{ LIMIT }}</div>"),
+    ("vue_global", "<div>{{ $slots.default }}</div>"),
+    ("external_module", "<div>{{ helper(count) }}</div>"),
+    ("unknown", "<div>{{ other }}</div>"),
+    ("mixed_text", "<p>Hi {{ title }}, {{ other }}!</p>"),
+    (
+        "shorthand_object",
+        r#"<div :foo="{ count, title, other }"></div>"#,
+    ),
+    (
+        "bind_member",
+        r#"<div :id="state.id" :class="{ a: count }"></div>"#,
+    ),
+    ("bind_style", r#"<div :style="{ color: theme }"></div>"#),
+    (
+        "bind_arrow",
+        r#"<div :fn="(e) => handler(e, count)"></div>"#,
+    ),
+    (
+        "bind_globals",
+        r#"<div :a="Math.max(count, LIMIT)" :b="undefined"></div>"#,
+    ),
+    ("handler_setup_const", r#"<div @click="handler"></div>"#),
+    ("handler_setup_ref", r#"<div @click="count"></div>"#),
+    ("handler_options_method", r#"<div @click="method"></div>"#),
+    ("handler_options_padded", r#"<div @click=" method "></div>"#),
+    (
+        "handler_options_member",
+        r#"<div @click="method.bind"></div>"#,
+    ),
+    (
+        "handler_options_modifiers",
+        r#"<div @click.stop="method" @keyup.enter="method"></div>"#,
+    ),
+    ("handler_inline_update", r#"<div @click="count++"></div>"#),
+    (
+        "handler_inline_call",
+        r#"<div @click="handler(count, other)"></div>"#,
+    ),
+    (
+        "handler_inline_assign",
+        r#"<div @click="msg = title"></div>"#,
+    ),
+    (
+        "handler_arrow",
+        r#"<div @focus="() => handler(count)"></div>"#,
+    ),
+    ("handler_multi_statement", r#"<div @keyup="a; b"></div>"#),
+    ("handler_props", r#"<div @click="title"></div>"#),
+    ("model_native", r#"<input v-model="msg">"#),
+    ("model_native_ref", r#"<input v-model="count">"#),
+    ("model_native_member", r#"<input v-model="state.value">"#),
+    ("model_component", r#"<MyComp v-model="msg" />"#),
+    ("model_component_arg", r#"<MyComp v-model:title="title" />"#),
+    (
+        "vfor_alias_shadows",
+        r#"<li v-for="count in items">{{ count }} {{ other }}</li>"#,
+    ),
+    (
+        "vfor_destructured",
+        r#"<li v-for="({ title }, i) in items" :key="i">{{ title }} {{ count }}</li>"#,
+    ),
+    (
+        "slot_param_shadows",
+        r#"<MyComp v-slot="{ count }">{{ count }} {{ msg }}</MyComp>"#,
+    ),
+    (
+        "slot_default_value",
+        r#"<MyComp #default="{ x = count }">{{ x }}</MyComp>"#,
+    ),
+    (
+        "dynamic_key_simple",
+        r#"<div :[count]="1" @[method]="handler"></div>"#,
+    ),
+    ("dynamic_key_member", r#"<div :[state.key]="1"></div>"#),
+    ("dynamic_key_template", "<div :[`k-${count}`]=\"1\"></div>"),
+    ("component_setup_const", "<MyComp />"),
+    ("component_kebab", "<my-comp />"),
+    ("component_external", "<FooBar />"),
+    ("component_props_named", "<Icon />"),
+    ("component_dotted", "<Ns.Item />"),
+    ("component_unknown", "<Other />"),
+    (
+        "component_mixed",
+        "<div><MyComp /><Other /><Ns.Item /></div>",
+    ),
+    (
+        "component_children",
+        "<MyComp><span>{{ count }}</span></MyComp>",
+    ),
+    (
+        "component_props",
+        r#"<MyComp :title="title" @update="handler" />"#,
+    ),
+    ("component_dynamic", r#"<component :is="view" />"#),
+    ("directive_setup", r#"<div v-focus></div>"#),
+    ("directive_setup_value", r#"<div v-focus="count"></div>"#),
+    ("directive_unknown", r#"<div v-other="count"></div>"#),
+    ("directive_mixed", r#"<div v-focus v-other></div>"#),
+    ("directive_kebab", r#"<div v-my-dir></div>"#),
+    (
+        "show_if",
+        r#"<div v-if="count"><span v-show="msg"></span></div>"#,
+    ),
+    (
+        "html_text",
+        r#"<div v-html="rawHtml"></div><p v-text="title"></p>"#,
+    ),
+    ("v_once", "<div v-once>{{ count }}</div>"),
+    ("v_memo", r#"<div v-memo="[count]">{{ msg }}</div>"#),
+    (
+        "slot_outlet",
+        r#"<slot :item="count" name="x">{{ msg }}</slot>"#,
+    ),
+    (
+        "bind_object_spread",
+        r#"<div v-bind="attrs" v-on="listeners"></div>"#,
+    ),
+    (
+        "props_alias_object",
+        r#"<div :foo="{ label }" @click="label = 1"></div>"#,
+    ),
+];
+
+fn metadata() -> BindingMetadata {
+    let entries: &[(&str, BindingType)] = &[
+        ("count", BindingType::SetupRef),
+        ("msg", BindingType::SetupLet),
+        ("handler", BindingType::SetupConst),
+        ("state", BindingType::SetupReactiveConst),
+        ("theme", BindingType::SetupMaybeRef),
+        ("title", BindingType::Props),
+        ("label", BindingType::PropsAliased),
+        ("d", BindingType::Data),
+        ("method", BindingType::Options),
+        ("LIMIT", BindingType::LiteralConst),
+        ("$slots", BindingType::VueGlobal),
+        ("helper", BindingType::ExternalModule),
+        ("FooBar", BindingType::ExternalModule),
+        ("MyComp", BindingType::SetupConst),
+        ("Icon", BindingType::Props),
+        ("Ns", BindingType::SetupConst),
+        ("vFocus", BindingType::SetupConst),
+        ("vMyDir", BindingType::SetupLet),
+        ("view", BindingType::SetupRef),
+        ("rawHtml", BindingType::SetupRef),
+        ("attrs", BindingType::SetupConst),
+        ("listeners", BindingType::SetupConst),
+        ("items", BindingType::SetupConst),
+    ];
+    let mut bindings = FxHashMap::default();
+    for (name, kind) in entries {
+        bindings.insert((*name).into(), *kind);
+    }
+    let mut props_aliases = FxHashMap::default();
+    props_aliases.insert("label".into(), "aria-label".into());
+    BindingMetadata {
+        bindings,
+        props_aliases,
+        is_script_setup: true,
+    }
+}
+
+fn binding_kind(kind: BindingType) -> BindingKind {
+    match kind {
+        BindingType::SetupLet => BindingKind::SetupLet,
+        BindingType::SetupMaybeRef => BindingKind::SetupMaybeRef,
+        BindingType::SetupRef => BindingKind::SetupRef,
+        BindingType::SetupReactiveConst => BindingKind::SetupReactiveConst,
+        BindingType::SetupConst => BindingKind::SetupConst,
+        BindingType::Props => BindingKind::Props,
+        BindingType::PropsAliased => BindingKind::PropsAliased,
+        BindingType::Data => BindingKind::Data,
+        BindingType::Options => BindingKind::Options,
+        BindingType::LiteralConst => BindingKind::LiteralConst,
+        BindingType::JsGlobalUniversal => BindingKind::JsGlobalUniversal,
+        BindingType::JsGlobalBrowser => BindingKind::JsGlobalBrowser,
+        BindingType::JsGlobalNode => BindingKind::JsGlobalNode,
+        BindingType::JsGlobalDeno => BindingKind::JsGlobalDeno,
+        BindingType::JsGlobalBun => BindingKind::JsGlobalBun,
+        BindingType::VueGlobal => BindingKind::VueGlobal,
+        BindingType::ExternalModule => BindingKind::ExternalModule,
+    }
+}
+
+fn table(metadata: &BindingMetadata) -> BindingTable {
+    BindingTable::new(
+        metadata
+            .bindings
+            .iter()
+            .map(|(name, kind)| (name.as_str(), binding_kind(*kind))),
+        metadata
+            .props_aliases
+            .iter()
+            .map(|(local, key)| (local.as_str(), key.as_str())),
+        metadata.is_script_setup,
+    )
+}
+
+fn shipped_options(mode: CodegenMode) -> DomCompilerOptions {
+    DomCompilerOptions {
+        mode,
+        prefix_identifiers: true,
+        binding_metadata: Some(metadata()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn binding_metadata_in_function_mode_matches_the_shipped_dom_lane() {
+    let metadata = metadata();
+    let table = table(&metadata);
+    support::assert_s2_matches_shipped_with_options(
+        BATTERY,
+        &shipped_options(CodegenMode::Function),
+        &CodegenOptions::default(),
+        &DomEmitOptions {
+            prefix_identifiers: true,
+            bindings: Some(&table),
+            ..DomEmitOptions::DEFAULT
+        },
+    );
+}
+
+#[test]
+fn binding_metadata_in_module_mode_matches_the_shipped_dom_lane() {
+    let metadata = metadata();
+    let table = table(&metadata);
+    support::assert_s2_matches_shipped_with_options(
+        BATTERY,
+        &shipped_options(CodegenMode::Module),
+        &CodegenOptions::default(),
+        &DomEmitOptions {
+            mode: DomEmitMode::Module,
+            prefix_identifiers: true,
+            bindings: Some(&table),
+            ..DomEmitOptions::DEFAULT
+        },
+    );
+}
+
+/// Exact spellings the dual-run above would also accept from a lane that
+/// ignored the table entirely if the shipped side regressed alongside it:
+/// the six-argument module signature, the `$setup.` read, the `$setup`
+/// component tag, the `$setup["vFocus"]` directive and the guarded
+/// Options API handler.
+#[test]
+fn binding_metadata_spellings_are_pinned() {
+    let metadata = metadata();
+    let table = table(&metadata);
+    let allocator = vize_s0::Allocator::new();
+    let options = DomEmitOptions {
+        mode: DomEmitMode::Module,
+        prefix_identifiers: true,
+        bindings: Some(&table),
+        ..DomEmitOptions::DEFAULT
+    };
+    let emit = |src: &str| {
+        vize_s1_to_s2::emit_dom_source_with_options(
+            &allocator,
+            src,
+            vize_s1_to_s2::LegacyCaps::VUE3,
+            &options,
+        )
+        .expect("binding witness must emit")
+        .assembled()
+    };
+    assert_eq!(
+        emit("<div>{{ count }}</div>"),
+        "import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n\nexport function render(_ctx, _cache, $props, $setup, $data, $options) {\n  return (_openBlock(), _createElementBlock(\"div\", null, _toDisplayString($setup.count), 1 /* TEXT */))\n}"
+    );
+    assert_eq!(
+        emit(r#"<MyComp v-focus @click="method" />"#),
+        "import { withDirectives as _withDirectives, openBlock as _openBlock, createBlock as _createBlock } from \"vue\"\n\nexport function render(_ctx, _cache, $props, $setup, $data, $options) {\n  const _directive_focus = $setup[\"vFocus\"]\n  \n  return _withDirectives((_openBlock(), _createBlock($setup.MyComp, { onClick: (...args) => (_ctx.method && _ctx.method(...args)) }, null, 8 /* PROPS */, [\"onClick\"])), [\n    [_directive_focus]\n  ])\n}"
+    );
+}

--- a/crates/vize_s1_to_s2/Cargo.toml
+++ b/crates/vize_s1_to_s2/Cargo.toml
@@ -46,6 +46,7 @@ davinci_harness = { workspace = true }
 davinci_test_support.workspace = true
 insta = { workspace = true }
 toml = { workspace = true }
+vize_atelier_core = { workspace = true }
 vize_atelier_sfc = { workspace = true }
 vize_atelier_dom = { workspace = true }
 vize_croquis = { workspace = true }
@@ -64,4 +65,8 @@ required-features = ["davinci-differential"]
 
 [[test]]
 name = "davinci_dom_corpus_prefixed"
+required-features = ["davinci-differential"]
+
+[[test]]
+name = "davinci_dom_corpus_bindings"
 required-features = ["davinci-differential"]

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -120,7 +120,7 @@ pub use self::entry::{
 pub use self::error::{EmitError, UnsupportedReason, UnsupportedRefusal};
 use self::fragment::emit_root;
 use self::helper::Helper;
-pub use self::options::{DomEmitMode, DomEmitOptions};
+pub use self::options::{BindingKind, BindingTable, DomEmitMode, DomEmitOptions};
 
 fn emit_if_op(cx: &mut EmitCx<'_>, if_op: &IfOp<'_>, id: Option<NodeId>) -> Result<(), EmitError> {
     vif::emit_if(cx, if_op, id)
@@ -213,7 +213,7 @@ struct EmitCx<'facts> {
     /// way out instead of being pushed verbatim.
     prefix_identifiers: bool,
     /// The transform scope and codegen slot params the prefixer consults.
-    scope: prefix::PrefixScope,
+    scope: prefix::PrefixScope<'facts>,
 }
 
 /// Emit a DOM render function from an already-lowered (and typically
@@ -224,18 +224,18 @@ pub fn emit_dom(lowered: &Lowered<'_>, facts: &S2Facts) -> Result<DomEmit, EmitE
 }
 
 /// [`emit_dom`] under explicit [`DomEmitOptions`].
-pub fn emit_dom_with_options(
-    lowered: &Lowered<'_>,
-    facts: &S2Facts,
-    options: &DomEmitOptions<'_>,
+pub fn emit_dom_with_options<'f>(
+    lowered: &'f Lowered<'_>,
+    facts: &'f S2Facts,
+    options: &DomEmitOptions<'f>,
 ) -> Result<DomEmit, EmitError> {
     emit_dom_with_emit_budget(lowered, facts, options).map(|(emit, _)| emit)
 }
 
-fn emit_dom_with_emit_budget(
-    lowered: &Lowered<'_>,
-    facts: &S2Facts,
-    options: &DomEmitOptions<'_>,
+fn emit_dom_with_emit_budget<'f>(
+    lowered: &'f Lowered<'_>,
+    facts: &'f S2Facts,
+    options: &DomEmitOptions<'f>,
 ) -> Result<(DomEmit, u32), EmitError> {
     if lowered
         .diagnostics
@@ -272,36 +272,43 @@ fn emit_dom_with_emit_budget(
         static_cache,
         parent_ns: Namespace::Html,
         prefix_identifiers: options.prefix_identifiers,
-        scope: prefix::PrefixScope::default(),
+        scope: prefix::PrefixScope::new(options.bindings),
     };
     let filters = &facts.legacy.filters;
     if facts.legacy.filter_helper_precedes_components {
         cx.buf.prefer(Helper::ResolveFilter);
     }
     let mut helper_walk = PageWalk::new();
+    let prefer_cx = helper_preference::PreferCx {
+        facts,
+        for_wrappers: &lowered.for_wrappers,
+        bindings: options.bindings,
+    };
     helper_preference::prefer_helpers(
         &mut cx.buf,
-        facts,
-        &lowered.for_wrappers,
+        &prefer_cx,
         &mut helper_walk,
         &lowered.root,
     );
     fragment::prefer_root_fragment(&mut cx.buf, &lowered.root);
-    cx.buf.push(options.mode.render_signature());
+    cx.buf
+        .push(options.mode.render_signature(options.bindings.is_some()));
     cx.buf.indent();
     cx.buf.newline();
     let names = component::collect_names(&lowered.root);
     let dirs = directive::collect_names(&lowered.root);
+    let mut resolved_assets = false;
     if !names.is_empty() {
-        component::emit_resolves(&mut cx, &names);
+        resolved_assets |= component::emit_resolves(&mut cx, &names);
     }
     if !dirs.is_empty() {
-        directive::emit_resolves(&mut cx, &dirs);
+        resolved_assets |= directive::emit_resolves(&mut cx, &dirs);
     }
     if !filters.is_empty() {
         filter::emit_resolves(&mut cx, filters);
+        resolved_assets = true;
     }
-    if !names.is_empty() || !dirs.is_empty() || !filters.is_empty() {
+    if resolved_assets {
         cx.buf.newline();
     }
     cx.buf.push("return ");

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -1,5 +1,6 @@
 //! Component emission, including slots, builtins, and dynamic components.
 
+pub(super) mod binding;
 mod call_props;
 mod checks;
 mod children_arg;
@@ -165,6 +166,7 @@ fn emit_call(
     } else if let Some(helper) = builtin::helper(component.name) {
         cx.buf.use_helper(helper);
         cx.buf.push(helper.alias());
+    } else if binding::push_tag(cx, component.name) {
     } else {
         cx.buf
             .push(asset_ident("component", component.name).as_str());

--- a/crates/vize_s1_to_s2/src/emit/component/binding.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/binding.rs
@@ -1,0 +1,122 @@
+//! Component tags that resolve to a script binding
+//! (`CodegenContext::resolve_component_binding` /
+//! `push_component_binding_tag`, non-inline): the tag, its camelized and
+//! PascalCased spellings, with props bindings kept only as a fallback,
+//! and a dotted `Foo.Bar` suffix carried through.
+
+use vize_s0::{String, camelize, capitalize};
+
+use super::super::EmitCx;
+use super::super::options::{BindingKind, BindingTable};
+
+pub(in crate::emit) struct ComponentBinding<'a> {
+    pub(in crate::emit) name: String,
+    #[allow(dead_code)]
+    pub(in crate::emit) kind: BindingKind,
+    pub(in crate::emit) suffix: Option<&'a str>,
+}
+
+/// The binding a component tag resolves to, if the table names one.
+pub(in crate::emit) fn resolve<'a>(
+    table: &BindingTable,
+    component: &'a str,
+) -> Option<ComponentBinding<'a>> {
+    let (base, suffix) = match component.split_once('.') {
+        Some((base, suffix)) => (base, Some(suffix)),
+        None => (component, None),
+    };
+    let (name, kind) = resolve_base(table, base)?;
+    Some(ComponentBinding { name, kind, suffix })
+}
+
+/// Whether the emit resolves `component` through the binding table.
+pub(in crate::emit) fn resolves(cx: &EmitCx<'_>, component: &str) -> bool {
+    cx.scope
+        .bindings()
+        .is_some_and(|table| resolve(table, component).is_some())
+}
+
+/// Push the `$setup.Name` (`.suffix`) tag; `false` when the tag is not a
+/// binding and the caller falls back to the resolved asset.
+pub(in crate::emit) fn push_tag(cx: &mut EmitCx<'_>, component: &str) -> bool {
+    let Some(binding) = cx
+        .scope
+        .bindings()
+        .and_then(|table| resolve(table, component))
+    else {
+        return false;
+    };
+    cx.buf.push("$setup.");
+    cx.buf.push(binding.name.as_str());
+    if let Some(suffix) = binding.suffix {
+        cx.buf.push(".");
+        cx.buf.push(suffix);
+    }
+    true
+}
+
+fn resolve_base(table: &BindingTable, name: &str) -> Option<(String, BindingKind)> {
+    let mut prop_fallback = None;
+    if let Some(binding) = candidate(table, String::from(name), &mut prop_fallback) {
+        return Some(binding);
+    }
+    let camel = camelize(name);
+    if camel.as_str() != name
+        && let Some(binding) = candidate(table, camel.clone(), &mut prop_fallback)
+    {
+        return Some(binding);
+    }
+    let pascal = capitalize(&camel);
+    if pascal.as_str() != name
+        && pascal.as_str() != camel.as_str()
+        && let Some(binding) = candidate(table, pascal, &mut prop_fallback)
+    {
+        return Some(binding);
+    }
+    prop_fallback
+}
+
+fn candidate(
+    table: &BindingTable,
+    candidate: String,
+    prop_fallback: &mut Option<(String, BindingKind)>,
+) -> Option<(String, BindingKind)> {
+    let kind = table.kind(candidate.as_str())?;
+    if kind.is_props() {
+        if prop_fallback.is_none() {
+            *prop_fallback = Some((candidate, kind));
+        }
+        return None;
+    }
+    Some((candidate, kind))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve;
+    use crate::emit::options::{BindingKind, BindingTable};
+
+    #[test]
+    fn tags_resolve_exact_camel_pascal_with_props_fallback() {
+        let table = BindingTable::new(
+            [
+                ("MyComp", BindingKind::SetupConst),
+                ("fooBar", BindingKind::ExternalModule),
+                ("Icon", BindingKind::Props),
+                ("Ns", BindingKind::SetupConst),
+            ],
+            [],
+            true,
+        );
+        assert_eq!(resolve(&table, "MyComp").unwrap().name.as_str(), "MyComp");
+        assert_eq!(resolve(&table, "my-comp").unwrap().name.as_str(), "MyComp");
+        assert_eq!(resolve(&table, "foo-bar").unwrap().name.as_str(), "fooBar");
+        let icon = resolve(&table, "icon").unwrap();
+        assert_eq!(icon.name.as_str(), "Icon");
+        assert_eq!(icon.kind, BindingKind::Props);
+        let dotted = resolve(&table, "Ns.Item").unwrap();
+        assert_eq!(dotted.name.as_str(), "Ns");
+        assert_eq!(dotted.suffix, Some("Item"));
+        assert!(resolve(&table, "other").is_none());
+    }
+}

--- a/crates/vize_s1_to_s2/src/emit/component/preamble.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/preamble.rs
@@ -12,9 +12,19 @@ pub(in crate::emit) fn collect_names<'a>(root: &Region<'a>) -> StdVec<&'a str> {
     names
 }
 
-pub(in crate::emit) fn emit_resolves(cx: &mut EmitCx<'_>, names: &[&str]) {
-    cx.buf.use_resolve_component();
+/// `generate_assets` over the components: tags that resolve to a script
+/// binding are skipped (they are pushed as `$setup.Name` at the call).
+/// Returns whether any `resolveComponent` line was written.
+pub(in crate::emit) fn emit_resolves(cx: &mut EmitCx<'_>, names: &[&str]) -> bool {
+    let mut resolved = false;
     for name in names {
+        if super::binding::resolves(cx, name) {
+            continue;
+        }
+        if !resolved {
+            cx.buf.use_resolve_component();
+            resolved = true;
+        }
         cx.buf.push("const ");
         cx.buf.push(asset_ident("component", name).as_str());
         cx.buf.push(" = ");
@@ -24,6 +34,7 @@ pub(in crate::emit) fn emit_resolves(cx: &mut EmitCx<'_>, names: &[&str]) {
         cx.buf.push("\")");
         cx.buf.newline();
     }
+    resolved
 }
 
 fn collect_from<'a>(region: &Region<'a>, names: &mut StdVec<&'a str>) {

--- a/crates/vize_s1_to_s2/src/emit/directive.rs
+++ b/crates/vize_s1_to_s2/src/emit/directive.rs
@@ -51,18 +51,48 @@ pub(super) fn collect_names<'a>(root: &'a Region<'a>) -> StdVec<&'a str> {
     names
 }
 
-pub(super) fn emit_resolves(cx: &mut EmitCx<'_>, names: &[&str]) {
-    cx.buf.use_resolve_directive();
+/// `generate_assets` over the directives: a `vFoo` script binding reads
+/// `$setup["vFoo"]` (its non-inline object), anything else resolves at
+/// runtime. Returns whether any line was written.
+pub(super) fn emit_resolves(cx: &mut EmitCx<'_>, names: &[&str]) -> bool {
     for name in names {
         cx.buf.push("const ");
         cx.buf.push(asset_ident("directive", name).as_str());
         cx.buf.push(" = ");
-        cx.buf.push(Buf::resolve_directive_alias());
-        cx.buf.push("(\"");
-        cx.buf.push(name);
-        cx.buf.push("\")");
+        let binding_name = imported_directive_binding_name(name);
+        match cx
+            .scope
+            .bindings()
+            .and_then(|table| table.kind(binding_name.as_str()))
+        {
+            Some(kind) => {
+                cx.buf
+                    .push(kind.non_inline_template_prefix().trim_end_matches('.'));
+                cx.buf.push("[\"");
+                cx.buf
+                    .push(super::js::escape_js_string(binding_name.as_str()).as_str());
+                cx.buf.push("\"]");
+            }
+            None => {
+                cx.buf.use_resolve_directive();
+                cx.buf.push(Buf::resolve_directive_alias());
+                cx.buf.push("(\"");
+                cx.buf.push(name);
+                cx.buf.push("\")");
+            }
+        }
         cx.buf.newline();
     }
+    !names.is_empty()
+}
+
+/// `imported_directive_binding_name`: `v` + PascalCase(camelize(name)).
+fn imported_directive_binding_name(name: &str) -> vize_s0::String {
+    let pascal = vize_s0::capitalize(&vize_s0::camelize(name));
+    let mut binding = vize_s0::String::with_capacity(1 + pascal.len());
+    binding.push('v');
+    binding.push_str(pascal.as_str());
+    binding
 }
 
 pub(super) fn wrap_element(

--- a/crates/vize_s1_to_s2/src/emit/helper_preference.rs
+++ b/crates/vize_s1_to_s2/src/emit/helper_preference.rs
@@ -11,26 +11,42 @@ use crate::pass::walk::PageWalk;
 
 use super::buf::Buf;
 use super::helper::Helper;
+use super::options::BindingTable;
 use super::{builtin, directive, sfc_style, slots};
 use slot_order::{
     component_slot_content, direct_slot_carrier_precedes_slot_outlet, has_slot_outlet,
     op_is_direct_slot_carrier, prefer_slot_helpers,
 };
 
+/// What the preference walk reads besides the region it is walking.
+pub(super) struct PreferCx<'a> {
+    pub(super) facts: &'a S2Facts,
+    pub(super) for_wrappers: &'a SideTable<ForWrapper>,
+    /// The script bindings, when the emit carries them: a component tag
+    /// named there resolves to `$setup` and never marks `resolveComponent`
+    /// during the transform (`lane::element`, which matches the tag
+    /// verbatim — the camelize/PascalCase widening is codegen's alone).
+    pub(super) bindings: Option<&'a BindingTable>,
+}
+
+impl PreferCx<'_> {
+    fn tag_is_binding(&self, tag: &str) -> bool {
+        self.bindings.is_some_and(|table| table.contains(tag))
+    }
+}
+
 pub(super) fn prefer_helpers(
     buf: &mut Buf,
-    facts: &S2Facts,
-    for_wrappers: &SideTable<ForWrapper>,
+    cx: &PreferCx<'_>,
     walk: &mut PageWalk,
     region: &Region<'_>,
 ) {
-    prefer_region_helpers(buf, facts, for_wrappers, walk, region, false, false);
+    prefer_region_helpers(buf, cx, walk, region, false, false);
 }
 
 fn prefer_region_helpers(
     buf: &mut Buf,
-    facts: &S2Facts,
-    for_wrappers: &SideTable<ForWrapper>,
+    cx: &PreferCx<'_>,
     walk: &mut PageWalk,
     region: &Region<'_>,
     template_slot_context: bool,
@@ -45,8 +61,7 @@ fn prefer_region_helpers(
     for (index, op) in region.ops.iter().enumerate() {
         prefer_op_helpers(
             buf,
-            facts,
-            for_wrappers,
+            cx,
             walk,
             op,
             slot_context,
@@ -58,8 +73,7 @@ fn prefer_region_helpers(
 
 fn prefer_op_helpers(
     buf: &mut Buf,
-    facts: &S2Facts,
-    for_wrappers: &SideTable<ForWrapper>,
+    cx: &PreferCx<'_>,
     walk: &mut PageWalk,
     op: &Op<'_>,
     slot_context: bool,
@@ -84,8 +98,7 @@ fn prefer_op_helpers(
             let child_slot_context = slot_context || slot_template;
             prefer_region_helpers(
                 buf,
-                facts,
-                for_wrappers,
+                cx,
                 walk,
                 &element.children,
                 child_slot_context,
@@ -101,17 +114,16 @@ fn prefer_op_helpers(
                 buf.prefer(Helper::RenderSlot);
             }
             directive::prefer_helpers(buf, bindings);
-            if !builtin::is_dynamic_component(component) {
+            if !builtin::is_dynamic_component(component) && !cx.tag_is_binding(component.name) {
                 buf.prefer(Helper::ResolveComponent);
             }
             walk.skip(bindings.len());
-            if id.and_then(|id| facts.slot_facts.get(id)).is_some() {
+            if id.and_then(|id| cx.facts.slot_facts.get(id)).is_some() {
                 prefer_slot_helpers(buf, &component.children);
             }
             prefer_region_helpers(
                 buf,
-                facts,
-                for_wrappers,
+                cx,
                 walk,
                 &component.children,
                 slot_context,
@@ -123,8 +135,7 @@ fn prefer_op_helpers(
             walk.skip(slot.bindings.len());
             prefer_region_helpers(
                 buf,
-                facts,
-                for_wrappers,
+                cx,
                 walk,
                 &slot.fallback,
                 slot_context,
@@ -138,14 +149,7 @@ fn prefer_op_helpers(
             buf.prefer(Helper::Fragment);
             buf.prefer(Helper::CreateComment);
             for branch in if_op.branches.iter() {
-                prefer_if_branch_helpers(
-                    buf,
-                    facts,
-                    for_wrappers,
-                    walk,
-                    &branch.region,
-                    slot_context,
-                );
+                prefer_if_branch_helpers(buf, cx, walk, &branch.region, slot_context);
             }
         }
         Op::For(for_op) => {
@@ -154,12 +158,11 @@ fn prefer_op_helpers(
             buf.prefer(Helper::CreateBlock);
             buf.prefer(Helper::Fragment);
             let suppress_root_directives = id
-                .and_then(|id| for_wrappers.get(id))
+                .and_then(|id| cx.for_wrappers.get(id))
                 .is_some_and(|_| super::tpl::should_unwrap_for(&for_op.region.ops));
             prefer_region_helpers(
                 buf,
-                facts,
-                for_wrappers,
+                cx,
                 walk,
                 &for_op.region,
                 slot_context,
@@ -170,7 +173,7 @@ fn prefer_op_helpers(
         Op::Interpolation(_) => {
             buf.prefer(Helper::ToDisplayString);
             if id
-                .and_then(|id| facts.text_facts.get(id))
+                .and_then(|id| cx.facts.text_facts.get(id))
                 .is_some_and(|text| text.parts.iter().any(|part| !part.dynamic))
             {
                 buf.prefer(Helper::CreateText);
@@ -181,13 +184,12 @@ fn prefer_op_helpers(
 
 fn prefer_if_branch_helpers(
     buf: &mut Buf,
-    facts: &S2Facts,
-    for_wrappers: &SideTable<ForWrapper>,
+    cx: &PreferCx<'_>,
     walk: &mut PageWalk,
     region: &Region<'_>,
     slot_context: bool,
 ) {
     for op in region.ops.iter() {
-        prefer_op_helpers(buf, facts, for_wrappers, walk, op, slot_context, false);
+        prefer_op_helpers(buf, cx, walk, op, slot_context, false);
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/on/wrapped.rs
+++ b/crates/vize_s1_to_s2/src/emit/on/wrapped.rs
@@ -22,13 +22,25 @@ pub(in crate::emit) fn emit_wrapped_handler(
         cx.buf.push(Buf::with_modifiers_alias());
         cx.buf.push("(");
     }
-    match on.handler {
-        Some(expr) if cx.prefixing() => {
+    let options_api = on
+        .handler
+        .and_then(|expr| options_api_handler_name(cx, &expr));
+    match (options_api, on.handler) {
+        // `generate_options_api_handler_reference`: a bare Options API
+        // method name is guarded and forwarded, never prefixed.
+        (Some(name), _) => {
+            cx.buf.push("(...args) => (_ctx.");
+            cx.buf.push(name);
+            cx.buf.push(" && _ctx.");
+            cx.buf.push(name);
+            cx.buf.push("(...args))");
+        }
+        (None, Some(expr)) if cx.prefixing() => {
             let text = cx.prefixed_handler(&expr)?;
             cx.buf.push(text.as_str());
         }
-        Some(ExprRef::Js(js)) => emit_handler(cx, on, js, is_plain_element),
-        Some(ExprRef::Opaque(opaque)) if opaque.reason == OpaqueReason::MultiStatement => {
+        (None, Some(ExprRef::Js(js))) => emit_handler(cx, on, js, is_plain_element),
+        (None, Some(ExprRef::Opaque(opaque))) if opaque.reason == OpaqueReason::MultiStatement => {
             let padding = authored_handler_padding(cx.source, on, opaque.source, opaque.span);
             // The shipped codegen prefix-parses the text: `a; b` reads as the
             // reference `a` and is pushed raw.
@@ -53,8 +65,8 @@ pub(in crate::emit) fn emit_wrapped_handler(
                 super::super::on_body::emit(cx, opaque.source, padding);
             }
         }
-        None => cx.buf.push("() => {}"),
-        Some(expr) => {
+        (None, None) => cx.buf.push("() => {}"),
+        (None, Some(expr)) => {
             return Err(EmitError::unsupported_at(
                 Reason::OnHandlerNotJs,
                 expr.span(),
@@ -72,6 +84,25 @@ pub(in crate::emit) fn emit_wrapped_handler(
         cx.buf.push(")");
     }
     Ok(())
+}
+
+/// `options_api_handler_name`: the trimmed authored text is a simple
+/// identifier the binding table records as an Options API member.
+fn options_api_handler_name<'a>(cx: &EmitCx<'_>, expr: &ExprRef<'a>) -> Option<&'a str> {
+    let source = match expr {
+        ExprRef::Js(js) => js.source,
+        ExprRef::Opaque(opaque) => opaque.source,
+        ExprRef::Foreign(_) | ExprRef::Filter(_) => return None,
+    }
+    .trim();
+    if !super::super::prefix::is_simple_identifier(source) {
+        return None;
+    }
+    cx.scope
+        .bindings()
+        .and_then(|table| table.kind(source))
+        .filter(|kind| *kind == super::super::options::BindingKind::Options)
+        .map(|_| source)
 }
 
 fn emit_mod_array(cx: &mut EmitCx<'_>, mods: &[&str]) {

--- a/crates/vize_s1_to_s2/src/emit/once.rs
+++ b/crates/vize_s1_to_s2/src/emit/once.rs
@@ -71,6 +71,7 @@ fn emit_component_target(
     } else if let Some(helper) = builtin::helper(component.name) {
         cx.buf.use_helper(helper);
         cx.buf.push(helper.alias());
+    } else if super::component::binding::push_tag(cx, component.name) {
     } else {
         cx.buf
             .push(asset_ident("component", component.name).as_str());

--- a/crates/vize_s1_to_s2/src/emit/options.rs
+++ b/crates/vize_s1_to_s2/src/emit/options.rs
@@ -7,6 +7,10 @@
 //! emitter silently assumes — it is production surface the series has
 //! not reached yet, and the witness for it does not exist.
 
+use alloc::vec::Vec as StdVec;
+
+use vize_s0::String;
+
 /// Which module form the render function is emitted in — the shipped
 /// lane's `CodegenMode`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -16,21 +20,173 @@ pub enum DomEmitMode {
     /// signature (the shipped default).
     #[default]
     Function,
-    /// `import { … } from "vue"` plus `export function render(_ctx, _cache)`.
-    /// The six-argument signature returns with binding metadata, which the
-    /// emitter does not carry yet.
+    /// `import { … } from "vue"` plus `export function render(_ctx, _cache)`;
+    /// the six-argument signature returns with binding metadata.
     Module,
 }
 
 impl DomEmitMode {
-    /// The render-function header the shipped lane writes for this mode
-    /// without binding metadata.
+    /// The render-function header the shipped lane writes for this mode.
     #[must_use]
-    pub(super) const fn render_signature(self) -> &'static str {
-        match self {
-            Self::Function => "function render(_ctx, _cache, $props, $setup, $data, $options) {",
-            Self::Module => "export function render(_ctx, _cache) {",
+    pub(super) const fn render_signature(self, with_bindings: bool) -> &'static str {
+        match (self, with_bindings) {
+            (Self::Function, _) => {
+                "function render(_ctx, _cache, $props, $setup, $data, $options) {"
+            }
+            (Self::Module, true) => {
+                "export function render(_ctx, _cache, $props, $setup, $data, $options) {"
+            }
+            (Self::Module, false) => "export function render(_ctx, _cache) {",
         }
+    }
+}
+
+/// The shipped lane's `BindingType`: how a template identifier resolves
+/// once script analysis has named it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindingKind {
+    /// `let` in `<script setup>`.
+    SetupLet,
+    /// `const` in `<script setup>` that may hold a ref.
+    SetupMaybeRef,
+    /// `const` in `<script setup>` that is a ref.
+    SetupRef,
+    /// `reactive()` / `shallowReactive()` const.
+    SetupReactiveConst,
+    /// Non-reactive `const` (functions, classes, plain values).
+    SetupConst,
+    /// A declared prop.
+    Props,
+    /// A destructured prop with an alias.
+    PropsAliased,
+    /// `data()` member.
+    Data,
+    /// Options API member (computed, methods, inject).
+    Options,
+    /// A literal constant.
+    LiteralConst,
+    /// A universal JavaScript global.
+    JsGlobalUniversal,
+    /// A browser-only global.
+    JsGlobalBrowser,
+    /// A Node.js-only global.
+    JsGlobalNode,
+    /// A Deno-only global.
+    JsGlobalDeno,
+    /// A Bun-only global.
+    JsGlobalBun,
+    /// A Vue instance global (`$slots`, `$emit`, …).
+    VueGlobal,
+    /// Imported from another module.
+    ExternalModule,
+}
+
+impl BindingKind {
+    /// The member prefix the shipped lane writes in non-inline mode
+    /// (`BindingType::non_inline_template_prefix`).
+    #[must_use]
+    pub const fn non_inline_template_prefix(self) -> &'static str {
+        match self {
+            Self::SetupLet
+            | Self::SetupMaybeRef
+            | Self::SetupRef
+            | Self::SetupReactiveConst
+            | Self::SetupConst
+            | Self::LiteralConst
+            | Self::JsGlobalUniversal
+            | Self::JsGlobalBrowser
+            | Self::JsGlobalNode
+            | Self::JsGlobalDeno
+            | Self::JsGlobalBun
+            | Self::ExternalModule => "$setup.",
+            Self::Props | Self::PropsAliased => "$props.",
+            Self::Data => "$data.",
+            Self::Options => "$options.",
+            Self::VueGlobal => "_ctx.",
+        }
+    }
+
+    /// Props and aliased props.
+    #[must_use]
+    pub const fn is_props(self) -> bool {
+        matches!(self, Self::Props | Self::PropsAliased)
+    }
+}
+
+/// The shipped lane's `BindingMetadata`: names the script analysis
+/// resolved, with the destructured-prop aliases.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BindingTable {
+    /// `(name, kind)` sorted by name for binary search.
+    names: StdVec<(String, BindingKind)>,
+    /// `(local, prop key)` for `const { key: local } = defineProps()`.
+    aliases: StdVec<(String, String)>,
+    /// Whether the bindings come from `<script setup>`.
+    is_script_setup: bool,
+}
+
+impl BindingTable {
+    /// Build a table; later duplicates of a name win, as a map insert would.
+    #[must_use]
+    pub fn new<'n>(
+        names: impl IntoIterator<Item = (&'n str, BindingKind)>,
+        aliases: impl IntoIterator<Item = (&'n str, &'n str)>,
+        is_script_setup: bool,
+    ) -> Self {
+        let mut table = Self {
+            names: StdVec::new(),
+            aliases: StdVec::new(),
+            is_script_setup,
+        };
+        for (name, kind) in names {
+            match table
+                .names
+                .binary_search_by(|(entry, _)| entry.as_str().cmp(name))
+            {
+                Ok(index) => table.names[index].1 = kind,
+                Err(index) => table.names.insert(index, (String::from(name), kind)),
+            }
+        }
+        for (local, key) in aliases {
+            match table
+                .aliases
+                .binary_search_by(|(entry, _)| entry.as_str().cmp(local))
+            {
+                Ok(index) => table.aliases[index].1 = String::from(key),
+                Err(index) => table
+                    .aliases
+                    .insert(index, (String::from(local), String::from(key))),
+            }
+        }
+        table
+    }
+
+    /// The kind recorded for `name`.
+    #[must_use]
+    pub fn kind(&self, name: &str) -> Option<BindingKind> {
+        self.names
+            .binary_search_by(|(entry, _)| entry.as_str().cmp(name))
+            .ok()
+            .map(|index| self.names[index].1)
+    }
+
+    /// Whether `name` is recorded at all.
+    #[must_use]
+    pub fn contains(&self, name: &str) -> bool {
+        self.kind(name).is_some()
+    }
+
+    /// The destructured-prop aliases as `(local, key)` pairs.
+    pub fn aliases(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.aliases
+            .iter()
+            .map(|(local, key)| (local.as_str(), key.as_str()))
+    }
+
+    /// Whether the bindings come from `<script setup>`.
+    #[must_use]
+    pub const fn is_script_setup(&self) -> bool {
+        self.is_script_setup
     }
 }
 
@@ -46,8 +202,13 @@ pub struct DomEmitOptions<'a> {
     /// [`DomEmitMode::Function`] (`"Vue"` by default).
     pub runtime_global_name: &'a str,
     /// The shipped lane's `prefix_identifiers`: free identifiers become
-    /// `_ctx.` member accesses (`emit::prefix`), without binding metadata.
+    /// member accesses (`emit::prefix`).
     pub prefix_identifiers: bool,
+    /// The shipped lane's `binding_metadata`, honoured in non-inline mode:
+    /// prefixed identifiers resolve to `$setup.` / `$props.` / `$data.` /
+    /// `$options.`, components and directives resolve to `$setup` members,
+    /// and the render signature carries all six arguments.
+    pub bindings: Option<&'a BindingTable>,
 }
 
 impl DomEmitOptions<'static> {
@@ -58,6 +219,7 @@ impl DomEmitOptions<'static> {
         runtime_module_name: "vue",
         runtime_global_name: "Vue",
         prefix_identifiers: false,
+        bindings: None,
     };
 }
 
@@ -69,7 +231,7 @@ impl Default for DomEmitOptions<'static> {
 
 #[cfg(test)]
 mod tests {
-    use super::{DomEmitMode, DomEmitOptions};
+    use super::{BindingKind, BindingTable, DomEmitMode, DomEmitOptions};
 
     #[test]
     fn default_options_project_the_shipped_codegen_defaults() {
@@ -80,6 +242,7 @@ mod tests {
                 runtime_module_name: "vue",
                 runtime_global_name: "Vue",
                 prefix_identifiers: false,
+                bindings: None,
             }
         );
     }
@@ -87,12 +250,57 @@ mod tests {
     #[test]
     fn render_signatures_match_the_shipped_lane_per_mode() {
         assert_eq!(
-            DomEmitMode::Function.render_signature(),
+            DomEmitMode::Function.render_signature(false),
             "function render(_ctx, _cache, $props, $setup, $data, $options) {"
         );
         assert_eq!(
-            DomEmitMode::Module.render_signature(),
+            DomEmitMode::Module.render_signature(false),
             "export function render(_ctx, _cache) {"
+        );
+        assert_eq!(
+            DomEmitMode::Module.render_signature(true),
+            "export function render(_ctx, _cache, $props, $setup, $data, $options) {"
+        );
+    }
+
+    #[test]
+    fn binding_table_lookups_and_alias_order() {
+        let table = BindingTable::new(
+            [
+                ("msg", BindingKind::SetupRef),
+                ("Comp", BindingKind::SetupConst),
+                ("msg", BindingKind::SetupLet),
+            ],
+            [("local", "prop-key")],
+            true,
+        );
+        assert_eq!(table.kind("msg"), Some(BindingKind::SetupLet));
+        assert_eq!(table.kind("Comp"), Some(BindingKind::SetupConst));
+        assert_eq!(table.kind("other"), None);
+        assert!(table.contains("Comp"));
+        assert_eq!(
+            table.aliases().collect::<alloc::vec::Vec<_>>(),
+            [("local", "prop-key")]
+        );
+        assert!(table.is_script_setup());
+    }
+
+    #[test]
+    fn non_inline_prefixes_match_the_shipped_binding_types() {
+        assert_eq!(
+            BindingKind::SetupRef.non_inline_template_prefix(),
+            "$setup."
+        );
+        assert_eq!(BindingKind::Props.non_inline_template_prefix(), "$props.");
+        assert_eq!(BindingKind::Data.non_inline_template_prefix(), "$data.");
+        assert_eq!(
+            BindingKind::Options.non_inline_template_prefix(),
+            "$options."
+        );
+        assert_eq!(BindingKind::VueGlobal.non_inline_template_prefix(), "_ctx.");
+        assert_eq!(
+            BindingKind::ExternalModule.non_inline_template_prefix(),
+            "$setup."
         );
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/prefix.rs
+++ b/crates/vize_s1_to_s2/src/emit/prefix.rs
@@ -12,6 +12,7 @@
 //! shipped lane is the bar, so the ports keep the shipped quirks (the
 //! second `$event =>` wrap, the two different strips, the prefix parse).
 
+mod aliases;
 mod codegen_visitor;
 mod collector;
 mod compat;
@@ -26,7 +27,7 @@ mod splice;
 mod strip;
 mod targets;
 
-pub(super) use globals::is_global_allowed;
+pub(super) use globals::{is_global_allowed, is_simple_identifier};
 pub(super) use scope::{PrefixScope, ScopeMark};
 pub(super) use slot_defaults::prefix_slot_defaults;
 
@@ -145,7 +146,7 @@ pub(super) struct Refused;
 
 /// `process_expression` then the codegen consumption for `site`.
 pub(super) fn prefix_expression(
-    scope: &PrefixScope,
+    scope: &PrefixScope<'_>,
     content: &Content<'_>,
     js: Option<&JsExpr<'_>>,
     site: Site,
@@ -159,7 +160,7 @@ pub(super) fn prefix_expression(
 }
 
 /// The codegen consumption alone (text the transform did not rewrite).
-pub(super) fn consume(scope: &PrefixScope, code: String, site: Site) -> String {
+pub(super) fn consume(scope: &PrefixScope<'_>, code: String, site: Site) -> String {
     match site {
         Site::Expression => {
             let code = if code.contains("//") {
@@ -180,7 +181,7 @@ pub(super) fn consume(scope: &PrefixScope, code: String, site: Site) -> String {
 
 /// `process_inline_handler` + `generate_event_handler`.
 pub(super) fn prefix_handler(
-    scope: &PrefixScope,
+    scope: &PrefixScope<'_>,
     content: &Content<'_>,
     js: Option<&JsExpr<'_>>,
 ) -> Result<String, Refused> {
@@ -193,7 +194,7 @@ pub(super) fn prefix_handler(
 }
 
 /// `emit_dynamic_directive_arg` under `prefix_identifiers`.
-pub(super) fn prefix_dynamic_arg(scope: &PrefixScope, js: &JsExpr<'_>) -> String {
+pub(super) fn prefix_dynamic_arg(scope: &PrefixScope<'_>, js: &JsExpr<'_>) -> String {
     let content = js.source;
     if let Some(local) = content
         .strip_prefix("_ctx.")

--- a/crates/vize_s1_to_s2/src/emit/prefix/aliases.rs
+++ b/crates/vize_s1_to_s2/src/emit/prefix/aliases.rs
@@ -1,0 +1,108 @@
+//! `rewrite_props_aliases`, ported: the destructured-prop alias projection
+//! the shipped lane runs as a find/replace post-pass over the rewritten
+//! text (`$props.local` → `$props.key`, or `$props["key"]` when the key
+//! is not an identifier). The transform projects both `__props` and
+//! `$props`; the codegen visitor projects `$props` alone.
+
+use core::fmt::Write as _;
+
+use vize_s0::String;
+
+use super::super::options::BindingTable;
+use super::globals::is_simple_identifier;
+
+pub(super) fn rewrite_props_aliases(
+    code: String,
+    bindings: Option<&BindingTable>,
+    objects: &[&str],
+) -> String {
+    let Some(table) = bindings else {
+        return code;
+    };
+    let mut rewritten = code;
+    for (local, key) in table.aliases() {
+        for object in objects {
+            rewritten = replace_prefixed_alias_access(rewritten, object, local, key);
+        }
+    }
+    rewritten
+}
+
+fn prop_access_expression(object: &str, key: &str) -> String {
+    let mut out = String::with_capacity(object.len() + key.len() + 4);
+    out.push_str(object);
+    if is_simple_identifier(key) {
+        out.push('.');
+        out.push_str(key);
+        return out;
+    }
+    out.push('[');
+    // The shipped lane spells the key with `{:?}` (Rust string escaping).
+    let _ = write!(&mut out, "{key:?}");
+    out.push(']');
+    out
+}
+
+fn is_identifier_continue(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '$'
+}
+
+fn replace_prefixed_alias_access(code: String, object: &str, local: &str, key: &str) -> String {
+    let mut needle = String::with_capacity(object.len() + local.len() + 1);
+    needle.push_str(object);
+    needle.push('.');
+    needle.push_str(local);
+    if !code.contains(needle.as_str()) {
+        return code;
+    }
+    let replacement = prop_access_expression(object, key);
+
+    let mut result = String::with_capacity(code.len());
+    let mut cursor = 0;
+    while let Some(rel_pos) = code[cursor..].find(needle.as_str()) {
+        let start = cursor + rel_pos;
+        let end = start + needle.len();
+        let after_ok = code[end..]
+            .chars()
+            .next()
+            .is_none_or(|c| !is_identifier_continue(c));
+        result.push_str(&code[cursor..start]);
+        if after_ok {
+            result.push_str(replacement.as_str());
+        } else {
+            result.push_str(&code[start..end]);
+        }
+        cursor = end;
+    }
+    result.push_str(&code[cursor..]);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rewrite_props_aliases;
+    use crate::emit::options::{BindingKind, BindingTable};
+    use vize_s0::String;
+
+    #[test]
+    fn aliases_project_onto_their_prop_keys() {
+        let table = BindingTable::new(
+            [
+                ("label", BindingKind::PropsAliased),
+                ("x", BindingKind::PropsAliased),
+            ],
+            [("label", "aria-label"), ("x", "posX")],
+            true,
+        );
+        let code = String::from("$props.label + $props.labelled + __props.x + $props.x");
+        assert_eq!(
+            rewrite_props_aliases(code, Some(&table), &["__props", "$props"]).as_str(),
+            "$props[\"aria-label\"] + $props.labelled + __props.posX + $props.posX"
+        );
+        let untouched = String::from("$props.label");
+        assert_eq!(
+            rewrite_props_aliases(untouched, None, &["$props"]).as_str(),
+            "$props.label"
+        );
+    }
+}

--- a/crates/vize_s1_to_s2/src/emit/prefix/codegen_visitor.rs
+++ b/crates/vize_s1_to_s2/src/emit/prefix/codegen_visitor.rs
@@ -20,7 +20,7 @@ use super::scope::PrefixScope;
 use super::splice::splice_replacements;
 
 struct IdentifierVisitor<'s> {
-    scope: &'s PrefixScope,
+    scope: &'s PrefixScope<'s>,
     rewrites: StdVec<(usize, usize, String)>,
     local_vars: StdVec<String>,
     assignment_targets: StdVec<usize>,
@@ -119,8 +119,9 @@ impl Visit<'_> for IdentifierVisitor<'_> {
         }
         let start = (ident.span.start - self.offset) as usize;
         let end = (ident.span.end - self.offset) as usize;
-        let mut replacement = String::with_capacity(5 + name.len());
-        replacement.push_str("_ctx.");
+        let prefix = self.scope.codegen_prefix(name);
+        let mut replacement = String::with_capacity(prefix.len() + name.len());
+        replacement.push_str(prefix);
         replacement.push_str(name);
         self.rewrites.push((start, end, replacement));
     }
@@ -149,9 +150,11 @@ impl Visit<'_> for IdentifierVisitor<'_> {
             }
             let start = (prop.span.start - self.offset) as usize;
             let end = (prop.span.end - self.offset) as usize;
-            let mut replacement = String::with_capacity(name.len() * 2 + 7);
+            let prefix = self.scope.codegen_prefix(name);
+            let mut replacement = String::with_capacity(name.len() * 2 + prefix.len() + 2);
             replacement.push_str(name);
-            replacement.push_str(": _ctx.");
+            replacement.push_str(": ");
+            replacement.push_str(prefix);
             replacement.push_str(name);
             self.rewrites.push((start, end, replacement));
             return;
@@ -185,7 +188,7 @@ fn prefix_via_expr(
     expr: &oxc_ast::ast::Expression<'_>,
     offset: u32,
     content: &str,
-    scope: &PrefixScope,
+    scope: &PrefixScope<'_>,
 ) -> String {
     let mut visitor = IdentifierVisitor {
         scope,
@@ -195,12 +198,16 @@ fn prefix_via_expr(
         offset,
     };
     visitor.visit_expression(expr);
-    splice_replacements(content, visitor.rewrites)
+    super::aliases::rewrite_props_aliases(
+        splice_replacements(content, visitor.rewrites),
+        scope.bindings(),
+        &["$props"],
+    )
 }
 
 /// `prefix_identifiers_with_context`: wrapped expression parse, then a
 /// program parse, then the raw text.
-pub(super) fn prefix_identifiers_with_context(content: &str, scope: &PrefixScope) -> String {
+pub(super) fn prefix_identifiers_with_context(content: &str, scope: &PrefixScope<'_>) -> String {
     let source_type = SourceType::default().with_module(true);
     let allocator = Allocator::new();
     let mut wrapped = String::with_capacity(content.len() + 2);
@@ -225,7 +232,11 @@ pub(super) fn prefix_identifiers_with_context(content: &str, scope: &PrefixScope
         offset: 0,
     };
     visitor.visit_program(&parsed.program);
-    splice_replacements(content, visitor.rewrites)
+    super::aliases::rewrite_props_aliases(
+        splice_replacements(content, visitor.rewrites),
+        scope.bindings(),
+        &["$props"],
+    )
 }
 
 /// `prefix_identifiers_with_context_node`: the retained AST when the
@@ -233,7 +244,7 @@ pub(super) fn prefix_identifiers_with_context(content: &str, scope: &PrefixScope
 pub(super) fn prefix_identifiers_with_context_node(
     content: &str,
     retained: Option<Retained<'_, '_>>,
-    scope: &PrefixScope,
+    scope: &PrefixScope<'_>,
 ) -> String {
     if let Some(retained) = retained
         && retained.offset == 0

--- a/crates/vize_s1_to_s2/src/emit/prefix/collector.rs
+++ b/crates/vize_s1_to_s2/src/emit/prefix/collector.rs
@@ -25,7 +25,7 @@ use super::globals::is_global_allowed;
 use super::scope::PrefixScope;
 
 pub(super) struct IdentifierCollector<'s, 'a> {
-    scope: &'s PrefixScope,
+    scope: &'s PrefixScope<'s>,
     /// The walked text; read by the inline-mode assignment scan once
     /// binding metadata lands.
     #[allow(dead_code)]
@@ -39,7 +39,7 @@ pub(super) struct IdentifierCollector<'s, 'a> {
 
 impl<'s, 'a> IdentifierCollector<'s, 'a> {
     /// The legacy wrapped-parse collector: spans count the synthetic `(`.
-    pub(super) fn new(scope: &'s PrefixScope, source: &'a str) -> Self {
+    pub(super) fn new(scope: &'s PrefixScope<'s>, source: &'a str) -> Self {
         Self {
             scope,
             source,
@@ -53,7 +53,11 @@ impl<'s, 'a> IdentifierCollector<'s, 'a> {
 
     /// The retained-AST collector over the bare content, whose AST spans
     /// are `offset` bytes before their position in `source`.
-    pub(super) fn new_unwrapped(scope: &'s PrefixScope, source: &'a str, offset: usize) -> Self {
+    pub(super) fn new_unwrapped(
+        scope: &'s PrefixScope<'s>,
+        source: &'a str,
+        offset: usize,
+    ) -> Self {
         Self {
             offset,
             ..Self::new(scope, source)

--- a/crates/vize_s1_to_s2/src/emit/prefix/handler.rs
+++ b/crates/vize_s1_to_s2/src/emit/prefix/handler.rs
@@ -20,7 +20,7 @@ use super::strip::strip_scope_prefixes_for_slot_params;
 pub(super) fn process_inline_handler(
     content: &str,
     retained: Option<Retained<'_, '_>>,
-    scope: &PrefixScope,
+    scope: &PrefixScope<'_>,
 ) -> RewriteResult {
     if is_function_expression_node(content, retained) {
         return rewrite_expression(content, retained, scope, false);
@@ -63,7 +63,7 @@ pub(super) fn process_inline_handler(
 /// `generate_event_handler` over an `is_ref_transformed` node: strip the
 /// slot-param prefixes, then re-derive the shape from the processed text
 /// (the retained AST no longer applies to rewritten bytes).
-pub(super) fn finish_event_handler(processed: String, scope: &PrefixScope) -> String {
+pub(super) fn finish_event_handler(processed: String, scope: &PrefixScope<'_>) -> String {
     let processed = if scope.has_slot_params() {
         strip_scope_prefixes_for_slot_params(scope, processed.as_str())
     } else {

--- a/crates/vize_s1_to_s2/src/emit/prefix/rewrite.rs
+++ b/crates/vize_s1_to_s2/src/emit/prefix/rewrite.rs
@@ -42,14 +42,14 @@ fn js_module() -> SourceType {
 pub(super) fn rewrite_expression(
     content: &str,
     retained: Option<Retained<'_, '_>>,
-    scope: &PrefixScope,
+    scope: &PrefixScope<'_>,
     as_params: bool,
 ) -> RewriteResult {
     if !as_params
         && let Some(retained) = retained
         && js_module_compatible(retained.ast, retained.source)
     {
-        return rewrite_retained(content, retained, scope);
+        return project_aliases(rewrite_retained(content, retained, scope), scope);
     }
     let overflows = expression_exceeds_max_depth(content);
     if overflows || !expression_has_balanced_delimiters(content) {
@@ -64,13 +64,29 @@ pub(super) fn rewrite_expression(
             parse_error: !parses_as_params(content),
         };
     }
-    rewrite_reparsed(content, scope)
+    project_aliases(rewrite_reparsed(content, scope), scope)
+}
+
+/// The transform's `rewrite_props_aliases` post-pass over both prop
+/// objects; a parse failure passes the raw text through untouched.
+fn project_aliases(result: RewriteResult, scope: &PrefixScope<'_>) -> RewriteResult {
+    if result.parse_error {
+        return result;
+    }
+    RewriteResult {
+        code: super::aliases::rewrite_props_aliases(
+            result.code,
+            scope.bindings(),
+            &["__props", "$props"],
+        ),
+        parse_error: false,
+    }
 }
 
 fn rewrite_retained(
     content: &str,
     retained: Retained<'_, '_>,
-    scope: &PrefixScope,
+    scope: &PrefixScope<'_>,
 ) -> RewriteResult {
     let mut collector = IdentifierCollector::new_unwrapped(scope, content, retained.offset);
     collector.visit_expression(retained.ast);
@@ -81,7 +97,7 @@ fn rewrite_retained(
     }
 }
 
-fn rewrite_reparsed(content: &str, scope: &PrefixScope) -> RewriteResult {
+fn rewrite_reparsed(content: &str, scope: &PrefixScope<'_>) -> RewriteResult {
     let allocator = Allocator::new();
     let mut wrapped = String::with_capacity(content.len() + 2);
     wrapped.push('(');

--- a/crates/vize_s1_to_s2/src/emit/prefix/scope.rs
+++ b/crates/vize_s1_to_s2/src/emit/prefix/scope.rs
@@ -19,16 +19,23 @@
 //! the raw alias / slot patterns instead and asks
 //! [`super::params::destructure_params_contain`] per query: no list is
 //! materialised, and the allocation gate's window stays at its baseline.
+//!
+//! The binding table (P2-11 installment 86) decides *which* prefix a
+//! free name gets: the shipped `get_identifier_prefix` in non-inline mode.
 
 use alloc::vec::Vec as StdVec;
 
 use vize_s0::{SmallVec, String};
 
+use super::super::options::BindingTable;
+use super::globals::is_global_allowed;
+
 #[derive(Default)]
-pub(in crate::emit) struct PrefixScope {
+pub(in crate::emit) struct PrefixScope<'b> {
     transform: StdVec<String>,
     slot_params: StdVec<String>,
     patterns: SmallVec<[String; 4]>,
+    bindings: Option<&'b BindingTable>,
 }
 
 #[derive(Clone, Copy)]
@@ -38,7 +45,19 @@ pub(in crate::emit) struct ScopeMark {
     patterns: usize,
 }
 
-impl PrefixScope {
+impl<'b> PrefixScope<'b> {
+    pub(in crate::emit) fn new(bindings: Option<&'b BindingTable>) -> Self {
+        Self {
+            bindings,
+            ..Self::default()
+        }
+    }
+
+    /// The binding table the emit runs under, if any.
+    pub(in crate::emit) fn bindings(&self) -> Option<&'b BindingTable> {
+        self.bindings
+    }
+
     pub(in crate::emit) fn mark(&self) -> ScopeMark {
         ScopeMark {
             transform: self.transform.len(),
@@ -102,12 +121,64 @@ impl PrefixScope {
         &self.slot_params
     }
 
-    /// `get_identifier_prefix` without binding metadata: `None` for
-    /// globals and transform-scope names, `_ctx.` otherwise.
+    /// `get_identifier_prefix` in non-inline mode: `None` for globals and
+    /// transform-scope names, the binding's render-function prefix
+    /// (`$props.` for props) when the table names it, `_ctx.` otherwise.
     pub(super) fn identifier_prefix(&self, name: &str) -> Option<&'static str> {
-        if super::globals::is_global_allowed(name) || self.is_in_transform_scope(name) {
+        if is_global_allowed(name) || self.is_in_transform_scope(name) {
             return None;
         }
-        Some("_ctx.")
+        Some(self.codegen_prefix(name))
+    }
+
+    /// The codegen `IdentifierVisitor` prefix (no scope or allowlist check;
+    /// the visitor applies those first): the binding's non-inline prefix,
+    /// `_ctx.` for names the table does not know.
+    pub(super) fn codegen_prefix(&self, name: &str) -> &'static str {
+        match self.bindings.and_then(|table| table.kind(name)) {
+            Some(kind) if kind.is_props() => "$props.",
+            Some(kind) => kind.non_inline_template_prefix(),
+            None => "_ctx.",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PrefixScope;
+    use crate::emit::options::{BindingKind, BindingTable};
+
+    #[test]
+    fn identifier_prefix_follows_the_binding_table_in_non_inline_mode() {
+        let table = BindingTable::new(
+            [
+                ("count", BindingKind::SetupRef),
+                ("title", BindingKind::Props),
+                ("label", BindingKind::PropsAliased),
+                ("d", BindingKind::Data),
+                ("method", BindingKind::Options),
+                ("$slots", BindingKind::VueGlobal),
+            ],
+            [],
+            true,
+        );
+        let mut scope = PrefixScope::new(Some(&table));
+        assert_eq!(scope.identifier_prefix("count"), Some("$setup."));
+        assert_eq!(scope.identifier_prefix("title"), Some("$props."));
+        assert_eq!(scope.identifier_prefix("label"), Some("$props."));
+        assert_eq!(scope.identifier_prefix("d"), Some("$data."));
+        assert_eq!(scope.identifier_prefix("method"), Some("$options."));
+        assert_eq!(scope.identifier_prefix("$slots"), Some("_ctx."));
+        assert_eq!(scope.identifier_prefix("other"), Some("_ctx."));
+        assert_eq!(scope.identifier_prefix("Math"), None);
+        scope.push_for([Some("count"), None, None]);
+        assert_eq!(scope.identifier_prefix("count"), None);
+    }
+
+    #[test]
+    fn without_a_table_every_free_name_is_ctx() {
+        let scope = PrefixScope::new(None);
+        assert_eq!(scope.identifier_prefix("count"), Some("_ctx."));
+        assert_eq!(scope.codegen_prefix("count"), "_ctx.");
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/prefix/strip.rs
+++ b/crates/vize_s1_to_s2/src/emit/prefix/strip.rs
@@ -24,7 +24,10 @@ pub(super) fn contains_slot_param_scope_prefix(content: &str) -> bool {
         .any(|prefix| content.contains(prefix))
 }
 
-pub(super) fn strip_scope_prefixes_for_slot_params(scope: &PrefixScope, content: &str) -> String {
+pub(super) fn strip_scope_prefixes_for_slot_params(
+    scope: &PrefixScope<'_>,
+    content: &str,
+) -> String {
     if !contains_slot_param_scope_prefix(content) {
         return String::from(content);
     }
@@ -64,7 +67,7 @@ pub(super) fn strip_scope_prefixes_for_slot_params(scope: &PrefixScope, content:
     result
 }
 
-pub(super) fn strip_ctx_prefix_for_slot_params(scope: &PrefixScope, content: &str) -> String {
+pub(super) fn strip_ctx_prefix_for_slot_params(scope: &PrefixScope<'_>, content: &str) -> String {
     let mut result = String::from(content);
     for param in scope.slot_params() {
         let mut prefixed = String::with_capacity(5 + param.len());

--- a/crates/vize_s1_to_s2/src/lib.rs
+++ b/crates/vize_s1_to_s2/src/lib.rs
@@ -63,9 +63,9 @@ pub mod pass;
 
 pub use dom::DOM_LANE_FLAG;
 pub use emit::{
-    DomEmit, DomEmitBudget, DomEmitMode, DomEmitOptions, EmitError, ObservedDomEmit,
-    UnsupportedReason, UnsupportedRefusal, emit_dom, emit_dom_source, emit_dom_source_observed,
-    emit_dom_source_observed_with_options, emit_dom_source_with_caps,
+    BindingKind, BindingTable, DomEmit, DomEmitBudget, DomEmitMode, DomEmitOptions, EmitError,
+    ObservedDomEmit, UnsupportedReason, UnsupportedRefusal, emit_dom, emit_dom_source,
+    emit_dom_source_observed, emit_dom_source_observed_with_options, emit_dom_source_with_caps,
     emit_dom_source_with_caps_observed, emit_dom_source_with_options, emit_dom_with_options,
 };
 pub use lower::{

--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus_bindings.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus_bindings.rs
@@ -1,0 +1,118 @@
+//! Davinci P2-11 DOM corpus-runnable entry under binding metadata
+//! (installment 86): the same committed battery and
+//! `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=<dir>` widening as
+//! `davinci_dom_corpus`, with both lanes compiled in module mode under
+//! `prefix_identifiers: true` and the SFC's own (non-inline) binding
+//! metadata — the dev-server shape of a `<script setup>` component.
+
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+mod davinci_dom_corpus_support;
+
+use davinci_dom_corpus_support::{
+    Lane, Report, assert_clean_corpus, assert_empty, compare_sfc_template_lane, compare_sweep_lane,
+};
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "template_only",
+        r#"<template><div class="x">{{ msg }}</div></template>"#,
+    ),
+    (
+        "script_setup",
+        r#"<script setup>const msg = "hi"</script><template><p>{{ msg }}</p></template>"#,
+    ),
+    (
+        "script_setup_bindings",
+        r#"<script setup>
+import { ref } from "vue"
+import Child from "./Child.vue"
+const props = defineProps({ title: String })
+const count = ref(0)
+let draft = ""
+function bump() { count.value++ }
+const vFocus = { mounted(el) { el.focus() } }
+</script>
+<template>
+  <Child :title="title" @bump="bump" v-focus>{{ count }} {{ draft }} {{ other }}</Child>
+  <input v-model="draft" @keyup.enter="bump">
+</template>"#,
+    ),
+    (
+        "options_api",
+        r#"<script>
+export default { data() { return { n: 1 } }, methods: { go() {} } }
+</script>
+<template><button @click="go">{{ n }}</button></template>"#,
+    ),
+    (
+        "slot_template",
+        r#"<template><Foo><template #default="{ item }"><span>{{ item }}{{ other }}</span></template></Foo></template>"#,
+    ),
+    (
+        "handlers_and_loops",
+        r#"<template><ul><li v-for="item in items" :key="item.id" @click="select(item, extra)">{{ item.label }}</li></ul></template>"#,
+    ),
+];
+
+#[test]
+fn binding_metadata_dom_emit_agrees_on_sfc_templates() {
+    std::thread::Builder::new()
+        .stack_size(256 * 1024 * 1024)
+        .spawn(binding_metadata_dom_emit_agrees_on_sfc_templates_body)
+        .expect("spawn P2-11 binding DOM corpus thread")
+        .join()
+        .expect("P2-11 binding DOM corpus thread must not panic");
+}
+
+fn binding_metadata_dom_emit_agrees_on_sfc_templates_body() {
+    let mut report = Report::default();
+    for (name, source) in BATTERY {
+        compare_sfc_template_lane(name, source, &mut report, Lane::Bindings);
+    }
+    assert_eq!(report.templates, BATTERY.len() as u64);
+    assert_eq!(report.old_error_skips, 0, "battery old-lane error skips");
+    assert_empty("battery S2 refusals", &report.s2_refusals);
+    assert_empty("battery divergences", &report.divergences);
+
+    let Some(sweep) = davinci_test_support::corpus::resolve_env_sweep() else {
+        eprintln!("VIZE_DAVINCI_DIFFERENTIAL_CORPUS unset: committed battery only");
+        return;
+    };
+    assert!(
+        !sweep.files.is_empty(),
+        "corpus sweep found no .vue files under {}",
+        sweep.root.display()
+    );
+
+    let corpus = compare_sweep_lane(&sweep, Lane::Bindings);
+    eprintln!(
+        "davinci binding DOM corpus sweep: scope={} files={} unreadable={} parsed={} templates={} compared={} old_error_skips={} s2_refusals={} divergences={}",
+        sweep.scope_label(),
+        corpus.files,
+        corpus.unreadable_count,
+        corpus.parsed,
+        corpus.templates,
+        corpus.compared,
+        corpus.old_error_skips,
+        corpus.s2_refusal_count,
+        corpus.divergence_count,
+    );
+    eprintln!(
+        "davinci binding DOM corpus refusal reasons: {:?}",
+        corpus.s2_refusal_reasons
+    );
+    eprintln!(
+        "davinci binding DOM corpus old-lane error reasons: {:?}",
+        corpus.old_error_reasons
+    );
+    eprintln!(
+        "davinci binding DOM corpus refusal samples: {:?}",
+        corpus.s2_refusal_samples
+    );
+    assert!(
+        corpus.compared > 0,
+        "a corpus sweep that compares nothing proves nothing"
+    );
+    assert_clean_corpus(&corpus);
+}

--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus_support/mod.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus_support/mod.rs
@@ -3,12 +3,14 @@ mod allowlist;
 use std::{collections::BTreeMap, fs};
 
 use davinci_test_support::corpus::CorpusSweep;
+use vize_atelier_core::options::{BindingMetadata, BindingType, CodegenMode};
 use vize_atelier_dom::errors::ErrorCode;
 use vize_atelier_dom::{DomCompilerOptions, compile_template_with_options};
-use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
+use vize_atelier_sfc::{SfcCompileOptions, SfcDescriptor, SfcParseOptions, compile_sfc, parse_sfc};
 use vize_s0::Allocator;
 use vize_s1_to_s2::{
-    DomEmitOptions, EmitError, LegacyCaps, emit_dom_source, emit_dom_source_with_options,
+    BindingKind, BindingTable, DomEmitMode, DomEmitOptions, EmitError, LegacyCaps, emit_dom_source,
+    emit_dom_source_with_options,
 };
 
 /// Which shipped-lane option surface the comparison runs under.
@@ -18,6 +20,10 @@ pub enum Lane {
     Default,
     /// `prefix_identifiers: true` on both sides (P2-11 installment 85).
     Prefixed,
+    /// Module mode + `prefix_identifiers` + the SFC's own binding metadata
+    /// (non-inline) on both sides (P2-11 installment 86): the dev-server
+    /// shape of a `<script setup>` component.
+    Bindings,
 }
 
 pub use allowlist::old_lane_skip_is_allowed;
@@ -83,6 +89,18 @@ pub fn compare_sfc_template_lane(name: &str, source: &str, report: &mut Report, 
         return;
     };
     report.templates += 1;
+    let bindings = match lane {
+        Lane::Bindings => match sfc_bindings(&descriptor) {
+            Ok(bindings) => bindings,
+            Err(reason) => {
+                report.old_error_skips += 1;
+                *report.old_error_reasons.entry(reason).or_default() += 1;
+                return;
+            }
+        },
+        Lane::Default | Lane::Prefixed => None,
+    };
+    let table = bindings.as_ref().map(binding_table);
 
     let old_allocator = Allocator::new();
     let (_, errors, old) = match lane {
@@ -92,6 +110,16 @@ pub fn compare_sfc_template_lane(name: &str, source: &str, report: &mut Report, 
             &template.content,
             DomCompilerOptions {
                 prefix_identifiers: true,
+                ..Default::default()
+            },
+        ),
+        Lane::Bindings => compile_template_with_options(
+            &old_allocator,
+            &template.content,
+            DomCompilerOptions {
+                mode: CodegenMode::Module,
+                prefix_identifiers: true,
+                binding_metadata: bindings.clone(),
                 ..Default::default()
             },
         ),
@@ -127,7 +155,7 @@ pub fn compare_sfc_template_lane(name: &str, source: &str, report: &mut Report, 
         // (JS dialect, no `is_ts`), so TypeScript-syntax templates fail with
         // the non-recoverable `InvalidExpression`; those skips are the lane's
         // own admission boundary, not corpus drift.
-        let prefixed_ts_skip = matches!(lane, Lane::Prefixed)
+        let prefixed_ts_skip = matches!(lane, Lane::Prefixed | Lane::Bindings)
             && actual_codes.iter().all(|code| code == "InvalidExpression");
         if !prefixed_ts_skip && !old_lane_skip_is_allowed(name, &actual_codes) {
             report.unexpected_old_error_skips += 1;
@@ -150,6 +178,17 @@ pub fn compare_sfc_template_lane(name: &str, source: &str, report: &mut Report, 
             LegacyCaps::VUE3,
             &DomEmitOptions {
                 prefix_identifiers: true,
+                ..DomEmitOptions::DEFAULT
+            },
+        ),
+        Lane::Bindings => emit_dom_source_with_options(
+            &new_allocator,
+            &template.content,
+            LegacyCaps::VUE3,
+            &DomEmitOptions {
+                mode: DomEmitMode::Module,
+                prefix_identifiers: true,
+                bindings: table.as_ref(),
                 ..DomEmitOptions::DEFAULT
             },
         ),
@@ -185,6 +224,54 @@ pub fn compare_sfc_template_lane(name: &str, source: &str, report: &mut Report, 
             ));
         }
     }
+}
+
+/// The binding metadata the production SFC compile hands its template
+/// compile: `compile_sfc` over the descriptor, defaults otherwise.
+fn sfc_bindings(descriptor: &SfcDescriptor<'_>) -> Result<Option<BindingMetadata>, String> {
+    match compile_sfc(descriptor, SfcCompileOptions::default()) {
+        Ok(result) => Ok(result.bindings),
+        Err(error) => Err(format!(
+            "SfcCompileError:{}",
+            error.code.as_deref().unwrap_or("unknown")
+        )),
+    }
+}
+
+fn binding_kind(kind: BindingType) -> BindingKind {
+    match kind {
+        BindingType::SetupLet => BindingKind::SetupLet,
+        BindingType::SetupMaybeRef => BindingKind::SetupMaybeRef,
+        BindingType::SetupRef => BindingKind::SetupRef,
+        BindingType::SetupReactiveConst => BindingKind::SetupReactiveConst,
+        BindingType::SetupConst => BindingKind::SetupConst,
+        BindingType::Props => BindingKind::Props,
+        BindingType::PropsAliased => BindingKind::PropsAliased,
+        BindingType::Data => BindingKind::Data,
+        BindingType::Options => BindingKind::Options,
+        BindingType::LiteralConst => BindingKind::LiteralConst,
+        BindingType::JsGlobalUniversal => BindingKind::JsGlobalUniversal,
+        BindingType::JsGlobalBrowser => BindingKind::JsGlobalBrowser,
+        BindingType::JsGlobalNode => BindingKind::JsGlobalNode,
+        BindingType::JsGlobalDeno => BindingKind::JsGlobalDeno,
+        BindingType::JsGlobalBun => BindingKind::JsGlobalBun,
+        BindingType::VueGlobal => BindingKind::VueGlobal,
+        BindingType::ExternalModule => BindingKind::ExternalModule,
+    }
+}
+
+pub fn binding_table(metadata: &BindingMetadata) -> BindingTable {
+    BindingTable::new(
+        metadata
+            .bindings
+            .iter()
+            .map(|(name, kind)| (name.as_str(), binding_kind(*kind))),
+        metadata
+            .props_aliases
+            .iter()
+            .map(|(local, key)| (local.as_str(), key.as_str())),
+        metadata.is_script_setup,
+    )
 }
 
 fn refusal_reason(error: &EmitError) -> &'static str {

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -21,8 +21,8 @@ or `collections` modules does not bypass the boundary.
 
 ## Retained `alloc::vec::Vec` inventory
 
-The four library trees in the reviewed inventory contain 73 production files,
-85 direct `alloc::vec::Vec` paths, and 288 bound `Vec`/`StdVec` uses. "Direct"
+The four library trees in the reviewed inventory contain 74 production files,
+86 direct `alloc::vec::Vec` paths, and 292 bound `Vec`/`StdVec` uses. "Direct"
 counts imports and fully-qualified paths; "bound" counts every type,
 constructor, and method path reached through a direct `Vec` import or alias.
 The executable ledger requires strict equality, so both growth and reduction
@@ -34,7 +34,7 @@ must update the file row and aggregate evidence in the same change.
 | analysis |     7 |            8 |         18 | Diagnostics, side tables, filters, and verifier results grow with the input; no inline bound is established.       |
 | lower    |    12 |           12 |         46 | Lowering worklists and owned results grow with source-tree shape. Bounded substructures may migrate independently. |
 | pass     |    13 |           13 |         51 | Facts, provenance, and traversal worklists grow with the number of operations.                                     |
-| emit     |    28 |           28 |        109 | Ordered output buffers and collected emission inputs grow with the document.                                       |
+| emit     |    29 |           29 |        113 | Ordered output buffers and collected emission inputs grow with the document.                                       |
 
 This is not an endorsement of every retained allocation. A focused change may
 replace a site with `SmallVec` after measuring a bound; that change lowers the
@@ -71,9 +71,9 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::String`       |    11 |           11 |         53 |
 | s2       | `vize_s0::Vec`          |     9 |            9 |         17 |
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
-| s1_to_s2 | `alloc::vec::Vec`       |    53 |           53 |        206 |
+| s1_to_s2 | `alloc::vec::Vec`       |    54 |           54 |        210 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    76 |           80 |        366 |
+| s1_to_s2 | `vize_s0::String`       |    80 |           85 |        387 |
 | s1_to_s2 | `vize_s0::Vec`          |    15 |           16 |         67 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     4 |            4 |          9 |
 

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -44,12 +44,13 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit.rs	1	2	1	1	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/buf.rs	1	6	1	8	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/buf/helper_order.rs	1	2	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/buf/preamble.rs	0	0	1	3	0	0	0	0
+s1_to_s2	-	crates/vize_s1_to_s2/src/emit/component/binding.rs	0	0	1	6	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/component/call_props.rs	1	1	1	1	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/component/preamble.rs	1	3	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/create_slots.rs	1	5	1	4	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/create_slots/entry.rs	1	1	1	2	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/cx.rs	0	0	1	10	0	0	0	0
-s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/directive.rs	1	6	0	0	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/directive.rs	1	6	2	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/entity.rs	0	0	1	3	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/entry.rs	0	0	1	3	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/filter.rs	0	0	1	1	0	0	0	0
@@ -66,7 +67,9 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/model.rs	1	6	1	9	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/model_key.rs	0	0	1	8	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/on.rs	0	0	1	5	0	0	1	3
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/on_dynamic.rs	1	5	0	0	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/options.rs	1	4	1	7	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/prefix.rs	0	0	1	10	0	0	0	0
+s1_to_s2	-	crates/vize_s1_to_s2/src/emit/prefix/aliases.rs	0	0	1	8	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/prefix/codegen_visitor.rs	1	9	1	11	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/prefix/collector.rs	1	10	1	6	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/prefix/handler.rs	0	0	1	6	0	0	0	0

--- a/tests/tooling/davinci-storage-inventory.ts
+++ b/tests/tooling/davinci-storage-inventory.ts
@@ -42,9 +42,9 @@ export const categoryReasons: Record<VecCategory, string> = {
 };
 
 export const expectedProductionAllocVec: StorageSummary = {
-  files: 73,
-  directPaths: 85,
-  boundUses: 288,
+  files: 74,
+  directPaths: 86,
+  boundUses: 292,
 };
 
 function count(value: string, line: number): number {

--- a/tests/tooling/davinci-v-on-storage.test.ts
+++ b/tests/tooling/davinci-v-on-storage.test.ts
@@ -180,7 +180,7 @@ test("the natural committed v-on corpus fits the two-entry inline buckets", () =
     "the Mealie-shaped dynamic slot fixture keeps its natural modified v-on spelling",
   );
   assert.deepEqual(classify("@click.prevent"), { options: 0, event: 1, keys: 0 });
-  assert.equal(spellings.length, 209, "update the measured corpus evidence intentionally");
+  assert.equal(spellings.length, 212, "update the measured corpus evidence intentionally");
   assert.deepEqual(maxima, { options: 2, event: 2, keys: 2 });
 });
 


### PR DESCRIPTION
P2-11 installment 86, stacked on the 84/85 branch (#5615).

## Why

Installment 85 gave the S2 DOM emitter `prefix_identifiers`, but every free name became `_ctx.`. Production SFC compiles also hand the shipped lane a `BindingMetadata`, and in non-inline mode that table decides which member each name reads. Without it the emitter cannot stand in for `compile_template` on any `<script setup>` component — the remaining blocker for the production-lane switch.

## What

`DomEmitOptions::bindings` carries a neutral `BindingTable` (`BindingKind` mirrors the shipped `BindingType`), honoured exactly where the shipped lane honours it:

- `PrefixScope::identifier_prefix` / `codegen_prefix` return the binding's `non_inline_template_prefix` (`$setup.` / `$props.` / `$data.` / `$options.`; `_ctx.` for Vue globals and unknown names), through both the transform rewrite and the codegen visitor.
- `rewrite_props_aliases` projects destructured prop aliases onto their keys — `__props`/`$props` in the transform, `$props` alone in the codegen visitor, with the shipped `{:?}` key spelling.
- Component tags resolve exact → camelize → PascalCase with props kept only as a fallback, plus a dotted `Foo.Bar` suffix; a resolved tag reads `$setup.Name` and writes no `resolveComponent` asset.
- A `vFoo` directive binding reads `$setup["vFoo"]` instead of `resolveDirective`.
- An Options API method handler becomes the guarded `(...args) => (_ctx.m && _ctx.m(...args))` reference.
- Module mode carries the six-argument render signature when bindings are present.

### One asymmetry worth naming

The helper-preference walk takes the table as well, because the shipped lane is not self-consistent here: the transform skips `resolveComponent` on a **verbatim** tag match (`lane::element`), while codegen skips the *asset* through the camelize/PascalCase widening. A kebab tag bound as PascalCase therefore still orders the helper as if it resolved at runtime. Seven corpus files diverged on that import ordering alone until the walk matched it.

## Witness

Byte-for-byte against `compile_template_with_options`:

- new `davinci_s2_binding_metadata` battery — 62 templates × (function mode, module mode)
- new corpus lane `davinci_dom_corpus_bindings` (module + prefix + each SFC's own bindings) over the 21 hydrated projects: **12,215 files, 11,657 templates compared, 0 S2 refusals, 0 divergences**
- the default and prefixed corpus lanes stay at 0 divergences
- `cargo test -p vize_s1_to_s2 -p vize_atelier_dom` — 833 tests green
- allocation gate unchanged at 60 allocs for `s1_to_s2_emit_p2_11_dom_surface` (the default lane records no binding work)

The 406 old-lane skips are TypeScript-syntax templates the shipped lane rejects without `is_ts` — installment 87's surface, unchanged from lane 85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791021465&installation_model_id=422833&pr_number=5620&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5620&signature=e3d2e1d483ad993bc1a302067c5c1e5dd765543cf326e32109012709778e0de6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->