### PR TITLE
test(davinci): cover inline static props in option matrix

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_option_matrix.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_option_matrix.rs
@@ -171,7 +171,7 @@ fn table(metadata: &BindingMetadata) -> BindingTable {
     support::bindings::binding_table(metadata)
 }
 
-fn production_option_battery(inline: bool) -> Vec<(&'static str, &'static str)> {
+fn production_option_battery() -> Vec<(&'static str, &'static str)> {
     let mut battery =
         Vec::with_capacity(PRODUCTION_DOM_BATTERY_NAMES.len() + PRODUCTION_LAYOUT_BATTERY.len());
     battery.extend(
@@ -185,12 +185,7 @@ fn production_option_battery(inline: bool) -> Vec<(&'static str, &'static str)> 
         PRODUCTION_DOM_BATTERY_NAMES.len(),
         "every selected shared DOM battery case must exist"
     );
-    battery.extend(
-        PRODUCTION_LAYOUT_BATTERY
-            .iter()
-            .copied()
-            .filter(|(name, _)| !inline || !INLINE_BATTERY_SKIP.contains(name)),
-    );
+    battery.extend(PRODUCTION_LAYOUT_BATTERY.iter().copied());
     battery
 }
 
@@ -198,7 +193,7 @@ fn production_option_battery(inline: bool) -> Vec<(&'static str, &'static str)> 
 /// that share a props object most often.
 #[test]
 fn cached_handlers_and_scope_id_agree_with_the_shipped_lane() {
-    let battery = production_option_battery(false);
+    let battery = production_option_battery();
     support::assert_s2_matches_shipped_with_options(
         &battery,
         &DomCompilerOptions {
@@ -222,7 +217,7 @@ fn cached_handlers_and_scope_id_agree_with_the_shipped_lane() {
 fn the_script_setup_configuration_agrees_with_the_shipped_lane() {
     let metadata = metadata();
     let table = table(&metadata);
-    let battery = production_option_battery(false);
+    let battery = production_option_battery();
     support::assert_s2_matches_shipped_with_options(
         &battery,
         &DomCompilerOptions {
@@ -245,14 +240,39 @@ fn the_script_setup_configuration_agrees_with_the_shipped_lane() {
     );
 }
 
-/// Held out of the `inline` production-layout cases below by one **pre-existing divergence
-/// that predates the option work**: under `inline`, the shipped lane hoists
-/// a component's (or builtin's) static props to `_hoisted_1` while the S2
-/// lane emits them inline. It reproduces with `cache_handlers` and
-/// `scope_id` both off, so it belongs to the `inline` surface
-/// (installment 89), not to this matrix. Recorded here rather than silently
-/// dropped; every other case in the battery runs under `inline`.
-const INLINE_BATTERY_SKIP: &[&str] = &["component_static_prop", "teleport"];
+#[test]
+fn inline_component_static_props_stay_in_the_option_matrix() {
+    let metadata = metadata();
+    let table = table(&metadata);
+    support::assert_s2_matches_shipped_with_options(
+        &[
+            ("component_static_prop", r#"<MyComp a="1" />"#),
+            (
+                "teleport_static_prop",
+                r##"<Teleport to="#a"><div @click="a++">x</div></Teleport>"##,
+            ),
+        ],
+        &DomCompilerOptions {
+            mode: CodegenMode::Module,
+            prefix_identifiers: true,
+            inline: true,
+            cache_handlers: true,
+            scope_id: Some(SCOPE_ID.into()),
+            binding_metadata: Some(metadata.clone()),
+            ..Default::default()
+        },
+        &CodegenOptions::default(),
+        &DomEmitOptions {
+            mode: DomEmitMode::Module,
+            prefix_identifiers: true,
+            inline: true,
+            cache_handlers: true,
+            scope_id: Some(SCOPE_ID),
+            bindings: Some(&table),
+            ..DomEmitOptions::DEFAULT
+        },
+    );
+}
 
 /// The same, inlined into `setup()`, where setup bindings are read off the
 /// closure and a `SetupConst` handler stops being cached.
@@ -260,7 +280,7 @@ const INLINE_BATTERY_SKIP: &[&str] = &["component_static_prop", "teleport"];
 fn the_inline_script_setup_configuration_agrees_with_the_shipped_lane() {
     let metadata = metadata();
     let table = table(&metadata);
-    let battery = production_option_battery(true);
+    let battery = production_option_battery();
     support::assert_s2_matches_shipped_with_options(
         &battery,
         &DomCompilerOptions {


### PR DESCRIPTION
## Summary
- remove the stale inline production-option skip for component and builtin static-prop shapes
- add a focused P2-11 proof that inline component and Teleport static-prop cases match the shipped DOM lane under the production option bundle

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_option_matrix -- --nocapture
- cargo fmt --all --check
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791192010&installation_model_id=422833&pr_number=5740&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5740&signature=cd8a475ff543999b288757df01e4329fd4a7b71c3587e9b791075153f7ff7ce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->