### PR TITLE
fix(typechecker): isolate pnpm baseline installs

### DIFF
--- a/legacy-tools/fixtures/typecheck-dependency-prepare.mjs
+++ b/legacy-tools/fixtures/typecheck-dependency-prepare.mjs
@@ -235,7 +235,13 @@ async function runBaselineCommand(command, fixtureRoot, timeoutMs, managerRunner
 export function installArguments(manager) {
   return {
     npm: ["ci", "--ignore-scripts", "--prefer-offline", "--no-audit", "--no-fund"],
-    pnpm: ["install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"],
+    pnpm: [
+      "install",
+      "--frozen-lockfile",
+      "--ignore-scripts",
+      "--prefer-offline",
+      "--ignore-workspace",
+    ],
     yarn: ["install", "--immutable", "--mode=skip-build"],
   }[manager];
 }

--- a/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
+++ b/tests/tooling/_helpers/typecheck-divergence-report-fixture.ts
@@ -36,6 +36,14 @@ export const script = path.join(
   "typecheck-divergence-report.rs",
 );
 export const commitSha = "a".repeat(40);
+export const pnpmInstallCommand = [
+  "pnpm",
+  "install",
+  "--frozen-lockfile",
+  "--ignore-scripts",
+  "--prefer-offline",
+  "--ignore-workspace",
+];
 
 /** The one diagnostic both sides report, so the default fixture diverges nowhere. */
 export const sharedVizeDiagnostic = "error:1:1 [TS2322] shared";
@@ -202,7 +210,7 @@ export function setup(options: FixtureOptions = {}) {
       sha256: sha256(fs.readFileSync(path.join(fixtureRoot, "pnpm-lock.yaml"))),
     },
     install: {
-      command: ["pnpm", "install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"],
+      command: pnpmInstallCommand,
       durationMs: 1,
       exitCode: 0,
       stdoutSha256: sha256("installed"),

--- a/tests/tooling/support/typecheck-dependency-prepare-fixture.ts
+++ b/tests/tooling/support/typecheck-dependency-prepare-fixture.ts
@@ -27,7 +27,13 @@ export const packageManagers = [
     version: "10.0.0",
     lockfile: "pnpm-lock.yaml",
     lockfileContents: "lockfileVersion: '9.0'\n",
-    installArgs: ["install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"],
+    installArgs: [
+      "install",
+      "--frozen-lockfile",
+      "--ignore-scripts",
+      "--prefer-offline",
+      "--ignore-workspace",
+    ],
   },
   {
     name: "yarn",

--- a/tests/tooling/typecheck-dependency-prepare.test.ts
+++ b/tests/tooling/typecheck-dependency-prepare.test.ts
@@ -76,6 +76,28 @@ test("dependency prepare uses each pinned manager's immutable install command", 
   }
 });
 
+test("dependency prepare keeps pnpm fixtures out of parent workspaces", () => {
+  const packageManager = packageManagers.find((candidate) => candidate.name === "pnpm");
+  assert.ok(packageManager);
+  const fixture = setup(packageManager);
+  try {
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const invocation = JSON.parse(fs.readFileSync(fixture.invocationPath, "utf8"));
+    assert.equal(invocation.cwd, fixture.fixtureRoot);
+    assert.equal(invocation.env.corepackProjectSpec, "0");
+    assert.deepEqual(invocation.managerArgs, [
+      "install",
+      "--frozen-lockfile",
+      "--ignore-scripts",
+      "--prefer-offline",
+      "--ignore-workspace",
+    ]);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
 test("dependency prepare rejects a mismatched detected package manager version", () => {
   const fixture = setup();
   try {

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import {
   cleanup,
   commitSha,
+  pnpmInstallCommand,
   readJson,
   root,
   run,
@@ -67,7 +68,7 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
           .digest("hex"),
       },
       install: {
-        command: ["pnpm", "install", "--frozen-lockfile", "--ignore-scripts", "--prefer-offline"],
+        command: pnpmInstallCommand,
         exitCode: 0,
         stdoutSha256: createHash("sha256").update("installed").digest("hex"),
         stderrSha256: createHash("sha256").update("").digest("hex"),

--- a/tools/commands/fixtures/typecheck-dependency-prepare.rs
+++ b/tools/commands/fixtures/typecheck-dependency-prepare.rs
@@ -384,6 +384,7 @@ fn install_arguments(manager: &str) -> Result<Vec<String>, String> {
             "--frozen-lockfile",
             "--ignore-scripts",
             "--prefer-offline",
+            "--ignore-workspace",
         ]
         .iter()
         .map(|value| (*value).to_string())


### PR DESCRIPTION
## Summary
- add `--ignore-workspace` to pnpm typecheck baseline dependency installs
- keep the JavaScript helper, Rust Script CI command, and divergence evidence fixtures in sync
- cover the parent-workspace isolation contract in the dependency-prep tests

## Validation
- `node --test tests/tooling/typecheck-dependency-prepare.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts tests/tooling/typecheck-divergence-report-timeout.test.ts tests/tooling/typecheck-dependency-prepare-isolation-tsconfigs.test.ts`
- `git diff --check origin/main...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791154406&installation_model_id=422833&pr_number=5686&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5686&signature=60fa162bdd3a62c80ac3eeb9d2ea5d84701eface9161b9199a0b955fb480ddd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->