### PR TITLE
test(davinci): pin dom option switch boundary

### DIFF
--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -96,25 +96,28 @@ test("DOM S2 production switch classifies every compiler option", () => {
     "DomCompilerOptions",
   );
 
-  assert.deepEqual(fields, [
-    "mode",
-    "prefix_identifiers",
-    "hoist_static",
-    "cache_handlers",
-    "scope_id",
-    "ssr",
-    "source_map",
-    "comments",
-    "experimental_in_tag_comments",
-    "experimental_patterned_template",
-    "component_name",
-    "inline",
-    "custom_renderer",
-    "binding_metadata",
-    "is_ts",
-    "dialect",
-    "croquis",
-  ]);
+  assert.deepEqual(
+    [...fields].sort(),
+    [
+      "mode",
+      "prefix_identifiers",
+      "hoist_static",
+      "cache_handlers",
+      "scope_id",
+      "ssr",
+      "source_map",
+      "comments",
+      "experimental_in_tag_comments",
+      "experimental_patterned_template",
+      "component_name",
+      "inline",
+      "custom_renderer",
+      "binding_metadata",
+      "is_ts",
+      "dialect",
+      "croquis",
+    ].sort(),
+  );
 
   assert.deepEqual(
     sortedUnique([...compilerOptionsProjectedToS2, ...compilerOptionsHeldAtDefault]),
@@ -124,11 +127,13 @@ test("DOM S2 production switch classifies every compiler option", () => {
 
 test("DOM S2 emit options stay scoped to the supported switch surface", () => {
   assert.deepEqual(
-    publicStructFieldNames(
-      readRepoFile("crates", "vize_s1_to_s2", "src", "emit", "options.rs"),
-      "DomEmitOptions",
-    ),
-    s2EmitOptionFields,
+    [
+      ...publicStructFieldNames(
+        readRepoFile("crates", "vize_s1_to_s2", "src", "emit", "options.rs"),
+        "DomEmitOptions",
+      ),
+    ].sort(),
+    [...s2EmitOptionFields].sort(),
   );
 });
 

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -4,9 +4,48 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 
-import { metadata, repoRoot, workspacePackage } from "./support/davinci-stage-dependencies.ts";
+import {
+  metadata,
+  readRepoFile,
+  repoRoot,
+  workspacePackage,
+} from "./support/davinci-stage-dependencies.ts";
 
 const domStageDeps = new Set(["vize_davinci", "vize_s1_to_s2", "vize_s2"]);
+const compilerOptionsProjectedToS2 = [
+  "mode",
+  "prefix_identifiers",
+  "cache_handlers",
+  "scope_id",
+  "component_name",
+  "inline",
+  "binding_metadata",
+  "is_ts",
+  "dialect",
+];
+const compilerOptionsHeldAtDefault = [
+  "hoist_static",
+  "ssr",
+  "source_map",
+  "comments",
+  "experimental_in_tag_comments",
+  "experimental_patterned_template",
+  "custom_renderer",
+  "croquis",
+];
+const s2EmitOptionFields = [
+  "mode",
+  "runtime_module_name",
+  "runtime_global_name",
+  "prefix_identifiers",
+  "inline",
+  "component_name",
+  "cache_handlers",
+  "hoisted_scope_id",
+  "scope_id",
+  "is_ts",
+  "bindings",
+];
 
 test("DOM compiler keeps the published S2 renderer available for profiling", () => {
   const dependencies = workspacePackage(metadata, "vize_atelier_dom").dependencies;
@@ -50,3 +89,78 @@ test("source-map-disabled DOM compile records the S2 profiling counter", () => {
   assert.equal(result.status, 0, result.stderr || result.stdout);
   assert.match(result.stdout, /profile_reports_real_s2_dom_walks \.\.\. ok/u);
 });
+
+test("DOM S2 production switch classifies every compiler option", () => {
+  const fields = publicStructFieldNames(
+    readRepoFile("crates", "vize_atelier_dom", "src", "options.rs"),
+    "DomCompilerOptions",
+  );
+
+  assert.deepEqual(fields, [
+    "mode",
+    "prefix_identifiers",
+    "hoist_static",
+    "cache_handlers",
+    "scope_id",
+    "ssr",
+    "source_map",
+    "comments",
+    "experimental_in_tag_comments",
+    "experimental_patterned_template",
+    "component_name",
+    "inline",
+    "custom_renderer",
+    "binding_metadata",
+    "is_ts",
+    "dialect",
+    "croquis",
+  ]);
+
+  assert.deepEqual(
+    sortedUnique([...compilerOptionsProjectedToS2, ...compilerOptionsHeldAtDefault]),
+    [...fields].sort(),
+  );
+});
+
+test("DOM S2 emit options stay scoped to the supported switch surface", () => {
+  assert.deepEqual(
+    publicStructFieldNames(
+      readRepoFile("crates", "vize_s1_to_s2", "src", "emit", "options.rs"),
+      "DomEmitOptions",
+    ),
+    s2EmitOptionFields,
+  );
+});
+
+function sortedUnique(values: string[]): string[] {
+  const unique = new Set(values);
+  assert.equal(unique.size, values.length, "option classification has duplicates");
+  return [...unique].sort();
+}
+
+function publicStructFieldNames(source: string, structName: string): string[] {
+  const declaration = new RegExp(String.raw`pub struct ${structName}(?:<[^>]+>)?\s*\{`, "u").exec(
+    source,
+  );
+  assert.ok(declaration, `missing ${structName} declaration`);
+
+  const bodyStart = source.indexOf("{", declaration.index);
+  const bodyEnd = matchingBraceIndex(source, bodyStart);
+  const body = source.slice(bodyStart + 1, bodyEnd);
+  return [...body.matchAll(/^\s*pub\s+([A-Za-z_][A-Za-z0-9_]*)\s*:/gmu)].map(([, field]) => field);
+}
+
+function matchingBraceIndex(source: string, start: number): number {
+  let depth = 0;
+  for (let index = start; index < source.length; index += 1) {
+    if (source[index] === "{") {
+      depth += 1;
+    } else if (source[index] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  assert.fail("unterminated struct body");
+}


### PR DESCRIPTION
## Summary
- classify every DomCompilerOptions field for the S2 production switch as projected or default-held
- pin DomEmitOptions to the supported S2 switch surface
- make future option additions fail closed in the production-boundary tooling test

## Validation
- node --test tests/tooling/davinci-phase2-ledger.test.ts tests/tooling/davinci-traversal-budgets.test.ts tests/tooling/davinci-dom-production-boundary.test.ts
- vp check tests/tooling/davinci-dom-production-boundary.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791172083&installation_model_id=422833&pr_number=5709&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5709&signature=ab155972ef2881bfa8c681f1a5600c3de4939d28d01112fa256594e27ab510d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage for production compiler configuration and output settings.
  - Added validation to ensure supported compiler options are consistently classified and remain synchronized with generated output configuration.
  - Added checks that public configuration fields are complete, unique, and accurately represented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->