### PR TITLE
test(lsp): add layoutit-grid authored oracle

### DIFF
--- a/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 22, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 23, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -782,6 +782,7 @@
           "tests/_fixtures/_git/vue-bits",
           "tests/_fixtures/_git/shadcn-vue",
           "tests/_fixtures/_git/splitpanes",
+          "tests/_fixtures/_git/layoutit-grid",
           "tests/_fixtures/_git/vue-charts",
           "tests/_fixtures/_git/vue-datepicker",
           "tests/_fixtures/_git/vue-flow",

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 22,
+    "minimumProjectCount": 23,
     "trackingIssue": 3952
   },
   "projects": [
@@ -4288,6 +4288,157 @@
         "syntax-highlighter",
         "lsp"
       ],
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "src/components/common/GridAutoFlowSelect.vue",
+          "symbol": "onInput",
+          "usageAnchor": "@input=\"onInput\"",
+          "declarationAnchor": "const onInput = (event: Event) => {",
+          "hoverContains": [
+            "const onInput: (event: Event) => void"
+          ],
+          "renameTo": "__vizeRenamedOnInput"
+        },
+        "componentBoundary": {
+          "importerFile": "src/App.vue",
+          "componentFile": "src/components/LayoutEditor.vue",
+          "tagName": "LayoutEditor",
+          "tagAnchor": "\n  <LayoutEditor ",
+          "completionItemCount": 29,
+          "completionItems": [
+            {
+              "label": "v-if",
+              "rank": 0
+            },
+            {
+              "label": "v-else-if",
+              "rank": 1
+            },
+            {
+              "label": "v-else",
+              "rank": 2
+            },
+            {
+              "label": "v-for",
+              "rank": 3
+            },
+            {
+              "label": "v-on",
+              "rank": 4
+            },
+            {
+              "label": "v-bind",
+              "rank": 5
+            },
+            {
+              "label": "v-model",
+              "rank": 6
+            },
+            {
+              "label": "v-slot",
+              "rank": 7
+            },
+            {
+              "label": "v-show",
+              "rank": 8
+            },
+            {
+              "label": "v-pre",
+              "rank": 9
+            },
+            {
+              "label": "v-once",
+              "rank": 10
+            },
+            {
+              "label": "v-memo",
+              "rank": 11
+            },
+            {
+              "label": "v-cloak",
+              "rank": 12
+            },
+            {
+              "label": "v-text",
+              "rank": 13
+            },
+            {
+              "label": "v-html",
+              "rank": 14
+            },
+            {
+              "label": "@",
+              "rank": 15
+            },
+            {
+              "label": ":",
+              "rank": 16
+            },
+            {
+              "label": "#",
+              "rank": 17
+            },
+            {
+              "label": "@click",
+              "rank": 18
+            },
+            {
+              "label": "@input",
+              "rank": 19
+            },
+            {
+              "label": "@change",
+              "rank": 20
+            },
+            {
+              "label": "@submit",
+              "rank": 21
+            },
+            {
+              "label": "@keydown",
+              "rank": 22
+            },
+            {
+              "label": "@keyup",
+              "rank": 23
+            },
+            {
+              "label": "@focus",
+              "rank": 24
+            },
+            {
+              "label": "@blur",
+              "rank": 25
+            },
+            {
+              "label": "@mouseenter",
+              "rank": 26
+            },
+            {
+              "label": "@mouseleave",
+              "rank": 27
+            },
+            {
+              "label": "save-design",
+              "rank": 28
+            }
+          ],
+          "dependencyEdit": {
+            "anchor": "const { saveDesign } = defineProps<{ saveDesign?: (area) => string }>()",
+            "replacement": "const { saveDesign } = defineProps<{ saveDesign?: (area) => string; vizeOracleProbe?: boolean }>()",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "src/components/__VizeOracleLayoutEditor.vue",
+          "renamedFile": "src/components/__VizeOracleRenamedLayoutEditor.vue",
+          "originalImportSpecifier": "./components/LayoutEditor.vue",
+          "copiedImportSpecifier": "./components/__VizeOracleLayoutEditor.vue",
+          "renamedImportSpecifier": "./components/__VizeOracleRenamedLayoutEditor.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizeLayoutitGridFileLifecycleMarker__"
+        }
+      },
       "diff": "e2e-vrt"
     },
     {

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 22,
+      "authored-lsp": 23,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,


### PR DESCRIPTION
## Summary
- add a Layoutit Grid authored LSP oracle covering template binding rename/hover, component completion, and file lifecycle
- ratchet the authored LSP oracle project gate from 22 to 23 for #3952

## Verification
- node --test --test-concurrency=1 tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts
- node --test --test-concurrency=1 tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts
- FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=121 FIXTURE_REPORT_DIR=/tmp/vize-layoutit-grid-lsp-3952 REAL_PROJECT_LSP_TIMEOUT_MS=600000 VIZE_LSP_BIN=target/ci/vize CORSA_PATH="$PWD/node_modules/@typescript/typescript-darwin-arm64/lib/tsc" node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791156978&installation_model_id=422833&pr_number=5690&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5690&signature=a740ce05505f3613369d904916134f2a862c1440bb723d108a193ad33098f66b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded validation coverage for the Layout Editor project.
  - Added checks for input handling, component completion suggestions, related property updates, and fixture file copy/rename scenarios.
  - Added the project to compatibility validation.
  - Increased the minimum project coverage threshold and updated compatibility reporting to reflect the additional validated fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->