### PR TITLE
test(vscode): cover VSIX host entrypoint policy

### DIFF
--- a/tests/tooling/vscode-vsix-policy.test.ts
+++ b/tests/tooling/vscode-vsix-policy.test.ts
@@ -10,6 +10,60 @@ function readText(relativePath: string): string {
   return fs.readFileSync(path.join(root, relativePath), "utf8");
 }
 
+function readJson(relativePath: string): unknown {
+  return JSON.parse(readText(relativePath));
+}
+
+test("VSIX package policy keeps the production CJS host entrypoint shippable", () => {
+  const manifest = readJson("editors/vscode/package.json") as { main?: string };
+  const packConfig = readText("editors/vscode/vite.config.ts");
+  const ignore = readText("editors/vscode/.vscodeignore");
+  const smoke = readText("tools/commands/editors/vscode/assert-vsix-package.rs");
+
+  assert.equal(manifest.main, "./dist/extension.cjs");
+  assert.match(packConfig, /entry:\s*\["src\/extension\.ts"\]/);
+  assert.match(packConfig, /outDir:\s*"dist"/);
+  assert.match(packConfig, /format:\s*"cjs"/);
+  assert.match(packConfig, /platform:\s*"node"/);
+  assert.match(packConfig, /neverBundle:\s*\["vscode"\]/);
+  assert.doesNotMatch(ignore, /^dist\/?$/m);
+  assert.match(smoke, /"extension\/dist\/extension\.cjs"/);
+  assert.match(
+    smoke,
+    /assert_json_string\(&package_json, &\["main"\], "\.\/dist\/extension\.cjs"\)\?/,
+  );
+  assert.match(smoke, /"exports\.activate="/);
+  assert.match(smoke, /"exports\.deactivate="/);
+  assert.match(smoke, /"sourceMappingURL="/);
+});
+
+test("VSIX package policy excludes source-only extension host inputs", () => {
+  const ignore = readText("editors/vscode/.vscodeignore");
+  const smoke = readText("tools/commands/editors/vscode/assert-vsix-package.rs");
+
+  for (const pattern of [
+    "src/",
+    "test/",
+    "test-fixtures/",
+    ".vscode-test/",
+    "tsconfig.json",
+    "vite.config.ts",
+  ]) {
+    assert.match(ignore, new RegExp(`^${escapeRegExp(pattern)}$`, "m"));
+  }
+
+  for (const forbidden of [
+    "extension/.vscode-test/",
+    "extension/src/",
+    "extension/test/",
+    "extension/test-fixtures/",
+    "extension/tsconfig.json",
+    "extension/vite.config.ts",
+  ]) {
+    assert.match(smoke, new RegExp(escapeRegExp(forbidden)));
+  }
+});
+
 test("VSIX package policy excludes workspace manifests from shipped files", () => {
   assert.match(readText("editors/vscode/.vscodeignore"), /^pnpm-workspace\.yaml$/m);
   assert.match(
@@ -26,3 +80,7 @@ test("VSIX archive reader escapes unzip member globs", () => {
   assert.match(reader, /matches!\(character, '\[' \| '\]' \| '\*' \| '\?' \| '\\\\'\)/);
   assert.match(smoke, /let vsix = absolute_from_cwd\(&vsix\)\?/);
 });
+
+function escapeRegExp(source: string): string {
+  return source.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary
- Add VSIX policy smoke coverage tying the VS Code manifest main field to the CJS pack output.
- Assert source-only host harness inputs stay excluded while the shipped entrypoint remains packaged.

## Validation
- vp install --frozen-lockfile --prefer-offline
- node --test --test-concurrency=1 tests/tooling/vscode*.test.ts
- vp run check:vscode-extension
- vp run test:vscode-extension:vsix
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 50

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5679"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791148033&installation_model_id=422833&pr_number=5679&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5679&signature=5d4c42aa0e58c90b9088c6e49f6df3f4b61ab4f52b5b4c2bb8d90d5ceeffcda0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->