### PR TITLE
fix(patina): accept line in matrix diagnostics

### DIFF
--- a/tools/commands/fixtures/tool-matrix-report.rs
+++ b/tools/commands/fixtures/tool-matrix-report.rs
@@ -1653,6 +1653,7 @@ fn validate_linter_output(
                     "column",
                     "endColumn",
                     "endLine",
+                    "line",
                     "message",
                     "ruleDocsPath",
                     "ruleId",
@@ -2339,4 +2340,70 @@ fn repo_root() -> Result<PathBuf, String> {
             .map(Path::to_path_buf)
             .ok_or_else(|| "cannot resolve Vize repository root from script path".to_string())
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn linter_project() -> Value {
+        json!({ "id": "fixture" })
+    }
+
+    fn linter_output(message: Value) -> Value {
+        json!([
+            {
+                "file": "src/App.vue",
+                "messages": [message],
+                "errorCount": 1,
+                "warningCount": 0
+            }
+        ])
+    }
+
+    fn linter_message() -> Value {
+        json!({
+            "ruleId": "vue/permitted-contents",
+            "ruleDocsPath": "docs/content/rules/vue.md",
+            "severity": 2,
+            "message": "[vize:vue/permitted-contents] synthetic diagnostic",
+            "line": 4,
+            "column": 5,
+            "endLine": 4,
+            "endColumn": 9
+        })
+    }
+
+    #[test]
+    fn linter_validator_accepts_required_line_without_help() {
+        let output = linter_output(linter_message());
+
+        validate_linter_output(
+            &linter_project(),
+            &output,
+            1,
+            Some(&[String::from("src/App.vue")]),
+        )
+        .expect("line is required even when help is absent");
+    }
+
+    #[test]
+    fn linter_validator_rejects_missing_line_without_help() {
+        let mut message = linter_message();
+        message.as_object_mut().unwrap().remove("line");
+        let output = linter_output(message);
+
+        let error = validate_linter_output(
+            &linter_project(),
+            &output,
+            1,
+            Some(&[String::from("src/App.vue")]),
+        )
+        .expect_err("line must remain part of the linter message schema");
+
+        assert!(
+            error.contains("messages[0] keys must be"),
+            "unexpected error: {error}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- align the Rust fixture Matrix linter validator with the JSON linter contract by requiring `line` on messages without `help`
- add regression coverage for help-less diagnostics carrying `line`

## Verification
- rustfmt --check --edition 2024 tools/commands/fixtures/tool-matrix-report.rs
- rust-script --test tools/commands/fixtures/tool-matrix-report.rs linter_validator -- --nocapture
- node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts tests/tooling/fixture-tool-matrix-linter.test.ts tests/tooling/fixture-tool-matrix-report.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791167327&installation_model_id=422833&pr_number=5699&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5699&signature=2d213ade9a344f01661492a883f93d4bbc41b02f0940164125d9a007c50b9050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of linter messages to ensure required line information is always present.
  - Invalid message formats that omit required fields are now rejected consistently.

- **Tests**
  - Added coverage to protect the linter message schema and prevent regressions in validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->