### PR TITLE
fix(release): dry-run the crates publish frontier

### DIFF
--- a/tests/tooling/moonbit-publish-crates-selected.test.ts
+++ b/tests/tooling/moonbit-publish-crates-selected.test.ts
@@ -95,9 +95,6 @@ test("publish_crates can target the JSX and Patina handoff set", () => {
     );
     assert.equal(selectedDryRun.status, 0, selectedDryRun.stderr);
     assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
-      ["package", "--locked", "--no-verify", "-p", "vize_atelier_jsx", "-p", "vize_patina"].join(
-        " ",
-      ),
       `info --registry crates-io vize_atelier_jsx@${version}`,
       "publish --dry-run --locked -p vize_patina",
     ]);

--- a/tests/tooling/moonbit-publish-crates.test.ts
+++ b/tests/tooling/moonbit-publish-crates.test.ts
@@ -126,7 +126,7 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
         "const args = process.argv.slice(2);",
         "fs.appendFileSync(process.env.CARGO_LOG, args.join(' ') + '\\n');",
         "const [command] = args;",
-        "if (command === 'package' && process.env.TEST_FAIL_PACKAGE) process.exit(1);",
+        "if (command === 'publish' && args.includes('--dry-run') && process.env.TEST_FAIL_PUBLISH_DRY_RUN) process.exit(1);",
         "const unresolved = (process.env.TEST_UNRESOLVED_CRATES || '').split(',');",
         "if (command === 'info' && unresolved.includes(args.at(-1).split('@')[0])) { console.error('not in registry index'); process.exit(1); }",
         "if (command === 'package' || command === 'publish' || command === 'info') process.exit(0);",
@@ -186,12 +186,6 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
         },
       });
     };
-    const expectedPackage = [
-      "package",
-      "--locked",
-      "--no-verify",
-      ...publishedCrates.flatMap((name) => ["-p", name]),
-    ].join(" ");
     const expectedFrontier = (crateName: string) =>
       ["publish", "--dry-run", "--locked", "-p", crateName].join(" ");
     const expectedInfo = (crateName: string) => `info --registry crates-io ${crateName}@${version}`;
@@ -199,7 +193,6 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
     const nonePublished = runDryRun([]);
     assert.equal(nonePublished.status, 0, nonePublished.stderr);
     assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
-      expectedPackage,
       expectedFrontier(publishedCrates[0]),
     ]);
     const curlCalls = fs.readFileSync(curlLogPath, "utf8").trim().split("\n");
@@ -221,7 +214,6 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
     const partial = runDryRun(somePublished);
     assert.equal(partial.status, 0, partial.stderr);
     assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
-      expectedPackage,
       ...somePublished.map(expectedInfo),
       expectedFrontier(publishedCrates[5]),
     ]);
@@ -231,10 +223,10 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
 
     const allPublished = runDryRun(publishedCrates);
     assert.equal(allPublished.status, 0, allPublished.stderr);
-    assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
-      expectedPackage,
-      ...publishedCrates.map(expectedInfo),
-    ]);
+    assert.deepEqual(
+      fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"),
+      publishedCrates.map(expectedInfo),
+    );
     assert.match(allPublished.stdout, /Every crate .* already published and resolvable/);
 
     for (const [envName, diagnostic] of [
@@ -246,7 +238,7 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
       const failedQuery = runDryRun([], { [envName]: publishedCrates[0] });
       assert.notEqual(failedQuery.status, 0);
       assert.match(failedQuery.stderr, diagnostic);
-      assert.equal(fs.readFileSync(cargoLogPath, "utf8").trim(), expectedPackage);
+      assert.equal(fs.readFileSync(cargoLogPath, "utf8"), "");
       assert.equal(fs.readFileSync(curlLogPath, "utf8").trim().split("\n").length, 1);
     }
 
@@ -255,10 +247,10 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
     });
     assert.notEqual(unresolvedPrefix.status, 0);
     assert.match(unresolvedPrefix.stderr, /could not resolve .*vize_davinci/i);
-    assert.deepEqual(fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"), [
-      expectedPackage,
-      ...somePublished.slice(0, 3).map(expectedInfo),
-    ]);
+    assert.deepEqual(
+      fs.readFileSync(cargoLogPath, "utf8").trim().split("\n"),
+      somePublished.slice(0, 3).map(expectedInfo),
+    );
     assert.equal(fs.readFileSync(curlLogPath, "utf8").trim().split("\n").length, 3);
 
     const unresolvedAll = runDryRun(publishedCrates, {
@@ -274,11 +266,16 @@ test("publish_crates native script covers publish and idempotent dry-run modes",
     );
     assert.doesNotMatch(unresolvedAllCargo, /^publish --dry-run/m);
 
-    const packageFailure = runDryRun([], { TEST_FAIL_PACKAGE: "1" });
-    assert.notEqual(packageFailure.status, 0);
-    assert.match(packageFailure.stderr, /Crate package validation failed/);
-    assert.equal(fs.readFileSync(cargoLogPath, "utf8").trim(), expectedPackage);
-    assert.equal(fs.readFileSync(curlLogPath, "utf8"), "");
+    const frontierFailure = runDryRun([], { TEST_FAIL_PUBLISH_DRY_RUN: "1" });
+    assert.notEqual(frontierFailure.status, 0);
+    assert.match(frontierFailure.stderr, /Crate publish dry-run failed/);
+    assert.equal(
+      fs.readFileSync(cargoLogPath, "utf8").trim(),
+      expectedFrontier(publishedCrates[0]),
+    );
+    const frontierCurlLog = fs.readFileSync(curlLogPath, "utf8").trim();
+    assert.notEqual(frontierCurlLog, "");
+    assert.equal(frontierCurlLog.split("\n").length, 1);
 
     for (const invalidArgs of [["--unknown"], ["--dry-run", "extra"]]) {
       fs.writeFileSync(cargoLogPath, "");

--- a/tools/moon/cmd/publish_crates/main.mbt
+++ b/tools/moon/cmd/publish_crates/main.mbt
@@ -205,18 +205,6 @@ async fn run_app() -> Int {
   }
 
   if dry_run {
-    let package_args = ["package", "--locked", "--no-verify"]
-    for crate_name in publish_targets {
-      package_args.push("-p")
-      package_args.push(crate_name)
-    }
-    let plan_label = if selected_crates.is_empty() { "complete supported" } else { "selected" }
-    println("Packaging the \{plan_label} crate plan for v\{version}...")
-    if @process.run("cargo", package_args) != 0 {
-      @stdio.stderr.write("Crate package validation failed for v\{version}.\n")
-      return 1
-    }
-
     let mut frontier : String? = None
     for crate_name in publish_targets {
       match query_crate_version(crate_name, version) {
@@ -259,7 +247,7 @@ async fn run_app() -> Int {
       return 1
     }
     println(
-      "Package validation covered all supported crates; registry dry-run covered \{frontier}.",
+      "Registry dry-run covered \{frontier}; downstream crates are validated after each serial publish step.",
     )
     return 0
   }


### PR DESCRIPTION
## Summary
- stop the crates.io dry-run from packaging every supported crate before any new workspace crate is published
- keep registry prefix resolution checks, then dry-run only the first missing publish frontier
- update the publish script tests to match the serial publish contract

## Validation
- env RUNNER_TEMP=/private/tmp/vize-moonbit-runner MOON_BIN=/private/tmp/vize-moonbit-runner/moonbit-shims/moon node --test tests/tooling/source-file-lengths.test.ts tests/tooling/moonbit-publish-crates.test.ts tests/tooling/moonbit-publish-crates-selected.test.ts
- git diff --check

## Release Note
This unblocks the v0.392.0 release-preflight failure where `cargo package` tried to validate downstream stage crates before `vize_davinci` had been published and resolved from crates.io.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791127982&installation_model_id=422833&pr_number=5660&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5660&signature=d474d3f49a1777d00df082a9d5dbe97290973fb173b2abc57dfb95792fa812b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Changes**
  - Dry-run publishing now checks registry status and validates only the first unpublished crate, rather than packaging every selected crate.
  - Subsequent crates are validated after earlier crates are published.
  - Updated completion messaging to reflect the streamlined dry-run validation flow.
  - Improved validation for missing, unknown, and duplicate crate selections, with clear usage errors and no publish attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->