### PR TITLE
test(lsp): pin absent declaration capability

### DIFF
--- a/tests/tooling/lsp-declaration-capability.test.ts
+++ b/tests/tooling/lsp-declaration-capability.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { firstLocation, offsetToPosition } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { ServerCapabilities } from "./support/lsp/protocol.ts";
+import { LspRequestError, LspSession } from "./support/lsp/session.ts";
+
+const source = `<script setup lang="ts">
+const message = "hello"
+</script>
+
+<template>
+  <span>{{ message }}</span>
+</template>
+`;
+
+type DeclarationCapabilities = ServerCapabilities & {
+  declarationProvider?: unknown;
+};
+
+test("vize lsp keeps textDocument/declaration fail-closed until #3953 implements it", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-declaration-capability");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const filePath = path.join(workspaceDir, "Widget.vue");
+  const uri = pathToFileURL(filePath).href;
+  const session = new LspSession();
+
+  try {
+    const init = (await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: false,
+    })) as { capabilities?: DeclarationCapabilities };
+    assert.equal(init.capabilities?.declarationProvider, undefined);
+
+    fs.writeFileSync(filePath, source, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: source },
+    });
+
+    const position = offsetToPosition(source, source.lastIndexOf("message }}</span>") + 3);
+    await assert.rejects(
+      session.request("textDocument/declaration", {
+        textDocument: { uri },
+        position,
+      }),
+      (error) =>
+        error instanceof LspRequestError &&
+        error.method === "textDocument/declaration" &&
+        error.code === -32601,
+    );
+
+    const definition = (await session.request("textDocument/definition", {
+      textDocument: { uri },
+      position,
+    })) as Array<{ uri: string; range: { start: { line: number; character: number } } }>;
+    const location = firstLocation(definition);
+    assert.equal(location.uri, uri);
+    assert.deepEqual(location.range.start, offsetToPosition(source, source.indexOf("message =")));
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a live LSP oracle for `textDocument/declaration` under #3953
- assert initialize does not advertise `declarationProvider`
- assert the unsupported request returns `-32601` and `textDocument/definition` still resolves authored Vue source afterward

## Testing
- `node --test tests/tooling/lsp-declaration-capability.test.ts tests/tooling/lsp-capabilities.test.ts`
- `cargo fmt --all --check`
- `cargo test -p vize_maestro server::capabilities` passed before the clean rebase; the post-rebase rerun was blocked by local disk `ENOSPC` during compilation
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`
- `git diff --check origin/main..HEAD`

Refs #3953

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791173825&installation_model_id=422833&pr_number=5711&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5711&signature=b802a154fcfc5be2b987269b26173e06d865f358d604b86ed7ff54a06c067990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->