### PR TITLE
feat(davinci): resolve self-referencing components in the S2 DOM emit

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_component_name.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_component_name.rs
@@ -1,0 +1,129 @@
+//! P2-11 installment 88 witness: **`component_name`**. An SFC knows its
+//! own name (its file stem), and a component tag that resolves to it is a
+//! self-reference — the shipped lane asks the runtime to resolve it as
+//! one, `_resolveComponent("Foo", true)`, so a recursive component finds
+//! itself. Compared byte-for-byte with the shipped lane.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use vize_atelier_core::options::{CodegenMode, CodegenOptions};
+use vize_atelier_dom::DomCompilerOptions;
+use vize_s1_to_s2::{DomEmitMode, DomEmitOptions};
+
+const BATTERY: &[(&str, &str)] = &[
+    ("exact", "<div><Foo /></div>"),
+    ("kebab_of_own_name", "<div><foo-bar /></div>"),
+    ("camel_of_own_name", "<div><fooBar /></div>"),
+    ("other_component", "<div><Other /></div>"),
+    ("mixed", "<div><Foo /><Other /></div>"),
+    ("nested_self", "<Foo><Foo /></Foo>"),
+    ("self_in_v_if", r#"<div><Foo v-if="ok" /></div>"#),
+    (
+        "self_in_v_for",
+        r#"<div><Foo v-for="i in n" :key="i" /></div>"#,
+    ),
+    ("self_with_props", r#"<Foo :depth="n" @done="ok" />"#),
+    ("dotted_not_self", "<div><Foo.Bar /></div>"),
+    ("builtin_untouched", "<Transition><Foo /></Transition>"),
+    ("dynamic_untouched", r#"<component :is="Foo" />"#),
+];
+
+fn shipped(name: &str, mode: CodegenMode) -> DomCompilerOptions {
+    DomCompilerOptions {
+        mode,
+        component_name: Some(name.into()),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn component_name_in_function_mode_matches_the_shipped_dom_lane() {
+    support::assert_s2_matches_shipped_with_options(
+        BATTERY,
+        &shipped("FooBar", CodegenMode::Function),
+        &CodegenOptions::default(),
+        &DomEmitOptions {
+            component_name: Some("FooBar"),
+            ..DomEmitOptions::DEFAULT
+        },
+    );
+}
+
+#[test]
+fn component_name_in_module_mode_matches_the_shipped_dom_lane() {
+    support::assert_s2_matches_shipped_with_options(
+        BATTERY,
+        &shipped("FooBar", CodegenMode::Module),
+        &CodegenOptions::default(),
+        &DomEmitOptions {
+            mode: DomEmitMode::Module,
+            component_name: Some("FooBar"),
+            ..DomEmitOptions::DEFAULT
+        },
+    );
+}
+
+/// A name that matches nothing in the battery leaves every resolution
+/// alone — the flag is the *only* thing the option changes.
+#[test]
+fn an_unrelated_component_name_changes_nothing() {
+    support::assert_s2_matches_shipped_with_options(
+        BATTERY,
+        &shipped("Unrelated", CodegenMode::Function),
+        &CodegenOptions::default(),
+        &DomEmitOptions {
+            component_name: Some("Unrelated"),
+            ..DomEmitOptions::DEFAULT
+        },
+    );
+}
+
+/// The exact spelling, so a lane that dropped the flag on both sides
+/// could not pass the dual run above unnoticed.
+#[test]
+fn the_self_reference_flag_is_pinned() {
+    let allocator = vize_s0::Allocator::new();
+    let emit = |src: &str, own: Option<&str>| {
+        vize_s1_to_s2::emit_dom_source_with_options(
+            &allocator,
+            src,
+            vize_s1_to_s2::LegacyCaps::VUE3,
+            &DomEmitOptions {
+                component_name: own,
+                ..DomEmitOptions::DEFAULT
+            },
+        )
+        .expect("component-name witness must emit")
+        .assembled()
+    };
+    let asset = |src: &str, own: Option<&str>| {
+        emit(src, own)
+            .lines()
+            .find(|line| line.contains("_resolveComponent("))
+            .unwrap_or_default()
+            .trim()
+            .to_string()
+    };
+    assert_eq!(
+        asset("<div><Foo /></div>", Some("Foo")),
+        "const _component_Foo = _resolveComponent(\"Foo\", true)"
+    );
+    assert_eq!(
+        asset("<div><foo-bar /></div>", Some("FooBar")),
+        "const _component_foo_bar = _resolveComponent(\"foo-bar\", true)"
+    );
+    assert_eq!(
+        asset("<div><Foo /></div>", Some("Other")),
+        "const _component_Foo = _resolveComponent(\"Foo\")"
+    );
+    assert_eq!(
+        asset("<div><Foo /></div>", None),
+        "const _component_Foo = _resolveComponent(\"Foo\")"
+    );
+}

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -214,6 +214,9 @@ struct EmitCx<'facts> {
     prefix_identifiers: bool,
     /// The shipped lane's `is_ts`: expressions are type-erased first.
     is_ts: bool,
+    /// The shipped lane's `component_name`, for the self-reference flag
+    /// on `resolveComponent`.
+    component_name: Option<&'facts str>,
     /// The transform scope and codegen slot params the prefixer consults.
     scope: prefix::PrefixScope<'facts>,
 }
@@ -280,6 +283,7 @@ fn emit_dom_with_emit_budget<'f>(
         parent_ns: Namespace::Html,
         prefix_identifiers: options.prefix_identifiers,
         is_ts: options.is_ts,
+        component_name: options.component_name,
         scope: prefix::PrefixScope::new(
             options.bindings,
             options.prefix_identifiers,

--- a/crates/vize_s1_to_s2/src/emit/component/preamble.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/preamble.rs
@@ -31,10 +31,26 @@ pub(in crate::emit) fn emit_resolves(cx: &mut EmitCx<'_>, names: &[&str]) -> boo
         cx.buf.push(Buf::resolve_component_alias());
         cx.buf.push("(\"");
         cx.buf.push(name);
-        cx.buf.push("\")");
+        cx.buf.push("\"");
+        if cx
+            .component_name
+            .is_some_and(|own| is_self_reference(name, own))
+        {
+            cx.buf.push(", true");
+        }
+        cx.buf.push(")");
         cx.buf.newline();
     }
     resolved
+}
+
+/// `is_self_component_reference`: the tag verbatim, or its PascalCased
+/// spelling, equals the component's own name.
+fn is_self_reference(component: &str, own: &str) -> bool {
+    if component == own {
+        return true;
+    }
+    vize_s0::capitalize(&vize_s0::camelize(component)).as_str() == own
 }
 
 fn collect_from<'a>(region: &Region<'a>, names: &mut StdVec<&'a str>) {

--- a/crates/vize_s1_to_s2/src/emit/options.rs
+++ b/crates/vize_s1_to_s2/src/emit/options.rs
@@ -204,6 +204,10 @@ pub struct DomEmitOptions<'a> {
     /// The shipped lane's `prefix_identifiers`: free identifiers become
     /// member accesses (`emit::prefix`).
     pub prefix_identifiers: bool,
+    /// The shipped lane's `component_name`: the SFC's own name (its file
+    /// stem). A component tag that resolves to it is a self-reference, and
+    /// the shipped lane asks the runtime to resolve it as one.
+    pub component_name: Option<&'a str>,
     /// The shipped lane's `is_ts`: template expressions are TypeScript,
     /// so each one is type-erased (`emit::prefix::typescript`) before the
     /// identifier pass reads it.
@@ -223,6 +227,7 @@ impl DomEmitOptions<'static> {
         runtime_module_name: "vue",
         runtime_global_name: "Vue",
         prefix_identifiers: false,
+        component_name: None,
         is_ts: false,
         bindings: None,
     };
@@ -247,6 +252,7 @@ mod tests {
                 runtime_module_name: "vue",
                 runtime_global_name: "Vue",
                 prefix_identifiers: false,
+                component_name: None,
                 is_ts: false,
                 bindings: None,
             }

--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus_support/mod.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus_support/mod.rs
@@ -77,6 +77,16 @@ pub fn compare_sweep_lane(sweep: &CorpusSweep, lane: Lane) -> Report {
     report
 }
 
+/// `extract_component_name`: the filename's stem, `anonymous` when the
+/// path has none.
+fn component_name_of(path: &str) -> std::string::String {
+    std::path::Path::new(path)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("anonymous")
+        .to_owned()
+}
+
 pub fn compare_sfc_template(name: &str, source: &str, report: &mut Report) {
     compare_sfc_template_lane(name, source, report, Lane::Default)
 }
@@ -105,6 +115,8 @@ pub fn compare_sfc_template_lane(name: &str, source: &str, report: &mut Report, 
     let table = bindings.as_ref().map(binding_table);
     // `compile_template_block` derives `is_ts` from the script blocks' lang.
     let is_ts = matches!(lane, Lane::Bindings) && sfc_is_ts(&descriptor);
+    // `extract_component_name`: the SFC filename's stem.
+    let component_name = matches!(lane, Lane::Bindings).then(|| component_name_of(name));
 
     let old_allocator = Allocator::new();
     let (_, errors, old) = match lane {
@@ -124,6 +136,9 @@ pub fn compare_sfc_template_lane(name: &str, source: &str, report: &mut Report, 
                 mode: CodegenMode::Module,
                 prefix_identifiers: true,
                 is_ts,
+                component_name: component_name
+                    .as_ref()
+                    .map(|name| vize_s0::String::from(name.as_str())),
                 binding_metadata: bindings.clone(),
                 ..Default::default()
             },
@@ -194,6 +209,7 @@ pub fn compare_sfc_template_lane(name: &str, source: &str, report: &mut Report, 
                 mode: DomEmitMode::Module,
                 prefix_identifiers: true,
                 is_ts,
+                component_name: component_name.as_deref(),
                 bindings: table.as_ref(),
                 ..DomEmitOptions::DEFAULT
             },


### PR DESCRIPTION
P2-11 installment 88, stacked on the 84–87 branch (#5615).

## Why

`compile_template_block` hands the DOM compiler the SFC's own name (its file stem, via `extract_component_name`). `generate_assets` uses it for exactly one decision: a component tag that resolves to that name is a **self-reference**, so its asset becomes `_resolveComponent("Foo", true)` and the runtime resolves the component against itself. Every recursive component in the corpus takes that path, and the S2 emitter had no way to express it.

## What

- `DomEmitOptions::component_name` carries the name.
- The component preamble mirrors `is_self_component_reference`: the tag verbatim, or its PascalCased spelling, compared against that name.

## Witness

- new `davinci_s2_component_name` battery — 12 templates × function and module mode, plus a run under an *unrelated* name (proving the flag is the only thing the option moves) and the pinned asset spellings (`_resolveComponent("foo-bar", true)` for a kebab tag whose PascalCase is the component's own name)
- the binding corpus lane now derives the name exactly as `extract_component_name` does and passes it on both sides: **12,062 templates compared, 0 refusals, 0 divergences**
- default and prefixed corpus lanes unchanged at 0 divergences
- `cargo test -p vize_s1_to_s2 -p vize_atelier_dom` — 851 tests green
- allocation gate unchanged at 60 allocs; storage, v-on, stage-dependency and production-boundary gates green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791025934&installation_model_id=422833&pr_number=5622&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5622&signature=b824da526a3a81c1e8cf47abff893954350e8d6b3e97f6cad7cc5a830c1e2b8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->