### PR TITLE
feat(jsx): seed s2 lowering projection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3621,6 +3621,7 @@ dependencies = [
  "vize_carton",
  "vize_croquis",
  "vize_relief",
+ "vize_s2",
 ]
 
 [[package]]

--- a/crates/vize_atelier_jsx/Cargo.toml
+++ b/crates/vize_atelier_jsx/Cargo.toml
@@ -11,6 +11,7 @@ metadata.vize.stability = "compatibility-preview"
 [dependencies]
 # Internal crates
 vize_s0 = { workspace = true }
+vize_s2 = { workspace = true }
 vize_relief = { workspace = true }
 vize_croquis = { workspace = true }
 vize_atelier_core = { workspace = true }

--- a/crates/vize_atelier_jsx/src/finder.rs
+++ b/crates/vize_atelier_jsx/src/finder.rs
@@ -29,7 +29,7 @@ use self::signature::{destructured_prop_names, formal_parameters_range, type_par
 use crate::diagnostics::JsxDiagnostic;
 use crate::lower::{Lowerer, ScopedStyleExpr};
 use crate::mode::{DirectiveKind, JsxOutputMode, classify_directive};
-use crate::{ComponentSetupSpan, LoweredRoot, StyleExprSpan};
+use crate::{ComponentSetupSpan, LoweredRoot, StyleExprSpan, s2};
 
 /// Lower every outermost JSX root in `program` into a [`LoweredRoot`].
 pub(crate) fn lower_program_roots<'a>(
@@ -274,9 +274,11 @@ impl<'ast> Visit<'ast> for RootLowerer<'_, '_, '_, '_> {
         self.lowerer
             .set_current_output_mode(mode.unwrap_or(self.default_mode));
         let root = self.lowerer.lower_element_root(element);
+        let s2 = s2::try_lower_root(self.lowerer.bump(), self.lowerer.mapper().source(), &root);
         let (scoped_css, scoped_style_exprs) = self.take_scoped_style();
         self.roots.push(LoweredRoot {
             root,
+            s2,
             mode,
             component_name: self.current_name(),
             component_setup: self.current_setup_for_span(element.span),
@@ -290,9 +292,11 @@ impl<'ast> Visit<'ast> for RootLowerer<'_, '_, '_, '_> {
         self.lowerer
             .set_current_output_mode(mode.unwrap_or(self.default_mode));
         let root = self.lowerer.lower_fragment_root(fragment);
+        let s2 = s2::try_lower_root(self.lowerer.bump(), self.lowerer.mapper().source(), &root);
         let (scoped_css, scoped_style_exprs) = self.take_scoped_style();
         self.roots.push(LoweredRoot {
             root,
+            s2,
             mode,
             component_name: self.current_name(),
             component_setup: self.current_setup_for_span(fragment.span),

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -1,7 +1,7 @@
 //! Shared JSX/TSX lowering layer for Vize.
 //!
-//! This crate turns OXC-parsed JSX/TSX into Vize's shared template IR
-//! ([`vize_relief::RootNode`]) exactly once, so the VDOM
+//! This crate turns OXC-parsed JSX/TSX into Vize's shared template IR and its
+//! Davinci S2 projection exactly once, so the VDOM
 //! ([`vize_atelier_dom`](https://docs.rs/vize_atelier_dom)) and Vapor
 //! (`vize_atelier_vapor`) backends, the type checker, the LSP, and Patina all
 //! consume the same lowered representation instead of forking JSX-only logic.
@@ -40,6 +40,7 @@ pub mod lang;
 pub mod lower;
 pub mod mode;
 pub mod parse;
+pub mod s2;
 pub mod scoped;
 pub mod span;
 pub mod ssr;
@@ -81,8 +82,13 @@ pub use vdom::{VdomCompileOptions, VdomComponent, VdomOutput, compile_to_vdom};
 /// A single lowered render root plus the component metadata recovered from its
 /// enclosing function.
 pub struct LoweredRoot<'a> {
-    /// The lowered template IR.
+    /// The legacy lowered template IR, retained for compatibility consumers
+    /// while P2-16 moves JSX production paths toward [`Self::s2`].
     pub root: RootNode<'a>,
+    /// The neutral S2 representation or the exact family not yet admitted by
+    /// JSX-to-S2 lowering. A refusal is observable input to the migration lane;
+    /// it must not become a silent fallback after the lane selects S2.
+    pub s2: Result<s2::JsxS2Root<'a>, s2::S2Refusal>,
     /// Output mode override from the nearest enclosing component function's
     /// `"use vue:vapor"` / `"use vue:vdom"` directive prologue, if any. `None`
     /// means the configured default applies.

--- a/crates/vize_atelier_jsx/src/s2.rs
+++ b/crates/vize_atelier_jsx/src/s2.rs
@@ -1,0 +1,250 @@
+//! The first JSX-to-S2 lowering seam.
+//!
+//! This module deliberately admits only the lossless, local subset needed to
+//! establish the S2 representation without inventing fallback semantics.
+//! Callers receive a typed refusal for every Relief form whose S2 facts or DOM
+//! realization have not landed yet. P2-16 expands the admitted family until
+//! this is the authoritative JSX lowering.
+
+use vize_relief::{
+    ElementType, ExpressionNode, Namespace as ReliefNamespace, PropNode, RootNode,
+    TemplateChildNode,
+};
+use vize_s0::{Allocator, Box, Vec};
+use vize_s2::expr::ExprRef;
+use vize_s2::op::{
+    Attribute, ComponentOp, ElementOp, InterpolationOp, Namespace, Op, Region, TextOp,
+};
+
+/// A JSX render root represented as S2 operations.
+#[derive(Debug)]
+pub struct JsxS2Root<'a> {
+    /// The complete JSX/TSX module source backing every S2 span.
+    pub source: &'a str,
+    /// Render operations in authored order.
+    pub root: Region<'a>,
+    /// Number of operations, including attached bindings when they land.
+    pub op_count: u32,
+}
+
+/// A construct which needs a dedicated S2 lowering and must not be silently
+/// projected through the static foundation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum S2Refusal {
+    /// A Vue/JSX directive needs its matching S2 binding op and fact channel.
+    Directive,
+    /// A transformed Relief-only child needs an S2 structural lowering.
+    TransformedChild,
+    /// A JSX root contains a Relief child not represented by this foundation.
+    UnsupportedChild,
+    /// An element kind requires its dedicated S2 operation or realization.
+    UnsupportedElement,
+    /// A Relief expression is compound rather than one authored JS span.
+    CompoundExpression,
+}
+
+/// Project the already-lowered JSX root into the initial, lossless S2 subset.
+///
+/// The projection keeps absolute source spans and parses interpolation text via
+/// [`ExprRef`]. It intentionally refuses instead of degrading directive,
+/// control-flow, slot, or compound-expression semantics.
+pub fn try_lower_root<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    root: &RootNode<'a>,
+) -> Result<JsxS2Root<'a>, S2Refusal> {
+    let mut op_count = 0;
+    let ops = lower_children(allocator, &root.children, &mut op_count)?;
+    Ok(JsxS2Root {
+        source,
+        root: Region { ops },
+        op_count,
+    })
+}
+
+fn lower_children<'a>(
+    allocator: &'a Allocator,
+    children: &[TemplateChildNode<'a>],
+    op_count: &mut u32,
+) -> Result<Vec<'a, Op<'a>>, S2Refusal> {
+    let mut ops = Vec::new_in(&allocator);
+    for child in children {
+        ops.push(lower_child(allocator, child, op_count)?);
+    }
+    Ok(ops)
+}
+
+fn lower_child<'a>(
+    allocator: &'a Allocator,
+    child: &TemplateChildNode<'a>,
+    op_count: &mut u32,
+) -> Result<Op<'a>, S2Refusal> {
+    *op_count = op_count.saturating_add(1);
+    match child {
+        TemplateChildNode::Text(text) => Ok(Op::Text(Box::new_in(
+            TextOp {
+                content: text.content,
+                span: text.loc.span,
+            },
+            &allocator,
+        ))),
+        TemplateChildNode::Interpolation(interpolation) => {
+            let expression = lower_expression(allocator, &interpolation.content)?;
+            Ok(Op::Interpolation(Box::new_in(
+                InterpolationOp {
+                    expression,
+                    span: interpolation.loc.span,
+                },
+                &allocator,
+            )))
+        }
+        TemplateChildNode::Element(element) => lower_element(allocator, element, op_count),
+        TemplateChildNode::If(_)
+        | TemplateChildNode::IfBranch(_)
+        | TemplateChildNode::For(_)
+        | TemplateChildNode::TextCall(_)
+        | TemplateChildNode::CompoundExpression(_)
+        | TemplateChildNode::Hoisted(_) => Err(S2Refusal::TransformedChild),
+        TemplateChildNode::Comment(_) => Err(S2Refusal::UnsupportedChild),
+    }
+}
+
+fn lower_element<'a>(
+    allocator: &'a Allocator,
+    element: &vize_relief::ElementNode<'a>,
+    op_count: &mut u32,
+) -> Result<Op<'a>, S2Refusal> {
+    let attributes = lower_attributes(allocator, &element.props)?;
+    let children = Region {
+        ops: lower_children(allocator, &element.children, op_count)?,
+    };
+    match element.tag_type {
+        ElementType::Element => Ok(Op::Element(Box::new_in(
+            ElementOp {
+                tag: element.tag,
+                namespace: namespace(element.ns),
+                attributes,
+                bindings: Vec::new_in(&allocator),
+                children,
+                span: element.loc.span,
+            },
+            &allocator,
+        ))),
+        ElementType::Component => Ok(Op::Component(Box::new_in(
+            ComponentOp {
+                name: element.tag,
+                attributes,
+                bindings: Vec::new_in(&allocator),
+                children,
+                span: element.loc.span,
+            },
+            &allocator,
+        ))),
+        ElementType::Slot | ElementType::Template => Err(S2Refusal::UnsupportedElement),
+    }
+}
+
+fn lower_attributes<'a>(
+    allocator: &'a Allocator,
+    props: &[PropNode<'a>],
+) -> Result<Vec<'a, Attribute<'a>>, S2Refusal> {
+    let mut attributes = Vec::new_in(&allocator);
+    for prop in props {
+        match prop {
+            PropNode::Attribute(attribute) => attributes.push(Attribute {
+                name: attribute.name,
+                value: attribute.value.as_ref().map(|value| value.content),
+                span: attribute.loc.span,
+            }),
+            PropNode::Directive(_) => return Err(S2Refusal::Directive),
+        }
+    }
+    Ok(attributes)
+}
+
+fn lower_expression<'a>(
+    allocator: &'a Allocator,
+    expression: &ExpressionNode<'a>,
+) -> Result<ExprRef<'a>, S2Refusal> {
+    match expression {
+        ExpressionNode::Simple(simple) => Ok(ExprRef::parse_js_in(
+            allocator,
+            simple.content,
+            simple.loc.span,
+        )),
+        ExpressionNode::Compound(_) => Err(S2Refusal::CompoundExpression),
+    }
+}
+
+const fn namespace(namespace: ReliefNamespace) -> Namespace {
+    match namespace {
+        ReliefNamespace::Html => Namespace::Html,
+        ReliefNamespace::Svg => Namespace::Svg,
+        ReliefNamespace::MathMl => Namespace::MathMl,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use vize_s0::Allocator;
+    use vize_s2::op::Op;
+
+    use crate::{JsxLang, lower_source};
+
+    use super::S2Refusal;
+
+    #[test]
+    fn lower_source_attaches_static_intrinsic_s2_root() {
+        let allocator = Allocator::new();
+        let source = "const App = () => <div id=\"x\">hello {name}<span hidden /></div>";
+        let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+        let root = lowered.roots.first().expect("one JSX root");
+
+        let s2 = root.s2.as_ref().expect("static intrinsic S2 root");
+        assert_eq!(s2.source, source);
+        assert_eq!(s2.op_count, 4);
+        let Op::Element(element) = &s2.root.ops[0] else {
+            panic!("root is an element");
+        };
+        assert_eq!(element.tag, "div");
+        assert_eq!(element.attributes[0].name, "id");
+        assert_eq!(element.attributes[0].value, Some("x"));
+        let Op::Interpolation(interpolation) = &element.children.ops[1] else {
+            panic!("second child is interpolation");
+        };
+        assert_eq!(interpolation.expression.source(), "name");
+        assert_eq!(
+            interpolation.expression.span().start,
+            source.find("name").unwrap() as u32
+        );
+    }
+
+    #[test]
+    fn lower_source_attaches_component_s2_root() {
+        let allocator = Allocator::new();
+        let source = "const App = () => <Panel title=\"x\" />";
+        let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+        let root = lowered.roots.first().expect("one JSX root");
+
+        let s2 = root.s2.as_ref().expect("component S2 root");
+        let Op::Component(component) = &s2.root.ops[0] else {
+            panic!("root is a component");
+        };
+        assert_eq!(component.name, "Panel");
+        assert_eq!(component.attributes[0].name, "title");
+    }
+
+    #[test]
+    fn directive_needs_its_own_s2_binding_lowering() {
+        let allocator = Allocator::new();
+        let lowered = lower_source(
+            &allocator,
+            allocator.as_oxc(),
+            "const App = () => <div id={name} />",
+            JsxLang::Jsx,
+        );
+        let root = lowered.roots.first().expect("one JSX root");
+
+        assert!(matches!(root.s2, Err(S2Refusal::Directive)));
+    }
+}

--- a/crates/vize_atelier_jsx/src/ssr.rs
+++ b/crates/vize_atelier_jsx/src/ssr.rs
@@ -105,6 +105,7 @@ pub(crate) fn compile_lowered_root_to_ssr(
 ) -> SsrComponent {
     let LoweredRoot {
         mut root,
+        s2: _,
         mode,
         component_name,
         component_setup,

--- a/crates/vize_atelier_jsx/src/vapor.rs
+++ b/crates/vize_atelier_jsx/src/vapor.rs
@@ -135,6 +135,7 @@ pub(crate) fn compile_root_to_vapor(
 
     let LoweredRoot {
         mut root,
+        s2: _,
         mode,
         component_name,
         component_setup,

--- a/crates/vize_atelier_jsx/src/vdom.rs
+++ b/crates/vize_atelier_jsx/src/vdom.rs
@@ -155,6 +155,7 @@ pub(crate) fn compile_root_to_vdom(
 ) -> VdomComponent {
     let LoweredRoot {
         mut root,
+        s2: _,
         mode,
         component_name,
         component_setup,


### PR DESCRIPTION
## Summary
- add an initial JSX-to-S2 projection for static intrinsic/component roots, text, interpolation, and static attributes
- attach each `lower_source` root to either an S2 artifact or a typed S2 refusal while VDOM/SSR/Vapor keep the existing Relief path
- leave Patina and typechecker snapshots untouched

## Validation
- `cargo fmt --check`
- `cargo test -p vize_atelier_jsx --lib s2::tests -- --nocapture`
- `cargo test -p vize_atelier_jsx --lib`
- `cargo test -p vize_atelier_jsx --test babel_compat_oracle --test v_slots`
- `cargo test -p vize_atelier_jsx --test modes`
- `cargo test -p vize_atelier_jsx`
- `node crates/vize_atelier_jsx/tests/babel_compat/oracle.mjs --check`
- `node --test tests/tooling/babel-jsx-oracle.test.ts`
- `node --test tests/tooling/davinci-phase2-ledger.test.ts`
- `node --test tests/tooling/davinci-stage-dependencies.test.ts`
- `cargo check -p vize_atelier_jsx --features legacy --locked`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20`
- `git diff HEAD^ --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5725"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791182912&installation_model_id=422833&pr_number=5725&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5725&signature=cf6afa4bbfe91fae73d77a520c874815a1af76eda014c6c54cf77c23616bec0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSX lowering support for the shared S2 representation.
  * JSX roots now preserve source text, authored operation order, and operation counts.
  * Added typed handling for JSX constructs that cannot be represented in S2.
  * Added coverage for intrinsic elements, components, and unsupported directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->