### PR TITLE
test(typecheck): reject stale documented divergence rows

### DIFF
--- a/tests/tooling/typecheck-divergence-report-ledger.test.ts
+++ b/tests/tooling/typecheck-divergence-report-ledger.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import {
+  cleanup,
+  readJson,
+  run,
+  setup,
+  writeJson,
+} from "./_helpers/typecheck-divergence-report-fixture.ts";
+
+const duplicateListenerDifference = {
+  project: "fixture",
+  file: "src/App.vue",
+  severity: "error",
+  line: 3,
+  column: 1,
+  vize: null,
+  baseline: {
+    code: 1117,
+    message: "An object literal cannot have multiple properties with the same name.",
+  },
+  issue: 5722,
+  reason:
+    "vue-tsc reports a duplicate generated listener key for legal paired event directives; " +
+    "Vize intentionally keeps listener directives out of the props literal.",
+};
+
+function writeDocumentedDifferences(fixture: ReturnType<typeof setup>) {
+  const ledgerPath = path.join(fixture.fixtureRoot, "documented-differences.json");
+  writeJson(ledgerPath, {
+    schema: "vize.compatDocumentedDifferences",
+    version: 1,
+    differences: [duplicateListenerDifference],
+  });
+  return ledgerPath;
+}
+
+test("typecheck divergence report accepts a reproducing documented difference", () => {
+  const fixture = setup({
+    baselineOutput:
+      "src/App.vue(1,1): error TS2322: shared\n" +
+      "src/App.vue(3,1): error TS1117: An object literal cannot have multiple properties with the same name.\n",
+  });
+  try {
+    const result = run(fixture, {}, [
+      "--documented-differences",
+      writeDocumentedDifferences(fixture),
+    ]);
+    assert.equal(result.status, 0, result.stderr);
+    const artifact = readJson(path.join(fixture.reportDir, "fixture-typecheck-divergence.json"));
+    assert.equal(artifact.divergence.summary.documentedDifferenceCount, 1);
+    assert.equal(artifact.divergence.summary.falseNegativeCount, 0);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("typecheck divergence report rejects a stale documented difference", () => {
+  const fixture = setup();
+  try {
+    const result = run(fixture, {}, [
+      "--documented-differences",
+      writeDocumentedDifferences(fixture),
+    ]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Documented typecheck difference ledger is stale for fixture/);
+    assert.match(result.stderr, /src\/App\.vue:3:1/);
+    assert.equal(
+      fs.existsSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json")),
+      false,
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tools/commands/fixtures/typecheck-divergence-report.rs
+++ b/tools/commands/fixtures/typecheck-divergence-report.rs
@@ -200,6 +200,8 @@ fn write_project_artifact(root: &Path, args: &Args, project: &Value) -> Result<V
         );
     }
     let documented_differences = read_documented_differences(&args.documented_differences)?;
+    let expected_documented_differences =
+        select_documented_differences(&documented_differences, &project_id, &fixture_root)?;
     let divergence = compare_typecheck_diagnostics(
         project_id.clone(),
         &fixture_root,
@@ -208,6 +210,13 @@ fn write_project_artifact(root: &Path, args: &Args, project: &Value) -> Result<V
         &typecheck_source_roots,
         &documented_differences,
     )?;
+    if args.budget_mode == "enforce" {
+        reject_stale_documented_differences(
+            &project_id,
+            &expected_documented_differences,
+            &divergence,
+        )?;
+    }
     let coverage = if let Some(reason) = baseline
         .run_error
         .as_deref()
@@ -1884,6 +1893,45 @@ fn documented_json(record: &DocumentedDifference) -> Value {
         "issue": record.issue,
         "reason": record.reason,
     })
+}
+
+fn reject_stale_documented_differences(
+    project_id: &str,
+    expected: &[DocumentedDifference],
+    divergence: &Value,
+) -> Result<(), String> {
+    if expected.is_empty() {
+        return Ok(());
+    }
+    let observed = divergence
+        .get("documentedDifferences")
+        .and_then(Value::as_array)
+        .ok_or_else(|| divergence_error("comparison is missing documented differences"))?;
+    if observed.len() == expected.len() {
+        return Ok(());
+    }
+    let observed_keys = observed.iter().map(documented_key).collect::<BTreeSet<_>>();
+    let stale = expected
+        .iter()
+        .filter(|difference| {
+            let value = documented_json(difference);
+            !observed_keys.contains(&documented_key(&value))
+        })
+        .collect::<Vec<_>>();
+    if stale.is_empty() {
+        return Ok(());
+    }
+    let examples = stale
+        .iter()
+        .take(3)
+        .map(|difference| format!("{}:{}:{}", difference.file, difference.line, difference.column))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(format!(
+        "Documented typecheck difference ledger is stale for {project_id}: {} of {} entries did not reproduce; remove converged rows from tests/_fixtures/compat-documented-differences.json ({examples})",
+        stale.len(),
+        expected.len(),
+    ))
 }
 
 fn pair_documented_differences(


### PR DESCRIPTION
Summary:
- fail real-project typecheck divergence reports in enforce mode when selected documented rows no longer reproduce
- add a focused #5722 duplicate-listener ledger regression for reproducing and stale rows

Validation:
- node --test --test-concurrency=1 tests/tooling/typecheck-divergence-report-ledger.test.ts tests/tooling/typecheck-divergence-mutation-delta.test.ts tests/tooling/typecheck-divergence-report*.test.ts tests/tooling/typecheck-divergence-ledger.test.ts tests/tooling/typecheck-divergence.test.ts
- cargo fmt --all --check
- git diff --check origin/main...HEAD
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main

Refs #5722
Refs #3984

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Typecheck divergence reports now reject stale documented-difference entries and provide clear file, line, and column locations for mismatches.
  * Valid documented differences continue to be accepted and reported accurately, including documented and false-negative counts.
  * Enforced checks no longer produce a report artifact when the documented-difference ledger contains stale entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->