### PR TITLE
test(davinci): pin s2 dynamic bind option surface

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_dynamic_bind_options.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_dynamic_bind_options.rs
@@ -1,0 +1,108 @@
+//! P2-11 witness: dynamic `v-bind` modifier keys under the production
+//! option bundle. Default-lane tests cover the modifier spelling; this
+//! keeps the S2 DOM emitter aligned when module output, prefixing,
+//! binding metadata, TypeScript erasure, scoped CSS and cached handlers
+//! all share the same props object.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use vize_atelier_core::options::{BindingMetadata, BindingType, CodegenMode, CodegenOptions};
+use vize_atelier_dom::DomCompilerOptions;
+use vize_s1_to_s2::{BindingTable, DomEmitMode, DomEmitOptions};
+
+const SCOPE_ID: &str = "data-v-dyn";
+
+const BATTERY: &[(&str, &str)] = &[
+    (
+        "native_dynamic_camel_scoped",
+        r#"<div :[key].camel="value"></div>"#,
+    ),
+    (
+        "native_dynamic_prop_attr_ts_handler",
+        r#"<input :[key].prop.attr="value as any" @change="track(value)">"#,
+    ),
+    (
+        "component_dynamic_template_literal_camel",
+        r#"<Widget :[`data-${id}`].camel="value" :title="title" />"#,
+    ),
+    (
+        "component_v_for_dynamic_prop_key",
+        r#"<Widget v-for="item in items" :key="item.id" :[field].prop="item.value" />"#,
+    ),
+    (
+        "slot_outlet_dynamic_camel_scoped",
+        r#"<slot :[slotProp].camel="value" name="row">fallback {{ title }}</slot>"#,
+    ),
+    (
+        "spread_then_dynamic_attr",
+        r#"<div v-bind="bag" :[key].attr="value"></div>"#,
+    ),
+];
+
+fn metadata() -> BindingMetadata {
+    support::bindings::script_setup_metadata(&[
+        ("key", BindingType::SetupRef),
+        ("value", BindingType::SetupMaybeRef),
+        ("track", BindingType::SetupConst),
+        ("Widget", BindingType::SetupConst),
+        ("id", BindingType::SetupLet),
+        ("title", BindingType::Props),
+        ("items", BindingType::SetupConst),
+        ("field", BindingType::SetupRef),
+        ("slotProp", BindingType::SetupRef),
+        ("bag", BindingType::SetupLet),
+    ])
+}
+
+fn dom_options(metadata: &BindingMetadata, inline: bool) -> DomCompilerOptions {
+    DomCompilerOptions {
+        mode: CodegenMode::Module,
+        prefix_identifiers: true,
+        inline,
+        cache_handlers: true,
+        scope_id: Some(SCOPE_ID.into()),
+        binding_metadata: Some(metadata.clone()),
+        is_ts: true,
+        ..Default::default()
+    }
+}
+
+fn emit_options<'a>(table: &'a BindingTable, inline: bool) -> DomEmitOptions<'a> {
+    DomEmitOptions {
+        mode: DomEmitMode::Module,
+        prefix_identifiers: true,
+        inline,
+        cache_handlers: true,
+        scope_id: Some(SCOPE_ID),
+        bindings: Some(table),
+        is_ts: true,
+        ..DomEmitOptions::DEFAULT
+    }
+}
+
+fn assert_dynamic_bind_options(inline: bool) {
+    let metadata = metadata();
+    let table = support::bindings::binding_table(&metadata);
+    support::assert_s2_matches_shipped_with_options(
+        BATTERY,
+        &dom_options(&metadata, inline),
+        &CodegenOptions::default(),
+        &emit_options(&table, inline),
+    );
+}
+
+#[test]
+fn dynamic_bind_modifiers_match_the_script_setup_option_bundle() {
+    assert_dynamic_bind_options(false);
+}
+
+#[test]
+fn dynamic_bind_modifiers_match_the_inline_script_setup_option_bundle() {
+    assert_dynamic_bind_options(true);
+}


### PR DESCRIPTION
## Summary
- add a focused P2-11 S2 DOM parity witness for dynamic `v-bind` modifier keys under the production option bundle
- cover native, component, slot outlet, and spread cases across module and inline script-setup output

## Validation
- `TMPDIR=$PWD/target/vize-tests/tmp TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp cargo test -p vize_atelier_dom --test davinci_s2_dynamic_bind_options -- --nocapture`
- `cargo fmt --check`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791175123&installation_model_id=422833&pr_number=5714&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5714&signature=1a7a59551af0dd14f5133d0218ff596c391a21dce2f24680f60d2ddc5572c460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage verifying consistent handling of dynamic `v-bind` modifier keys across DOM compilation and emission.
  - Tests include native elements, components, loops, slots, spread attributes, and both inline and non-inline modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->