### PR TITLE
perf(canon): cache package route fs probes

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -71,6 +71,7 @@ pub(super) fn collect_transitive_local_imports_with_resolver(
     aliases: Option<&PathAliasResolver>,
     packages: &mut PackageRouteResolver,
 ) -> TransitiveLocalImports {
+    packages.begin_validation_epoch();
     let options = options.into();
     let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
     let mut registered: FxHashSet<PathBuf> = FxHashSet::default();

--- a/crates/vize_canon/src/package_route.rs
+++ b/crates/vize_canon/src/package_route.rs
@@ -8,7 +8,7 @@
 use std::path::{Component, Path, PathBuf};
 
 use serde_json::Value;
-use vize_carton::cstr;
+use vize_carton::{FxHashMap, cstr};
 
 #[path = "package_route/cache.rs"]
 mod cache;
@@ -60,11 +60,37 @@ impl PackageSourceOptions {
     }
 }
 
+#[derive(Default)]
+pub(super) struct PackagePathCache {
+    paths: FxHashMap<PathBuf, PathBuf>,
+}
+
+impl PackagePathCache {
+    fn clear(&mut self) {
+        self.paths.clear();
+    }
+
+    fn canonicalize(&mut self, path: &Path) -> PathBuf {
+        if let Some(cached) = self.paths.get(path) {
+            return cached.clone();
+        }
+        let canonical = vize_carton::path::canonicalize_non_verbatim(path);
+        self.paths.insert(path.to_path_buf(), canonical.clone());
+        canonical
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.paths.len()
+    }
+}
+
 fn lookup_uncached(
     importer_dir: &Path,
     specifier: &str,
     options: PackageSourceOptions,
     search: &mut PackageSearchCache,
+    canonical_paths: &mut PackagePathCache,
 ) -> PackageRouteLookup {
     let mut invalidation_paths = Vec::new();
     let mut watchable_negative = false;
@@ -75,6 +101,7 @@ fn lookup_uncached(
         &mut invalidation_paths,
         search,
         &mut watchable_negative,
+        canonical_paths,
     );
     if let Some(route) = route.as_ref() {
         invalidation_paths.extend(route.invalidation_paths());
@@ -97,6 +124,7 @@ fn resolve_uncached(
     invalidation_paths: &mut Vec<PathBuf>,
     search: &mut PackageSearchCache,
     watchable_negative: &mut bool,
+    canonical_paths: &mut PackagePathCache,
 ) -> Option<PackageRoute> {
     let (package_link_root, manifest, request, package_name) = if specifier.starts_with('#') {
         let (root, manifest) = nearest_package_manifest(importer_dir, invalidation_paths, search)?;
@@ -123,8 +151,8 @@ fn resolve_uncached(
             .map_or_else(|| ".".to_owned(), |subpath| cstr!("./{subpath}").into());
         (root, manifest, request, Some(package_name))
     };
-    let package_root = canonical_path(&package_link_root);
-    let manifest_path = canonical_path(&package_root.join("package.json"));
+    let package_root = canonical_path(&package_link_root, canonical_paths);
+    let manifest_path = canonical_path(&package_root.join("package.json"), canonical_paths);
     let mappings = if specifier.starts_with('#') {
         manifest.get("imports")
     } else {
@@ -150,6 +178,7 @@ fn resolve_uncached(
                 invalidation_paths,
                 search,
                 watchable_negative,
+                canonical_paths,
             ) {
                 nested_routes.push(route);
             }
@@ -165,16 +194,19 @@ fn resolve_uncached(
     let mut source_targets = Vec::new();
     for candidate in &candidates {
         invalidation_paths.push(candidate.clone());
-        let mut resolved = resolve_sources(candidate, options, invalidation_paths);
+        let mut resolved = resolve_sources(candidate, options, invalidation_paths, canonical_paths);
         if resolved.is_empty() && candidate.extension().is_some_and(|ext| ext == "vue") {
             resolved.push(source::ResolvedPackageSource {
-                source_path: canonical_path(candidate),
-                native_probe_path: canonical_path(&candidate.with_extension("d.vue.ts")),
+                source_path: canonical_path(candidate, canonical_paths),
+                native_probe_path: canonical_path(
+                    &candidate.with_extension("d.vue.ts"),
+                    canonical_paths,
+                ),
             });
         }
         for source in resolved {
             let route_source = PackageRouteSource {
-                target_path: canonical_path(candidate),
+                target_path: canonical_path(candidate, canonical_paths),
                 source_path: source.source_path,
                 native_probe_path: source.native_probe_path,
             };
@@ -217,8 +249,8 @@ fn inside_node_modules(path: &Path) -> bool {
         .any(|component| matches!(component, Component::Normal(part) if part == "node_modules"))
 }
 
-fn canonical_path(path: &Path) -> PathBuf {
-    vize_carton::path::canonicalize_non_verbatim(path)
+fn canonical_path(path: &Path, cache: &mut PackagePathCache) -> PathBuf {
+    cache.canonicalize(path)
 }
 
 /// Preserve the logical package spelling, including a workspace symlink.

--- a/crates/vize_canon/src/package_route/cache.rs
+++ b/crates/vize_canon/src/package_route/cache.rs
@@ -11,6 +11,10 @@ use super::{
     PackagePathCache, PackageResolutionContext, PackageRoute, PackageRouteMetrics,
     PackageSourceOptions, logical_absolute, lookup_uncached,
 };
+pub use lookup::PackageRouteLookup;
+
+#[path = "cache_lookup.rs"]
+mod lookup;
 
 type ResolutionKey = (
     PathBuf,
@@ -60,23 +64,6 @@ struct CachedPackageRouteLookup {
     stamps: Vec<InputStamp>,
     last_used: u64,
     last_validated_epoch: u64,
-}
-
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct PackageRouteLookup {
-    pub(super) route: Option<PackageRoute>,
-    pub(super) invalidation_paths: Vec<PathBuf>,
-    pub(super) watchable_negative: bool,
-}
-
-impl PackageRouteLookup {
-    pub fn into_parts(self) -> (Option<PackageRoute>, Vec<PathBuf>) {
-        (self.route, self.invalidation_paths)
-    }
-
-    pub fn is_watchable_negative(&self) -> bool {
-        self.route.is_none() && self.watchable_negative
-    }
 }
 
 impl PackageRouteResolver {
@@ -358,79 +345,5 @@ impl PackageRouteResolver {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{PackageRouteResolver, RESOLUTION_CACHE_CAPACITY};
-
-    #[test]
-    fn route_cache_has_a_measured_hard_bound() {
-        let root = tempfile::tempdir().unwrap();
-        let importer = root.path().join("src");
-        std::fs::create_dir_all(&importer).unwrap();
-        let mut resolver = PackageRouteResolver::default();
-        for index in 0..=RESOLUTION_CACHE_CAPACITY {
-            let _ = resolver.lookup(
-                &importer,
-                &format!("package-{index}"),
-                crate::PackageSourceOptions::new(false, false),
-            );
-        }
-
-        let metrics = resolver.metrics();
-        assert_eq!(
-            metrics.resolution_cache_entries,
-            RESOLUTION_CACHE_CAPACITY as u64
-        );
-        assert_eq!(metrics.resolution_cache_evictions, 1);
-    }
-
-    #[test]
-    fn validation_epoch_reuses_stamp_snapshots_for_shared_route_inputs() {
-        let root = tempfile::tempdir().unwrap();
-        let importer = root.path().join("packages/app/src");
-        std::fs::create_dir_all(&importer).unwrap();
-        write_package(
-            root.path(),
-            "pkg-a",
-            r#"{"name":"pkg-a","types":"./index.ts"}"#,
-        );
-        write_package(
-            root.path(),
-            "pkg-b",
-            r#"{"name":"pkg-b","types":"./index.ts"}"#,
-        );
-        let mut resolver = PackageRouteResolver::default();
-        resolver.begin_validation_epoch();
-
-        let _ = resolver.lookup(
-            &importer,
-            "pkg-a",
-            crate::PackageSourceOptions::new(false, false),
-        );
-        let _ = resolver.lookup(
-            &importer,
-            "pkg-b",
-            crate::PackageSourceOptions::new(false, false),
-        );
-
-        let (canonical_paths, stamp_paths, stamp_captures) =
-            resolver.debug_validation_cache_counts();
-        assert!(canonical_paths > 0);
-        assert!(stamp_paths > 0);
-        assert_eq!(stamp_captures, stamp_paths);
-
-        let _ = resolver.lookup(
-            &importer,
-            "pkg-a",
-            crate::PackageSourceOptions::new(false, false),
-        );
-        let (_, _, repeated_stamp_captures) = resolver.debug_validation_cache_counts();
-        assert_eq!(repeated_stamp_captures, stamp_captures);
-    }
-
-    fn write_package(root: &std::path::Path, name: &str, manifest: &str) {
-        let package = root.join("packages/app/node_modules").join(name);
-        std::fs::create_dir_all(&package).unwrap();
-        std::fs::write(package.join("package.json"), manifest).unwrap();
-        std::fs::write(package.join("index.ts"), "export const value = 1;\n").unwrap();
-    }
-}
+#[path = "cache_tests.rs"]
+mod tests;

--- a/crates/vize_canon/src/package_route/cache.rs
+++ b/crates/vize_canon/src/package_route/cache.rs
@@ -3,10 +3,13 @@ use std::path::{Path, PathBuf};
 use vize_carton::{FxHashMap, String};
 
 use super::search::PackageSearchCache;
-use super::stamp::{InputStamp, stamp_paths, stamps_are_current};
+use super::stamp::{
+    InputStamp, InputStampCache, stamp_paths, stamp_paths_with_cache, stamps_are_current,
+    stamps_are_current_with_cache,
+};
 use super::{
-    PackageResolutionContext, PackageRoute, PackageRouteMetrics, PackageSourceOptions,
-    logical_absolute, lookup_uncached,
+    PackagePathCache, PackageResolutionContext, PackageRoute, PackageRouteMetrics,
+    PackageSourceOptions, logical_absolute, lookup_uncached,
 };
 
 type ResolutionKey = (
@@ -31,6 +34,9 @@ pub struct PackageRouteResolver {
 struct PackageRouteResolverState {
     resolutions: FxHashMap<ResolutionKey, CachedPackageRouteLookup>,
     search: PackageSearchCache,
+    canonical_paths: PackagePathCache,
+    stamp_snapshots: InputStampCache,
+    validation_epoch: u64,
     cache_hits: u64,
     cache_misses: u64,
     refresh_considered_routes: u64,
@@ -53,6 +59,7 @@ struct CachedPackageRouteLookup {
     lookup: PackageRouteLookup,
     stamps: Vec<InputStamp>,
     last_used: u64,
+    last_validated_epoch: u64,
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -73,6 +80,17 @@ impl PackageRouteLookup {
 }
 
 impl PackageRouteResolver {
+    pub fn begin_validation_epoch(&mut self) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.validation_epoch = state.validation_epoch.wrapping_add(1).max(1);
+        state.canonical_paths.clear();
+        state.stamp_snapshots.clear();
+        state.search.begin_validation_epoch();
+    }
+
     /// Derive one importer occurrence context through the resolver-owned
     /// manifest cache. The returned inputs join the binding's reverse index.
     pub fn resolution_context(
@@ -148,11 +166,32 @@ impl PackageRouteResolver {
             options,
             context,
         );
-        let cached = state
-            .resolutions
-            .get(&key)
-            .filter(|cached| stamps_are_current(&cached.stamps))
-            .map(|cached| cached.lookup.clone());
+        let validation_epoch = state.validation_epoch;
+        let cached_entry = state.resolutions.get(&key).map(|cached| {
+            (
+                cached.last_validated_epoch,
+                cached.stamps.clone(),
+                cached.lookup.clone(),
+            )
+        });
+        let cached = cached_entry.and_then(|(last_validated_epoch, stamps, lookup)| {
+            let current = validation_epoch != 0 && last_validated_epoch == validation_epoch
+                || if validation_epoch == 0 {
+                    stamps_are_current(&stamps)
+                } else {
+                    stamps_are_current_with_cache(&stamps, &mut state.stamp_snapshots)
+                };
+            if current {
+                if validation_epoch != 0
+                    && let Some(cached) = state.resolutions.get_mut(&key)
+                {
+                    cached.last_validated_epoch = validation_epoch;
+                }
+                Some(lookup)
+            } else {
+                None
+            }
+        });
         if let Some(cached) = cached {
             state.clock = state.clock.wrapping_add(1);
             let clock = state.clock;
@@ -164,8 +203,23 @@ impl PackageRouteResolver {
         }
         state.cache_misses += 1;
         state.resolutions.remove(&key);
-        let lookup = lookup_uncached(&logical_importer_dir, specifier, options, &mut state.search);
-        let stamps = stamp_paths(&lookup.invalidation_paths);
+        if state.validation_epoch == 0 {
+            state.canonical_paths.clear();
+        }
+        let mut canonical_paths = std::mem::take(&mut state.canonical_paths);
+        let lookup = lookup_uncached(
+            &logical_importer_dir,
+            specifier,
+            options,
+            &mut state.search,
+            &mut canonical_paths,
+        );
+        state.canonical_paths = canonical_paths;
+        let stamps = if state.validation_epoch == 0 {
+            stamp_paths(&lookup.invalidation_paths)
+        } else {
+            stamp_paths_with_cache(&lookup.invalidation_paths, &mut state.stamp_snapshots)
+        };
         if state.resolutions.len() >= RESOLUTION_CACHE_CAPACITY {
             let oldest = state
                 .resolutions
@@ -179,12 +233,14 @@ impl PackageRouteResolver {
         }
         state.clock = state.clock.wrapping_add(1);
         let clock = state.clock;
+        let validation_epoch = state.validation_epoch;
         state.resolutions.insert(
             key,
             CachedPackageRouteLookup {
                 lookup: lookup.clone(),
                 stamps,
                 last_used: clock,
+                last_validated_epoch: validation_epoch,
             },
         );
         lookup
@@ -197,6 +253,9 @@ impl PackageRouteResolver {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         state.resolutions.clear();
         state.search.clear();
+        state.canonical_paths.clear();
+        state.stamp_snapshots.clear();
+        state.validation_epoch = 0;
         state.cache_hits = 0;
         state.cache_misses = 0;
         state.refresh_considered_routes = 0;
@@ -283,6 +342,19 @@ impl PackageRouteResolver {
             last_reachability_packages: state.last_reachability_packages,
         }
     }
+
+    #[cfg(test)]
+    fn debug_validation_cache_counts(&self) -> (usize, usize, usize) {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (
+            state.canonical_paths.len(),
+            state.stamp_snapshots.len(),
+            state.stamp_snapshots.captures(),
+        )
+    }
 }
 
 #[cfg(test)]
@@ -309,5 +381,56 @@ mod tests {
             RESOLUTION_CACHE_CAPACITY as u64
         );
         assert_eq!(metrics.resolution_cache_evictions, 1);
+    }
+
+    #[test]
+    fn validation_epoch_reuses_stamp_snapshots_for_shared_route_inputs() {
+        let root = tempfile::tempdir().unwrap();
+        let importer = root.path().join("packages/app/src");
+        std::fs::create_dir_all(&importer).unwrap();
+        write_package(
+            root.path(),
+            "pkg-a",
+            r#"{"name":"pkg-a","types":"./index.ts"}"#,
+        );
+        write_package(
+            root.path(),
+            "pkg-b",
+            r#"{"name":"pkg-b","types":"./index.ts"}"#,
+        );
+        let mut resolver = PackageRouteResolver::default();
+        resolver.begin_validation_epoch();
+
+        let _ = resolver.lookup(
+            &importer,
+            "pkg-a",
+            crate::PackageSourceOptions::new(false, false),
+        );
+        let _ = resolver.lookup(
+            &importer,
+            "pkg-b",
+            crate::PackageSourceOptions::new(false, false),
+        );
+
+        let (canonical_paths, stamp_paths, stamp_captures) =
+            resolver.debug_validation_cache_counts();
+        assert!(canonical_paths > 0);
+        assert!(stamp_paths > 0);
+        assert_eq!(stamp_captures, stamp_paths);
+
+        let _ = resolver.lookup(
+            &importer,
+            "pkg-a",
+            crate::PackageSourceOptions::new(false, false),
+        );
+        let (_, _, repeated_stamp_captures) = resolver.debug_validation_cache_counts();
+        assert_eq!(repeated_stamp_captures, stamp_captures);
+    }
+
+    fn write_package(root: &std::path::Path, name: &str, manifest: &str) {
+        let package = root.join("packages/app/node_modules").join(name);
+        std::fs::create_dir_all(&package).unwrap();
+        std::fs::write(package.join("package.json"), manifest).unwrap();
+        std::fs::write(package.join("index.ts"), "export const value = 1;\n").unwrap();
     }
 }

--- a/crates/vize_canon/src/package_route/cache_lookup.rs
+++ b/crates/vize_canon/src/package_route/cache_lookup.rs
@@ -1,0 +1,20 @@
+use std::path::PathBuf;
+
+use super::super::PackageRoute;
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct PackageRouteLookup {
+    pub(in crate::package_route) route: Option<PackageRoute>,
+    pub(in crate::package_route) invalidation_paths: Vec<PathBuf>,
+    pub(in crate::package_route) watchable_negative: bool,
+}
+
+impl PackageRouteLookup {
+    pub fn into_parts(self) -> (Option<PackageRoute>, Vec<PathBuf>) {
+        (self.route, self.invalidation_paths)
+    }
+
+    pub fn is_watchable_negative(&self) -> bool {
+        self.route.is_none() && self.watchable_negative
+    }
+}

--- a/crates/vize_canon/src/package_route/cache_tests.rs
+++ b/crates/vize_canon/src/package_route/cache_tests.rs
@@ -1,0 +1,73 @@
+use super::{PackageRouteResolver, RESOLUTION_CACHE_CAPACITY};
+
+#[test]
+fn route_cache_has_a_measured_hard_bound() {
+    let root = tempfile::tempdir().unwrap();
+    let importer = root.path().join("src");
+    std::fs::create_dir_all(&importer).unwrap();
+    let mut resolver = PackageRouteResolver::default();
+    for index in 0..=RESOLUTION_CACHE_CAPACITY {
+        let _ = resolver.lookup(
+            &importer,
+            &format!("package-{index}"),
+            crate::PackageSourceOptions::new(false, false),
+        );
+    }
+
+    let metrics = resolver.metrics();
+    assert_eq!(
+        metrics.resolution_cache_entries,
+        RESOLUTION_CACHE_CAPACITY as u64
+    );
+    assert_eq!(metrics.resolution_cache_evictions, 1);
+}
+
+#[test]
+fn validation_epoch_reuses_stamp_snapshots_for_shared_route_inputs() {
+    let root = tempfile::tempdir().unwrap();
+    let importer = root.path().join("packages/app/src");
+    std::fs::create_dir_all(&importer).unwrap();
+    write_package(
+        root.path(),
+        "pkg-a",
+        r#"{"name":"pkg-a","types":"./index.ts"}"#,
+    );
+    write_package(
+        root.path(),
+        "pkg-b",
+        r#"{"name":"pkg-b","types":"./index.ts"}"#,
+    );
+    let mut resolver = PackageRouteResolver::default();
+    resolver.begin_validation_epoch();
+
+    let _ = resolver.lookup(
+        &importer,
+        "pkg-a",
+        crate::PackageSourceOptions::new(false, false),
+    );
+    let _ = resolver.lookup(
+        &importer,
+        "pkg-b",
+        crate::PackageSourceOptions::new(false, false),
+    );
+
+    let (canonical_paths, stamp_paths, stamp_captures) = resolver.debug_validation_cache_counts();
+    assert!(canonical_paths > 0);
+    assert!(stamp_paths > 0);
+    assert_eq!(stamp_captures, stamp_paths);
+
+    let _ = resolver.lookup(
+        &importer,
+        "pkg-a",
+        crate::PackageSourceOptions::new(false, false),
+    );
+    let (_, _, repeated_stamp_captures) = resolver.debug_validation_cache_counts();
+    assert_eq!(repeated_stamp_captures, stamp_captures);
+}
+
+fn write_package(root: &std::path::Path, name: &str, manifest: &str) {
+    let package = root.join("packages/app/node_modules").join(name);
+    std::fs::create_dir_all(&package).unwrap();
+    std::fs::write(package.join("package.json"), manifest).unwrap();
+    std::fs::write(package.join("index.ts"), "export const value = 1;\n").unwrap();
+}

--- a/crates/vize_canon/src/package_route/search.rs
+++ b/crates/vize_canon/src/package_route/search.rs
@@ -3,14 +3,16 @@ use std::path::{Path, PathBuf};
 use serde_json::Value;
 use vize_carton::FxHashMap;
 
-use super::stamp::{InputStamp, manifest_path};
+use super::stamp::{InputStamp, InputStampCache, manifest_path};
 
 const MANIFEST_CACHE_CAPACITY: usize = 1_024;
 
 #[derive(Default)]
 pub(super) struct PackageSearchCache {
     manifests: FxHashMap<PathBuf, CachedManifest>,
+    stamp_snapshots: InputStampCache,
     manifest_reads: u64,
+    validation_epoch: u64,
     clock: u64,
     evictions: u64,
 }
@@ -19,14 +21,22 @@ struct CachedManifest {
     stamp: InputStamp,
     value: Option<Value>,
     last_used: u64,
+    last_validated_epoch: u64,
 }
 
 impl PackageSearchCache {
     pub(super) fn clear(&mut self) {
         self.manifests.clear();
+        self.stamp_snapshots.clear();
         self.manifest_reads = 0;
+        self.validation_epoch = 0;
         self.clock = 0;
         self.evictions = 0;
+    }
+
+    pub(super) fn begin_validation_epoch(&mut self) {
+        self.validation_epoch = self.validation_epoch.wrapping_add(1).max(1);
+        self.stamp_snapshots.clear();
     }
 
     pub(super) fn manifest_reads(&self) -> u64 {
@@ -43,20 +53,31 @@ impl PackageSearchCache {
 
     fn read_manifest(&mut self, root: &Path) -> Option<Value> {
         let path = manifest_path(root);
-        let cached = self
-            .manifests
-            .get(&path)
-            .filter(|cached| cached.stamp.is_current())
-            .map(|cached| cached.value.clone());
-        if let Some(cached) = cached {
-            self.clock = self.clock.wrapping_add(1);
-            if let Some(entry) = self.manifests.get_mut(&path) {
-                entry.last_used = self.clock;
+        let validation_epoch = self.validation_epoch;
+        if let Some(cached) = self.manifests.get_mut(&path) {
+            let current = validation_epoch != 0 && cached.last_validated_epoch == validation_epoch
+                || if validation_epoch == 0 {
+                    cached.stamp.is_current()
+                } else {
+                    cached
+                        .stamp
+                        .is_current_with_cache(&mut self.stamp_snapshots)
+                };
+            if current {
+                if validation_epoch != 0 {
+                    cached.last_validated_epoch = validation_epoch;
+                }
+                self.clock = self.clock.wrapping_add(1);
+                cached.last_used = self.clock;
+                return cached.value.clone();
             }
-            return cached;
         }
         self.manifests.remove(&path);
-        let stamp = InputStamp::capture(&path);
+        let stamp = if self.validation_epoch == 0 {
+            InputStamp::capture(&path)
+        } else {
+            self.stamp_snapshots.capture(&path)
+        };
         self.manifest_reads += 1;
         let value = std::fs::read_to_string(&path)
             .ok()
@@ -79,6 +100,7 @@ impl PackageSearchCache {
                 stamp,
                 value: value.clone(),
                 last_used: self.clock,
+                last_validated_epoch: self.validation_epoch,
             },
         );
         value

--- a/crates/vize_canon/src/package_route/source.rs
+++ b/crates/vize_canon/src/package_route/source.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 use vize_carton::cstr;
 
-use super::{PackageSourceOptions, canonical_path};
+use super::{PackagePathCache, PackageSourceOptions, canonical_path};
 
 pub(super) struct ResolvedPackageSource {
     pub(super) source_path: PathBuf,
@@ -26,18 +26,28 @@ pub(super) fn resolve_sources(
     base: &Path,
     options: PackageSourceOptions,
     consulted: &mut Vec<PathBuf>,
+    canonical_paths: &mut PackagePathCache,
 ) -> Vec<ResolvedPackageSource> {
     let mut resolved = Vec::new();
     // A declaration sidecar stands in for its runtime module even when that
     // module is absent, so probe it before requiring `base` on disk.
     for sidecar in declaration_sidecars(base) {
-        record_if_file(&sidecar, &sidecar, consulted, &mut resolved);
+        record_if_file(
+            &sidecar,
+            &sidecar,
+            consulted,
+            &mut resolved,
+            canonical_paths,
+        );
     }
-    consulted.push(canonical_path(base));
+    consulted.push(canonical_path(base, canonical_paths));
     if base.is_file() && accepted_source(base, options) {
         resolved.push(ResolvedPackageSource {
-            source_path: canonical_path(base),
-            native_probe_path: canonical_path(&native_probe_for_source(base, base)),
+            source_path: canonical_path(base, canonical_paths),
+            native_probe_path: canonical_path(
+                &native_probe_for_source(base, base),
+                canonical_paths,
+            ),
         });
     }
     // A manifest may name the built runtime target (`./dist/index.js`) that a
@@ -45,17 +55,29 @@ pub(super) fn resolve_sources(
     // extension in the same place, so swap the extension before appending one.
     for twin in typescript_twins(base) {
         let probe = native_probe_for_source(base, &twin);
-        record_if_file(&twin, &probe, consulted, &mut resolved);
+        record_if_file(&twin, &probe, consulted, &mut resolved, canonical_paths);
     }
     for extension in source_extensions(options) {
         let candidate = append_extension(base, extension);
         let probe = native_probe_for_source(base, &candidate);
-        record_if_file(&candidate, &probe, consulted, &mut resolved);
+        record_if_file(
+            &candidate,
+            &probe,
+            consulted,
+            &mut resolved,
+            canonical_paths,
+        );
     }
     for extension in source_extensions(options) {
         let candidate = base.join(cstr!("index{extension}").as_str());
         let probe = native_probe_for_source(base, &candidate);
-        record_if_file(&candidate, &probe, consulted, &mut resolved);
+        record_if_file(
+            &candidate,
+            &probe,
+            consulted,
+            &mut resolved,
+            canonical_paths,
+        );
     }
     resolved.sort_by(|left, right| {
         (&left.source_path, &left.native_probe_path)
@@ -72,13 +94,14 @@ fn record_if_file(
     native_probe: &Path,
     consulted: &mut Vec<PathBuf>,
     resolved: &mut Vec<ResolvedPackageSource>,
+    canonical_paths: &mut PackagePathCache,
 ) {
-    let path = canonical_path(path);
+    let path = canonical_path(path, canonical_paths);
     consulted.push(path.clone());
     if path.is_file() {
         resolved.push(ResolvedPackageSource {
             source_path: path,
-            native_probe_path: canonical_path(native_probe),
+            native_probe_path: canonical_path(native_probe, canonical_paths),
         });
     }
 }

--- a/crates/vize_canon/src/package_route/stamp.rs
+++ b/crates/vize_canon/src/package_route/stamp.rs
@@ -2,6 +2,8 @@
 
 use std::path::{Path, PathBuf};
 
+use vize_carton::FxHashMap;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct InputStamp {
     path: PathBuf,
@@ -18,6 +20,46 @@ enum InputKind {
     Directory,
     Symlink,
     Other,
+}
+
+#[derive(Default)]
+pub(crate) struct InputStampCache {
+    snapshots: FxHashMap<PathBuf, InputStamp>,
+    #[cfg(test)]
+    captures: usize,
+}
+
+impl InputStampCache {
+    pub(crate) fn clear(&mut self) {
+        self.snapshots.clear();
+        #[cfg(test)]
+        {
+            self.captures = 0;
+        }
+    }
+
+    pub(crate) fn capture(&mut self, path: &Path) -> InputStamp {
+        if let Some(stamp) = self.snapshots.get(path) {
+            return stamp.clone();
+        }
+        #[cfg(test)]
+        {
+            self.captures += 1;
+        }
+        let stamp = InputStamp::capture(path);
+        self.snapshots.insert(path.to_path_buf(), stamp.clone());
+        stamp
+    }
+
+    #[cfg(test)]
+    pub(crate) fn captures(&self) -> usize {
+        self.captures
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.snapshots.len()
+    }
 }
 
 impl InputStamp {
@@ -64,6 +106,10 @@ impl InputStamp {
     pub(crate) fn is_current(&self) -> bool {
         *self == Self::capture(&self.path)
     }
+
+    pub(crate) fn is_current_with_cache(&self, cache: &mut InputStampCache) -> bool {
+        *self == cache.capture(&self.path)
+    }
 }
 
 /// Canonicalize a changed path even after its final components were deleted.
@@ -108,10 +154,45 @@ pub(super) fn stamp_paths(paths: &[PathBuf]) -> Vec<InputStamp> {
     paths.iter().cloned().map(InputStamp::capture).collect()
 }
 
+pub(super) fn stamp_paths_with_cache(
+    paths: &[PathBuf],
+    cache: &mut InputStampCache,
+) -> Vec<InputStamp> {
+    paths.iter().map(|path| cache.capture(path)).collect()
+}
+
 pub(super) fn stamps_are_current(stamps: &[InputStamp]) -> bool {
     stamps.iter().all(InputStamp::is_current)
 }
 
+pub(super) fn stamps_are_current_with_cache(
+    stamps: &[InputStamp],
+    cache: &mut InputStampCache,
+) -> bool {
+    stamps
+        .iter()
+        .all(|stamp| stamp.is_current_with_cache(cache))
+}
+
 pub(super) fn manifest_path(root: &Path) -> PathBuf {
     root.join("package.json")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InputStamp, InputStampCache};
+
+    #[test]
+    fn stamp_cache_captures_each_path_once_per_epoch() {
+        let root = tempfile::tempdir().unwrap();
+        let file = root.path().join("package.json");
+        std::fs::write(&file, r#"{"name":"pkg"}"#).unwrap();
+        let stamp = InputStamp::capture(&file);
+        let mut cache = InputStampCache::default();
+
+        assert!(stamp.is_current_with_cache(&mut cache));
+        assert!(stamp.is_current_with_cache(&mut cache));
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.captures(), 1);
+    }
 }


### PR DESCRIPTION
Closes #5633.

## Summary
- Cache package route path probes during Canon import validation.
- Reuse package file state checks while keeping invalidation bounded to the validation pass.

## Tests
- cargo test -p vize_canon package_route
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check