### PR TITLE
test(tooling): add epic spinners authored lsp oracle

### DIFF
--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -26,6 +26,8 @@ mod component_alias_props_tests;
 #[cfg(test)]
 mod component_lower_camel_props_tests;
 #[cfg(test)]
+mod component_options_api_props_tests;
+#[cfg(test)]
 mod component_props_tests;
 #[cfg(test)]
 mod component_pug_props_tests;

--- a/crates/vize_maestro/src/ide/completion/component_options_api_props_tests.rs
+++ b/crates/vize_maestro/src/ide/completion/component_options_api_props_tests.rs
@@ -1,0 +1,68 @@
+use std::fs;
+
+use tower_lsp::lsp_types::{CompletionResponse, Url};
+
+use super::CompletionService;
+use crate::{ide::IdeContext, server::ServerState};
+
+#[test]
+fn template_component_prop_completion_resolves_options_api_runtime_props() {
+    let dir = tempfile::tempdir().unwrap();
+    let child_path = dir.path().join("Child.vue");
+    fs::write(
+        &child_path,
+        r#"<script lang="ts">
+export default {
+  props: {
+    count: {
+      default: 2
+    },
+    html: null,
+    vizeOracleProbe: {
+      type: Boolean,
+      default: false,
+    },
+  },
+}
+</script>
+"#,
+    )
+    .unwrap();
+
+    let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+</script>
+<template><Child  /></template>
+"#;
+    let parent_path = dir.path().join("Parent.vue");
+    fs::write(&parent_path, source).unwrap();
+
+    let uri = Url::from_file_path(&parent_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    let offset = source.find("<Child  />").unwrap() + "<Child ".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert!(has_label(&labels, "count"), "{labels:?}");
+    assert!(has_label(&labels, "html"), "{labels:?}");
+    assert!(has_label(&labels, "vize-oracle-probe"), "{labels:?}");
+}
+
+fn completion_labels(response: CompletionResponse) -> Vec<String> {
+    match response {
+        CompletionResponse::Array(items) => items,
+        CompletionResponse::List(list) => list.items,
+    }
+    .into_iter()
+    .map(|item| item.label)
+    .collect()
+}
+
+fn has_label(labels: &[String], expected: &str) -> bool {
+    labels.iter().any(|label| label == expected)
+}

--- a/crates/vize_maestro/src/ide/completion/template/component_meta.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_meta.rs
@@ -214,7 +214,7 @@ pub(super) fn extract_component_metadata(
             }
         }
 
-        if legacy_vue2 {
+        if options_api || legacy_vue2 {
             for (name, binding_type) in summary.bindings.iter() {
                 if binding_type == BindingType::Props && seen_props.insert(name.to_string()) {
                     props.push(ComponentProp {

--- a/crates/vize_maestro/src/ide/corsa_support.rs
+++ b/crates/vize_maestro/src/ide/corsa_support.rs
@@ -19,6 +19,7 @@ mod html_attribute_tests;
 mod html_tag;
 mod location_merge;
 mod rename_merge;
+mod rename_missing;
 mod svg_attribute;
 mod virtual_document;
 mod workspace_edit;
@@ -43,6 +44,7 @@ pub(crate) use html_attribute::{
 pub(crate) use html_tag::{html_tag_request_path, html_tag_virtual_document, native_dom_tag_info};
 pub(crate) use location_merge::merge_canonical_locations;
 pub(crate) use rename_merge::merge_authored_rename;
+pub(crate) use rename_missing::merge_missing_authored_rename;
 use virtual_document::{
     MatchedVirtualDocument, is_virtual_document_uri, match_virtual_document, virtual_document_path,
 };

--- a/crates/vize_maestro/src/ide/corsa_support/rename_missing.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/rename_missing.rs
@@ -1,0 +1,262 @@
+use std::cmp::Ordering;
+
+use tower_lsp::lsp_types::{
+    AnnotatedTextEdit, DocumentChangeOperation, DocumentChanges, OneOf,
+    OptionalVersionedTextDocumentIdentifier, Range, TextDocumentEdit, TextEdit, Url, WorkspaceEdit,
+};
+
+use crate::ide::IdeContext;
+
+/// Keep the canonical rename answer, then append authored SFC edits for ranges
+/// it missed.
+///
+/// The canonical path can preserve TypeScript-specific rewrite shapes such as
+/// destructuring aliases. Authored rename is still valuable for Vue ranges the
+/// canonical virtual document did not return, but it must not replace a range
+/// the canonical answer already rewrote.
+pub(crate) fn merge_missing_authored_rename(
+    ctx: &IdeContext<'_>,
+    canonical: Option<WorkspaceEdit>,
+    authored: Option<WorkspaceEdit>,
+) -> Option<WorkspaceEdit> {
+    let Some(mut canonical) = canonical else {
+        return authored.map(order_edits_by_position);
+    };
+    let Some(authored_edits) = authored
+        .and_then(|edit| edit.changes)
+        .and_then(|mut changes| changes.remove(ctx.uri))
+        .filter(|edits| !edits.is_empty())
+    else {
+        return Some(order_edits_by_position(canonical));
+    };
+
+    if workspace_edit_touch_count(&canonical, ctx.uri) > 1 {
+        return Some(order_edits_by_position(canonical));
+    }
+
+    let missing = authored_edits
+        .into_iter()
+        .filter(|edit| !workspace_edit_overlaps_range(&canonical, ctx.uri, edit.range))
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Some(order_edits_by_position(canonical));
+    }
+
+    append_missing_text_edits(ctx, &mut canonical, missing);
+    Some(order_edits_by_position(canonical))
+}
+
+fn append_missing_text_edits(
+    ctx: &IdeContext<'_>,
+    edit: &mut WorkspaceEdit,
+    authored_edits: Vec<TextEdit>,
+) {
+    // Clients prefer `documentChanges` whenever it is present, so authored
+    // supplemental edits have to land in the same container as the canonical
+    // edits.
+    match edit.document_changes.as_mut() {
+        Some(DocumentChanges::Edits(edits)) => {
+            append_to_document_edits(ctx, edits, authored_edits);
+        }
+        Some(DocumentChanges::Operations(operations)) => {
+            append_to_operations(ctx, operations, authored_edits);
+        }
+        None => {
+            let entry = edit
+                .changes
+                .get_or_insert_with(Default::default)
+                .entry(ctx.uri.clone())
+                .or_default();
+            append_text_edits(entry, authored_edits);
+        }
+    }
+}
+
+fn append_to_document_edits(
+    ctx: &IdeContext<'_>,
+    edits: &mut Vec<TextDocumentEdit>,
+    authored_edits: Vec<TextEdit>,
+) {
+    for edit in edits.iter_mut() {
+        if edit.text_document.uri == *ctx.uri {
+            append_annotatable_edits(&mut edit.edits, authored_edits);
+            return;
+        }
+    }
+    edits.push(authored_document_edit(ctx, authored_edits));
+}
+
+fn append_to_operations(
+    ctx: &IdeContext<'_>,
+    operations: &mut Vec<DocumentChangeOperation>,
+    authored_edits: Vec<TextEdit>,
+) {
+    for operation in operations.iter_mut() {
+        if let DocumentChangeOperation::Edit(edit) = operation
+            && edit.text_document.uri == *ctx.uri
+        {
+            append_annotatable_edits(&mut edit.edits, authored_edits);
+            return;
+        }
+    }
+    operations.push(DocumentChangeOperation::Edit(authored_document_edit(
+        ctx,
+        authored_edits,
+    )));
+}
+
+fn authored_document_edit(ctx: &IdeContext<'_>, authored_edits: Vec<TextEdit>) -> TextDocumentEdit {
+    TextDocumentEdit {
+        text_document: OptionalVersionedTextDocumentIdentifier {
+            uri: ctx.uri.clone(),
+            version: None,
+        },
+        edits: authored_edits.into_iter().map(OneOf::Left).collect(),
+    }
+}
+
+fn append_text_edits(edits: &mut Vec<TextEdit>, authored_edits: Vec<TextEdit>) {
+    for edit in authored_edits {
+        if !edits.iter().any(|kept| kept.range == edit.range) {
+            edits.push(edit);
+        }
+    }
+}
+
+fn append_annotatable_edits(
+    edits: &mut Vec<OneOf<TextEdit, AnnotatedTextEdit>>,
+    authored_edits: Vec<TextEdit>,
+) {
+    for edit in authored_edits {
+        if !edits
+            .iter()
+            .any(|kept| annotatable_edit_range(kept) == edit.range)
+        {
+            edits.push(OneOf::Left(edit));
+        }
+    }
+}
+
+fn workspace_edit_overlaps_range(edit: &WorkspaceEdit, uri: &Url, range: Range) -> bool {
+    if edit
+        .changes
+        .as_ref()
+        .and_then(|changes| changes.get(uri))
+        .is_some_and(|edits| edits.iter().any(|edit| ranges_overlap(edit.range, range)))
+    {
+        return true;
+    }
+
+    match edit.document_changes.as_ref() {
+        Some(DocumentChanges::Edits(edits)) => edits.iter().any(|edit| {
+            edit.text_document.uri == *uri
+                && edit
+                    .edits
+                    .iter()
+                    .any(|edit| ranges_overlap(annotatable_edit_range(edit), range))
+        }),
+        Some(DocumentChanges::Operations(operations)) => operations.iter().any(|operation| {
+            if let DocumentChangeOperation::Edit(edit) = operation {
+                edit.text_document.uri == *uri
+                    && edit
+                        .edits
+                        .iter()
+                        .any(|edit| ranges_overlap(annotatable_edit_range(edit), range))
+            } else {
+                false
+            }
+        }),
+        None => false,
+    }
+}
+
+fn workspace_edit_touch_count(edit: &WorkspaceEdit, uri: &Url) -> usize {
+    let mut count = edit
+        .changes
+        .as_ref()
+        .and_then(|changes| changes.get(uri))
+        .map_or(0, Vec::len);
+
+    match edit.document_changes.as_ref() {
+        Some(DocumentChanges::Edits(edits)) => {
+            count += edits
+                .iter()
+                .filter(|edit| edit.text_document.uri == *uri)
+                .map(|edit| edit.edits.len())
+                .sum::<usize>();
+        }
+        Some(DocumentChanges::Operations(operations)) => {
+            count += operations
+                .iter()
+                .filter_map(|operation| {
+                    if let DocumentChangeOperation::Edit(edit) = operation
+                        && edit.text_document.uri == *uri
+                    {
+                        Some(edit.edits.len())
+                    } else {
+                        None
+                    }
+                })
+                .sum::<usize>();
+        }
+        None => {}
+    }
+
+    count
+}
+
+fn order_edits_by_position(mut edit: WorkspaceEdit) -> WorkspaceEdit {
+    if let Some(changes) = edit.changes.as_mut() {
+        for edits in changes.values_mut() {
+            edits.sort_by(|a, b| compare_ranges(&a.range, &b.range));
+        }
+    }
+
+    match edit.document_changes.as_mut() {
+        Some(DocumentChanges::Edits(edits)) => {
+            for edit in edits.iter_mut() {
+                sort_annotatable_edits(&mut edit.edits);
+            }
+        }
+        Some(DocumentChanges::Operations(operations)) => {
+            for operation in operations.iter_mut() {
+                if let DocumentChangeOperation::Edit(edit) = operation {
+                    sort_annotatable_edits(&mut edit.edits);
+                }
+            }
+        }
+        None => {}
+    }
+
+    edit
+}
+
+fn sort_annotatable_edits(edits: &mut [OneOf<TextEdit, AnnotatedTextEdit>]) {
+    edits.sort_by(|a, b| compare_ranges(&annotatable_edit_range(a), &annotatable_edit_range(b)));
+}
+
+fn compare_ranges(a: &Range, b: &Range) -> Ordering {
+    compare_positions(a.start, b.start).then(compare_positions(a.end, b.end))
+}
+
+fn ranges_overlap(a: Range, b: Range) -> bool {
+    compare_positions(a.start, b.end).is_lt() && compare_positions(b.start, a.end).is_lt()
+}
+
+fn compare_positions(
+    a: tower_lsp::lsp_types::Position,
+    b: tower_lsp::lsp_types::Position,
+) -> Ordering {
+    a.line.cmp(&b.line).then(a.character.cmp(&b.character))
+}
+
+fn annotatable_edit_range(edit: &OneOf<TextEdit, AnnotatedTextEdit>) -> Range {
+    match edit {
+        OneOf::Left(edit) => edit.range,
+        OneOf::Right(edit) => edit.text_edit.range,
+    }
+}
+
+#[cfg(test)]
+#[path = "rename_missing_tests.rs"]
+mod tests;

--- a/crates/vize_maestro/src/ide/corsa_support/rename_missing_tests.rs
+++ b/crates/vize_maestro/src/ide/corsa_support/rename_missing_tests.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+
+use tower_lsp::lsp_types::{Position, Range, TextEdit, Url, WorkspaceEdit};
+
+use super::merge_missing_authored_rename;
+use crate::{ide::IdeContext, server::ServerState};
+
+const SOURCE: &str =
+    "<script setup lang=\"ts\">\nconst total = 1\n</script>\n<template>{{ total }}</template>\n";
+
+#[test]
+fn appends_missing_authored_ranges_after_canonical_rename() {
+    let state = ServerState::new();
+    let uri = Url::parse("file:///workspace/Scenario.vue").unwrap();
+    state
+        .documents
+        .open(uri.clone(), SOURCE.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, SOURCE);
+    let ctx = IdeContext::new(&state, &uri, SOURCE.find("total").unwrap()).unwrap();
+
+    let script_edit = edit(1, 6, 1, 11);
+    let template_edit = edit(3, 13, 3, 18);
+    let canonical = changes(&uri, vec![template_edit.clone()]);
+    let authored = changes(&uri, vec![script_edit.clone(), template_edit.clone()]);
+
+    let merged =
+        merge_missing_authored_rename(&ctx, Some(canonical), Some(authored)).expect("merged edit");
+    let merged = merged.changes.expect("merged changes");
+
+    assert_eq!(merged[&uri], vec![script_edit, template_edit]);
+}
+
+#[test]
+fn keeps_canonical_text_for_overlapping_authored_ranges() {
+    let state = ServerState::new();
+    let uri = Url::parse("file:///workspace/Scenario.vue").unwrap();
+    state
+        .documents
+        .open(uri.clone(), SOURCE.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, SOURCE);
+    let ctx = IdeContext::new(&state, &uri, SOURCE.find("total").unwrap()).unwrap();
+
+    let mut canonical_edit = edit(1, 0, 1, 11);
+    canonical_edit.new_text = "const quantity".to_string();
+    let mut authored_edit = edit(1, 6, 1, 11);
+    authored_edit.new_text = "renamed".to_string();
+
+    let merged = merge_missing_authored_rename(
+        &ctx,
+        Some(changes(&uri, vec![canonical_edit.clone()])),
+        Some(changes(&uri, vec![authored_edit])),
+    )
+    .expect("merged edit");
+    let merged = merged.changes.expect("merged changes");
+
+    assert_eq!(merged[&uri], vec![canonical_edit]);
+}
+
+#[test]
+fn keeps_multi_range_canonical_rename_authoritative() {
+    let state = ServerState::new();
+    let uri = Url::parse("file:///workspace/Scenario.vue").unwrap();
+    state
+        .documents
+        .open(uri.clone(), SOURCE.to_string(), 1, "vue".to_string());
+    state.update_virtual_docs(&uri, SOURCE);
+    let ctx = IdeContext::new(&state, &uri, SOURCE.find("total").unwrap()).unwrap();
+
+    let canonical = changes(&uri, vec![edit(1, 6, 1, 11), edit(3, 13, 3, 18)]);
+    let authored = changes(
+        &uri,
+        vec![edit(1, 6, 1, 11), edit(3, 13, 3, 18), edit(3, 36, 3, 41)],
+    );
+
+    let merged = merge_missing_authored_rename(&ctx, Some(canonical.clone()), Some(authored))
+        .expect("merged edit");
+
+    assert_eq!(merged, canonical);
+}
+
+fn changes(uri: &Url, edits: Vec<TextEdit>) -> WorkspaceEdit {
+    WorkspaceEdit {
+        changes: Some(HashMap::from([(uri.clone(), edits)])),
+        document_changes: None,
+        change_annotations: None,
+    }
+}
+
+fn edit(start_line: u32, start_character: u32, end_line: u32, end_character: u32) -> TextEdit {
+    TextEdit {
+        range: Range::new(
+            Position::new(start_line, start_character),
+            Position::new(end_line, end_character),
+        ),
+        new_text: "quantity".to_string(),
+    }
+}

--- a/crates/vize_maestro/src/ide/rename.rs
+++ b/crates/vize_maestro/src/ide/rename.rs
@@ -27,7 +27,7 @@ use vize_canon::CorsaBridge;
 
 use super::IdeContext;
 #[cfg(feature = "native")]
-use crate::ide::corsa_support;
+use crate::ide::corsa_support as corsa;
 #[cfg(feature = "native")]
 use crate::virtual_code::{ArtCursorPosition, BlockType};
 
@@ -135,7 +135,7 @@ impl RenameService {
         if let canonical::Answer::Available(edit) =
             canonical::rename(ctx, new_name, corsa_bridge.as_deref()).await
         {
-            return edit;
+            return corsa::merge_missing_authored_rename(ctx, edit, Self::rename(ctx, new_name));
         }
         let corsa_result = match ctx.block_type? {
             BlockType::Template => {
@@ -159,7 +159,7 @@ impl RenameService {
 
         // Corsa only renames the virtual document the request opened, so the
         // authored edits carry the other blocks of this SFC.
-        corsa_support::merge_authored_rename(ctx, corsa_result, Self::rename(ctx, new_name))
+        corsa::merge_authored_rename(ctx, corsa_result, Self::rename(ctx, new_name))
     }
 
     #[cfg(feature = "native")]
@@ -173,14 +173,14 @@ impl RenameService {
         let vts_offset =
             crate::ide::hover::HoverService::sfc_to_virtual_ts_offset(ctx, ctx.offset)?;
         let (line, character) = crate::ide::offset_to_position(&template.content, vts_offset);
-        let request_path = corsa_support::template_request_path(ctx.uri);
+        let request_path = corsa::template_request_path(ctx.uri);
         let uri = bridge
             .open_or_update_virtual_document(&request_path, &template.content)
             .await
             .ok()?;
         let response = bridge.prepare_rename(&uri, line, character).await.ok()??;
         let response = serde_json::from_value(response).ok()?;
-        corsa_support::map_corsa_prepare_rename(ctx, &uri, response)
+        corsa::map_corsa_prepare_rename(ctx, &uri, response)
     }
 
     #[cfg(feature = "native")]
@@ -194,14 +194,14 @@ impl RenameService {
         let template = virtual_docs.art_template(info.variant_index)?;
         let vts_offset = template.source_map.to_generated(ctx.offset as u32)? as usize;
         let (line, character) = crate::ide::offset_to_position(&template.content, vts_offset);
-        let request_path = corsa_support::art_template_request_path(ctx.uri, info.variant_index);
+        let request_path = corsa::art_template_request_path(ctx.uri, info.variant_index);
         let uri = bridge
             .open_or_update_virtual_document(&request_path, &template.content)
             .await
             .ok()?;
         let response = bridge.prepare_rename(&uri, line, character).await.ok()??;
         let response = serde_json::from_value(response).ok()?;
-        corsa_support::map_corsa_prepare_rename(ctx, &uri, response)
+        corsa::map_corsa_prepare_rename(ctx, &uri, response)
     }
 
     #[cfg(feature = "native")]
@@ -220,14 +220,14 @@ impl RenameService {
         let vts_offset =
             crate::ide::hover::HoverService::sfc_to_virtual_ts_script_offset(ctx, ctx.offset)?;
         let (line, character) = crate::ide::offset_to_position(&script_doc.content, vts_offset);
-        let request_path = corsa_support::script_request_path(ctx.uri, is_setup);
+        let request_path = corsa::script_request_path(ctx.uri, is_setup);
         let uri = bridge
             .open_or_update_virtual_document(&request_path, &script_doc.content)
             .await
             .ok()?;
         let response = bridge.prepare_rename(&uri, line, character).await.ok()??;
         let response = serde_json::from_value(response).ok()?;
-        corsa_support::map_corsa_prepare_rename(ctx, &uri, response)
+        corsa::map_corsa_prepare_rename(ctx, &uri, response)
     }
 
     #[cfg(feature = "native")]
@@ -242,7 +242,7 @@ impl RenameService {
         let vts_offset =
             crate::ide::hover::HoverService::sfc_to_virtual_ts_offset(ctx, ctx.offset)?;
         let (line, character) = crate::ide::offset_to_position(&template.content, vts_offset);
-        let request_path = corsa_support::template_request_path(ctx.uri);
+        let request_path = corsa::template_request_path(ctx.uri);
         let uri = bridge
             .open_or_update_virtual_document(&request_path, &template.content)
             .await
@@ -252,7 +252,7 @@ impl RenameService {
             .await
             .ok()??;
         let edit = serde_json::from_value(edit).ok()?;
-        corsa_support::map_corsa_workspace_edit(ctx, edit)
+        corsa::map_corsa_workspace_edit(ctx, edit)
     }
 
     #[cfg(feature = "native")]
@@ -267,7 +267,7 @@ impl RenameService {
         let template = virtual_docs.art_template(info.variant_index)?;
         let vts_offset = template.source_map.to_generated(ctx.offset as u32)? as usize;
         let (line, character) = crate::ide::offset_to_position(&template.content, vts_offset);
-        let request_path = corsa_support::art_template_request_path(ctx.uri, info.variant_index);
+        let request_path = corsa::art_template_request_path(ctx.uri, info.variant_index);
         let uri = bridge
             .open_or_update_virtual_document(&request_path, &template.content)
             .await
@@ -277,7 +277,7 @@ impl RenameService {
             .await
             .ok()??;
         let edit = serde_json::from_value(edit).ok()?;
-        corsa_support::map_corsa_workspace_edit(ctx, edit)
+        corsa::map_corsa_workspace_edit(ctx, edit)
     }
 
     #[cfg(feature = "native")]
@@ -297,7 +297,7 @@ impl RenameService {
         let vts_offset =
             crate::ide::hover::HoverService::sfc_to_virtual_ts_script_offset(ctx, ctx.offset)?;
         let (line, character) = crate::ide::offset_to_position(&script_doc.content, vts_offset);
-        let request_path = corsa_support::script_request_path(ctx.uri, is_setup);
+        let request_path = corsa::script_request_path(ctx.uri, is_setup);
         let uri = bridge
             .open_or_update_virtual_document(&request_path, &script_doc.content)
             .await
@@ -307,7 +307,7 @@ impl RenameService {
             .await
             .ok()??;
         let edit = serde_json::from_value(edit).ok()?;
-        corsa_support::map_corsa_workspace_edit(ctx, edit)
+        corsa::map_corsa_workspace_edit(ctx, edit)
     }
 
     fn is_renameable(word: &str, ctx: &IdeContext) -> bool {

--- a/crates/vize_maestro/src/ide/rename/corsa_options_api_tests.rs
+++ b/crates/vize_maestro/src/ide/rename/corsa_options_api_tests.rs
@@ -1,0 +1,136 @@
+use std::{fs, sync::Arc};
+
+use tower_lsp::lsp_types::{PrepareRenameResponse, Range, Url};
+use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+
+use super::RenameService;
+use crate::{ide::IdeContext, server::ServerState};
+
+#[test]
+fn canonical_options_api_template_rename_includes_authored_declaration() {
+    crate::runtime::block_on(async {
+        let Some(tsgo_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let project = tempfile::TempDir::new().expect("temp project");
+        let project_root = project
+            .path()
+            .canonicalize()
+            .expect("canonical project root");
+        let src = project_root.join("src");
+        fs::create_dir_all(&src).expect("src");
+        fs::write(
+            project_root.join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .expect("tsconfig");
+
+        let source = r#"<template>
+  <div :style="sliderLeft + '; width: 50%;'"></div>
+</template>
+<script lang="ts">
+export default {
+  computed: {
+    sliderLeft () {
+      return 'left: 0%'
+    }
+  }
+}
+</script>
+"#;
+        let path = src.join("Tab.vue");
+        fs::write(&path, source).expect("source");
+        let uri = Url::from_file_path(&path).expect("uri");
+        let state = ServerState::new();
+        state.set_workspace_root(project_root.clone());
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+        let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(tsgo_path),
+            working_dir: Some(project_root),
+            timeout_ms: 30_000,
+            ..Default::default()
+        }));
+        bridge.spawn().await.expect("tsgo session");
+
+        let query_offset = source.find("sliderLeft +").expect("template binding") + 1;
+        let ctx = IdeContext::new(&state, &uri, query_offset).expect("context");
+        let prepare = RenameService::prepare_rename_with_corsa(&ctx, Some(Arc::clone(&bridge)))
+            .await
+            .expect("prepare rename");
+        assert_eq!(authored_text(source, prepare_range(prepare)), "sliderLeft");
+
+        let edit =
+            RenameService::rename_with_corsa(&ctx, "renamedSliderLeft", Some(Arc::clone(&bridge)))
+                .await
+                .expect("rename");
+        bridge.shutdown().await.expect("shutdown");
+
+        let changes = edit.changes.expect("plain workspace changes");
+        assert_eq!(changes.keys().collect::<Vec<_>>(), [&uri]);
+        let edits = changes.get(&uri).expect("SFC edits");
+        assert_eq!(edits.len(), 2, "template and declaration edits: {edits:#?}");
+        assert!(
+            edits
+                .iter()
+                .all(|edit| edit.new_text == "renamedSliderLeft")
+        );
+        assert!(
+            edits
+                .iter()
+                .any(|edit| authored_text(source, edit.range) == "sliderLeft"
+                    && edit.range.start.line == 1),
+            "missing template edit: {edits:#?}"
+        );
+        assert!(
+            edits
+                .iter()
+                .any(|edit| authored_text(source, edit.range) == "sliderLeft"
+                    && edit.range.start.line == 6),
+            "missing Options API declaration edit: {edits:#?}"
+        );
+    });
+}
+
+fn prepare_range(response: PrepareRenameResponse) -> Range {
+    match response {
+        PrepareRenameResponse::Range(range)
+        | PrepareRenameResponse::RangeWithPlaceholder { range, .. } => range,
+        PrepareRenameResponse::DefaultBehavior { .. } => panic!("expected an authored range"),
+    }
+}
+
+fn authored_text(source: &str, range: Range) -> &str {
+    let start = crate::ide::position_to_offset(source, range.start.line, range.start.character)
+        .expect("source start");
+    let end = crate::ide::position_to_offset(source, range.end.line, range.end.character)
+        .expect("source end");
+    &source[start..end]
+}
+
+fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    vize_s0::corsa_resolver::resolve_corsa_executable(
+        vize_s0::corsa_resolver::CorsaResolveRequest {
+            project_root: Some(workspace_root),
+            ..Default::default()
+        },
+    )
+    .ok()
+}

--- a/crates/vize_maestro/src/ide/rename/tests.rs
+++ b/crates/vize_maestro/src/ide/rename/tests.rs
@@ -1,5 +1,9 @@
 use super::RenameService;
 
+#[cfg(feature = "native")]
+#[path = "corsa_options_api_tests.rs"]
+mod corsa_options_api_tests;
+
 /// Renaming a local binding must not rewrite a same-named prop
 /// *attribute name* on a component usage — that token belongs to the
 /// child's own prop symbol, and rewriting it silently breaks the call

--- a/crates/vize_maestro/src/server/diagnostic_publishing.rs
+++ b/crates/vize_maestro/src/server/diagnostic_publishing.rs
@@ -13,6 +13,9 @@ impl MaestroServer {
     /// document still has the version opened by the caller. Empty initial
     /// results are withheld so consumers do not mistake the parser/lint pass
     /// for the terminal combined result from the queued type-diagnostic pass.
+    /// Non-empty sync results are still useful as prompt feedback, but they
+    /// stay unversioned for the same reason: a versioned publish is the
+    /// complete parser/lint/typecheck answer for that document version.
     ///
     /// This deliberately bypasses `publish_collected_diagnostics`: Corsa has
     /// not been attempted yet, so its one-shot "type checking unavailable"
@@ -38,7 +41,7 @@ impl MaestroServer {
             && self.state.documents.version(uri) == Some(expected)
         {
             self.client
-                .publish_diagnostics(uri.clone(), diagnostics, Some(expected))
+                .publish_diagnostics(uri.clone(), diagnostics, None)
                 .await;
         }
     }

--- a/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 26, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 27, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -766,6 +766,7 @@
         "fixturePaths": [
           "tests/_fixtures/_git/ant-design-vue",
           "tests/_fixtures/_git/element-plus",
+          "tests/_fixtures/_git/epic-spinners",
           "tests/_fixtures/_git/hoppscotch",
           "tests/_fixtures/_git/inspira-ui",
           "tests/_fixtures/_git/reka-ui",

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 26,
+    "minimumProjectCount": 27,
     "trackingIssue": 3952
   },
   "projects": [
@@ -3467,7 +3467,73 @@
         "syntax-highlighter",
         "lsp"
       ],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "packages/docs/src/components/Tab.vue",
+          "symbol": "sliderLeft",
+          "usageAnchor": ":style=\"sliderLeft + '; width: 50%;'\"",
+          "declarationAnchor": "      sliderLeft () {",
+          "hoverContains": ["const sliderLeft: string"],
+          "renameTo": "__vizeRenamedSliderLeft"
+        },
+        "componentBoundary": {
+          "importerFile": "packages/docs/src/components/ModalVue.vue",
+          "componentFile": "packages/docs/src/components/Tab.vue",
+          "tagName": "Tabs",
+          "tagAnchor": "<Tabs ",
+          "completionItemCount": 33,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "count", "rank": 28 },
+            { "label": "npm", "rank": 29 },
+            { "label": "vue", "rank": 30 },
+            { "label": "html", "rank": 31 },
+            { "label": "css", "rank": 32 }
+          ],
+          "dependencyEdit": {
+            "anchor": "    props: {\n      count: {\n        default: 2\n      },\n",
+            "replacement": "    props: {\n      vizeOracleProbe: {\n        type: Boolean,\n        default: false,\n      },\n      count: {\n        default: 2\n      },\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "packages/docs/src/components/__VizeOracleTab.vue",
+          "renamedFile": "packages/docs/src/components/__VizeOracleRenamedTab.vue",
+          "originalImportSpecifier": "./Tab.vue",
+          "copiedImportSpecifier": "./__VizeOracleTab.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedTab.vue",
+          "markerInsertionAnchor": "<script lang=\"ts\">\n",
+          "markerSymbol": "__vizeEpicSpinnersTabMarker__"
+        }
+      }
     },
     {
       "id": "portal-vue",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 26,
+      "authored-lsp": 27,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,

--- a/tests/tooling/lsp-initial-diagnostics-version.test.ts
+++ b/tests/tooling/lsp-initial-diagnostics-version.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+
+import { isDiagnosticsForUri } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { PublishDiagnosticsParams } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+test("initial sync diagnostics publish before terminal versioned diagnostics", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-initial-diagnostics-version");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    fs.writeFileSync(
+      path.join(workspaceDir, "vize.config.json"),
+      JSON.stringify({
+        lsp: { lint: true, typecheck: true },
+        typeChecker: {
+          corsaPath: "./vize-missing-corsa-for-initial-sync-diagnostics",
+        },
+      }),
+      "utf8",
+    );
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: true,
+      typecheck: true,
+    });
+
+    const filePath = path.join(workspaceDir, "InitialSync.vue");
+    const uri = pathToFileURL(filePath).href;
+    const text = `<template><div /></template>
+<style>.root { color: red; }</style>
+`;
+    fs.writeFileSync(filePath, text, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text },
+    });
+
+    const initial = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, uri) &&
+        (params as PublishDiagnosticsParams).version == null &&
+        (params as PublishDiagnosticsParams).diagnostics.length > 0,
+      10000,
+    )) as PublishDiagnosticsParams;
+
+    assert.equal(initial.version, undefined);
+    assert.ok(initial.diagnostics.some((diagnostic) => diagnostic.source === "vize/lint"));
+
+    const terminal = (await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) =>
+        isDiagnosticsForUri(params, uri) && (params as PublishDiagnosticsParams).version === 1,
+      10000,
+    )) as PublishDiagnosticsParams;
+
+    assert.equal(terminal.version, 1);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/real-project-lsp.test.ts
+++ b/tests/tooling/real-project-lsp.test.ts
@@ -66,9 +66,10 @@ test("LSP report records resolved server binary provenance", () => {
       { GITHUB_SHA: "1".repeat(40), VIZE_LSP_BIN: binary },
       { resolveLaunchCommand: () => [binary, "lsp"] },
     );
+    const relativeBinary = path.relative(process.cwd(), binary);
     assert.deepEqual(report.evidence.vizeBinary, {
       command: [binary, "lsp"],
-      path: binary,
+      path: relativeBinary.startsWith("..") ? binary : relativeBinary,
       sha256: createHash("sha256").update("fake vize binary").digest("hex"),
     });
   } finally {


### PR DESCRIPTION
Refs #3952

## Summary
- keep non-empty didOpen sync diagnostics unversioned until the terminal combined publish
- merge missing authored rename ranges after the canonical rename answer without polluting richer canonical multi-edit renames
- expose Options API runtime props in component completions
- add Epic Spinners to the authored real-project LSP oracle matrix and ratchet the authored count to 27

## Validation
- cargo fmt
- cargo test -p vize_maestro canonical_rename_edits_authored_cross_vue_files
- cargo test -p vize_maestro rename_missing
- cargo test -p vize_maestro options_api
- cargo test -p vize_maestro did_open_defers_without_publishing_an_empty_terminal_result
- cargo build -p vize
- node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/vue-ecosystem-fixtures-typecheck.test.ts tests/tooling/fixture-compatibility-ledger.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- TMPDIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize--3952-lsp-publish-parity-20260905/target/vize-tests/tmp TEMP=/Users/ubugeeei/Source/github.com/ubugeeei/vize--3952-lsp-publish-parity-20260905/target/vize-tests/tmp TMP=/Users/ubugeeei/Source/github.com/ubugeeei/vize--3952-lsp-publish-parity-20260905/target/vize-tests/tmp node --test tests/tooling/lsp-initial-diagnostics-version.test.ts
- TMPDIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize--3952-lsp-publish-parity-20260905/target/vize-tests/tmp TEMP=/Users/ubugeeei/Source/github.com/ubugeeei/vize--3952-lsp-publish-parity-20260905/target/vize-tests/tmp TMP=/Users/ubugeeei/Source/github.com/ubugeeei/vize--3952-lsp-publish-parity-20260905/target/vize-tests/tmp FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=97 node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts