### PR TITLE
test(davinci): pin S2 DOM profile ladder budget

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
@@ -44,14 +44,10 @@ fn profile_reports_real_s2_dom_walks() {
         "normal DOM compilation must not instantiate the profiling observer"
     );
 
-    profiler.clear();
-    profiler.enable();
-
+    let profile = ProfileScope::enable();
     let allocator = Allocator::new();
     let (_, errors, result) = compile_template(&allocator, "<div>{{ msg }}</div>");
-
-    profiler.disable();
-    let counters = profiler.counter_summary();
+    let counters = profile.finish();
 
     assert!(errors.is_empty());
     assert!(!result.code.is_empty());
@@ -70,6 +66,7 @@ fn profile_reports_ladder_s2_dom_walk_budget() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
+    profiler.clear();
 
     for fixture in &LADDER {
         let template =
@@ -83,14 +80,10 @@ fn profile_reports_ladder_s2_dom_walk_budget() {
             fixture.name
         );
 
-        profiler.clear();
-        profiler.enable();
-
+        let profile = ProfileScope::enable();
         let allocator = Allocator::new();
         let (_, errors, result) = compile_template(&allocator, template);
-
-        profiler.disable();
-        let counters = profiler.counter_summary();
+        let counters = profile.finish();
 
         assert!(
             errors.is_empty(),
@@ -117,8 +110,6 @@ fn profile_reports_ladder_s2_dom_walk_budget() {
             6 + expected.0
         );
     }
-
-    profiler.clear();
 }
 
 #[test]
@@ -126,6 +117,7 @@ fn source_map_disabled_scope_id_uses_compatibility_codegen() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
+    profiler.clear();
     let source = r#"<div class="scoped">{{ msg }}</div>"#;
     let scoped_options = DomCompilerOptions {
         scope_id: Some("data-v-direct".into()),
@@ -142,14 +134,10 @@ fn source_map_disabled_scope_id_uses_compatibility_codegen() {
     );
     assert!(compat_errors.is_empty());
 
-    profiler.clear();
-    profiler.enable();
-
+    let profile = ProfileScope::enable();
     let allocator = Allocator::new();
     let (_, errors, result) = compile_template_with_options(&allocator, source, scoped_options);
-
-    profiler.disable();
-    let counters = profiler.counter_summary();
+    let counters = profile.finish();
 
     assert!(errors.is_empty());
     assert_eq!(result.preamble, compat.preamble);
@@ -166,6 +154,7 @@ fn source_map_disabled_hoisted_scope_id_stays_on_s2_codegen() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
+    profiler.clear();
     let source = r#"<div :class="{ active }"><svg><rect class="marker" x="1" /></svg></div>"#;
     let compat_allocator = Allocator::new();
     let (_, compat_errors, compat) = compile_template_with_options_and_hoisted_scope_id(
@@ -179,9 +168,7 @@ fn source_map_disabled_hoisted_scope_id_stays_on_s2_codegen() {
     );
     assert!(compat_errors.is_empty());
 
-    profiler.clear();
-    profiler.enable();
-
+    let profile = ProfileScope::enable();
     let allocator = Allocator::new();
     let (_, errors, result) = compile_template_with_options_and_hoisted_scope_id(
         &allocator,
@@ -190,8 +177,7 @@ fn source_map_disabled_hoisted_scope_id_stays_on_s2_codegen() {
         Some("data-v-hoist".into()),
     );
 
-    profiler.disable();
-    let counters = profiler.counter_summary();
+    let counters = profile.finish();
 
     assert!(errors.is_empty());
     assert_eq!(counter(&counters, "davinci.s2_dom.files"), 1);
@@ -204,6 +190,7 @@ fn source_map_disabled_comments_use_compatibility_codegen() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
+    profiler.clear();
     let source = "<div><!--kept--><span>probe</span></div>";
     let options = DomCompilerOptions {
         comments: true,
@@ -220,14 +207,10 @@ fn source_map_disabled_comments_use_compatibility_codegen() {
     );
     assert!(compat_errors.is_empty());
 
-    profiler.clear();
-    profiler.enable();
-
+    let profile = ProfileScope::enable();
     let allocator = Allocator::new();
     let (_, errors, result) = compile_template_with_options(&allocator, source, options);
-
-    profiler.disable();
-    let counters = profiler.counter_summary();
+    let counters = profile.finish();
 
     assert!(errors.is_empty());
     assert_eq!(result.preamble, compat.preamble);
@@ -254,6 +237,31 @@ fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
         .iter()
         .find(|entry| entry.name == name)
         .map(|entry| entry.total)
+}
+
+struct ProfileScope;
+
+impl ProfileScope {
+    fn enable() -> Self {
+        let profiler = global_profiler();
+        profiler.clear();
+        profiler.enable();
+        Self
+    }
+
+    fn finish(self) -> CounterSummary {
+        let profiler = global_profiler();
+        profiler.disable();
+        profiler.counter_summary()
+    }
+}
+
+impl Drop for ProfileScope {
+    fn drop(&mut self) {
+        let profiler = global_profiler();
+        profiler.disable();
+        profiler.clear();
+    }
 }
 
 fn s2_dom_emit_count(fixture: &str) -> (u64, u64) {

--- a/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
@@ -7,6 +7,7 @@
     clippy::disallowed_types
 )]
 
+use davinci_harness::fixtures::{LADDER, template_block};
 use vize_atelier_dom::{
     DomCompilerOptions, compile_template, compile_template_with_options,
     compile_template_with_options_and_hoisted_scope_id,
@@ -15,6 +16,15 @@ use vize_s0::Allocator;
 use vize_s0::profiler::{CounterSummary, global_profiler};
 
 static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+const S2_DOM_EMIT_COUNTS: [(&str, u64, u64); 6] = [
+    ("small", 1, 5),
+    ("medium", 1, 33),
+    ("large", 1, 54),
+    ("stress-deep", 1, 72),
+    ("stress-wide", 1, 2),
+    ("stress-interp", 1, 201),
+];
 
 #[test]
 fn profile_reports_real_s2_dom_walks() {
@@ -53,6 +63,62 @@ fn profile_reports_real_s2_dom_walks() {
     assert_eq!(counter(&counters, "davinci.s2_dom.emit.walks"), 1);
     assert!(counter(&counters, "davinci.s2_dom.emit.visits") > 0);
     assert_eq!(counter(&counters, "davinci.s2_dom.total.walks"), 7);
+}
+
+#[test]
+fn profile_reports_ladder_s2_dom_walk_budget() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+
+    for fixture in &LADDER {
+        let template =
+            template_block(fixture.source).expect("every ladder fixture has a template block");
+        let expected = s2_dom_emit_count(fixture.name);
+        let compat_allocator = Allocator::new();
+        let (_, compat_errors, compat) = compile_template(&compat_allocator, template);
+        assert!(
+            compat_errors.is_empty(),
+            "{} compatibility compile should be diagnostic-free",
+            fixture.name
+        );
+
+        profiler.clear();
+        profiler.enable();
+
+        let allocator = Allocator::new();
+        let (_, errors, result) = compile_template(&allocator, template);
+
+        profiler.disable();
+        let counters = profiler.counter_summary();
+
+        assert!(
+            errors.is_empty(),
+            "{} profiled compile should be diagnostic-free",
+            fixture.name
+        );
+        assert_eq!(
+            result.preamble, compat.preamble,
+            "{} profiled S2 emit must keep the compatibility preamble",
+            fixture.name
+        );
+        assert_eq!(
+            result.code, compat.code,
+            "{} profiled S2 emit must keep the compatibility code",
+            fixture.name
+        );
+        assert_eq!(counter(&counters, "davinci.s2_dom.files"), 1);
+        assert_eq!(counter(&counters, "davinci.s2_dom.transform.walks"), 6);
+        assert_eq!(counter(&counters, "davinci.s2_dom.transform.passes"), 6);
+        assert_eq!(counter(&counters, "davinci.s2_dom.emit.walks"), expected.0);
+        assert_eq!(counter(&counters, "davinci.s2_dom.emit.visits"), expected.1);
+        assert_eq!(
+            counter(&counters, "davinci.s2_dom.total.walks"),
+            6 + expected.0
+        );
+    }
+
+    profiler.clear();
 }
 
 #[test]
@@ -188,6 +254,14 @@ fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
         .iter()
         .find(|entry| entry.name == name)
         .map(|entry| entry.total)
+}
+
+fn s2_dom_emit_count(fixture: &str) -> (u64, u64) {
+    S2_DOM_EMIT_COUNTS
+        .iter()
+        .find(|(name, _, _)| *name == fixture)
+        .map(|(_, walks, visits)| (*walks, *visits))
+        .unwrap_or_else(|| panic!("{fixture} has no pinned S2 DOM emit count"))
 }
 
 fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {


### PR DESCRIPTION
## Summary

- add a ladder-level DOM profiler oracle for the S2 render path
- assert profiled S2 DOM output stays byte-identical to the compatibility codegen on every Davinci ladder template
- pin `davinci.s2_dom` transform, emit and total walk counters to the P2-12b observer counts

## Validation

- `cargo fmt --all --check`
- `cargo test -p vize_atelier_dom --test davinci_s2_profile`
- `cargo test -p vize_s1_to_s2 --test emit_budget_observer`
- `node --test tests/tooling/davinci-dom-production-boundary.test.ts`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `node --test tests/tooling/davinci-phase2-ledger.test.ts`
- `node --test tests/tooling/davinci-traversal-budgets.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791135846&installation_model_id=422833&pr_number=5663&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5663&signature=94db294879cd8de4c4b96a7dce9a37e4091d2d26230bff01a2a9f263f329e017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added profiling coverage for LADDER fixtures to verify S2 DOM emission walk and visit budgets.
  * Confirmed profiled compilation remains diagnostic-free and produces output identical to compatibility compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->