### PR TITLE
test(davinci): gate runtime global s2 profiling

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
@@ -8,11 +8,14 @@
 )]
 
 use davinci_harness::fixtures::{LADDER, template_block};
+use vize_atelier_core::options::{CodegenOptions, TemplateSyntaxMode};
 use vize_atelier_dom::{
     DomCompilerOptions, compile_template, compile_template_with_options,
     compile_template_with_options_and_hoisted_scope_id,
+    compile_template_with_template_syntax_and_codegen_options,
 };
 use vize_s0::Allocator;
+use vize_s0::String;
 use vize_s0::profiler::{CounterSummary, global_profiler};
 
 static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -183,6 +186,51 @@ fn source_map_disabled_hoisted_scope_id_stays_on_s2_codegen() {
     assert_eq!(counter(&counters, "davinci.s2_dom.files"), 1);
     assert_eq!(result.preamble, compat.preamble);
     assert_eq!(result.code, compat.code);
+}
+
+#[test]
+fn source_map_disabled_runtime_global_name_stays_on_s2_codegen() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+    let source = r#"<button @click="go">{{ label }}</button>"#;
+    let codegen = CodegenOptions {
+        runtime_global_name: String::from("RuntimeVue"),
+        ..Default::default()
+    };
+    let compat_allocator = Allocator::new();
+    let (_, compat_errors, compat) = compile_template_with_template_syntax_and_codegen_options(
+        &compat_allocator,
+        source,
+        DomCompilerOptions {
+            source_map: true,
+            ..Default::default()
+        },
+        TemplateSyntaxMode::Standard,
+        codegen.clone(),
+    );
+    assert!(compat_errors.is_empty());
+
+    let profile = ProfileScope::enable();
+    let allocator = Allocator::new();
+    let (_, errors, result) = compile_template_with_template_syntax_and_codegen_options(
+        &allocator,
+        source,
+        DomCompilerOptions::default(),
+        TemplateSyntaxMode::Standard,
+        codegen,
+    );
+    let counters = profile.finish();
+
+    assert!(errors.is_empty());
+    assert_eq!(result.preamble, compat.preamble);
+    assert_eq!(result.code, compat.code);
+    assert_eq!(
+        counter(&counters, "davinci.s2_dom.files"),
+        1,
+        "custom runtime-global compiles are covered by the S2 production option surface"
+    );
 }
 
 #[test]

--- a/davinci-road/plan/phase-2-records/p2-11/installment-101.md
+++ b/davinci-road/plan/phase-2-records/p2-11/installment-101.md
@@ -1,0 +1,27 @@
+# P2-11 Installment 101 - Runtime Global Profiling
+
+> Part of the [P2-11 series record](../p2-11.md), split per installment.
+> PR: _pending - the number, merge date and squash SHA are filled in at
+> merge, as every prior installment's line was._
+
+This installment connects installment 84's custom runtime global-name emitter
+parity witness to the production-side S2 selector. Adapter-provided
+`CodegenOptions::runtime_global_name` is not a DOM compiler option, so it can
+quietly lose S2 coverage unless the profiled compile path exercises the same
+projection that `DomEmitOptions` already exposes.
+
+With source maps disabled, a custom runtime global compile now has a direct
+machine gate: it must enter S2 profiling, record the `davinci.s2_dom.*`
+counters and stay byte-identical with the compatibility source-map compile.
+The source-map request remains the compatibility boundary because S2 still
+emits no map.
+
+## Evidence
+
+`crates/vize_atelier_dom/tests/davinci_s2_profile.rs` now asserts that a
+source-map-free DOM compile using `runtime_global_name = "RuntimeVue"` stays on
+S2 under profiling and produces the same preamble and render body as the
+compatibility source-map compile.
+
+This installment does not tick P2-11. The production-lane switch remains
+open, and the old DOM lane is still the shipped non-profiled compile path.


### PR DESCRIPTION
## Summary
- add a profiled DOM compile gate for adapter-provided `runtime_global_name`
- assert source-map-free runtime-global compiles enter S2 and stay byte-identical with the compatibility source-map compile
- record P2-11 installment 101

## Validation
- `cargo test -p vize_atelier_dom --test davinci_s2_profile source_map_disabled_runtime_global_name_stays_on_s2_codegen -- --exact`
- `cargo test -p vize_atelier_dom --test davinci_s2_profile`
- `cargo test -p vize_atelier_dom --test davinci_s2_source_map`
- `node --test tests/tooling/davinci-dom-production-boundary.test.ts tests/tooling/davinci-stage-release-firewall.test.ts tests/tooling/davinci-phase2-ledger.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791153597&installation_model_id=422833&pr_number=5685&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5685&signature=e478e5758a2b7ed91daae3ed7389a1c9e5a231386b50df39420ace3cb477a1df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->