### PR TITLE
fix(typechecker): preserve inherited baseline path aliases

### DIFF
--- a/legacy-tools/fixtures/typecheck-baseline-outside-aliases.mjs
+++ b/legacy-tools/fixtures/typecheck-baseline-outside-aliases.mjs
@@ -24,7 +24,10 @@ import {
  *
  * A mapping is retargeted only when its target sits under an outside
  * `node_modules/<name>` (or `@scope/name`) directory and the fixture already
- * has that package. Interior `*` patterns are not guessed.
+ * has that package. Interior `*` patterns are not guessed. When the generated
+ * baseline config is placed in another directory, every emitted mapping is also
+ * relocated to that config directory so inherited relative aliases keep their
+ * source meaning.
  *
  * Package-name `extends` is followed only inside the fixture, matching the
  * package-name overlay. Climbing into Vize would load Vize's `#app` mappings.
@@ -41,7 +44,7 @@ export function rewriteOutsideAliasPaths(fixtureRoot, sourceConfigPath, configDi
   let changed = false;
   for (const [name, targets] of Object.entries(declared.paths)) {
     if (!Array.isArray(targets)) continue;
-    rewritten[name] = retargetAliasMapping(
+    const remapped = retargetAliasMapping(
       root,
       mapping,
       declared.dir,
@@ -52,6 +55,8 @@ export function rewriteOutsideAliasPaths(fixtureRoot, sourceConfigPath, configDi
         changed = true;
       },
     );
+    rewritten[name] = remapped;
+    if (!isPackageMappingName(name) && !sameStringArray(targets, remapped)) changed = true;
   }
   return changed ? rewritten : null;
 }
@@ -221,6 +226,11 @@ function resolveRelativeExtends(fromConfig, specifier, fixtureRoot) {
 function isInside(root, target) {
   const path = relative(root, target);
   return path !== "" && !path.startsWith("..") && !path.startsWith("/");
+}
+
+function sameStringArray(left, right) {
+  if (left.length !== right.length) return false;
+  return left.every((entry, index) => entry === right[index]);
 }
 
 function configRelativePath(from, to) {

--- a/legacy-tools/fixtures/typecheck-baseline-outside-paths.mjs
+++ b/legacy-tools/fixtures/typecheck-baseline-outside-paths.mjs
@@ -16,8 +16,10 @@ import { loadTsconfigExtendsChain } from "./typecheck-baseline-extends-chain.mjs
  * Setting `paths` on the generated baseline replaces the inherited object, so
  * this copies every mapping, re-homes it to the generated config directory, and
  * only then retargets package names whose original target is outside and whose
- * fixture-local `node_modules/<name>` is already a real package. No rewrite
- * means the generated config leaves `paths` unset and inherits.
+ * fixture-local `node_modules/<name>` is already a real package. Even when no
+ * package retarget is possible, a generated config that lives in `.vize-baseline`
+ * still needs the relocated mappings so relative targets keep the source
+ * tsconfig's meaning.
  * Vize's `check --tsconfig` still reads the fixture config, so a matching
  * untracked overlay is written next to the source when a rewrite exists. Git
  * porcelain uses `--untracked-files=no`, so the overlay does not dirty the
@@ -47,7 +49,7 @@ export function rewriteOutsidePackagePaths(fixtureRoot, sourceConfigPath, config
   let changed = false;
   for (const [name, targets] of Object.entries(declared.paths)) {
     if (!Array.isArray(targets)) continue;
-    rewritten[name] = retargetPathMapping(
+    const remapped = retargetPathMapping(
       root,
       mapping,
       declared.dir,
@@ -58,6 +60,8 @@ export function rewriteOutsidePackagePaths(fixtureRoot, sourceConfigPath, config
         changed = true;
       },
     );
+    rewritten[name] = remapped;
+    if (!sameStringArray(targets, remapped)) changed = true;
   }
   return changed ? rewritten : null;
 }
@@ -339,6 +343,11 @@ function isInside(root, target) {
 function isTypesPackageRoot(directory) {
   const normalized = directory.replaceAll("\\", "/");
   return normalized.endsWith("/node_modules/@types");
+}
+
+function sameStringArray(left, right) {
+  if (left.length !== right.length) return false;
+  return left.every((entry, index) => entry === right[index]);
 }
 
 function configRelativePath(from, to) {

--- a/tests/tooling/typecheck-baseline-outside-aliases.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-aliases.test.ts
@@ -138,7 +138,7 @@ test("an interior star in a hash alias is not guessed", () => {
   }
 });
 
-test("an outside hash alias with no fixture-local package is left inherited", () => {
+test("an outside hash alias with no fixture-local package is preserved from a moved config", () => {
   const { outer, fixtureRoot, outsideNuxt } = scaffold();
   try {
     const sourcePath = path.join(fixtureRoot, "tsconfig.json");
@@ -153,8 +153,10 @@ test("an outside hash alias with no fixture-local package is left inherited", ()
       })}\n`,
     );
     assert.equal(
-      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
-      null,
+      rewriteOutsideAliasPaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline"))?.[
+        "#app"
+      ][0],
+      "../../node_modules/nuxt/dist/app",
     );
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });

--- a/tests/tooling/typecheck-baseline-outside-paths-subpath.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-paths-subpath.test.ts
@@ -115,7 +115,7 @@ test("a trailing-star mapping under dist keeps that directory", () => {
   }
 });
 
-test("a missing fixture subpath is left inherited", () => {
+test("a missing fixture subpath is preserved from a moved config", () => {
   const { fixtureRoot, outer, outsideVue } = scaffold();
   try {
     const local = path.join(fixtureRoot, "node_modules", "vue");
@@ -130,9 +130,9 @@ test("a missing fixture subpath is left inherited", () => {
         },
       })}\n`,
     );
-    assert.equal(
+    assert.deepEqual(
       rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
-      null,
+      { vue: ["../../node_modules/vue/dist/vue"] },
     );
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });

--- a/tests/tooling/typecheck-baseline-outside-paths.test.ts
+++ b/tests/tooling/typecheck-baseline-outside-paths.test.ts
@@ -86,7 +86,7 @@ test("an outside mapping reached only through extends is still retargeted", () =
   }
 });
 
-test("an outside path with no fixture-local copy is left inherited", () => {
+test("an outside path with no fixture-local copy is preserved from a moved config", () => {
   const { outer, fixtureRoot, outsideRouter } = scaffold();
   try {
     const sourcePath = path.join(fixtureRoot, "tsconfig.json");
@@ -99,8 +99,12 @@ test("an outside path with no fixture-local copy is left inherited", () => {
       })}\n`,
     );
     assert.equal(
-      rewriteOutsidePackagePaths(fixtureRoot, sourcePath, path.join(fixtureRoot, ".vize-baseline")),
-      null,
+      rewriteOutsidePackagePaths(
+        fixtureRoot,
+        sourcePath,
+        path.join(fixtureRoot, ".vize-baseline"),
+      )?.["vue-router"][0],
+      "../../node_modules/vue-router",
     );
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });
@@ -130,6 +134,50 @@ test("materialized baseline writes the retargeted paths onto the generated confi
     );
     assert.deepEqual(JSON.parse(project.source).compilerOptions.paths, {
       "vue-router": ["../node_modules/vue-router"],
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});
+
+test("materialized baseline preserves package-local aliases from a moved config", () => {
+  const { outer, fixtureRoot } = scaffold();
+  try {
+    const packageRoot = path.join(fixtureRoot, "packages/core");
+    fs.mkdirSync(path.join(packageRoot, "src/shared"), { recursive: true });
+    fs.writeFileSync(path.join(packageRoot, "src/App.vue"), "<template />\n");
+    fs.writeFileSync(path.join(packageRoot, "src/shared/index.ts"), "export const ok = true;\n");
+    fs.writeFileSync(
+      path.join(packageRoot, "tsconfig.app.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "@/*": ["./src/*"],
+          },
+        },
+      })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(packageRoot, "tsconfig.check.json"),
+      `{ "extends": "./tsconfig.app.json" }\n`,
+    );
+    const reportDir = path.join(outer, "report");
+    fs.mkdirSync(reportDir);
+    const project = materializeBaselineProject(
+      fixtureRoot,
+      reportDir,
+      {
+        id: "fixture",
+        tsconfig: "packages/core/tsconfig.check.json",
+        typecheckPerformance: {
+          baseline: { tsconfig: "packages/core/tsconfig.check.json" },
+          corpusGlobs: ["packages/core/src/**/*.vue"],
+        },
+      },
+      { fileCount: 1, files: [{ file: "packages/core/src/App.vue" }] },
+    );
+    assert.deepEqual(JSON.parse(project.source).compilerOptions.paths, {
+      "@/*": ["../src/*"],
     });
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -252,6 +252,39 @@ test("typecheck divergence progress logging is opt-in", () => {
   }
 });
 
+test("typecheck divergence baseline preserves inherited path aliases from moved configs", () => {
+  const fixture = setup();
+  try {
+    fs.writeFileSync(
+      path.join(fixture.fixtureRoot, "tsconfig.app.json"),
+      `${JSON.stringify({
+        compilerOptions: {
+          paths: {
+            "@/*": ["./src/*"],
+          },
+        },
+      })}\n`,
+    );
+    fs.writeFileSync(
+      path.join(fixture.fixtureRoot, "tsconfig.check.json"),
+      `{ "extends": "./tsconfig.app.json" }\n`,
+    );
+    updateJson(fixture.registryPath, (registry) => {
+      registry.projects[0].tsconfig = "tsconfig.check.json";
+      registry.projects[0].typecheckPerformance.baseline = { tsconfig: "tsconfig.check.json" };
+    });
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+
+    const config = readJson(path.join(fixture.reportDir, "fixture-vue-tsc.tsconfig.json"));
+    assert.deepEqual(config.compilerOptions.paths, {
+      "@/*": ["../src/*"],
+    });
+  } finally {
+    cleanup(fixture);
+  }
+});
+
 test("typecheck divergence report skips shards without typecheck performance targets", () => {
   const fixture = setup();
   try {

--- a/tools/commands/fixtures/typecheck-divergence-report.rs
+++ b/tools/commands/fixtures/typecheck-divergence-report.rs
@@ -586,6 +586,7 @@ fn materialize_baseline_project(
     fs::create_dir_all(&config_dir)
         .map_err(|error| format!("cannot create {}: {error}", config_dir.display()))?;
     let source_document = read_tsconfig_jsonc(&source_path)?;
+    let compiler_paths = winning_compiler_paths(fixture_root, &source_path)?;
     let mut dot_roots = dot_directory_include_roots(fixture_root, vize_report);
     let fixture_roots = [fixture_root.to_path_buf()];
     dot_roots.extend(discover_dot_directory_include_roots(&fixture_roots)?);
@@ -609,16 +610,23 @@ fn materialize_baseline_project(
         "rootDir".to_string(),
         json!(config_relative_path(&config_dir, fixture_root)),
     );
-    let source_base_url = source_document
-        .pointer("/compilerOptions/baseUrl")
-        .and_then(Value::as_str)
-        .map(|base_url| source_dir.join(base_url));
-    let path_mapping_root = source_base_url.as_deref().unwrap_or(source_dir);
-    let mut paths = source_path_mappings(path_mapping_root, &config_dir, &source_document);
+    let path_mapping_root = compiler_paths
+        .base_url
+        .as_ref()
+        .map(|base_url| base_url.dir.join(&base_url.value))
+        .or_else(|| compiler_paths.paths.as_ref().map(|paths| paths.dir.clone()));
+    let mut paths = compiler_paths
+        .paths
+        .as_ref()
+        .zip(path_mapping_root.as_deref())
+        .map(|(paths, path_mapping_root)| {
+            source_path_mappings(path_mapping_root, &config_dir, &paths.value)
+        })
+        .unwrap_or_default();
     extend_local_vue_runtime_paths(fixture_root, &config_dir, &mut paths)?;
     if !paths.is_empty() {
         compiler_options.insert("paths".to_string(), Value::Object(paths));
-        if source_base_url.is_some() {
+        if compiler_paths.base_url.is_some() {
             compiler_options.insert("baseUrl".to_string(), json!("."));
         }
     }
@@ -3924,6 +3932,101 @@ fn read_tsconfig_jsonc(path: &Path) -> Result<Value, String> {
         .map_err(|error| format!("cannot parse JSON {}: {error}", path.display()))
 }
 
+struct CompilerPaths {
+    paths: Option<DeclaredPaths>,
+    base_url: Option<DeclaredBaseUrl>,
+}
+
+struct DeclaredPaths {
+    dir: PathBuf,
+    value: serde_json::Map<String, Value>,
+}
+
+struct DeclaredBaseUrl {
+    dir: PathBuf,
+    value: String,
+}
+
+fn winning_compiler_paths(
+    fixture_root: &Path,
+    source_path: &Path,
+) -> Result<CompilerPaths, String> {
+    let mut chain = Vec::new();
+    collect_tsconfig_extends_chain(fixture_root, source_path, &mut BTreeSet::new(), &mut chain)?;
+    let mut paths = None;
+    let mut base_url = None;
+    for (path, document) in chain {
+        let dir = path
+            .parent()
+            .ok_or_else(|| format!("tsconfig has no parent: {}", path.display()))?
+            .to_path_buf();
+        if let Some(value) = document
+            .pointer("/compilerOptions/paths")
+            .and_then(Value::as_object)
+        {
+            paths = Some(DeclaredPaths {
+                dir: dir.clone(),
+                value: value.clone(),
+            });
+        }
+        if let Some(value) = document
+            .pointer("/compilerOptions/baseUrl")
+            .and_then(Value::as_str)
+        {
+            base_url = Some(DeclaredBaseUrl {
+                dir,
+                value: value.to_string(),
+            });
+        }
+    }
+    Ok(CompilerPaths { paths, base_url })
+}
+
+fn collect_tsconfig_extends_chain(
+    fixture_root: &Path,
+    path: &Path,
+    seen: &mut BTreeSet<PathBuf>,
+    chain: &mut Vec<(PathBuf, Value)>,
+) -> Result<(), String> {
+    let normalized = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    if !seen.insert(normalized.clone()) {
+        return Ok(());
+    }
+    let document = read_tsconfig_jsonc(&normalized)?;
+    if let Some(parent) = document
+        .get("extends")
+        .and_then(Value::as_str)
+        .and_then(|extends| resolve_relative_tsconfig_extends(fixture_root, &normalized, extends))
+    {
+        collect_tsconfig_extends_chain(fixture_root, &parent, seen, chain)?;
+    }
+    chain.push((normalized, document));
+    Ok(())
+}
+
+fn resolve_relative_tsconfig_extends(
+    fixture_root: &Path,
+    from_config: &Path,
+    specifier: &str,
+) -> Option<PathBuf> {
+    if !(specifier.starts_with("./") || specifier.starts_with("../")) {
+        return None;
+    }
+    let base = from_config.parent()?.join(specifier);
+    let candidates = if base.extension().is_some() {
+        vec![base]
+    } else {
+        vec![base.with_extension("json"), base]
+    };
+    candidates.into_iter().find(|candidate| {
+        candidate.exists()
+            && candidate
+                .canonicalize()
+                .ok()
+                .is_some_and(|path| path_stays_inside(fixture_root, &path))
+    })
+}
+
 fn strip_jsonc_sugar(source: &str) -> String {
     let mut out = String::with_capacity(source.len());
     let mut chars = source.chars().peekable();
@@ -3986,14 +4089,8 @@ fn is_dot_directory(name: &str) -> bool {
 fn source_path_mappings(
     source_dir: &Path,
     config_dir: &Path,
-    source_document: &Value,
+    declared: &serde_json::Map<String, Value>,
 ) -> serde_json::Map<String, Value> {
-    let Some(declared) = source_document
-        .pointer("/compilerOptions/paths")
-        .and_then(Value::as_object)
-    else {
-        return serde_json::Map::new();
-    };
     declared
         .iter()
         .filter_map(|(name, targets)| {


### PR DESCRIPTION
## Summary
- preserve inherited relative `compilerOptions.paths` when materializing typecheck baseline configs under `.vize-baseline`
- keep JS baseline helpers aligned with the generated config location so non-retargeted mappings are still relocated correctly
- add focused coverage for inherited aliases, missing subpaths, and the Rust divergence report path

## Validation
- `node --test tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-baseline-outside-paths.test.ts tests/tooling/typecheck-baseline-outside-paths-star.test.ts tests/tooling/typecheck-baseline-outside-paths-subpath.test.ts tests/tooling/typecheck-baseline-outside-paths-package-extends.test.ts tests/tooling/typecheck-baseline-outside-paths-baseurl.test.ts tests/tooling/typecheck-baseline-outside-paths-config-dir.test.ts tests/tooling/typecheck-baseline-outside-aliases.test.ts tests/tooling/typecheck-baseline-outside-aliases-package-extends.test.ts tests/tooling/typecheck-baseline-outside-catchall.test.ts`
- `rustfmt --check tools/commands/fixtures/typecheck-divergence-report.rs`
- `git diff --check`
- `VIZE_TYPECHECK_DIVERGENCE_PROGRESS=1 rust-script tools/commands/fixtures/typecheck-divergence-report.rs --registry /tmp/vize-reka-only-registry.json --report-dir real-project-results/shard-4 --shard-index 0 --shard-count 1 --budget-mode record-only --vize-bin npm/cli/bin/vize --vue-tsc-bin tests/node_modules/.bin/vue-tsc`

## Reka UI focused result
- Vize diagnostics: 65
- vue-tsc diagnostics: 30
- Shared: 4
- False positives: 61
- False negatives: 26
- Coverage: 729/729 Vue files, missing 0, unexpected 0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791169186&installation_model_id=422833&pr_number=5703&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5703&signature=d14f955e9a29f488c653b9a8d456e00f2a8be1d25eda96b4db1fce16a5eed4b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->