### PR TITLE
fix(typechecker): avoid synthetic slot prop shadowing

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/external_slot_payloads.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/external_slot_payloads.rs
@@ -251,6 +251,85 @@ function takesString(value: string) {
 }
 
 #[test]
+fn unnamed_inner_slot_does_not_shadow_outer_scoped_slot_payload() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "external-slot-payload-unnamed-inner-slot",
+        &[
+            (
+                "src/List.vue",
+                r#"<script setup lang="ts">
+defineSlots<{
+  default(props: { item: { title: string }; index: number }): any;
+}>();
+
+defineProps<{ items: Array<{ title: string }> }>();
+</script>
+
+<template>
+  <div v-for="(item, index) in items" :key="item.title">
+    <slot :item="item" :index="index" />
+  </div>
+</template>
+"#,
+            ),
+            (
+                "src/Card.vue",
+                r#"<script setup lang="ts">
+defineSlots<{
+  title(): any;
+}>();
+</script>
+
+<template>
+  <section>
+    <slot name="title" />
+  </section>
+</template>
+"#,
+            ),
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+import List from './List.vue';
+import Card from './Card.vue';
+
+const items = [{ title: 'Ready' }];
+
+function takesString(value: string) {
+  return value;
+}
+</script>
+
+<template>
+  <List :items="items">
+    <template #default="slotProps">
+      <Card>
+        <template #title>{{ takesString(slotProps.item.title) }}</template>
+      </Card>
+    </template>
+  </List>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+    let _ = std::fs::remove_dir_all(&project_root);
+
+    assert!(
+        snapshot.is_empty(),
+        "a slot without authored props must not shadow outer scoped-slot payloads: {snapshot:#?}"
+    );
+}
+
+#[test]
 fn any_v_for_key_matches_vue_tsc_object_fallback() {
     if resolve_test_tsgo_binary().is_none() {
         return;

--- a/crates/vize_canon/src/virtual_ts/scope/slot_scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/slot_scope.rs
@@ -118,7 +118,7 @@ pub(super) fn generate_v_slot_scope(
 ) {
     let scope_id = scope.id.as_u32();
     append!(*ts, "\n{indent}// v-slot scope: #{}\n", data.name);
-    let props_pattern = data.props_pattern.as_deref().unwrap_or("slotProps");
+    let props_pattern = slot_props_pattern(data, scope_id);
     let safe_slot_name = to_safe_identifier_fragment(data.name.as_str());
     let props_type = slot_payload_type(
         ts,
@@ -143,14 +143,14 @@ pub(super) fn generate_v_slot_scope(
         ts,
         indent,
         cstr!("_slot_{safe_slot_name}_{scope_id}").as_str(),
-        props_pattern,
+        props_pattern.as_str(),
         &props_type,
     );
     map_slot_props_pattern(
         mappings,
         scope,
         ctx.template_offset,
-        props_pattern,
+        props_pattern.as_str(),
         function_gen_start,
         ts,
     );
@@ -203,7 +203,7 @@ pub(super) fn generate_v_slot_props_scope(
     inner_indent: &str,
 ) {
     let scope_id = scope.id.as_u32();
-    let props_pattern = data.props_pattern.as_deref().unwrap_or("slotProps");
+    let props_pattern = slot_props_pattern(data, scope_id);
     let safe_slot_name = to_safe_identifier_fragment(data.name.as_str());
     append!(
         *ts,
@@ -229,14 +229,14 @@ pub(super) fn generate_v_slot_props_scope(
         ts,
         indent,
         cstr!("_slot_props_{safe_slot_name}_{scope_id}").as_str(),
-        props_pattern,
+        props_pattern.as_str(),
         &props_type,
     );
     map_slot_props_pattern(
         mappings,
         scope,
         ctx.source_context.offset,
-        props_pattern,
+        props_pattern.as_str(),
         function_gen_start,
         ts,
     );
@@ -253,6 +253,13 @@ pub(super) fn generate_v_slot_props_scope(
 
     ts.push_str(indent);
     ts.push_str("};\n");
+}
+
+fn slot_props_pattern(data: &VSlotScopeData, scope_id: u32) -> String {
+    data.props_pattern
+        .as_ref()
+        .map(|pattern| pattern.as_str().into())
+        .unwrap_or_else(|| cstr!("__vize_slot_props_{scope_id}"))
 }
 
 fn map_slot_props_pattern(


### PR DESCRIPTION
## Summary
- Avoid synthesizing a generic slot prop name for v-slot blocks that do not declare slot props.
- Keep unnamed inner slots from shadowing outer scoped-slot payload variables.
- Add a focused regression covering an outer scoped slot read inside an unnamed inner slot.

## Validation
- cargo test -p vize_canon external_slot_payloads -- --nocapture
- cargo test -p vize_canon slot_component_bindings -- --nocapture
- cargo fmt --check
- git diff --check origin/fix/typecheck-baseline-support-includes..HEAD
- cargo build --profile ci -p vize
- rust-script tools/commands/fixtures/tool-matrix-report.rs --project primevue-volt --tool typechecker --vize-bin target/ci/vize --output-dir .vize/primevue-volt-divergence-local --timeout-ms 900000 --heartbeat-ms 30000

Real-project note: the focused primevue-volt run now reports no diagnostics for apps/volt/doc/timeline/TemplateDoc.vue and total Vize errors dropped from 208 to 201. The local full vue-tsc comparator was blocked by the fixture-generated TypeScript 5.7 config error TS5103 for ignoreDeprecations=6.0; the pull request matrix will provide the authoritative comparison.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791164499&installation_model_id=422833&pr_number=5698&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5698&signature=3c11e2d4d5b43150a27f4096fcfa65e5ae1705dc334e709b235edccf0242daf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->