### PR TITLE
test(lsp): pin absent implementation capability

### DIFF
--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -85,6 +85,7 @@ fn default_features_advertise_non_opinionated_providers() {
     assert!(capabilities.document_formatting_provider.is_none());
     assert!(capabilities.document_range_formatting_provider.is_none());
     assert!(capabilities.document_on_type_formatting_provider.is_none());
+    assert!(capabilities.implementation_provider.is_none());
 }
 
 /// The trigger set is `@vue/language-server`'s, character for character, so an
@@ -177,6 +178,7 @@ fn all_features_skip_unimplemented_providers_and_keep_implemented_ones() {
             .and_then(|workspace| workspace.file_operations)
             .is_some()
     );
+    assert!(capabilities.implementation_provider.is_none());
 }
 
 #[test]

--- a/tests/tooling/lsp-implementation-capability.test.ts
+++ b/tests/tooling/lsp-implementation-capability.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { firstLocation, offsetToPosition } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { ServerCapabilities } from "./support/lsp/protocol.ts";
+import { LspRequestError, LspSession } from "./support/lsp/session.ts";
+
+const source = `<script setup lang="ts">
+const message = "hello"
+</script>
+
+<template>
+  <span>{{ message }}</span>
+</template>
+`;
+
+type ImplementationCapabilities = ServerCapabilities & {
+  implementationProvider?: unknown;
+};
+
+test("vize lsp keeps textDocument/implementation fail-closed until #3953 implements it", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-implementation-capability");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const filePath = path.join(workspaceDir, "Widget.vue");
+  const uri = pathToFileURL(filePath).href;
+  const session = new LspSession();
+
+  try {
+    const init = (await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: false,
+    })) as { capabilities?: ImplementationCapabilities };
+    assert.equal(init.capabilities?.implementationProvider, undefined);
+
+    fs.writeFileSync(filePath, source, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: source },
+    });
+
+    const position = offsetToPosition(source, source.lastIndexOf("message }}</span>") + 3);
+    await assert.rejects(
+      session.request("textDocument/implementation", {
+        textDocument: { uri },
+        position,
+      }),
+      (error) =>
+        error instanceof LspRequestError &&
+        error.method === "textDocument/implementation" &&
+        error.code === -32601,
+    );
+
+    const definition = (await session.request("textDocument/definition", {
+      textDocument: { uri },
+      position,
+    })) as Array<{ uri: string; range: { start: { line: number; character: number } } }>;
+    const location = firstLocation(definition);
+    assert.equal(location.uri, uri);
+    assert.deepEqual(location.range.start, offsetToPosition(source, source.indexOf("message =")));
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a focused LSP oracle for textDocument/implementation staying fail-closed until #3953 implements it
- assert implementationProvider remains absent from Maestro capability contracts

## Validation
- VIZE_LSP_BIN=$PWD/target/debug/vize TMPDIR=$PWD/target/vize-tests/tmp TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp node --test tests/tooling/lsp-implementation-capability.test.ts tests/tooling/lsp-capabilities.test.ts
- TMPDIR=$PWD/target/vize-tests/tmp TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp cargo test -p vize_maestro server::capabilities
- cargo fmt --all --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10
- git diff --cached --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791175392&installation_model_id=422833&pr_number=5716&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5716&signature=fb174ffdd2c04eb89b6669da7ba7783cc336778e4bfb5e718de0c1aaf40b4f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->