### PR TITLE
test(lsp): record real-project server provenance

### DIFF
--- a/tests/tooling/real-project-lsp.test.ts
+++ b/tests/tooling/real-project-lsp.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -43,12 +44,36 @@ test("LSP report summarizes authored feature coverage from project evidence", ()
   );
 
   assert.equal(report.summary.projectCount, 3);
-  assert.equal(report.version, 3);
+  assert.equal(report.version, 4);
+  assert.equal(report.commitSha, "0".repeat(40));
+  assert.equal(report.evidence.commitSha, "0".repeat(40));
+  assert.deepEqual(report.evidence.runtime, { name: "node", version: process.versions.node });
   assert.equal(report.summary.authoredFeatureProjectCount, 1);
   assert.deepEqual(report.summary.missingAuthoredFeatureProjectIds, [
     "missing-oracle",
     "also-missing-oracle",
   ]);
+});
+
+test("LSP report records resolved server binary provenance", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "vize-lsp-report-provenance-"));
+  try {
+    const binary = path.join(workspace, "vize");
+    fs.writeFileSync(binary, "fake vize binary");
+    const report = createLspReport(
+      { enforced: true, projects: [], shardCount: 1, shardIndex: 0 },
+      [],
+      { GITHUB_SHA: "1".repeat(40), VIZE_LSP_BIN: binary },
+      { resolveLaunchCommand: () => [binary, "lsp"] },
+    );
+    assert.deepEqual(report.evidence.vizeBinary, {
+      command: [binary, "lsp"],
+      path: binary,
+      sha256: createHash("sha256").update("fake vize binary").digest("hex"),
+    });
+  } finally {
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
 });
 
 test("real-project LSP lifecycle opens an authored file and restores exact diagnostics", async () => {

--- a/tests/tooling/support/real-project-lsp-report.ts
+++ b/tests/tooling/support/real-project-lsp-report.ts
@@ -1,8 +1,10 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveVizeLaunchCommand } from "./lsp/launch.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 const reportName = "lsp-lifecycle-summary.json";
@@ -60,6 +62,16 @@ export type LspResponseEvidence = {
   count: number;
   durationMs: number;
   sha256: string;
+};
+
+export type LspReportEvidence = {
+  commitSha: string;
+  runtime: { name: "node"; version: string };
+  vizeBinary: {
+    command: string[];
+    path: string | null;
+    sha256: string | null;
+  };
 };
 
 export type AuthoredFileLifecycleEvidence = {
@@ -139,11 +151,16 @@ export function createLspReport(
   selection: ReturnType<typeof selectProjects>,
   projects: LspProjectEvidence[],
   environment: NodeJS.ProcessEnv,
+  dependencies: {
+    resolveLaunchCommand?: (environment: NodeJS.ProcessEnv) => string[];
+  } = {},
 ) {
+  const evidence = createReportEvidence(environment, dependencies);
   return {
     schema: "vize.realProjectLspLifecycle",
-    version: 3,
-    commitSha: resolveCommitSha(environment),
+    version: 4,
+    commitSha: evidence.commitSha,
+    evidence,
     shard: { count: selection.shardCount, index: selection.shardIndex },
     summary: {
       projectCount: projects.length,
@@ -158,6 +175,49 @@ export function createLspReport(
     },
     projects,
   };
+}
+
+function createReportEvidence(
+  environment: NodeJS.ProcessEnv,
+  dependencies: {
+    resolveLaunchCommand?: (environment: NodeJS.ProcessEnv) => string[];
+  },
+): LspReportEvidence {
+  const command =
+    dependencies.resolveLaunchCommand?.(environment) ??
+    resolveVizeLaunchCommand(
+      (candidate) =>
+        spawnSync(candidate, ["--version"], {
+          cwd: root,
+          encoding: "utf8",
+        }).status === 0,
+      environment.VIZE_LSP_BIN,
+    );
+  const binaryPath = resolvedBinaryPath(command[0]);
+  return {
+    commitSha: resolveCommitSha(environment),
+    runtime: { name: "node", version: process.versions.node },
+    vizeBinary: {
+      command,
+      path: binaryPath == null ? null : displayBinaryPath(binaryPath),
+      sha256: binaryPath == null ? null : sha256File(binaryPath),
+    },
+  };
+}
+
+function resolvedBinaryPath(command: string): string | null {
+  if (command === "cargo") return null;
+  const resolved = path.isAbsolute(command) ? command : path.resolve(root, command);
+  return fs.existsSync(resolved) && fs.statSync(resolved).isFile() ? resolved : null;
+}
+
+function displayBinaryPath(binaryPath: string): string {
+  const relative = path.relative(root, binaryPath);
+  return relative.startsWith("..") ? binaryPath : relative;
+}
+
+function sha256File(binaryPath: string): string {
+  return createHash("sha256").update(fs.readFileSync(binaryPath)).digest("hex");
 }
 
 export function writeLspReport(


### PR DESCRIPTION
## Summary

- stamp the real-project LSP report with commit, Node runtime, and resolved server binary evidence
- record the resolved server command, binary path, and sha256 when the measured binary is a concrete file
- bump the report schema to v4 and pin the provenance shape in tests

Refs #3952.

## Tests

- node --test tests/tooling/real-project-lsp.test.ts
- node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/source-file-lengths.test.ts
- vp run --workspace-root check:ci
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791156471&installation_model_id=422833&pr_number=5689&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5689&signature=eff9fcb8d8176af9044eda7948ccaffca47a29c808f59259c063c3a7d090d22e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->