### PR TITLE
feat(lsp): prepare call hierarchy items

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -13,6 +13,8 @@ use super::types::{CorsaBridgeConfig, CorsaBridgeError};
 use super::worker::{BoundedWorker, WorkerError};
 use crate::corsa_client::CorsaProjectClient;
 
+#[path = "bridge/call_hierarchy.rs"]
+mod call_hierarchy;
 #[path = "bridge/declaration.rs"]
 mod declaration;
 #[path = "bridge/documents.rs"]

--- a/crates/vize_canon/src/corsa_bridge/bridge/call_hierarchy.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge/call_hierarchy.rs
@@ -1,0 +1,26 @@
+use serde_json::Value;
+
+use super::CorsaBridge;
+use crate::corsa_bridge::types::CorsaBridgeError;
+
+impl CorsaBridge {
+    /// Prepare call-hierarchy items for a symbol at a position.
+    ///
+    /// The editor LSP transport owns this protocol shape; callers keep the raw
+    /// payload so they can map the item URI and both ranges with their local
+    /// authored-source model.
+    pub async fn prepare_call_hierarchy(
+        &self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, CorsaBridgeError> {
+        let uri = uri.to_owned();
+        self.with_client(move |client| {
+            client
+                .prepare_call_hierarchy_raw(uri.as_str(), line, character)
+                .map_err(CorsaBridgeError::CommunicationError)
+        })
+        .await
+    }
+}

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -43,9 +43,9 @@ mod tests;
 mod type_definition;
 
 use requests::{
-    RawCompletionRequest, RawDefinitionRequest, RawHoverRequest, RawPrepareRenameRequest,
-    RawReferencesRequest, RawRenameRequest, RawSignatureHelpRequest, RawWillRenameFilesRequest,
-    signature_help_request_params, will_rename_files_request_params,
+    RawCompletionRequest, RawDefinitionRequest, RawHoverRequest, RawPrepareCallHierarchyRequest,
+    RawPrepareRenameRequest, RawReferencesRequest, RawRenameRequest, RawSignatureHelpRequest,
+    RawWillRenameFilesRequest, signature_help_request_params, will_rename_files_request_params,
 };
 use responder::spawn_responder;
 
@@ -181,6 +181,23 @@ impl EditorLspSession {
                 })),
         )
         .map_err(|error| cstr!("Failed to request editor LSP definition: {error}"))
+    }
+
+    fn prepare_call_hierarchy(
+        &mut self,
+        document_uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        let uri = self.ready_document_uri(document_uri)?;
+        block_on(
+            self.client
+                .request::<RawPrepareCallHierarchyRequest>(serde_json::json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": line, "character": character },
+                })),
+        )
+        .map_err(|error| cstr!("Failed to request editor LSP call hierarchy: {error}"))
     }
 
     fn references(

--- a/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
@@ -88,6 +88,20 @@ impl CorsaProjectClient {
         })
     }
 
+    pub(in crate::lsp_client) fn prepare_call_hierarchy_via_editor_lsp(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        if !self.document_texts.contains_key(uri) {
+            return Ok(None);
+        }
+        self.request_with_editor_lsp_recovery(|session| {
+            session.prepare_call_hierarchy(uri, line, character)
+        })
+    }
+
     pub(in crate::lsp_client) fn references_via_editor_lsp(
         &mut self,
         uri: &str,

--- a/crates/vize_canon/src/lsp_client/editor_lsp/requests.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/requests.rs
@@ -54,6 +54,14 @@ impl lsp_types::request::Request for RawImplementationRequest {
     const METHOD: &'static str = "textDocument/implementation";
 }
 
+pub(super) struct RawPrepareCallHierarchyRequest;
+
+impl lsp_types::request::Request for RawPrepareCallHierarchyRequest {
+    type Params = Value;
+    type Result = Option<Value>;
+    const METHOD: &'static str = "textDocument/prepareCallHierarchy";
+}
+
 pub(super) struct RawReferencesRequest;
 
 impl lsp_types::request::Request for RawReferencesRequest {

--- a/crates/vize_canon/src/lsp_client/editor_lsp/tests.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/tests.rs
@@ -1,6 +1,56 @@
 use super::*;
 
 #[test]
+fn prepare_call_hierarchy_uses_editor_lsp_runtime_items() {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return;
+    }
+    let Some(corsa_path) = resolve_tsgo_binary() else {
+        return;
+    };
+
+    let project = tempfile::TempDir::new().expect("temp project");
+    std::fs::write(
+        project.path().join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .expect("tsconfig");
+    let src = project.path().join("src");
+    std::fs::create_dir_all(&src).expect("src");
+    let source = "export function run(value: string): string { return value }\nrun('x')\n";
+    let path = src.join("call-hierarchy.ts");
+    std::fs::write(&path, source).expect("source");
+    let uri = format!("file://{}", path.display());
+    let mut documents = FxHashMap::default();
+    documents.insert(uri.clone().into(), source.into());
+
+    let mut session = EditorLspSession::spawn(
+        corsa_path.to_str().expect("utf8 path"),
+        project.path(),
+        project.path(),
+    )
+    .expect("editor LSP session");
+    session.synchronize(&documents).expect("synchronize source");
+    let response = session.prepare_call_hierarchy(&uri, 0, "export function ".len() as u32);
+    session.shutdown().expect("shutdown");
+
+    let items = response
+        .expect("prepareCallHierarchy request should succeed")
+        .expect("runtime should return call hierarchy items");
+    assert_eq!(items[0]["name"], "run");
+    assert_eq!(items[0]["selectionRange"]["start"]["character"], 16);
+}
+
+#[test]
 fn signature_help_request_defaults_to_manual_invocation() {
     let uri = Uri::from_str("file:///workspace/App.vue.ts").unwrap();
     let params = signature_help_request_params(&uri, 4, 7, None);
@@ -9,6 +59,19 @@ fn signature_help_request_defaults_to_manual_invocation() {
         params["context"],
         serde_json::json!({"triggerKind": 1, "isRetrigger": false})
     );
+}
+
+fn resolve_tsgo_binary() -> Option<std::path::PathBuf> {
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    vize_s0::corsa_resolver::resolve_corsa_executable(
+        vize_s0::corsa_resolver::CorsaResolveRequest {
+            project_root: Some(workspace_root),
+            ..Default::default()
+        },
+    )
+    .ok()
 }
 
 #[test]

--- a/crates/vize_canon/src/lsp_client/queries.rs
+++ b/crates/vize_canon/src/lsp_client/queries.rs
@@ -100,6 +100,15 @@ impl CorsaProjectClient {
         self.implementation_via_editor_lsp(uri, line, character)
     }
 
+    pub(crate) fn prepare_call_hierarchy_raw(
+        &mut self,
+        uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        self.prepare_call_hierarchy_via_editor_lsp(uri, line, character)
+    }
+
     pub(crate) fn references_raw(
         &mut self,
         uri: &str,

--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 pub mod auto_import;
 pub mod auto_insert;
+pub mod call_hierarchy;
 pub mod code_action;
 pub mod code_lens;
 pub mod completion;
@@ -43,6 +44,7 @@ pub mod type_definition;
 pub mod type_service;
 pub mod workspace_symbols;
 pub use auto_insert::AutoInsertService;
+pub use call_hierarchy::CallHierarchyService;
 pub use code_action::CodeActionService;
 pub use code_lens::CodeLensService;
 pub use completion::{CompletionService, TRIGGER_CHARACTERS, trigger_characters};

--- a/crates/vize_maestro/src/ide/call_hierarchy.rs
+++ b/crates/vize_maestro/src/ide/call_hierarchy.rs
@@ -1,0 +1,114 @@
+//! Type-aware `textDocument/prepareCallHierarchy` for authored Vue files.
+
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
+
+#[cfg(feature = "native")]
+use std::sync::Arc;
+
+#[cfg(feature = "native")]
+use tower_lsp::lsp_types::{CallHierarchyItem, Location, Range};
+#[cfg(feature = "native")]
+use vize_canon::{CorsaBridge, LspLocation, LspPosition, LspRange};
+
+#[cfg(feature = "native")]
+use super::{IdeContext, corsa_support};
+#[cfg(feature = "native")]
+use crate::virtual_code::BlockType;
+
+/// Checker-backed call-hierarchy service.
+pub struct CallHierarchyService;
+
+#[cfg(feature = "native")]
+impl CallHierarchyService {
+    /// Prepare call-hierarchy items through Corsa's standard LSP surface and
+    /// map every visible item span back onto authored source.
+    pub async fn prepare_with_corsa(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> Option<Vec<CallHierarchyItem>> {
+        let bridge = corsa_bridge?;
+        if !bridge.is_initialized() {
+            return None;
+        }
+
+        match ctx.block_type? {
+            BlockType::Template | BlockType::Script | BlockType::ScriptSetup
+                if !ctx.uri.path().ends_with(".art.vue") =>
+            {
+                Self::prepare_in_canonical_sfc(ctx, &bridge).await
+            }
+            BlockType::Template
+            | BlockType::Script
+            | BlockType::ScriptSetup
+            | BlockType::Style(_)
+            | BlockType::Art(_) => None,
+        }
+    }
+
+    async fn prepare_in_canonical_sfc(
+        ctx: &IdeContext<'_>,
+        bridge: &CorsaBridge,
+    ) -> Option<Vec<CallHierarchyItem>> {
+        let document = corsa_support::open_canonical_virtual_project_document(ctx, bridge).await?;
+        let (line, character) =
+            corsa_support::canonical_source_offset_to_position(&document, ctx.offset)?;
+        let items = bridge
+            .prepare_call_hierarchy(&document.request_uri, line, character)
+            .await
+            .ok()??;
+        let items = serde_json::from_value::<Vec<CallHierarchyItem>>(items).ok()?;
+        let items = items
+            .into_iter()
+            .filter_map(|item| Self::map_canonical_item(ctx, &document, item))
+            .collect::<Vec<_>>();
+
+        (!items.is_empty()).then_some(items)
+    }
+
+    fn map_canonical_item(
+        ctx: &IdeContext<'_>,
+        document: &corsa_support::CanonicalVirtualDocument,
+        item: CallHierarchyItem,
+    ) -> Option<CallHierarchyItem> {
+        let selection =
+            Self::map_canonical_item_range(ctx, document, &item.uri, item.selection_range)?;
+        let range = Self::map_canonical_item_range(ctx, document, &item.uri, item.range)
+            .filter(|range| range.uri == selection.uri)
+            .unwrap_or_else(|| selection.clone());
+
+        Some(CallHierarchyItem {
+            uri: selection.uri,
+            range: range.range,
+            selection_range: selection.range,
+            ..item
+        })
+    }
+
+    fn map_canonical_item_range(
+        ctx: &IdeContext<'_>,
+        document: &corsa_support::CanonicalVirtualDocument,
+        uri: &tower_lsp::lsp_types::Url,
+        range: Range,
+    ) -> Option<Location> {
+        corsa_support::map_canonical_corsa_location(
+            ctx,
+            document,
+            &LspLocation {
+                uri: uri.to_string(),
+                range: LspRange {
+                    start: LspPosition {
+                        line: range.start.line,
+                        character: range.start.character,
+                    },
+                    end: LspPosition {
+                        line: range.end.line,
+                        character: range.end.character,
+                    },
+                },
+            },
+        )
+    }
+}
+
+#[cfg(all(test, feature = "native"))]
+mod tests;

--- a/crates/vize_maestro/src/ide/call_hierarchy/tests.rs
+++ b/crates/vize_maestro/src/ide/call_hierarchy/tests.rs
@@ -1,0 +1,106 @@
+use std::{path::PathBuf, sync::Arc};
+
+use tower_lsp::lsp_types::{CallHierarchyItem, Url};
+use vize_canon::{CorsaBridge, CorsaBridgeConfig};
+
+use super::CallHierarchyService;
+use crate::{ide::IdeContext, server::ServerState};
+
+#[test]
+fn prepare_call_hierarchy_maps_script_setup_function_to_authored_source() {
+    crate::runtime::block_on(async {
+        let Some(corsa_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        std::fs::create_dir_all(&src).expect("src");
+        std::fs::write(
+            project.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .expect("tsconfig");
+
+        let source = r#"<script setup lang="ts">
+function run(value: string): string {
+  return value
+}
+</script>
+<template>
+  <button @click="run('template')">{{ run('label') }}</button>
+</template>
+"#;
+        let path = src.join("App.vue");
+        std::fs::write(&path, source).expect("source");
+        let uri = Url::from_file_path(&path).expect("source uri");
+        let state = ServerState::new();
+        state.set_workspace_root(project.path().to_path_buf());
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+        let offset = source
+            .find("run(value")
+            .expect("script setup call hierarchy marker")
+            + "r".len();
+        let ctx = IdeContext::new(&state, &uri, offset).expect("context");
+        let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(corsa_path),
+            working_dir: Some(project.path().to_path_buf()),
+            timeout_ms: 30_000,
+            ..Default::default()
+        }));
+        bridge.spawn().await.expect("tsgo session");
+
+        let items = CallHierarchyService::prepare_with_corsa(&ctx, Some(bridge.clone()))
+            .await
+            .expect("call hierarchy items");
+        bridge.shutdown().await.expect("shutdown");
+
+        let item = single_item(items);
+        assert_eq!(item.uri, uri);
+        assert_eq!(authored_text(source, item.selection_range), "run");
+        assert!(
+            !item.uri.path().ends_with(".vue.ts"),
+            "generated URI leaked: {item:#?}",
+        );
+    });
+}
+
+fn single_item(mut items: Vec<CallHierarchyItem>) -> CallHierarchyItem {
+    assert_eq!(items.len(), 1, "{items:#?}");
+    items.remove(0)
+}
+
+fn authored_text(source: &str, range: tower_lsp::lsp_types::Range) -> &str {
+    let start = crate::ide::position_to_offset(source, range.start.line, range.start.character)
+        .expect("source start");
+    let end = crate::ide::position_to_offset(source, range.end.line, range.end.character)
+        .expect("source end");
+    &source[start..end]
+}
+
+fn resolve_tsgo_binary() -> Option<PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    vize_s0::corsa_resolver::resolve_corsa_executable(
+        vize_s0::corsa_resolver::CorsaResolveRequest {
+            project_root: Some(workspace_root),
+            ..Default::default()
+        },
+    )
+    .ok()
+}

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -2,11 +2,11 @@
 #![allow(clippy::disallowed_methods)]
 
 use tower_lsp::lsp_types::{
-    CodeActionKind, CodeActionOptions, CodeActionProviderCapability, CodeLensOptions,
-    ColorProviderCapability, CompletionOptions, DeclarationCapability, DocumentLinkOptions,
-    DocumentOnTypeFormattingOptions, FileOperationFilter, FileOperationPattern,
-    FileOperationPatternKind, FileOperationRegistrationOptions, FoldingRangeProviderCapability,
-    HoverProviderCapability, ImplementationProviderCapability,
+    CallHierarchyServerCapability, CodeActionKind, CodeActionOptions, CodeActionProviderCapability,
+    CodeLensOptions, ColorProviderCapability, CompletionOptions, DeclarationCapability,
+    DocumentLinkOptions, DocumentOnTypeFormattingOptions, FileOperationFilter,
+    FileOperationPattern, FileOperationPatternKind, FileOperationRegistrationOptions,
+    FoldingRangeProviderCapability, HoverProviderCapability, ImplementationProviderCapability,
     LinkedEditingRangeServerCapabilities, OneOf, RenameOptions, SaveOptions,
     SelectionRangeProviderCapability, SemanticTokenModifier, SemanticTokenType,
     SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
@@ -225,9 +225,12 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
             && features.typecheck
             && cfg!(feature = "native"))
         .then_some(DeclarationCapability::Simple(true)),
+        call_hierarchy_provider: (features.definition
+            && features.typecheck
+            && cfg!(feature = "native"))
+        .then_some(CallHierarchyServerCapability::Simple(true)),
         // Features not yet implemented
         execute_command_provider: None,
-        call_hierarchy_provider: None,
         moniker_provider: None,
         experimental: features.auto_insert.then(|| {
             serde_json::json!({

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -82,6 +82,10 @@ fn default_features_advertise_non_opinionated_providers() {
         capabilities.declaration_provider.is_some(),
         cfg!(feature = "native")
     );
+    assert_eq!(
+        capabilities.call_hierarchy_provider.is_some(),
+        cfg!(feature = "native")
+    );
     assert!(matches!(
         capabilities.selection_range_provider,
         Some(SelectionRangeProviderCapability::Simple(true))
@@ -173,6 +177,10 @@ fn all_features_skip_unimplemented_providers_and_keep_implemented_ones() {
     );
     assert_eq!(
         capabilities.declaration_provider.is_some(),
+        cfg!(feature = "native")
+    );
+    assert_eq!(
+        capabilities.call_hierarchy_provider.is_some(),
         cfg!(feature = "native")
     );
     assert!(capabilities.references_provider.is_some());

--- a/crates/vize_maestro/src/server/capabilities/tests/feature_gating.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests/feature_gating.rs
@@ -34,6 +34,7 @@ fn individual_feature_flags_gate_matching_providers() {
                     || capabilities.type_definition_provider.is_some()
                     || capabilities.implementation_provider.is_some()
                     || capabilities.declaration_provider.is_some()
+                    || capabilities.call_hierarchy_provider.is_some()
             },
         ),
         (
@@ -43,6 +44,7 @@ fn individual_feature_flags_gate_matching_providers() {
                 capabilities.type_definition_provider.is_some()
                     || capabilities.implementation_provider.is_some()
                     || capabilities.declaration_provider.is_some()
+                    || capabilities.call_hierarchy_provider.is_some()
             },
         ),
         (

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -18,8 +18,8 @@ use tower_lsp::{
         LinkedEditingRanges, Location, PrepareRenameResponse, ReferenceParams, RenameFilesParams,
         RenameParams, SelectionRange, SelectionRangeParams, SemanticTokensParams,
         SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult, ServerInfo,
-        SignatureHelp, SignatureHelpParams, SymbolInformation, TextDocumentPositionParams,
-        TextEdit, WorkspaceEdit, WorkspaceSymbolParams,
+        SymbolInformation, TextDocumentPositionParams, TextEdit, WorkspaceEdit,
+        WorkspaceSymbolParams,
     },
 };
 
@@ -28,18 +28,23 @@ use tower_lsp::{
 use tower_lsp::lsp_types::{Position, Range};
 
 use super::{MaestroServer, server_capabilities};
-#[cfg(feature = "native")]
-use crate::ide::SignatureHelpService;
 use crate::ide::{
     CompletionService, DocumentHighlightService, DocumentLinkService, HoverService, IdeContext,
     ReferencesService, RenameService, SemanticTokensService, position_to_offset,
 };
 
+mod call_hierarchy;
 mod navigation;
+mod signature_help;
+use call_hierarchy::{
+    CHIncomingParams, CHIncomingResponse, CHItems, CHOutgoingParams, CHOutgoingResponse,
+    CHPrepareParams,
+};
 use navigation::{
     DeclParams, DeclResponse, DefParams, DefResponse, ImplParams, ImplResponse, TypeDefParams,
     TypeDefResponse,
 };
+use signature_help::{SigHelp, SigHelpParams};
 
 #[tower_lsp::async_trait]
 impl LanguageServer for MaestroServer {
@@ -232,55 +237,8 @@ impl LanguageServer for MaestroServer {
         Ok(item)
     }
 
-    async fn signature_help(&self, params: SignatureHelpParams) -> Result<Option<SignatureHelp>> {
-        if !self.state.lsp_features().signature_help {
-            return Ok(None);
-        }
-
-        #[cfg(feature = "native")]
-        {
-            let context = params
-                .context
-                .and_then(|context| serde_json::to_value(context).ok());
-            let uri = &params.text_document_position_params.text_document.uri;
-            let position = params.text_document_position_params.position;
-
-            let Some(content) = self.state.documents.text(uri) else {
-                return Ok(None);
-            };
-            let Some(offset) = position_to_offset(&content, position.line, position.character)
-            else {
-                return Ok(None);
-            };
-
-            let ctx = IdeContext::with_content(&self.state, uri, offset, content);
-            let corsa_bridge = self.state.get_corsa_bridge().await;
-
-            if crate::utils::is_jsx_path(uri.path()) {
-                if self.state.jsx_typecheck_enabled() {
-                    return Ok(crate::ide::JsxService::signature_help_with_context(
-                        &ctx,
-                        corsa_bridge,
-                        context,
-                    )
-                    .await);
-                }
-                return Ok(None);
-            }
-
-            return Ok(SignatureHelpService::signature_help_with_corsa_context(
-                &ctx,
-                corsa_bridge,
-                context,
-            )
-            .await);
-        }
-
-        #[cfg(not(feature = "native"))]
-        {
-            let _ = params;
-            Ok(None)
-        }
+    async fn signature_help(&self, params: SigHelpParams) -> Result<Option<SigHelp>> {
+        signature_help::signature_help(self, params).await
     }
 
     async fn goto_definition(&self, params: DefParams) -> Result<Option<DefResponse>> {
@@ -297,6 +255,20 @@ impl LanguageServer for MaestroServer {
 
     async fn goto_implementation(&self, params: ImplParams) -> Result<Option<ImplResponse>> {
         navigation::goto_implementation(self, params).await
+    }
+
+    async fn prepare_call_hierarchy(&self, params: CHPrepareParams) -> Result<Option<CHItems>> {
+        call_hierarchy::prepare(self, params).await
+    }
+
+    async fn incoming_calls(&self, params: CHIncomingParams) -> Result<Option<CHIncomingResponse>> {
+        let _ = params;
+        Ok(None)
+    }
+
+    async fn outgoing_calls(&self, params: CHOutgoingParams) -> Result<Option<CHOutgoingResponse>> {
+        let _ = params;
+        Ok(None)
     }
 
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {

--- a/crates/vize_maestro/src/server/handlers/call_hierarchy.rs
+++ b/crates/vize_maestro/src/server/handlers/call_hierarchy.rs
@@ -1,0 +1,54 @@
+use tower_lsp::{
+    jsonrpc::Result,
+    lsp_types::{
+        CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,
+        CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
+    },
+};
+
+use super::super::MaestroServer;
+#[cfg(feature = "native")]
+use crate::ide::{CallHierarchyService, IdeContext, position_to_offset};
+
+pub(super) type CHPrepareParams = CallHierarchyPrepareParams;
+pub(super) type CHItems = Vec<CallHierarchyItem>;
+pub(super) type CHIncomingParams = CallHierarchyIncomingCallsParams;
+pub(super) type CHIncomingResponse = Vec<CallHierarchyIncomingCall>;
+pub(super) type CHOutgoingParams = CallHierarchyOutgoingCallsParams;
+pub(super) type CHOutgoingResponse = Vec<CallHierarchyOutgoingCall>;
+
+pub(super) async fn prepare(
+    server: &MaestroServer,
+    params: CHPrepareParams,
+) -> Result<Option<CHItems>> {
+    if !server.state.lsp_features().definition || !server.state.lsp_features().typecheck {
+        return Ok(None);
+    }
+
+    #[cfg(feature = "native")]
+    {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+
+        let Some(content) = server.state.documents.text(uri) else {
+            return Ok(None);
+        };
+        let Some(offset) = position_to_offset(&content, position.line, position.character) else {
+            return Ok(None);
+        };
+
+        let ctx = IdeContext::with_content(&server.state, uri, offset, content);
+        if crate::utils::is_jsx_path(uri.path()) {
+            return Ok(None);
+        }
+
+        let corsa_bridge = server.state.get_corsa_bridge().await;
+        return Ok(CallHierarchyService::prepare_with_corsa(&ctx, corsa_bridge).await);
+    }
+
+    #[cfg(not(feature = "native"))]
+    {
+        let _ = params;
+        Ok(None)
+    }
+}

--- a/crates/vize_maestro/src/server/handlers/signature_help.rs
+++ b/crates/vize_maestro/src/server/handlers/signature_help.rs
@@ -1,0 +1,64 @@
+use tower_lsp::{
+    jsonrpc::Result,
+    lsp_types::{SignatureHelp, SignatureHelpParams},
+};
+
+use super::super::MaestroServer;
+#[cfg(feature = "native")]
+use crate::ide::{IdeContext, SignatureHelpService, position_to_offset};
+
+pub(super) type SigHelpParams = SignatureHelpParams;
+pub(super) type SigHelp = SignatureHelp;
+
+pub(super) async fn signature_help(
+    server: &MaestroServer,
+    params: SigHelpParams,
+) -> Result<Option<SigHelp>> {
+    if !server.state.lsp_features().signature_help {
+        return Ok(None);
+    }
+
+    #[cfg(feature = "native")]
+    {
+        let context = params
+            .context
+            .and_then(|context| serde_json::to_value(context).ok());
+        let uri = &params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+
+        let Some(content) = server.state.documents.text(uri) else {
+            return Ok(None);
+        };
+        let Some(offset) = position_to_offset(&content, position.line, position.character) else {
+            return Ok(None);
+        };
+
+        let ctx = IdeContext::with_content(&server.state, uri, offset, content);
+        let corsa_bridge = server.state.get_corsa_bridge().await;
+
+        if crate::utils::is_jsx_path(uri.path()) {
+            if server.state.jsx_typecheck_enabled() {
+                return Ok(crate::ide::JsxService::signature_help_with_context(
+                    &ctx,
+                    corsa_bridge,
+                    context,
+                )
+                .await);
+            }
+            return Ok(None);
+        }
+
+        return Ok(SignatureHelpService::signature_help_with_corsa_context(
+            &ctx,
+            corsa_bridge,
+            context,
+        )
+        .await);
+    }
+
+    #[cfg(not(feature = "native"))]
+    {
+        let _ = params;
+        Ok(None)
+    }
+}

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -111,6 +111,7 @@ const EDITOR_BUNDLE_CAPABILITIES = {
   declarationProvider: true,
   typeDefinitionProvider: true,
   implementationProvider: true,
+  callHierarchyProvider: true,
   referencesProvider: true,
   documentHighlightProvider: true,
   documentSymbolProvider: true,
@@ -184,8 +185,8 @@ const EDITOR_BUNDLE_CAPABILITIES = {
   },
   // Absent on purpose, and therefore absent from this object: the three
   // formatting providers (opt-in, see below),
-  // `executeCommandProvider`, `callHierarchyProvider`, `monikerProvider` and
-  // `experimental` is absent unless the private client explicitly opts in.
+  // `executeCommandProvider`, `monikerProvider` and `experimental` is absent
+  // unless the private client explicitly opts in.
 };
 
 test("vize lsp advertises exactly this capability set for the default editor bundle", async () => {

--- a/tests/tooling/support/lsp/protocol.ts
+++ b/tests/tooling/support/lsp/protocol.ts
@@ -74,6 +74,7 @@ export type ServerCapabilities = {
     triggerCharacters?: string[];
     resolveProvider?: boolean;
   };
+  callHierarchyProvider?: unknown;
   declarationProvider?: unknown;
   definitionProvider?: unknown;
   typeDefinitionProvider?: unknown;


### PR DESCRIPTION
## Summary
- route `textDocument/prepareCallHierarchy` through the existing Corsa editor LSP transport
- map prepared call hierarchy items back to authored Vue SFC ranges before advertising the provider
- split call-hierarchy and signature-help routing into focused handler modules so source-length guards stay green

Refs #3953.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo check -p vize_maestro --features native`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize_canon prepare_call_hierarchy_uses_editor_lsp_runtime_items --features native`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize_maestro prepare_call_hierarchy_maps_script_setup_function_to_authored_source --features native`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo test -p vize_maestro server::capabilities --features native`
- `CARGO_TARGET_DIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target cargo build -p vize`
- `VIZE_LSP_BIN=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target/debug/vize node --test tests/tooling/lsp-capabilities.test.ts`