### PR TITLE
fix(carton): read top-level vue compatibility

### DIFF
--- a/crates/vize/tests/lint_vue_compatibility_cli.rs
+++ b/crates/vize/tests/lint_vue_compatibility_cli.rs
@@ -86,3 +86,49 @@ const title = 'legacy'
 
     let _ = fs::remove_dir_all(project_root);
 }
+
+#[test]
+fn lint_top_level_vue2_compatibility_disables_vue34_props_shorthand() {
+    let project_root = temp_project_dir();
+    write_project_file(
+        &project_root,
+        "src/DataCard.vue",
+        r#"<script setup lang="ts">
+interface Props {
+  height?: string
+}
+withDefaults(defineProps<Props>(), { height: '' })
+</script>
+
+<template>
+  <v-card :height="height">sample</v-card>
+</template>
+"#,
+    );
+    write_project_file(
+        &project_root,
+        "vize.config.ts",
+        r#"export default {
+  compatibility: { vueVersion: '2.7' }
+}
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "lint",
+            "--preset",
+            "opinionated",
+            "--config",
+            "vize.config.ts",
+            "src/DataCard.vue",
+        ])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{}", output_details(&output));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("vue/prefer-props-shorthand"), "{stdout}");
+
+    let _ = fs::remove_dir_all(project_root);
+}

--- a/crates/vize_carton/src/config/loader/lint_features.rs
+++ b/crates/vize_carton/src/config/loader/lint_features.rs
@@ -84,7 +84,12 @@ pub fn load_config_and_linter_with_lint_features_and_source(
     path: Option<&Path>,
 ) -> (LoadedConfigWithFeatures, LinterConfig, LinterFeatureFlags) {
     let loaded = load_raw_config_with_source(path);
-    let compiler_compatibility_vue_version = loaded.config.compiler.compatibility.vue_version;
+    let compiler_compatibility_vue_version = loaded
+        .config
+        .compiler
+        .compatibility
+        .vue_version
+        .or(loaded.config.compatibility.vue_version);
     let compiler_vapor = loaded
         .config
         .compiler
@@ -118,7 +123,12 @@ pub fn load_config_and_linter_plan_with_lint_features_and_source(
     LinterFeatureFlags,
 ) {
     let loaded = load_raw_config_with_source(path);
-    let compiler_compatibility_vue_version = loaded.config.compiler.compatibility.vue_version;
+    let compiler_compatibility_vue_version = loaded
+        .config
+        .compiler
+        .compatibility
+        .vue_version
+        .or(loaded.config.compatibility.vue_version);
     let compiler_vapor = loaded
         .config
         .compiler
@@ -152,7 +162,12 @@ pub fn load_config_and_linter_plan_with_rule_options_and_lint_features_and_sourc
     LinterFeatureFlags,
 ) {
     let loaded = load_raw_config_with_source(path);
-    let compiler_compatibility_vue_version = loaded.config.compiler.compatibility.vue_version;
+    let compiler_compatibility_vue_version = loaded
+        .config
+        .compiler
+        .compatibility
+        .vue_version
+        .or(loaded.config.compatibility.vue_version);
     let compiler_vapor = loaded
         .config
         .compiler

--- a/crates/vize_carton/src/config/loader/tests.rs
+++ b/crates/vize_carton/src/config/loader/tests.rs
@@ -128,6 +128,22 @@ fn load_compiler_vue_version_reads_compiler_compatibility_key() {
 }
 
 #[test]
+fn load_compiler_vue_version_reads_top_level_compatibility_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(
+        &config_path,
+        r#"{ "compatibility": { "vueVersion": "2.7" } }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        load_compiler_vue_version(Some(&config_path)),
+        Some(VueVersion::V2_7)
+    );
+}
+
+#[test]
 fn load_compiler_vue_version_defaults_to_unset_for_vue3() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("vize.config.json");

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -41,6 +41,13 @@ pub use linter_rule_options::{
 pub use type_checker::TypeCheckerConfig;
 pub use vue::{ParseVueVersionError, VueVersion};
 
+/// Legacy top-level compatibility aliases accepted by older config examples.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(crate) struct RawCompatibilityConfig {
+    pub(crate) vue_version: Option<vue::VueVersion>,
+}
+
 /// Effective shared configuration.
 #[derive(Debug, Clone, Default, Serialize)]
 #[serde(default)]
@@ -179,6 +186,7 @@ pub(crate) struct RawVizeConfig {
     pub dialect: Option<VueDialect>,
     pub formatter: FormatterConfig,
     pub(crate) compiler: RawCompilerConfig,
+    pub(crate) compatibility: RawCompatibilityConfig,
     pub(crate) experimentals: RawExperimentalsConfig,
     pub(crate) vue: RawVueConfig,
     pub linter: RawLinterConfig,
@@ -257,6 +265,7 @@ impl RawVizeConfig {
             dialect,
             formatter,
             compiler,
+            compatibility,
             experimentals,
             vue,
             linter: _,
@@ -272,7 +281,10 @@ impl RawVizeConfig {
 
         // Default-on (matches vue-tsc); explicit `false` opts out.
         let type_checker_options_api = raw_type_checker.options_api.unwrap_or(true);
-        let vue_version = vue.version.or(compiler.compatibility.vue_version);
+        let vue_version = vue
+            .version
+            .or(compiler.compatibility.vue_version)
+            .or(compatibility.vue_version);
         // A Vue 2 / 2.7 dialect implies legacy template lowering. Every consumer
         // downstream of the virtual-TS generator already collapses the two into
         // `legacy_vue2 || dialect ∈ {V2, V2_7}`, but the flag itself gates

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -1,5 +1,6 @@
 //! Shared config model.
 
+mod compatibility;
 mod compiler;
 mod entries;
 mod experimentals;
@@ -40,13 +41,6 @@ pub use linter_rule_options::{
 };
 pub use type_checker::TypeCheckerConfig;
 pub use vue::{ParseVueVersionError, VueVersion};
-
-/// Legacy top-level compatibility aliases accepted by older config examples.
-#[derive(Debug, Clone, Default, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
-pub(crate) struct RawCompatibilityConfig {
-    pub(crate) vue_version: Option<vue::VueVersion>,
-}
 
 /// Effective shared configuration.
 #[derive(Debug, Clone, Default, Serialize)]
@@ -186,7 +180,7 @@ pub(crate) struct RawVizeConfig {
     pub dialect: Option<VueDialect>,
     pub formatter: FormatterConfig,
     pub(crate) compiler: RawCompilerConfig,
-    pub(crate) compatibility: RawCompatibilityConfig,
+    pub(crate) compatibility: compatibility::RawCompatibilityConfig,
     pub(crate) experimentals: RawExperimentalsConfig,
     pub(crate) vue: RawVueConfig,
     pub linter: RawLinterConfig,

--- a/crates/vize_carton/src/config/model/compatibility.rs
+++ b/crates/vize_carton/src/config/model/compatibility.rs
@@ -1,0 +1,8 @@
+use super::vue;
+
+/// Legacy top-level compatibility aliases accepted by older config examples.
+#[derive(Debug, Clone, Default, serde::Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(crate) struct RawCompatibilityConfig {
+    pub(crate) vue_version: Option<vue::VueVersion>,
+}


### PR DESCRIPTION
## Summary
- accept top-level `compatibility.vueVersion` as a legacy alias for Vue compatibility
- thread that alias into lint feature loading so Vue 2.7 disables Vue 3.4-only shorthand diagnostics
- add config-loader and CLI regressions for #5570's `vize.config.ts` shape

Closes #5570

## Verification
- `rtk cargo test -p vize_carton load_compiler_vue_version_reads_top_level_compatibility_key`
- `rtk cargo test -p vize --test lint_vue_compatibility_cli`
- `rtk cargo test -p vize_patina prefer_props_shorthand --lib`
- `rtk cargo fmt --all -- --check`
- `rtk cargo clippy -p vize_carton --lib -- -D warnings -D clippy::wildcard_imports`
- `rtk cargo clippy -p vize_patina --lib -- -D warnings -D clippy::wildcard_imports`
- `rtk node --test tests/tooling/source-file-lengths.test.ts`
- `rtk git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791089603&installation_model_id=422833&pr_number=5639&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5639&signature=ba55c2db656757ef4ebcd883eae8e785d82cd47474f5629f1731c87ad2c4fe84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->