### PR TITLE
fix(canon): keep external tsconfig inputs

### DIFF
--- a/crates/vize/src/commands/check/runner/resolve.rs
+++ b/crates/vize/src/commands/check/runner/resolve.rs
@@ -126,10 +126,9 @@ pub(super) fn project_root_has_package_boundary(project_root: &Path) -> bool {
 pub(super) fn retain_project_files(files: &mut Vec<PathBuf>, project_root: &Path) {
     // Ambient `compilerOptions.types` packages can resolve from an ancestor
     // `node_modules` outside the source root. The virtual project extends the
-    // real tsconfig and lets TypeScript load those packages normally; trying to
-    // mirror them as source roots fails because they have no path relative to
-    // the virtual project root.
-    files.retain(|path| path.starts_with(project_root));
+    // real tsconfig and lets TypeScript load those packages normally.
+    files
+        .retain(|path| path.starts_with(project_root) || !path_has_component(path, "node_modules"));
 }
 
 fn has_source_input_outside_root(root: &Path, files: &[PathBuf]) -> bool {

--- a/crates/vize/src/commands/check/runner/tests.rs
+++ b/crates/vize/src/commands/check/runner/tests.rs
@@ -22,6 +22,7 @@ fn unique_case_dir(name: &str) -> PathBuf {
 }
 
 mod nuxt_root;
+mod retained_files;
 #[test]
 fn suppresses_nuxt_nitro_import_meta_conflict_false_positive() {
     let diagnostic = vize_canon::BatchDiagnostic {

--- a/crates/vize/src/commands/check/runner/tests/retained_files.rs
+++ b/crates/vize/src/commands/check/runner/tests/retained_files.rs
@@ -1,0 +1,15 @@
+use super::unique_case_dir;
+
+#[test]
+fn retains_authored_external_inputs_but_drops_external_node_modules() {
+    let workspace = unique_case_dir("retained-external-inputs");
+    let package_root = workspace.join("packages/app");
+    let app = package_root.join("src/main.ts");
+    let shared = workspace.join("shared/globals.d.ts");
+    let types_package = workspace.join("node_modules/@types/vize/index.d.ts");
+    let mut files = vec![app.clone(), shared.clone(), types_package];
+
+    super::super::resolve::retain_project_files(&mut files, &package_root);
+
+    assert_eq!(files, vec![app, shared]);
+}

--- a/crates/vize/tests/check_tsconfig_outside_package_cli.rs
+++ b/crates/vize/tests/check_tsconfig_outside_package_cli.rs
@@ -1,0 +1,132 @@
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+#[path = "support/corsa_path.rs"]
+mod corsa_path;
+#[path = "support/corsa_requirement.rs"]
+mod corsa_requirement;
+
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use vize_s0::cstr;
+
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn unique_case_dir(name: &str) -> PathBuf {
+    static NEXT_CASE_ID: AtomicUsize = AtomicUsize::new(0);
+    let case_id = NEXT_CASE_ID.fetch_add(1, Ordering::Relaxed);
+    workspace_root().join("target/vize-tests/tests").join(
+        cstr!(
+            "check-tsconfig-outside-package-{name}-{}-{case_id}",
+            std::process::id()
+        )
+        .as_str(),
+    )
+}
+
+fn resolve_test_corsa_path() -> Option<String> {
+    corsa_path::resolve(workspace_root().as_path())
+}
+
+fn write_file(root: &Path, relative_path: &str, content: &str) {
+    let file_path = root.join(relative_path);
+    if let Some(parent) = file_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(file_path, content).unwrap();
+}
+
+fn assert_external_declaration_is_checked(case_name: &str, tsconfig: &str) {
+    let Some(corsa_path) = corsa_requirement::required_or_skip(resolve_test_corsa_path()) else {
+        return;
+    };
+    let workspace = unique_case_dir(case_name);
+    let _ = std::fs::remove_dir_all(&workspace);
+    std::fs::create_dir_all(&workspace).unwrap();
+    write_file(&workspace, "package.json", r#"{ "private": true }"#);
+    write_file(&workspace, "app/package.json", r#"{ "private": true }"#);
+    write_file(&workspace, "app/tsconfig.json", tsconfig);
+    write_file(
+        &workspace,
+        "shared/globals.d.ts",
+        r#"interface AmbientPayload {
+  label: string;
+}
+
+declare const ambientPayload: AmbientPayload;
+"#,
+    );
+    write_file(
+        &workspace,
+        "app/src/a.ts",
+        r#"const label: string = ambientPayload.label;
+export {};
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(workspace.join("app"))
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", "--tsconfig", "tsconfig.json", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "check failed:\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["errorCount"], 0, "{stdout}\n{stderr}");
+    assert_eq!(json["fileCount"], 2, "{stdout}\n{stderr}");
+
+    let _ = std::fs::remove_dir_all(&workspace);
+}
+
+#[test]
+fn check_keeps_tsconfig_files_entry_outside_nearest_package_root() {
+    assert_external_declaration_is_checked(
+        "files",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "files": ["../shared/globals.d.ts", "src/a.ts"]
+}"#,
+    );
+}
+
+#[test]
+fn check_keeps_tsconfig_include_entry_outside_nearest_package_root() {
+    assert_external_declaration_is_checked(
+        "include",
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["../shared/**/*.d.ts", "src/**/*"]
+}"#,
+    );
+}


### PR DESCRIPTION
## Summary
- keep authored tsconfig program inputs outside the nearest package root instead of dropping declaration-only shared files
- continue dropping ancestor node_modules type packages so Corsa can resolve them from the real extended tsconfig
- add unit and CLI regressions for files/include entries outside a package-local tsconfig

Closes #5629.

## Tests
- cargo test -p vize retains_authored_external_inputs_but_drops_external_node_modules --lib
- cargo test -p vize --test check_tsconfig_outside_package_cli
- cargo test -p vize --test check_tsconfig_types_cli check_loads_parent_type_packages_without_mirroring_them_as_sources
- cargo test -p vize --test check_absolute_paths_cli
- cargo test -p vize --lib
- cargo clippy -p vize --lib --test check_tsconfig_outside_package_cli -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check
- node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/davinci-assertion-lint.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791095013&installation_model_id=422833&pr_number=5646&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5646&signature=766e22716e9d5923ee12be914d2c1aaadb2717d9a2eac516aaad538bbbe23720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `vize check` now correctly type-checks ambient declaration files located outside the nearest project root.
  * Type definitions from ancestor `node_modules` directories can now be resolved while unrelated external files remain excluded.

* **Tests**
  * Added coverage for TypeScript configurations referencing shared declarations through `files` and `include` entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->