### PR TITLE
test(vscode): guard hidden host smoke commands

### DIFF
--- a/tests/tooling/vscode-vsix-policy.test.ts
+++ b/tests/tooling/vscode-vsix-policy.test.ts
@@ -72,6 +72,33 @@ test("VSIX package policy excludes workspace manifests from shipped files", () =
   );
 });
 
+test("VSIX package policy keeps hidden host-smoke commands out of the manifest", () => {
+  const manifest = readJson("editors/vscode/package.json") as {
+    activationEvents?: string[];
+    contributes?: { commands?: Array<{ command?: string }> };
+  };
+  const extensionCore = readText("editors/vscode/src/extension-core.ts");
+  const smoke = readText("tools/commands/editors/vscode/assert-vsix-package.rs");
+  const hiddenCommands = [
+    ...extensionCore.matchAll(/export const HOST_TEST_[A-Z_]+_COMMAND = "(vize\.test\.[^"]+)";/g),
+  ].map((match) => match[1]);
+
+  assert.deepEqual(hiddenCommands.sort(), [
+    "vize.test.executeCompletion",
+    "vize.test.getServerInfo",
+  ]);
+  const contributedCommands = new Set(
+    (manifest.contributes?.commands ?? []).map((command) => command.command),
+  );
+  const activationEvents = new Set(manifest.activationEvents ?? []);
+  for (const command of hiddenCommands) {
+    assert.equal(contributedCommands.has(command), false);
+    assert.equal(activationEvents.has(`onCommand:${command}`), false);
+  }
+  assert.match(smoke, /assert_no_hidden_host_test_commands/);
+  assert.match(smoke, /starts_with\("vize\.test\."\)/);
+});
+
 test("VSIX archive reader escapes unzip member globs", () => {
   const reader = readText("tools/support/editors/archive.rs");
   const smoke = readText("tools/commands/editors/vscode/assert-vsix-package.rs");

--- a/tools/commands/editors/vscode/assert-vsix-package.rs
+++ b/tools/commands/editors/vscode/assert-vsix-package.rs
@@ -83,6 +83,7 @@ fn run() -> Result<(), String> {
 
     assert_unique_json_strings(&package_json, &["activationEvents"])?;
     let activation_events = json_string_array(&package_json, &["activationEvents"])?;
+    assert_no_hidden_host_test_commands(&activation_events, "activationEvents")?;
     let commands = package_json
         .pointer("/contributes/commands")
         .and_then(Value::as_array)
@@ -108,6 +109,7 @@ fn run() -> Result<(), String> {
         }
     }
     assert_unique_values(&command_names, "contributes.commands")?;
+    assert_no_hidden_host_test_commands(&command_names, "contributes.commands")?;
     for event in ["onLanguage:vue", "onLanguage:art-vue"] {
         if !activation_events.contains(&event.to_string()) {
             return Err(format!("activationEvents missing {event}"));
@@ -473,6 +475,18 @@ fn assert_unique_values(values: &[String], label: &str) -> Result<(), String> {
     let unique = values.iter().collect::<HashSet<_>>();
     if unique.len() != values.len() {
         return Err(format!("{label} must not contain duplicates"));
+    }
+    Ok(())
+}
+
+fn assert_no_hidden_host_test_commands(values: &[String], label: &str) -> Result<(), String> {
+    for value in values {
+        let command = value.strip_prefix("onCommand:").unwrap_or(value);
+        if command.starts_with("vize.test.") {
+            return Err(format!(
+                "{label} must not expose hidden host smoke command: {value}"
+            ));
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary
- make the VSIX package assertion reject shipped `vize.test.*` command contributions or activation events
- add a VSIX policy test tying the hidden host-smoke command constants to the shipped manifest and package gate

## Validation
- `node --test tests/tooling/vscode-vsix-policy.test.ts tests/tooling/vscode-extension-manifest.test.ts tests/tooling/vscode-host-test-commands.test.ts tests/tooling/editor-package-tasks.test.ts`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `rustfmt --edition 2024 --check tools/commands/editors/vscode/assert-vsix-package.rs`
- `rust-script --debug tools/commands/editors/vscode/assert-vsix-package.rs /tmp/vize-missing-smoke.vsix` (compiled, then failed on the deliberately missing VSIX)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791162970&installation_model_id=422833&pr_number=5696&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5696&signature=37ded90d31d247f416f9f420bb08ab5c561a0a6ebc28c11ebe17dff2952ebbdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->