### PR TITLE
feat(jsx): project dynamic binds into s2

### DIFF
--- a/crates/vize_atelier_jsx/src/s2.rs
+++ b/crates/vize_atelier_jsx/src/s2.rs
@@ -13,7 +13,8 @@ use vize_relief::{
 use vize_s0::{Allocator, Box, Vec};
 use vize_s2::expr::ExprRef;
 use vize_s2::op::{
-    Attribute, ComponentOp, ElementOp, InterpolationOp, Namespace, Op, Region, TextOp,
+    Attribute, BindOp, BindingOp, ComponentOp, DynamicName, ElementOp, InterpolationOp, Namespace,
+    Op, Region, TextOp,
 };
 
 /// A JSX render root represented as S2 operations.
@@ -114,7 +115,8 @@ fn lower_element<'a>(
     element: &vize_relief::ElementNode<'a>,
     op_count: &mut u32,
 ) -> Result<Op<'a>, S2Refusal> {
-    let attributes = lower_attributes(allocator, &element.props)?;
+    let props = lower_props(allocator, &element.props)?;
+    *op_count = op_count.saturating_add(props.binding_count);
     let children = Region {
         ops: lower_children(allocator, &element.children, op_count)?,
     };
@@ -123,8 +125,8 @@ fn lower_element<'a>(
             ElementOp {
                 tag: element.tag,
                 namespace: namespace(element.ns),
-                attributes,
-                bindings: Vec::new_in(&allocator),
+                attributes: props.attributes,
+                bindings: props.bindings,
                 children,
                 span: element.loc.span,
             },
@@ -133,8 +135,8 @@ fn lower_element<'a>(
         ElementType::Component => Ok(Op::Component(Box::new_in(
             ComponentOp {
                 name: element.tag,
-                attributes,
-                bindings: Vec::new_in(&allocator),
+                attributes: props.attributes,
+                bindings: props.bindings,
                 children,
                 span: element.loc.span,
             },
@@ -144,11 +146,18 @@ fn lower_element<'a>(
     }
 }
 
-fn lower_attributes<'a>(
+struct LoweredProps<'a> {
+    attributes: Vec<'a, Attribute<'a>>,
+    bindings: Vec<'a, BindingOp<'a>>,
+    binding_count: u32,
+}
+
+fn lower_props<'a>(
     allocator: &'a Allocator,
     props: &[PropNode<'a>],
-) -> Result<Vec<'a, Attribute<'a>>, S2Refusal> {
+) -> Result<LoweredProps<'a>, S2Refusal> {
     let mut attributes = Vec::new_in(&allocator);
+    let mut bindings = Vec::new_in(&allocator);
     for prop in props {
         match prop {
             PropNode::Attribute(attribute) => attributes.push(Attribute {
@@ -156,10 +165,67 @@ fn lower_attributes<'a>(
                 value: attribute.value.as_ref().map(|value| value.content),
                 span: attribute.loc.span,
             }),
-            PropNode::Directive(_) => return Err(S2Refusal::Directive),
+            PropNode::Directive(directive) => {
+                bindings.push(lower_binding(allocator, directive)?);
+            }
         }
     }
-    Ok(attributes)
+    let binding_count = bindings.len() as u32;
+    Ok(LoweredProps {
+        attributes,
+        bindings,
+        binding_count,
+    })
+}
+
+fn lower_binding<'a>(
+    allocator: &'a Allocator,
+    directive: &vize_relief::DirectiveNode<'a>,
+) -> Result<BindingOp<'a>, S2Refusal> {
+    if directive.name != "bind" {
+        return Err(S2Refusal::Directive);
+    }
+
+    let name = lower_dynamic_name(allocator, directive.arg.as_ref())?;
+    let mut modifiers = Vec::new_in(&allocator);
+    for modifier in &directive.modifiers {
+        modifiers.push(modifier.content);
+    }
+    let value = directive
+        .exp
+        .as_ref()
+        .map(|expression| lower_expression(allocator, expression))
+        .transpose()?;
+
+    Ok(BindingOp::Bind(Box::new_in(
+        BindOp {
+            name,
+            modifiers,
+            value,
+            span: directive.loc.span,
+        },
+        &allocator,
+    )))
+}
+
+fn lower_dynamic_name<'a>(
+    allocator: &'a Allocator,
+    name: Option<&ExpressionNode<'a>>,
+) -> Result<Option<DynamicName<'a>>, S2Refusal> {
+    let Some(name) = name else {
+        return Ok(None);
+    };
+    match name {
+        ExpressionNode::Simple(simple) if simple.is_static => {
+            Ok(Some(DynamicName::Static(simple.content)))
+        }
+        ExpressionNode::Simple(simple) => Ok(Some(DynamicName::Dynamic(ExprRef::parse_js_in(
+            allocator,
+            simple.content,
+            simple.loc.span,
+        )))),
+        ExpressionNode::Compound(_) => Err(S2Refusal::CompoundExpression),
+    }
 }
 
 fn lower_expression<'a>(
@@ -235,12 +301,12 @@ mod tests {
     }
 
     #[test]
-    fn directive_needs_its_own_s2_binding_lowering() {
+    fn non_bind_directive_needs_its_own_s2_binding_lowering() {
         let allocator = Allocator::new();
         let lowered = lower_source(
             &allocator,
             allocator.as_oxc(),
-            "const App = () => <div id={name} />",
+            "const App = () => <div v-show={visible} />",
             JsxLang::Jsx,
         );
         let root = lowered.roots.first().expect("one JSX root");

--- a/crates/vize_atelier_jsx/tests/s2_projection.rs
+++ b/crates/vize_atelier_jsx/tests/s2_projection.rs
@@ -1,0 +1,44 @@
+//! P2-16 JSX-to-S2 projection witnesses.
+
+use vize_atelier_jsx::{JsxLang, lower_source};
+use vize_s0::Allocator;
+use vize_s2::op::{BindingOp, DynamicName, Op};
+
+#[test]
+fn dynamic_bind_props_project_to_s2_bindings() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <div id={name} {...attrs} disabled />";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    assert!(!lowered.has_errors(), "{:?}", lowered.diagnostics);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("dynamic bindings are admitted");
+    assert_eq!(s2.op_count, 3);
+    let Op::Element(element) = &s2.root.ops[0] else {
+        panic!("root is an element");
+    };
+    assert_eq!(element.attributes.len(), 1);
+    assert_eq!(element.attributes[0].name, "disabled");
+    assert_eq!(element.bindings.len(), 2);
+
+    let BindingOp::Bind(id) = &element.bindings[0] else {
+        panic!("first binding is ui.bind");
+    };
+    assert!(matches!(id.name, Some(DynamicName::Static("id"))));
+    let id_value = id.value.expect("id binding has a value");
+    assert_eq!(id_value.source(), "name");
+    assert_eq!(id_value.span().start, source.find("name").unwrap() as u32);
+    assert_eq!(id.span.start, source.find("id={name}").unwrap() as u32);
+
+    let BindingOp::Bind(spread) = &element.bindings[1] else {
+        panic!("second binding is ui.bind");
+    };
+    assert!(spread.name.is_none());
+    let spread_value = spread.value.expect("spread binding has a value");
+    assert_eq!(spread_value.source(), "attrs");
+    assert_eq!(
+        spread_value.span().start,
+        source.find("attrs").unwrap() as u32
+    );
+    assert_eq!(spread.span.start, source.find("{...attrs}").unwrap() as u32);
+}


### PR DESCRIPTION
## Summary
- admit JSX dynamic v-bind props and object spreads into the P2-16 S2 projection
- attach them as existing ui.bind ops while preserving static attributes and source spans
- keep non-bind directives as typed S2 refusals for later slices

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p vize_atelier_jsx --test s2_projection dynamic_bind_props_project_to_s2_bindings
- cargo test -p vize_atelier_jsx --lib s2::tests::
- cargo test -p vize_atelier_jsx --test babel_compat_oracle

## Local limitation
- cargo test -p vize_atelier_jsx hit local disk exhaustion while linking multiple integration test binaries: ld write failed with errno=28

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5728"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791187730&installation_model_id=422833&pr_number=5728&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5728&signature=ba033072455214053393b15baf35af71723f89352d948aa8ca27d5dab2d0d904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `bind` directives during JSX processing, including static and dynamic property names.
  - Binding modifiers and optional expressions are now supported for both native elements and components.
  - Dynamic properties, spread attributes, and boolean attributes are handled with improved operation tracking and source mapping.

- **Bug Fixes**
  - Unsupported directives and compound dynamic property names now receive clear, typed refusals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->