### PR TITLE
test(lsp): add element plus authored oracle

### DIFF
--- a/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 24, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 25, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -765,6 +765,7 @@
         "type": "fixtures",
         "fixturePaths": [
           "tests/_fixtures/_git/ant-design-vue",
+          "tests/_fixtures/_git/element-plus",
           "tests/_fixtures/_git/hoppscotch",
           "tests/_fixtures/_git/inspira-ui",
           "tests/_fixtures/_git/reka-ui",

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 24,
+    "minimumProjectCount": 25,
     "trackingIssue": 3952
   },
   "projects": [
@@ -263,6 +263,69 @@
         "corpusGlobs": ["packages/**/*.vue", "ssr-testing/**/*.vue"],
         "maxFalsePositiveRatio": 0.05,
         "maxFalseNegativeRatio": 0.05
+      },
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "packages/components/anchor/src/anchor-link.vue",
+          "symbol": "cls",
+          "usageAnchor": ":class=\"cls\"",
+          "declarationAnchor": "const cls = computed(() => [",
+          "hoverContains": ["const cls:"],
+          "renameTo": "__vizeRenamedCls"
+        },
+        "componentBoundary": {
+          "importerFile": "packages/components/cascader-panel/src/menu.vue",
+          "componentFile": "packages/components/cascader-panel/src/node.vue",
+          "tagName": "el-cascader-node",
+          "tagAnchor": "<el-cascader-node\n            ",
+          "completionItemCount": 30,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "node", "rank": 28 },
+            { "label": "menu-id", "rank": 29 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  menuId?: string\n",
+            "replacement": "  menuId?: string\n  vizeOracleProbe?: boolean\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "packages/components/cascader-panel/src/__VizeOracleCascaderNode.vue",
+          "renamedFile": "packages/components/cascader-panel/src/__VizeOracleRenamedCascaderNode.vue",
+          "originalImportSpecifier": "./node.vue",
+          "copiedImportSpecifier": "./__VizeOracleCascaderNode.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedCascaderNode.vue",
+          "markerInsertionAnchor": "import type { CheckboxValueType } from '@element-plus/components/checkbox'\n\n",
+          "markerSymbol": "__vizeElementPlusCascaderNodeMarker__"
+        }
       }
     },
     {

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 24,
+      "authored-lsp": 25,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,


### PR DESCRIPTION
## Summary
- add an Element Plus authored real-project LSP oracle for #3952
- cover authored hover, definition, references, rename, component completion, unsaved dependency completion repair, and file lifecycle behavior
- raise the authored LSP oracle ratchets from 24 to 25

## Verification
- vp install --frozen-lockfile --prefer-offline
- node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts
- node --test tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/davinci-phase2-ledger.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --limit 50
- git diff --check
- cargo build -p vize
- FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=2 REAL_PROJECT_LSP_TIMEOUT_MS=600000 node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts