### PR TITLE
feat(jsx): project event handlers into s2

### DIFF
--- a/crates/vize_atelier_jsx/src/s2.rs
+++ b/crates/vize_atelier_jsx/src/s2.rs
@@ -14,7 +14,7 @@ use vize_s0::{Allocator, Box, Vec};
 use vize_s2::expr::ExprRef;
 use vize_s2::op::{
     Attribute, BindOp, BindingOp, ComponentOp, DynamicName, ElementOp, InterpolationOp, Namespace,
-    Op, Region, TextOp,
+    OnOp, Op, Region, TextOp,
 };
 
 /// A JSX render root represented as S2 operations.
@@ -182,30 +182,50 @@ fn lower_binding<'a>(
     allocator: &'a Allocator,
     directive: &vize_relief::DirectiveNode<'a>,
 ) -> Result<BindingOp<'a>, S2Refusal> {
-    if directive.name != "bind" {
+    if !matches!(directive.name, "bind" | "on") {
         return Err(S2Refusal::Directive);
     }
 
     let name = lower_dynamic_name(allocator, directive.arg.as_ref())?;
-    let mut modifiers = Vec::new_in(&allocator);
-    for modifier in &directive.modifiers {
-        modifiers.push(modifier.content);
-    }
-    let value = directive
+    let modifiers = lower_modifiers(allocator, directive);
+    let expression = directive
         .exp
         .as_ref()
         .map(|expression| lower_expression(allocator, expression))
         .transpose()?;
 
-    Ok(BindingOp::Bind(Box::new_in(
-        BindOp {
-            name,
-            modifiers,
-            value,
-            span: directive.loc.span,
-        },
-        &allocator,
-    )))
+    match directive.name {
+        "bind" => Ok(BindingOp::Bind(Box::new_in(
+            BindOp {
+                name,
+                modifiers,
+                value: expression,
+                span: directive.loc.span,
+            },
+            &allocator,
+        ))),
+        "on" => Ok(BindingOp::On(Box::new_in(
+            OnOp {
+                name,
+                modifiers,
+                handler: expression,
+                span: directive.loc.span,
+            },
+            &allocator,
+        ))),
+        _ => unreachable!("directive name was admitted above"),
+    }
+}
+
+fn lower_modifiers<'a>(
+    allocator: &'a Allocator,
+    directive: &vize_relief::DirectiveNode<'a>,
+) -> Vec<'a, &'a str> {
+    let mut modifiers = Vec::new_in(&allocator);
+    for modifier in &directive.modifiers {
+        modifiers.push(modifier.content);
+    }
+    modifiers
 }
 
 fn lower_dynamic_name<'a>(

--- a/crates/vize_atelier_jsx/tests/s2_projection.rs
+++ b/crates/vize_atelier_jsx/tests/s2_projection.rs
@@ -42,3 +42,75 @@ fn dynamic_bind_props_project_to_s2_bindings() {
     );
     assert_eq!(spread.span.start, source.find("{...attrs}").unwrap() as u32);
 }
+
+#[test]
+fn v_on_directives_project_to_s2_on_bindings() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <button v-on:click={handle} />";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    assert!(!lowered.has_errors(), "{:?}", lowered.diagnostics);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("event binding is admitted");
+    assert_eq!(s2.op_count, 2);
+    let Op::Element(element) = &s2.root.ops[0] else {
+        panic!("root is an element");
+    };
+    assert_eq!(element.bindings.len(), 1);
+
+    let BindingOp::On(click) = &element.bindings[0] else {
+        panic!("binding is ui.on");
+    };
+    assert!(matches!(click.name, Some(DynamicName::Static("click"))));
+    assert!(click.modifiers.is_empty());
+    let handler = click.handler.expect("event binding has a handler");
+    assert_eq!(handler.source(), "handle");
+    assert_eq!(handler.span().start, source.find("handle").unwrap() as u32);
+    let event_attr = "v-on:click={handle}";
+    let event_attr_start = source.find(event_attr).unwrap() as u32;
+    assert_eq!(click.span.start, event_attr_start);
+    assert_eq!(click.span.end, event_attr_start + event_attr.len() as u32);
+}
+
+#[test]
+fn event_handler_directives_project_to_s2_on_bindings() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <button id=\"save\" disabled={isDisabled} \
+                  onClickPassiveCapture={handle} />";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    assert!(!lowered.has_errors(), "{:?}", lowered.diagnostics);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("event bindings are admitted");
+    assert_eq!(s2.op_count, 3);
+    let Op::Element(element) = &s2.root.ops[0] else {
+        panic!("root is an element");
+    };
+    assert_eq!(element.attributes.len(), 1);
+    assert_eq!(element.attributes[0].name, "id");
+    assert_eq!(element.attributes[0].value, Some("save"));
+    assert_eq!(element.bindings.len(), 2);
+
+    let BindingOp::Bind(disabled) = &element.bindings[0] else {
+        panic!("first binding is ui.bind");
+    };
+    assert!(matches!(
+        disabled.name,
+        Some(DynamicName::Static("disabled"))
+    ));
+    let disabled_value = disabled.value.expect("disabled binding has a value");
+    assert_eq!(disabled_value.source(), "isDisabled");
+
+    let BindingOp::On(click) = &element.bindings[1] else {
+        panic!("second binding is ui.on");
+    };
+    assert!(matches!(click.name, Some(DynamicName::Static("click"))));
+    assert_eq!(click.modifiers.as_slice(), ["passive", "capture"]);
+    let handler = click.handler.expect("event binding has a handler");
+    assert_eq!(handler.source(), "handle");
+    assert_eq!(handler.span().start, source.find("handle").unwrap() as u32);
+    let event_attr = "onClickPassiveCapture={handle}";
+    let event_attr_start = source.find(event_attr).unwrap() as u32;
+    assert_eq!(click.span.start, event_attr_start);
+    assert_eq!(click.span.end, event_attr_start + event_attr.len() as u32);
+}


### PR DESCRIPTION
## Summary
- lower Relief `on` directives from JSX into S2 `ui.on` bindings
- preserve static event names, authored modifier order, handler expressions, and directive spans
- keep unsupported directive families on the existing typed refusal path

## Validation
- `cargo fmt --check`
- `git diff --check`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`
- `cargo test -p vize_atelier_jsx --test s2_projection`
- `cargo test -p vize_atelier_jsx --test events`
- `cargo test -p vize_atelier_jsx --test directives`
- `cargo test -p vize_atelier_jsx --test attributes`
- `cargo test -p vize_atelier_jsx --test babel_compat_oracle`
- `cargo test -p vize_atelier_jsx`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791189721&installation_model_id=422833&pr_number=5731&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5731&signature=1fb5da51904384e815ef9f18d8e86bc1817d31af266d3f180a865e8cc44a3fe6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->