### PR TITLE
test(lsp): add vue charts authored oracle

### DIFF
--- a/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 20, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 21, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -782,6 +782,7 @@
           "tests/_fixtures/_git/vue-bits",
           "tests/_fixtures/_git/shadcn-vue",
           "tests/_fixtures/_git/splitpanes",
+          "tests/_fixtures/_git/vue-charts",
           "tests/_fixtures/_git/vue-datepicker",
           "tests/_fixtures/_git/vue-sonner"
         ]

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 20,
+    "minimumProjectCount": 21,
     "trackingIssue": 3952
   },
   "projects": [
@@ -1094,7 +1094,77 @@
       "vueGlobs": ["packages/**/*.vue", "docs/**/*.vue", "playground/**/*.vue"],
       "tsconfig": "tsconfig.json",
       "coverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "playground/nuxt/app/components/area-charts/AreaChartDefault.vue",
+          "symbol": "chartData",
+          "usageAnchor": ":data=\"chartData\"",
+          "declarationAnchor": "const chartData = [",
+          "hoverContains": ["const chartData:", "desktop: number"],
+          "renameTo": "__vizeRenamedChartData"
+        },
+        "componentBoundary": {
+          "importerFile": "playground/nuxt/app/components/bar-charts/BarChartLabel.vue",
+          "componentFile": "playground/nuxt/app/components/ui/chart/ChartTooltipContent.vue",
+          "tagName": "ChartTooltipContent",
+          "tagAnchor": "<ChartTooltipContent\n                ",
+          "completionItemCount": 37,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "active", "rank": 28 },
+            { "label": "payload", "rank": 29 },
+            { "label": "label", "rank": 30 },
+            { "label": "label-formatter", "rank": 31 },
+            { "label": "name-key", "rank": 32 },
+            { "label": "indicator", "rank": 33 },
+            { "label": "hide-label", "rank": 34 },
+            { "label": "hide-indicator", "rank": 35 },
+            { "label": "label-key", "rank": 36 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  labelKey?: string\n",
+            "replacement": "  labelKey?: string\n  vizeOracleProbe?: boolean\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "playground/nuxt/app/components/ui/chart/__VizeOracleChartTooltipContent.vue",
+          "renamedFile": "playground/nuxt/app/components/ui/chart/__VizeOracleRenamedChartTooltipContent.vue",
+          "originalImportSpecifier": "~/components/ui/chart/ChartTooltipContent.vue",
+          "copiedImportSpecifier": "~/components/ui/chart/__VizeOracleChartTooltipContent.vue",
+          "renamedImportSpecifier": "~/components/ui/chart/__VizeOracleRenamedChartTooltipContent.vue",
+          "markerInsertionAnchor": "import type { ChartConfig } from './types'\n\n",
+          "markerSymbol": "__vizeVueChartsFileLifecycleMarker__"
+        }
+      }
     },
     {
       "id": "vaul-vue",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 20,
+      "authored-lsp": 21,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,


### PR DESCRIPTION
## Summary

- add a Vue Charts authored LSP oracle for #3952
- pin typed `chartData` hover, definition, references, and rename on authored Vue source
- pin the `BarChartLabel -> ChartTooltipContent` component-boundary completion order plus dependency edit and file lifecycle repair
- ratchet authored real-project LSP coverage from 20 to 21 projects

## Validation

- `cargo check -p vize -p vize_maestro`
- `cargo build -p vize`
- `REAL_PROJECT_LSP_TIMEOUT_MS=600000 FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=17 node --test tests/tooling/real-project-lsp.test.ts`
- `node --test tests/tooling/typed-dx-roadmap.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts`
- `cargo fmt --all --check`
- `git diff --check origin/main..HEAD`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`

## Note

- `tests/tooling/real-project-matrix-summary.test.ts` was not used as a local gate because this fresh worktree has no installed root JS dependencies, so it cannot resolve `yaml`.

Refs #3952.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791148382&installation_model_id=422833&pr_number=5680&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5680&signature=ef9ab74a7325b4e95108a8c87eb5847337765cf0a447b819b00549467e34afa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Vue ecosystem test fixtures to require broader project coverage.
  * Added oracle configuration coverage for template binding, component boundaries, and file lifecycle scenarios in the Vue charts fixture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->