### PR TITLE
fix(release): extend divergence baseline budgets

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -257,13 +257,13 @@ jobs:
             glyph_exit_code=1
           fi
           exit "$glyph_exit_code"
-
       - name: Enforce typechecker baseline divergence
         id: typecheck_divergence
         if: ${{ !cancelled() }}
         continue-on-error: true
         env:
           BUDGET_MODE: ${{ inputs.typecheck_divergence_mode || 'enforce' }}
+          VIZE_TYPECHECK_DIVERGENCE_PROGRESS: "1"
         run: |
           rust-script tools/commands/fixtures/typecheck-divergence-report.rs \
             --report-dir "$FIXTURE_REPORT_DIR" \

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -34,7 +34,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "11.5.0",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 1200000,
+        "hangTimeoutMs": 2400000,
         "corpusGlobs": ["playground/src/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -162,7 +162,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "10.33.4",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 2400000,
         "corpusGlobs": ["packages/hoppscotch-common/src/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -259,7 +259,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "11.5.0",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 2400000,
         "corpusGlobs": ["packages/**/*.vue", "ssr-testing/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -443,7 +443,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "10.13.1",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 2400000,
         "corpusGlobs": ["packages/core/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -483,7 +483,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "9.6.0",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 2400000,
         "corpusGlobs": ["packages/primevue/src/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -521,7 +521,7 @@
           "tsconfig": "apps/volt/.nuxt/tsconfig.json",
           "prepare": ["pnpm", "--filter", "volt", "exec", "nuxt", "prepare"]
         },
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 2400000,
         "corpusGlobs": ["apps/volt/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -559,7 +559,7 @@
           "tsconfig": "apps/showcase/.nuxt/tsconfig.json",
           "prepare": ["pnpm", "--filter", "showcase", "exec", "nuxt", "prepare"]
         },
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 2400000,
         "corpusGlobs": ["apps/showcase/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
@@ -593,7 +593,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "10.26.1",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 2400000,
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
       }
@@ -649,7 +649,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "10.28.2",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 2400000,
         "maxFalsePositiveRatio": 0.02,
         "maxFalseNegativeRatio": 0.02,
         "largeProjectRegressionTarget": true
@@ -750,7 +750,7 @@
           "tsconfig": ".nuxt/tsconfig.app.json",
           "prepare": ["pnpm", "exec", "nuxt", "prepare"]
         },
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 2400000,
         "maxFalsePositiveRatio": 0.02,
         "maxFalseNegativeRatio": 0.02,
         "largeProjectRegressionTarget": true
@@ -854,7 +854,7 @@
         "packageManager": "pnpm",
         "packageManagerVersion": "10.30.1",
         "lockfile": "pnpm-lock.yaml",
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 2400000,
         "maxFalsePositiveRatio": 0.02,
         "maxFalseNegativeRatio": 0.02,
         "largeProjectRegressionTarget": true
@@ -1626,7 +1626,7 @@
         "packageManager": "npm",
         "packageManagerVersion": "11.9.0",
         "lockfile": "package-lock.json",
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 2400000,
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
       }
@@ -1960,7 +1960,7 @@
         "packageManager": "yarn",
         "packageManagerVersion": "4.9.2",
         "lockfile": "yarn.lock",
-        "hangTimeoutMs": 600000,
+        "hangTimeoutMs": 2400000,
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
       }

--- a/tests/tooling/real-project-matrix-summary.test.ts
+++ b/tests/tooling/real-project-matrix-summary.test.ts
@@ -11,11 +11,13 @@ import {
 test("real-project workflow gates every measured surface on one verdict", () => {
   const steps = realProjectMatrixSteps();
   const divergenceIndex = steps.indexOf(findStep(steps, "Enforce typechecker baseline divergence"));
+  const divergence = steps[divergenceIndex];
   const verdict = findStep(steps, "Enforce all real-project surface verdicts");
   const verdictIndex = steps.indexOf(verdict);
   const summaryIndex = steps.indexOf(findStep(steps, "Publish shard summary"));
 
   assert.ok(divergenceIndex < verdictIndex && verdictIndex < summaryIndex);
+  assert.equal(divergence.env.VIZE_TYPECHECK_DIVERGENCE_PROGRESS, "1");
   assert.equal(verdict.if, "${{ always() }}");
   assert.equal(verdict.shell, "bash");
   assert.deepEqual(verdict.env, {

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -222,6 +222,33 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
   }
 });
 
+test("typecheck divergence progress logging is opt-in", () => {
+  const fixture = setup({ vizeDiagnostics: [], baselineOutput: "" });
+  try {
+    const quiet = run(fixture);
+    assert.equal(quiet.status, 0, quiet.stderr);
+    assert.doesNotMatch(quiet.stderr, /^\[typecheck-divergence\]/mu);
+
+    const result = run(fixture, { VIZE_TYPECHECK_DIVERGENCE_PROGRESS: "1" });
+    assert.equal(result.status, 0, result.stderr);
+    const progressLines = result.stderr.trimEnd().split("\n");
+    assert.equal(progressLines.length, 5);
+    assert.equal(progressLines[0], "[typecheck-divergence] start projectId=fixture timeoutMs=5000");
+    assert.equal(progressLines[1], "[typecheck-divergence] run projectId=fixture command=baseline");
+    assert.match(
+      progressLines[2],
+      /^\[typecheck-divergence\] finish projectId=fixture command=baseline durationMs=\d+ status=2$/u,
+    );
+    assert.equal(progressLines[3], "[typecheck-divergence] run projectId=fixture command=coverage");
+    assert.match(
+      progressLines[4],
+      /^\[typecheck-divergence\] finish projectId=fixture command=coverage durationMs=\d+ status=0$/u,
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});
+
 test("typecheck divergence report skips shards without typecheck performance targets", () => {
   const fixture = setup();
   try {

--- a/tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts
@@ -37,19 +37,19 @@ interface FixtureProject {
 
 const requiredTypecheckProjects = ["voicevox", "elk", "misskey"] as const;
 const releaseBaselineTimeouts = {
-  "vue-vben-admin": 1_200_000,
-  hoppscotch: 600_000,
-  "element-plus": 600_000,
-  "reka-ui": 600_000,
-  primevue: 600_000,
-  "primevue-volt": 600_000,
-  "primevue-showcase": 600_000,
-  vuetify: 600_000,
-  voicevox: 600_000,
-  elk: 600_000,
-  misskey: 600_000,
-  "lx-music-desktop": 600_000,
-  "vuestic-admin": 600_000,
+  "vue-vben-admin": 2_400_000,
+  hoppscotch: 2_400_000,
+  "element-plus": 2_400_000,
+  "reka-ui": 2_400_000,
+  primevue: 2_400_000,
+  "primevue-volt": 2_400_000,
+  "primevue-showcase": 2_400_000,
+  vuetify: 2_400_000,
+  voicevox: 2_400_000,
+  elk: 2_400_000,
+  misskey: 2_400_000,
+  "lx-music-desktop": 2_400_000,
+  "vuestic-admin": 2_400_000,
 } as const;
 
 function readRegistry(): { projects: FixtureProject[] } {
@@ -75,7 +75,7 @@ test("typecheck baselines have complete budgets and bounded release coverage", (
     );
     assert.match(performance.packageManagerVersion, /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/);
     assert.ok(Number.isSafeInteger(performance.hangTimeoutMs));
-    assert.ok(performance.hangTimeoutMs > 0 && performance.hangTimeoutMs <= 1_200_000);
+    assert.ok(performance.hangTimeoutMs > 0 && performance.hangTimeoutMs <= 2_400_000);
     assert.ok(performance.maxFalsePositiveRatio >= 0 && performance.maxFalsePositiveRatio <= 1);
     assert.equal(performance.maxFalseNegativeRatio, performance.maxFalsePositiveRatio);
   }
@@ -93,7 +93,7 @@ test("large typechecker fixtures have performance safeguards and bench wiring", 
     assert.ok(project, `${id} should be registered`);
     assert.equal(project?.typecheckPerformance?.enabled, true);
     assert.equal(project?.typecheckPerformance?.largeProjectRegressionTarget, true);
-    assert.ok((project?.typecheckPerformance?.hangTimeoutMs ?? Infinity) <= 600_000);
+    assert.ok((project?.typecheckPerformance?.hangTimeoutMs ?? Infinity) <= 2_400_000);
     assert.ok((project?.typecheckPerformance?.maxFalsePositiveRatio ?? Infinity) <= 0.02);
     assert.ok((project?.typecheckPerformance?.maxFalseNegativeRatio ?? Infinity) <= 0.02);
     assert.match(

--- a/tools/commands/fixtures/typecheck-divergence-report.rs
+++ b/tools/commands/fixtures/typecheck-divergence-report.rs
@@ -82,6 +82,7 @@ fn run() -> Result<(), String> {
 
 fn write_project_artifact(root: &Path, args: &Args, project: &Value) -> Result<Value, String> {
     validate_performance(project)?;
+    let project_id = project_string(project, "id")?;
     let fixture_root = root.join(project_string(project, "fixturePath")?);
     let summary = read_and_validate_summary(root, &args.report_dir, project)?;
     let vize_run = read_and_validate_vize_run(root, &args.report_dir, project, &summary)?;
@@ -134,6 +135,10 @@ fn write_project_artifact(root: &Path, args: &Args, project: &Value) -> Result<V
         .get("hangTimeoutMs")
         .and_then(Value::as_u64)
         .unwrap_or(5_000);
+    let progress_enabled = env::var_os("VIZE_TYPECHECK_DIVERGENCE_PROGRESS").is_some();
+    if progress_enabled {
+        eprintln!("[typecheck-divergence] start projectId={project_id} timeoutMs={timeout_ms}");
+    }
     let baseline_args = vec![
         "--noEmit".to_string(),
         "--pretty".to_string(),
@@ -149,6 +154,9 @@ fn write_project_artifact(root: &Path, args: &Args, project: &Value) -> Result<V
         "-p".to_string(),
         baseline_config.path.display().to_string(),
     ];
+    if progress_enabled {
+        eprintln!("[typecheck-divergence] run projectId={project_id} command=baseline");
+    }
     let baseline = run_capture_limited(
         &args.vue_tsc_bin,
         &baseline_args,
@@ -157,6 +165,13 @@ fn write_project_artifact(root: &Path, args: &Args, project: &Value) -> Result<V
         "vue-tsc baseline",
         &[0, 1, 2],
     )?;
+    if progress_enabled {
+        eprintln!(
+            "[typecheck-divergence] finish projectId={project_id} command=baseline durationMs={} status={}",
+            baseline.duration_ms, baseline.status
+        );
+        eprintln!("[typecheck-divergence] run projectId={project_id} command=coverage");
+    }
     let coverage_baseline = run_capture_limited(
         &args.vue_tsc_bin,
         &coverage_args,
@@ -165,9 +180,15 @@ fn write_project_artifact(root: &Path, args: &Args, project: &Value) -> Result<V
         "vue-tsc coverage baseline",
         &[0, 1, 2],
     )?;
+    if progress_enabled {
+        eprintln!(
+            "[typecheck-divergence] finish projectId={project_id} command=coverage durationMs={} status={}",
+            coverage_baseline.duration_ms, coverage_baseline.status
+        );
+    }
     let documented_differences = read_documented_differences(root)?;
     let divergence = compare_typecheck_diagnostics(
-        project_string(project, "id")?,
+        project_id.clone(),
         &fixture_root,
         &vize_run.payload["parsed"],
         &baseline.output,
@@ -202,7 +223,7 @@ fn write_project_artifact(root: &Path, args: &Args, project: &Value) -> Result<V
     let artifact = json!({
         "schema": "vize.fixtureTypecheckDivergenceRun",
         "version": 6,
-        "project": project_string(project, "id")?,
+        "project": project_id.clone(),
         "revision": project.get("revision").cloned().unwrap_or(Value::Null),
         "tsconfig": source_project,
         "evidence": summary["evidence"],
@@ -231,7 +252,6 @@ fn write_project_artifact(root: &Path, args: &Args, project: &Value) -> Result<V
         "budget": budget,
         "divergence": divergence,
     });
-    let project_id = project_string(project, "id")?;
     let json_path = args
         .report_dir
         .join(format!("{project_id}-typecheck-divergence.json"));


### PR DESCRIPTION
## Summary
- extend all release typechecker divergence baseline budgets to 2,400,000ms so the baseline and coverage passes have the same per-project runner budget as core tool sweeps
- keep the release timeout registry ratchet aligned with the fixture budgets
- print project/phase progress from the divergence report to make future matrix stalls diagnosable

## Evidence
- Release run 33904412363 triggered Real Project Matrix run 33904511807 at tag v0.392.0
- Matrix jobs 101126159410, 101126159496, 101126159514, 101126159552, and 101126159674 failed on 600,000ms vue-tsc baseline or coverage baseline timeouts
- Matrix job 101126159498 showed vue-vben-admin still timed out at the previous 1,200,000ms coverage baseline budget, so this PR aligns the divergence budget with CORE_TOOLS_TIMEOUT_MS
- Job 101126159674 also exposed the separate Hoppscotch LSP authored hover failure now being investigated independently

## Validation
- cargo fmt --all
- node --test tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts tests/tooling/typecheck-divergence-report-timeout.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts
- vp check --fix tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts tools/commands/fixtures/typecheck-divergence-report.rs
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Increased the allowed time for type-checking performance checks across supported Vue ecosystem fixtures.
  - Updated validation thresholds to reflect the extended timeout allowance.
  - Added coverage to verify optional progress reporting and workflow configuration.

- **Developer Experience**
  - Added opt-in progress reporting for baseline and coverage operations, including start, completion, elapsed time, and exit status details.
  - Improved consistency of project identification in diagnostic reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->