### PR TITLE
fix(release): drain typecheck baseline output

### DIFF
--- a/tests/tooling/typecheck-divergence-mutation-oracle.test.ts
+++ b/tests/tooling/typecheck-divergence-mutation-oracle.test.ts
@@ -11,6 +11,8 @@ import {
   updateJson,
 } from "./_helpers/typecheck-divergence-report-fixture.ts";
 
+const outerHarnessTimeoutMs = 20_000;
+
 function artifactPath(fixture: ReturnType<typeof setup>, extension: string) {
   return path.join(fixture.reportDir, `fixture-typecheck-divergence.${extension}`);
 }
@@ -72,10 +74,10 @@ setInterval(() => {}, 1000);
     fs.chmodSync(fixture.vize, 0o755);
 
     const startedAt = Date.now();
-    const result = run(fixture, {}, [], { timeoutMs: 8_000 });
+    const result = run(fixture, {}, [], { timeoutMs: outerHarnessTimeoutMs });
     assert.equal(result.status, 1);
     assert.ok(
-      Date.now() - startedAt < 8_000,
+      Date.now() - startedAt < outerHarnessTimeoutMs,
       "timeout handling must not wait for a Vize mutation process tree that ignores SIGTERM",
     );
     const artifact = readJson(artifactPath(fixture, "json"));

--- a/tests/tooling/typecheck-divergence-report-timeout.test.ts
+++ b/tests/tooling/typecheck-divergence-report-timeout.test.ts
@@ -12,6 +12,8 @@ import {
   writeVueTsc,
 } from "./_helpers/typecheck-divergence-report-fixture.ts";
 
+const outerHarnessTimeoutMs = 20_000;
+
 function artifactPath(fixture: ReturnType<typeof setup>) {
   return path.join(fixture.reportDir, "fixture-typecheck-divergence.json");
 }
@@ -37,11 +39,11 @@ setInterval(() => {}, 1000);`,
     );
 
     const startedAt = Date.now();
-    const result = run(fixture, {}, [], { timeoutMs: 8_000 });
+    const result = run(fixture, {}, [], { timeoutMs: outerHarnessTimeoutMs });
     const reason = "vue-tsc baseline failed to run: spawn timed out after 80ms";
     assert.equal(result.status, 1);
     assert.ok(
-      Date.now() - startedAt < 8_000,
+      Date.now() - startedAt < outerHarnessTimeoutMs,
       "timeout handling must not wait for a vue-tsc process tree that ignores SIGTERM",
     );
     assert.equal(result.stderr, `${unusableFailure(reason)}\n`);
@@ -68,7 +70,7 @@ test("typecheck divergence report records a vue-tsc coverage timeout as an unusa
   try {
     updateJson(
       fixture.registryPath,
-      (registry) => (registry.projects[0].typecheckPerformance.hangTimeoutMs = 80),
+      (registry) => (registry.projects[0].typecheckPerformance.hangTimeoutMs = 500),
     );
     writeVueTsc(
       fixture.vueTsc,
@@ -82,11 +84,11 @@ test("typecheck divergence report records a vue-tsc coverage timeout as an unusa
     );
 
     const startedAt = Date.now();
-    const result = run(fixture, {}, [], { timeoutMs: 8_000 });
-    const reason = "vue-tsc coverage baseline failed to run: spawn timed out after 80ms";
+    const result = run(fixture, {}, [], { timeoutMs: outerHarnessTimeoutMs });
+    const reason = "vue-tsc coverage baseline failed to run: spawn timed out after 500ms";
     assert.equal(result.status, 1);
     assert.ok(
-      Date.now() - startedAt < 8_000,
+      Date.now() - startedAt < outerHarnessTimeoutMs,
       "coverage timeout handling must not wait for the outer test timeout",
     );
     assert.equal(result.stderr, `${unusableFailure(reason)}\n`);
@@ -99,6 +101,48 @@ test("typecheck divergence report records a vue-tsc coverage timeout as an unusa
     assert.equal(artifact.baseline.coverage.unusableReason, reason);
     assert.equal(artifact.mutationOracle.unusableReason, reason);
     assert.equal(artifact.budget.verdict, "unusable");
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("typecheck divergence report drains verbose vue-tsc coverage output", () => {
+  if (process.platform === "win32") return;
+
+  const fixture = setup();
+  try {
+    updateJson(
+      fixture.registryPath,
+      (registry) => (registry.projects[0].typecheckPerformance.hangTimeoutMs = 1_000),
+    );
+    writeVueTsc(
+      fixture.vueTsc,
+      `if (process.argv.includes("--listFilesOnly")) {
+  fs.writeSync(1, process.cwd() + "/src/App.vue\\n");
+  const filler = process.cwd() + "/src/generated-support-file.ts\\n";
+  for (let index = 0; index < 50_000; index++) fs.writeSync(1, filler);
+  process.exit(0);
+}
+
+let output = "src/App.vue(1,1): error TS2322: shared\\n";
+const source = fs.readFileSync("src/App.vue", "utf8");
+const marker = "__vize_typecheck_mutation_probe: string = 1";
+if (source.includes(marker)) {
+  const line = source.slice(0, source.indexOf(marker)).split(/\\r?\\n/).length;
+  output += \`src/App.vue(\${line},1): error TS2322: Type 'number' is not assignable to type 'string'.\\n\`;
+}
+process.stdout.write(output);
+process.exit(2);`,
+      fixture.invocationPath,
+    );
+
+    const result = run(fixture, {}, [], { timeoutMs: outerHarnessTimeoutMs });
+    assert.equal(result.status, 0, result.stderr);
+    const artifact = readJson(artifactPath(fixture));
+    assert.equal(artifact.baseline.coverageRunError, null);
+    assert.equal(artifact.baseline.coverage.baselineVueFileCount, 1);
+    assert.equal(artifact.baseline.coverage.verdict, "usable");
+    assert.equal(artifact.budget.verdict, "passed");
   } finally {
     cleanup(fixture);
   }
@@ -120,7 +164,9 @@ setInterval(() => {}, 1000);`,
       fixture.invocationPath,
     );
 
-    const result = run(fixture, {}, ["--budget-mode", "record-only"], { timeoutMs: 8_000 });
+    const result = run(fixture, {}, ["--budget-mode", "record-only"], {
+      timeoutMs: outerHarnessTimeoutMs,
+    });
     const reason = "vue-tsc baseline failed to run: spawn timed out after 80ms";
     assert.equal(result.status, 0, result.stderr);
     assert.ok(

--- a/tools/commands/fixtures/typecheck-divergence-report.rs
+++ b/tools/commands/fixtures/typecheck-divergence-report.rs
@@ -17,6 +17,7 @@ use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     env, fs,
+    io::Read,
     path::{Path, PathBuf},
     process::{Command, ExitCode, Stdio},
     thread,
@@ -2574,29 +2575,41 @@ fn run_capture_limited(
     let mut child = child_command
         .spawn()
         .map_err(|error| format!("{label} failed to run: {error}"))?;
-    loop {
-        if child
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| format!("{label} failed to capture stdout"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| format!("{label} failed to capture stderr"))?;
+    let stdout_reader = thread::spawn(move || read_child_output(stdout));
+    let stderr_reader = thread::spawn(move || read_child_output(stderr));
+    let status = loop {
+        if let Some(status) = child
             .try_wait()
             .map_err(|error| format!("{label} failed to run: {error}"))?
-            .is_some()
         {
-            break;
+            break status;
         }
         if started.elapsed() >= Duration::from_millis(timeout_ms) {
             kill_child_group(&mut child);
+            // Timeout artifacts only need the failure reason. Descendants may
+            // keep inherited stdio open, so this path must not join readers.
+            drop(stdout_reader);
+            drop(stderr_reader);
             return Err(timeout_error(label, timeout_ms));
         }
         thread::sleep(Duration::from_millis(5));
-    }
-    let output = child
-        .wait_with_output()
-        .map_err(|error| format!("{label} failed to run: {error}"))?;
-    let status = output.status.code().unwrap_or(1);
+    };
+    let status = status.code().unwrap_or(1);
+    let stdout = join_output_reader(stdout_reader, label, "stdout")?;
+    let stderr = join_output_reader(stderr_reader, label, "stderr")?;
     if !allowed_statuses.contains(&status) {
         return Err(format!("{label} exited with unsupported status {status}"));
     }
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let stdout = String::from_utf8_lossy(&stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&stderr).into_owned();
     Ok(ToolRun {
         command: display_command(command, args),
         status,
@@ -2606,6 +2619,24 @@ fn run_capture_limited(
         duration_ms: started.elapsed().as_millis(),
         parsed: None,
     })
+}
+
+fn read_child_output<R: Read>(mut pipe: R) -> Result<Vec<u8>, String> {
+    let mut output = Vec::new();
+    pipe.read_to_end(&mut output)
+        .map_err(|error| format!("failed to read child output: {error}"))?;
+    Ok(output)
+}
+
+fn join_output_reader(
+    reader: thread::JoinHandle<Result<Vec<u8>, String>>,
+    label: &str,
+    stream: &str,
+) -> Result<Vec<u8>, String> {
+    reader
+        .join()
+        .map_err(|_| format!("{label} {stream} reader panicked"))?
+        .map_err(|error| format!("{label} failed to run: {error}"))
 }
 
 fn timeout_error(label: &str, timeout_ms: u64) -> String {


### PR DESCRIPTION
## Summary
- drain typecheck baseline stdout/stderr while the child process is running
- cover verbose vue-tsc --listFilesOnly output so release matrix coverage probes do not block on full pipes

## Validation
- node --test tests/tooling/typecheck-divergence-report-timeout.test.ts
- node --test tests/tooling/typecheck-divergence-report.test.ts
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check origin/main...HEAD

## Release Evidence
- addresses v0.393.0 Real Project Matrix typecheck-divergence coverage probe timeouts on run 33923412513

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791154438&installation_model_id=422833&pr_number=5687&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5687&signature=749dfc61f3199118f1e68ddfc40bd04bb830d76555d8a7591b8f2e8eab929bed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved typecheck divergence reporting when processing very large diagnostic output.
  - Prevented report generation from hanging or timing out while collecting compiler output.
  - Improved timeout handling for processes that do not respond promptly to termination requests.
  - Ensured compiler output from both standard output and error streams is captured reliably.

- **Tests**
  - Added coverage for verbose output scenarios and verified that usable baseline results are still recorded.
  - Updated timeout checks to better reflect expected behavior in slower environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->