### PR TITLE
fix(atelier): preserve utf8 in v-for bindings

### DIFF
--- a/crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/scope_prefix.rs
@@ -54,9 +54,28 @@ pub(crate) fn strip_scope_prefixes_for_slot_params(ctx: &CodegenContext, content
             continue;
         }
 
-        result.push(bytes[i] as char);
-        i += 1;
+        let character = content[i..].chars().next().expect("valid UTF-8 boundary");
+        result.push(character);
+        i += character.len_utf8();
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_scope_prefixes_for_slot_params;
+    use crate::{codegen::CodegenContext, options::CodegenOptions};
+    use vize_s0::String;
+
+    #[test]
+    fn preserves_utf8_while_stripping_scope_prefixes() {
+        let mut ctx = CodegenContext::new(CodegenOptions::default());
+        ctx.add_slot_params(&[String::new("i")]);
+
+        let content = "`\u{2795} ${$setup.n}`";
+
+        assert_eq!(strip_scope_prefixes_for_slot_params(&ctx, content), content);
+        assert_eq!(strip_scope_prefixes_for_slot_params(&ctx, "$setup.i"), "i");
+    }
 }

--- a/crates/vize_atelier_dom/src/prefix_identifier_tests.rs
+++ b/crates/vize_atelier_dom/src/prefix_identifier_tests.rs
@@ -1,6 +1,7 @@
 //! Prefix identifier coverage for dynamic DOM keys.
 
 use super::{DomCompilerOptions, compile_template_with_options};
+use vize_atelier_core::options::{BindingMetadata, BindingType, CodegenMode};
 use vize_s0::Allocator;
 
 /// SFC / module-mode compile sets `DomCompilerOptions.prefix_identifiers`, but
@@ -42,4 +43,53 @@ fn prefixed_compound_dynamic_bind_and_on_keys_walk_identifiers() {
         "on key was not prefixed:\n{}",
         on.code
     );
+}
+
+#[test]
+fn v_for_attribute_template_literal_preserves_non_ascii_after_prefixing() {
+    let allocator = Allocator::new();
+    let options = DomCompilerOptions {
+        mode: CodegenMode::Function,
+        prefix_identifiers: true,
+        inline: false,
+        ..Default::default()
+    };
+
+    let (_, errors, result) = compile_template_with_options(
+        &allocator,
+        "<span v-for=\"i in 1\" :title=\"`\u{2795} ${n}`\"></span>",
+        options,
+    );
+
+    assert!(errors.is_empty(), "Errors: {:?}", errors);
+    insta::assert_snapshot!(result.code.as_str());
+}
+
+#[test]
+fn v_for_script_setup_template_literal_preserves_non_ascii_after_prefixing() {
+    use vize_s0::FxHashMap;
+
+    let allocator = Allocator::new();
+    let mut bindings = FxHashMap::default();
+    bindings.insert("n".into(), BindingType::SetupConst);
+    let options = DomCompilerOptions {
+        mode: CodegenMode::Function,
+        prefix_identifiers: true,
+        inline: false,
+        binding_metadata: Some(BindingMetadata {
+            bindings,
+            props_aliases: FxHashMap::default(),
+            is_script_setup: true,
+        }),
+        ..Default::default()
+    };
+
+    let (_, errors, result) = compile_template_with_options(
+        &allocator,
+        "<span v-for=\"i in 1\" :title=\"`\u{2795} ${n}`\"></span>",
+        options,
+    );
+
+    assert!(errors.is_empty(), "Errors: {:?}", errors);
+    insta::assert_snapshot!(result.code.as_str());
 }

--- a/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__prefix_identifier_tests__v_for_attribute_template_literal_preserves_non_ascii_after_prefixing.snap
+++ b/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__prefix_identifier_tests__v_for_attribute_template_literal_preserves_non_ascii_after_prefixing.snap
@@ -1,0 +1,9 @@
+---
+source: crates/vize_atelier_dom/src/prefix_identifier_tests.rs
+expression: result.code.as_str()
+---
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(_Fragment, null, _renderList(1, (i) => {
+    return _createElementVNode("span", { title: `➕ ${_ctx.n}` }, null, 8 /* PROPS */, ["title"])
+  }), 64 /* STABLE_FRAGMENT */))
+}

--- a/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__prefix_identifier_tests__v_for_script_setup_template_literal_preserves_non_ascii_after_prefixing.snap
+++ b/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__prefix_identifier_tests__v_for_script_setup_template_literal_preserves_non_ascii_after_prefixing.snap
@@ -1,0 +1,9 @@
+---
+source: crates/vize_atelier_dom/src/prefix_identifier_tests.rs
+expression: result.code.as_str()
+---
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(_Fragment, null, _renderList(1, (i) => {
+    return _createElementVNode("span", { title: `➕ ${$setup.n}` }, null, 8 /* PROPS */, ["title"])
+  }), 64 /* STABLE_FRAGMENT */))
+}


### PR DESCRIPTION
## Summary
- copy non-stripped scope-prefix text by UTF-8 characters instead of raw bytes
- add a focused scope-prefix unit regression
- snapshot the DOM render output for both `_ctx` and `<script setup>` `$setup` v-for attribute bindings with non-ASCII template literals

Closes #5613.
Supersedes #5614 with the same bug fix adapted to base-repo CI/source-length constraints.

## Tests
- cargo test -p vize_atelier_core preserves_utf8_while_stripping_scope_prefixes --lib
- env INSTA_UPDATE=always cargo test -p vize_atelier_dom v_for_attribute_template_literal_preserves_non_ascii_after_prefixing --lib
- env INSTA_UPDATE=always cargo test -p vize_atelier_dom v_for_script_setup_template_literal_preserves_non_ascii_after_prefixing --lib
- cargo test -p vize_atelier_core --lib
- cargo test -p vize_atelier_dom --lib
- cargo clippy -p vize_atelier_core -p vize_atelier_dom --lib -- -D warnings -D clippy::wildcard_imports
- cargo fmt --check
- node --test tests/tooling/source-file-lengths.test.ts
- node --test tests/tooling/davinci-assertion-lint.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5647"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791095346&installation_model_id=422833&pr_number=5647&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5647&signature=0fa743b9a4282aa66a5345ff3cc3a02c79f54ba8bf4b246f306f2d931f054a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->