### PR TITLE
test(typecheck): cover boolean defaults in overloads

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/optional_boolean_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/optional_boolean_props.rs
@@ -103,3 +103,52 @@ acceptDisabled(disabled);
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
+
+#[test]
+fn with_defaults_preserves_optional_boolean_props_for_overload_resolution() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "with-defaults-optional-boolean-overloads",
+        &[(
+            "src/Foo.vue",
+            r#"<script setup lang="ts" generic="T">
+interface Props<T> {
+  defaultValue?: T;
+  disabled?: boolean;
+}
+
+const props = withDefaults(defineProps<Props<T>>(), {
+  defaultValue: undefined,
+});
+
+declare function acceptState(value: { disabled: true; defaultValue?: T }): void;
+declare function acceptState(value: { disabled: false; defaultValue?: T }): void;
+declare function acceptState(value: { disabled: boolean; defaultValue?: T }): void;
+
+acceptState({
+  defaultValue: props.defaultValue,
+  disabled: props.disabled,
+});
+</script>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/Foo.vue"
+                && *code == Some(2769)
+                && message.contains("No overload matches this call"))
+        }),
+        "withDefaults should keep optional boolean props usable by overloads, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}


### PR DESCRIPTION
## Summary
- add a focused regression for generic withDefaults props passed through overload resolution
- lock the Reka UI TS2769 shape behind the optional boolean props test coverage

## Validation
- cargo fmt --all --check
- cargo test -p vize_canon optional_boolean_props -- --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791190652&installation_model_id=422833&pr_number=5734&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5734&signature=cc403fde598cc621afde718f607cce4054318d49aacf770f032ae73219666dfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->