### PR TITLE
fix(davinci): ignore static v-for keys for fragment flags

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_corpus_residuals.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_corpus_residuals.rs
@@ -37,6 +37,10 @@ const BATTERY: &[(&str, &str)] = &[
         "consul_key_browser_v_for_item_in_conditional_class_keeps_patch_flag",
         r#"<div v-for="row in rows" :key="row.key" class="row" :class="'session' in row && row.session ? 'locked' : ''"></div>"#,
     ),
+    (
+        "template_else_if_static_keyed_v_for_item_keeps_unkeyed_fragment",
+        r#"<article v-if="kind === 'story'" key="story"><h1>{{ title }}</h1></article><template v-else-if="kind === 'gallery'"><img v-for="src in images" key="img"></template><aside v-else key="fallback">none</aside>"#,
+    ),
 ];
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_for.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_for.rs
@@ -11,6 +11,10 @@ mod support;
 
 const BATTERY: &[(&str, &str)] = &[
     (
+        "static_key",
+        r#"<div v-for="item in list" key="row">{{ item }}</div>"#,
+    ),
+    (
         "obj",
         r#"<div v-for="{ id } in list" :key="id">{{ id }}</div>"#,
     ),

--- a/crates/vize_atelier_dom/tests/davinci_s2_memo.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_memo.rs
@@ -41,6 +41,10 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<div v-for="item in items" :key="item.id" v-memo="[item.selected]">{{ item.name }}</div>"#,
     ),
     (
+        "native_v_for_static_key",
+        r#"<div v-for="item in items" key="row" v-memo="[item.selected]">{{ item.name }}</div>"#,
+    ),
+    (
         "component_v_for",
         r#"<Foo v-for="item in items" :key="item.id" v-memo="[item.selected]" :prop="item.prop" />"#,
     ),
@@ -85,6 +89,11 @@ const PATCH_CASES: &[PatchCase] = &[
         name: "native_v_for",
         src: r#"<div v-for="item in items" :key="item.id" v-memo="[item.selected]">{{ item.name }}</div>"#,
         sites: &["1 /* TEXT */", "128 /* KEYED_FRAGMENT */"],
+    },
+    PatchCase {
+        name: "native_v_for_static_key",
+        src: r#"<div v-for="item in items" key="row" v-memo="[item.selected]">{{ item.name }}</div>"#,
+        sites: &["1 /* TEXT */", "256 /* UNKEYED_FRAGMENT */"],
     },
     PatchCase {
         name: "component_v_for",

--- a/crates/vize_s1_to_s2/src/emit/vfor.rs
+++ b/crates/vize_s1_to_s2/src/emit/vfor.rs
@@ -14,7 +14,7 @@ use super::buf::Buf;
 use super::helper::Helper;
 use super::js::{RawJs, expr_source};
 use super::prefix::Site;
-use keys::{has_item_key, item_key_js, memo_item_key_js};
+use keys::{has_dynamic_item_key, item_key_js, memo_item_key_js};
 
 pub(super) fn emit_for(
     cx: &mut EmitCx<'_>,
@@ -82,16 +82,13 @@ fn emit_for_scoped(
         match for_op.region.ops.as_slice() {
             [Op::Element(element)] => (
                 element.bindings.len(),
-                has_item_key(&element.attributes, &element.bindings),
+                has_dynamic_item_key(&element.bindings),
             ),
             [Op::Component(component)] => (
                 component.bindings.len(),
-                has_item_key(&component.attributes, &component.bindings),
+                has_dynamic_item_key(&component.bindings),
             ),
-            [Op::Slot(slot)] => (
-                slot.bindings.len(),
-                has_item_key(&slot.attributes, &slot.bindings),
-            ),
+            [Op::Slot(slot)] => (slot.bindings.len(), has_dynamic_item_key(&slot.bindings)),
             _ => return Err(EmitError::unsupported_at(Reason::ForItemShape, for_op.span)),
         }
     };

--- a/crates/vize_s1_to_s2/src/emit/vfor/keys.rs
+++ b/crates/vize_s1_to_s2/src/emit/vfor/keys.rs
@@ -12,15 +12,14 @@ pub(super) fn memo_item_key_js(
     ops: &[Op<'_>],
 ) -> Result<Option<String>, EmitError> {
     match ops {
-        [Op::Element(element)] => item_key_js(cx, &element.attributes, &element.bindings),
-        [Op::Component(component)] => item_key_js(cx, &component.attributes, &component.bindings),
+        [Op::Element(element)] => dynamic_item_key_js(cx, &element.bindings),
+        [Op::Component(component)] => dynamic_item_key_js(cx, &component.bindings),
         _ => Ok(None),
     }
 }
 
-pub(super) fn item_key_js(
+fn dynamic_item_key_js(
     cx: &EmitCx<'_>,
-    attributes: &[Attribute<'_>],
     bindings: &[BindingOp<'_>],
 ) -> Result<Option<String>, EmitError> {
     for binding in bindings {
@@ -35,6 +34,17 @@ pub(super) fn item_key_js(
             return Ok(Some(String::from(source.as_str())));
         }
     }
+    Ok(None)
+}
+
+pub(super) fn item_key_js(
+    cx: &EmitCx<'_>,
+    attributes: &[Attribute<'_>],
+    bindings: &[BindingOp<'_>],
+) -> Result<Option<String>, EmitError> {
+    if let Some(key) = dynamic_item_key_js(cx, bindings)? {
+        return Ok(Some(key));
+    }
     for attr in attributes {
         if attr.name == "key" {
             let mut out = String::from("\"");
@@ -46,12 +56,11 @@ pub(super) fn item_key_js(
     Ok(None)
 }
 
-pub(super) fn has_item_key(attributes: &[Attribute<'_>], bindings: &[BindingOp<'_>]) -> bool {
-    attributes.iter().any(|attr| attr.name == "key")
-        || bindings.iter().any(|binding| {
-            matches!(
-                binding,
-                BindingOp::Bind(bind) if crate::emit::props_bind::is_key_bind_name(bind)
-            )
-        })
+pub(super) fn has_dynamic_item_key(bindings: &[BindingOp<'_>]) -> bool {
+    bindings.iter().any(|binding| {
+        matches!(
+            binding,
+            BindingOp::Bind(bind) if crate::emit::props_bind::is_key_bind_name(bind)
+        )
+    })
 }

--- a/davinci-road/plan/phase-2-records/p2-11/installment-102.md
+++ b/davinci-road/plan/phase-2-records/p2-11/installment-102.md
@@ -1,0 +1,34 @@
+# P2-11 Installment 102 - Static V-For Key Fragment Flags
+
+> Part of the [P2-11 series record](../p2-11.md), split per installment.
+> PR: _pending - the number, merge date and squash SHA are filled in at
+> merge, as every prior installment's line was._
+
+This installment closes a reduced S2 DOM residual from the committed fixture
+tree: a `v-for` item with static `key="..."` must still emit the static key on
+the item props, but it must not make the wrapping fragment keyed. The shipped
+DOM lane only treats dynamic `:key` bindings as the fragment-key signal for
+plain `v-for` items. Static keys belong to item props, so the surrounding
+fragment keeps `UNKEYED_FRAGMENT`.
+
+The same rule also applies to `v-memo` item reuse guards. A static key is not
+read back as `_cached.key === ...`; only a dynamic item key participates in
+that guard. The S2 DOM emitter now shares that dynamic-key decision instead of
+letting the prop key path and the fragment-key path drift.
+
+## Evidence
+
+`crates/vize_atelier_dom/tests/davinci_s2_corpus_residuals.rs` promotes the
+reduced corpus witness from `vif/chain-keys.vue`, where the `v-else-if`
+template contains `<img v-for="src in images" key="img">` between statically
+keyed conditional siblings.
+
+`crates/vize_atelier_dom/tests/davinci_s2_for.rs` pins the plain native
+`v-for` static-key case byte-for-byte against the shipped lane, while
+`crates/vize_atelier_dom/tests/davinci_s2_memo.rs` pins both byte output and
+the per-node patch-site expectation for a static-keyed `v-memo` loop.
+
+The focused smoke corpus probe over `crates/vize_s1_to_s2/tests/fixtures`
+now compares the committed DOM-output samples with zero divergences. This
+installment does not tick P2-11. The production-lane switch remains open, and
+the old DOM lane is still the shipped compile path.

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -73,7 +73,7 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
 | s1_to_s2 | `alloc::vec::Vec`       |    58 |           58 |        223 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    84 |           88 |        417 |
+| s1_to_s2 | `vize_s0::String`       |    84 |           88 |        418 |
 | s1_to_s2 | `vize_s0::Vec`          |    15 |           16 |         67 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     4 |            4 |          9 |
 

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -97,7 +97,7 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/slots.rs	1	3	0	0	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/slots/capture.rs	1	2	1	2	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/slots/group.rs	1	3	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/tpl.rs	0	0	1	3	0	0	0	0
-s1_to_s2	-	crates/vize_s1_to_s2/src/emit/vfor/keys.rs	0	0	1	4	0	0	0	0
+s1_to_s2	-	crates/vize_s1_to_s2/src/emit/vfor/keys.rs	0	0	1	5	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/vif.rs	0	0	1	2	0	0	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower.rs	1	2	1	1	0	0	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/binding.rs	1	1	1	9	1	7	0	0


### PR DESCRIPTION
## Summary

- treat only dynamic `:key` bindings as the plain `v-for` fragment-key signal
- keep static `key="..."` on item props while preserving `UNKEYED_FRAGMENT` parity
- add S2 DOM residual, `v-for`, `v-memo`, storage, and P2-11 installment 102 witnesses

## Validation

- `cargo test -p vize_atelier_dom --test davinci_s2_corpus_residuals --test davinci_s2_for --test davinci_s2_memo -- --nocapture`
- `cargo test -p vize_s1_to_s2 --test emit_for --test emit_memo --test emit_if -- --nocapture`
- `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=crates/vize_s1_to_s2/tests/fixtures cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture`
- `node --test tests/tooling/davinci-storage-policy.test.ts`
- `cargo fmt --check`
- `git diff --check`
- `node --test tests/tooling/davinci-phase2-ledger.test.ts`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20`