### PR TITLE
feat(atelier-dom): route scoped profiling through s2

### DIFF
--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -83,7 +83,6 @@ pub(super) fn s2_emit_supported(
     has_croquis: bool,
 ) -> bool {
     !codegen.source_map
-        && options.scope_id.is_none()
         && options.hoist_static
         && !options.ssr
         && !options.comments

--- a/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
@@ -113,7 +113,7 @@ fn profile_reports_ladder_s2_dom_walk_budget() {
 }
 
 #[test]
-fn source_map_disabled_scope_id_uses_compatibility_codegen() {
+fn source_map_disabled_scope_id_stays_on_s2_codegen() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
@@ -143,9 +143,9 @@ fn source_map_disabled_scope_id_uses_compatibility_codegen() {
     assert_eq!(result.preamble, compat.preamble);
     assert_eq!(result.code, compat.code);
     assert_eq!(
-        counter_total(&counters, "davinci.s2_dom.files"),
-        None,
-        "direct scope_id compiles must not be routed through S2 yet"
+        counter(&counters, "davinci.s2_dom.files"),
+        1,
+        "direct scope_id compiles are covered by the S2 production option surface"
     );
 }
 

--- a/davinci-road/plan/phase-2-records/p2-11/installment-100.md
+++ b/davinci-road/plan/phase-2-records/p2-11/installment-100.md
@@ -1,0 +1,25 @@
+# P2-11 Installment 100 - Scoped Compile Profiling
+
+> Part of the [P2-11 series record](../p2-11.md), split per installment.
+> PR: _pending - the number, merge date and squash SHA are filled in at
+> merge, as every prior installment's line was._
+
+This installment connects installment 99's `scope_id` emitter parity witness to
+the production-side S2 selector. Direct scoped DOM compiles no longer stay on
+compatibility codegen when profiling is enabled: with `source_map` disabled,
+the compiler routes them through the S2 DOM emitter and records the same
+`davinci.s2_dom.*` counters as unscoped output.
+
+The source-map request remains the compatibility boundary. S2 still emits no
+map, so the production switch is narrowed without weakening the documented
+source-map contract or changing the shipped non-profiled lane.
+
+## Evidence
+
+`crates/vize_atelier_dom/tests/davinci_s2_profile.rs` now asserts that a
+direct `scope_id` compile enters S2 profiling and stays byte-identical with the
+compatibility source-map compile. This keeps `scope_id` in the measured
+production option surface instead of as an emitter-only witness.
+
+This installment does not tick P2-11. The production-lane switch remains
+open, and the old DOM lane is still the shipped compile path.


### PR DESCRIPTION
## Summary
- route source-map-disabled scoped DOM compiles through the S2 emitter when profiling is enabled
- keep source-map requests on the compatibility path
- add the P2-11 installment 100 record for the production option readiness step

## Validation
- TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp TMPDIR=$PWD/target/vize-tests/tmp cargo test -p vize_atelier_dom --test davinci_s2_profile source_map_disabled_scope_id_stays_on_s2_codegen -- --exact
- TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp TMPDIR=$PWD/target/vize-tests/tmp cargo test -p vize_atelier_dom --test davinci_s2_profile
- TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp TMPDIR=$PWD/target/vize-tests/tmp cargo test -p vize_atelier_dom --test davinci_s2_scope_id
- TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp TMPDIR=$PWD/target/vize-tests/tmp node --test tests/tooling/davinci-dom-production-boundary.test.ts tests/tooling/davinci-stage-release-firewall.test.ts
- TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp TMPDIR=$PWD/target/vize-tests/tmp cargo test -p vize_atelier_dom --test davinci_s2_source_map
- node --test tests/tooling/davinci-phase2-ledger.test.ts
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791151492&installation_model_id=422833&pr_number=5681&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5681&signature=2088e275d6704c7f562c8f45b3e882b2d620c85edfafba02cd245118feae535b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Scoped DOM compilations now use the S2 generation path when source maps are disabled.
  - Profiling results for scoped and unscoped compilations now report consistent S2 DOM metrics.

- **Documentation**
  - Added a record documenting the updated compilation and profiling behavior, including the continued compatibility boundary when source maps are requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->