### PR TITLE
fix(typechecker): preserve fixture pnpm workspaces

### DIFF
--- a/tests/tooling/typecheck-dependency-prepare.test.ts
+++ b/tests/tooling/typecheck-dependency-prepare.test.ts
@@ -98,6 +98,36 @@ test("dependency prepare keeps pnpm fixtures out of parent workspaces", () => {
   }
 });
 
+test("dependency prepare preserves a pnpm fixture's own workspace manifest", () => {
+  const packageManager = packageManagers.find((candidate) => candidate.name === "pnpm");
+  assert.ok(packageManager);
+  const fixture = setup(packageManager);
+  try {
+    fs.writeFileSync(path.join(fixture.fixtureRoot, "pnpm-workspace.yaml"), "packages: []\n");
+    git(fixture.fixtureRoot, ["add", "pnpm-workspace.yaml"]);
+    commit(fixture.fixtureRoot, "add fixture workspace");
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const artifact = JSON.parse(fs.readFileSync(artifactPath(fixture), "utf8"));
+    assert.deepEqual(artifact.install.command, [
+      "pnpm",
+      "install",
+      "--frozen-lockfile",
+      "--ignore-scripts",
+      "--prefer-offline",
+    ]);
+    const invocation = JSON.parse(fs.readFileSync(fixture.invocationPath, "utf8"));
+    assert.deepEqual(invocation.managerArgs, [
+      "install",
+      "--frozen-lockfile",
+      "--ignore-scripts",
+      "--prefer-offline",
+    ]);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
 test("dependency prepare rejects a mismatched detected package manager version", () => {
   const fixture = setup();
   try {

--- a/tools/commands/fixtures/typecheck-dependency-prepare.rs
+++ b/tools/commands/fixtures/typecheck-dependency-prepare.rs
@@ -13,7 +13,7 @@
 #[path = "../../support/common.rs"]
 mod common;
 
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::{
     env, fs,
@@ -146,7 +146,7 @@ fn prepare_project_dependencies(
             "Detected {manager} version {detected_version} does not match {manager_version}"
         ));
     }
-    let install_args = install_arguments(&manager)?;
+    let install_args = install_arguments(&manager, &fixture_root)?;
     let started = Instant::now();
     let install = run_package_manager(&runner, &install_args, &fixture_root, args.timeout_ms)
         .map_err(|error| format!("{} install failed to run: {error}", runner.label))?;
@@ -219,9 +219,8 @@ fn select_typecheck_performance_projects(
         .iter()
         .enumerate()
         .filter_map(|(index, project)| {
-            (index % shard_count == shard_index
-                && has_enabled_typecheck_performance(project))
-            .then_some(project)
+            (index % shard_count == shard_index && has_enabled_typecheck_performance(project))
+                .then_some(project)
         })
         .collect())
 }
@@ -367,7 +366,7 @@ fn run_baseline_prepare(
     }))
 }
 
-fn install_arguments(manager: &str) -> Result<Vec<String>, String> {
+fn install_arguments(manager: &str, fixture_root: &Path) -> Result<Vec<String>, String> {
     match manager {
         "npm" => Ok([
             "ci",
@@ -379,16 +378,21 @@ fn install_arguments(manager: &str) -> Result<Vec<String>, String> {
         .iter()
         .map(|value| (*value).to_string())
         .collect()),
-        "pnpm" => Ok([
-            "install",
-            "--frozen-lockfile",
-            "--ignore-scripts",
-            "--prefer-offline",
-            "--ignore-workspace",
-        ]
-        .iter()
-        .map(|value| (*value).to_string())
-        .collect()),
+        "pnpm" => {
+            let mut args = [
+                "install",
+                "--frozen-lockfile",
+                "--ignore-scripts",
+                "--prefer-offline",
+            ]
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect::<Vec<_>>();
+            if !fixture_root.join("pnpm-workspace.yaml").is_file() {
+                args.push("--ignore-workspace".to_string());
+            }
+            Ok(args)
+        }
         "yarn" => Ok(["install", "--immutable", "--mode=skip-build"]
             .iter()
             .map(|value| (*value).to_string())


### PR DESCRIPTION
## Summary
- keep fixture-local pnpm workspaces active during typecheck dependency preparation
- still pass `--ignore-workspace` for pnpm fixtures without their own workspace manifest
- add a regression test for fixture-owned `pnpm-workspace.yaml` installs

## Release blocker
- release run `33930530829` started `v0.394.0` from `f431f1775de0a43120070cc62147c0626854aadb`
- Real Project Matrix run `33930594599` failed because pnpm workspace fixtures did not write typecheck dependency evidence after `--ignore-workspace` erased fixture-local workspace config
- reproduced on `element-plus` and `reka-ui`; also confirmed the same fix writes evidence for `vue-vben-admin`, `vuetify`, `elk`, `primevue`, `primevue-volt`, and `primevue-showcase`

## Validation
- `node --test --test-concurrency=1 tests/tooling/typecheck-dependency-prepare.test.ts tests/tooling/typecheck-dependency-prepare-timeout.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts tests/tooling/source-file-lengths.test.ts`
- `vp run --workspace-root check:ci`
- `git diff --check origin/main...HEAD`
- focused real fixture prep: shards 0, 2, 4, 6, 7, 8, and 11 all wrote typecheck dependency evidence
- shard 5 wrote `primevue-typecheck-dependencies.json`; local verification stopped afterward on `lx-music-desktop` because local npm `11.19.0` does not match its pinned `11.9.0`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791158782&installation_model_id=422833&pr_number=5692&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5692&signature=b85fa8c24f819160ad02d519bd8509c6bc93bc8df11db9356bb088cd94dd5253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->