### PR TITLE
test(davinci): cover runtime module profiling

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_runtime_module_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_runtime_module_profile.rs
@@ -1,0 +1,99 @@
+//! P2-11 witness: custom runtime module names stay on the profiled S2 DOM
+//! production selector. Direct emitter tests cover the spelling; this keeps
+//! the production routing from silently falling back to compatibility codegen.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use vize_atelier_core::options::{CodegenMode, CodegenOptions, TemplateSyntaxMode};
+use vize_atelier_dom::{
+    DomCompilerOptions, compile_template_with_template_syntax_and_codegen_options,
+};
+use vize_s0::Allocator;
+use vize_s0::String;
+use vize_s0::profiler::{CounterSummary, global_profiler};
+
+#[test]
+fn source_map_disabled_runtime_module_name_stays_on_s2_codegen() {
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+    let source = r#"<button @click="go">{{ label }}</button>"#;
+    let codegen = CodegenOptions {
+        runtime_module_name: String::from("@scope/vue-runtime"),
+        ..Default::default()
+    };
+    let compat_allocator = Allocator::new();
+    let (_, compat_errors, compat) = compile_template_with_template_syntax_and_codegen_options(
+        &compat_allocator,
+        source,
+        DomCompilerOptions {
+            mode: CodegenMode::Module,
+            source_map: true,
+            ..Default::default()
+        },
+        TemplateSyntaxMode::Standard,
+        codegen.clone(),
+    );
+    assert!(compat_errors.is_empty());
+
+    let profile = ProfileScope::enable();
+    let allocator = Allocator::new();
+    let (_, errors, result) = compile_template_with_template_syntax_and_codegen_options(
+        &allocator,
+        source,
+        DomCompilerOptions {
+            mode: CodegenMode::Module,
+            ..Default::default()
+        },
+        TemplateSyntaxMode::Standard,
+        codegen,
+    );
+    let counters = profile.finish();
+
+    assert!(errors.is_empty());
+    assert_eq!(result.preamble, compat.preamble);
+    assert_eq!(result.code, compat.code);
+    assert_eq!(
+        counter(&counters, "davinci.s2_dom.files"),
+        1,
+        "custom runtime-module compiles are covered by the S2 production option surface"
+    );
+}
+
+fn counter(counters: &CounterSummary, name: &str) -> u64 {
+    counters
+        .entries
+        .iter()
+        .find(|entry| entry.name == name)
+        .unwrap_or_else(|| panic!("missing {name} profile counter"))
+        .total
+}
+
+struct ProfileScope;
+
+impl ProfileScope {
+    fn enable() -> Self {
+        let profiler = global_profiler();
+        profiler.clear();
+        profiler.enable();
+        Self
+    }
+
+    fn finish(self) -> CounterSummary {
+        let profiler = global_profiler();
+        profiler.disable();
+        profiler.counter_summary()
+    }
+}
+
+impl Drop for ProfileScope {
+    fn drop(&mut self) {
+        let profiler = global_profiler();
+        profiler.disable();
+        profiler.clear();
+    }
+}

--- a/davinci-road/plan/phase-2-records/p2-11/installment-106.md
+++ b/davinci-road/plan/phase-2-records/p2-11/installment-106.md
@@ -1,0 +1,33 @@
+# P2-11 Installment 106 - Runtime Module Profiling
+
+> Part of the [P2-11 series record](../p2-11.md), split per installment.
+> PR: _pending - the number, merge date and squash SHA are filled in at
+> merge, as every prior installment's line was._
+
+This installment connects installment 84's custom runtime module-name emitter
+parity witness to the production-side S2 selector. Module output can import
+helpers from an adapter-provided `CodegenOptions::runtime_module_name`, and
+that projection must stay covered by the profiled source-map-free DOM compile
+path rather than only by direct emitter tests.
+
+The source-map request remains the compatibility boundary because S2 still
+emits no map. With source maps disabled, a custom runtime module compile now
+enters S2 profiling, records the `davinci.s2_dom.*` counters and stays
+byte-identical with the compatibility source-map compile.
+
+## Evidence
+
+`crates/vize_atelier_dom/tests/davinci_s2_runtime_module_profile.rs` asserts
+that a module-mode DOM compile using
+`runtime_module_name = "@scope/vue-runtime"` stays on S2 under profiling and
+produces the same import preamble and render body as the compatibility
+source-map compile.
+
+Focused gate:
+
+```sh
+cargo test -p vize_atelier_dom --test davinci_s2_runtime_module_profile
+```
+
+This installment does not tick P2-11. The production-lane switch remains
+open, and the old DOM lane is still the shipped non-profiled compile path.


### PR DESCRIPTION
Summary:
- add a focused S2 DOM production-profile witness for custom runtime module names
- record P2-11 installment 106 without changing the shipped DOM lane

Validation:
- cargo test -p vize_atelier_dom --test davinci_s2_runtime_module_profile --test davinci_s2_profile --test davinci_s2_module_mode --test davinci_s2_option_matrix --test davinci_s2_option_families
- cargo fmt --all --check
- git diff --check origin/main...HEAD
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 50
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791194294&installation_model_id=422833&pr_number=5744&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5744&signature=0c6c49282fbd5c4ed8db919fb459490a94a0baffb5772bfda7900d7a53aa619b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->