### PR TITLE
fix(davinci): keep v-for in-conditional class patch flag

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_corpus_residuals.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_corpus_residuals.rs
@@ -33,6 +33,10 @@ const BATTERY: &[(&str, &str)] = &[
         "foreign_defs_with_static_bound_gradient_caches_as_legacy",
         r##"<svg class="va-icon-vuestic"><defs><linearGradient :id="'ORIGINAL'" x1="0%" y1="50%" y2="50%"><stop offset="0%" stop-color="#4AE387" /><stop offset="100%" stop-color="#C8EA13" /></linearGradient></defs><path :fill="textColor" /></svg>"##,
     ),
+    (
+        "consul_key_browser_v_for_item_in_conditional_class_keeps_patch_flag",
+        r#"<div v-for="row in rows" :key="row.key" class="row" :class="'session' in row && row.session ? 'locked' : ''"></div>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_s1_to_s2/src/emit/props.rs
+++ b/crates/vize_s1_to_s2/src/emit/props.rs
@@ -151,11 +151,13 @@ pub(super) fn bind_patch(
                     "ref" => flag |= 512,
                     "class"
                         if bind_value_is_static_patchless(bind, is_ts)
-                            || bind_value_uses_legacy_patchless_runtime_expr(bind) => {}
+                            || (!for_item
+                                && bind_value_uses_legacy_patchless_runtime_expr(bind)) => {}
                     "class" if !is_component => flag |= 2,
                     "style"
                         if bind_value_is_static_patchless(bind, is_ts)
-                            || bind_value_uses_legacy_patchless_runtime_expr(bind) => {}
+                            || (!for_item
+                                && bind_value_uses_legacy_patchless_runtime_expr(bind)) => {}
                     "style" if !is_component => flag |= 4,
                     "key" => {}
                     key if key.ends_with("Modifiers")

--- a/crates/vize_s1_to_s2/tests/emit_for.rs
+++ b/crates/vize_s1_to_s2/tests/emit_for.rs
@@ -164,6 +164,13 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+fn v_for_item_with_in_conditional_class_keeps_the_legacy_patch_flag() {
+    assert_shipped_parity(
+        r#"<div v-for="row in rows" :key="row.key" class="row" :class="'session' in row && row.session ? 'locked' : ''"></div>"#,
+    );
+}
+
+#[test]
 fn a_destructured_v_for_component_uses_the_pattern() {
     assert_eq!(
         assembled(r#"<Foo v-for="{ id } in list" :key="id" />"#),


### PR DESCRIPTION
## Summary
- keep legacy in-conditional class/style patchless suppression out of `v-for` item patch flag calculation
- add a reduced `v-for` item guard and a residual DOM battery case for the dbx ConsulKeyBrowser regression

## Evidence
- reproduced on current `origin/main`: `ConsulKeyBrowser.vue` had `old_len=54384`, `new_len=54369`, `s2_refusals=0`, `divergences=1`; S2 omitted `2 /* CLASS */` on the `v-for` row
- reduced guard failed before the fix and passes after it
- dbx consul component shard now reports `files=12`, `compared=12`, `s2_refusals=0`, `divergences=0`

## Validation
- `cargo fmt --check`
- `cargo test -p vize_s1_to_s2 --test emit_for -- --nocapture`
- `cargo test -p vize_s1_to_s2 --test emit_static unparenthesized_in_conditionals_drop_legacy_class_and_style_patch_flags -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_corpus_residuals -- --nocapture`
- `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=tests/_fixtures/_git/dbx/apps/desktop/src/components/consul cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus dom_emit_agrees_on_sfc_templates -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791155040&installation_model_id=422833&pr_number=5688&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5688&signature=47ef20ebe0f209572dc68fc6250f1ec6cab20f1747463ce0c0730a3af47d1311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->