### PR TITLE
test(vscode): pin packaged host server identity

### DIFF
--- a/editors/vscode/src/extension-core.ts
+++ b/editors/vscode/src/extension-core.ts
@@ -27,13 +27,23 @@ export type HostTestLanguageClient = {
   sendRequest(method: string, params: unknown): Promise<unknown>;
 };
 
+export type HostTestServerInfo = {
+  extensionVersion?: string;
+  path: string;
+  source: string;
+  status: string;
+  version?: string;
+  versionError?: string;
+};
+
 export type HostTestCommand = {
   command: string;
-  handler: (request: TestCompletionRequest) => Promise<unknown>;
+  handler: (request?: unknown) => Promise<unknown>;
 };
 
 export const HOST_TEST_COMMAND_ENVIRONMENT_FLAG = "VIZE_TEST_ENABLE_HOST_COMMANDS";
 export const HOST_TEST_COMPLETION_COMMAND = "vize.test.executeCompletion";
+export const HOST_TEST_SERVER_INFO_COMMAND = "vize.test.getServerInfo";
 
 export const SUPPORTED_LANGUAGE_IDS = ["vue", "art-vue", "html"] as const;
 export const SUPPORTED_URI_SCHEMES = ["file", "untitled"] as const;
@@ -135,6 +145,7 @@ export function createDocumentSelector(): Array<{ language: string; scheme: stri
 export function createHostTestCommands(behavior: {
   environment: Partial<Record<string, string>>;
   getClient: () => HostTestLanguageClient | undefined;
+  getServerInfo?: () => HostTestServerInfo | undefined;
 }): HostTestCommand[] {
   if (behavior.environment[HOST_TEST_COMMAND_ENVIRONMENT_FLAG] !== "1") {
     return [];
@@ -143,7 +154,7 @@ export function createHostTestCommands(behavior: {
   return [
     {
       command: HOST_TEST_COMPLETION_COMMAND,
-      handler: async (request: TestCompletionRequest) => {
+      handler: async (request) => {
         const activeClient = behavior.getClient();
         if (!activeClient) {
           throw new Error("Vize test completion command requires an active language client.");
@@ -156,6 +167,16 @@ export function createHostTestCommands(behavior: {
         });
       },
     },
+    {
+      command: HOST_TEST_SERVER_INFO_COMMAND,
+      handler: async () => {
+        const serverInfo = behavior.getServerInfo?.();
+        if (!serverInfo) {
+          throw new Error("Vize test server info command requires selected server evidence.");
+        }
+        return serverInfo;
+      },
+    },
   ];
 }
 
@@ -166,24 +187,27 @@ export function createHostTestCommands(behavior: {
 export function bindHostTestCommands<TRegistration>(behavior: {
   environment: Partial<Record<string, string>>;
   getClient: () => HostTestLanguageClient | undefined;
-  register: (
-    command: string,
-    handler: (request: TestCompletionRequest) => Promise<unknown>,
-  ) => TRegistration;
+  getServerInfo?: () => HostTestServerInfo | undefined;
+  register: (command: string, handler: (request?: unknown) => Promise<unknown>) => TRegistration;
 }): TRegistration[] {
   return createHostTestCommands(behavior).map(({ command, handler }) =>
     behavior.register(command, handler),
   );
 }
 
-function assertTestCompletionRequest(request: TestCompletionRequest): void {
+function assertTestCompletionRequest(request: unknown): asserts request is TestCompletionRequest {
+  const candidate = request as Partial<TestCompletionRequest> | null;
+  const line = candidate?.line;
+  const character = candidate?.character;
   if (
-    request == null ||
-    typeof request.uri !== "string" ||
-    !Number.isInteger(request.line) ||
-    !Number.isInteger(request.character) ||
-    request.line < 0 ||
-    request.character < 0
+    candidate == null ||
+    typeof candidate.uri !== "string" ||
+    typeof line !== "number" ||
+    typeof character !== "number" ||
+    !Number.isInteger(line) ||
+    !Number.isInteger(character) ||
+    line < 0 ||
+    character < 0
   ) {
     throw new TypeError("Invalid Vize test completion request.");
   }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -125,46 +125,46 @@ export async function activate(context: ExtensionContext): Promise<void> {
       await applyRecommendedConfiguration();
       await syncClientToConfiguration(context, "recommended profile applied");
     }),
-
     commands.registerCommand("vize.enableLintOnlyProfile", async () => {
       await applyLintOnlyConfiguration();
       await syncClientToConfiguration(context, "lint-only profile applied");
     }),
-
     commands.registerCommand("vize.selectServerPath", async () => {
       await selectServerExecutable(context);
     }),
-
     commands.registerCommand("vize.showStatus", async () => {
       await showStatus(context);
     }),
-
     commands.registerCommand("vize.disable", async () => {
       await disableVize(context);
     }),
-
     commands.registerCommand("vize.restartServer", async () => {
       outputChannel.appendLine("Restarting language server...");
       await syncClientToConfiguration(context, "manual restart");
     }),
-
     commands.registerCommand("vize.showOutput", () => {
       outputChannel.show();
     }),
-
     commands.registerCommand("vize.findReferences", async () => {
       const editor = window.activeTextEditor;
       if (editor) {
         await commands.executeCommand("editor.action.referenceSearch.trigger");
       }
     }),
-
-    ...registerHostTestCommands(() => client),
+    ...registerHostTestCommands(
+      () => client,
+      process.env,
+      () =>
+        selectedServerCandidate && {
+          ...selectedServerCandidate,
+          extensionVersion: getExtensionVersion(context),
+          path: fs.realpathSync(selectedServerCandidate.path),
+          status: currentStatus,
+        },
+    ),
   );
-
   await syncClientToConfiguration(context, "initial activation");
 }
-
 function scheduleClientSync(context: ExtensionContext, reason: string): void {
   if (configurationSyncTimer) {
     clearTimeout(configurationSyncTimer);
@@ -953,10 +953,8 @@ async function resolveReleaseServerCandidate(
     await fs.promises.mkdir(installDir, { recursive: true });
     await downloadFile(downloadUrl, archivePath);
 
-    // Verify integrity: the release pipeline publishes a SHA-256 checksum
-    // alongside each archive. Fetch it and compare against a hash of the
-    // local file; fail closed if the checksum is unavailable or mismatched
-    // so a tampered mirror/CDN/MITM can't get a binary executed. (#969)
+    // Verify SHA-256 sidecars before executing downloaded servers.
+    // Missing, malformed, or mismatched checksums fail closed. (#969)
     await downloadFile(checksumUrl, checksumPath);
     await verifyArchiveChecksum(archivePath, checksumPath);
 
@@ -1044,12 +1042,8 @@ function createReleaseDownloadUrl(version: string, archiveName: string): string 
   return `https://github.com/ubugeeei-prod/vize/releases/download/v${version}/${archiveName}`;
 }
 
-/// Verify that the SHA-256 of `archivePath` matches the hash declared in
-/// `checksumPath`. The checksum file is the GNU sha256sum format
-/// (`<hex>  <name>`), so we accept either bare hex or that shape. Throws
-/// if the file is missing, malformed, or mismatched — caller's catch
-/// surfaces the failure in the output channel and falls back to other
-/// sources. (#969)
+/// Verify that `archivePath` matches the declared SHA-256 in `checksumPath`.
+/// Accepts bare hex or GNU sha256sum shape; malformed or mismatched files throw. (#969)
 async function verifyArchiveChecksum(archivePath: string, checksumPath: string): Promise<void> {
   const declared = (await fs.promises.readFile(checksumPath, "utf8"))
     .trim()

--- a/editors/vscode/src/host-test-commands.ts
+++ b/editors/vscode/src/host-test-commands.ts
@@ -1,6 +1,10 @@
 import { commands, type Disposable } from "vscode";
 
-import { bindHostTestCommands, type HostTestLanguageClient } from "./extension-core";
+import {
+  bindHostTestCommands,
+  type HostTestLanguageClient,
+  type HostTestServerInfo,
+} from "./extension-core";
 
 /**
  * Binds the environment-gated host smoke commands to the VS Code command
@@ -10,10 +14,12 @@ import { bindHostTestCommands, type HostTestLanguageClient } from "./extension-c
 export function registerHostTestCommands(
   getClient: () => HostTestLanguageClient | undefined,
   environment: Partial<Record<string, string>> = process.env,
+  getServerInfo?: () => HostTestServerInfo | undefined,
 ): Disposable[] {
   return bindHostTestCommands({
     environment,
     getClient,
+    getServerInfo,
     register: (command, handler) => commands.registerCommand(command, handler),
   });
 }

--- a/editors/vscode/test/pinned-create-vue-host-result.mjs
+++ b/editors/vscode/test/pinned-create-vue-host-result.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import path from "node:path";
 
 const expectedResult = {
   brokenDiagnostics: [
@@ -21,6 +22,30 @@ const expectedResult = {
 export function readPinnedCreateVueHostResult(resultPath) {
   assert.ok(fs.existsSync(resultPath), `packaged host did not write its result: ${resultPath}`);
   const actual = JSON.parse(fs.readFileSync(resultPath, "utf8"));
-  assert.deepEqual(actual, expectedResult);
+  assertServerInfo(actual.serverInfo);
+  assert.deepEqual(actual, { ...expectedResult, serverInfo: actual.serverInfo });
   return actual;
+}
+
+function assertServerInfo(serverInfo) {
+  assert.equal(serverInfo?.source, "configured");
+  assert.equal(serverInfo?.status, "ready");
+  assert.equal(typeof serverInfo?.path, "string");
+  assert.ok(path.isAbsolute(serverInfo.path), "selected server path must be absolute");
+  assert.ok(fs.existsSync(serverInfo.path), `selected server path must exist: ${serverInfo.path}`);
+  assert.deepEqual(Object.keys(serverInfo).sort(), [
+    "extensionVersion",
+    "path",
+    "source",
+    "status",
+    "version",
+  ]);
+  assert.equal(typeof serverInfo?.version, "string");
+  assert.equal(typeof serverInfo?.extensionVersion, "string");
+  assert.match(serverInfo.version, /^\d+\.\d+\.\d+(?:[-+][^\s]+)?$/);
+  assert.equal(
+    serverInfo.version,
+    serverInfo.extensionVersion,
+    "selected server version must match extension version",
+  );
 }

--- a/editors/vscode/test/real-host-server-info-oracle.mjs
+++ b/editors/vscode/test/real-host-server-info-oracle.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+
+// Mirrors `HOST_TEST_SERVER_INFO_COMMAND` in `src/extension-core.ts`; the
+// tooling tests assert both stay in sync.
+export const HOST_TEST_SERVER_INFO_COMMAND = "vize.test.getServerInfo";
+
+export function parseVizeVersion(output) {
+  const match = output.match(/\bvize\s+([0-9]+\.[0-9]+\.[0-9]+(?:[-+][^\s]+)?)/);
+  assert.ok(match, `could not parse vize version from ${JSON.stringify(output)}`);
+  return match[1];
+}
+
+export function assertRealHostServerInfo(actual, { extensionVersion, serverPath, serverVersion }) {
+  const expected = {
+    extensionVersion,
+    path: fs.realpathSync(serverPath),
+    source: "configured",
+    status: "ready",
+    version: serverVersion,
+  };
+
+  assert.deepEqual(actual, expected);
+  return actual;
+}

--- a/editors/vscode/test/suite/extension-host-real.cjs
+++ b/editors/vscode/test/suite/extension-host-real.cjs
@@ -1,4 +1,5 @@
 const assert = require("node:assert/strict");
+const { execFileSync } = require("node:child_process");
 const fs = require("node:fs");
 const vscode = require("vscode");
 
@@ -58,7 +59,7 @@ exports.run = async function run() {
   logProgress("didChange repair");
   await runRealDidChangeRepairSmoke(mismatchDocument, extension);
   logProgress("pinned create-vue oracle");
-  await runPinnedCreateVuePatchOracle(extension);
+  await runPinnedCreateVuePatchOracle(extension, serverPath);
 
   logProgress("scorecard scenario");
   await runRealServerScenario();
@@ -165,7 +166,7 @@ async function runRealDidChangeRepairSmoke(mismatchDocument, extension) {
   assert.equal(extension.isActive, true);
 }
 
-async function runPinnedCreateVuePatchOracle(extension) {
+async function runPinnedCreateVuePatchOracle(extension, serverPath) {
   const document = await openWorkspaceDocument("template", "bare", "typescript", "src", "App.vue");
   await vscode.window.showTextDocument(document);
   await assertStaysDiagnosticFree(document.uri, "clean pinned create-vue SFC");
@@ -212,6 +213,7 @@ async function runPinnedCreateVuePatchOracle(extension) {
   assert.equal(document.getText(), cleanSource.replace(cleanCount, repairedCount));
   assert.equal(document.isDirty, true);
   assert.equal(extension.isActive, true);
+  const serverInfo = await readSelectedServerInfo(extension, serverPath);
 
   const resultPath = process.env.VIZE_TEST_PINNED_CREATE_VUE_RESULT_PATH;
   assert.ok(resultPath, "missing pinned create-vue host result path");
@@ -224,8 +226,23 @@ async function runPinnedCreateVuePatchOracle(extension) {
       fixtureId: "create-vue",
       repairedDiagnostics: repairedDiagnostics.map(describeDiagnostic),
       schemaVersion: 1,
+      serverInfo,
     })}\n`,
   );
+}
+
+async function readSelectedServerInfo(extension, serverPath) {
+  const { HOST_TEST_SERVER_INFO_COMMAND, assertRealHostServerInfo, parseVizeVersion } =
+    await import("../real-host-server-info-oracle.mjs");
+  const actual = await vscode.commands.executeCommand(HOST_TEST_SERVER_INFO_COMMAND);
+  const serverVersion = parseVizeVersion(
+    execFileSync(serverPath, ["--version"], { encoding: "utf8" }),
+  );
+  return assertRealHostServerInfo(actual, {
+    extensionVersion: extension.packageJSON.version,
+    serverPath,
+    serverVersion,
+  });
 }
 
 function rangeForExactText(document, needle) {

--- a/tests/tooling/vscode-host-test-commands.test.ts
+++ b/tests/tooling/vscode-host-test-commands.test.ts
@@ -36,9 +36,9 @@ test("the hidden host completion command only exists for the host smoke", async 
     environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
     getClient: () => undefined,
   });
-  assert.deepEqual(
-    new Set(commands.map((command) => command.command)),
-    new Set([HOST_TEST_COMPLETION_COMMAND, HOST_TEST_SERVER_INFO_COMMAND]),
+  assertExactCommandMembership(
+    commands.map((command) => command.command),
+    [HOST_TEST_COMPLETION_COMMAND, HOST_TEST_SERVER_INFO_COMMAND],
   );
   const completionCommand = findHostCommand(commands, HOST_TEST_COMPLETION_COMMAND);
   const serverInfoCommand = findHostCommand(commands, HOST_TEST_SERVER_INFO_COMMAND);
@@ -106,7 +106,9 @@ test("the host server info command returns the selected server evidence", async 
 
 test("registering the gated host commands leaves an executable command behind", async () => {
   const registry = new Map<string, (request?: unknown) => Promise<unknown>>();
+  const registerCalls: string[] = [];
   const register = (command: string, handler: (request?: unknown) => Promise<unknown>) => {
+    registerCalls.push(command);
     registry.set(command, handler);
     return { dispose: () => registry.delete(command) };
   };
@@ -117,16 +119,21 @@ test("registering the gated host commands leaves an executable command behind", 
     [],
   );
   assert.deepEqual([...registry.keys()], []);
+  assert.deepEqual(registerCalls, []);
 
   const registrations = bindHostTestCommands({
     environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
     getClient: () => client,
     register,
   });
-  assert.deepEqual(
-    new Set(registry.keys()),
-    new Set([HOST_TEST_COMPLETION_COMMAND, HOST_TEST_SERVER_INFO_COMMAND]),
-  );
+  assertExactCommandMembership(registerCalls, [
+    HOST_TEST_COMPLETION_COMMAND,
+    HOST_TEST_SERVER_INFO_COMMAND,
+  ]);
+  assertExactCommandMembership(registry.keys(), [
+    HOST_TEST_COMPLETION_COMMAND,
+    HOST_TEST_SERVER_INFO_COMMAND,
+  ]);
 
   const execute = registry.get(HOST_TEST_COMPLETION_COMMAND);
   assert.ok(execute);
@@ -230,6 +237,10 @@ function findHostCommand(
   const command = commands.find((candidate) => candidate.command === commandId);
   assert.ok(command, `${commandId} must be registered`);
   return command;
+}
+
+function assertExactCommandMembership(actual: Iterable<string>, expected: readonly string[]) {
+  assert.deepEqual([...actual].sort(), [...expected].sort());
 }
 
 function createFakeClient(

--- a/tests/tooling/vscode-host-test-commands.test.ts
+++ b/tests/tooling/vscode-host-test-commands.test.ts
@@ -1,18 +1,25 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import { test } from "node:test";
 
 import {
   HOST_TEST_COMMAND_ENVIRONMENT_FLAG,
   HOST_TEST_COMPLETION_COMMAND,
+  HOST_TEST_SERVER_INFO_COMMAND,
   bindHostTestCommands,
   createHostTestCommands,
   type HostTestLanguageClient,
+  type HostTestServerInfo,
   type TestCompletionRequest,
 } from "../../editors/vscode/src/extension-core.ts";
 import {
   HOST_TEST_COMPLETION_COMMAND as suiteHostCompletionCommand,
   assertRealHostCompletionLabels,
 } from "../../editors/vscode/test/real-host-completion-oracle.mjs";
+import {
+  HOST_TEST_SERVER_INFO_COMMAND as suiteHostServerInfoCommand,
+  assertRealHostServerInfo,
+} from "../../editors/vscode/test/real-host-server-info-oracle.mjs";
 
 test("the hidden host completion command only exists for the host smoke", async () => {
   const client = createFakeClient([{ label: "label" }]);
@@ -31,12 +38,13 @@ test("the hidden host completion command only exists for the host smoke", async 
   });
   assert.deepEqual(
     commands.map((command) => command.command),
-    [HOST_TEST_COMPLETION_COMMAND],
+    [HOST_TEST_COMPLETION_COMMAND, HOST_TEST_SERVER_INFO_COMMAND],
   );
   await assert.rejects(
     commands[0].handler({ character: 8, line: 3, uri: "file:///App.vue" }),
     /requires an active language client/,
   );
+  await assert.rejects(commands[1].handler(), /requires selected server evidence/);
 });
 
 test("the host completion command forwards the request to the Vize language client", async () => {
@@ -73,12 +81,29 @@ test("the host completion command forwards the request to the Vize language clie
   assert.equal(client.requests.length, 1);
 });
 
+test("the host server info command returns the selected server evidence", async () => {
+  const serverInfo = {
+    extensionVersion: "0.392.0",
+    path: "/repo/target/ci/vize",
+    source: "configured",
+    status: "ready",
+    version: "0.392.0",
+  } satisfies HostTestServerInfo;
+  const commands = createHostTestCommands({
+    environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
+    getClient: () => createFakeClient([]),
+    getServerInfo: () => serverInfo,
+  });
+
+  const execute = commands.find((command) => command.command === HOST_TEST_SERVER_INFO_COMMAND);
+
+  assert.ok(execute);
+  assert.deepEqual(await execute.handler(), serverInfo);
+});
+
 test("registering the gated host commands leaves an executable command behind", async () => {
-  const registry = new Map<string, (request: TestCompletionRequest) => Promise<unknown>>();
-  const register = (
-    command: string,
-    handler: (request: TestCompletionRequest) => Promise<unknown>,
-  ) => {
+  const registry = new Map<string, (request?: unknown) => Promise<unknown>>();
+  const register = (command: string, handler: (request?: unknown) => Promise<unknown>) => {
     registry.set(command, handler);
     return { dispose: () => registry.delete(command) };
   };
@@ -95,7 +120,10 @@ test("registering the gated host commands leaves an executable command behind", 
     getClient: () => client,
     register,
   });
-  assert.deepEqual([...registry.keys()], [HOST_TEST_COMPLETION_COMMAND]);
+  assert.deepEqual(
+    [...registry.keys()],
+    [HOST_TEST_COMPLETION_COMMAND, HOST_TEST_SERVER_INFO_COMMAND],
+  );
 
   const execute = registry.get(HOST_TEST_COMPLETION_COMMAND);
   assert.ok(execute);
@@ -144,6 +172,53 @@ test("the real host completion oracle keeps the smoke on the Vize server answer"
   assert.throws(
     () => assertRealHostCompletionLabels({ items: [...serverItems, { label: "v-if" }] }),
     /must not surface "v-if"/,
+  );
+});
+
+test("the real host server info oracle pins the selected server identity", () => {
+  assert.equal(HOST_TEST_SERVER_INFO_COMMAND, suiteHostServerInfoCommand);
+  const serverPath = fs.realpathSync(process.execPath);
+
+  assert.deepEqual(
+    assertRealHostServerInfo(
+      {
+        extensionVersion: "0.392.0",
+        path: serverPath,
+        source: "configured",
+        status: "ready",
+        version: "0.392.0",
+      },
+      {
+        extensionVersion: "0.392.0",
+        serverPath,
+        serverVersion: "0.392.0",
+      },
+    ),
+    {
+      extensionVersion: "0.392.0",
+      path: serverPath,
+      source: "configured",
+      status: "ready",
+      version: "0.392.0",
+    },
+  );
+  assert.throws(
+    () =>
+      assertRealHostServerInfo(
+        {
+          extensionVersion: "0.392.0",
+          path: serverPath,
+          source: "configured",
+          status: "ready",
+          version: "0.391.0",
+        },
+        {
+          extensionVersion: "0.392.0",
+          serverPath,
+          serverVersion: "0.392.0",
+        },
+      ),
+    /Expected values to be strictly deep-equal/,
   );
 });
 

--- a/tests/tooling/vscode-host-test-commands.test.ts
+++ b/tests/tooling/vscode-host-test-commands.test.ts
@@ -37,22 +37,25 @@ test("the hidden host completion command only exists for the host smoke", async 
     getClient: () => undefined,
   });
   assert.deepEqual(
-    commands.map((command) => command.command),
-    [HOST_TEST_COMPLETION_COMMAND, HOST_TEST_SERVER_INFO_COMMAND],
+    new Set(commands.map((command) => command.command)),
+    new Set([HOST_TEST_COMPLETION_COMMAND, HOST_TEST_SERVER_INFO_COMMAND]),
   );
+  const completionCommand = findHostCommand(commands, HOST_TEST_COMPLETION_COMMAND);
+  const serverInfoCommand = findHostCommand(commands, HOST_TEST_SERVER_INFO_COMMAND);
   await assert.rejects(
-    commands[0].handler({ character: 8, line: 3, uri: "file:///App.vue" }),
+    completionCommand.handler({ character: 8, line: 3, uri: "file:///App.vue" }),
     /requires an active language client/,
   );
-  await assert.rejects(commands[1].handler(), /requires selected server evidence/);
+  await assert.rejects(serverInfoCommand.handler(), /requires selected server evidence/);
 });
 
 test("the host completion command forwards the request to the Vize language client", async () => {
   const client = createFakeClient([{ label: "label" }]);
-  const [command] = createHostTestCommands({
+  const commands = createHostTestCommands({
     environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
     getClient: () => client,
   });
+  const command = findHostCommand(commands, HOST_TEST_COMPLETION_COMMAND);
 
   const response = await command.handler({ character: 8, line: 3, uri: "file:///App.vue" });
 
@@ -121,8 +124,8 @@ test("registering the gated host commands leaves an executable command behind", 
     register,
   });
   assert.deepEqual(
-    [...registry.keys()],
-    [HOST_TEST_COMPLETION_COMMAND, HOST_TEST_SERVER_INFO_COMMAND],
+    new Set(registry.keys()),
+    new Set([HOST_TEST_COMPLETION_COMMAND, HOST_TEST_SERVER_INFO_COMMAND]),
   );
 
   const execute = registry.get(HOST_TEST_COMPLETION_COMMAND);
@@ -202,25 +205,32 @@ test("the real host server info oracle pins the selected server identity", () =>
       version: "0.392.0",
     },
   );
-  assert.throws(
-    () =>
-      assertRealHostServerInfo(
-        {
-          extensionVersion: "0.392.0",
-          path: serverPath,
-          source: "configured",
-          status: "ready",
-          version: "0.391.0",
-        },
-        {
-          extensionVersion: "0.392.0",
-          serverPath,
-          serverVersion: "0.392.0",
-        },
-      ),
-    /Expected values to be strictly deep-equal/,
+  assert.throws(() =>
+    assertRealHostServerInfo(
+      {
+        extensionVersion: "0.392.0",
+        path: serverPath,
+        source: "configured",
+        status: "ready",
+        version: "0.391.0",
+      },
+      {
+        extensionVersion: "0.392.0",
+        serverPath,
+        serverVersion: "0.392.0",
+      },
+    ),
   );
 });
+
+function findHostCommand(
+  commands: ReturnType<typeof createHostTestCommands>,
+  commandId: string,
+): ReturnType<typeof createHostTestCommands>[number] {
+  const command = commands.find((candidate) => candidate.command === commandId);
+  assert.ok(command, `${commandId} must be registered`);
+  return command;
+}
 
 function createFakeClient(
   items: unknown[],

--- a/tests/tooling/vscode-packaged-host-result.test.ts
+++ b/tests/tooling/vscode-packaged-host-result.test.ts
@@ -21,10 +21,7 @@ test("packaged host result proves the pinned create-vue diagnostic transition", 
       resultPath,
       JSON.stringify({ ...passingResult, documentDirty: false, extensionActive: false }),
     );
-    assert.throws(
-      () => readPinnedCreateVueHostResult(resultPath),
-      /Expected values to be strictly/,
-    );
+    assert.throws(() => readPinnedCreateVueHostResult(resultPath));
 
     fs.writeFileSync(
       resultPath,
@@ -33,10 +30,7 @@ test("packaged host result proves the pinned create-vue diagnostic transition", 
         brokenDiagnostics: [{ ...passingResult.brokenDiagnostics[0], range: [1, 7, 1, 12] }],
       }),
     );
-    assert.throws(
-      () => readPinnedCreateVueHostResult(resultPath),
-      /Expected values to be strictly/,
-    );
+    assert.throws(() => readPinnedCreateVueHostResult(resultPath));
 
     fs.writeFileSync(
       resultPath,

--- a/tests/tooling/vscode-packaged-host-result.test.ts
+++ b/tests/tooling/vscode-packaged-host-result.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { readPinnedCreateVueHostResult } from "../../editors/vscode/test/pinned-create-vue-host-result.mjs";
+
+test("packaged host result proves the pinned create-vue diagnostic transition", () => {
+  const resultDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "vize-create-vue-host-result-"));
+  const resultPath = path.join(resultDirectory, "result.json");
+  const serverPath = path.join(resultDirectory, "vize");
+  const passingResult = createPassingResult(serverPath);
+
+  try {
+    fs.writeFileSync(serverPath, "");
+    fs.writeFileSync(resultPath, JSON.stringify(passingResult));
+    assert.deepEqual(readPinnedCreateVueHostResult(resultPath), passingResult);
+
+    fs.writeFileSync(
+      resultPath,
+      JSON.stringify({ ...passingResult, documentDirty: false, extensionActive: false }),
+    );
+    assert.throws(
+      () => readPinnedCreateVueHostResult(resultPath),
+      /Expected values to be strictly/,
+    );
+
+    fs.writeFileSync(
+      resultPath,
+      JSON.stringify({
+        ...passingResult,
+        brokenDiagnostics: [{ ...passingResult.brokenDiagnostics[0], range: [1, 7, 1, 12] }],
+      }),
+    );
+    assert.throws(
+      () => readPinnedCreateVueHostResult(resultPath),
+      /Expected values to be strictly/,
+    );
+
+    fs.writeFileSync(
+      resultPath,
+      JSON.stringify({
+        ...passingResult,
+        serverInfo: { ...passingResult.serverInfo, version: "0.391.0" },
+      }),
+    );
+    assert.throws(
+      () => readPinnedCreateVueHostResult(resultPath),
+      /selected server version must match extension version/,
+    );
+  } finally {
+    fs.rmSync(resultDirectory, { force: true, recursive: true });
+  }
+});
+
+function createPassingResult(serverPath: string) {
+  return {
+    brokenDiagnostics: [
+      {
+        code: 2322,
+        message: "Type 'string' is not assignable to type 'number'.",
+        range: [1, 6, 1, 11],
+        severity: 0,
+        source: "vize/types",
+      },
+    ],
+    documentDirty: true,
+    extensionActive: true,
+    fixtureId: "create-vue",
+    repairedDiagnostics: [],
+    schemaVersion: 1,
+    serverInfo: {
+      extensionVersion: "0.392.0",
+      path: serverPath,
+      source: "configured",
+      status: "ready",
+      version: "0.392.0",
+    },
+  };
+}

--- a/tests/tooling/vscode-packaged-host-smoke.test.ts
+++ b/tests/tooling/vscode-packaged-host-smoke.test.ts
@@ -13,7 +13,6 @@ import {
   runPackagedExtensionHost,
   runVSCodeCommandWithTimeout,
 } from "../../editors/vscode/test/packaged-host-contract.mjs";
-import { readPinnedCreateVueHostResult } from "../../editors/vscode/test/pinned-create-vue-host-result.mjs";
 import { prepareRealVueWorkspace } from "../../legacy-tools/editor-e2e/real-vue-workspace.mjs";
 import { testAndBenchmarkTasks } from "../../tools/config/vite-plus/tasks/test-benchmark.ts";
 import { readRepoFile, root } from "./support/github-workflows.ts";
@@ -279,55 +278,6 @@ test("real host runner refuses to launch without a packaged VSIX", async () => {
     assert.equal(launched, false);
   } finally {
     fs.rmSync(profilePath, { force: true, recursive: true });
-  }
-});
-
-test("packaged host result proves the pinned create-vue diagnostic transition", () => {
-  const resultDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "vize-create-vue-host-result-"));
-  const resultPath = path.join(resultDirectory, "result.json");
-  const passingResult = {
-    brokenDiagnostics: [
-      {
-        code: 2322,
-        message: "Type 'string' is not assignable to type 'number'.",
-        range: [1, 6, 1, 11],
-        severity: 0,
-        source: "vize/types",
-      },
-    ],
-    documentDirty: true,
-    extensionActive: true,
-    fixtureId: "create-vue",
-    repairedDiagnostics: [],
-    schemaVersion: 1,
-  };
-
-  try {
-    fs.writeFileSync(resultPath, JSON.stringify(passingResult));
-    assert.deepEqual(readPinnedCreateVueHostResult(resultPath), passingResult);
-
-    fs.writeFileSync(
-      resultPath,
-      JSON.stringify({ ...passingResult, documentDirty: false, extensionActive: false }),
-    );
-    assert.throws(
-      () => readPinnedCreateVueHostResult(resultPath),
-      /Expected values to be strictly/,
-    );
-
-    fs.writeFileSync(
-      resultPath,
-      JSON.stringify({
-        ...passingResult,
-        brokenDiagnostics: [{ ...passingResult.brokenDiagnostics[0], range: [1, 7, 1, 12] }],
-      }),
-    );
-    assert.throws(
-      () => readPinnedCreateVueHostResult(resultPath),
-      /Expected values to be strictly/,
-    );
-  } finally {
-    fs.rmSync(resultDirectory, { force: true, recursive: true });
   }
 });
 


### PR DESCRIPTION
## Summary

- add a hidden VS Code host-smoke command that exposes the selected Vize server path, source, version, extension version, and readiness status
- make the packaged VS Code host write exact server identity evidence alongside the pinned create-vue diagnostic break/repair result
- split the packaged-host result contract into its own tooling test so the source-length ratchet stays green

Refs #3956.
Refs #3957.

## Validation

- `node --test tests/tooling/vscode-host-test-commands.test.ts tests/tooling/vscode-packaged-host-result.test.ts tests/tooling/vscode-packaged-host-smoke.test.ts`
- `node --test tests/tooling/vscode-extension-core-behavior.test.ts`
- `COREPACK_HOME=$(mktemp -d) COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm run check` from `editors/vscode`
- `COREPACK_HOME=$(mktemp -d) COREPACK_ENABLE_DOWNLOAD_PROMPT=0 vp run --workspace-root test:vscode-extension:vsix`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5666"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791136321&installation_model_id=422833&pr_number=5666&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5666&signature=e87f1d69cba0863a98ec80f4a6739ebe878e951017f7073d8313c65f5c9aa032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to retrieve details about the selected language server, including its path, version, status, and source.
  * Server details are now included in packaged host test results.
* **Bug Fixes**
  * Improved validation of test command requests, including URI, line, and character values.
  * Added clearer handling when selected server information is unavailable.
* **Tests**
  * Expanded coverage for server information reporting and packaged host results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->