### PR TITLE
test(tooling): add vue-datepicker authored lsp oracle

### DIFF
--- a/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 18, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 19, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -781,7 +781,8 @@
           "tests/_fixtures/_git/vue-vben-admin",
           "tests/_fixtures/_git/vue-bits",
           "tests/_fixtures/_git/shadcn-vue",
-          "tests/_fixtures/_git/splitpanes"
+          "tests/_fixtures/_git/splitpanes",
+          "tests/_fixtures/_git/vue-datepicker"
         ]
       },
       "evidence": {

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 18,
+    "minimumProjectCount": 19,
     "trackingIssue": 3952
   },
   "projects": [
@@ -3962,6 +3962,169 @@
         "syntax-highlighter",
         "lsp"
       ],
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "packages/playground/src/App.vue",
+          "symbol": "date",
+          "usageAnchor": "v-model=\"date\"",
+          "declarationAnchor": "const date = ref(new Date());",
+          "hoverContains": [
+            "const date: Date"
+          ],
+          "renameTo": "__vizeRenamedDate"
+        },
+        "componentBoundary": {
+          "importerFile": "packages/lib/src/VueDatePicker/components/DatePicker/DpHeader.vue",
+          "componentFile": "packages/lib/src/VueDatePicker/components/Common/ArrowBtn.vue",
+          "tagName": "ArrowBtn",
+          "tagAnchor": "class=\"dp--month-year-wrap\">\n        <ArrowBtn\n          ",
+          "completionItemCount": 32,
+          "completionItems": [
+            {
+              "label": "v-if",
+              "rank": 0
+            },
+            {
+              "label": "v-else-if",
+              "rank": 1
+            },
+            {
+              "label": "v-else",
+              "rank": 2
+            },
+            {
+              "label": "v-for",
+              "rank": 3
+            },
+            {
+              "label": "v-on",
+              "rank": 4
+            },
+            {
+              "label": "v-bind",
+              "rank": 5
+            },
+            {
+              "label": "v-model",
+              "rank": 6
+            },
+            {
+              "label": "v-slot",
+              "rank": 7
+            },
+            {
+              "label": "v-show",
+              "rank": 8
+            },
+            {
+              "label": "v-pre",
+              "rank": 9
+            },
+            {
+              "label": "v-once",
+              "rank": 10
+            },
+            {
+              "label": "v-memo",
+              "rank": 11
+            },
+            {
+              "label": "v-cloak",
+              "rank": 12
+            },
+            {
+              "label": "v-text",
+              "rank": 13
+            },
+            {
+              "label": "v-html",
+              "rank": 14
+            },
+            {
+              "label": "@",
+              "rank": 15
+            },
+            {
+              "label": ":",
+              "rank": 16
+            },
+            {
+              "label": "#",
+              "rank": 17
+            },
+            {
+              "label": "@click",
+              "rank": 18
+            },
+            {
+              "label": "@input",
+              "rank": 19
+            },
+            {
+              "label": "@change",
+              "rank": 20
+            },
+            {
+              "label": "@submit",
+              "rank": 21
+            },
+            {
+              "label": "@keydown",
+              "rank": 22
+            },
+            {
+              "label": "@keyup",
+              "rank": 23
+            },
+            {
+              "label": "@focus",
+              "rank": 24
+            },
+            {
+              "label": "@blur",
+              "rank": 25
+            },
+            {
+              "label": "@mouseenter",
+              "rank": 26
+            },
+            {
+              "label": "@mouseleave",
+              "rank": 27
+            },
+            {
+              "label": "aria-label",
+              "rank": 28
+            },
+            {
+              "label": "el-name",
+              "rank": 29
+            },
+            {
+              "label": "disabled",
+              "rank": 30
+            },
+            {
+              "label": "inactive",
+              "rank": 31
+            }
+          ],
+          "dependencyEdit": {
+            "anchor": "    inactive?: boolean;\n",
+            "replacement": "    inactive?: boolean;\n    vizeOracleProbe?: boolean;\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "packages/lib/src/VueDatePicker/components/Common/__VizeOracleArrowBtn.vue",
+          "renamedFile": "packages/lib/src/VueDatePicker/components/Common/__VizeOracleRenamedArrowBtn.vue",
+          "originalImportSpecifier": "@/components/Common/ArrowBtn.vue",
+          "copiedImportSpecifier": "@/components/Common/__VizeOracleArrowBtn.vue",
+          "renamedImportSpecifier": "@/components/Common/__VizeOracleRenamedArrowBtn.vue",
+          "markerInsertionAnchor": "<script lang=\"ts\" setup>\n",
+          "markerSymbol": "__vizeVueDatepickerArrowBtnMarker__"
+        }
+      },
       "diff": "curator-compare"
     },
     {

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 18,
+      "authored-lsp": 19,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,


### PR DESCRIPTION
## Summary

- add `vue-datepicker` to the #3952 authored real-project LSP oracle matrix
- pin authored `App.vue` template hover, definition, references, and rename for `date`
- pin the `DpHeader.vue` to `ArrowBtn.vue` component boundary, completion order, dependency refresh, and file lifecycle
- ratchet authored LSP coverage from 18 to 19 fixtures

## Validation

- `vp install --frozen-lockfile --prefer-offline`
- `cargo build -p vize`
- `node --test --test-concurrency=1 tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts`
- `CORSA_PATH="$PWD/node_modules/@typescript/typescript-darwin-arm64/lib/tsc" VIZE_LSP_BIN=target/debug/vize FIXTURE_REPORT_DIR=.vize/lsp-authored-oracle-slice REAL_PROJECT_LSP_TIMEOUT_MS=600000 node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts`
- `git diff --check`

Refs #3952.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791136236&installation_model_id=422833&pr_number=5665&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5665&signature=dd21b2b2989dc8a4bbe101f7fd9260d51b5048d93413fe79de0cb05560cf55aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->