### PR TITLE
test(lsp): pin auto-insert configuration mapping

### DIFF
--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -103,6 +103,29 @@ fn on_type_formatting_advertises_the_vue_language_server_trigger_set() {
 }
 
 #[test]
+fn auto_insertion_advertises_positional_vscode_configuration_sections() {
+    let experimental = server_capabilities(all_features())
+        .experimental
+        .expect("auto insertion should advertise a private client capability");
+
+    assert_eq!(
+        experimental,
+        serde_json::json!({
+            "autoInsertionProvider": {
+                "triggerCharacters": ["}", "=", ">", "/", "\\w"],
+                "configurationSections": [
+                    ["vize.autoInsert.bracketSpacing"],
+                    ["vize.autoInsert.autoCreateQuotes"],
+                    ["vize.autoInsert.autoClosingTags"],
+                    ["vize.autoInsert.autoClosingTags"],
+                    ["vize.autoInsert.dotValue"]
+                ]
+            }
+        })
+    );
+}
+
+#[test]
 fn all_features_skip_unimplemented_providers_and_keep_implemented_ones() {
     let capabilities = server_capabilities(all_features());
 


### PR DESCRIPTION
## Summary
- add a Maestro capability unit test for the private auto-insert provider
- pin the positional mapping between auto-insert trigger characters and VS Code configuration sections

## Validation
- cargo test -p vize_maestro auto_insertion_advertises_positional_vscode_configuration_sections
- cargo test -p vize_maestro server::capabilities::tests
- node --test tests/tooling/lsp-capabilities.test.ts
- node --test tests/tooling/lsp-auto-insertion.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791153115&installation_model_id=422833&pr_number=5684&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5684&signature=a18660257a5e77477a848b75bd59bf77adbc4bd7c1f56b3328b3b2f013d109f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage verifying that auto-insertion capabilities advertise the expected trigger characters and configuration sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->