### PR TITLE
fix(musea-vrt): count anti-aliased image diffs

### DIFF
--- a/npm/builder/vite-musea/src/cli/commands.test.ts
+++ b/npm/builder/vite-musea/src/cli/commands.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { hasCiBlockingVrtResult, isArtFileInput } from "./commands.ts";
+import { hasCiBlockingVrtResult, isArtFileInput, createVrtOptions } from "./commands.ts";
+import { parseArgs } from "./index.ts";
 import type { VrtSummary } from "../vrt.ts";
 
 function summary(overrides: Partial<VrtSummary>): VrtSummary {
@@ -32,4 +33,43 @@ void test("VRT CI allows clean and newly-created baselines", () => {
 void test("generate rejects existing art-file inputs", () => {
   assert.equal(isArtFileInput("src/components/Button.art.vue"), true);
   assert.equal(isArtFileInput("src/components/Button.vue"), false);
+});
+
+void test("CLI threshold accepts zero as an explicit threshold", () => {
+  const options = parseArgs(["-t", "0"]);
+
+  assert.equal(options.threshold, 0);
+  assert.equal(options.thresholdProvided, true);
+});
+
+void test("CLI VRT options preserve config threshold when CLI threshold is omitted", () => {
+  const options = parseArgs([]);
+  options.vrt = {
+    threshold: 0,
+    capture: { settleTime: 250 },
+    comparison: { antiAliasing: false },
+    viewports: [{ width: 320, height: 240, name: "tiny" }],
+  };
+
+  assert.deepEqual(createVrtOptions(options), {
+    snapshotDir: ".vize/snapshots",
+    threshold: 0,
+    capture: { settleTime: 250 },
+    comparison: { antiAliasing: false },
+    viewports: [{ width: 320, height: 240, name: "tiny" }],
+  });
+});
+
+void test("CLI threshold overrides configured VRT threshold", () => {
+  const options = parseArgs(["--threshold", "0"]);
+  options.vrt = {
+    threshold: 10,
+    comparison: { antiAliasing: false },
+  };
+
+  assert.deepEqual(createVrtOptions(options), {
+    snapshotDir: ".vize/snapshots",
+    threshold: 0,
+    comparison: { antiAliasing: false },
+  });
 });

--- a/npm/builder/vite-musea/src/cli/commands.ts
+++ b/npm/builder/vite-musea/src/cli/commands.ts
@@ -9,8 +9,8 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { MuseaVrtRunner, generateVrtReport, generateVrtJsonReport } from "../vrt.js";
-import type { VrtSummary } from "../vrt.js";
-import type { ArtFileInfo, VrtOptions } from "../types/index.js";
+import type { ExtendedVrtOptions, VrtSummary } from "../vrt.js";
+import type { ArtFileInfo } from "../types/index.js";
 
 import type { CliOptions } from "./index.js";
 
@@ -22,6 +22,17 @@ export function isArtFileInput(filePath: string): boolean {
   return filePath.endsWith(".art.vue");
 }
 
+export function createVrtOptions(options: CliOptions): ExtendedVrtOptions {
+  const configured = options.vrt ?? {};
+  return {
+    ...configured,
+    snapshotDir: path.join(options.output, "snapshots"),
+    threshold: options.thresholdProvided
+      ? options.threshold
+      : (configured.threshold ?? options.threshold),
+  };
+}
+
 export async function runVrt(options: CliOptions, artFiles: ArtFileInfo[]): Promise<void> {
   const totalVariants = artFiles.reduce(
     (sum, art) => sum + art.variants.filter((v) => !v.skipVrt).length,
@@ -30,14 +41,8 @@ export async function runVrt(options: CliOptions, artFiles: ArtFileInfo[]): Prom
 
   console.log(`  Testing ${totalVariants} variant(s) across ${artFiles.length} art file(s)\n`);
 
-  // Initialize VRT runner
-  const vrtOptions: VrtOptions = {
-    snapshotDir: path.join(options.output, "snapshots"),
-    threshold: options.threshold,
-  };
-
   const runner = new MuseaVrtRunner({
-    ...vrtOptions,
+    ...createVrtOptions(options),
     ci: options.ci ? { failOnDiff: true, jsonReport: options.json } : undefined,
   });
 
@@ -139,12 +144,7 @@ export async function runVrt(options: CliOptions, artFiles: ArtFileInfo[]): Prom
 }
 
 export async function runApprove(options: CliOptions, artFiles: ArtFileInfo[]): Promise<void> {
-  const vrtOptions: VrtOptions = {
-    snapshotDir: path.join(options.output, "snapshots"),
-    threshold: options.threshold,
-  };
-
-  const runner = new MuseaVrtRunner(vrtOptions);
+  const runner = new MuseaVrtRunner(createVrtOptions(options));
 
   try {
     console.log("  Launching browser...");
@@ -175,12 +175,7 @@ export async function runApprove(options: CliOptions, artFiles: ArtFileInfo[]): 
 }
 
 export async function runClean(options: CliOptions, artFiles: ArtFileInfo[]): Promise<void> {
-  const vrtOptions: VrtOptions = {
-    snapshotDir: path.join(options.output, "snapshots"),
-    threshold: options.threshold,
-  };
-
-  const runner = new MuseaVrtRunner(vrtOptions);
+  const runner = new MuseaVrtRunner(createVrtOptions(options));
 
   console.log("  Scanning for orphaned snapshots...\n");
 

--- a/npm/builder/vite-musea/src/cli/config.test.ts
+++ b/npm/builder/vite-musea/src/cli/config.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { loadMuseaVrtOptions } from "./config.ts";
+
+void test("loads Musea VRT options from vite config plugin options", async () => {
+  const workspace = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-vrt-config-"));
+  const pluginOptionsUrl = pathToFileURL(path.resolve("src/plugin/options.ts")).href;
+  const configPath = path.join(workspace, "vite.config.ts");
+
+  await fs.promises.writeFile(
+    configPath,
+    `
+      import { attachMuseaOptions } from ${JSON.stringify(pluginOptionsUrl)};
+
+      export default {
+        plugins: [
+          attachMuseaOptions(
+            { name: "vite-plugin-musea" },
+            {
+              vrt: {
+                threshold: 0,
+                viewports: [{ width: 320, height: 240, name: "tiny" }],
+                capture: { settleTime: 250, waitForNetwork: false },
+                comparison: { antiAliasing: false },
+              },
+            },
+          ),
+        ],
+      };
+    `,
+  );
+
+  assert.deepEqual(await loadMuseaVrtOptions(configPath, workspace), {
+    threshold: 0,
+    viewports: [{ width: 320, height: 240, name: "tiny" }],
+    capture: { settleTime: 250, waitForNetwork: false },
+    comparison: { antiAliasing: false },
+  });
+});
+
+void test("ignores vite plugins without Musea VRT options", async () => {
+  const workspace = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-vrt-config-"));
+  const configPath = path.join(workspace, "vite.config.ts");
+
+  await fs.promises.writeFile(
+    configPath,
+    `
+      export default {
+        plugins: [
+          {
+            name: "other-plugin",
+            vrt: {
+              threshold: 0,
+            },
+          },
+        ],
+      };
+    `,
+  );
+
+  assert.equal(await loadMuseaVrtOptions(configPath, workspace), undefined);
+});
+
+void test("missing vite config has no Musea VRT options", async () => {
+  const workspace = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-vrt-config-"));
+
+  assert.equal(await loadMuseaVrtOptions("vite.config.ts", workspace), undefined);
+});

--- a/npm/builder/vite-musea/src/cli/config.ts
+++ b/npm/builder/vite-musea/src/cli/config.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { loadConfigFromFile, type PluginOption } from "vite";
+
+import type { MuseaVrtOptions } from "../types/index.js";
+import { readMuseaOptions } from "../plugin/options.js";
+
+export async function loadMuseaVrtOptions(
+  configPath: string,
+  cwd = process.cwd(),
+): Promise<MuseaVrtOptions | undefined> {
+  const resolvedConfigPath = path.isAbsolute(configPath)
+    ? configPath
+    : path.resolve(cwd, configPath);
+  if (!(await fileExists(resolvedConfigPath))) return undefined;
+
+  const loaded = await loadConfigFromFile(
+    {
+      command: "serve",
+      mode: "development",
+      isPreview: false,
+      isSsrBuild: false,
+    },
+    resolvedConfigPath,
+  );
+  if (!loaded) return undefined;
+
+  const plugins: unknown[] = [];
+  await collectPlugins(loaded.config.plugins, plugins);
+
+  for (const plugin of plugins) {
+    const options = readMuseaOptions(plugin);
+    if (options?.vrt) return options.vrt;
+  }
+  return undefined;
+}
+
+async function collectPlugins(
+  input: PluginOption | Promise<PluginOption> | undefined,
+  plugins: unknown[],
+) {
+  const resolved = await input;
+  if (!resolved) return;
+
+  if (Array.isArray(resolved)) {
+    for (const item of resolved) {
+      await collectPlugins(item, plugins);
+    }
+    return;
+  }
+
+  plugins.push(resolved);
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/npm/builder/vite-musea/src/cli/index.ts
+++ b/npm/builder/vite-musea/src/cli/index.ts
@@ -21,9 +21,13 @@
  *   -h, --help       Show help
  */
 
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { ArtFileInfo } from "../types/index.js";
 import { scanArtFiles, parseArtFile } from "./utils.js";
 import { runVrt, runApprove, runClean, runGenerate } from "./commands.js";
+import { loadMuseaVrtOptions } from "./config.js";
+import type { MuseaVrtOptions } from "../types/index.js";
 
 type Command = "run" | "approve" | "clean" | "generate";
 
@@ -33,6 +37,7 @@ export interface CliOptions {
   config: string;
   output: string;
   threshold: number;
+  thresholdProvided: boolean;
   json: boolean;
   ci: boolean;
   a11y: boolean;
@@ -40,15 +45,17 @@ export interface CliOptions {
   baseUrl: string;
   pattern?: string;
   componentPath?: string;
+  vrt?: MuseaVrtOptions;
 }
 
-function parseArgs(args: string[]): CliOptions {
+export function parseArgs(args: string[]): CliOptions {
   const options: CliOptions = {
     command: "run",
     update: false,
     config: "vite.config.ts",
     output: ".vize",
     threshold: 0.1,
+    thresholdProvided: false,
     json: false,
     ci: false,
     a11y: false,
@@ -100,7 +107,8 @@ function parseArgs(args: string[]): CliOptions {
         break;
       case "-t":
       case "--threshold":
-        options.threshold = parseFloat(args[++i]) || 0.1;
+        options.threshold = parseThreshold(args[++i]);
+        options.thresholdProvided = true;
         break;
       case "--json":
         options.json = true;
@@ -123,6 +131,11 @@ function parseArgs(args: string[]): CliOptions {
   }
 
   return options;
+}
+
+function parseThreshold(value: string | undefined): number {
+  const threshold = Number.parseFloat(value ?? "");
+  return Number.isFinite(threshold) ? threshold : 0.1;
 }
 
 function printHelp(): void {
@@ -208,6 +221,8 @@ async function main(): Promise<void> {
     return;
   }
 
+  options.vrt = await loadMuseaVrtOptions(options.config, cwd);
+
   // Scan for art files
   console.log("  Scanning for art files...");
   const artFilePaths = await scanArtFiles(cwd);
@@ -249,7 +264,14 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error) => {
-  console.error("Fatal error:", error);
-  process.exit(1);
-});
+if (isDirectRun()) {
+  main().catch((error) => {
+    console.error("Fatal error:", error);
+    process.exit(1);
+  });
+}
+
+function isDirectRun(): boolean {
+  const entrypoint = process.argv[1];
+  return entrypoint ? fileURLToPath(import.meta.url) === path.resolve(entrypoint) : false;
+}

--- a/npm/builder/vite-musea/src/index.ts
+++ b/npm/builder/vite-musea/src/index.ts
@@ -17,6 +17,7 @@ export { musea } from "./plugin/index.js";
 
 export type {
   MuseaOptions,
+  MuseaVrtOptions,
   MuseaTokenPreviewConfig,
   MuseaTokenPreviewKind,
   MuseaTokenPreviewRule,

--- a/npm/builder/vite-musea/src/plugin/index.test.ts
+++ b/npm/builder/vite-musea/src/plugin/index.test.ts
@@ -6,6 +6,8 @@ import {
   assertStaticPreviewRuntimeSupported,
   resolveStaticPreviewVueVersion,
 } from "./static-preview.js";
+import { musea } from "./index.js";
+import { readMuseaOptions } from "./options.js";
 
 void test("musea plugin is inactive in Vite test mode", () => {
   assert.equal(shouldApplyMuseaPlugin({ command: "serve", mode: "test" }), false);
@@ -17,6 +19,14 @@ void test("musea plugin remains active during Vite serve outside test mode", () 
 
 void test("musea plugin remains active during production builds", () => {
   assert.equal(shouldApplyMuseaPlugin({ command: "build", mode: "production" }), true);
+});
+
+void test("musea plugin carries VRT options for the CLI config loader", () => {
+  const [plugin] = musea({ vrt: { threshold: 0, comparison: { antiAliasing: false } } });
+
+  assert.deepEqual(readMuseaOptions(plugin), {
+    vrt: { threshold: 0, comparison: { antiAliasing: false } },
+  });
 });
 
 void test("storybook compatibility build does not inject static gallery input by default", () => {

--- a/npm/builder/vite-musea/src/plugin/index.ts
+++ b/npm/builder/vite-musea/src/plugin/index.ts
@@ -38,6 +38,7 @@ import { processMuseaArtFile } from "./art-processing.js";
 import { transformMuseaVirtualModule } from "./virtual-transform.js";
 import { resolvePreviewCssPath } from "./preview-css.js";
 import { resolveStaticPreviewVueVersion } from "./static-preview.js";
+import { attachMuseaOptions } from "./options.js";
 
 export function musea(options: MuseaOptions = {}): Plugin[] {
   let include = options.include ?? ["**/*.art.vue"];
@@ -311,7 +312,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
     if (info) artFiles.set(filePath, info);
   }
 
-  return [mainPlugin];
+  return [attachMuseaOptions(mainPlugin, options)];
 }
 
 function resolveProjectRoot(projectRoot: string | undefined, viteRoot: string): string | undefined {

--- a/npm/builder/vite-musea/src/plugin/options.ts
+++ b/npm/builder/vite-musea/src/plugin/options.ts
@@ -1,0 +1,22 @@
+import type { MuseaOptions } from "../types/index.js";
+
+const MUSEA_OPTIONS_KEY = "__vizeMuseaOptions";
+
+type MuseaPluginOptionsCarrier = {
+  [MUSEA_OPTIONS_KEY]?: MuseaOptions;
+};
+
+export function attachMuseaOptions<T extends object>(plugin: T, options: MuseaOptions): T {
+  Object.defineProperty(plugin, MUSEA_OPTIONS_KEY, {
+    configurable: false,
+    enumerable: false,
+    value: options,
+    writable: false,
+  });
+  return plugin;
+}
+
+export function readMuseaOptions(plugin: unknown): MuseaOptions | undefined {
+  if (!plugin || typeof plugin !== "object") return undefined;
+  return (plugin as MuseaPluginOptionsCarrier)[MUSEA_OPTIONS_KEY];
+}

--- a/npm/builder/vite-musea/src/types/index.ts
+++ b/npm/builder/vite-musea/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { MuseaThemeColors, MuseaTheme, MuseaOptions } from "./plugin.js";
+export type { MuseaThemeColors, MuseaTheme, MuseaOptions, MuseaVrtOptions } from "./plugin.js";
 
 export type {
   MuseaTokenPreviewConfig,

--- a/npm/builder/vite-musea/src/types/plugin.ts
+++ b/npm/builder/vite-musea/src/types/plugin.ts
@@ -1,4 +1,4 @@
-import type { VrtOptions } from "./vrt.js";
+import type { CaptureConfig, CiConfig, ComparisonConfig, VrtOptions } from "./vrt.js";
 import type { MuseaTokenPreviewConfig } from "../tokens/preview.js";
 
 export type MuseaVueVersion = 0.11 | 1 | 2 | "2.7" | 3 | "legacy";
@@ -38,6 +38,12 @@ export interface MuseaTheme {
   base?: "dark" | "light";
   /** Color overrides. */
   colors: MuseaThemeColors;
+}
+
+export interface MuseaVrtOptions extends VrtOptions {
+  capture?: CaptureConfig;
+  comparison?: ComparisonConfig;
+  ci?: CiConfig;
 }
 
 /**
@@ -85,7 +91,7 @@ export interface MuseaOptions {
   /**
    * VRT (Visual Regression Testing) configuration.
    */
-  vrt?: VrtOptions;
+  vrt?: MuseaVrtOptions;
 
   /**
    * Path to a Style Dictionary tokens JSON file/directory or Tailwind CSS theme file.

--- a/npm/builder/vite-musea/src/vrt/runner-comparison.test.ts
+++ b/npm/builder/vite-musea/src/vrt/runner-comparison.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { PNG } from "pngjs";
+
+import { writePng } from "./comparison.ts";
+import { compareImages } from "./runner-comparison.ts";
+
+void test("anti-aliased pixels still count as visual diffs", async () => {
+  const workspace = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-vrt-aa-"));
+  const baselinePath = path.join(workspace, "baseline.png");
+  const currentPath = path.join(workspace, "current.png");
+  const diffPath = path.join(workspace, "diff.png");
+  const baseline = createSolidPng(3, 3, { r: 255, g: 255, b: 255 });
+  const current = createSolidPng(3, 3, { r: 255, g: 255, b: 255 });
+
+  setPixel(current, 1, 1, { r: 0, g: 0, b: 0 });
+  setPixel(current, 1, 0, { r: 0, g: 0, b: 0 });
+  await writePng(baseline, baselinePath);
+  await writePng(current, currentPath);
+
+  const result = await compareImages(baselinePath, currentPath, diffPath, { antiAliasing: true });
+
+  assert.equal(result.diffPixels, 2);
+  assert.equal(result.totalPixels, 9);
+  assert.equal(await fileExists(diffPath), true);
+});
+
+function createSolidPng(
+  width: number,
+  height: number,
+  color: { r: number; g: number; b: number },
+): PNG {
+  const png = new PNG({ width, height });
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      setPixel(png, x, y, color);
+    }
+  }
+  return png;
+}
+
+function setPixel(png: PNG, x: number, y: number, color: { r: number; g: number; b: number }) {
+  const idx = (y * png.width + x) * 4;
+  png.data[idx] = color.r;
+  png.data[idx + 1] = color.g;
+  png.data[idx + 2] = color.b;
+  png.data[idx + 3] = 255;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.promises.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/npm/builder/vite-musea/src/vrt/runner-comparison.ts
+++ b/npm/builder/vite-musea/src/vrt/runner-comparison.ts
@@ -229,6 +229,7 @@ export async function compareImages(
         // Anti-aliasing detection: check if pixel is likely AA
         if (useAntiAliasing && isAntiAliased(baseline, current, x, y, width, height)) {
           // Mark as AA (yellow)
+          diffPixels++;
           diff.data[idx] = 255;
           diff.data[idx + 1] = 200;
           diff.data[idx + 2] = 0;


### PR DESCRIPTION
Closes #5580.

## Summary
- Count anti-aliased image differences in Musea VRT threshold decisions.
- Keep VRT comparison configuration reachable from the Vite config path.

## Tests
- CI required checks are running on this PR.