### PR TITLE
fix(maestro): gate type-definition navigation on typecheck

### DIFF
--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -210,13 +210,13 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
             .document_links
             .then_some(ColorProviderCapability::Simple(true)),
 
-        // Checker-backed type definitions share the go-to-definition switch:
-        // disabling navigation must not spawn type-checker/editor work.
-        type_definition_provider: (features.definition && cfg!(feature = "native"))
-            .then_some(TypeDefinitionProviderCapability::Simple(true)),
-        // Checker-backed implementation navigation uses Corsa directly: the
-        // provider stays hidden when typecheck is disabled because no lexical
-        // fallback can answer implementation semantics.
+        // Checker-backed type-definition and implementation navigation use
+        // Corsa directly: the providers stay hidden when typecheck is disabled
+        // because no lexical fallback can answer their semantics.
+        type_definition_provider: (features.definition
+            && features.typecheck
+            && cfg!(feature = "native"))
+        .then_some(TypeDefinitionProviderCapability::Simple(true)),
         implementation_provider: (features.definition
             && features.typecheck
             && cfg!(feature = "native"))

--- a/crates/vize_maestro/src/server/capabilities/tests/feature_gating.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests/feature_gating.rs
@@ -38,7 +38,10 @@ fn individual_feature_flags_gate_matching_providers() {
         (
             "typecheck",
             |features| features.typecheck = false,
-            |capabilities| capabilities.implementation_provider.is_some(),
+            |capabilities| {
+                capabilities.type_definition_provider.is_some()
+                    || capabilities.implementation_provider.is_some()
+            },
         ),
         (
             "references",

--- a/crates/vize_maestro/src/server/handlers/navigation.rs
+++ b/crates/vize_maestro/src/server/handlers/navigation.rs
@@ -70,7 +70,7 @@ pub(super) async fn goto_type_definition(
     server: &MaestroServer,
     params: GotoTypeDefinitionParams,
 ) -> Result<Option<GotoTypeDefinitionResponse>> {
-    if !server.state.lsp_features().definition {
+    if !server.state.lsp_features().definition || !server.state.lsp_features().typecheck {
         return Ok(None);
     }
 

--- a/crates/vize_maestro/src/server/handlers/tests/requests.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests.rs
@@ -158,6 +158,11 @@ disabled_open_doc_request_returns_none!(
     &[("definition", false)],
     |server, uri| server.goto_type_definition(type_definition_params(&uri))
 );
+disabled_open_doc_request_returns_none!(
+    type_definition_disabled_when_typecheck_is_off_returns_none,
+    &[("definition", true), ("typecheck", false)],
+    |server, uri| server.goto_type_definition(type_definition_params(&uri))
+);
 enabled_missing_doc_request_returns_none!(
     type_definition_missing_document_returns_none,
     &[("definition", true)],

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -279,6 +279,7 @@ test("vize lsp per-feature init flags toggle individual providers independently"
       assert.equal(capabilities.completionProvider, undefined);
       assert.equal(capabilities.hoverProvider, undefined);
       assert.equal(capabilities.definitionProvider, undefined);
+      assert.equal(capabilities.typeDefinitionProvider, undefined);
       assert.equal(capabilities.referencesProvider, undefined);
       assert.equal(capabilities.documentHighlightProvider, undefined);
       // A sibling editor provider is untouched.
@@ -291,9 +292,9 @@ test("vize lsp per-feature init flags toggle individual providers independently"
     { editor: true, typecheck: false },
     (capabilities) => {
       assert.equal(capabilities.implementationProvider, undefined);
+      assert.equal(capabilities.typeDefinitionProvider, undefined);
       // Definition keeps its lexical/editor fallback when typecheck is disabled.
       assert.equal(capabilities.definitionProvider, true);
-      assert.equal(capabilities.typeDefinitionProvider, true);
     },
   );
 

--- a/tests/tooling/lsp-editor-feature-routing.test.ts
+++ b/tests/tooling/lsp-editor-feature-routing.test.ts
@@ -48,6 +48,10 @@ const DISABLED_REQUESTS: RequestCase[] = [
     params: (uri) => ({ textDocument: { uri }, position }),
   },
   {
+    method: "textDocument/typeDefinition",
+    params: (uri) => ({ textDocument: { uri }, position }),
+  },
+  {
     method: "textDocument/implementation",
     params: (uri) => ({ textDocument: { uri }, position }),
   },

--- a/tests/tooling/lsp-type-definition-capability.test.ts
+++ b/tests/tooling/lsp-type-definition-capability.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { firstLocation, isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { ServerCapabilities } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+const source = `<script setup lang="ts">
+interface Product {
+  name: string
+}
+
+const product = {} as Product
+</script>
+
+<template>
+  <span>{{ product.name }}</span>
+</template>
+`;
+
+test("vize lsp maps textDocument/typeDefinition from authored SFC template bindings", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-type-definition-capability");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  fs.writeFileSync(
+    path.join(workspaceDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+        },
+        include: ["**/*"],
+      },
+      null,
+      2,
+    ),
+  );
+  const filePath = path.join(workspaceDir, "Card.vue");
+  const uri = pathToFileURL(filePath).href;
+  const session = new LspSession();
+
+  try {
+    const init = (await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: true,
+    })) as { capabilities?: ServerCapabilities };
+    assert.equal(init.capabilities?.typeDefinitionProvider, true);
+
+    fs.writeFileSync(filePath, source, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: source },
+    });
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri),
+      60_000,
+    );
+
+    const position = offsetToPosition(source, source.lastIndexOf("product.name") + 3);
+    const typeDefinition = await session.request("textDocument/typeDefinition", {
+      textDocument: { uri },
+      position,
+    });
+    const location = firstLocation(typeDefinition as never);
+    assert.equal(location.uri, uri);
+    assert.deepEqual(location.range.start, offsetToPosition(source, source.indexOf("Product {")));
+    assert.ok(!location.uri.endsWith(".vue.ts"), JSON.stringify(typeDefinition));
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/support/lsp/assertions.ts
+++ b/tests/tooling/support/lsp/assertions.ts
@@ -64,6 +64,13 @@ export async function assertEmptyEditorRequests(
       },
     ],
     [
+      "textDocument/typeDefinition",
+      {
+        textDocument: { uri },
+        position,
+      },
+    ],
+    [
       "textDocument/implementation",
       {
         textDocument: { uri },

--- a/tests/tooling/support/lsp/protocol.ts
+++ b/tests/tooling/support/lsp/protocol.ts
@@ -75,6 +75,7 @@ export type ServerCapabilities = {
     resolveProvider?: boolean;
   };
   definitionProvider?: unknown;
+  typeDefinitionProvider?: unknown;
   documentHighlightProvider?: unknown;
   documentFormattingProvider?: unknown;
   documentLinkProvider?: { resolveProvider?: boolean };


### PR DESCRIPTION
## Summary
- add authored SFC protocol coverage for `textDocument/typeDefinition` mapping template bindings back to the source `.vue` interface
- keep type-definition capability advertisement and request routing behind the `typecheck` feature
- include type-definition in disabled editor request coverage and shared LSP protocol typing

Progresses #3953.

## Validation
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo check -p vize_canon -p vize_maestro -p vize`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize_maestro server::capabilities -- --nocapture`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize_maestro server::handlers::tests::requests::type_definition -- --nocapture`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize_maestro ide::type_definition::tests::canonical_type_definition_maps_template_binding_to_authored_interface -- --exact --nocapture`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo build -p vize`
- `env CORSA_PATH=/Users/ubugeeei/Source/github.com/ubugeeei/corsa-bind/ref/corsa-upstream/.cache/tsgo TMPDIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize--3953-type-definition-authored-sfc-20260905/target/vize-tests/tmp TEMP=/Users/ubugeeei/Source/github.com/ubugeeei/vize--3953-type-definition-authored-sfc-20260905/target/vize-tests/tmp TMP=/Users/ubugeeei/Source/github.com/ubugeeei/vize--3953-type-definition-authored-sfc-20260905/target/vize-tests/tmp VIZE_LSP_BIN=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target/debug/vize node --test tests/tooling/lsp-type-definition-capability.test.ts tests/tooling/lsp-declaration-capability.test.ts tests/tooling/lsp-capabilities.test.ts tests/tooling/lsp-editor-feature-routing.test.ts`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo fmt --all --check`
- `/Users/ubugeeei/Source/github.com/ubugeeei/vize/node_modules/.bin/oxfmt --check tests/tooling/lsp-type-definition-capability.test.ts tests/tooling/lsp-declaration-capability.test.ts tests/tooling/lsp-capabilities.test.ts tests/tooling/lsp-editor-feature-routing.test.ts tests/tooling/support/lsp/assertions.ts tests/tooling/support/lsp/protocol.ts`
- `git diff --check`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `rust-script tools/commands/ci/source-file-lengths.rs`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791188987&installation_model_id=422833&pr_number=5730&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5730&signature=33393eeb88561ff612c82e1862fff8032133bf178efe691daae94951faba39ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Type definition navigation is now available only when both definition lookup and type checking are enabled.
  * Disabled or unavailable type definition requests now return an inert response.
  * Type definition results correctly map template bindings back to their original source declarations.
* **Tests**
  * Added coverage for capability gating, disabled requests, editor behavior, and source mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->