### PR TITLE
fix(davinci): align model outlet option families

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_option_families.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_option_families.rs
@@ -1,0 +1,155 @@
+//! P2-11: production-option families for `v-model` and `<slot>` outlets.
+//! The combination matrix covers broad DOM shapes; this witness keeps the
+//! option bundle pinned on two late high-churn families whose props,
+//! handlers, dynamic keys, cache slots and scope pairs interact.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use vize_atelier_core::options::{BindingMetadata, BindingType, CodegenMode, CodegenOptions};
+use vize_atelier_dom::DomCompilerOptions;
+use vize_s1_to_s2::{BindingTable, DomEmitMode, DomEmitOptions};
+
+const SCOPE_ID: &str = "data-v-abc123";
+
+const MODEL_FAMILY: &[(&str, &str)] = &[
+    ("model_text_trim", r#"<input v-model.trim="msg">"#),
+    (
+        "model_checkbox_handler",
+        r#"<input type="checkbox" v-model="checked" @change="track(checked)">"#,
+    ),
+    (
+        "model_select_vfor",
+        r#"<select v-model="choice"><option v-for="item in items" :key="item.id" :value="item.value">{{ item.label }}</option></select>"#,
+    ),
+    (
+        "model_component_named",
+        r#"<MyComp v-model:title="title" />"#,
+    ),
+    (
+        "model_component_dynamic_modifier",
+        r#"<MyComp v-model:[field].trim="msg" />"#,
+    ),
+    (
+        "model_component_spread",
+        r#"<MyComp v-bind="modelProps" v-model="msg" />"#,
+    ),
+    (
+        "model_listener_order",
+        r#"<MyComp @update:modelValue="track" v-model="msg" />"#,
+    ),
+    (
+        "model_component_vfor",
+        r#"<MyComp v-for="item in items" v-model="item.value" :key="item.id" />"#,
+    ),
+];
+
+const OUTLET_FAMILY: &[(&str, &str)] = &[
+    (
+        "outlet_dynamic_name_props",
+        r#"<slot :name="slotName" foo="bar" :item="row">fallback {{ msg }}</slot>"#,
+    ),
+    (
+        "outlet_dynamic_event_modifier",
+        r#"<slot @[event].once.capture="handler" :[propKey]="value"></slot>"#,
+    ),
+    (
+        "outlet_spread_mixed",
+        r#"<slot v-bind="slotProps" @pick="choose(row)" v-on="listeners"></slot>"#,
+    ),
+    (
+        "outlet_forwarded_scoped",
+        r#"<Bar v-slot="{ row }"><Foo><slot @[row.event]="row.handler"></slot></Foo></Bar>"#,
+    ),
+    (
+        "outlet_vfor_dynamic_event",
+        r#"<slot v-for="item in items" @[item.event]="item.handler">x</slot>"#,
+    ),
+    ("outlet_style_prop", r#"<slot :style="{ color }"></slot>"#),
+];
+
+fn metadata() -> BindingMetadata {
+    support::bindings::script_setup_metadata(&[
+        ("msg", BindingType::SetupLet),
+        ("checked", BindingType::SetupRef),
+        ("choice", BindingType::SetupRef),
+        ("items", BindingType::SetupConst),
+        ("track", BindingType::SetupConst),
+        ("MyComp", BindingType::SetupConst),
+        ("title", BindingType::Props),
+        ("field", BindingType::SetupRef),
+        ("modelProps", BindingType::SetupLet),
+        ("slotName", BindingType::SetupRef),
+        ("row", BindingType::SetupLet),
+        ("event", BindingType::SetupRef),
+        ("handler", BindingType::SetupConst),
+        ("propKey", BindingType::SetupRef),
+        ("value", BindingType::SetupMaybeRef),
+        ("slotProps", BindingType::SetupLet),
+        ("choose", BindingType::SetupConst),
+        ("listeners", BindingType::SetupLet),
+        ("Bar", BindingType::SetupConst),
+        ("Foo", BindingType::SetupConst),
+        ("color", BindingType::SetupRef),
+    ])
+}
+
+fn dom_options(metadata: &BindingMetadata, inline: bool) -> DomCompilerOptions {
+    DomCompilerOptions {
+        mode: CodegenMode::Module,
+        prefix_identifiers: true,
+        inline,
+        cache_handlers: true,
+        scope_id: Some(SCOPE_ID.into()),
+        binding_metadata: Some(metadata.clone()),
+        is_ts: true,
+        ..Default::default()
+    }
+}
+
+fn emit_options<'a>(table: &'a BindingTable, inline: bool) -> DomEmitOptions<'a> {
+    DomEmitOptions {
+        mode: DomEmitMode::Module,
+        prefix_identifiers: true,
+        inline,
+        cache_handlers: true,
+        scope_id: Some(SCOPE_ID),
+        is_ts: true,
+        bindings: Some(table),
+        ..DomEmitOptions::DEFAULT
+    }
+}
+
+fn assert_family(inline: bool) {
+    let metadata = metadata();
+    let table = support::bindings::binding_table(&metadata);
+    let dom = dom_options(&metadata, inline);
+    let emit = emit_options(&table, inline);
+    support::assert_s2_matches_shipped_with_options(
+        MODEL_FAMILY,
+        &dom,
+        &CodegenOptions::default(),
+        &emit,
+    );
+    support::assert_s2_matches_shipped_with_options(
+        OUTLET_FAMILY,
+        &dom,
+        &CodegenOptions::default(),
+        &emit,
+    );
+}
+
+#[test]
+fn script_setup_option_families_match_the_shipped_lane() {
+    assert_family(false);
+}
+
+#[test]
+fn inline_script_setup_option_families_match_the_shipped_lane() {
+    assert_family(true);
+}

--- a/crates/vize_s1_to_s2/src/emit/model_key.rs
+++ b/crates/vize_s1_to_s2/src/emit/model_key.rs
@@ -44,19 +44,25 @@ pub(super) fn emit_update(
 ) -> Result<(), EmitError> {
     emit_update_key(cx, key)?;
     cx.buf.push(": ");
-    emit_cached_assignment(cx, model, source)
+    if matches!(key, ModelUpdateKey::Dynamic(_)) && cx.prefixing() {
+        return emit_dynamic_assignment(cx, model);
+    }
+    emit_cached_assignment(cx, model, source, matches!(key, ModelUpdateKey::Static(_)))
 }
 
 /// The synthesized `onUpdate:` assignment is an inline handler, so
-/// `cache_handlers` hoists it into the same `_cache` array the authored
-/// ones use. Shared with the merged-handler array, where a `v-model` and
-/// an authored listener on the same key both take a slot.
+/// `cache_handlers` hoists static update keys into the same `_cache` array the
+/// authored ones use. Dynamic model arguments stay uncached in the shipped
+/// lane because the key expression and modifier object share one normalized
+/// props object. Shared with the merged-handler array, where a `v-model` and an
+/// authored listener on the same static key both take a slot.
 pub(super) fn emit_cached_assignment(
     cx: &mut EmitCx<'_>,
     model: &ModelOp<'_>,
     source: &str,
+    cacheable: bool,
 ) -> Result<(), EmitError> {
-    let cached = cx.caches_handlers();
+    let cached = cacheable && cx.caches_handlers();
     if cached {
         let slot = cx.once_cache_index;
         cx.once_cache_index += 1;
@@ -70,6 +76,14 @@ pub(super) fn emit_cached_assignment(
     if cached {
         cx.buf.push(")");
     }
+    Ok(())
+}
+
+fn emit_dynamic_assignment(cx: &mut EmitCx<'_>, model: &ModelOp<'_>) -> Result<(), EmitError> {
+    let source = super::model::value_source(cx, model, Site::Raw)?;
+    cx.buf.push("$event => ((");
+    cx.buf.push(source.as_str());
+    cx.buf.push(") = $event)");
     Ok(())
 }
 

--- a/crates/vize_s1_to_s2/src/emit/props_object.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_object.rs
@@ -81,7 +81,8 @@ pub(super) fn emit_props_object(
         return Ok(());
     }
     let extra = usize::from(if_key.is_some()) + usize::from(scope_id.is_some());
-    let compact_multiline = if_key.is_none() && pieces_are_dynamic_model_products(&visible);
+    let compact_multiline =
+        if_key.is_none() && scope_id.is_none() && pieces_are_dynamic_model_products(&visible);
     let v_for_merge_arg_multiline = skip_normalize && for_item && visible.len() + extra > 1;
     let multiline = !compact_multiline
         && (force_multiline

--- a/crates/vize_s1_to_s2/src/emit/props_object_merge.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_object_merge.rs
@@ -46,7 +46,7 @@ pub(super) fn emit_handlers(
             Piece::On(event) => on::emit_on_value(cx, event, is_plain_element)?,
             Piece::ModelUpdate { model, .. } => {
                 let source = super::model::js_source(model)?;
-                super::model_key::emit_cached_assignment(cx, model, source.as_str())?;
+                super::model_key::emit_cached_assignment(cx, model, source.as_str(), true)?;
             }
             _ => {}
         }

--- a/davinci-road/plan/phase-2-records/p2-11/installment-104.md
+++ b/davinci-road/plan/phase-2-records/p2-11/installment-104.md
@@ -1,0 +1,33 @@
+# P2-11 Installment 104 - Model And Outlet Option Families
+
+> Part of the [P2-11 series record](../p2-11.md), split per installment.
+> PR: _pending - the number, merge date and squash SHA are filled in at
+> merge, as every prior installment's line was._
+
+This installment extends the production-option combination witness from the
+generic DOM matrix into the two late P2-11 families that most often combine
+props layout, handler caching, dynamic keys and scoped-style attrs:
+`v-model` and `<slot>` outlets.
+
+The new family gate runs representative native and component `v-model` shapes,
+including modifiers, dynamic arguments, listener ordering, spreads and `v-for`,
+alongside slot outlets with dynamic names, dynamic props, dynamic events,
+spreads, forwarding and `v-for`. Each family runs under the same SFC-shaped
+option bundle in both non-inline and inline modes: module output, prefixed
+identifiers, script setup binding metadata, `cache_handlers`, `scope_id` and
+`is_ts`.
+
+## Evidence
+
+`crates/vize_atelier_dom/tests/davinci_s2_option_families.rs` compares the S2
+DOM emitter against the shipped DOM lane byte-for-byte for the model and outlet
+family batteries under the combined production options.
+
+The focused gate is:
+
+```sh
+cargo test -p vize_atelier_dom --test davinci_s2_option_families
+```
+
+This installment does not tick P2-11. The production-lane switch remains open,
+and the old DOM lane is still the shipped non-profiled compile path.


### PR DESCRIPTION
## Summary
- add a P2-11 production-option family gate for v-model and slot outlets
- keep dynamic model update handlers uncached when the model argument is dynamic
- keep scoped dynamic model product props on the shipped multiline layout

## Validation
- cargo fmt --check
- cargo test -p vize_atelier_dom --test davinci_s2_option_families
- cargo test -p vize_atelier_dom --test davinci_s2_option_matrix --test davinci_s2_model --test davinci_s2_outlets --test davinci_s2_cache_handlers --test davinci_s2_cache_slot_order
- cargo test -p vize_s1_to_s2
- cargo clippy -p vize_s1_to_s2 -- -D warnings -D clippy::wildcard_imports
- cargo clippy -p vize_atelier_dom --test davinci_s2_option_families -- -D warnings -D clippy::wildcard_imports
- node --test tests/tooling/davinci-phase2-ledger.test.ts tests/tooling/source-file-lengths.test.ts
- rust-script tools/commands/davinci/assertion-lint.rs
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791163404&installation_model_id=422833&pr_number=5697&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5697&signature=472a3dc5a71249f5f05c51c14e1d0f2fc298dd0ac192d7dee318761822e796c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->