### PR TITLE
feat(davinci): emit scoped CSS ids from S2 DOM

### DIFF
--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -123,6 +123,7 @@ pub(super) fn s2_emit_options<'a>(
         component_name: options.component_name.as_deref(),
         cache_handlers: options.cache_handlers,
         hoisted_scope_id,
+        scope_id: options.scope_id.as_deref(),
         is_ts: options.is_ts,
         bindings,
     }

--- a/crates/vize_atelier_dom/tests/davinci_s2_scope_id.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_scope_id.rs
@@ -1,0 +1,124 @@
+//! P2-11 installment 91 witness: **`scope_id`**. `<style scoped>` gives the
+//! SFC an attribute name that every element's props object carries as a
+//! trailing `"data-v-abc123": ""` pair. Compared byte-for-byte with the
+//! shipped lane.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use vize_atelier_core::options::CodegenOptions;
+use vize_atelier_dom::DomCompilerOptions;
+use vize_s1_to_s2::DomEmitOptions;
+
+const SCOPE_ID: &str = "data-v-abc123";
+
+const BATTERY: &[(&str, &str)] = &[
+    ("empty_element", "<div></div>"),
+    ("text_only", "<div>hello</div>"),
+    ("static_attr", r#"<div class="a"></div>"#),
+    ("two_static_attrs", r#"<div id="x" class="a"></div>"#),
+    ("dynamic_bind", r#"<div :id="x"></div>"#),
+    ("static_and_dynamic", r#"<div class="a" :id="x"></div>"#),
+    ("interpolation", "<div>{{ msg }}</div>"),
+    ("handler", r#"<div @click="go"></div>"#),
+    ("nested", "<div><span>hi</span></div>"),
+    ("dynamic_class", r#"<div :class="cls"></div>"#),
+    (
+        "static_class_and_style",
+        r#"<div class="a" style="color:red"></div>"#,
+    ),
+    ("dynamic_style", r#"<div :style="s"></div>"#),
+    ("multi_root", "<div></div><span></span>"),
+    ("deep_static", "<div><p><em>x</em></p></div>"),
+    ("static_siblings", "<div><i>a</i><b>b</b></div>"),
+    ("v_if", r#"<div v-if="ok">x</div>"#),
+    ("v_if_else", r#"<div v-if="ok">x</div><div v-else>y</div>"#),
+    ("v_for", r#"<li v-for="i in items" :key="i">{{ i }}</li>"#),
+    (
+        "v_for_static_child",
+        r#"<li v-for="i in items" :key="i"><b>x</b></li>"#,
+    ),
+    ("component", "<MyComp />"),
+    ("component_with_prop", r#"<MyComp :a="x" />"#),
+    ("component_static_prop", r#"<MyComp a="1" />"#),
+    ("component_with_slot", "<MyComp><span>x</span></MyComp>"),
+    ("slot_outlet", "<slot />"),
+    ("template_root", "<template><div>x</div></template>"),
+    ("svg", r#"<svg><path d="M0 0"/></svg>"#),
+    ("v_once", "<div v-once>x</div>"),
+    ("v_html", r#"<div v-html="raw"></div>"#),
+    ("v_show", r#"<div v-show="ok"></div>"#),
+    ("v_model", r#"<input v-model="v">"#),
+    ("ref_attr", r#"<div ref="el"></div>"#),
+    ("spread_bind", r#"<div v-bind="obj"></div>"#),
+    ("spread_and_static", r#"<div class="a" v-bind="obj"></div>"#),
+    ("spread_on", r#"<div v-on="handlers"></div>"#),
+    ("dynamic_bind_key", r#"<div :[k]="v"></div>"#),
+    ("teleport", r##"<Teleport to="#a"><div>x</div></Teleport>"##),
+    ("keepalive", "<KeepAlive><MyComp /></KeepAlive>"),
+];
+
+fn dual_run(battery: &[(&str, &str)]) {
+    support::assert_s2_matches_shipped_with_options(
+        battery,
+        &DomCompilerOptions {
+            scope_id: Some(SCOPE_ID.into()),
+            ..Default::default()
+        },
+        &CodegenOptions::default(),
+        &DomEmitOptions {
+            scope_id: Some(SCOPE_ID),
+            ..DomEmitOptions::DEFAULT
+        },
+    );
+}
+
+#[test]
+fn scope_id_matches_the_shipped_dom_lane() {
+    dual_run(BATTERY);
+}
+
+/// The option must actually do something: a lane that ignored it would
+/// still pass the dual runs above. Full outputs, not substrings.
+#[test]
+fn the_option_is_what_produces_the_scope_attribute() {
+    let allocator = vize_s0::Allocator::new();
+    let body = |src: &str, scope_id: Option<&str>| {
+        vize_s1_to_s2::emit_dom_source_with_options(
+            &allocator,
+            src,
+            vize_s1_to_s2::LegacyCaps::VUE3,
+            &DomEmitOptions {
+                scope_id,
+                ..DomEmitOptions::DEFAULT
+            },
+        )
+        .expect("scope-id witness must emit")
+        .assembled()
+    };
+    const PREAMBLE: &str = "const { mergeProps: _mergeProps, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue\n\nfunction render(_ctx, _cache, $props, $setup, $data, $options) {\n";
+    let render = |scope_id: Option<&str>| {
+        let src = r#"<div class="a" v-bind="obj"></div>"#;
+        let out = body(src, scope_id);
+        out.strip_prefix(PREAMBLE)
+            .unwrap_or_else(|| panic!("unexpected preamble in:\n{out}"))
+            .to_string()
+    };
+    assert_eq!(
+        (render(None), render(Some(SCOPE_ID))),
+        (
+            // Off: the spread merges only the authored props.
+            "  return (_openBlock(), _createElementBlock(\"div\", _mergeProps({ class: \"a\" }, obj), null, 16 /* FULL_PROPS */))\n}"
+                .to_string(),
+            // On: the scope pair rides one trailing `mergeProps` argument,
+            // never each segment.
+            "  return (_openBlock(), _createElementBlock(\"div\", _mergeProps({ class: \"a\" }, obj, { \"data-v-abc123\": \"\" }), null, 16 /* FULL_PROPS */))\n}"
+                .to_string(),
+        )
+    );
+}

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -35,7 +35,15 @@
 //! `v-text`, `v-bind` modifiers, dynamic `v-bind` keys / modifiers, and
 //! Vue 2 pipe filters legalized by `legacy-sugar`, and **module mode**
 //! ([`DomEmitOptions`]: `import { … } from "vue"` + `export function
-//! render(_ctx, _cache)`, custom runtime module / global names).
+//! render(_ctx, _cache)`, custom runtime module / global names), and
+//! **`cache_handlers`** (`_cache[n] || (_cache[n] = …)` around a `v-on`
+//! handler, guarded-and-forwarded when it is a reference, dropping the
+//! handler from the patch flag; suppressed under `v-for` / slot params),
+//! and **`scope_id`** (`<style scoped>`'s `"data-v-abc123": ""` pair on
+//! every props object — inline, hoisted and component alike, and once as a
+//! trailing `mergeProps` argument rather than per spread segment).
+//! The old lane stays the shipped compile path; [`super::DOM_LANE_FLAG`]
+//! is named here and *read* in the atelier_dom witness.
 
 mod budget;
 mod buf;
@@ -188,6 +196,11 @@ struct EmitCx<'facts> {
     /// Scoped-style attr that only module-level static VNode hoists bake into
     /// props; runtime VNodes rely on Vue's current scope id.
     hoisted_scope_id: Option<&'facts str>,
+    /// The shipped lane's `scope_id`, emitted as the trailing props pair.
+    scope_id: Option<&'facts str>,
+    /// `CodegenContext::skip_scope_id`: inside a `mergeProps` call the scope
+    /// pair is emitted once as a trailing argument, never per segment.
+    skip_scope_id: bool,
     /// `(digit offset in `buf.code`, ordering key, slot number)` for
     /// every `_cache` index written so far. The shipped codegen takes a
     /// slot when it *reaches* the construct, so the ordering key is where

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -82,6 +82,7 @@ mod props_object;
 mod props_object_merge;
 mod props_static;
 mod props_value;
+mod run;
 mod sfc_style;
 mod slot_root;
 mod slots;
@@ -97,14 +98,13 @@ mod vnode_static;
 mod vtext;
 
 use alloc::vec::Vec as StdVec;
-use vize_davinci::diagnostic::Severity;
 use vize_davinci::id::NodeId;
 use vize_davinci::side_table::SideTable;
 use vize_s0::String;
 use vize_s2::op::Namespace;
 use vize_s2::scope::ScopeFacts;
 
-use crate::lower::{ForWrapper, Lowered, WrapperKeys};
+use crate::lower::{ForWrapper, WrapperKeys};
 use crate::pass::S2Facts;
 use crate::pass::walk::PageWalk;
 
@@ -118,9 +118,9 @@ pub use self::entry::{
     DomEmit, emit_dom_source, emit_dom_source_with_caps, emit_dom_source_with_options,
 };
 pub use self::error::{EmitError, UnsupportedReason, UnsupportedRefusal};
-use self::fragment::emit_root;
-use self::helper::Helper;
 pub use self::options::{BindingKind, BindingTable, DomEmitMode, DomEmitOptions};
+use self::run::emit_dom_with_emit_budget;
+pub use self::run::{emit_dom, emit_dom_with_options};
 
 /// Per-emit numbering + helper buffer. Page-order ids re-derive the
 /// same arithmetic the S2 passes use so compound text facts resolve.
@@ -206,132 +206,4 @@ struct EmitCx<'facts> {
     component_name: Option<&'facts str>,
     /// The transform scope and codegen slot params the prefixer consults.
     scope: prefix::PrefixScope<'facts>,
-}
-
-/// Emit a DOM render function from an already-lowered (and typically
-/// transformed) S2 artifact under the shipped default options. `facts`
-/// is the transform product compounds compile from.
-pub fn emit_dom(lowered: &Lowered<'_>, facts: &S2Facts) -> Result<DomEmit, EmitError> {
-    emit_dom_with_options(lowered, facts, &DomEmitOptions::DEFAULT)
-}
-
-/// [`emit_dom`] under explicit [`DomEmitOptions`].
-pub fn emit_dom_with_options<'f>(
-    lowered: &'f Lowered<'_>,
-    facts: &'f S2Facts,
-    options: &DomEmitOptions<'f>,
-) -> Result<DomEmit, EmitError> {
-    emit_dom_with_emit_budget(lowered, facts, options).map(|(emit, _)| emit)
-}
-
-fn emit_dom_with_emit_budget<'f>(
-    lowered: &'f Lowered<'_>,
-    facts: &'f S2Facts,
-    options: &DomEmitOptions<'f>,
-) -> Result<(DomEmit, u32), EmitError> {
-    if options.is_ts && !cfg!(feature = "typescript") {
-        return Err(EmitError::unsupported(
-            UnsupportedReason::TypeScriptLaneUnavailable,
-        ));
-    }
-    if lowered
-        .diagnostics
-        .iter()
-        .any(|diagnostic| diagnostic.severity == Severity::Error)
-    {
-        return Err(EmitError::Diagnostics);
-    }
-    // `static_cache = inline || !hoists.is_empty()`.
-    let static_cache =
-        options.inline || static_cache::enabled(&lowered.root, facts, &lowered.wrappers);
-    let mut cx = EmitCx {
-        buf: Buf::new(options.inline),
-        source: lowered.source,
-        facts,
-        scopes: &lowered.scopes,
-        wrappers: &lowered.wrappers,
-        for_wrappers: &lowered.for_wrappers,
-        walk: PageWalk::new(),
-        scope_names: StdVec::new(),
-        if_branch_key: 0,
-        once_cache_index: 0,
-        once_depth: 0,
-        once_element_depth: 0,
-        in_v_for: false,
-        conditional_v_for_item: false,
-        template_for_item_single_root: false,
-        template_for_item_root_id: None,
-        template_if_branch_root: false,
-        template_if_for_branch_root: false,
-        suppress_template_for_child_key: false,
-        skip_memo: false,
-        slot_param_depth: 0,
-        hoist_static_vnodes: false,
-        transition_slot_root: false,
-        static_cache,
-        parent_ns: Namespace::Html,
-        prefix_identifiers: options.prefix_identifiers,
-        is_ts: options.is_ts,
-        cache_handlers: options.cache_handlers,
-        hoisted_scope_id: options.hoisted_scope_id,
-        cache_sites: StdVec::new(),
-        used_unref: core::cell::Cell::new(u32::MAX),
-        component_name: options.component_name,
-        scope: prefix::PrefixScope::new(
-            options.bindings,
-            options.prefix_identifiers,
-            options.is_ts,
-            options.inline,
-        ),
-    };
-    let filters = &facts.legacy.filters;
-    if facts.legacy.filter_helper_precedes_components {
-        cx.buf.prefer(Helper::ResolveFilter);
-    }
-    let mut helper_walk = PageWalk::new();
-    let prefer_cx = helper_preference::PreferCx {
-        facts,
-        for_wrappers: &lowered.for_wrappers,
-        bindings: options.bindings,
-    };
-    helper_preference::prefer_helpers(&mut cx.buf, &prefer_cx, &mut helper_walk, &lowered.root);
-    fragment::prefer_root_fragment(&mut cx.buf, &lowered.root);
-    cx.buf
-        .push(options.mode.render_signature(options.bindings.is_some()));
-    cx.buf.indent();
-    cx.buf.newline();
-    let names = component::collect_names(&lowered.root);
-    let dirs = directive::collect_names(&lowered.root);
-    let mut resolved_assets = false;
-    if !names.is_empty() {
-        resolved_assets |= component::emit_resolves(&mut cx, &names);
-    }
-    if !dirs.is_empty() {
-        resolved_assets |= directive::emit_resolves(&mut cx, &dirs);
-    }
-    if !filters.is_empty() {
-        filter::emit_resolves(&mut cx, filters);
-        resolved_assets = true;
-    }
-    if resolved_assets {
-        cx.buf.newline();
-    }
-    cx.buf.push("return ");
-    emit_root(&mut cx, &lowered.root)?;
-    cx.buf.deindent();
-    cx.buf.newline();
-    cx.buf.push("}");
-    // `_unref` is a *transform* registration: it lists with the pre-walk's
-    // preferred helpers, at the op whose expression needed it — ahead of a
-    // structural helper that op registers later (`renderList`).
-    let unref_visit = cx.used_unref.get();
-    if unref_visit != u32::MAX {
-        cx.buf.prefer_at_visit(Helper::Unref, unref_visit);
-        cx.buf.use_helper(Helper::Unref);
-    }
-    cache_slots::renumber(&mut cx);
-    let emit_visits = cx.walk.visits();
-    let preamble = cx.buf.preamble(options);
-    let code = cx.buf.code;
-    Ok((DomEmit { preamble, code }, emit_visits))
 }

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -92,7 +92,7 @@ pub(super) fn emit_call(
     let hoistable_static_props = if cx.hoisted_scope_id.is_some() {
         None
     } else {
-        call_props::hoistable_static_props(component, skip_is, &hoist_attrs, cx.is_ts)?
+        call_props::hoistable_static_props(component, skip_is, &hoist_attrs, cx.is_ts, cx.scope_id)?
     };
     if for_item
         && !has_component_root_slot

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -53,20 +53,21 @@ pub(super) fn hoistable_static_props(
     skip_is: bool,
     hoist_attrs: &[&Attribute<'_>],
     is_ts: bool,
+    scope_id: Option<&str>,
 ) -> Result<Option<ComponentHoistProps>, EmitError> {
     if skip_is {
         if has_rendered_binds(component, skip_is) {
             return Ok(None);
         }
         return Ok((!hoist_attrs.is_empty()).then(|| ComponentHoistProps {
-            source: compact_props_object(hoist_attrs.iter().copied()),
+            source: compact_props_object(hoist_attrs.iter().copied(), scope_id),
             dynamic_values: false,
             non_key: hoist_attrs.iter().any(|attr| attr.name != "key"),
             valued_prop: hoist_attrs.iter().any(|attr| attr.value.is_some()),
             all_static_binds: false,
         }));
     }
-    props_static::component_hoist_props(&component.attributes, &component.bindings, is_ts)
+    props_static::component_hoist_props(&component.attributes, &component.bindings, is_ts, scope_id)
 }
 
 pub(super) fn can_hoist_static_props(

--- a/crates/vize_s1_to_s2/src/emit/component/call_props/scans.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props/scans.rs
@@ -72,8 +72,13 @@ fn component_has_static_bind_props(
     component: &ComponentOp<'_>,
     is_ts: bool,
 ) -> Result<bool, EmitError> {
-    Ok(
-        props_static::component_hoist_props(&component.attributes, &component.bindings, is_ts)?
-            .is_some_and(|props| props.all_static_binds && props.valued_prop),
-    )
+    // A predicate over the component's own bind props: the scope pair is
+    // neither a bind nor dynamic, so it is deliberately not supplied here.
+    Ok(props_static::component_hoist_props(
+        &component.attributes,
+        &component.bindings,
+        is_ts,
+        None,
+    )?
+    .is_some_and(|props| props.all_static_binds && props.valued_prop))
 }

--- a/crates/vize_s1_to_s2/src/emit/cx.rs
+++ b/crates/vize_s1_to_s2/src/emit/cx.rs
@@ -339,3 +339,9 @@ impl EmitCx<'_> {
         Ok(())
     }
 }
+
+impl<'facts> EmitCx<'facts> {
+    pub(super) fn scope_id_here(&self) -> Option<&'facts str> {
+        (!self.skip_scope_id).then_some(self.scope_id).flatten()
+    }
+}

--- a/crates/vize_s1_to_s2/src/emit/hoist.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist.rs
@@ -8,10 +8,7 @@ mod cached_props;
 mod kids;
 mod props;
 
-pub(super) use props::{
-    compact_props_object, compact_props_object_with_scope, push_attr_pair, push_empty_attr_pair,
-    unique_attrs,
-};
+pub(super) use props::{compact_props_object, push_attr_pair, push_empty_attr_pair, unique_attrs};
 
 use vize_s0::String;
 use vize_s2::op::{ElementOp, Op};
@@ -50,8 +47,9 @@ pub(super) fn emit_cached_element(
     cx.buf.push("] || (_cache[");
     cx.push_cache_index(cache_slot);
     cx.buf.push("] = ");
-    cx.buf
-        .push(cached_element_rhs(element, true, cx.buf.indent_width(), cx.is_ts).as_str());
+    cx.buf.push(
+        cached_element_rhs(element, true, cx.buf.indent_width(), cx.is_ts, cx.scope_id).as_str(),
+    );
     cx.buf.push(")");
     Ok(())
 }
@@ -92,8 +90,10 @@ pub(super) fn emit_cached_elements_array(
         if hoist_needs_create_text(element) {
             cx.buf.use_create_text();
         }
-        cx.buf
-            .push(cached_element_rhs(element, true, cx.buf.indent_width(), cx.is_ts).as_str());
+        cx.buf.push(
+            cached_element_rhs(element, true, cx.buf.indent_width(), cx.is_ts, cx.scope_id)
+                .as_str(),
+        );
     }
 
     cx.buf.deindent();
@@ -108,12 +108,9 @@ pub(super) fn hoist_static_element(cx: &mut EmitCx<'_>, element: &ElementOp<'_>)
     if hoist_needs_create_text(element) {
         cx.buf.use_create_text();
     }
-    cx.buf.push_hoist(hoist_element_rhs(
-        element,
-        true,
-        cx.is_ts,
-        cx.hoisted_scope_id,
-    ))
+    let scope_id = cx.hoisted_scope_id.or(cx.scope_id);
+    cx.buf
+        .push_hoist(hoist_element_rhs(element, true, cx.is_ts, scope_id))
 }
 
 pub(super) fn is_hoistable(element: &ElementOp<'_>, is_ts: bool) -> bool {
@@ -144,7 +141,7 @@ fn hoist_element_rhs(
     element: &ElementOp<'_>,
     pure: bool,
     is_ts: bool,
-    hoisted_scope_id: Option<&str>,
+    scope_id: Option<&str>,
 ) -> String {
     let mut out = String::default();
     if pure {
@@ -156,7 +153,7 @@ fn hoist_element_rhs(
     out.push_str(element.tag);
     out.push('"');
     let kids = renderable_children(&element.children);
-    let props = static_vnode_props(element, true, is_ts, hoisted_scope_id);
+    let props = static_vnode_props(element, true, is_ts, scope_id);
     if props.is_some() || !kids.is_empty() {
         out.push_str(", ");
         if let Some(props) = props {
@@ -167,7 +164,7 @@ fn hoist_element_rhs(
     }
     if !kids.is_empty() {
         out.push_str(", ");
-        append_hoist_kids(&mut out, &kids, is_ts, hoisted_scope_id);
+        append_hoist_kids(&mut out, &kids, is_ts, scope_id);
     }
     out.push(')');
     out
@@ -178,9 +175,10 @@ fn cached_element_rhs(
     cached: bool,
     line_indent: usize,
     is_ts: bool,
+    scope_id: Option<&str>,
 ) -> String {
     let mut out = String::default();
-    append_cached_element_rhs(&mut out, element, cached, line_indent, is_ts);
+    append_cached_element_rhs(&mut out, element, cached, line_indent, is_ts, scope_id);
     out
 }
 
@@ -190,6 +188,7 @@ fn append_cached_element_rhs(
     cached: bool,
     line_indent: usize,
     is_ts: bool,
+    scope_id: Option<&str>,
 ) {
     out.push_str(Buf::create_element_vnode_alias());
     out.push('(');
@@ -198,8 +197,8 @@ fn append_cached_element_rhs(
     out.push('"');
     out.push_str(", ");
     if element.bindings.is_empty() && !element.attributes.is_empty() {
-        cached_props::push_object(out, element.attributes.iter(), line_indent);
-    } else if let Some(props) = cached_static_vnode_props(element, line_indent, is_ts) {
+        cached_props::push_object(out, element.attributes.iter(), line_indent, scope_id);
+    } else if let Some(props) = cached_static_vnode_props(element, line_indent, is_ts, scope_id) {
         out.push_str(props.as_str());
     } else {
         out.push_str("null");
@@ -209,7 +208,7 @@ fn append_cached_element_rhs(
     if kids.is_empty() {
         out.push_str("null");
     } else {
-        append_cached_kids(out, &kids, line_indent, is_ts);
+        append_cached_kids(out, &kids, line_indent, is_ts, scope_id);
     }
     if cached {
         out.push_str(", -1 /* CACHED */");
@@ -221,31 +220,36 @@ fn static_vnode_props(
     element: &ElementOp<'_>,
     include_bindings: bool,
     is_ts: bool,
-    hoisted_scope_id: Option<&str>,
+    scope_id: Option<&str>,
 ) -> Option<String> {
     if include_bindings {
-        return super::props_static::root_hoist_props_with_scope(
+        return super::props_static::root_hoist_props(
             &element.attributes,
             &element.bindings,
-            hoisted_scope_id,
             is_ts,
+            scope_id,
         )
         .ok()
         .flatten();
     }
-    compact_props_object_with_scope(element.attributes.iter(), hoisted_scope_id)
+    if element.attributes.is_empty() && scope_id.is_none() {
+        return None;
+    }
+    Some(compact_props_object(element.attributes.iter(), scope_id))
 }
 
 fn cached_static_vnode_props(
     element: &ElementOp<'_>,
     line_indent: usize,
     is_ts: bool,
+    scope_id: Option<&str>,
 ) -> Option<String> {
     super::props_static::cached_root_hoist_props(
         &element.attributes,
         &element.bindings,
         line_indent,
         is_ts,
+        scope_id,
     )
     .ok()
     .flatten()

--- a/crates/vize_s1_to_s2/src/emit/hoist/cached_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist/cached_props.rs
@@ -12,10 +12,11 @@ pub(super) fn push_object<'a>(
     out: &mut String,
     attributes: impl Iterator<Item = &'a Attribute<'a>>,
     line_indent: usize,
+    scope_id: Option<&str>,
 ) {
     let unique = unique_attrs(attributes);
     if unique.len() <= 1 {
-        out.push_str(compact_props_object(unique.iter().copied()).as_str());
+        out.push_str(compact_props_object(unique.iter().copied(), scope_id).as_str());
         return;
     }
 

--- a/crates/vize_s1_to_s2/src/emit/hoist/kids.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist/kids.rs
@@ -21,7 +21,7 @@ pub(super) fn append_hoist_kids(
     out: &mut String,
     kids: &[&Op<'_>],
     is_ts: bool,
-    hoisted_scope_id: Option<&str>,
+    scope_id: Option<&str>,
 ) {
     if kids.iter().all(|op| matches!(op, Op::Text(_))) {
         out.push('"');
@@ -48,9 +48,7 @@ pub(super) fn append_hoist_kids(
                 out.push(')');
             }
             Op::Element(element) => {
-                out.push_str(
-                    hoist_descendant_element_rhs(element, is_ts, hoisted_scope_id).as_str(),
-                );
+                out.push_str(hoist_descendant_element_rhs(element, is_ts, scope_id).as_str());
             }
             _ => {}
         }
@@ -61,7 +59,7 @@ pub(super) fn append_hoist_kids(
 fn hoist_descendant_element_rhs(
     element: &ElementOp<'_>,
     is_ts: bool,
-    hoisted_scope_id: Option<&str>,
+    scope_id: Option<&str>,
 ) -> String {
     let mut out = String::default();
     out.push_str(Buf::create_element_vnode_alias());
@@ -70,7 +68,7 @@ fn hoist_descendant_element_rhs(
     out.push_str(element.tag);
     out.push('"');
     let kids = renderable_children(&element.children);
-    let props = super::static_vnode_props(element, false, is_ts, hoisted_scope_id);
+    let props = super::static_vnode_props(element, false, is_ts, scope_id);
     if props.is_some() || !kids.is_empty() {
         out.push_str(", ");
         if let Some(props) = props {
@@ -81,7 +79,7 @@ fn hoist_descendant_element_rhs(
     }
     if !kids.is_empty() {
         out.push_str(", ");
-        append_hoist_kids(&mut out, &kids, is_ts, hoisted_scope_id);
+        append_hoist_kids(&mut out, &kids, is_ts, scope_id);
     }
     out.push(')');
     out
@@ -92,6 +90,7 @@ pub(super) fn append_cached_kids(
     kids: &[&Op<'_>],
     line_indent: usize,
     is_ts: bool,
+    scope_id: Option<&str>,
 ) {
     if kids.iter().all(|op| matches!(op, Op::Text(_))) {
         out.push('"');
@@ -115,7 +114,14 @@ pub(super) fn append_cached_kids(
                 push_cached_create_text_call(out, text.content);
             }
             Op::Element(element) => {
-                super::append_cached_element_rhs(out, element, false, line_indent + 2, is_ts);
+                super::append_cached_element_rhs(
+                    out,
+                    element,
+                    false,
+                    line_indent + 2,
+                    is_ts,
+                    scope_id,
+                );
             }
             _ => {}
         }

--- a/crates/vize_s1_to_s2/src/emit/hoist/props.rs
+++ b/crates/vize_s1_to_s2/src/emit/hoist/props.rs
@@ -9,21 +9,11 @@ use super::super::js::{escape_js_string, is_valid_js_identifier};
 /// hoisted `JsChildNode::Object` emission.
 pub(in crate::emit) fn compact_props_object<'a>(
     attributes: impl Iterator<Item = &'a Attribute<'a>>,
+    scope_id: Option<&str>,
 ) -> String {
     let unique = unique_attrs(attributes);
-    compact_props_object_from_unique(&unique, None)
-}
-
-pub(in crate::emit) fn compact_props_object_with_scope<'a>(
-    attributes: impl Iterator<Item = &'a Attribute<'a>>,
-    hoisted_scope_id: Option<&str>,
-) -> Option<String> {
-    let unique = unique_attrs(attributes);
-    let scope = hoisted_scope_id.filter(|scope| !unique.iter().any(|attr| attr.name == *scope));
-    if unique.is_empty() && scope.is_none() {
-        return None;
-    }
-    Some(compact_props_object_from_unique(&unique, scope))
+    let scope = scope_id.filter(|scope| !unique.iter().any(|attr| attr.name == *scope));
+    compact_props_object_from_unique(&unique, scope)
 }
 
 fn compact_props_object_from_unique(

--- a/crates/vize_s1_to_s2/src/emit/merge.rs
+++ b/crates/vize_s1_to_s2/src/emit/merge.rs
@@ -160,12 +160,29 @@ pub(super) fn emit_spread_props(
         skip_is,
         cx.suppress_template_for_child_key,
     )?;
+    let scope_id = cx.scope_id_here();
     if let Some(lone) = lone_kind_spread(&args) {
-        return match lone {
-            Arg::BindSpread(bind) => emit_normalize_guard(cx, bind),
-            Arg::OnSpread(on) => emit_to_handlers(cx, on),
-            Arg::Object { .. } => Err(EmitError::unsupported(Reason::LoneObjectArgument)),
-        };
+        // A scope id turns the lone spread into a merge: the shipped lane
+        // writes `_mergeProps(_normalizeProps(_guardReactiveProps(obj)),
+        // { "data-v-x": "" })` rather than the bare wrapper.
+        if scope_id.is_some() {
+            cx.buf.use_merge_props();
+            cx.buf.push(Buf::merge_props_alias());
+            cx.buf.push("(");
+        }
+        match lone {
+            Arg::BindSpread(bind) => emit_normalize_guard(cx, bind)?,
+            Arg::OnSpread(on) => emit_to_handlers(cx, on)?,
+            Arg::Object { .. } => {
+                return Err(EmitError::unsupported(Reason::LoneObjectArgument));
+            }
+        }
+        if let Some(sid) = scope_id {
+            cx.buf.push(", ");
+            push_scope_object(cx, sid);
+            cx.buf.push(")");
+        }
+        return Ok(());
     }
     let normalize_keyed_bind_spread = !for_item && key_and_bind_spread(&args);
     if normalize_keyed_bind_spread {
@@ -177,6 +194,10 @@ pub(super) fn emit_spread_props(
     cx.buf.use_merge_props();
     cx.buf.push(Buf::merge_props_alias());
     cx.buf.push("(");
+    // `skip_scope_id`: the pair rides one trailing argument, never each
+    // segment.
+    let previous_skip = cx.skip_scope_id;
+    cx.skip_scope_id = true;
     for (i, arg) in args.iter().enumerate() {
         if i > 0 {
             cx.buf.push(", ");
@@ -202,11 +223,23 @@ pub(super) fn emit_spread_props(
             }
         }
     }
+    cx.skip_scope_id = previous_skip;
+    if let Some(sid) = scope_id {
+        cx.buf.push(", ");
+        push_scope_object(cx, sid);
+    }
     cx.buf.push(")");
     if normalize_keyed_bind_spread {
         cx.buf.push(")");
     }
     Ok(())
+}
+
+/// The trailing `{ "data-v-x": "" }` argument a scoped SFC merges in.
+fn push_scope_object(cx: &mut EmitCx<'_>, scope_id: &str) {
+    cx.buf.push("{ \"");
+    cx.buf.push(scope_id);
+    cx.buf.push("\": \"\" }");
 }
 
 fn emit_normalize_guard(cx: &mut EmitCx<'_>, bind: &BindOp<'_>) -> Result<(), EmitError> {

--- a/crates/vize_s1_to_s2/src/emit/options.rs
+++ b/crates/vize_s1_to_s2/src/emit/options.rs
@@ -223,6 +223,10 @@ pub struct DomEmitOptions<'a> {
     /// VNodes receive scope attrs from Vue; only import-time hoists need it
     /// baked into generated props.
     pub hoisted_scope_id: Option<&'a str>,
+    /// The shipped lane's `scope_id`: `<style scoped>` gives the SFC an
+    /// attribute name (`data-v-abc123`) that every element's props object
+    /// carries as a trailing `"data-v-abc123": ""` pair.
+    pub scope_id: Option<&'a str>,
     /// The shipped lane's `is_ts`: template expressions are TypeScript,
     /// so each one is type-erased (`emit::prefix::typescript`) before the
     /// identifier pass reads it.
@@ -246,6 +250,7 @@ impl DomEmitOptions<'static> {
         component_name: None,
         cache_handlers: false,
         hoisted_scope_id: None,
+        scope_id: None,
         is_ts: false,
         bindings: None,
     };
@@ -274,6 +279,7 @@ mod tests {
                 component_name: None,
                 cache_handlers: false,
                 hoisted_scope_id: None,
+                scope_id: None,
                 is_ts: false,
                 bindings: None,
             }

--- a/crates/vize_s1_to_s2/src/emit/props_object.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_object.rs
@@ -59,8 +59,10 @@ pub(super) fn emit_props_object(
             ) && !(suppress_once_cache_dynamic && skip_once_cache_piece(piece))
         })
         .collect();
+    let scope_id = cx.scope_id_here();
     if let Some(key) = if_key
         && visible.is_empty()
+        && scope_id.is_none()
     {
         if empty_key_multiline {
             cx.buf.push("{");
@@ -78,7 +80,7 @@ pub(super) fn emit_props_object(
         }
         return Ok(());
     }
-    let extra = usize::from(if_key.is_some());
+    let extra = usize::from(if_key.is_some()) + usize::from(scope_id.is_some());
     let compact_multiline = if_key.is_none() && pieces_are_dynamic_model_products(&visible);
     let v_for_merge_arg_multiline = skip_normalize && for_item && visible.len() + extra > 1;
     let multiline = !compact_multiline
@@ -170,6 +172,19 @@ pub(super) fn emit_props_object(
             } => super::model_key::emit_modifiers(cx, name, modifiers)?,
         }
         i += 1;
+    }
+    if let Some(sid) = scope_id {
+        if i > 0 {
+            cx.buf.push(",");
+        }
+        if multiline {
+            cx.buf.newline();
+        } else if i > 0 {
+            cx.buf.push(" ");
+        }
+        cx.buf.push("\"");
+        cx.buf.push(sid);
+        cx.buf.push("\": \"\"");
     }
     if multiline {
         cx.buf.deindent();

--- a/crates/vize_s1_to_s2/src/emit/props_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static.rs
@@ -19,8 +19,7 @@ use hoist_pair::{
     has_prior_component_hoist_key, has_prior_for_item_hoist_key,
 };
 pub(super) use root_hoist::{
-    cached_root_hoist_props, root_hoist_props, root_hoist_props_with_scope,
-    static_vnode_surface_can_hoist,
+    cached_root_hoist_props, root_hoist_props, static_vnode_surface_can_hoist,
 };
 
 #[derive(Clone, Copy)]
@@ -104,6 +103,7 @@ pub(super) fn component_hoist_props(
     attributes: &[Attribute<'_>],
     bindings: &[BindingOp<'_>],
     is_ts: bool,
+    scope_id: Option<&str>,
 ) -> Result<Option<ComponentHoistProps>, EmitError> {
     let pieces = pieces(attributes, bindings, false)?;
     let mut out = String::from("{ ");
@@ -132,6 +132,15 @@ pub(super) fn component_hoist_props(
             out.push_str(", ");
         }
         out.push_str(prop.as_str());
+        emitted += 1;
+    }
+    if let Some(sid) = scope_id {
+        if emitted > 0 {
+            out.push_str(", ");
+        }
+        out.push_str("\"");
+        out.push_str(sid);
+        out.push_str("\": \"\"");
         emitted += 1;
     }
     if emitted == 0 {
@@ -192,7 +201,8 @@ pub(super) fn emit_inline<'a>(
     force_multiline: bool,
 ) {
     let unique = unique_attrs(attributes);
-    let multiline = unique.len() > 1 || force_multiline;
+    let scope_id = cx.scope_id_here();
+    let multiline = unique.len() + usize::from(scope_id.is_some()) > 1 || force_multiline;
     if multiline {
         cx.buf.push("{");
         cx.buf.indent();
@@ -221,6 +231,19 @@ pub(super) fn emit_inline<'a>(
         let mut pair = String::default();
         push_attr_pair(&mut pair, attr);
         cx.buf.push(pair.as_str());
+    }
+    if let Some(sid) = scope_id {
+        if !unique.is_empty() {
+            cx.buf.push(",");
+        }
+        if multiline {
+            cx.buf.newline();
+        } else if !unique.is_empty() {
+            cx.buf.push(" ");
+        }
+        cx.buf.push("\"");
+        cx.buf.push(sid);
+        cx.buf.push("\": \"\"");
     }
     if multiline {
         cx.buf.deindent();

--- a/crates/vize_s1_to_s2/src/emit/props_static/root_hoist.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static/root_hoist.rs
@@ -16,17 +16,9 @@ pub(in crate::emit) fn root_hoist_props(
     attributes: &[Attribute<'_>],
     bindings: &[BindingOp<'_>],
     is_ts: bool,
+    scope_id: Option<&str>,
 ) -> Result<Option<String>, EmitError> {
-    root_hoist_props_with_layout(attributes, bindings, None, None, is_ts)
-}
-
-pub(in crate::emit) fn root_hoist_props_with_scope(
-    attributes: &[Attribute<'_>],
-    bindings: &[BindingOp<'_>],
-    hoisted_scope_id: Option<&str>,
-    is_ts: bool,
-) -> Result<Option<String>, EmitError> {
-    root_hoist_props_with_layout(attributes, bindings, None, hoisted_scope_id, is_ts)
+    root_hoist_props_with_layout(attributes, bindings, None, is_ts, scope_id)
 }
 
 pub(in crate::emit) fn cached_root_hoist_props(
@@ -34,8 +26,9 @@ pub(in crate::emit) fn cached_root_hoist_props(
     bindings: &[BindingOp<'_>],
     line_indent: usize,
     is_ts: bool,
+    scope_id: Option<&str>,
 ) -> Result<Option<String>, EmitError> {
-    root_hoist_props_with_layout(attributes, bindings, Some(line_indent), None, is_ts)
+    root_hoist_props_with_layout(attributes, bindings, Some(line_indent), is_ts, scope_id)
 }
 
 /// The shipped `genObjectExpression`'s second multiline arm: a property
@@ -54,10 +47,10 @@ fn root_hoist_props_with_layout(
     attributes: &[Attribute<'_>],
     bindings: &[BindingOp<'_>],
     multiline_indent: Option<usize>,
-    hoisted_scope_id: Option<&str>,
     is_ts: bool,
+    scope_id: Option<&str>,
 ) -> Result<Option<String>, EmitError> {
-    let scope = hoisted_scope_id.filter(|scope| !attributes.iter().any(|attr| attr.name == *scope));
+    let scope = scope_id.filter(|scope| !attributes.iter().any(|attr| attr.name == *scope));
     if !can_root_hoist_props(attributes, bindings, is_ts)
         && !(attributes.is_empty() && bindings.is_empty() && scope.is_some())
     {

--- a/crates/vize_s1_to_s2/src/emit/run.rs
+++ b/crates/vize_s1_to_s2/src/emit/run.rs
@@ -1,0 +1,149 @@
+//! The S2 → DOM emit driver: option validation, [`EmitCx`] construction,
+//! preamble assembly and the render-function body.
+//!
+//! Split out of `emit.rs` so the module root stays the capability index
+//! and the type declarations; nothing here is new behaviour.
+
+use alloc::vec::Vec as StdVec;
+use vize_davinci::diagnostic::Severity;
+use vize_s2::op::Namespace;
+
+use crate::lower::Lowered;
+use crate::pass::S2Facts;
+use crate::pass::walk::PageWalk;
+
+use super::buf::Buf;
+use super::fragment::emit_root;
+use super::helper::Helper;
+use super::{
+    DomEmit, DomEmitOptions, EmitCx, EmitError, UnsupportedReason, cache_slots, component,
+    directive, filter, fragment, helper_preference, prefix, static_cache,
+};
+
+/// Emit a DOM render function from an already-lowered (and typically
+/// transformed) S2 artifact under the shipped default options. `facts`
+/// is the transform product compounds compile from.
+pub fn emit_dom(lowered: &Lowered<'_>, facts: &S2Facts) -> Result<DomEmit, EmitError> {
+    emit_dom_with_options(lowered, facts, &DomEmitOptions::DEFAULT)
+}
+
+/// [`emit_dom`] under explicit [`DomEmitOptions`].
+pub fn emit_dom_with_options<'f>(
+    lowered: &'f Lowered<'_>,
+    facts: &'f S2Facts,
+    options: &DomEmitOptions<'f>,
+) -> Result<DomEmit, EmitError> {
+    emit_dom_with_emit_budget(lowered, facts, options).map(|(emit, _)| emit)
+}
+
+pub(super) fn emit_dom_with_emit_budget<'f>(
+    lowered: &'f Lowered<'_>,
+    facts: &'f S2Facts,
+    options: &DomEmitOptions<'f>,
+) -> Result<(DomEmit, u32), EmitError> {
+    if options.is_ts && !cfg!(feature = "typescript") {
+        return Err(EmitError::unsupported(
+            UnsupportedReason::TypeScriptLaneUnavailable,
+        ));
+    }
+    if lowered
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.severity == Severity::Error)
+    {
+        return Err(EmitError::Diagnostics);
+    }
+    // `static_cache = inline || !hoists.is_empty()`.
+    let static_cache =
+        options.inline || static_cache::enabled(&lowered.root, facts, &lowered.wrappers);
+    let mut cx = EmitCx {
+        buf: Buf::new(options.inline),
+        source: lowered.source,
+        facts,
+        scopes: &lowered.scopes,
+        wrappers: &lowered.wrappers,
+        for_wrappers: &lowered.for_wrappers,
+        walk: PageWalk::new(),
+        scope_names: StdVec::new(),
+        if_branch_key: 0,
+        once_cache_index: 0,
+        once_depth: 0,
+        once_element_depth: 0,
+        in_v_for: false,
+        conditional_v_for_item: false,
+        template_for_item_single_root: false,
+        template_for_item_root_id: None,
+        template_if_branch_root: false,
+        template_if_for_branch_root: false,
+        suppress_template_for_child_key: false,
+        skip_memo: false,
+        slot_param_depth: 0,
+        hoist_static_vnodes: false,
+        transition_slot_root: false,
+        static_cache,
+        parent_ns: Namespace::Html,
+        prefix_identifiers: options.prefix_identifiers,
+        is_ts: options.is_ts,
+        cache_handlers: options.cache_handlers,
+        hoisted_scope_id: options.hoisted_scope_id,
+        cache_sites: StdVec::new(),
+        used_unref: core::cell::Cell::new(u32::MAX),
+        component_name: options.component_name,
+        scope: prefix::PrefixScope::new(
+            options.bindings,
+            options.prefix_identifiers,
+            options.is_ts,
+            options.inline,
+        ),
+    };
+    let filters = &facts.legacy.filters;
+    if facts.legacy.filter_helper_precedes_components {
+        cx.buf.prefer(Helper::ResolveFilter);
+    }
+    let mut helper_walk = PageWalk::new();
+    let prefer_cx = helper_preference::PreferCx {
+        facts,
+        for_wrappers: &lowered.for_wrappers,
+        bindings: options.bindings,
+    };
+    helper_preference::prefer_helpers(&mut cx.buf, &prefer_cx, &mut helper_walk, &lowered.root);
+    fragment::prefer_root_fragment(&mut cx.buf, &lowered.root);
+    cx.buf
+        .push(options.mode.render_signature(options.bindings.is_some()));
+    cx.buf.indent();
+    cx.buf.newline();
+    let names = component::collect_names(&lowered.root);
+    let dirs = directive::collect_names(&lowered.root);
+    let mut resolved_assets = false;
+    if !names.is_empty() {
+        resolved_assets |= component::emit_resolves(&mut cx, &names);
+    }
+    if !dirs.is_empty() {
+        resolved_assets |= directive::emit_resolves(&mut cx, &dirs);
+    }
+    if !filters.is_empty() {
+        filter::emit_resolves(&mut cx, filters);
+        resolved_assets = true;
+    }
+    if resolved_assets {
+        cx.buf.newline();
+    }
+    cx.buf.push("return ");
+    emit_root(&mut cx, &lowered.root)?;
+    cx.buf.deindent();
+    cx.buf.newline();
+    cx.buf.push("}");
+    // `_unref` is a *transform* registration: it lists with the pre-walk's
+    // preferred helpers, at the op whose expression needed it - ahead of a
+    // structural helper that op registers later (`renderList`).
+    let unref_visit = cx.used_unref.get();
+    if unref_visit != u32::MAX {
+        cx.buf.prefer_at_visit(Helper::Unref, unref_visit);
+        cx.buf.use_helper(Helper::Unref);
+    }
+    cache_slots::renumber(&mut cx);
+    let emit_visits = cx.walk.visits();
+    let preamble = cx.buf.preamble(options);
+    let code = cx.buf.code;
+    Ok((DomEmit { preamble, code }, emit_visits))
+}

--- a/crates/vize_s1_to_s2/src/emit/run.rs
+++ b/crates/vize_s1_to_s2/src/emit/run.rs
@@ -86,6 +86,8 @@ pub(super) fn emit_dom_with_emit_budget<'f>(
         is_ts: options.is_ts,
         cache_handlers: options.cache_handlers,
         hoisted_scope_id: options.hoisted_scope_id,
+        scope_id: options.scope_id,
+        skip_scope_id: false,
         cache_sites: StdVec::new(),
         used_unref: core::cell::Cell::new(u32::MAX),
         component_name: options.component_name,

--- a/crates/vize_s1_to_s2/src/emit/tpl.rs
+++ b/crates/vize_s1_to_s2/src/emit/tpl.rs
@@ -123,7 +123,9 @@ fn register_unwrapped_if_child_props_hoist(
     if !super::props_static::should_hoist(cx, id, PropHoistPosition::Nested) {
         return Ok(());
     }
-    if let Some(props) = super::props_static::root_hoist_props(attributes, bindings, cx.is_ts)? {
+    if let Some(props) =
+        super::props_static::root_hoist_props(attributes, bindings, cx.is_ts, cx.scope_id)?
+    {
         let _ = cx.buf.push_hoist(props);
     }
     Ok(())

--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -227,7 +227,12 @@ pub(super) fn emit_call(
     let hoisted_props =
         if allow_hoist && if_key.is_none() && !conditional_v_for_dynamic_text && should_hoist_props
         {
-            super::props_static::root_hoist_props(&element.attributes, &element.bindings, cx.is_ts)?
+            super::props_static::root_hoist_props(
+                &element.attributes,
+                &element.bindings,
+                cx.is_ts,
+                cx.scope_id,
+            )?
         } else {
             None
         };

--- a/davinci-road/plan/phase-2-records/p2-11/installment-99.md
+++ b/davinci-road/plan/phase-2-records/p2-11/installment-99.md
@@ -1,0 +1,49 @@
+# P2-11 Installment 99 - Scoped-CSS Scope Id
+
+> Part of the [P2-11 series record](../p2-11.md), split per installment.
+> PR: _pending - the number, merge date and squash SHA are filled in at
+> merge, as every prior installment's line was._
+
+This installment lands `scope_id`, which completes the DOM-relevant half of
+`CodegenOptions` in `DomEmitOptions`. What remains outside the emitter's
+surface is deliberate: `source_map` / `filename` belong to the structured S4
+emitter (P3-9), and `ssr` / `optimize_imports` are the SSR lane's (phase 3).
+
+## Why this one is wide
+
+`cache_handlers` had a single choke point. `scope_id` has none: `<style
+scoped>` puts a `"data-v-abc123": ""` pair on every props object, and the
+shipped lane builds props objects in several places. The S2 emitter mirrors
+that shape, so all of those surfaces need the id:
+
+- `emit::props_object` appends the pair last and counts it in the multiline
+  decision.
+- `emit::props_static::emit_inline` covers static-attributes-only paths.
+- `emit::props_static::{root_hoist_props, component_hoist_props}` covers
+  hoisted native and component prop objects.
+- `emit::hoist` threads the id through the static-VNode string builders.
+- `emit::merge` emits the pair once as a trailing `mergeProps` argument.
+
+Three behaviours were only discoverable by running the comparator:
+
+- A scope id un-refuses a prop-less hoist.
+- A `v-if` branch key stops taking the key-only shortcut.
+- A lone spread becomes a `mergeProps` call.
+
+## Evidence
+
+`crates/vize_atelier_dom/tests/davinci_s2_scope_id.rs` compares the S2 emit
+against the shipped lane byte-for-byte over 38 templates: empty and static
+elements, static and dynamic binds, class/style, multi-root, deep and
+sibling static trees, `v-if` / `v-else` / `v-for` and a `v-for` with a static
+child, components with static, dynamic and no props, a component with a slot,
+a slot outlet, a `<template>` root, foreign SVG, `v-once`, `v-html`,
+`v-show`, `v-model`, `ref`, all three spread shapes, a dynamic bind key, and
+`Teleport` / `KeepAlive`.
+
+`the_option_is_what_produces_the_scope_attribute` pins the full render body
+with the option off and on over the spread shape, so the trailing-argument
+rule is asserted rather than assumed.
+
+This installment does not tick P2-11. The production-lane switch remains
+open, and the old DOM lane is still the shipped compile path.

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -21,8 +21,8 @@ or `collections` modules does not bypass the boundary.
 
 ## Retained `alloc::vec::Vec` inventory
 
-The four library trees in the reviewed inventory contain 77 production files,
-89 direct `alloc::vec::Vec` paths, and 305 bound `Vec`/`StdVec` uses. "Direct"
+The four library trees in the reviewed inventory contain 78 production files,
+90 direct `alloc::vec::Vec` paths, and 305 bound `Vec`/`StdVec` uses. "Direct"
 counts imports and fully-qualified paths; "bound" counts every type,
 constructor, and method path reached through a direct `Vec` import or alias.
 The executable ledger requires strict equality, so both growth and reduction
@@ -34,7 +34,7 @@ must update the file row and aggregate evidence in the same change.
 | analysis |     7 |            8 |         18 | Diagnostics, side tables, filters, and verifier results grow with the input; no inline bound is established.       |
 | lower    |    12 |           12 |         46 | Lowering worklists and owned results grow with source-tree shape. Bounded substructures may migrate independently. |
 | pass     |    14 |           14 |         52 | Facts, provenance, and traversal worklists grow with the number of operations.                                     |
-| emit     |    31 |           31 |        125 | Ordered output buffers and collected emission inputs grow with the document.                                       |
+| emit     |    32 |           32 |        125 | Ordered output buffers and collected emission inputs grow with the document.                                       |
 
 This is not an endorsement of every retained allocation. A focused change may
 replace a site with `SmallVec` after measuring a bound; that change lowers the
@@ -71,9 +71,9 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::String`       |    11 |           11 |         53 |
 | s2       | `vize_s0::Vec`          |     9 |            9 |         17 |
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
-| s1_to_s2 | `alloc::vec::Vec`       |    57 |           57 |        223 |
+| s1_to_s2 | `alloc::vec::Vec`       |    58 |           58 |        223 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    84 |           88 |        419 |
+| s1_to_s2 | `vize_s0::String`       |    84 |           88 |        417 |
 | s1_to_s2 | `vize_s0::Vec`          |    15 |           16 |         67 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     4 |            4 |          9 |
 

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -40,7 +40,7 @@ s2	analysis	crates/vize_s2/src/scope.rs	1	1	1	2	0	0	0	0
 s2	analysis	crates/vize_s2/src/verify.rs	1	4	1	1	0	0	0	0
 s2	-	crates/vize_s2/src/verify/observer.rs	0	0	1	1	0	0	0	0
 s2	analysis	crates/vize_s2/src/verify/walk.rs	1	5	0	0	0	0	0	0
-s1_to_s2	emit	crates/vize_s1_to_s2/src/emit.rs	1	4	1	1	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit.rs	1	2	1	1	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/buf.rs	1	8	1	8	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/buf/helper_order.rs	1	2	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/buf/preamble.rs	0	0	1	3	0	0	0	0
@@ -59,7 +59,7 @@ s1_to_s2	-	crates/vize_s1_to_s2/src/emit/filter.rs	0	0	1	1	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/hoist.rs	0	0	1	8	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/hoist/cached_props.rs	0	0	1	1	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/hoist/kids.rs	1	1	1	6	0	0	0	0
-s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/hoist/props.rs	1	3	1	7	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/hoist/props.rs	1	3	1	6	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/js.rs	0	0	1	6	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/js_comment.rs	0	0	1	3	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/memo.rs	0	0	2	0	0	0	0	0
@@ -90,7 +90,8 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_object.rs	1	2	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_object/pieces.rs	1	3	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props_object_merge.rs	0	0	1	1	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props_static.rs	0	0	1	7	0	0	0	0
-s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_static/root_hoist.rs	1	1	1	7	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/props_static/root_hoist.rs	1	1	1	6	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/run.rs	1	2	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/props_static/hoist_pair.rs	0	0	1	8	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/slots.rs	1	3	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/slots/capture.rs	1	2	1	2	0	0	0	0

--- a/tests/tooling/davinci-storage-inventory.ts
+++ b/tests/tooling/davinci-storage-inventory.ts
@@ -42,8 +42,8 @@ export const categoryReasons: Record<VecCategory, string> = {
 };
 
 export const expectedProductionAllocVec: StorageSummary = {
-  files: 77,
-  directPaths: 89,
+  files: 78,
+  directPaths: 90,
   boundUses: 305,
 };
 


### PR DESCRIPTION
## Summary
- split the S2 DOM emit driver out of the module root while preserving current behavior
- thread normal scoped CSS scope ids through S2 DOM props, static hoists, components, and mergeProps
- add a byte-for-byte shipped-lane witness plus a P2-11 installment record

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_scope_id
- cargo test -p vize_atelier_dom --test davinci_s2_profile
- cargo test -p vize_s1_to_s2 --lib
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791147076&installation_model_id=422833&pr_number=5677&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5677&signature=d0fa7040fe42a4974a59f3056942fe289c0b701616eecd38bb1f6dcdadfc8aa8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scoped-style ID support to DOM code generation.
  * Scope IDs are now applied consistently across elements, components, static content, spreads, slots, SVG, and control-flow output.
  * Added configurable DOM emission options for supplying a scope ID.

* **Bug Fixes**
  * Corrected generated props so scope attributes are emitted when enabled without duplicating existing attributes.

* **Tests**
  * Added comprehensive coverage for scoped output across 38 template scenarios, including enabled and disabled configurations.

* **Documentation**
  * Added implementation records and updated storage-boundary inventory documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->