### PR TITLE
fix(ci): align typecheck fixture sharding

### DIFF
--- a/tests/tooling/typecheck-dependency-prepare.test.ts
+++ b/tests/tooling/typecheck-dependency-prepare.test.ts
@@ -229,6 +229,32 @@ test("dependency prepare skips empty typecheck shards", () => {
   }
 });
 
+test("dependency prepare shards the full fixture registry before filtering typecheck targets", () => {
+  const fixture = setup();
+  try {
+    writeJson(fixture.registryPath, {
+      projects: [
+        { ...fixture.project, id: "padding", typecheckPerformance: { enabled: false } },
+        fixture.project,
+      ],
+    });
+    git(fixture.fixtureRoot, ["add", "registry.json"]);
+    commit(fixture.fixtureRoot, "align typecheck shard selection");
+
+    const empty = run(fixture, ["--shard-index", "0", "--shard-count", "2"]);
+    assert.equal(empty.status, 0, empty.stderr);
+    assert.match(empty.stdout, /No typecheck performance projects selected/);
+    assert.equal(fs.existsSync(fixture.invocationPath), false);
+    assert.equal(fs.existsSync(artifactPath(fixture)), false);
+
+    const selected = run(fixture, ["--shard-index", "1", "--shard-count", "2"]);
+    assert.equal(selected.status, 0, selected.stderr);
+    assert.equal(fs.existsSync(artifactPath(fixture)), true);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
 test("dependency prepare prepares every selected typecheck target", () => {
   const selectedFixture = setup();
   try {

--- a/tests/tooling/typecheck-divergence-report-rejections.test.ts
+++ b/tests/tooling/typecheck-divergence-report-rejections.test.ts
@@ -264,3 +264,32 @@ test("typecheck divergence report skips shards with no registered performance pr
     cleanup(fixture);
   }
 });
+
+test("typecheck divergence report shards the full fixture registry before filtering typecheck targets", () => {
+  const fixture = setup();
+  try {
+    updateJson(fixture.registryPath, (registry) => {
+      registry.projects = [
+        { ...registry.projects[0], id: "padding", typecheckPerformance: { enabled: false } },
+        registry.projects[0],
+      ];
+    });
+
+    const empty = run(fixture, {}, ["--shard-index", "0", "--shard-count", "2"]);
+    assert.equal(empty.status, 0, empty.stderr);
+    assert.match(empty.stdout, /No typecheck performance projects selected/);
+    assert.equal(
+      fs.existsSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json")),
+      false,
+    );
+
+    const selected = run(fixture, {}, ["--shard-index", "1", "--shard-count", "2"]);
+    assert.equal(selected.status, 0, selected.stderr);
+    assert.equal(
+      fs.existsSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json")),
+      true,
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tools/commands/fixtures/typecheck-dependency-prepare.rs
+++ b/tools/commands/fixtures/typecheck-dependency-prepare.rs
@@ -220,14 +220,18 @@ fn select_typecheck_performance_projects(
         .enumerate()
         .filter_map(|(index, project)| {
             (index % shard_count == shard_index
-                && project
-                    .get("typecheckPerformance")
-                    .and_then(|value| value.get("enabled"))
-                    .and_then(Value::as_bool)
-                    == Some(true))
+                && has_enabled_typecheck_performance(project))
             .then_some(project)
         })
         .collect())
+}
+
+fn has_enabled_typecheck_performance(project: &Value) -> bool {
+    project
+        .get("typecheckPerformance")
+        .and_then(|value| value.get("enabled"))
+        .and_then(Value::as_bool)
+        == Some(true)
 }
 
 fn validate_typecheck_performance_target(

--- a/tools/commands/fixtures/typecheck-divergence-report.rs
+++ b/tools/commands/fixtures/typecheck-divergence-report.rs
@@ -3341,17 +3341,20 @@ fn select_typecheck_projects<'a>(
         .ok_or_else(|| "registry must list projects".to_string())?;
     Ok(projects
         .iter()
-        .filter(|project| {
-            project
-                .pointer("/typecheckPerformance/enabled")
-                .and_then(Value::as_bool)
-                == Some(true)
-        })
         .enumerate()
         .filter_map(|(index, project)| {
-            (index % args.shard_count == args.shard_index).then_some(project)
+            (index % args.shard_count == args.shard_index
+                && has_enabled_typecheck_performance(project))
+            .then_some(project)
         })
         .collect())
+}
+
+fn has_enabled_typecheck_performance(project: &Value) -> bool {
+    project
+        .pointer("/typecheckPerformance/enabled")
+        .and_then(Value::as_bool)
+        == Some(true)
 }
 
 fn validate_performance(project: &Value) -> Result<(), String> {


### PR DESCRIPTION
## Summary
- Align typecheck dependency preparation and divergence reporting with the real-project matrix's full-registry shard partitioning.
- Keep typecheckPerformance filtering after shard selection so typecheck-only targets cannot require artifacts from another matrix shard.
- Add regressions covering the previous mismatch.

## Release unblock
The failed v0.392.0 release preflight hit Real Project Matrix shards where typecheck divergence selected projects that the shard summary did not contain, e.g. element-plus/reka-ui. This makes all per-shard typecheck work use the same project partition as the summary and hydrated fixture set.

## Tests
- node --test tests/tooling/typecheck-dependency-prepare.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/source-file-lengths.test.ts
- git diff --check
- vp run --workspace-root check:ci

## Notes
- vp run --workspace-root test:scripts was also started after CI-style install, but the full local suite failed on pre-existing environment requirements: stale target/release/vize 0.387.0, unhydrated real fixtures, missing required TypeScript 7/Corsa runtime, and local Node 26 being outside the support matrix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791115174&installation_model_id=422833&pr_number=5657&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5657&signature=81601cea1326395506af9013dd7f17b7a011026a4ce77cf2f7c14c1854b6418c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected typecheck tooling sharding so projects are assigned to shards consistently, including projects excluded from typecheck processing.
  - Improved consistency between dependency preparation and divergence reporting when running partial shard sets.
  - Ensured disabled typecheck projects do not produce artifacts or reports.

- **Tests**
  - Added coverage validating shard assignment, filtering behavior, and artifact/report generation across multiple shard configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->