### PR TITLE
test(release): guard fresh init script path resolution

### DIFF
--- a/legacy-tools/npm/smoke-release-init-fresh.mjs
+++ b/legacy-tools/npm/smoke-release-init-fresh.mjs
@@ -21,6 +21,7 @@ import path from "node:path";
 
 import { run } from "./smoke-process.mjs";
 import { PACKAGE_MANAGERS } from "./smoke-release-init-managers.mjs";
+import { withPoisonedVizePath } from "./smoke-release-path-poison.mjs";
 import { FRESH_INIT_MATRIX, PROJECT_SHAPES } from "./smoke-release-init-shapes.mjs";
 import {
   assertFreshProject,
@@ -124,8 +125,9 @@ function runFreshProjectCell(context, cell) {
   assert.deepEqual(reportedDiagnostics(clean.report, projectRoot), []);
   assert.equal(clean.report.errorCount, 0);
   // The documented command, run exactly as `docs/content/guide/init.md` and the
-  // generated script spell it, with no extra arguments.
-  const documented = runGeneratedCheck(projectRoot, manager, []);
+  // generated script spell it, with no extra arguments. The poisoned PATH makes
+  // the command fail closed if it stops resolving the fresh project's package.
+  const documented = runGeneratedCheck(projectRoot, manager, [], withPoisonedVizePath(projectRoot));
   assert.equal(documented.status, 0, `documented vize:check failed\n${documented.stderr}`);
 
   const afterInit = snapshotFiles(projectRoot, tracked);

--- a/legacy-tools/npm/smoke-release-path-poison.mjs
+++ b/legacy-tools/npm/smoke-release-path-poison.mjs
@@ -1,0 +1,35 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const POISON_MESSAGE = "outside vize executable reached";
+
+function writeExecutable(filename, source) {
+  fs.writeFileSync(filename, source);
+  if (process.platform !== "win32") {
+    fs.chmodSync(filename, 0o755);
+  }
+}
+
+/**
+ * Places a failing `vize` command before the inherited PATH.
+ *
+ * Package-manager script runners should still prefer the fresh project's own
+ * `node_modules/.bin`; reaching this executable means the release smoke stopped
+ * proving the generated command against project-local artifacts.
+ */
+export function withPoisonedVizePath(projectRoot, env = process.env) {
+  const poisonDir = path.join(projectRoot, ".vize-path-poison");
+  fs.mkdirSync(poisonDir, { recursive: true });
+  writeExecutable(
+    path.join(poisonDir, "vize"),
+    ["#!/bin/sh", `echo '${POISON_MESSAGE}' >&2`, "exit 42", ""].join("\n"),
+  );
+  fs.writeFileSync(
+    path.join(poisonDir, "vize.cmd"),
+    ["@echo off", `echo ${POISON_MESSAGE} 1>&2`, "exit /b 42", ""].join("\r\n"),
+  );
+  return {
+    ...env,
+    PATH: [poisonDir, env.PATH ?? ""].filter((segment) => segment.length > 0).join(path.delimiter),
+  };
+}

--- a/tests/tooling/release-smoke-init-fresh.test.ts
+++ b/tests/tooling/release-smoke-init-fresh.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 import { parse } from "yaml";
 
@@ -9,6 +12,7 @@ import {
   runManager,
 } from "../../legacy-tools/npm/smoke-release-init-project.mjs";
 import { PACKAGE_MANAGERS } from "../../legacy-tools/npm/smoke-release-init-managers.mjs";
+import { withPoisonedVizePath } from "../../legacy-tools/npm/smoke-release-path-poison.mjs";
 import {
   FRESH_INIT_MATRIX,
   PROJECT_SHAPES,
@@ -277,6 +281,25 @@ function assertRuntimeSmokePackageManagers(workflow: string, jobName: string) {
 test("fresh install runtime smokes expose every package manager they matrix", () => {
   assertRuntimeSmokePackageManagers("native-smoke.yml", "fresh-install-smoke");
   assertRuntimeSmokePackageManagers("release.yml", "smoke-release-packages");
+});
+
+test("the documented generated check runs with outside vize path poison", () => {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-path-poison-"));
+  try {
+    const env = withPoisonedVizePath(projectRoot, { PATH: "/host/bin" });
+    const [poisonDir, inherited] = env.PATH.split(path.delimiter);
+    assert.equal(inherited, "/host/bin");
+    assert.match(fs.readFileSync(path.join(poisonDir, "vize"), "utf8"), /outside vize/);
+    assert.match(fs.readFileSync(path.join(poisonDir, "vize.cmd"), "utf8"), /outside vize/);
+
+    const freshDriver = readRepoFile("legacy-tools", "npm", "smoke-release-init-fresh.mjs");
+    assert.match(
+      freshDriver,
+      /runGeneratedCheck\(\s*projectRoot,\s*manager,\s*\[\],\s*withPoisonedVizePath/su,
+    );
+  } finally {
+    fs.rmSync(projectRoot, { force: true, recursive: true });
+  }
 });
 
 test("the fresh project runs with the host's Corsa overrides stripped", () => {


### PR DESCRIPTION
## Summary
- add a release-smoke helper that prepends a failing outside `vize` executable to `PATH`
- run the generated fresh-project `vize:check` script through that poisoned `PATH`, so package-manager execution must resolve project-local artifacts
- add tooling coverage for the new guard

## Validation
- `vp install --frozen-lockfile --prefer-offline`
- `node --test --test-concurrency=1 tests/tooling/release-smoke-init-fresh.test.ts tests/tooling/release-smoke-init-typecheck.test.ts tests/tooling/vscode-packaged-host-smoke.test.ts tests/tooling/release-smoke-install.test.ts`
- `vp run test` from `npm/cli`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10`
- `rust-script tools/commands/ci/verify-tool-layout.rs`
- `git diff --check origin/main...HEAD`

Refs #3956

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791170673&installation_model_id=422833&pr_number=5706&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5706&signature=c8f97d6809ef63002fbe5326a20a690211f675038a945ed60f3deef71468ac5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->