### PR TITLE
fix(davinci): keep vnode source within budget

### DIFF
--- a/crates/vize_s1_to_s2/src/emit/vnode.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode.rs
@@ -296,13 +296,6 @@ pub(super) fn emit_call(
     } else if !element.attributes.is_empty() {
         cx.buf.push(", ");
         super::props_static::emit_inline(cx, element.attributes.iter(), once_layout);
-    } else if let Some(scope_id) = cx
-        .scope_id_here()
-        .filter(|_| cx.in_v_for && (has_children || emit_flag))
-    {
-        cx.buf.push(", ");
-        let props = super::hoist::compact_props_object(element.attributes.iter(), Some(scope_id));
-        cx.buf.push(props.as_str());
     } else if empty_runtime_for {
         cx.buf.push(", { }");
     } else if has_children || emit_flag {


### PR DESCRIPTION
## Summary
- remove the v-for-only scoped props branch from the stacked option work
- keep vnode emission below the source-length gate
- leave the scoped cached/static prop layout fix covered by the option matrix

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_option_matrix --test davinci_s2_dom --test davinci_s2_cached_props_multiline
- cargo fmt --check
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-phase2-ledger.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791168678&installation_model_id=422833&pr_number=5702&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5702&signature=003dabcaaa71690e394fd1bd82f5071e9a0e4bea4e1d84ab29a6d1c17044a982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->