### PR TITLE
test(davinci): assert owned folio expression sources

### DIFF
--- a/crates/vize_s1_to_s2/tests/ir_contract_spans.rs
+++ b/crates/vize_s1_to_s2/tests/ir_contract_spans.rs
@@ -7,6 +7,8 @@ use std::fs;
 
 use davinci_test_support::surface_fixture as battery;
 use support::{assert_folio_spans_resolve, with_lowered, with_transformed};
+use vize_s0::{Allocator, SourceRoot, Span, String};
+use vize_s2::folio::{DisegnoFolio, FolioExpr, FolioInterpolation, FolioOp};
 
 #[test]
 fn owned_folio_spans_resolve_for_committed_battery() {
@@ -53,4 +55,39 @@ fn owned_folio_spans_resolve_for_optional_corpus() {
         sweep.files.len(),
         checked
     );
+}
+
+#[test]
+fn owned_folio_expression_sources_resolve_through_sfc_block_offsets() {
+    let source = "é prefix\n<template><p :id=\"item.id\">{{ item.name }}</p></template>";
+    let template_start = source.find("<p").expect("template body starts");
+    let template_end = source.find("</template>").expect("template closes");
+    let template = &source[template_start..template_end];
+    let root = SourceRoot::new(source).expect("source is small");
+    let block = root
+        .block(template, template_start as u32)
+        .expect("template block is an authored slice");
+
+    let allocator = Allocator::new();
+    let (tree, errors) = vize_s1::parse(&allocator, template);
+    let lowered = vize_s1_to_s2::lower_source_block(&allocator, &tree, &errors, block);
+    let folio = DisegnoFolio::of(&lowered.root.ops);
+
+    assert_folio_spans_resolve(source, &folio, "sfc-block-expression-slices");
+}
+
+#[test]
+#[should_panic(expected = "expression source is not authored")]
+fn owned_folio_rejects_same_length_expression_source_mismatches() {
+    let folio = DisegnoFolio {
+        ops: vec![FolioOp::Interpolation(FolioInterpolation {
+            expression: FolioExpr::Js {
+                source: String::from("y"),
+                span: Span::new(3, 4),
+            },
+            span: Span::new(0, 7),
+        })],
+    };
+
+    assert_folio_spans_resolve("{{ x }}", &folio, "corrupt-expression-source");
 }

--- a/crates/vize_s1_to_s2/tests/support/folio_spans.rs
+++ b/crates/vize_s1_to_s2/tests/support/folio_spans.rs
@@ -2,6 +2,7 @@
 //! S2 folio must resolve against the authored source.
 
 use vize_s0::{SourceRoot, Span};
+use vize_s2::expr::OpaqueReason;
 use vize_s2::folio::{
     DisegnoFolio, FolioAttribute, FolioBinding, FolioExpr, FolioForBinding, FolioName, FolioOp,
 };
@@ -184,12 +185,43 @@ fn assert_for_binding(
 
 fn assert_expr(source: &str, root: SourceRoot<'_>, expr: &FolioExpr, context: &str) {
     match expr {
-        FolioExpr::Js { span, .. }
-        | FolioExpr::Foreign { span, .. }
-        | FolioExpr::Opaque { span, .. }
-        | FolioExpr::Filter { span, .. } => {
-            assert_span(source, root, *span, "expression", context);
+        FolioExpr::Js {
+            source: expr_source,
+            span,
         }
+        | FolioExpr::Foreign {
+            source: expr_source,
+            span,
+            ..
+        }
+        | FolioExpr::Filter {
+            source: expr_source,
+            span,
+        } => {
+            assert_span(source, root, *span, "expression", context);
+            assert_expr_source(source, *span, expr_source.as_str(), context);
+        }
+        FolioExpr::Opaque {
+            reason,
+            source: expr_source,
+            span,
+        } => {
+            assert_span(source, root, *span, "expression", context);
+            if *reason != OpaqueReason::Compound {
+                assert_expr_source(source, *span, expr_source.as_str(), context);
+            }
+        }
+    }
+}
+
+fn assert_expr_source(source: &str, span: Span, expr_source: &str, context: &str) {
+    let slice = exact_slice(source, span);
+    if slice.len() == expr_source.len() {
+        assert_eq!(
+            slice, expr_source,
+            "expression source is not authored at @{}:{}: {context}",
+            span.start, span.end
+        );
     }
 }
 
@@ -201,4 +233,8 @@ fn assert_span(source: &str, root: SourceRoot<'_>, span: Span, label: &str, cont
         span.end,
         source.len()
     );
+}
+
+fn exact_slice(source: &str, span: Span) -> &str {
+    &source[span.start as usize..span.end as usize]
 }


### PR DESCRIPTION
## Summary
- tighten the P2-17 owned S2 folio span oracle so expression payloads must match authored slices when their lengths make that claim checkable
- add SFC source-block coverage plus a corrupt-folio canary for same-length expression source mismatches

## Validation
- cargo fmt --check
- cargo test -p vize_s1_to_s2 --test ir_contract_spans --test lowering_battery -- --nocapture
- cargo test -p vize_s1_to_s2 --test css_bind_sfc --test text_pass --test vfor_pass -- --nocapture
- node --test tests/tooling/davinci-phase2-ledger.test.ts tests/tooling/davinci-assertion-lint.test.ts
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791147955&installation_model_id=422833&pr_number=5678&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5678&signature=512da3ad879213a170bc865cfb648abd407ef431259a56c65f48256fd67fa7f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->