### PR TITLE
test(canon): cover content mapper watch diagnostics

### DIFF
--- a/.github/workflows/content-mapper-conformance.yml
+++ b/.github/workflows/content-mapper-conformance.yml
@@ -14,6 +14,7 @@ on:
       - "crates/vize/tests/content_mapper_tsgo_cli.rs"
       - "crates/vize/tests/content_mapper_tsgo_directives.rs"
       - "crates/vize/tests/content_mapper_tsgo_build.rs"
+      - "crates/vize/tests/content_mapper_tsgo_watch.rs"
       - "crates/vize/tests/content_mapper_importer_scoped_packages.rs"
       - "crates/vize/tests/check_*package*.rs"
       - "crates/vize/tests/check_*package*/**"
@@ -73,6 +74,7 @@ on:
       - "crates/vize/tests/content_mapper_tsgo_cli.rs"
       - "crates/vize/tests/content_mapper_tsgo_directives.rs"
       - "crates/vize/tests/content_mapper_tsgo_build.rs"
+      - "crates/vize/tests/content_mapper_tsgo_watch.rs"
       - "crates/vize/tests/content_mapper_importer_scoped_packages.rs"
       - "crates/vize/tests/check_*package*.rs"
       - "crates/vize/tests/check_*package*/**"
@@ -221,6 +223,7 @@ jobs:
           cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture
           cargo test -p vize --test content_mapper_tsgo_directives -- --nocapture
           cargo test -p vize --test content_mapper_tsgo_build -- --nocapture
+          cargo test -p vize --test content_mapper_tsgo_watch -- --nocapture
           cargo test -p vize --test content_mapper_importer_scoped_packages -- --nocapture
       - name: Run importer-scoped package resolution matrix
         env:

--- a/crates/vize/tests/content_mapper_tsgo_watch.rs
+++ b/crates/vize/tests/content_mapper_tsgo_watch.rs
@@ -1,0 +1,219 @@
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc::{Receiver, channel};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::json;
+
+const TSGO_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_TSGO";
+const VUE_ENV: &str = "VIZE_TEST_CONTENT_MAPPER_VUE";
+
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root should exist")
+}
+
+fn copy_fixture(source: &Path, destination: &Path) {
+    std::fs::create_dir_all(destination).unwrap();
+    for entry in std::fs::read_dir(source).unwrap() {
+        let entry = entry.unwrap();
+        if entry.file_name() == "node_modules" {
+            continue;
+        }
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_fixture(&source_path, &destination_path);
+        } else {
+            std::fs::copy(source_path, destination_path).unwrap();
+        }
+    }
+}
+
+fn install_packages(project_root: &Path) {
+    let mapper_root = project_root.join("node_modules/vize");
+    std::fs::create_dir_all(&mapper_root).unwrap();
+    std::fs::write(
+        mapper_root.join("package.json"),
+        serde_json::to_vec_pretty(&json!({
+            "name": "vize",
+            "private": true,
+            "typescript": {
+                "contentMapper": {
+                    "exec": [env!("CARGO_BIN_EXE_vize"), "content-mapper"],
+                    "compilerOptions": ["noUnusedLocals"],
+                },
+            },
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let vue_source = std::env::var_os(VUE_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let store = workspace_root().join("node_modules/.pnpm");
+            let mut candidates = std::fs::read_dir(&store)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", store.display()))
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_name().to_string_lossy().starts_with("vue@3."))
+                .map(|entry| entry.path().join("node_modules/vue"))
+                .filter(|path| path.join("package.json").is_file())
+                .collect::<Vec<_>>();
+            candidates.sort();
+            candidates.pop().unwrap_or_else(|| {
+                panic!(
+                    "no Vue 3 package found under {}; set {VUE_ENV}",
+                    store.display()
+                )
+            })
+        });
+    assert!(vue_source.join("package.json").is_file());
+    let vue_target = project_root.join("node_modules/vue");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(vue_source, vue_target).unwrap();
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_dir(vue_source, vue_target).unwrap();
+}
+
+struct WatchProcess {
+    child: Child,
+    output: String,
+    receiver: Receiver<String>,
+}
+
+impl WatchProcess {
+    fn spawn(tsgo: &Path, project_root: &Path, config: &str) -> Self {
+        let mut child = Command::new(tsgo)
+            .current_dir(project_root)
+            .args([
+                "--runExternalCode",
+                "--watch",
+                "-p",
+                config,
+                "--pretty",
+                "false",
+                "--watchFile",
+                "FixedPollingInterval",
+                "--watchDirectory",
+                "FixedPollingInterval",
+            ])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap_or_else(|error| panic!("failed to run {}: {error}", tsgo.display()));
+        let stdout = child.stdout.take().expect("watch stdout");
+        let stderr = child.stderr.take().expect("watch stderr");
+        let (sender, receiver) = channel();
+        for mut stream in [
+            Box::new(stdout) as Box<dyn std::io::Read + Send>,
+            Box::new(stderr) as Box<dyn std::io::Read + Send>,
+        ] {
+            let sender = sender.clone();
+            thread::spawn(move || {
+                let mut buffer = [0; 4096];
+                loop {
+                    match stream.read(&mut buffer) {
+                        Ok(0) => break,
+                        Ok(count) => {
+                            let chunk = String::from_utf8_lossy(&buffer[..count]).into_owned();
+                            if sender.send(chunk).is_err() {
+                                break;
+                            }
+                        }
+                        Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+                        Err(_) => break,
+                    }
+                }
+            });
+        }
+        Self {
+            child,
+            output: String::new(),
+            receiver,
+        }
+    }
+
+    fn wait_for(&mut self, start: usize, label: &str, predicate: impl Fn(&str) -> bool) {
+        let deadline = Instant::now() + Duration::from_secs(45);
+        while Instant::now() < deadline {
+            match self.receiver.recv_timeout(Duration::from_millis(200)) {
+                Ok(chunk) => self.output.push_str(&chunk),
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+            if predicate(&self.output[start..]) {
+                return;
+            }
+            if let Some(status) = self.child.try_wait().unwrap() {
+                panic!("watch exited before {label}: {status}\n{}", self.output);
+            }
+        }
+        panic!("timed out waiting for {label}\n{}", self.output);
+    }
+
+    fn assert_running(&mut self) {
+        assert!(
+            self.child.try_wait().unwrap().is_none(),
+            "watch exited after reaching idle state\n{}",
+            self.output
+        );
+    }
+}
+
+impl Drop for WatchProcess {
+    fn drop(&mut self) {
+        if self.child.try_wait().unwrap().is_none() {
+            let _ = self.child.kill();
+        }
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn standard_tsgo_watch_enters_idle_with_authored_mapper_diagnostics() {
+    let Some(tsgo) = std::env::var_os(TSGO_ENV).map(PathBuf::from) else {
+        eprintln!("skipping exact Content Mapper watch conformance: {TSGO_ENV} is not set");
+        return;
+    };
+    assert!(
+        tsgo.is_file(),
+        "{TSGO_ENV} is not a file: {}",
+        tsgo.display()
+    );
+
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/content_mapper_project");
+    let cases_root = workspace_root().join("target/vize-tests/tests");
+    std::fs::create_dir_all(&cases_root).unwrap();
+    let project = tempfile::Builder::new()
+        .prefix("content-mapper-watch-")
+        .tempdir_in(cases_root)
+        .unwrap();
+    copy_fixture(&fixture, project.path());
+    install_packages(project.path());
+
+    let mut clean = WatchProcess::spawn(&tsgo, project.path(), "tsconfig.json");
+    clean.wait_for(0, "clean watch idle state", |output| {
+        output.contains("Found 0 errors")
+            && output.contains("Watching for file changes")
+            && !output.contains("error TS")
+    });
+    clean.assert_running();
+    drop(clean);
+
+    let mut broken = WatchProcess::spawn(&tsgo, project.path(), "tsconfig.error.json");
+    broken.wait_for(0, "broken watch idle state", |output| {
+        output.contains("errors/Broken.vue")
+            && output.contains("TS2322")
+            && output.contains("not assignable to type 'number'")
+            && output.contains("src/Unused.vue")
+            && output.contains("TS6133")
+            && output.contains("Watching for file changes")
+    });
+    broken.assert_running();
+}

--- a/tests/tooling/content-mapper-workflow.test.ts
+++ b/tests/tooling/content-mapper-workflow.test.ts
@@ -33,6 +33,7 @@ const REQUIRED_TRIGGER_PATHS = [
   "crates/vize/tests/content_mapper_tsgo_cli.rs",
   "crates/vize/tests/content_mapper_tsgo_directives.rs",
   "crates/vize/tests/content_mapper_tsgo_build.rs",
+  "crates/vize/tests/content_mapper_tsgo_watch.rs",
   "crates/vize/tests/content_mapper_importer_scoped_packages.rs",
   "crates/vize/tests/check_*package*.rs",
   "crates/vize/tests/check_*package*/**",
@@ -190,6 +191,7 @@ test("Content Mapper conformance pins and runs the exact upstream project path",
   assert.match(job, /cargo test -p vize --test content_mapper_tsgo_cli -- --nocapture/);
   assert.match(job, /cargo test -p vize --test content_mapper_tsgo_directives -- --nocapture/);
   assert.match(job, /cargo test -p vize --test content_mapper_tsgo_build -- --nocapture/);
+  assert.match(job, /cargo test -p vize --test content_mapper_tsgo_watch -- --nocapture/);
   assert.match(job, /vp run --filter '\.\/npm\/native' build:ci/);
   assert.match(job, /\(cd npm\/cli && vp pack\)/);
   assert.match(job, /vp exec napi create-npm-dirs/);


### PR DESCRIPTION
## Summary
- add an exact tsgo `--watch` Content Mapper oracle for the mixed Vue fixture
- assert clean watch startup reaches idle with zero errors
- assert broken watch startup reports authored Vue diagnostics before staying in watch mode
- wire the new test into the Content Mapper Conformance workflow and its workflow contract test

Refs #3984.

## Validation
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/vize-content-mapper-tsgo cargo test -p vize --test content_mapper_tsgo_watch -- --nocapture`
- `VIZE_TEST_CONTENT_MAPPER_TSGO=/private/tmp/vize-content-mapper-tsgo cargo test -p vize --test content_mapper_tsgo_build -- --nocapture`
- `node --test tests/tooling/content-mapper-workflow.test.ts`
- `cargo fmt --all --check`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791175132&installation_model_id=422833&pr_number=5715&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5715&signature=dc587d8ef7398e97e510d51c1ab7c77903e0fa1ed4e753e467b13884fb6c07df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->