### PR TITLE
fix(patina): avoid leading v-for alias false positives

### DIFF
--- a/crates/vize_croquis/src/croquis/model.rs
+++ b/crates/vize_croquis/src/croquis/model.rs
@@ -6,7 +6,7 @@
 use super::Croquis;
 use super::bindings::UnusedTemplateVar;
 use super::bindings::UnusedVarContext;
-use crate::scope::{ScopeData, ScopeKind};
+use crate::scope::{ScopeBinding, ScopeData, ScopeKind, VForScopeData};
 use vize_carton::CompactString;
 use vize_relief::BindingType;
 
@@ -169,8 +169,6 @@ impl Croquis {
 
     /// Get unused template variables (v-for, v-slot variables that are not used)
     pub fn unused_template_vars(&self) -> Vec<UnusedTemplateVar> {
-        use crate::scope::{ScopeData, ScopeKind};
-
         let mut unused = Vec::new();
 
         for scope in self.scopes.iter() {
@@ -183,6 +181,12 @@ impl Croquis {
                 if !binding.is_used() {
                     let context = match scope.data() {
                         ScopeData::VFor(data) => {
+                            if !is_reportable_unused_v_for_alias(name, data, |alias| {
+                                scope.get_binding(alias).is_some_and(ScopeBinding::is_used)
+                            }) {
+                                continue;
+                            }
+
                             // Determine which kind of variable this is
                             if data
                                 .value_bindings
@@ -237,6 +241,79 @@ impl Croquis {
             unused_binding_count: self.unused_bindings.len(),
         }
     }
+}
+
+fn is_reportable_unused_v_for_alias(
+    name: &str,
+    data: &VForScopeData,
+    mut is_used: impl FnMut(&str) -> bool,
+) -> bool {
+    let Some(position) = v_for_alias_position(name, data) else {
+        return true;
+    };
+
+    match position {
+        VForAliasPosition::Value if is_simple_value_alias(name, data) => {
+            !v_for_alias_used_after(VForAliasPosition::Value, data, &mut is_used)
+        }
+        VForAliasPosition::Value => true,
+        VForAliasPosition::Key => {
+            !v_for_alias_used_after(VForAliasPosition::Key, data, &mut is_used)
+        }
+        VForAliasPosition::Index => true,
+    }
+}
+
+fn is_simple_value_alias(name: &str, data: &VForScopeData) -> bool {
+    data.value_bindings.len() == 1 && data.value_alias.as_str() == name
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum VForAliasPosition {
+    Value,
+    Key,
+    Index,
+}
+
+fn v_for_alias_position(name: &str, data: &VForScopeData) -> Option<VForAliasPosition> {
+    if data
+        .value_bindings
+        .iter()
+        .any(|value| value.as_str() == name)
+    {
+        return Some(VForAliasPosition::Value);
+    }
+    if data
+        .key_alias
+        .as_ref()
+        .is_some_and(|key| key.as_str() == name)
+    {
+        return Some(VForAliasPosition::Key);
+    }
+    if data
+        .index_alias
+        .as_ref()
+        .is_some_and(|index| index.as_str() == name)
+    {
+        return Some(VForAliasPosition::Index);
+    }
+    None
+}
+
+fn v_for_alias_used_after(
+    position: VForAliasPosition,
+    data: &VForScopeData,
+    is_used: &mut impl FnMut(&str) -> bool,
+) -> bool {
+    let key_is_later_used = position < VForAliasPosition::Key
+        && data.key_alias.as_ref().is_some_and(|key| is_used(key));
+    let index_is_later_used = position < VForAliasPosition::Index
+        && data
+            .index_alias
+            .as_ref()
+            .is_some_and(|index| is_used(index));
+
+    key_is_later_used || index_is_later_used
 }
 
 /// Statistics about a croquis.

--- a/crates/vize_croquis/src/drawer/template/directives/control_flow.rs
+++ b/crates/vize_croquis/src/drawer/template/directives/control_flow.rs
@@ -5,9 +5,9 @@
 
 use crate::ScopeBinding;
 use crate::drawer::Drawer;
-use crate::drawer::helpers::build_branch_guard;
+use crate::drawer::helpers::{VForScopeAliases, build_branch_guard, parse_v_for_scope_expression};
 use crate::scope::VForScopeData;
-use vize_carton::{CompactString, SmallVec, profile, smallvec};
+use vize_carton::{CompactString, SmallVec, appends, profile};
 use vize_relief::BindingType;
 use vize_relief::{ExpressionNode, ForNode, IfNode, PropNode};
 
@@ -88,32 +88,32 @@ impl Drawer {
         for_node: &ForNode<'_>,
         scope_vars: &mut Vec<CompactString>,
     ) {
-        let vars_added = profile!(
-            "croquis.template.v_for.extract_vars",
-            self.extract_for_vars(for_node)
-        );
+        let aliases = self.options.analyze_template_scopes.then(|| {
+            profile!(
+                "croquis.template.v_for.parse_scope_aliases",
+                self.extract_for_scope_aliases(for_node)
+            )
+        });
+        let vars_added = aliases
+            .as_ref()
+            .and_then(Option::as_ref)
+            .map(v_for_scope_bindings)
+            .unwrap_or_else(|| {
+                profile!(
+                    "croquis.template.v_for.extract_vars",
+                    self.extract_for_vars(for_node)
+                )
+            });
         let vars_count = vars_added.len();
 
-        if self.options.analyze_template_scopes && !vars_added.is_empty() {
-            let source_content = match &for_node.source {
-                ExpressionNode::Simple(s) => CompactString::new(s.content),
-                ExpressionNode::Compound(c) => {
-                    CompactString::new(c.loc.span.slice(&self.template_source))
-                }
-            };
-
-            let value_alias = vars_added
-                .first()
-                .cloned()
-                .unwrap_or_else(|| CompactString::const_new("_"));
-
+        if let Some(Some(aliases)) = aliases {
             let scope_id = self.croquis.scopes.enter_v_for_scope(
                 VForScopeData {
-                    value_alias: value_alias.clone(),
-                    value_bindings: smallvec![value_alias],
-                    key_alias: vars_added.get(1).cloned(),
-                    index_alias: vars_added.get(2).cloned(),
-                    source: source_content,
+                    value_alias: aliases.value_pattern,
+                    value_bindings: aliases.value_bindings,
+                    key_alias: aliases.key_alias,
+                    index_alias: aliases.index_alias,
+                    source: aliases.source,
                     key_expression: None,
                 },
                 for_node.loc.span.start,
@@ -176,5 +176,55 @@ impl Drawer {
         }
 
         vars
+    }
+
+    fn extract_for_scope_aliases(&self, for_node: &ForNode<'_>) -> Option<VForScopeAliases> {
+        let value = for_node
+            .value_alias
+            .as_ref()
+            .map(|alias| expression_content(alias, &self.template_source))?;
+        let source = expression_content(&for_node.source, &self.template_source);
+        let alias = match (&for_node.key_alias, &for_node.object_index_alias) {
+            (None, None) => CompactString::new(value),
+            (key, index) => {
+                let key = key
+                    .as_ref()
+                    .map(|alias| expression_content(alias, &self.template_source))
+                    .unwrap_or("");
+                let index = index
+                    .as_ref()
+                    .map(|alias| expression_content(alias, &self.template_source))
+                    .unwrap_or("");
+                let mut alias = CompactString::new("");
+                appends!(alias, "(", value, ", ", key, ", ", index, ")");
+                alias
+            }
+        };
+        let mut expr = CompactString::new("");
+        appends!(expr, &alias, " in ", source);
+        parse_v_for_scope_expression(&expr)
+    }
+}
+
+fn v_for_scope_bindings(aliases: &VForScopeAliases) -> Vec<CompactString> {
+    let mut bindings = Vec::with_capacity(
+        aliases.value_bindings.len()
+            + usize::from(aliases.key_alias.is_some())
+            + usize::from(aliases.index_alias.is_some()),
+    );
+    bindings.extend(aliases.value_bindings.iter().cloned());
+    if let Some(key) = &aliases.key_alias {
+        bindings.push(key.clone());
+    }
+    if let Some(index) = &aliases.index_alias {
+        bindings.push(index.clone());
+    }
+    bindings
+}
+
+fn expression_content<'a>(exp: &'a ExpressionNode<'_>, source: &'a str) -> &'a str {
+    match exp {
+        ExpressionNode::Simple(s) => s.content,
+        ExpressionNode::Compound(c) => c.loc.span.slice(source),
     }
 }

--- a/crates/vize_patina/src/linter/tests/v_for_unused_vars.rs
+++ b/crates/vize_patina/src/linter/tests/v_for_unused_vars.rs
@@ -38,3 +38,53 @@ fn test_lint_template_marks_v_for_alias_used_by_spread_expression() {
 
     assert_eq!(result.warning_count, 0, "{:?}", result.diagnostics);
 }
+
+#[test]
+fn test_lint_template_allows_leading_v_for_alias_when_index_is_used() {
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-vars".to_compact_string()]));
+    let source = r#"<template>
+  <HoverCardRoot v-for="(entry, index) in 20" :key="index">
+    {{ index }}
+  </HoverCardRoot>
+</template>"#;
+    let result = linter.lint_sfc(source, "HoverMultiCard.story.vue");
+
+    assert_eq!(result.warning_count, 0, "{:?}", result.diagnostics);
+}
+
+#[test]
+fn test_lint_template_allows_value_and_key_aliases_when_index_is_used() {
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-vars".to_compact_string()]));
+    let source = r#"<template>
+  <div v-for="(entry, key, index) in items" :key="index">{{ index }}</div>
+</template>"#;
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(result.warning_count, 0, "{:?}", result.diagnostics);
+}
+
+#[test]
+fn test_lint_template_reports_unused_destructured_value_before_used_index() {
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-vars".to_compact_string()]));
+    let source = r#"<template>
+  <div v-for="({ id, label }, index) in items" :key="index">{{ index }}</div>
+</template>"#;
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(result.warning_count, 2, "{:?}", result.diagnostics);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("'id'"))
+    );
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.message.contains("'label'"))
+    );
+}

--- a/tests/snapshots/lint/__snapshots__/reka-ui-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/reka-ui-lint.snap
@@ -3046,17 +3046,6 @@
     "file": "packages/core/src/HoverCard/story/HoverMultiCard.story.vue",
     "messages": [
       {
-        "ruleId": "vue/no-unused-vars",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-unused-vars] Variable 'entry' is defined by v-for but never used",
-        "line": 18,
-        "column": 19,
-        "endLine": 18,
-        "endColumn": 24,
-        "help": "If the variable is intentionally unused, prefix it with underscore: _item"
-      },
-      {
         "ruleId": "vue/require-scoped-style",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -3069,7 +3058,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "packages/core/src/HoverCard/story/_HoverCard.vue",

--- a/tests/tooling/patina-no-unused-vars-oracle.test.ts
+++ b/tests/tooling/patina-no-unused-vars-oracle.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { test } from "node:test";
+
+const repoRoot = path.resolve(import.meta.dirname, "../..");
+const requireFromBench = createRequire(
+  path.join(repoRoot, "tools", "benchmarks", "scripts", "package.json"),
+);
+const { ESLint } = requireFromBench("eslint") as typeof import("eslint");
+const pluginVue = requireFromBench("eslint-plugin-vue");
+const vueParser = requireFromBench("vue-eslint-parser");
+const typescriptParser = requireFromBench("@typescript-eslint/parser");
+
+const cases = [
+  {
+    id: "leading-value-alias-needed-for-index",
+    source: `<template><div v-for="(entry, index) in 20" :key="index">{{ index }}</div></template>`,
+    diagnostics: [],
+  },
+  {
+    id: "leading-value-and-key-aliases-needed-for-index",
+    source: `<template><div v-for="(entry, key, index) in items" :key="index">{{ index }}</div></template>`,
+    diagnostics: [],
+  },
+  {
+    id: "trailing-index-remains-reportable",
+    source: `<template><div v-for="(entry, index) in items" :key="entry">{{ entry }}</div></template>`,
+    diagnostics: ["'index' is defined but never used."],
+  },
+  {
+    id: "destructured-value-bindings-remain-reportable",
+    source: `<template><div v-for="({ id, label }, index) in items" :key="index">{{ index }}</div></template>`,
+    diagnostics: ["'id' is defined but never used.", "'label' is defined but never used."],
+  },
+] as const;
+
+test("no-unused-vars v-for tuple boundary stays pinned to eslint-plugin-vue 10.9.2", async () => {
+  assert.equal(requireFromBench("eslint-plugin-vue/package.json").version, "10.9.2");
+  assert.equal(requireFromBench("vue-eslint-parser/package.json").version, "10.4.1");
+
+  const eslint = new ESLint({
+    cwd: repoRoot,
+    overrideConfigFile: true,
+    overrideConfig: [
+      {
+        files: ["**/*.vue"],
+        languageOptions: {
+          parser: vueParser,
+          parserOptions: {
+            parser: typescriptParser,
+            ecmaVersion: "latest",
+            sourceType: "module",
+            extraFileExtensions: [".vue"],
+          },
+        },
+        plugins: { vue: pluginVue },
+        rules: { "vue/no-unused-vars": "warn" },
+      },
+    ],
+  });
+
+  for (const fixture of cases) {
+    const [result] = await eslint.lintText(fixture.source, {
+      filePath: path.join(repoRoot, "oracle", `${fixture.id}.vue`),
+    });
+    const diagnostics = result.messages
+      .filter((message) => message.ruleId === "vue/no-unused-vars")
+      .map((message) => message.message);
+    const parserErrors = result.messages.filter((message) => message.ruleId == null);
+
+    assert.deepEqual(parserErrors, [], `${fixture.id}: parser errors`);
+    assert.deepEqual(diagnostics, fixture.diagnostics, fixture.id);
+  }
+});


### PR DESCRIPTION
## Summary
- Match eslint-plugin-vue behavior for v-for tuple placeholders used to reach a later key/index alias.
- Keep destructured value aliases reportable and keep structured alias parsing behind template-scope analysis.
- Add Patina regressions, a Node oracle pinned to eslint-plugin-vue 10.9.2, and the reka-ui lint snapshot update.

## Validation
- cargo build -p vize
- cargo clippy -p vize_croquis -- -D warnings -D clippy::wildcard_imports
- cargo test -p vize_patina linter::tests::v_for_unused_vars -- --nocapture
- node --test tests/tooling/patina-no-unused-vars-oracle.test.ts
- VIZE_BIN=/Users/ubugeeei/Source/github.com/ubugeeei/vize--patina-lone-template-boundary/target/debug/vize node --test tests/snapshots/lint/reka-ui.ts
- node legacy-tools/fixtures/lint-divergence-report.mjs --project reka-ui --budget-mode record-only --output-dir target/patina-lint-divergence-reka-final --timeout-ms 600000 --vize-bin target/debug/vize
- cargo fmt -p vize_croquis -p vize_patina --check
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350

## Evidence
- reka-ui no longer reports the HoverMultiCard.story.vue vue/no-unused-vars false positive.
- Remaining reka-ui record-only false positives are four vue/no-template-target-blank findings covered by a separate slice.