### PR TITLE
fix(jsx): lower computed slot names

### DIFF
--- a/crates/vize_atelier_jsx/src/compat.rs
+++ b/crates/vize_atelier_jsx/src/compat.rs
@@ -30,12 +30,10 @@
 //!
 //! `optimize` has no Vize equivalent, because Vize's output is always optimized
 //! — which is what the plugin's `optimize: true` produces. `resolveType` is
-//! deferred, along with one other row:
+//! still deferred:
 //!
 //! - `options/resolve_type_on` — type-driven props/emits inference needs the
 //!   type-resolution work tracked on #1497 / #1502.
-//! - `slots/dynamic_slot_name` — a computed slot name warns and drops; it needs
-//!   dynamic-slot lowering.
 //!
 //! # Compat under SSR output
 //!

--- a/crates/vize_atelier_jsx/src/lower/slot.rs
+++ b/crates/vize_atelier_jsx/src/lower/slot.rs
@@ -105,24 +105,6 @@ impl<'a, 'm, 's: 'a> Lowerer<'a, 'm, 's> {
                 continue;
             };
 
-            if property.computed {
-                self.report(JsxDiagnostic::warning(
-                    "computed JSX slot names are not supported and were ignored",
-                    property.span.start,
-                    property.span.end,
-                ));
-                continue;
-            }
-
-            let Some((slot_name, name_span)) = static_key(&property.key) else {
-                self.report(JsxDiagnostic::warning(
-                    "unsupported JSX slot name; only identifier or string keys are allowed",
-                    property.key.span().start,
-                    property.key.span().end,
-                ));
-                continue;
-            };
-
             let Some(slot_fn) = SlotFn::from_value(&property.value) else {
                 self.report(JsxDiagnostic::warning(
                     "JSX slot values must be a function returning the slot content; ignored",
@@ -132,10 +114,22 @@ impl<'a, 'm, 's: 'a> Lowerer<'a, 'm, 's> {
                 continue;
             };
 
-            // Slot names come out of the parsed module, so they are copied
-            // into the compile arena before reaching the node.
-            let slot_name = self.bump().alloc_str(slot_name);
-            let template = self.build_slot_template(slot_name, name_span, &slot_fn);
+            let template = if property.computed {
+                self.build_dynamic_slot_template(property.key.span(), &slot_fn)
+            } else {
+                let Some((slot_name, name_span)) = static_key(&property.key) else {
+                    self.report(JsxDiagnostic::warning(
+                        "unsupported JSX slot name; only identifier or string keys are allowed",
+                        property.key.span().start,
+                        property.key.span().end,
+                    ));
+                    continue;
+                };
+                // Slot names come out of the parsed module, so they are copied
+                // into the compile arena before reaching the node.
+                let slot_name = self.bump().alloc_str(slot_name);
+                self.build_slot_template(slot_name, name_span, &slot_fn)
+            };
             out.push(TemplateChildNode::Element(Box::new_in(
                 template,
                 &self.bump(),
@@ -183,6 +177,25 @@ impl<'a, 'm, 's: 'a> Lowerer<'a, 'm, 's> {
         }
         node.props.push(PropNode::Directive(self.boxed(directive)));
 
+        node.children = self.extract_fn_slot_body(slot_fn);
+        node
+    }
+
+    fn build_dynamic_slot_template(
+        &mut self,
+        name_span: Span,
+        slot_fn: &SlotFn<'_>,
+    ) -> ElementNode<'a> {
+        let loc = self.mapper().location(slot_fn.span);
+        let mut node = ElementNode::new(self.bump(), "template", loc);
+        node.tag_type = ElementType::Template;
+        let mut directive =
+            DirectiveNode::new(self.bump(), "slot", self.mapper().location(name_span));
+        directive.arg = Some(self.dyn_expr(name_span));
+        if let Some(param_span) = slot_fn.param_span {
+            directive.exp = Some(self.dyn_expr(param_span));
+        }
+        node.props.push(PropNode::Directive(self.boxed(directive)));
         node.children = self.extract_fn_slot_body(slot_fn);
         node
     }

--- a/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md
@@ -55,9 +55,9 @@ numbers cannot drift from the verdict table.
 
 | Verdict    | Rows |
 | ---------- | ---: |
-| equivalent |   98 |
+| equivalent |   99 |
 | divergent  |    0 |
-| deferred   |    2 |
+| deferred   |    1 |
 
 ## Global divergences
 
@@ -219,17 +219,17 @@ it classifies as an intrinsic element but the DOM backend still resolves with
 
 ## Slots
 
-| Case                                 | Babel                                 | Vize today                                     | Compat mode                           | Verdict |
-| ------------------------------------ | ------------------------------------- | ---------------------------------------------- | ------------------------------------- | ------- |
-| `slots/object_children`              | object child becomes the slots object | `withCtx` slots + `_: 1`                       | no change                             | ✅      |
-| `slots/render_prop_child`            | `{default: () => 'foo'}`              | `default: () => [createTextVNode("foo")]`      | no change                             | ✅      |
-| `slots/scoped_param`                 | `default: s => …`                     | `default: withCtx((s) => […])`                 | no change                             | ✅      |
-| `slots/v_slots_with_children`        | `{default: () => […], ...slots}`      | same keys + `1024 /* DYNAMIC_SLOTS */` (#3467) | no change                             | ✅      |
-| `slots/v_slots_only`                 | slots object passed as children       | same + `1024 /* DYNAMIC_SLOTS */` (#3467)      | no change                             | ✅      |
-| `slots/v_slots_object_literal`       | object literal becomes the slots      | `withCtx` slots + `_: 1` (#3418)               | no change                             | ✅      |
-| `slots/v_slots_object_with_children` | `{default: () => […], bar: …}`        | same two slots, other literal order (#3418)    | no change                             | ✅      |
-| `slots/element_children_default`     | `{default: () => […]}`                | `withCtx` default slot + `_: 1`                | no change                             | ✅      |
-| `slots/dynamic_slot_name`            | `{[n]: () => …}`                      | warns and drops the slot                       | deferred: needs dynamic-slot lowering | ⏸       |
+| Case                                 | Babel                                 | Vize today                                     | Compat mode | Verdict |
+| ------------------------------------ | ------------------------------------- | ---------------------------------------------- | ----------- | ------- |
+| `slots/object_children`              | object child becomes the slots object | `withCtx` slots + `_: 1`                       | no change   | ✅      |
+| `slots/render_prop_child`            | `{default: () => 'foo'}`              | `default: () => [createTextVNode("foo")]`      | no change   | ✅      |
+| `slots/scoped_param`                 | `default: s => …`                     | `default: withCtx((s) => […])`                 | no change   | ✅      |
+| `slots/v_slots_with_children`        | `{default: () => […], ...slots}`      | same keys + `1024 /* DYNAMIC_SLOTS */` (#3467) | no change   | ✅      |
+| `slots/v_slots_only`                 | slots object passed as children       | same + `1024 /* DYNAMIC_SLOTS */` (#3467)      | no change   | ✅      |
+| `slots/v_slots_object_literal`       | object literal becomes the slots      | `withCtx` slots + `_: 1` (#3418)               | no change   | ✅      |
+| `slots/v_slots_object_with_children` | `{default: () => […], bar: …}`        | same two slots, other literal order (#3418)    | no change   | ✅      |
+| `slots/element_children_default`     | `{default: () => […]}`                | `withCtx` default slot + `_: 1`                | no change   | ✅      |
+| `slots/dynamic_slot_name`            | `{[n]: () => …}`                      | dynamic slot key + patch flag                  | no change   | ✅      |
 
 ### Forwarding an opaque slots object (#3467)
 

--- a/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs
@@ -102,10 +102,7 @@ pub const VERDICTS: &[(&str, Verdict)] = &[
     ("slots/v_slots_object_literal", Same),
     ("slots/v_slots_object_with_children", Same),
     ("slots/element_children_default", Same),
-    (
-        "slots/dynamic_slot_name",
-        Todo("computed slot names warn and drop; needs dynamic-slot lowering"),
-    ),
+    ("slots/dynamic_slot_name", Same),
     // -- children --------------------------------------------------------
     ("children/static_text", Same),
     ("children/text_interp_mix", Same),

--- a/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
+++ b/crates/vize_atelier_jsx/tests/babel_compat_oracle.rs
@@ -80,7 +80,7 @@ fn babel_compat_verdict_totals() {
             Verdict::Deferred(_) => deferred += 1,
         }
     }
-    assert_eq!((equivalent, divergent, deferred), (98, 0, 2));
+    assert_eq!((equivalent, divergent, deferred), (99, 0, 1));
     assert_eq!(VERDICTS.len(), 100);
 }
 

--- a/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/babel_compat_oracle__babel_compat__slots.snap
@@ -212,7 +212,7 @@ export function render(_ctx, _cache) {
 
 ## slots/dynamic_slot_name
 ### verdict
-deferred: computed slot names warn and drop; needs dynamic-slot lowering
+equivalent
 ### source (jsx)
 const A = () => <B>{{[n]: () => <i/>}}</B>;
 ### babel options
@@ -223,10 +223,14 @@ const A = () => _createVNode(_resolveComponent("B"), null, {
   [n]: () => _createVNode("i", null, null)
 });
 ### vize (vdom, babel compat)
-<Warning> computed JSX slot names are not supported and were ignored
-import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+import { resolveComponent as _resolveComponent, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 export function render(_ctx, _cache) {
   const _component_B = _resolveComponent("B")
 
-  return (_openBlock(), _createBlock(_component_B))
+  return (_openBlock(), _createBlock(_component_B, null, {
+    [n]: _withCtx(() => [
+      _createElementVNode("i")
+    ]),
+    _: 2 /* DYNAMIC */
+  }, 1024 /* DYNAMIC_SLOTS */))
 }

--- a/crates/vize_atelier_jsx/tests/v_slots.rs
+++ b/crates/vize_atelier_jsx/tests/v_slots.rs
@@ -294,5 +294,17 @@ fn spreads_keep_their_object_children_warning() {
         diagnostics("const A = () => <B v-slots={{...rest}}/>;"),
         vec!["spread in a JSX slot object is not supported and was ignored".to_string()]
     );
-    assert!(diagnostics("const A = () => <B v-slots={{[n]: () => <i/>}}/>;").is_empty());
+    let dynamic_source = "const π = n; const A = () => <B v-slots={{[π]: () => <i/>}}/>;";
+    assert_eq!(diagnostics(dynamic_source), Vec::<String>::new());
+    assert_eq!(
+        render_code(dynamic_source),
+        "export function render(_ctx, _cache) {\n  \
+         const _component_B = _resolveComponent(\"B\")\n  \n  \
+         return (_openBlock(), _createBlock(_component_B, null, {\n    \
+         [π]: _withCtx(() => [\n      \
+         _createElementVNode(\"i\")\n    \
+         ]),\n    \
+         _: 2 /* DYNAMIC */\n  \
+         }, 1024 /* DYNAMIC_SLOTS */))\n}"
+    );
 }

--- a/crates/vize_atelier_jsx/tests/v_slots.rs
+++ b/crates/vize_atelier_jsx/tests/v_slots.rs
@@ -287,15 +287,12 @@ fn a_repeated_v_slots_is_rejected() {
 }
 
 #[test]
-fn spreads_and_computed_keys_keep_their_object_children_warnings() {
-    // `lower_object_slots` is shared with the object-children idiom, so these
-    // stay warnings naming what was ignored rather than silence.
+fn spreads_keep_their_object_children_warning() {
+    // `lower_object_slots` is shared with the object-children idiom, so spread
+    // entries stay warnings naming what was ignored rather than silence.
     assert_eq!(
         diagnostics("const A = () => <B v-slots={{...rest}}/>;"),
         vec!["spread in a JSX slot object is not supported and was ignored".to_string()]
     );
-    assert_eq!(
-        diagnostics("const A = () => <B v-slots={{[n]: () => <i/>}}/>;"),
-        vec!["computed JSX slot names are not supported and were ignored".to_string()]
-    );
+    assert!(diagnostics("const A = () => <B v-slots={{[n]: () => <i/>}}/>;").is_empty());
 }


### PR DESCRIPTION
## Summary
- lower computed JSX object-slot keys into dynamic `v-slot` template arguments instead of warning and dropping them
- update the Babel compatibility oracle so `slots/dynamic_slot_name` is equivalent, moving totals to 99 equivalent / 0 divergent / 1 deferred

## Validation
- `cargo fmt --check`
- `cargo test -p vize_atelier_jsx`
- `node --test tests/tooling/babel-jsx-oracle.test.ts`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `vp check --no-lint crates/vize_atelier_jsx/src/compat.rs crates/vize_atelier_jsx/src/lower/slot.rs crates/vize_atelier_jsx/tests/BABEL_COMPAT_INVENTORY.md crates/vize_atelier_jsx/tests/babel_compat/verdicts.rs crates/vize_atelier_jsx/tests/babel_compat_oracle.rs crates/vize_atelier_jsx/tests/v_slots.rs`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for computed JSX slot names, including dynamic slot expressions and scoped slot content.
  - Computed slot names are now emitted as dynamic slots while preserving their expressions.

- **Bug Fixes**
  - Valid computed slot names no longer produce unsupported-slot warnings.

- **Documentation**
  - Updated compatibility documentation and status reporting to reflect support for dynamic slot names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->