### PR TITLE
feat(davinci): publish stage crate graph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,16 +68,20 @@ vize_vitrine = { path = "crates/vize_vitrine", default-features = false }
 vize_glyph = { path = "crates/vize_glyph" }
 vize_maestro = { path = "crates/vize_maestro" }
 vize_curator = { path = "crates/vize_curator" }
-vize_davinci = { path = "crates/vize_davinci" }
-vize_davinci_derive = { path = "crates/vize_davinci_derive" }
+
+# Publishable Davinci stage infrastructure. Stage crates keep their physical
+# names and version fallbacks so a publishable consumer can resolve the same
+# dependency graph from crates.io.
+vize_davinci = { path = "crates/vize_davinci", version = "=0.392.0" }
+vize_davinci_derive = { path = "crates/vize_davinci_derive", version = "=0.392.0" }
 
 # Davinci stage aliases. These are the preferred implementation names for new
 # code; S0 still aliases the published Carton package until a compatibility
 # change can move it to a physical stage name.
 vize_s0 = { package = "vize_carton", path = "crates/vize_carton", version = "=0.392.0" }
-vize_s1 = { path = "crates/vize_s1" }
-vize_s2 = { path = "crates/vize_s2" }
-vize_s1_to_s2 = { path = "crates/vize_s1_to_s2" }
+vize_s1 = { path = "crates/vize_s1", version = "=0.392.0" }
+vize_s2 = { path = "crates/vize_s2", version = "=0.392.0" }
+vize_s1_to_s2 = { path = "crates/vize_s1_to_s2", version = "=0.392.0" }
 
 # OXC dependencies (pinned to a specific upstream revision for reproducibility)
 oxc_parser = { version = "=0.142.0", git = "https://github.com/oxc-project/oxc", rev = "fc702c1fa9f0412d06ec6908b58cd395b826cf7f" }

--- a/crates/vize_atelier_core/Cargo.toml
+++ b/crates/vize_atelier_core/Cargo.toml
@@ -54,10 +54,9 @@ davinci_harness = { workspace = true }
 davinci_test_support = { workspace = true }
 insta = { workspace = true }
 
-# The Davinci S2 lane, test-space only (P2-9): dev-dependencies with no
-# version requirement are stripped on publish, which is the carve-out the
-# release gate (tests/tooling/moonbit-publish-crates.test.ts) encodes for
-# published crates exercising unpublished ones.
+# The Davinci S2 lane, test-space only (P2-9): dev-dependencies are stripped
+# on publish, so the release graph stays independent until a production lane
+# explicitly selects the published stage crates.
 vize_davinci = { workspace = true }
 vize_s2 = { workspace = true }
 vize_s1_to_s2 = { workspace = true }

--- a/crates/vize_atelier_core/tests/s2_support/mod.rs
+++ b/crates/vize_atelier_core/tests/s2_support/mod.rs
@@ -27,8 +27,7 @@
 //! `vize_atelier_core` is published; the Davinci crates are not, and
 //! the release gate (`tests/tooling/moonbit-publish-crates.test.ts`)
 //! rejects a published crate whose release graph names an unpublished
-//! one. Dev-dependencies with no version requirement are stripped on
-//! publish — the exact carve-out the gate encodes — so the S2 lane and
+//! one. Dev-dependencies are stripped on publish, so the S2 lane and
 //! this comparator ride dev-deps, never the compile path. The P1-7
 //! in-`src` comparator shape does not apply here because the shipped
 //! path has no migrated read yet: the S2 lane runs *beside* the legacy

--- a/crates/vize_atelier_dom/Cargo.toml
+++ b/crates/vize_atelier_dom/Cargo.toml
@@ -25,10 +25,9 @@ criterion = { workspace = true }
 davinci_harness = { workspace = true }
 insta = { workspace = true }
 
-# The Davinci S2 DOM lane, test-space only (P2-11): dev-dependencies with
-# no version requirement are stripped on publish, which is the carve-out
-# the release gate (tests/tooling/moonbit-publish-crates.test.ts) encodes
-# for published crates exercising unpublished ones.
+# The Davinci S2 DOM lane, test-space only (P2-11): dev-dependencies are
+# stripped on publish, so the release graph stays independent until the
+# production-lane switch moves these stage crates into normal dependencies.
 vize_davinci = { workspace = true }
 # The P2-11 witness batteries compile TypeScript templates, so the DOM
 # lane's dev graph turns on the stage library's `typescript` feature.

--- a/crates/vize_davinci/Cargo.toml
+++ b/crates/vize_davinci/Cargo.toml
@@ -6,7 +6,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Davinci - dump/round-trip substrate (Folio) for the Vize compiler rearchitecture"
-publish = false
 metadata.vize.stability = "experimental"
 
 [dependencies]

--- a/crates/vize_davinci/README.md
+++ b/crates/vize_davinci/README.md
@@ -1,0 +1,11 @@
+# vize_davinci
+
+`vize_davinci` provides the shared Davinci pipeline substrate: diagnostics,
+node identities, side tables, passes, and the `Folio` dump contract.
+
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
+## License
+
+MIT

--- a/crates/vize_davinci/src/lib.rs
+++ b/crates/vize_davinci/src/lib.rs
@@ -1,6 +1,9 @@
 //! Davinci - the dump/round-trip substrate for the Vize compiler
 //! rearchitecture.
 //!
+//! **Experimental:** the public API and dump format may change in any alpha
+//! release; record intentional breaking changes in the release notes.
+//!
 //! Named after Leonardo's manuscripts, whose folios carried both the drawing
 //! and the notes needed to read it back.
 //!

--- a/crates/vize_davinci_derive/Cargo.toml
+++ b/crates/vize_davinci_derive/Cargo.toml
@@ -6,7 +6,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Davinci - #[derive(Folio)] for the stage-dump contract (host build dependency; the generated code is no_std)"
-publish = false
 metadata.vize.stability = "experimental"
 
 [lib]

--- a/crates/vize_davinci_derive/README.md
+++ b/crates/vize_davinci_derive/README.md
@@ -1,0 +1,11 @@
+# vize_davinci_derive
+
+`vize_davinci_derive` provides `#[derive(Folio)]` for the Davinci stage-dump
+contract. It is a host-side proc macro; generated code remains target-neutral.
+
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
+## License
+
+MIT

--- a/crates/vize_davinci_derive/src/lib.rs
+++ b/crates/vize_davinci_derive/src/lib.rs
@@ -1,6 +1,9 @@
 //! `#[derive(Folio)]` - the mechanical half of the Davinci stage-dump
 //! contract.
 //!
+//! **Experimental:** generated format and macro API may change in any alpha
+//! release; record intentional breaking changes in the release notes.
+//!
 //! The derive generates `vize_davinci::folio::Folio`'s exact shape -
 //! `print(&self, w, mode)` and `parse(input) -> Result<Self, FolioError>` -
 //! for an owned document struct, following the normalization rules written

--- a/crates/vize_s1/Cargo.toml
+++ b/crates/vize_s1/Cargo.toml
@@ -13,7 +13,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "S1 - the lossless Vue-template surface tree (codename Sinopia, Davinci P2-7)"
-publish = false
 metadata.vize.stability = "experimental"
 
 [features]

--- a/crates/vize_s1/README.md
+++ b/crates/vize_s1/README.md
@@ -1,0 +1,11 @@
+# vize_s1
+
+`vize_s1` is Davinci's lossless Vue-template surface tree. Parsing and
+rendering preserve exact source bytes, including malformed input.
+
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
+## License
+
+MIT

--- a/crates/vize_s1/src/lib.rs
+++ b/crates/vize_s1/src/lib.rs
@@ -1,5 +1,8 @@
 //! S1 — the lossless Vue-template surface tree (codename Sinopia, Davinci P2-7).
 //!
+//! **Experimental:** the stage API may change in any alpha release; record
+//! intentional breaking changes in the release notes.
+//!
 //! A *sinopia* is the preparatory underdrawing beneath a fresco. When the
 //! finished layer is detached from the wall, the sinopia survives as the
 //! byte-faithful record of what was actually drawn — which is this crate's

--- a/crates/vize_s1_to_s2/Cargo.toml
+++ b/crates/vize_s1_to_s2/Cargo.toml
@@ -18,7 +18,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "S1-to-S2 - the Davinci Vue template lowering (codename Ricalco, P2-8)"
-publish = false
 metadata.vize.stability = "experimental"
 
 [features]
@@ -81,4 +80,3 @@ required-features = ["davinci-differential"]
 [[test]]
 name = "davinci_dom_corpus_bindings"
 required-features = ["davinci-differential"]
-

--- a/crates/vize_s1_to_s2/README.md
+++ b/crates/vize_s1_to_s2/README.md
@@ -1,0 +1,11 @@
+# vize_s1_to_s2
+
+`vize_s1_to_s2` lowers the lossless Vue S1 surface tree into the neutral S2
+semantic IR and can emit the observed DOM lane used for compatibility checks.
+
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
+## License
+
+MIT

--- a/crates/vize_s1_to_s2/src/lib.rs
+++ b/crates/vize_s1_to_s2/src/lib.rs
@@ -1,5 +1,8 @@
 //! S1→S2 — the Vue lowering (codename Ricalco, Davinci P2-8).
 //!
+//! **Experimental:** the lowering API may change in any alpha release; record
+//! intentional breaking changes in the release notes.
+//!
 //! A *ricalco* is the tracing that transfers a drawing onto a new
 //! surface. This crate traces the lossless Vue surface tree (S1,
 //! [`vize_s1`]) into the neutral semantic op family (S2,

--- a/crates/vize_s2/Cargo.toml
+++ b/crates/vize_s2/Cargo.toml
@@ -6,7 +6,6 @@ rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "S2 - the Davinci semantic IR (codename Disegno): the neutral op family every input dialect lowers into"
-publish = false
 metadata.vize.stability = "experimental"
 
 [dependencies]

--- a/crates/vize_s2/README.md
+++ b/crates/vize_s2/README.md
@@ -1,0 +1,11 @@
+# vize_s2
+
+`vize_s2` is Davinci's input-neutral semantic IR. Dialect-specific lowering
+crates use its operations, provenance, scope, and invariant checks.
+
+Support and deprecation guarantees are defined in the
+[Rust crate support tiers](https://github.com/ubugeeei-prod/vize/blob/main/docs/content/stability.md#rust-crate-support-tiers).
+
+## License
+
+MIT

--- a/crates/vize_s2/src/lib.rs
+++ b/crates/vize_s2/src/lib.rs
@@ -1,6 +1,9 @@
 //! S2 - the Davinci semantic IR (codename Disegno): the pivot stage and the
 //! primary consumer surface.
 //!
+//! **Experimental:** the stage API may change in any alpha release; record
+//! intentional breaking changes in the release notes.
+//!
 //! Named after Leonardo's *disegno*: the drawing that carries the idea,
 //! independent of the material it is later executed in.
 //!

--- a/docs/content/stability.md
+++ b/docs/content/stability.md
@@ -93,6 +93,8 @@ details are not compatibility surfaces.
 | `vize_armature`      | Alpha-supported       | Tools that parse Vue templates            | `vize_armature::{parse, Parser, Tokenizer}`     | One minor with `#[deprecated]`         |
 | `vize_croquis`       | Compatibility preview | Semantic and type-aware tooling authors   | `vize_croquis::{Croquis, Drawer}`               | One minor with `#[deprecated]`         |
 | `vize_croquis_cf`    | Experimental          | Opt-in whole-project analysis experiments | `vize_croquis_cf::CrossFileAnalyzer`            | No minimum; note breaks when practical |
+| `vize_davinci`       | Experimental          | Davinci pipeline and dump-format authors  | `vize_davinci::{Folio, Diagnostic, NodeId}`      | No minimum; note breaks when practical |
+| `vize_davinci_derive` | Experimental        | Davinci dump-format authors               | `vize_davinci_derive::Folio`                     | No minimum; note breaks when practical |
 | `vize_doctor`        | Experimental          | Application health analyzer authors       | `vize_doctor::{DoctorFinding, FindingEvidence}` | No minimum; note breaks when practical |
 | `vize_atelier_core`  | Alpha-supported       | Custom Vue compiler backend authors       | `vize_atelier_core::{transform, generate}`      | One minor with `#[deprecated]`         |
 | `vize_atelier_dom`   | Alpha-supported       | VDOM compiler and bundler integrations    | `vize_atelier_dom::compile_template`            | One minor with `#[deprecated]`         |
@@ -105,6 +107,9 @@ details are not compatibility surfaces.
 | `vize_fresco`        | Incubating            | TUI experiments                           | `vize_fresco::{RenderTree, LayoutEngine}`       | No minimum                             |
 | `vize_canon`         | Compatibility preview | Type-checker and editor integrations      | `vize_canon::{type_check_sfc, TypeChecker}`     | One minor with `#[deprecated]`         |
 | `vize_patina`        | Compatibility preview | Linter and Oxlint integrations            | `vize_patina::{lint, Linter}`                   | One minor with `#[deprecated]`         |
+| `vize_s1`            | Experimental          | Lossless Vue-template tooling authors     | `vize_s1::{parse, SurfaceTree}`                  | No minimum; note breaks when practical |
+| `vize_s1_to_s2`      | Experimental          | Vue lowering and compiler backend authors | `vize_s1_to_s2::{lower, emit_dom}`               | No minimum; note breaks when practical |
+| `vize_s2`            | Experimental          | Dialect-neutral compiler IR authors       | `vize_s2::{op, verify, S2Folio}`                 | No minimum; note breaks when practical |
 
 <!-- rust-crate-support:end -->
 

--- a/tests/tooling/davinci-s1-stage-alias.test.ts
+++ b/tests/tooling/davinci-s1-stage-alias.test.ts
@@ -13,7 +13,10 @@ function readRepoFile(...parts: string[]): string {
 test("Davinci S1 uses the physical crate package and directory", () => {
   const workspaceManifest = readRepoFile("Cargo.toml");
   assert.match(workspaceManifest, /^\s*"crates\/vize_s1",$/m);
-  assert.match(workspaceManifest, /^vize_s1 = \{ path = "crates\/vize_s1" \}$/m);
+  assert.match(
+    workspaceManifest,
+    /^vize_s1 = \{ path = "crates\/vize_s1", version = "=0\.390\.0" \}$/m,
+  );
   assert.doesNotMatch(workspaceManifest, /crates\/vize_sinopia/u);
   assert.doesNotMatch(workspaceManifest, /^vize_sinopia = /m);
 

--- a/tests/tooling/davinci-s1-stage-alias.test.ts
+++ b/tests/tooling/davinci-s1-stage-alias.test.ts
@@ -15,11 +15,15 @@ test("Davinci S1 uses the physical crate package and directory", () => {
   const workspaceManifest = readRepoFile("Cargo.toml");
   assert.match(workspaceManifest, /^\s*"crates\/vize_s1",$/m);
   const manifest = parseToml(workspaceManifest) as {
-    workspace?: { dependencies?: { vize_s1?: unknown } };
+    workspace?: { dependencies?: { vize_s1?: unknown }; package?: { version?: unknown } };
   };
+  const workspaceVersion = manifest.workspace?.package?.version;
+  if (typeof workspaceVersion !== "string") {
+    assert.fail("workspace package version must be declared");
+  }
   assert.deepEqual(manifest.workspace?.dependencies?.vize_s1, {
     path: "crates/vize_s1",
-    version: "=0.390.0",
+    version: `=${workspaceVersion}`,
   });
   assert.doesNotMatch(workspaceManifest, /crates\/vize_sinopia/u);
   assert.doesNotMatch(workspaceManifest, /^vize_sinopia = /m);

--- a/tests/tooling/davinci-s1-stage-alias.test.ts
+++ b/tests/tooling/davinci-s1-stage-alias.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { parse as parseToml } from "@iarna/toml";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
@@ -13,10 +14,13 @@ function readRepoFile(...parts: string[]): string {
 test("Davinci S1 uses the physical crate package and directory", () => {
   const workspaceManifest = readRepoFile("Cargo.toml");
   assert.match(workspaceManifest, /^\s*"crates\/vize_s1",$/m);
-  assert.match(
-    workspaceManifest,
-    /^vize_s1 = \{ path = "crates\/vize_s1", version = "=0\.390\.0" \}$/m,
-  );
+  const manifest = parseToml(workspaceManifest) as {
+    workspace?: { dependencies?: { vize_s1?: unknown } };
+  };
+  assert.deepEqual(manifest.workspace?.dependencies?.vize_s1, {
+    path: "crates/vize_s1",
+    version: "=0.390.0",
+  });
   assert.doesNotMatch(workspaceManifest, /crates\/vize_sinopia/u);
   assert.doesNotMatch(workspaceManifest, /^vize_sinopia = /m);
 

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -11,6 +11,7 @@ import {
   repoRoot,
   s2DomWitnessFiles,
   walkRustFiles,
+  workspaceDependencyDeclaration,
   workspacePackage,
 } from "./support/davinci-stage-dependencies.ts";
 
@@ -101,6 +102,11 @@ test("Davinci stage crates are publishable with registry-resolvable dependencies
         /^=\d+\.\d+\.\d+$/u,
         `${packageName} must give ${dependency.name} an exact registry fallback`,
       );
+      assert.equal(
+        dependency.req,
+        `=${workspacePackage(metadata, dependency.name).version}`,
+        `${packageName} must match ${dependency.name}'s published version`,
+      );
     }
   }
 });
@@ -124,20 +130,20 @@ test("Davinci fuzz harness imports stage packages through aliases", () => {
 test("Davinci S2 uses the physical crate directory", () => {
   const workspaceManifest = readRepoFile("Cargo.toml");
   assert.match(workspaceManifest, /^\s*"crates\/vize_s2",$/m);
-  assert.match(
-    workspaceManifest,
-    /^vize_s2 = \{ path = "crates\/vize_s2", version = "=\d+\.\d+\.\d+" \}$/m,
-  );
+  assert.deepEqual(workspaceDependencyDeclaration("vize_s2"), {
+    path: "crates/vize_s2",
+    version: "=0.390.0",
+  });
   assert.doesNotMatch(workspaceManifest, /crates\/vize_disegno/u);
 });
 
 test("Davinci S1-to-S2 uses the physical crate package and directory", () => {
   const workspaceManifest = readRepoFile("Cargo.toml");
   assert.match(workspaceManifest, /^\s*"crates\/vize_s1_to_s2",$/m);
-  assert.match(
-    workspaceManifest,
-    /^vize_s1_to_s2 = \{ path = "crates\/vize_s1_to_s2", version = "=\d+\.\d+\.\d+" \}$/m,
-  );
+  assert.deepEqual(workspaceDependencyDeclaration("vize_s1_to_s2"), {
+    path: "crates/vize_s1_to_s2",
+    version: "=0.390.0",
+  });
   assert.doesNotMatch(workspaceManifest, /crates\/vize_ricalco/u);
   assert.doesNotMatch(workspaceManifest, /^vize_ricalco = /m);
   assert.doesNotMatch(workspaceManifest, /package = "vize_ricalco"/u);

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -132,7 +132,7 @@ test("Davinci S2 uses the physical crate directory", () => {
   assert.match(workspaceManifest, /^\s*"crates\/vize_s2",$/m);
   assert.deepEqual(workspaceDependencyDeclaration("vize_s2"), {
     path: "crates/vize_s2",
-    version: "=0.390.0",
+    version: `=${workspacePackage(metadata, "vize_s2").version}`,
   });
   assert.doesNotMatch(workspaceManifest, /crates\/vize_disegno/u);
 });
@@ -142,7 +142,7 @@ test("Davinci S1-to-S2 uses the physical crate package and directory", () => {
   assert.match(workspaceManifest, /^\s*"crates\/vize_s1_to_s2",$/m);
   assert.deepEqual(workspaceDependencyDeclaration("vize_s1_to_s2"), {
     path: "crates/vize_s1_to_s2",
-    version: "=0.390.0",
+    version: `=${workspacePackage(metadata, "vize_s1_to_s2").version}`,
   });
   assert.doesNotMatch(workspaceManifest, /crates\/vize_ricalco/u);
   assert.doesNotMatch(workspaceManifest, /^vize_ricalco = /m);

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -12,7 +12,6 @@ import {
   s2DomWitnessFiles,
   walkRustFiles,
   workspacePackage,
-  type Package,
 } from "./support/davinci-stage-dependencies.ts";
 
 const aliases = new Map<string, ReadonlyArray<readonly [string, string | null]>>([
@@ -29,11 +28,13 @@ const aliases = new Map<string, ReadonlyArray<readonly [string, string | null]>>
   ],
 ]);
 
-const unpublishedDavinciStages = new Set(["vize_davinci", "vize_s1", "vize_s2", "vize_s1_to_s2"]);
-
-function isPublishable(pkg: Package): boolean {
-  return pkg.publish === null || pkg.publish.length > 0;
-}
+const publishedDavinciStages = new Set([
+  "vize_davinci_derive",
+  "vize_davinci",
+  "vize_s1",
+  "vize_s2",
+  "vize_s1_to_s2",
+]);
 
 test("Davinci crates import retained packages through stage aliases", () => {
   for (const [packageName, expectedAliases] of aliases) {
@@ -89,33 +90,19 @@ test("Davinci stage dependencies are one-way and acyclic", () => {
   }
 });
 
-test("Davinci stage crates stay out of published release graphs", () => {
-  for (const packageName of unpublishedDavinciStages) {
-    assert.deepEqual(
-      workspacePackage(metadata, packageName).publish,
-      [],
-      `${packageName} must stay publish=false until a dedicated stage-publication switch`,
-    );
-  }
-
-  const offenders: string[] = [];
-  const workspacePackages = new Set(metadata.packages.map((pkg) => pkg.name));
-
-  for (const pkg of metadata.packages.filter(isPublishable)) {
+test("Davinci stage crates are publishable with registry-resolvable dependencies", () => {
+  for (const packageName of publishedDavinciStages) {
+    const pkg = workspacePackage(metadata, packageName);
+    assert.equal(pkg.publish, null, `${packageName} must be publishable for the production switch`);
     for (const dependency of pkg.dependencies) {
-      if (!workspacePackages.has(dependency.name)) continue;
-      if (!unpublishedDavinciStages.has(dependency.name)) continue;
-      const strippedDevDependency = dependency.kind === "dev" && dependency.req === "*";
-      if (strippedDevDependency) continue;
-
-      offenders.push(
-        `${pkg.name} ${dependency.kind ?? "normal"} dependency ` +
-          `${dependency.rename ?? dependency.name}(${dependency.name}) req ${dependency.req}`,
+      if (dependency.kind !== null || !publishedDavinciStages.has(dependency.name)) continue;
+      assert.match(
+        dependency.req,
+        /^=\d+\.\d+\.\d+$/u,
+        `${packageName} must give ${dependency.name} an exact registry fallback`,
       );
     }
   }
-
-  assert.deepEqual(offenders, []);
 });
 
 test("Davinci fuzz harness imports stage packages through aliases", () => {
@@ -137,14 +124,20 @@ test("Davinci fuzz harness imports stage packages through aliases", () => {
 test("Davinci S2 uses the physical crate directory", () => {
   const workspaceManifest = readRepoFile("Cargo.toml");
   assert.match(workspaceManifest, /^\s*"crates\/vize_s2",$/m);
-  assert.match(workspaceManifest, /^vize_s2 = \{ path = "crates\/vize_s2" \}$/m);
+  assert.match(
+    workspaceManifest,
+    /^vize_s2 = \{ path = "crates\/vize_s2", version = "=\d+\.\d+\.\d+" \}$/m,
+  );
   assert.doesNotMatch(workspaceManifest, /crates\/vize_disegno/u);
 });
 
 test("Davinci S1-to-S2 uses the physical crate package and directory", () => {
   const workspaceManifest = readRepoFile("Cargo.toml");
   assert.match(workspaceManifest, /^\s*"crates\/vize_s1_to_s2",$/m);
-  assert.match(workspaceManifest, /^vize_s1_to_s2 = \{ path = "crates\/vize_s1_to_s2" \}$/m);
+  assert.match(
+    workspaceManifest,
+    /^vize_s1_to_s2 = \{ path = "crates\/vize_s1_to_s2", version = "=\d+\.\d+\.\d+" \}$/m,
+  );
   assert.doesNotMatch(workspaceManifest, /crates\/vize_ricalco/u);
   assert.doesNotMatch(workspaceManifest, /^vize_ricalco = /m);
   assert.doesNotMatch(workspaceManifest, /package = "vize_ricalco"/u);

--- a/tests/tooling/davinci-stage-dependencies.test.ts
+++ b/tests/tooling/davinci-stage-dependencies.test.ts
@@ -96,7 +96,7 @@ test("Davinci stage crates are publishable with registry-resolvable dependencies
     const pkg = workspacePackage(metadata, packageName);
     assert.equal(pkg.publish, null, `${packageName} must be publishable for the production switch`);
     for (const dependency of pkg.dependencies) {
-      if (dependency.kind !== null || !publishedDavinciStages.has(dependency.name)) continue;
+      if (dependency.kind === "dev" || !publishedDavinciStages.has(dependency.name)) continue;
       assert.match(
         dependency.req,
         /^=\d+\.\d+\.\d+$/u,

--- a/tests/tooling/davinci-stage-release-firewall.test.ts
+++ b/tests/tooling/davinci-stage-release-firewall.test.ts
@@ -3,7 +3,7 @@ import { test } from "node:test";
 
 import { metadata, workspacePackage, type Package } from "./support/davinci-stage-dependencies.ts";
 
-const unpublishedDavinciStages = new Set(["vize_davinci", "vize_s1", "vize_s2", "vize_s1_to_s2"]);
+const publishedDavinciStages = new Set(["vize_davinci", "vize_s1", "vize_s2", "vize_s1_to_s2"]);
 
 function isPublishable(pkg: Package): boolean {
   return pkg.publish === null || pkg.publish.length > 0;
@@ -43,30 +43,23 @@ test("Feature values resolve unpublished stages through dependency keys", () => 
   assert.equal(referencedWorkspaceFeaturePackage(pkg, "local_feature"), null);
 });
 
-test("Published crates expose no feature that enables unpublished Davinci stages", () => {
-  const offenders: string[] = [];
-
-  for (const pkg of metadata.packages.filter(isPublishable)) {
-    for (const [featureName, featureValues] of Object.entries(pkg.features)) {
-      for (const featureValue of featureValues) {
-        const referencedPackage = referencedWorkspaceFeaturePackage(pkg, featureValue);
-        if (!unpublishedDavinciStages.has(referencedPackage)) continue;
-        offenders.push(`${pkg.name} feature ${featureName} includes ${featureValue}`);
-      }
-    }
+test("Davinci stage crates are published before a production feature can select them", () => {
+  for (const packageName of publishedDavinciStages) {
+    assert.ok(
+      isPublishable(workspacePackage(metadata, packageName)),
+      `${packageName} is not publishable`,
+    );
   }
-
-  assert.deepEqual(offenders, []);
 });
 
-test("DOM S2 witnesses keep their unpublished stage edges test-space only", () => {
+test("DOM S2 witnesses remain test-space only until the production switch", () => {
   const dom = workspacePackage(metadata, "vize_atelier_dom");
   assert.deepEqual(dom.features, {
     legacy: ["vize_atelier_core/legacy"],
   });
 
   const stageEdges = dom.dependencies
-    .filter((dependency) => unpublishedDavinciStages.has(dependency.name))
+    .filter((dependency) => publishedDavinciStages.has(dependency.name))
     .map((dependency) => ({
       name: dependency.name,
       kind: dependency.kind,
@@ -81,7 +74,7 @@ test("DOM S2 witnesses keep their unpublished stage edges test-space only", () =
     {
       name: "vize_davinci",
       kind: "dev",
-      req: "*",
+      req: "=0.390.0",
       rename: null,
       optional: false,
       features: [],
@@ -89,14 +82,14 @@ test("DOM S2 witnesses keep their unpublished stage edges test-space only", () =
     {
       name: "vize_s1_to_s2",
       kind: "dev",
-      req: "*",
+      req: "=0.390.0",
       rename: null,
       optional: false,
       // The P2-11 witness batteries compile TypeScript templates, which the
       // stage library keeps behind an opt-in feature (its type erasure is the
       // one `std` API it reaches). What keeps this edge out of the published
-      // graph is the rest of this shape — `dev`, `*`, unrenamed, not optional
-      // — so selecting a lane on it changes nothing there.
+      // graph is the rest of this shape — `dev`, unrenamed, not optional — so
+      // selecting a lane on it changes nothing there.
       features: ["typescript"],
     },
   ]);

--- a/tests/tooling/davinci-stage-release-firewall.test.ts
+++ b/tests/tooling/davinci-stage-release-firewall.test.ts
@@ -9,6 +9,10 @@ function isPublishable(pkg: Package): boolean {
   return pkg.publish === null || pkg.publish.length > 0;
 }
 
+function versionRequirement(packageName: string): string {
+  return `=${workspacePackage(metadata, packageName).version}`;
+}
+
 type FeatureOwner = Pick<Package, "dependencies">;
 
 function featureDependencyKey(featureValue: string): string {
@@ -74,7 +78,7 @@ test("DOM S2 witnesses remain test-space only until the production switch", () =
     {
       name: "vize_davinci",
       kind: "dev",
-      req: "=0.390.0",
+      req: versionRequirement("vize_davinci"),
       rename: null,
       optional: false,
       features: [],
@@ -82,7 +86,7 @@ test("DOM S2 witnesses remain test-space only until the production switch", () =
     {
       name: "vize_s1_to_s2",
       kind: "dev",
-      req: "=0.390.0",
+      req: versionRequirement("vize_s1_to_s2"),
       rename: null,
       optional: false,
       // The P2-11 witness batteries compile TypeScript templates, which the

--- a/tests/tooling/docs-stability.test.ts
+++ b/tests/tooling/docs-stability.test.ts
@@ -114,12 +114,16 @@ test("Rust crate stability table matches Cargo metadata and crate documentation"
     assert.match(fs.readFileSync(readmePath, "utf8"), new RegExp(escapeRegExp(rustStabilityLink)));
 
     if (tier === "experimental" || tier === "incubating") {
-      const libTarget = pkg.targets.find(
-        (target) => target.kind.includes("lib") || target.crate_types.includes("rlib"),
+      const documentedTarget = pkg.targets.find(
+        (target) =>
+          target.kind.includes("lib") ||
+          target.kind.includes("proc-macro") ||
+          target.crate_types.includes("rlib") ||
+          target.crate_types.includes("proc-macro"),
       );
-      assert.ok(libTarget, `${pkg.name} must expose a library target`);
+      assert.ok(documentedTarget, `${pkg.name} must expose a documented library target`);
       assert.match(
-        fs.readFileSync(libTarget.src_path, "utf8"),
+        fs.readFileSync(documentedTarget.src_path, "utf8"),
         new RegExp(`\\*\\*${tier === "experimental" ? "Experimental" : "Incubating"}`),
         `${pkg.name} rustdoc must disclose its ${tier} status`,
       );

--- a/tests/tooling/moonbit-publish-crates.test.ts
+++ b/tests/tooling/moonbit-publish-crates.test.ts
@@ -61,7 +61,7 @@ test("publish_crates script keeps publishable workspace dependencies ordered", (
 
     for (const dependency of pkg.dependencies) {
       const dependencyOrder = publishOrder.get(dependency.name);
-      const strippedOnPublish = dependency.kind === "dev" && dependency.req === "*";
+      const strippedOnPublish = dependency.kind === "dev";
       if (!packages.has(dependency.name) || strippedOnPublish) continue;
       assert.ok(
         dependencyOrder != null,
@@ -226,7 +226,7 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
       expectedFrontier(publishedCrates[5]),
     ]);
     assert.match(partial.stdout, /vize_carton .* already published and resolvable/i);
-    assert.match(partial.stdout, /registry-resolvable frontier vize_atelier_dom/i);
+    assert.match(partial.stdout, /registry-resolvable frontier vize_s1/i);
     assert.equal(fs.readFileSync(curlLogPath, "utf8").trim().split("\n").length, 6);
 
     const allPublished = runDryRun(publishedCrates);
@@ -254,7 +254,7 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
       TEST_UNRESOLVED_CRATES: publishedCrates[2],
     });
     assert.notEqual(unresolvedPrefix.status, 0);
-    assert.match(unresolvedPrefix.stderr, /could not resolve .*vize_armature/i);
+    assert.match(unresolvedPrefix.stderr, /could not resolve .*vize_davinci/i);
     assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
       expectedPackage,
       ...somePublished.slice(0, 3).map(expectedInfo),

--- a/tests/tooling/support/davinci-stage-dependencies.ts
+++ b/tests/tooling/support/davinci-stage-dependencies.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { parse as parseToml } from "@iarna/toml";
 
 export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 
@@ -21,6 +22,7 @@ export type Package = {
   features: Record<string, string[]>;
   manifest_path: string;
   publish: string[] | null;
+  version: string;
 };
 
 export type Metadata = { packages: Package[] };
@@ -58,6 +60,25 @@ export function dependency(
 
 export function readRepoFile(...segments: string[]): string {
   return fs.readFileSync(path.join(repoRoot, ...segments), "utf8");
+}
+
+export function workspaceDependencyDeclaration(name: string): {
+  path: string;
+  version: string;
+} {
+  const manifest = parseToml(readRepoFile("Cargo.toml")) as {
+    workspace?: { dependencies?: Record<string, unknown> };
+  };
+  const declaration = manifest.workspace?.dependencies?.[name];
+  assert.ok(
+    declaration !== null && typeof declaration === "object" && !Array.isArray(declaration),
+    `workspace dependency ${name} must be a table`,
+  );
+
+  const { path: dependencyPath, version } = declaration as Record<string, unknown>;
+  assert.equal(typeof dependencyPath, "string", `${name} must declare a path`);
+  assert.equal(typeof version, "string", `${name} must declare a version`);
+  return { path: dependencyPath, version };
 }
 
 export function* walkRustFiles(directory: string): Generator<string> {

--- a/tools/moon/cmd/publish_crates/main.mbt
+++ b/tools/moon/cmd/publish_crates/main.mbt
@@ -5,19 +5,17 @@
 /// already published, it skips the publish call and only waits until the crate
 /// becomes resolvable from crates.io index queries.
 
-/// Ordered list of publishable crates.
-/// The order matters because many of these crates depend on previously
-/// published workspace crates via exact-version dependencies. The accompanying
-/// test asserts that this list remains topologically valid.
-/// Crates in `manual_publish_crates` are intentionally omitted here:
-/// crates.io Trusted Publishing can publish only crates whose trusted-publisher
-/// handoff is configured for this repository/workflow/environment. First
-/// publishes and crates whose handoff has not been completed yet must be
-/// published manually once before this job can own subsequent versions.
+/// Ordered list of publishable crates. The order is topological because each
+/// crate can require exact versions of earlier workspace crates.
 let published_crates : Array[String] = [
   "vize_carton",
+  "vize_davinci_derive",
+  "vize_davinci",
   "vize_relief",
   "vize_armature",
+  "vize_s1",
+  "vize_s2",
+  "vize_s1_to_s2",
   "vize_croquis",
   "vize_atelier_core",
   "vize_atelier_dom",
@@ -28,8 +26,7 @@ let published_crates : Array[String] = [
   "vize_fresco",
 ]
 
-/// Publishable crates that need manual owner-token work before GitHub Trusted
-/// Publishing can publish them from the release workflow.
+/// Crates without a completed Trusted Publishing handoff.
 let manual_publish_crates : Array[String] = [
   "vize_croquis_cf",
   "vize_atelier_jsx",
@@ -37,8 +34,7 @@ let manual_publish_crates : Array[String] = [
   "vize_doctor",
 ]
 
-/// Existing crates whose current version depends on a crate that still needs a
-/// manual publish handoff.
+/// Existing crates that depend on a crate still awaiting manual publication.
 let blocked_by_manual_publish_crates : Array[String] = [
   "vize_canon",
   "vize_patina",


### PR DESCRIPTION
## Summary

- make the Davinci stage crate closure publishable with exact registry fallbacks
- publish it in dependency order through the existing crates.io release workflow
- keep S2 DOM emission in test space until the separate production-lane switch

## Validation

- `node --test tests/tooling/davinci-stage-dependencies.test.ts`
- `node --test tests/tooling/davinci-stage-release-firewall.test.ts`
- `node --test tests/tooling/moonbit-publish-crates.test.ts` (dependency-order and partition checks pass; two execution-shape tests are blocked locally by the cached MoonBit dependency API mismatch)
- `cargo package -p vize_davinci_derive --allow-dirty --no-verify`
- `git diff --check`

The release-preflight workflow remains the authoritative verification for the full publish sequence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791034662&installation_model_id=422833&pr_number=5626&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5626&signature=8c7f0555b152216c58f33282e2dca863d7105ab9bbb93c62f353fecff94893c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Management**
  - Enabled publication of the Davinci and S1/S2 stage crates.
  - Added these crates to the release sequence while preserving dependency order.
  - Added exact-version fallback metadata for reliable published releases.

- **Documentation**
  - Added crate documentation, licensing details, support-tier listings, and experimental API notices.
  - Clarified handling of development-only dependencies during publication.

- **Tests**
  - Updated release checks for publishable stage crates, exact dependency versions, and revised publication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->