### PR TITLE
fix(vscode): gate reference command palette

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -353,6 +353,10 @@
         {
           "command": "vize.showOutput",
           "when": "editorLangId == vue || editorLangId == art-vue || editorLangId == html"
+        },
+        {
+          "command": "vize.findReferences",
+          "when": "editorLangId == vue || editorLangId == art-vue || editorLangId == html"
         }
       ]
     },

--- a/tests/tooling/vscode-extension-manifest.test.ts
+++ b/tests/tooling/vscode-extension-manifest.test.ts
@@ -68,7 +68,11 @@ function readManifest(): Manifest {
   ) as Manifest;
 }
 
-const LANGUAGE_SCOPED_COMMANDS = new Set(["vize.restartServer", "vize.showOutput"]);
+const LANGUAGE_SCOPED_COMMANDS = new Set([
+  "vize.findReferences",
+  "vize.restartServer",
+  "vize.showOutput",
+]);
 
 test("every contributed command has a matching onCommand activation event", () => {
   const manifest = readManifest();
@@ -105,16 +109,32 @@ test("command palette menu only references declared commands", () => {
 test("language-scoped commands are gated by an editor language guard", () => {
   const manifest = readManifest();
   const palette = manifest.contributes?.menus?.commandPalette ?? [];
+  const paletteByCommand = new Map<string, Array<{ command?: string; when?: string }>>();
 
   for (const item of palette) {
+    if (item.command) {
+      const entries = paletteByCommand.get(item.command) ?? [];
+      entries.push(item);
+      paletteByCommand.set(item.command, entries);
+    }
+
     if (LANGUAGE_SCOPED_COMMANDS.has(item.command ?? "")) {
       assert.match(item.when ?? "", /editorLangId == vue/);
       assert.match(item.when ?? "", /editorLangId == art-vue/);
+      assert.match(item.when ?? "", /editorLangId == html/);
     } else {
       // Profile/status commands are always available, so they must not carry a
       // language guard that would hide them from the palette.
       assert.equal(item.when, undefined, `${item.command} should not be language-gated`);
     }
+  }
+
+  for (const command of LANGUAGE_SCOPED_COMMANDS) {
+    assert.equal(
+      paletteByCommand.get(command)?.length,
+      1,
+      `${command} should have exactly one command-palette gate`,
+    );
   }
 });
 


### PR DESCRIPTION
## Summary
- hide the Find All References command outside supported Vue/HTML editor languages
- require every language-scoped VS Code command to have one guarded command-palette entry

## Verification
- node --test tests/tooling/vscode-extension-manifest.test.ts
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/vscode-extension-manifest.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791169806&installation_model_id=422833&pr_number=5704&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5704&signature=583cd9bf9ab287b5a3e19db5bbf2ed78de060f8d37b3d66215536abacf8ba2c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->