### PR TITLE
feat(maestro): route implementation navigation

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -15,6 +15,8 @@ use crate::corsa_client::CorsaProjectClient;
 
 #[path = "bridge/documents.rs"]
 mod documents;
+#[path = "bridge/implementation.rs"]
+mod implementation;
 mod language_features;
 pub(super) use documents::normalize_document_uri;
 

--- a/crates/vize_canon/src/corsa_bridge/bridge/implementation.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge/implementation.rs
@@ -1,0 +1,35 @@
+//! Implementation-location editor query forwarded through the Corsa session.
+
+use super::{CorsaBridge, parse_json_value};
+use crate::corsa_bridge::types::{CorsaBridgeError, LspDefinitionResponse, LspLocation};
+
+#[allow(clippy::disallowed_types)]
+impl CorsaBridge {
+    /// Get implementation locations for a symbol at a position.
+    pub async fn implementation(
+        &self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Vec<LspLocation>, CorsaBridgeError> {
+        let _timer = self.profiler.timer("corsa_implementation");
+        let uri = uri.to_owned();
+        let result = self
+            .with_client(move |client| {
+                client
+                    .implementation_raw(uri.as_str(), line, character)
+                    .map_err(CorsaBridgeError::CommunicationError)
+            })
+            .await?;
+
+        if let Some(timer) = _timer {
+            timer.record(&self.profiler);
+        }
+
+        if let Some(value) = result {
+            return Ok(parse_json_value::<LspDefinitionResponse>(value)?.into_locations());
+        }
+
+        Ok(Vec::new())
+    }
+}

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -31,6 +31,7 @@ use vize_s0::{FxHashMap, FxHashSet, String, cstr};
 
 mod client;
 mod file_rename;
+mod implementation;
 mod readiness;
 mod requests;
 mod responder;

--- a/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
@@ -62,6 +62,20 @@ impl CorsaProjectClient {
         })
     }
 
+    pub(in crate::lsp_client) fn implementation_via_editor_lsp(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        if !self.document_texts.contains_key(uri) {
+            return Ok(None);
+        }
+        self.request_with_editor_lsp_recovery(|session| {
+            session.implementation(uri, line, character)
+        })
+    }
+
     pub(in crate::lsp_client) fn references_via_editor_lsp(
         &mut self,
         uri: &str,

--- a/crates/vize_canon/src/lsp_client/editor_lsp/implementation.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/implementation.rs
@@ -1,0 +1,24 @@
+use corsa::runtime::block_on;
+use serde_json::Value;
+use vize_s0::{String, cstr};
+
+use super::{EditorLspSession, requests::RawImplementationRequest};
+
+impl EditorLspSession {
+    pub(super) fn implementation(
+        &mut self,
+        document_uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        let uri = self.ready_document_uri(document_uri)?;
+        block_on(
+            self.client
+                .request::<RawImplementationRequest>(serde_json::json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": line, "character": character },
+                })),
+        )
+        .map_err(|error| cstr!("Failed to request editor LSP implementation: {error}"))
+    }
+}

--- a/crates/vize_canon/src/lsp_client/editor_lsp/requests.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/requests.rs
@@ -38,6 +38,14 @@ impl lsp_types::request::Request for RawTypeDefinitionRequest {
     const METHOD: &'static str = "textDocument/typeDefinition";
 }
 
+pub(super) struct RawImplementationRequest;
+
+impl lsp_types::request::Request for RawImplementationRequest {
+    type Params = Value;
+    type Result = Option<Value>;
+    const METHOD: &'static str = "textDocument/implementation";
+}
+
 pub(super) struct RawReferencesRequest;
 
 impl lsp_types::request::Request for RawReferencesRequest {

--- a/crates/vize_canon/src/lsp_client/queries.rs
+++ b/crates/vize_canon/src/lsp_client/queries.rs
@@ -82,6 +82,15 @@ impl CorsaProjectClient {
         self.type_definition_via_editor_lsp(uri, line, character)
     }
 
+    pub(crate) fn implementation_raw(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        self.implementation_via_editor_lsp(uri, line, character)
+    }
+
     pub(crate) fn references_raw(
         &mut self,
         uri: &str,

--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -20,6 +20,7 @@ pub mod document_link;
 pub(crate) mod ecosystem;
 pub mod file_rename;
 pub mod hover;
+pub mod implementation;
 pub mod inlay_hint;
 pub mod jsx;
 pub mod linked_editing;
@@ -52,6 +53,7 @@ pub use document_highlight::DocumentHighlightService;
 pub use document_link::DocumentLinkService;
 pub use file_rename::FileRenameService;
 pub use hover::{HoverBuilder, HoverService};
+pub use implementation::ImplementationService;
 pub use inlay_hint::InlayHintService;
 pub use jsx::{
     JsxCodeActionService, JsxDocumentSymbolsService, JsxScopedStyleService,

--- a/crates/vize_maestro/src/ide/corsa_support/canonical_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/canonical_tests.rs
@@ -116,6 +116,68 @@ const label = user.name
 }
 
 #[test]
+fn canonical_location_maps_script_setup_class_member_implementation_target() {
+    let uri = Url::parse("file:///tmp/Implementation.vue").expect("uri");
+    let source = r#"<script setup lang="ts">
+interface Formatter {
+  format(value: string): string
+}
+
+class LabelFormatter implements Formatter {
+  format(value: string): string {
+    return value.toUpperCase()
+  }
+}
+</script>
+"#;
+    let state = ServerState::new();
+    let ctx = IdeContext::with_content(
+        &state,
+        &uri,
+        source.find("Formatter").unwrap(),
+        source.to_string(),
+    );
+    let doc = canonical_doc(&uri, source);
+    let generated_start = doc
+        .virtual_result
+        .code
+        .find("format(value: string): string {")
+        .expect("generated class method");
+    let generated_end = generated_start + "format".len();
+    let (start_line, start_character) =
+        crate::ide::offset_to_position(&doc.virtual_result.code, generated_start);
+    let (end_line, end_character) =
+        crate::ide::offset_to_position(&doc.virtual_result.code, generated_end);
+    let location = LspLocation {
+        uri: doc.request_uri.to_string(),
+        range: LspRange {
+            start: LspPosition {
+                line: start_line,
+                character: start_character,
+            },
+            end: LspPosition {
+                line: end_line,
+                character: end_character,
+            },
+        },
+    };
+
+    let mapped = map_canonical_corsa_location(&ctx, &doc, &location)
+        .expect("implementation target should map to authored class method");
+    let source_start = crate::ide::position_to_offset(
+        source,
+        mapped.range.start.line,
+        mapped.range.start.character,
+    )
+    .expect("mapped start");
+    let source_end =
+        crate::ide::position_to_offset(source, mapped.range.end.line, mapped.range.end.character)
+            .expect("mapped end");
+
+    assert_eq!(&source[source_start..source_end], "format");
+}
+
+#[test]
 fn canonical_source_offset_accounts_for_vue_import_rewrite_before_script_body() {
     let uri = Url::parse("file:///tmp/Parent.vue").expect("uri");
     let source = r#"<script setup lang="ts">

--- a/crates/vize_maestro/src/ide/implementation.rs
+++ b/crates/vize_maestro/src/ide/implementation.rs
@@ -1,0 +1,128 @@
+//! Type-aware `textDocument/implementation` for authored Vue files.
+
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
+
+#[cfg(feature = "native")]
+use std::sync::Arc;
+
+#[cfg(feature = "native")]
+use tower_lsp::lsp_types::GotoDefinitionResponse;
+#[cfg(feature = "native")]
+use vize_canon::CorsaBridge;
+
+#[cfg(feature = "native")]
+use super::{IdeContext, TypeDefinitionService, corsa_support};
+#[cfg(feature = "native")]
+use crate::virtual_code::{ArtCursorPosition, ArtVariantInfo, BlockType, VirtualDocument};
+
+/// Checker-backed implementation navigation service.
+pub struct ImplementationService;
+
+#[cfg(feature = "native")]
+impl ImplementationService {
+    /// Resolve implementation locations through Corsa's standard LSP surface
+    /// and map every returned location back onto authored source.
+    pub async fn implementation_with_corsa(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> Option<GotoDefinitionResponse> {
+        let bridge = corsa_bridge?;
+        if !bridge.is_initialized() {
+            return None;
+        }
+
+        match ctx.block_type? {
+            BlockType::Template | BlockType::Script | BlockType::ScriptSetup
+                if !ctx.uri.path().ends_with(".art.vue") =>
+            {
+                Self::implementation_in_canonical_sfc(ctx, &bridge).await
+            }
+            BlockType::Script => Self::implementation_in_split_script(ctx, &bridge, false).await,
+            BlockType::ScriptSetup => {
+                Self::implementation_in_split_script(ctx, &bridge, true).await
+            }
+            BlockType::Art(ArtCursorPosition::VariantTemplate(ref info)) => {
+                Self::implementation_in_art_variant(ctx, &bridge, info).await
+            }
+            BlockType::Template | BlockType::Style(_) | BlockType::Art(_) => None,
+        }
+    }
+
+    async fn implementation_in_canonical_sfc(
+        ctx: &IdeContext<'_>,
+        bridge: &CorsaBridge,
+    ) -> Option<GotoDefinitionResponse> {
+        let document = corsa_support::open_canonical_virtual_project_document(ctx, bridge).await?;
+        let (line, character) =
+            corsa_support::canonical_source_offset_to_position(&document, ctx.offset)?;
+        let locations = bridge
+            .implementation(&document.request_uri, line, character)
+            .await
+            .ok()?;
+        let locations = corsa_support::map_canonical_corsa_locations(ctx, &document, locations);
+        TypeDefinitionService::convert_locations(locations)
+    }
+
+    async fn implementation_in_split_script(
+        ctx: &IdeContext<'_>,
+        bridge: &CorsaBridge,
+        is_setup: bool,
+    ) -> Option<GotoDefinitionResponse> {
+        let virtual_docs = ctx.virtual_docs.as_ref()?;
+        let document = if is_setup {
+            virtual_docs.script_setup.as_ref()
+        } else {
+            virtual_docs.script.as_ref()
+        }?;
+        let generated_offset =
+            super::hover::HoverService::sfc_to_virtual_ts_script_offset(ctx, ctx.offset)?;
+        Self::implementation_in_virtual_document(
+            ctx,
+            bridge,
+            document,
+            generated_offset,
+            corsa_support::script_request_path(ctx.uri, is_setup),
+        )
+        .await
+    }
+
+    async fn implementation_in_art_variant(
+        ctx: &IdeContext<'_>,
+        bridge: &CorsaBridge,
+        info: &ArtVariantInfo,
+    ) -> Option<GotoDefinitionResponse> {
+        let document = ctx
+            .virtual_docs
+            .as_ref()?
+            .art_template(info.variant_index)?;
+        let generated_offset = document
+            .source_map
+            .to_generated_for(ctx.offset as u32, |features| features.definition)?
+            as usize;
+        Self::implementation_in_virtual_document(
+            ctx,
+            bridge,
+            document,
+            generated_offset,
+            corsa_support::art_template_request_path(ctx.uri, info.variant_index),
+        )
+        .await
+    }
+
+    async fn implementation_in_virtual_document(
+        ctx: &IdeContext<'_>,
+        bridge: &CorsaBridge,
+        document: &VirtualDocument,
+        generated_offset: usize,
+        request_path: vize_s0::String,
+    ) -> Option<GotoDefinitionResponse> {
+        let (line, character) = super::offset_to_position(&document.content, generated_offset);
+        let uri = bridge
+            .open_or_update_virtual_document(&request_path, &document.content)
+            .await
+            .ok()?;
+        let locations = bridge.implementation(&uri, line, character).await.ok()?;
+        let locations = corsa_support::map_corsa_locations(ctx, locations);
+        TypeDefinitionService::convert_locations(locations)
+    }
+}

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -6,8 +6,9 @@ use tower_lsp::lsp_types::{
     ColorProviderCapability, CompletionOptions, DocumentLinkOptions,
     DocumentOnTypeFormattingOptions, FileOperationFilter, FileOperationPattern,
     FileOperationPatternKind, FileOperationRegistrationOptions, FoldingRangeProviderCapability,
-    HoverProviderCapability, LinkedEditingRangeServerCapabilities, OneOf, RenameOptions,
-    SaveOptions, SelectionRangeProviderCapability, SemanticTokenModifier, SemanticTokenType,
+    HoverProviderCapability, ImplementationProviderCapability,
+    LinkedEditingRangeServerCapabilities, OneOf, RenameOptions, SaveOptions,
+    SelectionRangeProviderCapability, SemanticTokenModifier, SemanticTokenType,
     SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
     SemanticTokensServerCapabilities, ServerCapabilities, SignatureHelpOptions,
     TextDocumentSyncCapability, TextDocumentSyncKind, TextDocumentSyncOptions,
@@ -213,8 +214,14 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
         // disabling navigation must not spawn type-checker/editor work.
         type_definition_provider: (features.definition && cfg!(feature = "native"))
             .then_some(TypeDefinitionProviderCapability::Simple(true)),
+        // Checker-backed implementation navigation uses Corsa directly: the
+        // provider stays hidden when typecheck is disabled because no lexical
+        // fallback can answer implementation semantics.
+        implementation_provider: (features.definition
+            && features.typecheck
+            && cfg!(feature = "native"))
+        .then_some(ImplementationProviderCapability::Simple(true)),
         // Features not yet implemented
-        implementation_provider: None,
         declaration_provider: None,
         execute_command_provider: None,
         call_hierarchy_provider: None,

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -74,6 +74,10 @@ fn default_features_advertise_non_opinionated_providers() {
         capabilities.type_definition_provider.is_some(),
         cfg!(feature = "native")
     );
+    assert_eq!(
+        capabilities.implementation_provider.is_some(),
+        cfg!(feature = "native")
+    );
     assert!(matches!(
         capabilities.selection_range_provider,
         Some(SelectionRangeProviderCapability::Simple(true))
@@ -85,7 +89,6 @@ fn default_features_advertise_non_opinionated_providers() {
     assert!(capabilities.document_formatting_provider.is_none());
     assert!(capabilities.document_range_formatting_provider.is_none());
     assert!(capabilities.document_on_type_formatting_provider.is_none());
-    assert!(capabilities.implementation_provider.is_none());
 }
 
 /// The trigger set is `@vue/language-server`'s, character for character, so an
@@ -160,6 +163,10 @@ fn all_features_skip_unimplemented_providers_and_keep_implemented_ones() {
         capabilities.type_definition_provider.is_some(),
         cfg!(feature = "native")
     );
+    assert_eq!(
+        capabilities.implementation_provider.is_some(),
+        cfg!(feature = "native")
+    );
     assert!(capabilities.references_provider.is_some());
     assert!(capabilities.document_symbol_provider.is_some());
     assert!(capabilities.workspace_symbol_provider.is_some());
@@ -178,7 +185,6 @@ fn all_features_skip_unimplemented_providers_and_keep_implemented_ones() {
             .and_then(|workspace| workspace.file_operations)
             .is_some()
     );
-    assert!(capabilities.implementation_provider.is_none());
 }
 
 #[test]

--- a/crates/vize_maestro/src/server/capabilities/tests/feature_gating.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests/feature_gating.rs
@@ -32,7 +32,13 @@ fn individual_feature_flags_gate_matching_providers() {
             |capabilities| {
                 capabilities.definition_provider.is_some()
                     || capabilities.type_definition_provider.is_some()
+                    || capabilities.implementation_provider.is_some()
             },
+        ),
+        (
+            "typecheck",
+            |features| features.typecheck = false,
+            |capabilities| capabilities.implementation_provider.is_some(),
         ),
         (
             "references",

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -1,7 +1,4 @@
 //! LSP protocol handler implementations.
-//!
-//! Implements the `LanguageServer` trait for `MaestroServer`, dispatching
-//! requests to the appropriate IDE services.
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
 use tower_lsp::lsp_types::request::{GotoTypeDefinitionParams, GotoTypeDefinitionResponse};
@@ -27,9 +24,7 @@ use tower_lsp::{
     },
 };
 
-// Only the test modules below construct positions and ranges now that
-// `document_symbol` moved into `server::document_structure` and range
-// formatting into `server::format`; they reach these through `use super::*`.
+// Test modules still construct positions and ranges through `use super::*`.
 #[cfg(test)]
 use tower_lsp::lsp_types::{Position, Range};
 
@@ -42,6 +37,7 @@ use crate::ide::{
 };
 
 mod navigation;
+use navigation::{ImplParams, ImplResponse};
 
 #[tower_lsp::async_trait]
 impl LanguageServer for MaestroServer {
@@ -297,6 +293,10 @@ impl LanguageServer for MaestroServer {
         params: GotoTypeDefinitionParams,
     ) -> Result<Option<GotoTypeDefinitionResponse>> {
         navigation::goto_type_definition(self, params).await
+    }
+
+    async fn goto_implementation(&self, params: ImplParams) -> Result<Option<ImplResponse>> {
+        navigation::goto_implementation(self, params).await
     }
 
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {

--- a/crates/vize_maestro/src/server/handlers/navigation.rs
+++ b/crates/vize_maestro/src/server/handlers/navigation.rs
@@ -1,4 +1,7 @@
-use tower_lsp::lsp_types::request::{GotoTypeDefinitionParams, GotoTypeDefinitionResponse};
+use tower_lsp::lsp_types::request::{
+    GotoImplementationParams, GotoImplementationResponse, GotoTypeDefinitionParams,
+    GotoTypeDefinitionResponse,
+};
 use tower_lsp::{
     jsonrpc::Result,
     lsp_types::{GotoDefinitionParams, GotoDefinitionResponse},
@@ -7,7 +10,12 @@ use tower_lsp::{
 use super::super::MaestroServer;
 use crate::ide::{DefinitionService, IdeContext, position_to_offset};
 #[cfg(feature = "native")]
-use crate::ide::{JsxService, JsxTypeDefinitionService, TypeDefinitionService};
+use crate::ide::{
+    ImplementationService, JsxService, JsxTypeDefinitionService, TypeDefinitionService,
+};
+
+pub(super) type ImplParams = GotoImplementationParams;
+pub(super) type ImplResponse = GotoImplementationResponse;
 
 pub(super) async fn goto_definition(
     server: &MaestroServer,
@@ -90,6 +98,43 @@ pub(super) async fn goto_type_definition(
 
         let corsa_bridge = server.state.get_corsa_bridge().await;
         return Ok(TypeDefinitionService::type_definition_with_corsa(&ctx, corsa_bridge).await);
+    }
+
+    #[cfg(not(feature = "native"))]
+    {
+        let _ = params;
+        Ok(None)
+    }
+}
+
+pub(super) async fn goto_implementation(
+    server: &MaestroServer,
+    params: GotoImplementationParams,
+) -> Result<Option<GotoImplementationResponse>> {
+    if !server.state.lsp_features().definition {
+        return Ok(None);
+    }
+
+    #[cfg(feature = "native")]
+    {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+
+        let Some(content) = server.state.documents.text(uri) else {
+            return Ok(None);
+        };
+        let Some(offset) = position_to_offset(&content, position.line, position.character) else {
+            return Ok(None);
+        };
+
+        let ctx = IdeContext::with_content(&server.state, uri, offset, content);
+
+        if crate::utils::is_jsx_path(uri.path()) {
+            return Ok(None);
+        }
+
+        let corsa_bridge = server.state.get_corsa_bridge().await;
+        return Ok(ImplementationService::implementation_with_corsa(&ctx, corsa_bridge).await);
     }
 
     #[cfg(not(feature = "native"))]

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -109,6 +109,7 @@ const EDITOR_BUNDLE_CAPABILITIES = {
   },
   definitionProvider: true,
   typeDefinitionProvider: true,
+  implementationProvider: true,
   referencesProvider: true,
   documentHighlightProvider: true,
   documentSymbolProvider: true,
@@ -181,10 +182,9 @@ const EDITOR_BUNDLE_CAPABILITIES = {
     },
   },
   // Absent on purpose, and therefore absent from this object: the three
-  // formatting providers (opt-in, see below), `implementationProvider`,
-  // `declarationProvider`, `executeCommandProvider`, `callHierarchyProvider`,
-  // `monikerProvider` and `experimental` is absent unless the private client
-  // explicitly opts in.
+  // formatting providers (opt-in, see below), `declarationProvider`,
+  // `executeCommandProvider`, `callHierarchyProvider`, `monikerProvider` and
+  // `experimental` is absent unless the private client explicitly opts in.
 };
 
 test("vize lsp advertises exactly this capability set for the default editor bundle", async () => {
@@ -233,6 +233,7 @@ test("vize lsp editor:false strips editor providers but keeps lint-driven codeAc
       assert.equal(capabilities.hoverProvider, undefined);
       assert.equal(capabilities.definitionProvider, undefined);
       assert.equal(capabilities.typeDefinitionProvider, undefined);
+      assert.equal(capabilities.implementationProvider, undefined);
       assert.equal(capabilities.referencesProvider, undefined);
       assert.equal(capabilities.documentHighlightProvider, undefined);
 
@@ -282,6 +283,17 @@ test("vize lsp per-feature init flags toggle individual providers independently"
       assert.equal(capabilities.documentHighlightProvider, undefined);
       // A sibling editor provider is untouched.
       assert.equal(capabilities.documentSymbolProvider, true);
+    },
+  );
+
+  await withCapabilities(
+    "granular-typecheck-off",
+    { editor: true, typecheck: false },
+    (capabilities) => {
+      assert.equal(capabilities.implementationProvider, undefined);
+      // Definition keeps its lexical/editor fallback when typecheck is disabled.
+      assert.equal(capabilities.definitionProvider, true);
+      assert.equal(capabilities.typeDefinitionProvider, true);
     },
   );
 

--- a/tests/tooling/lsp-editor-feature-routing.test.ts
+++ b/tests/tooling/lsp-editor-feature-routing.test.ts
@@ -48,6 +48,10 @@ const DISABLED_REQUESTS: RequestCase[] = [
     params: (uri) => ({ textDocument: { uri }, position }),
   },
   {
+    method: "textDocument/implementation",
+    params: (uri) => ({ textDocument: { uri }, position }),
+  },
+  {
     method: "textDocument/references",
     params: (uri) => ({ textDocument: { uri }, position, context: { includeDeclaration: true } }),
   },

--- a/tests/tooling/lsp-implementation-capability.test.ts
+++ b/tests/tooling/lsp-implementation-capability.test.ts
@@ -3,17 +3,28 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
-import { firstLocation, offsetToPosition } from "./support/lsp/assertions.ts";
+import { firstLocation, isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
 import { testOutputRoot } from "./support/lsp/paths.ts";
 import type { ServerCapabilities } from "./support/lsp/protocol.ts";
-import { LspRequestError, LspSession } from "./support/lsp/session.ts";
+import { LspSession } from "./support/lsp/session.ts";
 
 const source = `<script setup lang="ts">
+interface Formatter {
+  format(value: string): string
+}
+
+class LabelFormatter implements Formatter {
+  format(value: string): string {
+    return value.toUpperCase()
+  }
+}
+
+const formatter: Formatter = new LabelFormatter()
 const message = "hello"
 </script>
 
 <template>
-  <span>{{ message }}</span>
+  <span>{{ formatter.format(message) }}</span>
 </template>
 `;
 
@@ -21,10 +32,27 @@ type ImplementationCapabilities = ServerCapabilities & {
   implementationProvider?: unknown;
 };
 
-test("vize lsp keeps textDocument/implementation fail-closed until #3953 implements it", async () => {
+test("vize lsp maps textDocument/implementation from authored SFC interfaces", async () => {
   const testRootDir = path.join(testOutputRoot, "lsp-implementation-capability");
   fs.mkdirSync(testRootDir, { recursive: true });
   const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  fs.writeFileSync(
+    path.join(workspaceDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+        },
+        include: ["**/*"],
+      },
+      null,
+      2,
+    ),
+  );
   const filePath = path.join(workspaceDir, "Widget.vue");
   const uri = pathToFileURL(filePath).href;
   const session = new LspSession();
@@ -33,34 +61,32 @@ test("vize lsp keeps textDocument/implementation fail-closed until #3953 impleme
     const init = (await session.initialize(workspaceDir, {
       editor: true,
       lint: false,
-      typecheck: false,
+      typecheck: true,
     })) as { capabilities?: ImplementationCapabilities };
-    assert.equal(init.capabilities?.implementationProvider, undefined);
+    assert.equal(init.capabilities?.implementationProvider, true);
 
     fs.writeFileSync(filePath, source, "utf8");
     session.notify("textDocument/didOpen", {
       textDocument: { uri, languageId: "vue", version: 1, text: source },
     });
-
-    const position = offsetToPosition(source, source.lastIndexOf("message }}</span>") + 3);
-    await assert.rejects(
-      session.request("textDocument/implementation", {
-        textDocument: { uri },
-        position,
-      }),
-      (error) =>
-        error instanceof LspRequestError &&
-        error.method === "textDocument/implementation" &&
-        error.code === -32601,
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri),
+      60_000,
     );
 
-    const definition = (await session.request("textDocument/definition", {
+    const position = offsetToPosition(source, source.indexOf("format(value: string): string"));
+    const implementation = await session.request("textDocument/implementation", {
       textDocument: { uri },
       position,
-    })) as Array<{ uri: string; range: { start: { line: number; character: number } } }>;
-    const location = firstLocation(definition);
+    });
+    const location = firstLocation(implementation as never);
     assert.equal(location.uri, uri);
-    assert.deepEqual(location.range.start, offsetToPosition(source, source.indexOf("message =")));
+    assert.deepEqual(
+      location.range.start,
+      offsetToPosition(source, source.indexOf("format(value: string): string {")),
+    );
+    assert.ok(!location.uri.endsWith(".vue.ts"), JSON.stringify(implementation));
   } finally {
     await session.shutdown();
     fs.rmSync(workspaceDir, { recursive: true, force: true });

--- a/tests/tooling/support/lsp/assertions.ts
+++ b/tests/tooling/support/lsp/assertions.ts
@@ -64,6 +64,13 @@ export async function assertEmptyEditorRequests(
       },
     ],
     [
+      "textDocument/implementation",
+      {
+        textDocument: { uri },
+        position,
+      },
+    ],
+    [
       "textDocument/references",
       {
         textDocument: { uri },

--- a/tests/tooling/support/lsp/protocol.ts
+++ b/tests/tooling/support/lsp/protocol.ts
@@ -86,6 +86,7 @@ export type ServerCapabilities = {
   documentSymbolProvider?: unknown;
   foldingRangeProvider?: unknown;
   hoverProvider?: unknown;
+  implementationProvider?: unknown;
   inlayHintProvider?: unknown;
   linkedEditingRangeProvider?: unknown;
   referencesProvider?: unknown;


### PR DESCRIPTION
## Summary
- add an authored SFC implementation-navigation oracle for interface methods
- route `textDocument/implementation` through the editor LSP and canonical authored range mapping
- advertise implementation only when definition and typecheck are enabled

## Validation
- `cargo fmt --all --check`
- `cargo check -p vize_canon -p vize_maestro -p vize`
- `cargo test -p vize_canon --lib lsp_client::editor_lsp -- --nocapture`
- `cargo test -p vize_maestro server::capabilities -- --nocapture`
- `cargo test -p vize_maestro ide::corsa_support::canonical_tests::canonical_location_maps_script_setup_class_member_implementation_target -- --exact`
- `cargo build -p vize`
- `CORSA_PATH=/Users/ubugeeei/Source/github.com/ubugeeei/corsa-bind/ref/corsa-upstream/.cache/tsgo TMPDIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize--3953-rename-editor-fallback-20260905/target/vize-tests/tmp TEMP=/Users/ubugeeei/Source/github.com/ubugeeei/vize--3953-rename-editor-fallback-20260905/target/vize-tests/tmp TMP=/Users/ubugeeei/Source/github.com/ubugeeei/vize--3953-rename-editor-fallback-20260905/target/vize-tests/tmp node --test tests/tooling/lsp-implementation-capability.test.ts tests/tooling/lsp-capabilities.test.ts tests/tooling/lsp-editor-feature-routing.test.ts`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.bin/oxfmt --check tests/tooling/lsp-capabilities.test.ts`
- `rust-script tools/commands/ci/source-file-lengths.rs`
- `git diff --check`

Progresses #3953.
