### PR TITLE
fix(carton): reject oversized numeric expression tokens

### DIFF
--- a/crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_5733.rs
+++ b/crates/vize_atelier_core/tests/fuzz_slow_unit_js_ts_expression_5733.rs
@@ -1,0 +1,28 @@
+//! Replay of the `js_ts_expression` long numeric-token slow units from #5733/#5737.
+
+use vize_atelier_core::steps::expression::{
+    expression_has_balanced_delimiters, expression_is_safe_to_parse, expression_nesting_depth,
+    prefix_identifiers_in_expression, strip_typescript_from_expression,
+};
+
+#[test]
+fn long_hex_numeric_literal_is_rejected_before_oxc_parse() {
+    let source = ["0X", &"C".repeat(4095)].concat();
+
+    assert_eq!(source.len(), 4097);
+    assert_eq!(expression_nesting_depth(&source), 0);
+    assert!(expression_has_balanced_delimiters(&source));
+    assert!(!expression_is_safe_to_parse(&source));
+    assert_eq!(prefix_identifiers_in_expression(&source).as_str(), source);
+    assert_eq!(strip_typescript_from_expression(&source).as_str(), source);
+}
+
+#[test]
+fn numeric_literal_budget_accepts_the_exact_boundary() {
+    let source = ["0x", &"c".repeat(4094)].concat();
+
+    assert_eq!(source.len(), 4096);
+    assert_eq!(expression_nesting_depth(&source), 0);
+    assert!(expression_has_balanced_delimiters(&source));
+    assert!(expression_is_safe_to_parse(&source));
+}

--- a/crates/vize_carton/src/expression_guard.rs
+++ b/crates/vize_carton/src/expression_guard.rs
@@ -20,21 +20,17 @@ pub use scan::is_expression_trailing_trivia;
 /// at depth 32 (#2944) cannot be caught, so every entry point shares this guard.
 pub const MAX_EXPRESSION_NESTING_DEPTH: usize = 31;
 
-/// Per-operator branch depth counted by the cumulative speculative type-angle
-/// budget.
-///
-/// Logical/nullish operators stop one parser branch, so low-depth comparison
-/// chains (`a < b && c < d`) must stay accepted. OXC still retains allocations
-/// from failed medium-depth type-argument attempts across those branches,
-/// however; enough of them OOM even when no single branch crosses
-/// [`MAX_EXPRESSION_NESTING_DEPTH`] (#4618). Counting only latched branches at
-/// half the hard limit keeps ordinary comparisons out of the cumulative budget.
+/// Per-operator branch depth counted by the cumulative speculative type-angle budget.
+/// Logical/nullish operators stop one parser branch, so low-depth comparison chains stay accepted;
+/// repeated failed medium-depth type-argument attempts still count toward #4618.
 const CUMULATIVE_SPECULATIVE_TYPE_ANGLE_MIN_DEPTH: usize = MAX_EXPRESSION_NESTING_DEPTH / 2;
+const MAX_NUMERIC_TOKEN_BYTES: usize = 4096;
 
 struct ExpressionNestingAnalysis {
     max_depth: usize,
     delimiters_balanced: bool,
     cumulative_speculative_type_angle_depth: usize,
+    oversized_numeric_token: bool,
 }
 
 fn flush_speculative_type_angle_segment(cumulative: &mut usize, segment_depth: &mut usize) {
@@ -78,6 +74,7 @@ fn analyze_expression_nesting(content: &str) -> ExpressionNestingAnalysis {
     let mut malformed_type_escape_opens = 0usize;
     let mut segment_speculative_type_angle_depth = 0usize;
     let mut cumulative_speculative_type_angle_depth = 0usize;
+    let mut oversized_numeric_token = false;
     let mut track_type_angles = false;
     let mut i = 0;
 
@@ -148,7 +145,9 @@ fn analyze_expression_nesting(content: &str) -> ExpressionNestingAnalysis {
                 continue;
             }
             b'0'..=b'9' => {
+                let start = i;
                 i = skip_number(bytes, i + 1);
+                oversized_numeric_token |= i - start > MAX_NUMERIC_TOKEN_BYTES;
                 can_start_regex = false;
                 continue;
             }
@@ -265,9 +264,8 @@ fn analyze_expression_nesting(content: &str) -> ExpressionNestingAnalysis {
             b',' | b';' | b':' | b'?' | b'!' | b'=' | b'+' | b'-' | b'*' | b'/' | b'%' | b'&'
             | b'|' | b'^' | b'~' => can_start_regex = true,
             // A `\` in code position begins an identifier escape for OXC's
-            // lexer (`\uXXXX` / `\u{...}`); a `\` that does not form a valid
-            // escape is a lexer error OXC recovers from without opening a new
-            // literal. Either way OXC never starts a string at a `'`/`"` — or a
+            // lexer (`\uXXXX` / `\u{...}`); invalid escapes recover without opening
+            // a new literal. Either way OXC never starts a string at a `'`/`"` — or a
             // template at a `` ` `` — that immediately follows a `\`. The
             // scanner used to advance past the lone `\` and then treat that
             // quote as a string opener, so `skip_quoted` ran to the next
@@ -287,11 +285,8 @@ fn analyze_expression_nesting(content: &str) -> ExpressionNestingAnalysis {
                 }
                 can_start_regex = false;
             }
-            // Every byte reaching this arm is identifier-like (`#` starts a
-            // private name, non-ASCII bytes continue multi-byte identifiers) or
-            // an invalid control character. None of them can precede a regex
-            // literal, and claiming they do lets `skip_regex` swallow arbitrary
-            // source, hiding real brackets from the depth guard (#3107).
+            // Identifier-like (`#`, non-ASCII) or invalid bytes cannot precede
+            // regex; doing so hid real brackets behind a false regex (#3107).
             _ => can_start_regex = false,
         }
 
@@ -322,6 +317,7 @@ fn analyze_expression_nesting(content: &str) -> ExpressionNestingAnalysis {
             && delimiters.is_empty()
             && template_interpolation_depths.is_empty(),
         cumulative_speculative_type_angle_depth,
+        oversized_numeric_token,
     }
 }
 
@@ -340,6 +336,7 @@ pub fn expression_is_safe_to_parse(content: &str) -> bool {
     analysis.delimiters_balanced
         && analysis.max_depth <= MAX_EXPRESSION_NESTING_DEPTH
         && analysis.cumulative_speculative_type_angle_depth <= MAX_EXPRESSION_NESTING_DEPTH
+        && !analysis.oversized_numeric_token
         && !operators::has_excessive_prefix_operator_run(content)
 }
 


### PR DESCRIPTION
## Summary
- reject oversized numeric expression tokens in the shared expression guard before OXC parsing
- add a js_ts_expression slow-unit regression for the long hex literal reproducer
- keep the exact 4096 byte numeric-token boundary accepted

Closes #5733.
Closes #5737.

## Validation
- TMPDIR=/tmp/vize-fuzz-js-ts-long-hex TEMP=/tmp/vize-fuzz-js-ts-long-hex TMP=/tmp/vize-fuzz-js-ts-long-hex cargo test -p vize_atelier_core --test fuzz_slow_unit_js_ts_expression_5733 -- --nocapture
- TMPDIR=/tmp/vize-fuzz-js-ts-long-hex TEMP=/tmp/vize-fuzz-js-ts-long-hex TMP=/tmp/vize-fuzz-js-ts-long-hex cargo test -p vize_atelier_core --test expression_nesting_guard -- --nocapture
- TMPDIR=/tmp/vize-fuzz-js-ts-long-hex TEMP=/tmp/vize-fuzz-js-ts-long-hex TMP=/tmp/vize-fuzz-js-ts-long-hex cargo test -p vize_atelier_core --test fuzz_slow_unit_js_ts_expression_3712 -- --nocapture
- TMPDIR=/tmp/vize-fuzz-js-ts-long-hex TEMP=/tmp/vize-fuzz-js-ts-long-hex TMP=/tmp/vize-fuzz-js-ts-long-hex cargo +nightly fuzz run --fuzz-dir tests/fuzz js_ts_expression /tmp/fuzz5737.WVhHzT/slow-unit-7eef465d0f0b600a3ad965b0d4cbdb8cc9e27ab3 -- -runs=1
- cargo fmt --all --check
- git diff --check HEAD~1..HEAD
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791193748&installation_model_id=422833&pr_number=5743&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5743&signature=0749fbd2addb03fdddfd0670aaf4805bcb1a48f9db40a1855584c19bb06150e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->