### PR TITLE
test(davinci): guard s2 option audit rows

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_option_audit.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_option_audit.rs
@@ -1,0 +1,95 @@
+//! P2-11: the option-surface audit guards.
+//!
+//! Several late S2 DOM parity fixes came from widening batteries until an
+//! option-specific path failed. These tests preserve the structural rows from
+//! that audit: cases whose parity should hold because the emitter routes the
+//! construct through the correct owner, not because a caller passed another
+//! flag.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use vize_atelier_core::options::CodegenOptions;
+use vize_atelier_dom::DomCompilerOptions;
+use vize_s1_to_s2::DomEmitOptions;
+
+const SCOPE_ID: &str = "data-v-abc123";
+
+/// Slot outlet props are not props on a real rendered element, so scoped CSS
+/// attrs stay out of the outlet itself while fallback elements still receive
+/// the normal scope pair.
+#[test]
+fn slot_outlets_take_no_scope_pair() {
+    let cases: &[(&str, &str)] = &[
+        ("outlet_props", r#"<slot :item="x" name="a">fb</slot>"#),
+        ("outlet_static_name", r#"<slot name="a"></slot>"#),
+        ("outlet_bare", "<slot />"),
+        (
+            "outlet_element_fallback",
+            r#"<slot><div class="c">f</div></slot>"#,
+        ),
+        ("outlet_dynamic_name", r#"<slot :name="n" />"#),
+        (
+            "outlet_in_for",
+            r#"<slot v-for="i in n" :key="i" :item="i" />"#,
+        ),
+    ];
+    support::assert_s2_matches_shipped_with_options(
+        cases,
+        &DomCompilerOptions {
+            cache_handlers: true,
+            scope_id: Some(SCOPE_ID.into()),
+            ..Default::default()
+        },
+        &CodegenOptions::default(),
+        &DomEmitOptions {
+            cache_handlers: true,
+            scope_id: Some(SCOPE_ID),
+            ..DomEmitOptions::DEFAULT
+        },
+    );
+}
+
+/// `cache_handlers` is uniform across structural emit sites; the variation is
+/// only Vue's slot-param scope gate, where both lanes suppress caching.
+#[test]
+fn cached_handlers_are_uniform_across_structural_positions() {
+    let cases: &[(&str, &str)] = &[
+        ("once_handler", r#"<div v-once @click="a++">x</div>"#),
+        (
+            "once_child_handler",
+            r#"<div v-once><a @click="a++">x</a></div>"#,
+        ),
+        ("memo_handler", r#"<div v-memo="[a]" @click="a++">x</div>"#),
+        (
+            "slot_scope_handler",
+            r#"<MyComp v-slot="{ r }"><a @click="go(r)">x</a></MyComp>"#,
+        ),
+        (
+            "outlet_fallback_handler",
+            r#"<slot :on="1"><a @click="a++">x</a></slot>"#,
+        ),
+        ("vif_handler", r#"<div v-if="ok" @click="a++">x</div>"#),
+        (
+            "vfor_handler",
+            r#"<div v-for="i in n" :key="i" @click="a++">x</div>"#,
+        ),
+    ];
+    support::assert_s2_matches_shipped_with_options(
+        cases,
+        &DomCompilerOptions {
+            cache_handlers: true,
+            ..Default::default()
+        },
+        &CodegenOptions::default(),
+        &DomEmitOptions {
+            cache_handlers: true,
+            ..DomEmitOptions::DEFAULT
+        },
+    );
+}


### PR DESCRIPTION
## Summary
- Add S2 DOM option-audit parity guards for slot outlet scoped CSS behavior.
- Add structural handler-cache parity coverage across once, memo, slot, outlet, v-if, and v-for positions.

## Validation
- `cargo test -p vize_atelier_dom --test davinci_s2_option_audit -- --nocapture`
- `cargo fmt --check`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791174179&installation_model_id=422833&pr_number=5712&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5712&signature=678441a9de24f9e1c51f58c3711dcf900e73bf09fcf71c034b4b9ea1ed1f0234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->