### PR TITLE
test(vscode): add generic host LSP request command

### DIFF
--- a/editors/vscode/src/host-test-core.ts
+++ b/editors/vscode/src/host-test-core.ts
@@ -8,6 +8,10 @@ export type TestCompletionRequest = TestTextDocumentPositionRequest;
 export type TestReferencesRequest = TestTextDocumentPositionRequest & {
   includeDeclaration?: boolean;
 };
+export type TestLspRequest = {
+  method: string;
+  params?: unknown;
+};
 
 export type HostTestLanguageClient = {
   sendRequest(method: string, params: unknown): Promise<unknown>;
@@ -29,6 +33,7 @@ export type HostTestCommand = {
 
 export const HOST_TEST_COMMAND_ENVIRONMENT_FLAG = "VIZE_TEST_ENABLE_HOST_COMMANDS";
 export const HOST_TEST_COMPLETION_COMMAND = "vize.test.executeCompletion";
+export const HOST_TEST_LSP_REQUEST_COMMAND = "vize.test.executeLspRequest";
 export const HOST_TEST_REFERENCES_COMMAND = "vize.test.executeReferences";
 export const HOST_TEST_SERVER_INFO_COMMAND = "vize.test.getServerInfo";
 
@@ -67,6 +72,14 @@ export function createHostTestCommands(behavior: {
           ...textDocumentPositionParams(request),
           context: { includeDeclaration: request.includeDeclaration ?? true },
         });
+      },
+    },
+    {
+      command: HOST_TEST_LSP_REQUEST_COMMAND,
+      handler: async (request) => {
+        const activeClient = requireActiveClient(behavior, "LSP request");
+        assertTestLspRequest(request);
+        return activeClient.sendRequest(request.method, request.params);
       },
     },
     {
@@ -115,6 +128,17 @@ function assertTestReferencesRequest(request: unknown): asserts request is TestR
     typeof (request as TestReferencesRequest).includeDeclaration !== "boolean"
   ) {
     throw new TypeError("Invalid Vize test references request.");
+  }
+}
+
+function assertTestLspRequest(request: unknown): asserts request is TestLspRequest {
+  const candidate = request as Partial<TestLspRequest> | null;
+  if (
+    candidate == null ||
+    typeof candidate.method !== "string" ||
+    candidate.method.trim().length === 0
+  ) {
+    throw new TypeError("Invalid Vize test LSP request.");
   }
 }
 

--- a/editors/vscode/test/real-host-lsp-request-oracle.mjs
+++ b/editors/vscode/test/real-host-lsp-request-oracle.mjs
@@ -1,0 +1,3 @@
+// Mirrors `HOST_TEST_LSP_REQUEST_COMMAND` in `src/host-test-core.ts`; the
+// tooling tests assert both stay in sync.
+export const HOST_TEST_LSP_REQUEST_COMMAND = "vize.test.executeLspRequest";

--- a/tests/tooling/vscode-host-lsp-request-command.test.ts
+++ b/tests/tooling/vscode-host-lsp-request-command.test.ts
@@ -1,0 +1,94 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  HOST_TEST_COMMAND_ENVIRONMENT_FLAG,
+  HOST_TEST_LSP_REQUEST_COMMAND,
+  createHostTestCommands,
+  type HostTestLanguageClient,
+  type TestLspRequest,
+} from "../../editors/vscode/src/host-test-core.ts";
+import { HOST_TEST_LSP_REQUEST_COMMAND as suiteHostLspRequestCommand } from "../../editors/vscode/test/real-host-lsp-request-oracle.mjs";
+
+test("the generic host LSP request command only exists for the host smoke", () => {
+  const client = createFakeClientResponse(null);
+
+  assert.equal(hasLspRequestCommand({ environment: {}, getClient: () => client }), false);
+  assert.equal(
+    hasLspRequestCommand({
+      environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "0" },
+      getClient: () => client,
+    }),
+    false,
+  );
+  assert.equal(
+    hasLspRequestCommand({
+      environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
+      getClient: () => client,
+    }),
+    true,
+  );
+});
+
+test("the generic host LSP request command forwards method and params", async () => {
+  const response = [{ contents: "hover" }];
+  const client = createFakeClientResponse(response);
+  const command = findLspRequestCommand({
+    environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
+    getClient: () => client,
+  });
+  const params = {
+    position: { character: 4, line: 2 },
+    textDocument: { uri: "file:///App.vue" },
+  };
+
+  assert.deepEqual(await command.handler({ method: "textDocument/hover", params }), response);
+  assert.deepEqual(client.requests, [["textDocument/hover", params]]);
+});
+
+test("the generic host LSP request command validates request shape", async () => {
+  const client = createFakeClientResponse(null);
+  const command = findLspRequestCommand({
+    environment: { [HOST_TEST_COMMAND_ENVIRONMENT_FLAG]: "1" },
+    getClient: () => client,
+  });
+
+  for (const invalid of [undefined, {}, { method: "" }, { method: "   " }, { method: 42 }]) {
+    await assert.rejects(
+      command.handler(invalid as TestLspRequest),
+      /Invalid Vize test LSP request/,
+    );
+  }
+  assert.deepEqual(client.requests, []);
+});
+
+test("the real host LSP request oracle keeps the command id in sync", () => {
+  assert.equal(HOST_TEST_LSP_REQUEST_COMMAND, suiteHostLspRequestCommand);
+});
+
+function hasLspRequestCommand(behavior: Parameters<typeof createHostTestCommands>[0]): boolean {
+  return createHostTestCommands(behavior).some(
+    (command) => command.command === HOST_TEST_LSP_REQUEST_COMMAND,
+  );
+}
+
+function findLspRequestCommand(behavior: Parameters<typeof createHostTestCommands>[0]) {
+  const command = createHostTestCommands(behavior).find(
+    (candidate) => candidate.command === HOST_TEST_LSP_REQUEST_COMMAND,
+  );
+  assert.ok(command, `${HOST_TEST_LSP_REQUEST_COMMAND} must be registered`);
+  return command;
+}
+
+function createFakeClientResponse(
+  response: unknown,
+): HostTestLanguageClient & { requests: [string, unknown][] } {
+  const requests: [string, unknown][] = [];
+  return {
+    requests,
+    sendRequest: async (method, params) => {
+      requests.push([method, params]);
+      return response;
+    },
+  };
+}

--- a/tests/tooling/vscode-host-test-commands.test.ts
+++ b/tests/tooling/vscode-host-test-commands.test.ts
@@ -5,6 +5,7 @@ import { test } from "node:test";
 import {
   HOST_TEST_COMMAND_ENVIRONMENT_FLAG,
   HOST_TEST_COMPLETION_COMMAND,
+  HOST_TEST_LSP_REQUEST_COMMAND,
   HOST_TEST_REFERENCES_COMMAND,
   HOST_TEST_SERVER_INFO_COMMAND,
   bindHostTestCommands,
@@ -23,7 +24,7 @@ import {
   assertRealHostServerInfo,
 } from "../../editors/vscode/test/real-host-server-info-oracle.mjs";
 
-test("the hidden host completion command only exists for the host smoke", async () => {
+test("the hidden host commands only exist for the host smoke", async () => {
   const client = createFakeClient([{ label: "label" }]);
   assert.deepEqual(createHostTestCommands({ environment: {}, getClient: () => client }), []);
   assert.deepEqual(
@@ -40,13 +41,23 @@ test("the hidden host completion command only exists for the host smoke", async 
   });
   assertExactCommandMembership(
     commands.map((command) => command.command),
-    [HOST_TEST_COMPLETION_COMMAND, HOST_TEST_REFERENCES_COMMAND, HOST_TEST_SERVER_INFO_COMMAND],
+    [
+      HOST_TEST_COMPLETION_COMMAND,
+      HOST_TEST_LSP_REQUEST_COMMAND,
+      HOST_TEST_REFERENCES_COMMAND,
+      HOST_TEST_SERVER_INFO_COMMAND,
+    ],
   );
   const completionCommand = findHostCommand(commands, HOST_TEST_COMPLETION_COMMAND);
+  const lspRequestCommand = findHostCommand(commands, HOST_TEST_LSP_REQUEST_COMMAND);
   const referencesCommand = findHostCommand(commands, HOST_TEST_REFERENCES_COMMAND);
   const serverInfoCommand = findHostCommand(commands, HOST_TEST_SERVER_INFO_COMMAND);
   await assert.rejects(
     completionCommand.handler({ character: 8, line: 3, uri: "file:///App.vue" }),
+    /requires an active language client/,
+  );
+  await assert.rejects(
+    lspRequestCommand.handler({ method: "textDocument/hover" }),
     /requires an active language client/,
   );
   await assert.rejects(
@@ -193,11 +204,13 @@ test("registering the gated host commands leaves an executable command behind", 
   });
   assertExactCommandMembership(registerCalls, [
     HOST_TEST_COMPLETION_COMMAND,
+    HOST_TEST_LSP_REQUEST_COMMAND,
     HOST_TEST_REFERENCES_COMMAND,
     HOST_TEST_SERVER_INFO_COMMAND,
   ]);
   assertExactCommandMembership(registry.keys(), [
     HOST_TEST_COMPLETION_COMMAND,
+    HOST_TEST_LSP_REQUEST_COMMAND,
     HOST_TEST_REFERENCES_COMMAND,
     HOST_TEST_SERVER_INFO_COMMAND,
   ]);

--- a/tests/tooling/vscode-vsix-policy.test.ts
+++ b/tests/tooling/vscode-vsix-policy.test.ts
@@ -85,6 +85,7 @@ test("VSIX package policy keeps hidden host-smoke commands out of the manifest",
 
   assert.deepEqual(hiddenCommands.sort(), [
     "vize.test.executeCompletion",
+    "vize.test.executeLspRequest",
     "vize.test.executeReferences",
     "vize.test.getServerInfo",
   ]);


### PR DESCRIPTION
## Summary
- add an env-gated hidden VS Code host command that forwards a generic LSP request through the active Vize LanguageClient
- add focused tooling coverage for gating, request validation, forwarding, and hidden manifest policy

## Validation
- node --test tests/tooling/vscode-host-test-commands.test.ts tests/tooling/vscode-host-lsp-request-command.test.ts tests/tooling/vscode-vsix-policy.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- vp check editors/vscode/src/host-test-core.ts editors/vscode/test/real-host-lsp-request-oracle.mjs tests/tooling/vscode-host-test-commands.test.ts tests/tooling/vscode-host-lsp-request-command.test.ts tests/tooling/vscode-vsix-policy.test.ts
- vp run check:vscode-extension

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791193253&installation_model_id=422833&pr_number=5742&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5742&signature=a23a86d4dd9a68cba869a5e1d73421f9b171bdb3643e3ba64f5f6eb51acebe14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->