### PR TITLE
test(lsp): add vue-flow authored oracle

### DIFF
--- a/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 21, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 22, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -784,6 +784,7 @@
           "tests/_fixtures/_git/splitpanes",
           "tests/_fixtures/_git/vue-charts",
           "tests/_fixtures/_git/vue-datepicker",
+          "tests/_fixtures/_git/vue-flow",
           "tests/_fixtures/_git/vue-sonner"
         ]
       },

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 21,
+    "minimumProjectCount": 22,
     "trackingIssue": 3952
   },
   "projects": [
@@ -2659,7 +2659,74 @@
         "syntax-highlighter",
         "lsp"
       ],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "docs/examples/connection-radius/App.vue",
+          "symbol": "nodes",
+          "usageAnchor": "\"nodes\" :connection-radius",
+          "declarationAnchor": "const nodes = ref([",
+          "hoverContains": [
+            "const nodes:"
+          ],
+          "renameTo": "__vizeRenamedNodes"
+        },
+        "componentBoundary": {
+          "importerFile": "docs/examples/connectionline/App.vue",
+          "componentFile": "docs/examples/connectionline/CustomConnectionLine.vue",
+          "tagName": "CustomConnectionLine",
+          "tagAnchor": "      <CustomConnectionLine ",
+          "completionItemCount": 32,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "source-x", "rank": 28 },
+            { "label": "source-y", "rank": 29 },
+            { "label": "target-x", "rank": 30 },
+            { "label": "target-y", "rank": 31 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  targetY: {\n    type: Number,\n    required: true,\n  },",
+            "replacement": "  targetY: {\n    type: Number,\n    required: true,\n  },\n  vizeOracleProbe: {\n    type: Boolean,\n    default: false,\n  },",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "docs/examples/connectionline/__VizeOracleCustomConnectionLine.vue",
+          "renamedFile": "docs/examples/connectionline/__VizeOracleRenamedCustomConnectionLine.vue",
+          "originalImportSpecifier": "./CustomConnectionLine.vue",
+          "copiedImportSpecifier": "./__VizeOracleCustomConnectionLine.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedCustomConnectionLine.vue",
+          "markerInsertionAnchor": "<script setup>\n",
+          "markerSymbol": "__vizeVueFlowConnectionLineMarker__"
+        }
+      }
     },
     {
       "id": "mavon-editor",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 21,
+      "authored-lsp": 22,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tests/tooling/real-project-lsp-authored-registry.test.ts
+++ b/tests/tooling/real-project-lsp-authored-registry.test.ts
@@ -32,6 +32,10 @@ test("authored LSP feature oracles are explicit and ratcheted", () => {
     configured.some((project) => project.id === "misskey"),
     "misskey must keep an authored LSP feature oracle",
   );
+  assert.ok(
+    configured.some((project) => project.id === "vue-flow"),
+    "vue-flow must keep an authored LSP feature oracle",
+  );
 
   const budgetOwnerIds = registry.projects
     .filter((project) => project.lspIncrementalBudget != null)


### PR DESCRIPTION
## Summary
- add Vue Flow to the real-project authored LSP oracle registry
- pin its template binding, component completion, dependency edit, and file lifecycle checks
- ratchet authored LSP compatibility coverage from 21 to 22 fixtures

## Validation
- vp install --frozen-lockfile --prefer-offline
- cargo build --profile ci -p vize
- CORSA_PATH=$PWD/node_modules/@typescript/typescript-darwin-arm64/lib/tsc VIZE_LSP_BIN=target/ci/vize REAL_PROJECT_LSP_TIMEOUT_MS=600000 FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=79 FIXTURE_REPORT_DIR=target/lsp-vue-flow node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts
- node --test tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791152067&installation_model_id=422833&pr_number=5682&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5682&signature=9863447881589ffa8a44e20d56b4010aa28900979a4af12c8977855629284e7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded authored LSP compatibility coverage from 21 to 22 fixture projects.
  - Added Vue Flow coverage for template bindings, component completions, and file lifecycle operations.
  - Added validation to ensure Vue Flow retains its authored LSP feature coverage.
  - Updated compatibility reporting expectations to reflect the expanded fixture set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->