### PR TITLE
test(vscode): share host feature reset keys

### DIFF
--- a/editors/vscode/test/suite/auto-insert-smoke.cjs
+++ b/editors/vscode/test/suite/auto-insert-smoke.cjs
@@ -2,32 +2,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const vscode = require("vscode");
-
-const featureSettingKeys = [
-  "lint.enable",
-  "diagnostics.enable",
-  "typecheck.enable",
-  "editor.enable",
-  "ecosystem.enable",
-  "optionsApi.enable",
-  "legacyVue2.enable",
-  "completion.enable",
-  "hover.enable",
-  "definition.enable",
-  "references.enable",
-  "documentSymbols.enable",
-  "workspaceSymbols.enable",
-  "codeActions.enable",
-  "rename.enable",
-  "codeLens.enable",
-  "formatting.enable",
-  "semanticTokens.enable",
-  "documentLinks.enable",
-  "foldingRanges.enable",
-  "inlayHints.enable",
-  "fileRename.enable",
-  "autoInsert.enable",
-];
+const { featureSettingKeys } = require("./extension-host-fixtures.cjs");
 
 exports.runAutoInsertSmoke = async function runAutoInsertSmoke() {
   const { logPath, serverPath } = getFakeServer();

--- a/editors/vscode/test/suite/real-server-support.cjs
+++ b/editors/vscode/test/suite/real-server-support.cjs
@@ -2,34 +2,7 @@ const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
 const vscode = require("vscode");
-
-// Every `vize.<key>.enable` switch the extension maps onto an LSP
-// initialization option. The real-server suites reset all of them so a run
-// never inherits a previous run's workspace settings.
-const featureSettingKeys = [
-  "lint.enable",
-  "diagnostics.enable",
-  "typecheck.enable",
-  "editor.enable",
-  "ecosystem.enable",
-  "optionsApi.enable",
-  "legacyVue2.enable",
-  "completion.enable",
-  "hover.enable",
-  "definition.enable",
-  "references.enable",
-  "documentSymbols.enable",
-  "workspaceSymbols.enable",
-  "codeActions.enable",
-  "rename.enable",
-  "codeLens.enable",
-  "formatting.enable",
-  "semanticTokens.enable",
-  "documentLinks.enable",
-  "foldingRanges.enable",
-  "inlayHints.enable",
-  "fileRename.enable",
-];
+const { featureSettingKeys } = require("./extension-host-fixtures.cjs");
 
 function assertPackagedExtension(extension) {
   const extensionsPath = getRequiredPath(

--- a/tests/tooling/vscode-host-feature-reset.test.ts
+++ b/tests/tooling/vscode-host-feature-reset.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import { createRequire } from "node:module";
+import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -8,20 +9,120 @@ import { FEATURE_SETTING_KEYS } from "../../editors/vscode/src/extension-core.ts
 
 const require = createRequire(import.meta.url);
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const moduleRuntime = require("node:module") as {
+  _load: (request: string, parent: unknown, isMain: boolean) => unknown;
+};
 const { featureSettingKeys } =
   require("../../editors/vscode/test/suite/extension-host-fixtures.cjs") as {
     featureSettingKeys: string[];
   };
 
-test("VS Code host smokes reset every extension feature switch before starting a server", () => {
+test("VS Code host smokes reset every extension feature switch before starting a server", async () => {
   assert.deepEqual([...featureSettingKeys].sort(), [...FEATURE_SETTING_KEYS].sort());
 
-  for (const relativePath of [
-    "editors/vscode/test/suite/auto-insert-smoke.cjs",
-    "editors/vscode/test/suite/real-server-support.cjs",
-  ]) {
-    const source = fs.readFileSync(path.join(root, relativePath), "utf8");
-    assert.match(source, /require\("\.\/extension-host-fixtures\.cjs"\)/, relativePath);
-    assert.doesNotMatch(source, /const featureSettingKeys\s*=\s*\[/, relativePath);
+  const realServerUpdates: ConfigurationUpdate[] = [];
+  const { prepareConfiguredRealServer } = requireWithVscodeStub(
+    "../../editors/vscode/test/suite/real-server-support.cjs",
+    createVscodeStub(realServerUpdates),
+  ) as {
+    prepareConfiguredRealServer: (serverPath: string) => Promise<void>;
+  };
+  await prepareConfiguredRealServer("/tmp/vize-language-server");
+  assertClearsEveryFeatureSwitch(realServerUpdates, "real server support");
+
+  const autoInsertUpdates: ConfigurationUpdate[] = [];
+  const stopAfterReset = new Error("stop after feature reset");
+  const { runAutoInsertSmoke } = requireWithVscodeStub(
+    "../../editors/vscode/test/suite/auto-insert-smoke.cjs",
+    createVscodeStub(autoInsertUpdates, stopAfterReset),
+  ) as {
+    runAutoInsertSmoke: () => Promise<void>;
+  };
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "vize-vscode-feature-reset-"));
+  const serverPath = path.join(tmp, "server.cjs");
+  const logPath = path.join(tmp, "server.log");
+  const previousServerPath = process.env.VIZE_TEST_SERVER_PATH;
+  const previousServerLog = process.env.VIZE_TEST_SERVER_LOG;
+  fs.writeFileSync(serverPath, "");
+  try {
+    process.env.VIZE_TEST_SERVER_PATH = serverPath;
+    process.env.VIZE_TEST_SERVER_LOG = logPath;
+    await assert.rejects(
+      () => runAutoInsertSmoke(),
+      (error) => error === stopAfterReset,
+    );
+  } finally {
+    if (previousServerPath === undefined) {
+      delete process.env.VIZE_TEST_SERVER_PATH;
+    } else {
+      process.env.VIZE_TEST_SERVER_PATH = previousServerPath;
+    }
+    if (previousServerLog === undefined) {
+      delete process.env.VIZE_TEST_SERVER_LOG;
+    } else {
+      process.env.VIZE_TEST_SERVER_LOG = previousServerLog;
+    }
+    fs.rmSync(tmp, { force: true, recursive: true });
   }
+  assertClearsEveryFeatureSwitch(autoInsertUpdates, "auto insert smoke");
 });
+
+type ConfigurationUpdate = {
+  key: string;
+  target: unknown;
+  value: unknown;
+};
+
+function requireWithVscodeStub(relativePath: string, vscode: unknown) {
+  const modulePath = require.resolve(relativePath);
+  delete require.cache[modulePath];
+  const load = moduleRuntime._load;
+  moduleRuntime._load = (request, parent, isMain) =>
+    request === "vscode" ? vscode : load(request, parent, isMain);
+  try {
+    return require(modulePath);
+  } finally {
+    moduleRuntime._load = load;
+  }
+}
+
+function createVscodeStub(updates: ConfigurationUpdate[], openTextDocumentError?: Error) {
+  const workspaceTarget = Symbol("workspace");
+  return {
+    ConfigurationTarget: { Workspace: workspaceTarget },
+    Uri: {
+      file: (fsPath: string) => ({ fsPath }),
+    },
+    workspace: {
+      getConfiguration(section: string) {
+        assert.equal(section, "vize");
+        return {
+          async update(key: string, value: unknown, target: unknown) {
+            updates.push({ key, target, value });
+          },
+        };
+      },
+      openTextDocument() {
+        if (openTextDocumentError) {
+          throw openTextDocumentError;
+        }
+        assert.fail("openTextDocument is outside this reset contract");
+      },
+      workspaceFolders: [{ uri: { fsPath: root } }],
+    },
+  };
+}
+
+function assertClearsEveryFeatureSwitch(updates: ConfigurationUpdate[], label: string) {
+  const missing = FEATURE_SETTING_KEYS.filter(
+    (key) => !updates.some((update) => update.key === key && update.value === undefined),
+  );
+  assert.deepEqual(missing, [], `${label} must clear every feature switch`);
+  for (const key of FEATURE_SETTING_KEYS) {
+    assert.equal(
+      updates.filter((update) => update.key === key && update.value === undefined).length,
+      1,
+      `${label} must clear ${key} exactly once`,
+    );
+  }
+}

--- a/tests/tooling/vscode-host-feature-reset.test.ts
+++ b/tests/tooling/vscode-host-feature-reset.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { FEATURE_SETTING_KEYS } from "../../editors/vscode/src/extension-core.ts";
+
+const require = createRequire(import.meta.url);
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const { featureSettingKeys } =
+  require("../../editors/vscode/test/suite/extension-host-fixtures.cjs") as {
+    featureSettingKeys: string[];
+  };
+
+test("VS Code host smokes reset every extension feature switch before starting a server", () => {
+  assert.deepEqual([...featureSettingKeys].sort(), [...FEATURE_SETTING_KEYS].sort());
+
+  for (const relativePath of [
+    "editors/vscode/test/suite/auto-insert-smoke.cjs",
+    "editors/vscode/test/suite/real-server-support.cjs",
+  ]) {
+    const source = fs.readFileSync(path.join(root, relativePath), "utf8");
+    assert.match(source, /require\("\.\/extension-host-fixtures\.cjs"\)/, relativePath);
+    assert.doesNotMatch(source, /const featureSettingKeys\s*=\s*\[/, relativePath);
+  }
+});


### PR DESCRIPTION
## Summary

- Add a tooling oracle that keeps VS Code host smoke reset keys equal to the extension feature-switch contract.
- Make the auto-insert and real-server host helpers reuse the shared host fixture keys instead of carrying duplicated lists.

## Validation

- `node --test tests/tooling/vscode-host-feature-reset.test.ts tests/tooling/vscode-extension-core-behavior.test.ts tests/tooling/vscode-host-test-commands.test.ts tests/tooling/vscode-packaged-host-result.test.ts`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --max-lines 350 --limit 5 --base-ref origin/main`
- `git diff --check origin/main`
- `oxfmt --check tests/tooling/vscode-host-feature-reset.test.ts editors/vscode/test/suite/auto-insert-smoke.cjs editors/vscode/test/suite/real-server-support.cjs`

Refs #3956.
Refs #3957.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791175029&installation_model_id=422833&pr_number=5713&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5713&signature=a7c89c02493d9c8df2d90b6e47002042737932b039a650dbdba3e48147e47a8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved VS Code smoke-test coverage by verifying that all feature switches are reset consistently.
  * Added validation that feature settings are sourced from a shared list across test scenarios.
* **Refactor**
  * Consolidated feature-setting definitions used by VS Code test tooling without changing available settings or externally visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->