### PR TITLE
test(canon): make shared dependency isolation hermetic

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/project_isolation.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/project_isolation.rs
@@ -21,7 +21,7 @@ fn concurrent_projects_share_dependencies_without_sharing_mutable_state() {
     let _ = std::fs::remove_dir_all(&case_root);
     let first_root = case_root.join("first");
     let second_root = case_root.join("second");
-    let shared_node_modules = case_root.join("shared-node-modules");
+    let shared_node_modules = case_root.join("node_modules");
     populate_shared_dependency_tree(&shared_node_modules);
     create_project(&first_root, "first");
     create_project(&second_root, "second");
@@ -134,7 +134,7 @@ fn persistent_sessions_refresh_independently_over_shared_dependencies() {
     let _ = std::fs::remove_dir_all(&case_root);
     let first_root = case_root.join("first");
     let second_root = case_root.join("second");
-    let shared_node_modules = case_root.join("shared-node-modules");
+    let shared_node_modules = case_root.join("node_modules");
     populate_shared_dependency_tree(&shared_node_modules);
     create_relative_project(&first_root, "first");
     create_relative_project(&second_root, "second");

--- a/crates/vize_canon/src/batch/type_checker/tests/project_isolation/support.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/project_isolation/support.rs
@@ -1,5 +1,8 @@
 use super::BatchTypeChecker;
-use crate::batch::{TypeCheckResult, TypeChecker};
+use crate::batch::{
+    TypeCheckResult, TypeChecker,
+    runtime_deps::{write_vue_facade, write_vue_runtime_dom_stub},
+};
 use std::{
     path::Path,
     sync::{Arc, Barrier},
@@ -80,14 +83,32 @@ pub(super) fn populate_shared_dependency_tree(shared_node_modules: &Path) {
         .expect("workspace root should exist")
         .join("node_modules");
     std::fs::create_dir_all(shared_node_modules).unwrap();
-    for entry in std::fs::read_dir(workspace_node_modules).unwrap() {
-        let entry = entry.unwrap();
-        if entry.file_name() == ".vize" {
-            continue;
+    if let Ok(entries) = std::fs::read_dir(workspace_node_modules) {
+        for entry in entries {
+            let entry = entry.unwrap();
+            if entry.file_name() == ".vize" {
+                continue;
+            }
+            std::os::unix::fs::symlink(entry.path(), shared_node_modules.join(entry.file_name()))
+                .unwrap();
         }
-        std::os::unix::fs::symlink(entry.path(), shared_node_modules.join(entry.file_name()))
-            .unwrap();
+        return;
     }
+
+    write_vue_facade(shared_node_modules).unwrap();
+    write_vue_runtime_dom_stub(shared_node_modules).unwrap();
+    write_vite_stub(shared_node_modules);
+}
+
+fn write_vite_stub(shared_node_modules: &Path) {
+    let vite = shared_node_modules.join("vite");
+    std::fs::create_dir_all(&vite).unwrap();
+    std::fs::write(
+        vite.join("package.json"),
+        r#"{"name":"vite","types":"client.d.ts"}"#,
+    )
+    .unwrap();
+    std::fs::write(vite.join("client.d.ts"), "").unwrap();
 }
 
 pub(super) fn link_shared_node_modules(project_root: &Path, shared_node_modules: &Path) {


### PR DESCRIPTION
## Summary
- make the Canon type-checker project-isolation fixture work without a checkout-local root node_modules
- use generated Vue/Vite runtime stubs as the fallback shared dependency tree
- keep the shared physical dependency path spelled as node_modules so TypeScript realpath package resolution matches production

## Validation
- cargo fmt --check
- TMPDIR="/Users/ubugeeei/Source/github.com/ubugeeei/vize--pr-4095-canon-isolation/target/vize-tests/tmp" TEMP="/Users/ubugeeei/Source/github.com/ubugeeei/vize--pr-4095-canon-isolation/target/vize-tests/tmp" TMP="/Users/ubugeeei/Source/github.com/ubugeeei/vize--pr-4095-canon-isolation/target/vize-tests/tmp" cargo test -q -p vize_canon project_isolation
- TMPDIR="/Users/ubugeeei/Source/github.com/ubugeeei/vize--pr-4095-canon-isolation/target/vize-tests/tmp" TEMP="/Users/ubugeeei/Source/github.com/ubugeeei/vize--pr-4095-canon-isolation/target/vize-tests/tmp" TMP="/Users/ubugeeei/Source/github.com/ubugeeei/vize--pr-4095-canon-isolation/target/vize-tests/tmp" cargo test -q -p vize_canon project_key_owns_the_materialization_lock_identity
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- TMPDIR="/Users/ubugeeei/Source/github.com/ubugeeei/vize--pr-4095-canon-isolation/target/vize-tests/tmp" TEMP="/Users/ubugeeei/Source/github.com/ubugeeei/vize--pr-4095-canon-isolation/target/vize-tests/tmp" TMP="/Users/ubugeeei/Source/github.com/ubugeeei/vize--pr-4095-canon-isolation/target/vize-tests/tmp" cargo test -q -p vize --test check_nuxt_tsconfig_isolation_cli

Refs #4095

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791126105&installation_model_id=422833&pr_number=5659&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5659&signature=bb978ac9365348ed899edd35549afc56e585da8fcaf676abcdd5feff2fa9364d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->