### PR TITLE
test(lsp): refresh Hoppscotch hover oracle

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -173,7 +173,7 @@
           "symbol": "classes",
           "usageAnchor": ":class=\"classes\"",
           "declarationAnchor": "const classes = computed(() => {",
-          "hoverContains": ["const classes: any"],
+          "hoverContains": ["const classes: string"],
           "renameTo": "__vizeRenamedClasses"
         },
         "componentBoundary": {


### PR DESCRIPTION
## Summary
- refresh Hoppscotch authored LSP hover oracle to the current type-backed response
- keep the authored template range and feature contract unchanged

## Findings
- reproduced the Real Project Matrix Hoppscotch failure locally on current origin/main
- direct hover response for `:class="classes"` is `const classes: string` on the authored token range
- this points to stale oracle text rather than an LSP implementation regression

## Validation
- `cargo build --profile ci -p vize`
- `env CORSA_PATH=$PWD/node_modules/@typescript/typescript-darwin-arm64/lib/tsc REAL_PROJECT_LSP_TIMEOUT_MS=600000 VIZE_LSP_BIN=target/ci/vize FIXTURE_REPORT_DIR=/tmp/vize-hoppscotch-lsp-local-rebased node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts`
- `node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts`
- `git diff --check HEAD~1..HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791139033&installation_model_id=422833&pr_number=5671&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5671&signature=60719b644d5f3e60ddfe664891e1b021d175b4bcea1faf9ede6778ef9a7fde35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->