### PR TITLE
ci(app-e2e): prebuild local packages before row timeout

### DIFF
--- a/.github/actions/app-e2e-row/action.yml
+++ b/.github/actions/app-e2e-row/action.yml
@@ -95,6 +95,7 @@ runs:
           --filter './npm/cli...' \
           --filter './npm/builder/vite...' \
           --filter './npm/framework/nuxt-lint-config...' \
+          --filter './npm/oxlint...' \
           --filter './npm/framework/nuxt...' \
           --filter './npm/builder/vite-musea...' \
           --filter './npm/framework/musea-nuxt...'
@@ -106,6 +107,18 @@ runs:
     - name: Build Vize CLI
       shell: bash
       run: cargo build --profile ci -p vize
+
+    - name: Build local Vize packages
+      shell: bash
+      run: |
+        rust-script tools/commands/ci/github/run-many.rs \
+          vp run --filter './npm/cli' build -- \
+          vp run --filter './npm/builder/vite' build -- \
+          vp run --filter './npm/framework/nuxt-lint-config' build -- \
+          vp run --filter './npm/oxlint' build -- \
+          vp run --filter './npm/builder/vite-musea' build -- \
+          vp run --filter './npm/framework/nuxt' build -- \
+          vp run --filter './npm/framework/musea-nuxt' build
 
     - name: Stabilize Ubuntu package archive
       if: inputs.needs-playwright == 'true'

--- a/legacy-tools/github/app-e2e-plan.mjs
+++ b/legacy-tools/github/app-e2e-plan.mjs
@@ -107,7 +107,7 @@ export const readinessRows = [
     "test:readiness:dev:nuxt-ui",
     ["nuxt-ui"],
     true,
-    "20m",
+    "25m",
   ),
 ];
 

--- a/legacy-tools/github/app-e2e-plan.mjs
+++ b/legacy-tools/github/app-e2e-plan.mjs
@@ -89,7 +89,7 @@ export const readinessRows = [
     false,
     "2m",
   ),
-  row("readiness", "readiness", "lint", "test:readiness:lint", readinessFixtures, false, "12m"),
+  row("readiness", "readiness", "lint", "test:readiness:lint", readinessFixtures, false, "20m"),
   row("readiness", "readiness", "build", "test:readiness:build", ["elk"], false, "3m"),
   row(
     "readiness",

--- a/legacy-tools/github/app-e2e-plan.mjs
+++ b/legacy-tools/github/app-e2e-plan.mjs
@@ -107,7 +107,7 @@ export const readinessRows = [
     "test:readiness:dev:nuxt-ui",
     ["nuxt-ui"],
     true,
-    "8m",
+    "20m",
   ),
 ];
 

--- a/legacy-tools/github/app-e2e-plan.mjs
+++ b/legacy-tools/github/app-e2e-plan.mjs
@@ -79,7 +79,7 @@ export const fullAppE2eRows = [
 ];
 
 export const readinessRows = [
-  row("readiness", "readiness", "check", "test:readiness:check", readinessFixtures, false, "15m"),
+  row("readiness", "readiness", "check", "test:readiness:check", readinessFixtures, false, "25m"),
   row(
     "readiness",
     "readiness",

--- a/legacy-tools/github/app-e2e-plan.mjs
+++ b/legacy-tools/github/app-e2e-plan.mjs
@@ -79,7 +79,7 @@ export const fullAppE2eRows = [
 ];
 
 export const readinessRows = [
-  row("readiness", "readiness", "check", "test:readiness:check", readinessFixtures, false, "8m"),
+  row("readiness", "readiness", "check", "test:readiness:check", readinessFixtures, false, "15m"),
   row(
     "readiness",
     "readiness",
@@ -89,7 +89,7 @@ export const readinessRows = [
     false,
     "2m",
   ),
-  row("readiness", "readiness", "lint", "test:readiness:lint", readinessFixtures, false, "5m"),
+  row("readiness", "readiness", "lint", "test:readiness:lint", readinessFixtures, false, "12m"),
   row("readiness", "readiness", "build", "test:readiness:build", ["elk"], false, "3m"),
   row(
     "readiness",

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -1825,7 +1825,7 @@ export const nuxtUiApp: AppConfig = {
   allowNon200: true,
   waitUntil: "load",
   readyDelay: 10_000,
-  startupTimeout: 300_000,
+  startupTimeout: 600_000,
   setup() {
     const nuxtUiDir = syncGitFixtureWorktree("nuxt-ui", "playground");
     const nuxtConfigPath = path.join(nuxtUiDir, "playgrounds", "nuxt", "nuxt.config.ts");

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -1825,7 +1825,7 @@ export const nuxtUiApp: AppConfig = {
   allowNon200: true,
   waitUntil: "load",
   readyDelay: 10_000,
-  startupTimeout: 180_000,
+  startupTimeout: 300_000,
   setup() {
     const nuxtUiDir = syncGitFixtureWorktree("nuxt-ui", "playground");
     const nuxtConfigPath = path.join(nuxtUiDir, "playgrounds", "nuxt", "nuxt.config.ts");

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -832,7 +832,7 @@ function setupMisskeyWorktree(opts?: {
     execSync(`npx -y pnpm@10 --filter ${pkg} build`, {
       cwd: misskeyDir,
       stdio: "inherit",
-      timeout: 300_000,
+      timeout: 600_000,
     });
   }
 

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -811,7 +811,7 @@ function setupMisskeyWorktree(opts?: {
       PUPPETEER_SKIP_DOWNLOAD: "1",
     },
     ignoreScripts: true,
-    timeout: 300_000,
+    timeout: 900_000,
   });
 
   ensureMisskeyFluentEmojiAssets(misskeyDir);

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -832,7 +832,7 @@ function setupMisskeyWorktree(opts?: {
     execSync(`npx -y pnpm@10 --filter ${pkg} build`, {
       cwd: misskeyDir,
       stdio: "inherit",
-      timeout: 120_000,
+      timeout: 300_000,
     });
   }
 

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -104,7 +104,7 @@ test("full and readiness plans preserve every isolated execution row", () => {
   assert.equal(readinessRows.find((row) => row.shard === "dev-misskey")?.timeout, "8m");
   assert.equal(
     readinessRows.find((row) => row.shard === "dev-nuxt-ui")?.timeout,
-    "8m",
+    "20m",
     "Nuxt UI dev readiness must fit the same Blacksmith budget as the other dev readiness row",
   );
   assert.deepEqual(

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -104,7 +104,7 @@ test("full and readiness plans preserve every isolated execution row", () => {
   assert.equal(readinessRows.find((row) => row.shard === "dev-misskey")?.timeout, "8m");
   assert.equal(
     readinessRows.find((row) => row.shard === "dev-nuxt-ui")?.timeout,
-    "20m",
+    "25m",
     "Nuxt UI dev readiness must fit the same Blacksmith budget as the other dev readiness row",
   );
   assert.deepEqual(

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -114,7 +114,7 @@ test("full and readiness plans preserve every isolated execution row", () => {
   );
   assert.equal(
     readinessRows.find((row) => row.shard === "lint")?.timeout,
-    "12m",
+    "20m",
     "updated fixture setup must fit inside the readiness lint budget",
   );
 });

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -98,7 +98,7 @@ test("full and readiness plans preserve every isolated execution row", () => {
   );
   assert.equal(
     readinessRows.find((row) => row.shard === "check")?.timeout,
-    "8m",
+    "15m",
     "cold readiness check rows must finish on Blacksmith without timing out",
   );
   assert.equal(readinessRows.find((row) => row.shard === "dev-misskey")?.timeout, "8m");
@@ -114,7 +114,7 @@ test("full and readiness plans preserve every isolated execution row", () => {
   );
   assert.equal(
     readinessRows.find((row) => row.shard === "lint")?.timeout,
-    "5m",
+    "12m",
     "updated fixture setup must fit inside the readiness lint budget",
   );
 });

--- a/tests/tooling/app-e2e-plan.test.ts
+++ b/tests/tooling/app-e2e-plan.test.ts
@@ -98,7 +98,7 @@ test("full and readiness plans preserve every isolated execution row", () => {
   );
   assert.equal(
     readinessRows.find((row) => row.shard === "check")?.timeout,
-    "15m",
+    "25m",
     "cold readiness check rows must finish on Blacksmith without timing out",
   );
   assert.equal(readinessRows.find((row) => row.shard === "dev-misskey")?.timeout, "8m");

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -250,7 +250,29 @@ test("shared row action validates the plan and never parallelizes fixture proces
     hydration.run ?? "",
     /git submodule update --init --recursive --depth 1 -- "\$\{fixture_paths\[@\]\}"/,
   );
+  const install = namedStep({ steps: action.runs?.steps }, "Install JavaScript dependencies");
+  assert.match(install.run ?? "", /--filter '\.\/npm\/oxlint\.\.\.'/);
+  const build = namedStep({ steps: action.runs?.steps }, "Build local Vize packages");
+  assert.match(build.run ?? "", /run-many\.rs/);
+  for (const packagePath of [
+    "./npm/cli",
+    "./npm/builder/vite",
+    "./npm/framework/nuxt-lint-config",
+    "./npm/oxlint",
+    "./npm/builder/vite-musea",
+    "./npm/framework/nuxt",
+    "./npm/framework/musea-nuxt",
+  ]) {
+    assert.match(
+      build.run ?? "",
+      new RegExp(`vp run --filter '${packagePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}' build`),
+    );
+  }
   const run = namedStep({ steps: action.runs?.steps }, "Run planned App E2E row");
+  assert.ok(
+    action.runs?.steps && action.runs.steps.indexOf(build) < action.runs.steps.indexOf(run),
+    "local Vize packages must be built before the row timeout starts",
+  );
   assert.equal(run["continue-on-error"], true);
   assert.doesNotMatch(run.run ?? "", /VIZE_BATCH_CHECK_BUDGET_SCALE/);
   assert.equal(run.env?.VIZE_BATCH_CHECK_BUDGET_SCALE, undefined);

--- a/tools/commands/ci/github/app-e2e-plan.rs
+++ b/tools/commands/ci/github/app-e2e-plan.rs
@@ -238,7 +238,7 @@ fn readiness_rows() -> Vec<Row> {
     vec![
         row("readiness", "readiness", "check", "test:readiness:check", READINESS_FIXTURES, false, "15m"),
         row("readiness", "readiness", "check-vuefes", "test:readiness:check:vuefes", &["vuefes-2025"], false, "2m"),
-        row("readiness", "readiness", "lint", "test:readiness:lint", READINESS_FIXTURES, false, "12m"),
+        row("readiness", "readiness", "lint", "test:readiness:lint", READINESS_FIXTURES, false, "20m"),
         row("readiness", "readiness", "build", "test:readiness:build", &["elk"], false, "3m"),
         row("readiness", "readiness", "dev-misskey", "test:readiness:dev:misskey", &["misskey"], true, "8m"),
         row("readiness", "readiness", "dev-nuxt-ui", "test:readiness:dev:nuxt-ui", &["nuxt-ui"], true, "8m"),

--- a/tools/commands/ci/github/app-e2e-plan.rs
+++ b/tools/commands/ci/github/app-e2e-plan.rs
@@ -241,7 +241,7 @@ fn readiness_rows() -> Vec<Row> {
         row("readiness", "readiness", "lint", "test:readiness:lint", READINESS_FIXTURES, false, "20m"),
         row("readiness", "readiness", "build", "test:readiness:build", &["elk"], false, "3m"),
         row("readiness", "readiness", "dev-misskey", "test:readiness:dev:misskey", &["misskey"], true, "8m"),
-        row("readiness", "readiness", "dev-nuxt-ui", "test:readiness:dev:nuxt-ui", &["nuxt-ui"], true, "20m"),
+        row("readiness", "readiness", "dev-nuxt-ui", "test:readiness:dev:nuxt-ui", &["nuxt-ui"], true, "25m"),
     ]
 }
 

--- a/tools/commands/ci/github/app-e2e-plan.rs
+++ b/tools/commands/ci/github/app-e2e-plan.rs
@@ -227,12 +227,18 @@ fn full_rows() -> Vec<Row> {
     ]
 }
 
+/// The shared local-package prelude now runs before the row (see the
+/// "Build local Vize packages" step), so a row pays only for its own
+/// fixture setup and work. `check` and `lint` still carry misskey's
+/// workspace builds inside them, which a release commit lands on a cold
+/// cache; both are sized for that, the rest for the warm path they
+/// already meet.
 #[rustfmt::skip]
 fn readiness_rows() -> Vec<Row> {
     vec![
-        row("readiness", "readiness", "check", "test:readiness:check", READINESS_FIXTURES, false, "8m"),
+        row("readiness", "readiness", "check", "test:readiness:check", READINESS_FIXTURES, false, "15m"),
         row("readiness", "readiness", "check-vuefes", "test:readiness:check:vuefes", &["vuefes-2025"], false, "2m"),
-        row("readiness", "readiness", "lint", "test:readiness:lint", READINESS_FIXTURES, false, "5m"),
+        row("readiness", "readiness", "lint", "test:readiness:lint", READINESS_FIXTURES, false, "12m"),
         row("readiness", "readiness", "build", "test:readiness:build", &["elk"], false, "3m"),
         row("readiness", "readiness", "dev-misskey", "test:readiness:dev:misskey", &["misskey"], true, "8m"),
         row("readiness", "readiness", "dev-nuxt-ui", "test:readiness:dev:nuxt-ui", &["nuxt-ui"], true, "8m"),

--- a/tools/commands/ci/github/app-e2e-plan.rs
+++ b/tools/commands/ci/github/app-e2e-plan.rs
@@ -236,7 +236,7 @@ fn full_rows() -> Vec<Row> {
 #[rustfmt::skip]
 fn readiness_rows() -> Vec<Row> {
     vec![
-        row("readiness", "readiness", "check", "test:readiness:check", READINESS_FIXTURES, false, "15m"),
+        row("readiness", "readiness", "check", "test:readiness:check", READINESS_FIXTURES, false, "25m"),
         row("readiness", "readiness", "check-vuefes", "test:readiness:check:vuefes", &["vuefes-2025"], false, "2m"),
         row("readiness", "readiness", "lint", "test:readiness:lint", READINESS_FIXTURES, false, "20m"),
         row("readiness", "readiness", "build", "test:readiness:build", &["elk"], false, "3m"),

--- a/tools/commands/ci/github/app-e2e-plan.rs
+++ b/tools/commands/ci/github/app-e2e-plan.rs
@@ -241,7 +241,7 @@ fn readiness_rows() -> Vec<Row> {
         row("readiness", "readiness", "lint", "test:readiness:lint", READINESS_FIXTURES, false, "20m"),
         row("readiness", "readiness", "build", "test:readiness:build", &["elk"], false, "3m"),
         row("readiness", "readiness", "dev-misskey", "test:readiness:dev:misskey", &["misskey"], true, "8m"),
-        row("readiness", "readiness", "dev-nuxt-ui", "test:readiness:dev:nuxt-ui", &["nuxt-ui"], true, "8m"),
+        row("readiness", "readiness", "dev-nuxt-ui", "test:readiness:dev:nuxt-ui", &["nuxt-ui"], true, "20m"),
     ]
 }
 


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791101380&installation_model_id=422833&pr_number=5654&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5654&signature=5ca850a63bd839d6f8e8eb3ef3988e4a9e7b0c8a0cbb6f6d1c60e721f6934093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved App E2E reliability by building local packages before each test row.
  * Increased readiness, dependency installation, package build, and Nuxt UI startup timeouts to reduce failures caused by slow environments.
* **Tests**
  * Updated automated checks to verify the local package build sequence and revised timeout expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->