### PR TITLE
fix(glyph): validate waivers across full corpus

### DIFF
--- a/legacy-tools/fixtures/glyph-corpus.mjs
+++ b/legacy-tools/fixtures/glyph-corpus.mjs
@@ -46,8 +46,20 @@ const maxFilesEnv = "VIZE_GLYPH_CORPUS_MAX_FILES_PER_PROJECT";
  * so shared fixture paths never make sibling registry ids look selected.
  */
 export function loadGlyphCorpusProjects() {
+  return materializeGlyphCorpusProjects(selectGlyphCorpusProjects(readGlyphCorpusRegistry()));
+}
+
+function loadAllGlyphCorpusProjects() {
+  return materializeGlyphCorpusProjects(selectGlyphCorpusProjects(readGlyphCorpusRegistry(), {}));
+}
+
+function readGlyphCorpusRegistry() {
   const registry = JSON.parse(readFileSync(registryPath, "utf8"));
-  return selectGlyphCorpusProjects(registry.projects).map((project) => {
+  return registry.projects;
+}
+
+function materializeGlyphCorpusProjects(projects) {
+  return projects.map((project) => {
     const fixtureDir = resolve(repoRoot, project.fixturePath);
     const hydrated = existsSync(fixtureDir) && readdirSync(fixtureDir).length > 0;
     return { ...project, fixtureDir, hydrated };
@@ -305,7 +317,7 @@ function nonNegativeInteger(value, name) {
 }
 
 export function loadKnownViolationLedger() {
-  return readKnownViolationLedger(knownViolationsPath, loadGlyphCorpusProjects());
+  return readKnownViolationLedger(knownViolationsPath, loadAllGlyphCorpusProjects());
 }
 
 /** Load the checked-in waiver ledger entries for one corpus property. */

--- a/tests/tooling/glyph-corpus-evidence.test.ts
+++ b/tests/tooling/glyph-corpus-evidence.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { test } from "node:test";
 
 import {
+  loadKnownViolations,
   selectGlyphCorpusProjects,
   writeGlyphCorpusPropertyEvidence,
 } from "../../legacy-tools/fixtures/glyph-corpus.mjs";
@@ -116,3 +117,28 @@ test("glyph corpus shard selection is bound to manifest project ids before hydra
     /must be less than/,
   );
 });
+
+test("glyph waiver ledger validation is not narrowed to the selected shard", () => {
+  const beforeIndex = process.env.FIXTURE_SHARD_INDEX;
+  const beforeCount = process.env.FIXTURE_SHARD_COUNT;
+  try {
+    process.env.FIXTURE_SHARD_INDEX = "10";
+    process.env.FIXTURE_SHARD_COUNT = "22";
+    const violations = loadKnownViolations("parse-preservation");
+    assert.ok(
+      violations.some((entry: { project: string }) => entry.project === "vitepress"),
+      "the current VitePress waiver should remain valid outside its matrix shard",
+    );
+  } finally {
+    restoreEnv("FIXTURE_SHARD_INDEX", beforeIndex);
+    restoreEnv("FIXTURE_SHARD_COUNT", beforeCount);
+  }
+});
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value == null) {
+    delete process.env[name];
+  } else {
+    process.env[name] = value;
+  }
+}


### PR DESCRIPTION
## Summary
- validate the glyph waiver ledger against the full formatter corpus instead of the currently selected matrix shard
- keep per-shard waiver consumption strict for hydrated selected projects
- add a regression test for loading the VitePress waiver outside its selected shard

## Validation
- node --test tests/tooling/glyph-corpus-evidence.test.ts tests/tooling/glyph-corpus-waivers.test.ts
- cargo build --profile ci -p vize
- FIXTURE_SHARD_INDEX=10 FIXTURE_SHARD_COUNT=22 FIXTURE_REPORT_DIR=/tmp/vize-glyph-report-shard-10-1788598773 VIZE_TEST_BIN=target/ci/vize node --test --test-concurrency=1 tests/tooling/sfc-baseline-routes.test.ts tests/tooling/sfc-baselines.test.ts tests/tooling/vue2-render-signature.test.ts tests/tooling/glyph-sfc-evidence.test.ts tests/tooling/sfc-equivalence.test.ts tests/tooling/glyph-corpus-idempotence.test.ts tests/tooling/glyph-corpus-parse-preservation.test.ts tests/tooling/glyph-pug-oracle.test.ts tests/tooling/glyph-corpus-lint-agreement.test.ts
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791190837&installation_model_id=422833&pr_number=5735&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5735&signature=18d4be4eaee93a6f9327502b93dbf50f02dcc3c6170b7231f5187ec6521ffafa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed glyph waiver validation so it consistently checks the complete project set, even when fixture shard settings are present.
  - Prevented valid waivers from being incorrectly reported as invalid when running within a selected shard.
  - Improved environment handling during validation to avoid test configuration affecting ledger coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->