### PR TITLE
test(vscode): add host references oracle

### DIFF
--- a/editors/vscode/src/extension-core.ts
+++ b/editors/vscode/src/extension-core.ts
@@ -17,34 +17,6 @@ export type InitializationOptionBehavior = {
   logDefaultProfile?: boolean;
 };
 
-export type TestCompletionRequest = {
-  character: number;
-  line: number;
-  uri: string;
-};
-
-export type HostTestLanguageClient = {
-  sendRequest(method: string, params: unknown): Promise<unknown>;
-};
-
-export type HostTestServerInfo = {
-  extensionVersion?: string;
-  path: string;
-  source: string;
-  status: string;
-  version?: string;
-  versionError?: string;
-};
-
-export type HostTestCommand = {
-  command: string;
-  handler: (request?: unknown) => Promise<unknown>;
-};
-
-export const HOST_TEST_COMMAND_ENVIRONMENT_FLAG = "VIZE_TEST_ENABLE_HOST_COMMANDS";
-export const HOST_TEST_COMPLETION_COMMAND = "vize.test.executeCompletion";
-export const HOST_TEST_SERVER_INFO_COMMAND = "vize.test.getServerInfo";
-
 export const SUPPORTED_LANGUAGE_IDS = ["vue", "art-vue", "html"] as const;
 export const SUPPORTED_URI_SCHEMES = ["file", "untitled"] as const;
 export const FEATURE_SETTING_KEYS = [
@@ -134,83 +106,6 @@ export function createDocumentSelector(): Array<{ language: string; scheme: stri
       language,
     })),
   );
-}
-
-/**
- * Hidden host-smoke hooks keep the packaged extension test on the Vize
- * LanguageClient without waiting on unrelated VS Code completion providers.
- * They only exist when the host smoke sets the environment flag, so the
- * shipped extension never contributes them.
- */
-export function createHostTestCommands(behavior: {
-  environment: Partial<Record<string, string>>;
-  getClient: () => HostTestLanguageClient | undefined;
-  getServerInfo?: () => HostTestServerInfo | undefined;
-}): HostTestCommand[] {
-  if (behavior.environment[HOST_TEST_COMMAND_ENVIRONMENT_FLAG] !== "1") {
-    return [];
-  }
-
-  return [
-    {
-      command: HOST_TEST_COMPLETION_COMMAND,
-      handler: async (request) => {
-        const activeClient = behavior.getClient();
-        if (!activeClient) {
-          throw new Error("Vize test completion command requires an active language client.");
-        }
-        assertTestCompletionRequest(request);
-
-        return activeClient.sendRequest("textDocument/completion", {
-          textDocument: { uri: request.uri },
-          position: { line: request.line, character: request.character },
-        });
-      },
-    },
-    {
-      command: HOST_TEST_SERVER_INFO_COMMAND,
-      handler: async () => {
-        const serverInfo = behavior.getServerInfo?.();
-        if (!serverInfo) {
-          throw new Error("Vize test server info command requires selected server evidence.");
-        }
-        return serverInfo;
-      },
-    },
-  ];
-}
-
-/**
- * Registers the gated host commands through the caller's command registry so
- * the wiring stays observable without a VS Code host.
- */
-export function bindHostTestCommands<TRegistration>(behavior: {
-  environment: Partial<Record<string, string>>;
-  getClient: () => HostTestLanguageClient | undefined;
-  getServerInfo?: () => HostTestServerInfo | undefined;
-  register: (command: string, handler: (request?: unknown) => Promise<unknown>) => TRegistration;
-}): TRegistration[] {
-  return createHostTestCommands(behavior).map(({ command, handler }) =>
-    behavior.register(command, handler),
-  );
-}
-
-function assertTestCompletionRequest(request: unknown): asserts request is TestCompletionRequest {
-  const candidate = request as Partial<TestCompletionRequest> | null;
-  const line = candidate?.line;
-  const character = candidate?.character;
-  if (
-    candidate == null ||
-    typeof candidate.uri !== "string" ||
-    typeof line !== "number" ||
-    typeof character !== "number" ||
-    !Number.isInteger(line) ||
-    !Number.isInteger(character) ||
-    line < 0 ||
-    character < 0
-  ) {
-    throw new TypeError("Invalid Vize test completion request.");
-  }
 }
 
 export function parseVizeVersion(output: string): string | undefined {

--- a/editors/vscode/src/host-test-commands.ts
+++ b/editors/vscode/src/host-test-commands.ts
@@ -4,11 +4,11 @@ import {
   bindHostTestCommands,
   type HostTestLanguageClient,
   type HostTestServerInfo,
-} from "./extension-core";
+} from "./host-test-core";
 
 /**
  * Binds the environment-gated host smoke commands to the VS Code command
- * registry. The gate itself lives in `extension-core` so the tooling tests can
+ * registry. The gate itself lives in `host-test-core` so the tooling tests can
  * exercise it without a VS Code host.
  */
 export function registerHostTestCommands(

--- a/editors/vscode/src/host-test-core.ts
+++ b/editors/vscode/src/host-test-core.ts
@@ -1,0 +1,147 @@
+export type TestTextDocumentPositionRequest = {
+  character: number;
+  line: number;
+  uri: string;
+};
+
+export type TestCompletionRequest = TestTextDocumentPositionRequest;
+export type TestReferencesRequest = TestTextDocumentPositionRequest & {
+  includeDeclaration?: boolean;
+};
+
+export type HostTestLanguageClient = {
+  sendRequest(method: string, params: unknown): Promise<unknown>;
+};
+
+export type HostTestServerInfo = {
+  extensionVersion?: string;
+  path: string;
+  source: string;
+  status: string;
+  version?: string;
+  versionError?: string;
+};
+
+export type HostTestCommand = {
+  command: string;
+  handler: (request?: unknown) => Promise<unknown>;
+};
+
+export const HOST_TEST_COMMAND_ENVIRONMENT_FLAG = "VIZE_TEST_ENABLE_HOST_COMMANDS";
+export const HOST_TEST_COMPLETION_COMMAND = "vize.test.executeCompletion";
+export const HOST_TEST_REFERENCES_COMMAND = "vize.test.executeReferences";
+export const HOST_TEST_SERVER_INFO_COMMAND = "vize.test.getServerInfo";
+
+/**
+ * Hidden host-smoke hooks keep the packaged extension test on the Vize
+ * LanguageClient without waiting on unrelated VS Code providers. They only
+ * exist when the host smoke sets the environment flag.
+ */
+export function createHostTestCommands(behavior: {
+  environment: Partial<Record<string, string>>;
+  getClient: () => HostTestLanguageClient | undefined;
+  getServerInfo?: () => HostTestServerInfo | undefined;
+}): HostTestCommand[] {
+  if (behavior.environment[HOST_TEST_COMMAND_ENVIRONMENT_FLAG] !== "1") {
+    return [];
+  }
+
+  return [
+    {
+      command: HOST_TEST_COMPLETION_COMMAND,
+      handler: async (request) => {
+        const activeClient = requireActiveClient(behavior, "completion");
+        assertTextDocumentPositionRequest(request, "completion");
+        return activeClient.sendRequest(
+          "textDocument/completion",
+          textDocumentPositionParams(request),
+        );
+      },
+    },
+    {
+      command: HOST_TEST_REFERENCES_COMMAND,
+      handler: async (request) => {
+        const activeClient = requireActiveClient(behavior, "references");
+        assertTestReferencesRequest(request);
+        return activeClient.sendRequest("textDocument/references", {
+          ...textDocumentPositionParams(request),
+          context: { includeDeclaration: request.includeDeclaration ?? true },
+        });
+      },
+    },
+    {
+      command: HOST_TEST_SERVER_INFO_COMMAND,
+      handler: async () => {
+        const serverInfo = behavior.getServerInfo?.();
+        if (!serverInfo) {
+          throw new Error("Vize test server info command requires selected server evidence.");
+        }
+        return serverInfo;
+      },
+    },
+  ];
+}
+
+/**
+ * Registers the gated host commands through the caller's command registry so
+ * the wiring stays observable without a VS Code host.
+ */
+export function bindHostTestCommands<TRegistration>(behavior: {
+  environment: Partial<Record<string, string>>;
+  getClient: () => HostTestLanguageClient | undefined;
+  getServerInfo?: () => HostTestServerInfo | undefined;
+  register: (command: string, handler: (request?: unknown) => Promise<unknown>) => TRegistration;
+}): TRegistration[] {
+  return createHostTestCommands(behavior).map(({ command, handler }) =>
+    behavior.register(command, handler),
+  );
+}
+
+function requireActiveClient(
+  behavior: { getClient: () => HostTestLanguageClient | undefined },
+  label: string,
+): HostTestLanguageClient {
+  const activeClient = behavior.getClient();
+  if (!activeClient) {
+    throw new Error(`Vize test ${label} command requires an active language client.`);
+  }
+  return activeClient;
+}
+
+function assertTestReferencesRequest(request: unknown): asserts request is TestReferencesRequest {
+  assertTextDocumentPositionRequest(request, "references");
+  if (
+    (request as TestReferencesRequest).includeDeclaration !== undefined &&
+    typeof (request as TestReferencesRequest).includeDeclaration !== "boolean"
+  ) {
+    throw new TypeError("Invalid Vize test references request.");
+  }
+}
+
+function assertTextDocumentPositionRequest(
+  request: unknown,
+  label: string,
+): asserts request is TestTextDocumentPositionRequest {
+  const candidate = request as Partial<TestTextDocumentPositionRequest> | null;
+  const line = candidate?.line;
+  const character = candidate?.character;
+  if (
+    candidate == null ||
+    typeof candidate.uri !== "string" ||
+    typeof line !== "number" ||
+    typeof character !== "number" ||
+    !Number.isInteger(line) ||
+    !Number.isInteger(character) ||
+    line < 0 ||
+    character < 0
+  ) {
+    throw new TypeError(`Invalid Vize test ${label} request.`);
+  }
+}
+
+function textDocumentPositionParams(request: TestTextDocumentPositionRequest) {
+  return {
+    textDocument: { uri: request.uri },
+    position: { line: request.line, character: request.character },
+  };
+}

--- a/editors/vscode/test/real-host-completion-oracle.mjs
+++ b/editors/vscode/test/real-host-completion-oracle.mjs
@@ -4,7 +4,7 @@ import assert from "node:assert/strict";
 // `{{ label }}` template expression. Keeping the oracle here lets both the real
 // extension host and the tooling tests run the same assertions, so a broken
 // command gate, registration, or request forwarding fails somewhere.
-// Mirrors `HOST_TEST_COMPLETION_COMMAND` in `src/extension-core.ts`; the tooling
+// Mirrors `HOST_TEST_COMPLETION_COMMAND` in `src/host-test-core.ts`; the tooling
 // tests assert both stay in sync.
 export const HOST_TEST_COMPLETION_COMMAND = "vize.test.executeCompletion";
 export const REQUIRED_TEMPLATE_COMPLETION_LABELS = ["Child", "amount", "label"];

--- a/editors/vscode/test/real-host-references-oracle.mjs
+++ b/editors/vscode/test/real-host-references-oracle.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+
+// Mirrors `HOST_TEST_REFERENCES_COMMAND` in `src/host-test-core.ts`; the
+// tooling tests assert both stay in sync.
+export const HOST_TEST_REFERENCES_COMMAND = "vize.test.executeReferences";
+
+const REQUIRED_REFERENCES = [
+  { label: "script declaration", range: [3, 6, 3, 11] },
+  { label: "prop binding usage", range: [9, 19, 9, 24] },
+  { label: "interpolation usage", range: [10, 10, 10, 15] },
+];
+
+export function assertRealHostReferences(actual, { uri }) {
+  assert.ok(Array.isArray(actual), "real host references must return locations");
+  const locations = actual.map(describeLocation).sort(compareLocation);
+
+  for (const location of locations) {
+    assert.equal(
+      location.uri,
+      uri,
+      `real host references must stay on the authored SFC, not a generated virtual document: ${JSON.stringify(locations)}`,
+    );
+  }
+
+  for (const required of REQUIRED_REFERENCES) {
+    assert.ok(
+      locations.some((location) => rangesEqual(location.range, required.range)),
+      `real host references must include the ${required.label}: ${JSON.stringify(locations)}`,
+    );
+  }
+
+  assert.equal(
+    locations.length,
+    REQUIRED_REFERENCES.length,
+    `real host references must not include extra generated or duplicate locations: ${JSON.stringify(locations)}`,
+  );
+  return locations;
+}
+
+function describeLocation(location) {
+  return {
+    range: [
+      location.range.start.line,
+      location.range.start.character,
+      location.range.end.line,
+      location.range.end.character,
+    ],
+    uri: location.uri,
+  };
+}
+
+function rangesEqual(left, right) {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+function compareLocation(left, right) {
+  return left.range[0] - right.range[0] || left.range[1] - right.range[1];
+}

--- a/editors/vscode/test/real-host-server-info-oracle.mjs
+++ b/editors/vscode/test/real-host-server-info-oracle.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 
-// Mirrors `HOST_TEST_SERVER_INFO_COMMAND` in `src/extension-core.ts`; the
+// Mirrors `HOST_TEST_SERVER_INFO_COMMAND` in `src/host-test-core.ts`; the
 // tooling tests assert both stay in sync.
 export const HOST_TEST_SERVER_INFO_COMMAND = "vize.test.getServerInfo";
 

--- a/editors/vscode/test/suite/extension-host-real.cjs
+++ b/editors/vscode/test/suite/extension-host-real.cjs
@@ -54,6 +54,8 @@ exports.run = async function run() {
   await runRealDiagnosticSmoke(mismatchDocument, cleanDocument);
   logProgress("completion");
   await runRealCompletionSmoke(mismatchDocument);
+  logProgress("references");
+  await runRealReferencesSmoke(mismatchDocument);
   logProgress("hover");
   await runRealHoverSmoke(mismatchDocument);
   logProgress("didChange repair");
@@ -107,6 +109,20 @@ async function runRealCompletionSmoke(mismatchDocument) {
   });
 
   assertRealHostCompletionLabels(completions);
+}
+
+async function runRealReferencesSmoke(mismatchDocument) {
+  const { HOST_TEST_REFERENCES_COMMAND, assertRealHostReferences } =
+    await import("../real-host-references-oracle.mjs");
+  const position = positionAfter(mismatchDocument, "{{ label }}", "{{ la");
+  const references = await vscode.commands.executeCommand(HOST_TEST_REFERENCES_COMMAND, {
+    character: position.character,
+    includeDeclaration: true,
+    line: position.line,
+    uri: mismatchDocument.uri.toString(),
+  });
+
+  assertRealHostReferences(references, { uri: mismatchDocument.uri.toString() });
 }
 
 async function runRealHoverSmoke(mismatchDocument) {

--- a/tests/tooling/vscode-host-references-oracle.test.ts
+++ b/tests/tooling/vscode-host-references-oracle.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { HOST_TEST_REFERENCES_COMMAND } from "../../editors/vscode/src/host-test-core.ts";
+import {
+  HOST_TEST_REFERENCES_COMMAND as suiteHostReferencesCommand,
+  assertRealHostReferences,
+} from "../../editors/vscode/test/real-host-references-oracle.mjs";
+
+test("the real host references oracle pins authored SFC locations", () => {
+  assert.equal(HOST_TEST_REFERENCES_COMMAND, suiteHostReferencesCommand);
+  const uri = "file:///workspace/src/App.vue";
+  const references = [
+    location(uri, 3, 6, 3, 11),
+    location(uri, 9, 19, 9, 24),
+    location(uri, 10, 10, 10, 15),
+  ];
+
+  assert.deepEqual(assertRealHostReferences(references, { uri }), [
+    { range: [3, 6, 3, 11], uri },
+    { range: [9, 19, 9, 24], uri },
+    { range: [10, 10, 10, 15], uri },
+  ]);
+  assert.throws(() => assertRealHostReferences(null, { uri }), /must return locations/);
+  assert.throws(
+    () => assertRealHostReferences(references.slice(1), { uri }),
+    /must include the script declaration/,
+  );
+  assert.throws(
+    () => assertRealHostReferences([...references, location(`${uri}.ts`, 0, 0, 0, 5)], { uri }),
+    /generated virtual document/,
+  );
+});
+
+function location(
+  uri: string,
+  startLine: number,
+  startChar: number,
+  endLine: number,
+  endChar: number,
+) {
+  return {
+    range: {
+      end: { character: endChar, line: endLine },
+      start: { character: startChar, line: startLine },
+    },
+    uri,
+  };
+}

--- a/tests/tooling/vscode-host-test-commands.test.ts
+++ b/tests/tooling/vscode-host-test-commands.test.ts
@@ -5,13 +5,15 @@ import { test } from "node:test";
 import {
   HOST_TEST_COMMAND_ENVIRONMENT_FLAG,
   HOST_TEST_COMPLETION_COMMAND,
+  HOST_TEST_REFERENCES_COMMAND,
   HOST_TEST_SERVER_INFO_COMMAND,
   bindHostTestCommands,
   createHostTestCommands,
   type HostTestLanguageClient,
   type HostTestServerInfo,
   type TestCompletionRequest,
-} from "../../editors/vscode/src/extension-core.ts";
+  type TestReferencesRequest,
+} from "../../editors/vscode/src/host-test-core.ts";
 import {
   HOST_TEST_COMPLETION_COMMAND as suiteHostCompletionCommand,
   assertRealHostCompletionLabels,
@@ -38,12 +40,17 @@ test("the hidden host completion command only exists for the host smoke", async 
   });
   assertExactCommandMembership(
     commands.map((command) => command.command),
-    [HOST_TEST_COMPLETION_COMMAND, HOST_TEST_SERVER_INFO_COMMAND],
+    [HOST_TEST_COMPLETION_COMMAND, HOST_TEST_REFERENCES_COMMAND, HOST_TEST_SERVER_INFO_COMMAND],
   );
   const completionCommand = findHostCommand(commands, HOST_TEST_COMPLETION_COMMAND);
+  const referencesCommand = findHostCommand(commands, HOST_TEST_REFERENCES_COMMAND);
   const serverInfoCommand = findHostCommand(commands, HOST_TEST_SERVER_INFO_COMMAND);
   await assert.rejects(
     completionCommand.handler({ character: 8, line: 3, uri: "file:///App.vue" }),
+    /requires an active language client/,
+  );
+  await assert.rejects(
+    referencesCommand.handler({ character: 8, line: 3, uri: "file:///App.vue" }),
     /requires an active language client/,
   );
   await assert.rejects(serverInfoCommand.handler(), /requires selected server evidence/);
@@ -82,6 +89,64 @@ test("the host completion command forwards the request to the Vize language clie
     );
   }
   assert.equal(client.requests.length, 1);
+});
+
+test("the host references command forwards the request to the Vize language client", async () => {
+  const response = [
+    {
+      range: { start: { character: 6, line: 3 }, end: { character: 11, line: 3 } },
+      uri: "file:///App.vue",
+    },
+  ];
+  const client = createFakeClientResponse(response);
+  const commands = createHostTestCommands({
+    environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
+    getClient: () => client,
+  });
+  const command = findHostCommand(commands, HOST_TEST_REFERENCES_COMMAND);
+
+  assert.deepEqual(
+    await command.handler({ character: 10, line: 9, uri: "file:///App.vue" }),
+    response,
+  );
+  assert.deepEqual(
+    await command.handler({
+      character: 10,
+      includeDeclaration: false,
+      line: 9,
+      uri: "file:///App.vue",
+    }),
+    response,
+  );
+  assert.deepEqual(client.requests, [
+    [
+      "textDocument/references",
+      {
+        context: { includeDeclaration: true },
+        position: { character: 10, line: 9 },
+        textDocument: { uri: "file:///App.vue" },
+      },
+    ],
+    [
+      "textDocument/references",
+      {
+        context: { includeDeclaration: false },
+        position: { character: 10, line: 9 },
+        textDocument: { uri: "file:///App.vue" },
+      },
+    ],
+  ]);
+
+  await assert.rejects(
+    command.handler({
+      character: 10,
+      includeDeclaration: "yes",
+      line: 9,
+      uri: "file:///App.vue",
+    } as TestReferencesRequest),
+    /Invalid Vize test references request/,
+  );
+  assert.equal(client.requests.length, 2);
 });
 
 test("the host server info command returns the selected server evidence", async () => {
@@ -128,10 +193,12 @@ test("registering the gated host commands leaves an executable command behind", 
   });
   assertExactCommandMembership(registerCalls, [
     HOST_TEST_COMPLETION_COMMAND,
+    HOST_TEST_REFERENCES_COMMAND,
     HOST_TEST_SERVER_INFO_COMMAND,
   ]);
   assertExactCommandMembership(registry.keys(), [
     HOST_TEST_COMPLETION_COMMAND,
+    HOST_TEST_REFERENCES_COMMAND,
     HOST_TEST_SERVER_INFO_COMMAND,
   ]);
 
@@ -246,12 +313,18 @@ function assertExactCommandMembership(actual: Iterable<string>, expected: readon
 function createFakeClient(
   items: unknown[],
 ): HostTestLanguageClient & { requests: [string, unknown][] } {
+  return createFakeClientResponse({ isIncomplete: false, items });
+}
+
+function createFakeClientResponse(
+  response: unknown,
+): HostTestLanguageClient & { requests: [string, unknown][] } {
   const requests: [string, unknown][] = [];
   return {
     requests,
     sendRequest: async (method, params) => {
       requests.push([method, params]);
-      return { isIncomplete: false, items };
+      return response;
     },
   };
 }

--- a/tests/tooling/vscode-vsix-policy.test.ts
+++ b/tests/tooling/vscode-vsix-policy.test.ts
@@ -77,14 +77,15 @@ test("VSIX package policy keeps hidden host-smoke commands out of the manifest",
     activationEvents?: string[];
     contributes?: { commands?: Array<{ command?: string }> };
   };
-  const extensionCore = readText("editors/vscode/src/extension-core.ts");
+  const hostTestCore = readText("editors/vscode/src/host-test-core.ts");
   const smoke = readText("tools/commands/editors/vscode/assert-vsix-package.rs");
   const hiddenCommands = [
-    ...extensionCore.matchAll(/export const HOST_TEST_[A-Z_]+_COMMAND = "(vize\.test\.[^"]+)";/g),
+    ...hostTestCore.matchAll(/export const HOST_TEST_[A-Z_]+_COMMAND = "(vize\.test\.[^"]+)";/g),
   ].map((match) => match[1]);
 
   assert.deepEqual(hiddenCommands.sort(), [
     "vize.test.executeCompletion",
+    "vize.test.executeReferences",
     "vize.test.getServerInfo",
   ]);
   const contributedCommands = new Set(


### PR DESCRIPTION
## Summary
- move hidden VS Code host smoke command plumbing into a dedicated host-test core module
- add an environment-gated references command that forwards directly to the active Vize language client
- pin the packaged host references smoke to authored App.vue ranges only

## Validation
- node --test tests/tooling/vscode-host-test-commands.test.ts tests/tooling/vscode-host-references-oracle.test.ts tests/tooling/vscode-vsix-policy.test.ts
- ../../node_modules/.pnpm/node_modules/.bin/tsc --noEmit -p editors/vscode/tsconfig.json
- ../../node_modules/.bin/vp check src vite.config.ts (from editors/vscode)
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10
- git diff --check HEAD~1..HEAD

Note: local vp run --workspace-root check:js stops before this slice on the existing native binding package version mismatch (expected 0.394.0, found 0.387.0); PR Actions will run the full gate on a fresh runner.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791171189&installation_model_id=422833&pr_number=5708&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5708&signature=47765fe5dd073a325c55398afb9f51635dd6bd75fb26701e8a56f1014b49273c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for validating references in Vue single-file components, including declaration-aware reference results.
  - Added host diagnostics that expose server information and language-service test operations when explicitly enabled.

- **Tests**
  - Expanded VS Code integration coverage for completion, references, server information, and request validation.
  - Added checks ensuring references point to authored files rather than generated virtual documents.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->