### PR TITLE
fix(ci): unblock every pull request — app-readiness rows and their in-row builds

### DIFF
--- a/.github/actions/setup-ubuntu-archive/action.yml
+++ b/.github/actions/setup-ubuntu-archive/action.yml
@@ -13,3 +13,8 @@ runs:
           exit 0
         fi
         printf '%s\n' 'http://archive.ubuntu.com/ubuntu' | sudo tee "$mirror_list" >/dev/null
+        sudo tee /etc/apt/apt.conf.d/80-vize-retry-downloads >/dev/null <<'APT'
+        Acquire::Retries "5";
+        Acquire::http::Timeout "30";
+        Acquire::https::Timeout "30";
+        APT

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -143,7 +143,7 @@ jobs:
     needs: app-readiness-plan
     if: needs.app-readiness-plan.outputs.run == 'true'
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.app-readiness-plan.outputs.matrix) }}

--- a/tests/_helpers/vize-local-packages.ts
+++ b/tests/_helpers/vize-local-packages.ts
@@ -110,7 +110,13 @@ export function ensureLocalVizePackagesBuilt(): void {
       execFileSync("npx", ["-y", "pnpm@10", "--filter", target.filter, "build"], {
         cwd: REPO_ROOT,
         stdio: "inherit",
-        timeout: 300_000,
+        // Every App E2E row runs this before its own fixture setup, and a
+        // release commit lands every pull request on a cold cache at once
+        // — where `@vizejs/vite-plugin` alone has passed five minutes. A
+        // build that overruns should slow the row down, not fail it with
+        // `spawnSync npx ETIMEDOUT`; the row's own budget is the limit
+        // that means something.
+        timeout: 900_000,
       });
     }
 

--- a/tests/tooling/github-workflows-check.test.ts
+++ b/tests/tooling/github-workflows-check.test.ts
@@ -45,7 +45,7 @@ test("PR CI jobs cap runtime with explicit timeouts", () => {
 
   for (const [jobName, minutes] of [
     ["app-readiness-plan", 10],
-    ["app-readiness-producer", 30],
+    ["app-readiness-producer", 40],
     ["app-readiness", 5],
   ] as const) {
     assert.match(

--- a/tests/tooling/github-workflows-setup.test.ts
+++ b/tests/tooling/github-workflows-setup.test.ts
@@ -7,6 +7,9 @@ test("apt-based CI setup pins Blacksmith to the canonical Ubuntu archive", () =>
   const action = readRepoFile(".github", "actions", "setup-ubuntu-archive", "action.yml");
   assert.match(action, /\/etc\/apt\/blacksmith-ubuntu-mirrors\.txt/);
   assert.match(action, /http:\/\/archive\.ubuntu\.com\/ubuntu/);
+  assert.match(action, /Acquire::Retries "5";/);
+  assert.match(action, /Acquire::http::Timeout "30";/);
+  assert.match(action, /Acquire::https::Timeout "30";/);
 
   const row = readRepoFile(".github", "actions", "app-e2e-row", "action.yml");
   const rowSetup = row.indexOf("uses: ./.github/actions/setup-ubuntu-archive");

--- a/tests/tooling/playwright-app-config.test.ts
+++ b/tests/tooling/playwright-app-config.test.ts
@@ -37,6 +37,14 @@ test("external fixture installs use the guarded helper", () => {
   assert.match(pnpmConfig, /minimumReleaseAgeExclude/);
 });
 
+test("misskey fixture install uses the cold-cache app readiness budget", () => {
+  const apps = readRepoFile("tests", "_helpers", "apps.ts");
+  assert.match(
+    apps,
+    /installPnpmDependencies\(misskeyDir,\s*\{[\s\S]*?ignoreScripts:\s*true,[\s\S]*?timeout:\s*900_000,/,
+  );
+});
+
 test("fixture pnpm workspace patch adds one release-age exclude", () => {
   const tempRoot = fs.mkdtempSync(path.join(root, ".fixture-pnpm-config-"));
   const workspacePath = path.join(tempRoot, "pnpm-workspace.yaml");


### PR DESCRIPTION
## Why

Every open pull request in the repository — mine and other authors' — is failing `app-readiness`, which blocks all merges.

There are **two** limits involved, one hiding the other.

### 1. The row budget killed the row first (exit code 124)

| row | budget | observed |
| --- | ---: | ---: |
| `lint` | 5m | ~5m59s (killed) |
| `dev-misskey` | 8m | ~9m36s (killed) |
| `check` | 8m | killed before reaching its assertions |
| `dev-nuxt-ui` | 8m | killed |

### 2. Underneath it, an in-row build cap (`spawnSync npx ETIMEDOUT`)

With the budgets raised, the rows ran on and reported the real cause:

```
[vize:setup] building @vizejs/vite-plugin...
Error: spawnSync npx ETIMEDOUT
  at tests/_helpers/vize-local-packages.ts:110
```

`ensureLocalVizePackagesBuilt` caps each local package build at five minutes. Every App E2E row runs it *before* its own fixture setup — which is exactly why `lint`, `check`, `dev-misskey` and `dev-nuxt-ui` all failed the same way, and `build` and `check-vuefes`, which finish before the cache goes cold, did not.

### What made it start now

Nothing about the work changed. The `v0.391.0` release commit (`0fe677a7b`) bumped every version, and because a pull request is tested as its **merge with `main`**, every open PR went cold-cache at the same moment. The ledger PR passed this gate at 06:19 and 06:35 and fails after ~07:00, which brackets the release.

## What

**Row budgets** — a readiness row runs the same command over the same fixture as its `full` counterpart, so it gets the same wall clock:

| row | before | after | rationale |
| --- | ---: | ---: | --- |
| `lint` | 5m | **10m** | full `lint/all` is 10m |
| `dev-misskey` | 8m | **12m** | full `dev/misskey` is 12m |
| `dev-nuxt-ui` | 8m | **15m** | full `dev/nuxt-ui` is 15m |
| `check` | 8m | **20m** | full `check/all` is 75m over a wider fixture set |

`check-vuefes` (2m) and `build` (3m) pass and keep their budgets — evidence-driven, not a blanket raise. The producer job's cap goes 30m → 40m so the widest row plus checkout, toolchain and install still fits.

**In-row builds** — `ensureLocalVizePackagesBuilt` 5m → 15m, and misskey's six workspace builds 2m → 5m each.

## Not weakened

No assertion changes. A row that fails still fails; a build that overruns now slows its row down instead of failing it, and the row's own budget — the limit that means something — is the one that fires first. The rule is written next to both tables so it does not drift back.

The planner's JS mirror and the pinned expectations (`app-e2e-plan`, `github-workflows-check`) move with the Rust planner; `app-e2e-plan`, `app-e2e-plan-dispatch`, `e2e-workflow`, `e2e-tasks`, `github-workflows-check` pass locally (29/29).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end test reliability by allowing additional time for application readiness and local package builds.
  - Added coverage to verify fixture setup uses the expected dependency installation safeguards and timeout settings.

- **Chores**
  - Updated automated workflow checks to reflect the extended readiness window, reducing failures caused by cold caches or slower environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->