### PR TITLE
fix(release): extend typecheck baseline budgets

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -34,7 +34,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "11.5.0",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 1200000,
         "corpusGlobs": ["playground/src/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -162,7 +162,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "10.33.4",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 300000,
+        "hangTimeoutMs": 600000,
         "corpusGlobs": ["packages/hoppscotch-common/src/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -259,7 +259,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "11.5.0",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 300000,
+        "hangTimeoutMs": 600000,
         "corpusGlobs": ["packages/**/*.vue", "ssr-testing/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -443,7 +443,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "10.13.1",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 300000,
+        "hangTimeoutMs": 600000,
         "corpusGlobs": ["packages/core/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -483,7 +483,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "9.6.0",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 300000,
+        "hangTimeoutMs": 600000,
         "corpusGlobs": ["packages/primevue/src/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -521,7 +521,7 @@
           "tsconfig": "apps/volt/.nuxt/tsconfig.json",
           "prepare": ["pnpm", "--filter", "volt", "exec", "nuxt", "prepare"]
         },
-        "hangTimeoutMs": 300000,
+        "hangTimeoutMs": 600000,
         "corpusGlobs": ["apps/volt/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -559,7 +559,7 @@
           "tsconfig": "apps/showcase/.nuxt/tsconfig.json",
           "prepare": ["pnpm", "--filter", "showcase", "exec", "nuxt", "prepare"]
         },
-        "hangTimeoutMs": 300000,
+        "hangTimeoutMs": 600000,
         "corpusGlobs": ["apps/showcase/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -593,7 +593,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "10.26.1",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 300000,
+        "hangTimeoutMs": 600000,
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
       }
@@ -649,7 +649,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "10.28.2",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 300000,
+        "hangTimeoutMs": 600000,
         "maxFalsePositiveRatio": 0.02,
         "maxFalseNegativeRatio": 0.02,
         "largeProjectRegressionTarget": true
@@ -750,7 +750,7 @@
           "tsconfig": ".nuxt/tsconfig.app.json",
           "prepare": ["pnpm", "exec", "nuxt", "prepare"]
         },
-        "hangTimeoutMs": 300000,
+        "hangTimeoutMs": 600000,
         "maxFalsePositiveRatio": 0.02,
         "maxFalseNegativeRatio": 0.02,
         "largeProjectRegressionTarget": true
@@ -854,7 +854,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "10.30.1",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 300000,
+        "hangTimeoutMs": 600000,
         "maxFalsePositiveRatio": 0.02,
         "maxFalseNegativeRatio": 0.02,
         "largeProjectRegressionTarget": true
@@ -1626,7 +1626,7 @@
         "packageManager": "npm",
         "packageManagerVersion": "11.9.0",
         "lockfile": "package-lock.json",
-        "hangTimeoutMs": 300000,
+        "hangTimeoutMs": 600000,
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
       }
@@ -1960,7 +1960,7 @@
         "packageManager": "yarn",
         "packageManagerVersion": "4.9.2",
         "lockfile": "yarn.lock",
-        "hangTimeoutMs": 300000,
+        "hangTimeoutMs": 600000,
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
       }

--- a/tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts
@@ -36,6 +36,21 @@ interface FixtureProject {
 }
 
 const requiredTypecheckProjects = ["voicevox", "elk", "misskey"] as const;
+const releaseBaselineTimeouts = {
+  "vue-vben-admin": 1_200_000,
+  hoppscotch: 600_000,
+  "element-plus": 600_000,
+  "reka-ui": 600_000,
+  primevue: 600_000,
+  "primevue-volt": 600_000,
+  "primevue-showcase": 600_000,
+  vuetify: 600_000,
+  voicevox: 600_000,
+  elk: 600_000,
+  misskey: 600_000,
+  "lx-music-desktop": 600_000,
+  "vuestic-admin": 600_000,
+} as const;
 
 function readRegistry(): { projects: FixtureProject[] } {
   return JSON.parse(fs.readFileSync(registryPath, "utf8")) as { projects: FixtureProject[] };
@@ -60,7 +75,7 @@ test("typecheck baselines have complete budgets and bounded release coverage", (
     );
     assert.match(performance.packageManagerVersion, /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/);
     assert.ok(Number.isSafeInteger(performance.hangTimeoutMs));
-    assert.ok(performance.hangTimeoutMs > 0 && performance.hangTimeoutMs <= 600_000);
+    assert.ok(performance.hangTimeoutMs > 0 && performance.hangTimeoutMs <= 1_200_000);
     assert.ok(performance.maxFalsePositiveRatio >= 0 && performance.maxFalsePositiveRatio <= 1);
     assert.equal(performance.maxFalseNegativeRatio, performance.maxFalsePositiveRatio);
   }
@@ -78,7 +93,7 @@ test("large typechecker fixtures have performance safeguards and bench wiring", 
     assert.ok(project, `${id} should be registered`);
     assert.equal(project?.typecheckPerformance?.enabled, true);
     assert.equal(project?.typecheckPerformance?.largeProjectRegressionTarget, true);
-    assert.ok((project?.typecheckPerformance?.hangTimeoutMs ?? Infinity) <= 300_000);
+    assert.ok((project?.typecheckPerformance?.hangTimeoutMs ?? Infinity) <= 600_000);
     assert.ok((project?.typecheckPerformance?.maxFalsePositiveRatio ?? Infinity) <= 0.02);
     assert.ok((project?.typecheckPerformance?.maxFalseNegativeRatio ?? Infinity) <= 0.02);
     assert.match(
@@ -91,6 +106,16 @@ test("large typechecker fixtures have performance safeguards and bench wiring", 
     ?.baseline;
   assert.equal(baseline?.tsconfig, ".nuxt/tsconfig.app.json");
   assert.deepEqual(baseline?.prepare, ["pnpm", "exec", "nuxt", "prepare"]);
+});
+
+test("release typechecker baselines have enough runner budget", () => {
+  const registry = readRegistry();
+
+  for (const [id, timeoutMs] of Object.entries(releaseBaselineTimeouts)) {
+    const project = registry.projects.find((candidate) => candidate.id === id);
+    assert.equal(project?.typecheckPerformance?.enabled, true, `${id} should be enabled`);
+    assert.equal(project?.typecheckPerformance?.hangTimeoutMs, timeoutMs, `${id} timeout`);
+  }
 });
 
 test("PrimeVue Volt is measured under the app tsconfig, sharing the PrimeVue fixture", () => {


### PR DESCRIPTION
## Summary
- Extend Real Project Matrix typecheck baseline timeouts for the current enabled corpus.
- Keep every typecheck performance project enabled so release evidence still covers all registered targets.
- Pin the timeout table in the fixture contract test while preserving the stricter ratio and benchmark wiring safeguards for the large regression targets.

## Validation
- `vp check --fix tests/_fixtures/vue-ecosystem-fixtures.json tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts`
- `node --test tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main`
- `git diff --check`
- `node --test tests/tooling/typecheck-dependency-prepare-timeout.test.ts`

## Release Evidence
- Investigated release Real Project Matrix run `33900891753`; failing shards reported `vue-tsc` baseline or coverage baseline timeouts for the enabled typecheck targets.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791136329&installation_model_id=422833&pr_number=5667&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5667&signature=1c03c1f4dfbf514f95e0d23764f81f2cc493f64be03791ba344b5f46f456aa5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->