### PR TITLE
fix(cli): include dot directories in recursive globs

### DIFF
--- a/crates/vize/src/commands/build/runner/collect.rs
+++ b/crates/vize/src/commands/build/runner/collect.rs
@@ -133,6 +133,9 @@ fn classify_input(input: &str) -> Result<BuildInput<'_>, InputError<'_>> {
 
 fn collect_walked_files(root: &Path, pattern: Option<&BuildGlob>, files: &mut Vec<PathBuf>) {
     let mut walker = WalkBuilder::new(root);
+    if pattern.is_some() {
+        walker.hidden(false);
+    }
     if let Some(max_depth) = pattern.and_then(BuildGlob::max_depth) {
         walker.max_depth(Some(max_depth));
     }

--- a/crates/vize/src/commands/build/runner/collect/tests.rs
+++ b/crates/vize/src/commands/build/runner/collect/tests.rs
@@ -129,6 +129,21 @@ fn collect_files_accepts_backslash_pattern_separators() {
 }
 
 #[test]
+fn recursive_globs_include_dot_directories() {
+    let root = unique_case_dir("build-dot-directory-glob");
+    let docs = root.join("docs/.vitepress/components");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir_all(&docs).unwrap();
+    let download_page = docs.join("DownloadPage.vue");
+    fs::write(&download_page, "<template><div /></template>").unwrap();
+
+    let collected = collect_files(&[root.join("**/*.vue").display().to_string()]).unwrap();
+    let _ = fs::remove_dir_all(&root);
+
+    assert_eq!(collected.files, vec![download_page]);
+}
+
+#[test]
 fn existing_paths_with_metacharacters_remain_literals() {
     let root = unique_case_dir("build-literal-metacharacter");
     let file = root.join("Component[old].vue");

--- a/crates/vize/src/commands/check/runner/collect.rs
+++ b/crates/vize/src/commands/check/runner/collect.rs
@@ -165,7 +165,7 @@ fn collect_from_dir_filtered(
     let normalized_dir = normalize_input_path(dir);
     let walker = WalkBuilder::new(dir)
         .standard_filters(true)
-        .hidden(true)
+        .hidden(matcher.is_none())
         .build_parallel();
 
     let collected = std::sync::Mutex::new(Vec::<PathBuf>::new());

--- a/crates/vize/src/commands/check/runner/collect_tests.rs
+++ b/crates/vize/src/commands/check/runner/collect_tests.rs
@@ -151,6 +151,23 @@ fn collect_check_files_filters_quoted_globs() {
 }
 
 #[test]
+fn collect_check_files_recursive_globs_include_dot_directories() {
+    let case_dir = unique_case_dir("collect-check-dot-directory-glob");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("docs/.vitepress/components")).unwrap();
+    let download_page = write_file(&case_dir, "docs/.vitepress/components/DownloadPage.vue", "");
+
+    let files = collect_check_files(
+        &vec![case_dir.join("**/*.vue").display().to_string()],
+        false,
+    );
+
+    assert_eq!(files, vec![download_page]);
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn collect_check_files_applies_entry_ignores() {
     let case_dir = unique_case_dir("collect-check-entry-ignores");
     let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize/src/commands/check/runner/collect_tests/vue_files.rs
+++ b/crates/vize/src/commands/check/runner/collect_tests/vue_files.rs
@@ -38,3 +38,16 @@ fn collect_vue_files_filters_quoted_globs() {
 
     let _ = fs::remove_dir_all(&case_dir);
 }
+
+#[test]
+fn collect_vue_files_recursive_globs_include_dot_directories() {
+    let case_dir = unique_case_dir("collect-vue-dot-directory-glob");
+    let _ = fs::remove_dir_all(&case_dir);
+    let download_page = write_file(&case_dir, "docs/.vitepress/components/DownloadPage.vue", "");
+
+    let files = collect_vue_files(&vec![case_dir.join("**/*.vue").display().to_string()]);
+
+    assert_eq!(files, vec![download_page]);
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize/src/commands/fmt/files.rs
+++ b/crates/vize/src/commands/fmt/files.rs
@@ -179,7 +179,7 @@ fn fmt_glob_match_options() -> MatchOptions {
     MatchOptions {
         case_sensitive: !cfg!(windows),
         require_literal_separator: true,
-        require_literal_leading_dot: true,
+        require_literal_leading_dot: false,
     }
 }
 

--- a/crates/vize/src/commands/fmt/files_tests.rs
+++ b/crates/vize/src/commands/fmt/files_tests.rs
@@ -58,13 +58,13 @@ fn explicit_relative_glob_respects_nested_gitignore() {
 }
 
 #[test]
-fn relative_globs_require_explicit_hidden_components() {
+fn relative_recursive_globs_include_dot_directories() {
     let cwd = std::env::current_dir().unwrap();
     let relative_root =
         PathBuf::from("tests").join(unique_case_dir("hidden-glob").file_name().unwrap());
     let root = cwd.join(&relative_root);
     let source = root.join("src/App.vue");
-    let hidden = root.join("docs/.vitepress/Theme.vue");
+    let hidden = root.join("docs/.vitepress/components/DownloadPage.vue");
     let _ = fs::remove_dir_all(&root);
     fs::create_dir_all(source.parent().unwrap()).unwrap();
     fs::create_dir_all(hidden.parent().unwrap()).unwrap();
@@ -74,16 +74,21 @@ fn relative_globs_require_explicit_hidden_components() {
     let implicit = collect_files(&[relative_root.join("**/*.vue").to_string_lossy()], None);
     let explicit = collect_files(
         &[relative_root
-            .join("docs/.vitepress/**/*.vue")
+            .join("docs/.vitepress/components/**/*.vue")
             .to_string_lossy()],
         None,
     );
     let _ = fs::remove_dir_all(&root);
 
-    assert_eq!(implicit, vec![relative_root.join("src/App.vue")]);
+    let mut expected = vec![
+        relative_root.join("docs/.vitepress/components/DownloadPage.vue"),
+        relative_root.join("src/App.vue"),
+    ];
+    expected.sort();
+    assert_eq!(implicit, expected);
     assert_eq!(
         explicit,
-        vec![relative_root.join("docs/.vitepress/Theme.vue")]
+        vec![relative_root.join("docs/.vitepress/components/DownloadPage.vue")]
     );
 }
 

--- a/crates/vize/src/commands/lint/collect.rs
+++ b/crates/vize/src/commands/lint/collect.rs
@@ -71,7 +71,7 @@ fn collect_lint_files_from_dir(
 ) {
     for entry in WalkBuilder::new(dir)
         .standard_filters(true)
-        .hidden(true)
+        .hidden(matcher.is_none())
         .build()
     {
         let Ok(entry) = entry else {
@@ -326,5 +326,21 @@ mod tests {
         );
 
         assert_eq!(files, vec![src.join("App.vue")]);
+    }
+
+    #[test]
+    fn recursive_globs_include_dot_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let docs = dir.path().join("docs/.vitepress/components");
+        fs::create_dir_all(&docs).unwrap();
+        let download_page = docs.join("DownloadPage.vue");
+        fs::write(&download_page, "").unwrap();
+
+        let files = collect_lint_files(
+            &[dir.path().join("**/*.vue").display().to_string().into()],
+            None,
+        );
+
+        assert_eq!(files, vec![download_page]);
     }
 }


### PR DESCRIPTION
## Summary
- include dot-directories when explicit recursive glob inputs are walked by build/check/lint collectors
- align fmt relative glob matching so `**/*.vue` reaches `docs/.vitepress` inputs
- add collector regressions for `docs/.vitepress/components/DownloadPage.vue` across build/check/lint/fmt paths

## Verification
- `cargo fmt --all --check`
- `cargo test -p vize commands::build::runner::collect -- --nocapture`
- `cargo test -p vize commands::check::runner::collect -- --nocapture`
- `cargo test -p vize commands::lint::collect -- --nocapture`
- `cargo test -p vize commands::fmt::files -- --nocapture`
- `cargo test -p vize --lib dot_directories -- --nocapture`

Matrix artifact checked: `/tmp/vize-matrix-33938716951-2433-r3/real-project-matrix-6` showed SPlayer missing `docs/.vitepress/components/DownloadPage.vue` from tool outputs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5701"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791168204&installation_model_id=422833&pr_number=5701&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5701&signature=e3b9a226a1c08e8f234b37517d6ba3fa1353f2f7f20127e986cf7bc6e7873903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Recursive glob patterns now discover files within hidden directories, including for build, check, format, and lint operations.
  - Hidden files remain excluded from standard directory scans unless explicitly matched by a glob.
- **Tests**
  - Added coverage confirming recursive glob patterns correctly include files in dot-prefixed directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->