### PR TITLE
test(lsp): add lew ui authored oracle

### DIFF
--- a/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 25, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 26, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -785,6 +785,7 @@
           "tests/_fixtures/_git/shadcn-vue",
           "tests/_fixtures/_git/splitpanes",
           "tests/_fixtures/_git/layoutit-grid",
+          "tests/_fixtures/_git/lew-ui",
           "tests/_fixtures/_git/vue-charts",
           "tests/_fixtures/_git/vue-datepicker",
           "tests/_fixtures/_git/vue-flow",

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 25,
+    "minimumProjectCount": 26,
     "trackingIssue": 3952
   },
   "projects": [
@@ -4616,6 +4616,70 @@
         "syntax-highlighter",
         "lsp"
       ],
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "docs/layout/LewCodeHighlighter.vue",
+          "symbol": "lang",
+          "usageAnchor": "\"lang as any\"",
+          "declarationAnchor": "  lang: {\n    type",
+          "hoverContains": ["const lang: string | undefined"],
+          "renameTo": "__vizeRenamedLang"
+        },
+        "componentBoundary": {
+          "importerFile": "docs/guide/QA.vue",
+          "componentFile": "docs/layout/LewCodeHighlighter.vue",
+          "tagName": "LewCodeHighlighter",
+          "tagAnchor": "    <LewCodeHighlighter :code=\"pre1\" ",
+          "completionItemCount": 31,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "code", "rank": 28 },
+            { "label": "lang", "rank": 29 },
+            { "label": "max-height", "rank": 30 }
+          ],
+          "dependencyEdit": {
+            "anchor": "  maxHeight: {\n    type: String,\n    default: '500px',\n  },",
+            "replacement": "  maxHeight: {\n    type: String,\n    default: '500px',\n  },\n  vizeOracleProbe: {\n    type: Boolean,\n    default: false,\n  },",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "docs/layout/__VizeOracleLewCodeHighlighter.vue",
+          "renamedFile": "docs/layout/__VizeOracleRenamedLewCodeHighlighter.vue",
+          "originalImportSpecifier": "../layout/LewCodeHighlighter.vue",
+          "copiedImportSpecifier": "../layout/__VizeOracleLewCodeHighlighter.vue",
+          "renamedImportSpecifier": "../layout/__VizeOracleRenamedLewCodeHighlighter.vue",
+          "markerInsertionAnchor": "import CodeBlock from 'shiki-code-block-vue'\n",
+          "markerSymbol": "__vizeLewUiCodeHighlighterMarker__"
+        }
+      },
       "diff": "curator-compare"
     },
     {

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 25,
+      "authored-lsp": 26,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,


### PR DESCRIPTION
## Summary
- add Lew UI as one authored real-project LSP oracle for #3952
- pin hover, definition, references, rename, completion, dependency-edit, and file lifecycle evidence for LewCodeHighlighter
- ratchet authored LSP registry and compatibility ledger to 26

## Validation
- vp install --frozen-lockfile --prefer-offline
- cargo build -p vize
- node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts tests/tooling/source-file-lengths.test.ts
- FIXTURE_SHARD_INDEX=123 FIXTURE_SHARD_COUNT=144 REAL_PROJECT_LSP_TIMEOUT_MS=600000 node --test tests/tooling/real-project-lsp.test.ts
- node --test tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts
- node --test tests/tooling/vue-ecosystem-fixtures.test.ts tests/tooling/requested-vue-fixtures.test.ts tests/tooling/check-fixtures-manifest.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791183280&installation_model_id=422833&pr_number=5726&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5726&signature=cac8c205d9b719309d273b7cee585fc5ccf6f76129122f29cf358b90259be3fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded authored LSP coverage to include the Lew UI fixture.
  - Added validation scenarios for template bindings, component-boundary completion, dependency editing, and file lifecycle behavior.
  - Updated compatibility checks to reflect coverage across 26 fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->