### PR TITLE
fix(patina): count invalid eslint baseline ranges

### DIFF
--- a/tools/commands/fixtures/lint-divergence-report.rs
+++ b/tools/commands/fixtures/lint-divergence-report.rs
@@ -10,7 +10,7 @@
 //! sha2 = "0.10"
 //! ```
 
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -750,20 +750,12 @@ fn collect_baseline_findings(results: &[Value], cwd: &Path) -> Result<BaselineIn
             }
             let rule_id = required_str(message, "ruleId", &label)?.to_string();
             let severity = severity(message.get("severity"), &label)?;
-            let line = required_u64(message, "line", &label)?;
-            let column = required_u64(message, "column", &label)?;
-            let end_line = message
-                .get("endLine")
-                .and_then(Value::as_u64)
-                .unwrap_or(line);
-            let end_column = message
-                .get("endColumn")
-                .and_then(Value::as_u64)
-                .unwrap_or(column);
-            if validate_range(&file, &rule_id, line, column, end_line, end_column).is_err() {
+            let Some((line, column, end_line, end_column)) =
+                baseline_range(message, &file, &rule_id)
+            else {
                 invalid_range_count += 1;
                 continue;
-            }
+            };
             findings.push(LintRecord {
                 file: file.clone(),
                 rule_id,
@@ -783,6 +775,22 @@ fn collect_baseline_findings(results: &[Value], cwd: &Path) -> Result<BaselineIn
         excluded_non_vue_count,
         invalid_range_count,
     })
+}
+
+fn baseline_range(message: &Value, file: &str, rule_id: &str) -> Option<(u64, u64, u64, u64)> {
+    let line = message.get("line").and_then(Value::as_u64)?;
+    let column = message.get("column").and_then(Value::as_u64)?;
+    let end_line = optional_baseline_u64(message.get("endLine"), line)?;
+    let end_column = optional_baseline_u64(message.get("endColumn"), column)?;
+    validate_range(file, rule_id, line, column, end_line, end_column).ok()?;
+    Some((line, column, end_line, end_column))
+}
+
+fn optional_baseline_u64(value: Option<&Value>, default: u64) -> Option<u64> {
+    match value {
+        None | Some(Value::Null) => Some(default),
+        Some(value) => value.as_u64(),
+    }
 }
 
 fn group_by_identity(records: &[LintRecord]) -> BTreeMap<String, Vec<LintRecord>> {
@@ -1707,4 +1715,71 @@ fn rustc_version() -> String {
 
 fn sha256(value: &str) -> String {
     format!("{:x}", Sha256::digest(value.as_bytes()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn baseline_zero_column_is_counted_as_invalid_range() {
+        let cwd = Path::new("/repo");
+        let results = json!([
+            {
+                "filePath": "/repo/src/App.vue",
+                "messages": [
+                    {
+                        "ruleId": "vue/no-v-html",
+                        "severity": 2,
+                        "line": 7,
+                        "column": 0,
+                        "endLine": 7,
+                        "endColumn": 1,
+                        "message": "bad location"
+                    }
+                ]
+            }
+        ]);
+
+        let baseline = collect_baseline_findings(results.as_array().unwrap(), cwd).unwrap();
+
+        assert!(baseline.findings.is_empty());
+        assert_eq!(baseline.invalid_range_count, 1);
+        assert_eq!(baseline.parse_error_count, 0);
+    }
+
+    #[test]
+    fn baseline_invalid_range_does_not_hide_valid_findings() {
+        let cwd = Path::new("/repo");
+        let results = json!([
+            {
+                "filePath": "/repo/src/App.vue",
+                "messages": [
+                    {
+                        "ruleId": "vue/no-v-html",
+                        "severity": 2,
+                        "line": 7,
+                        "column": 0,
+                        "message": "bad location"
+                    },
+                    {
+                        "ruleId": "vue/require-v-for-key",
+                        "severity": 1,
+                        "line": 9,
+                        "column": 3,
+                        "endLine": 9,
+                        "endColumn": 5,
+                        "message": "missing key"
+                    }
+                ]
+            }
+        ]);
+
+        let baseline = collect_baseline_findings(results.as_array().unwrap(), cwd).unwrap();
+
+        assert_eq!(baseline.findings.len(), 1);
+        assert_eq!(baseline.findings[0].rule_id, "vue/require-v-for-key");
+        assert_eq!(baseline.findings[0].line, 9);
+        assert_eq!(baseline.invalid_range_count, 1);
+    }
 }


### PR DESCRIPTION
## Summary
- count ESLint baseline messages with invalid source ranges as `baselineInvalidRangeCount`
- keep valid baseline findings flowing after an invalid range
- add Rust Script tests for zero-column baseline evidence

## Validation
- `rust-script --test tools/commands/fixtures/lint-divergence-report.rs`
- `node --test tests/tooling/lint-divergence.test.ts tests/tooling/lint-divergence-report.test.ts`
- `rustfmt --check tools/commands/fixtures/lint-divergence-report.rs`
- `git diff --check`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10`

## Matrix Evidence
- Run 33955782527 shard 3 aborted on `eslint results[19].column must be a positive integer`; this change routes that baseline row to invalid-range evidence instead of aborting the shard.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791190377&installation_model_id=422833&pr_number=5732&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5732&signature=e9d5c77c3da163246d881e10a419f363fa32ea1d1f499b14eeac9e9a33c0624c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->