### PR TITLE
fix(glyph): preserve VitePress hidden layout parse errors

### DIFF
--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -4,17 +4,18 @@
 
 mod block_indent;
 mod custom_block;
+mod opening_tag;
 mod raw_mask;
+mod script_block;
+mod style_block;
 mod template_block;
 mod template_indent;
 
 use crate::error::FormatError;
 use crate::options::FormatOptions;
-use crate::script;
-use crate::style;
 use std::borrow::Cow;
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-use vize_s0::{Allocator, FxHashMap, String, ToCompactString};
+use vize_s0::{Allocator, FxHashMap, String};
 
 /// Result of formatting a Vue SFC
 #[derive(Debug, Clone)]
@@ -122,16 +123,25 @@ impl<'a> GlyphFormatter<'a> {
                 output.extend_from_slice(newline);
             }
             match block {
-                Block::Script(script) => {
-                    self.format_script_block_fast(&mut output, script)?;
-                }
-                Block::Template(template) => {
-                    self.format_template_block_fast(&mut output, template)?;
-                }
+                Block::Script(script) => script_block::write_script_block(
+                    &mut output,
+                    script,
+                    self.options,
+                    self.allocator,
+                    source,
+                )?,
+                Block::Template(template) => template_block::write_template_block(
+                    &mut output,
+                    template,
+                    self.options,
+                    source,
+                )?,
                 Block::Style(style) => {
-                    self.format_style_block_fast(&mut output, style)?;
+                    style_block::write_style_block(&mut output, style, self.options, source)?
                 }
-                Block::Custom(block) => custom_block::format(&mut output, block, self.options)?,
+                Block::Custom(block) => {
+                    custom_block::format(&mut output, block, self.options, source)?
+                }
             }
         }
 
@@ -173,122 +183,6 @@ impl<'a> GlyphFormatter<'a> {
         }
 
         size
-    }
-
-    /// Format a script block using byte operations
-    #[inline]
-    fn format_script_block_fast(
-        &self,
-        output: &mut Vec<u8>,
-        block: &vize_atelier_sfc::SfcScriptBlock<'_>,
-    ) -> Result<(), FormatError> {
-        // Degrade gracefully on a script parse error: emit the original script
-        // body trimmed but otherwise unchanged, rather than failing the whole
-        // SFC format and dropping the template/style work. The script formatter
-        // delegates to oxc, which round-trips decorated class components
-        // (`@Component`/`@Prop()`/`@Emit()`) fine; this fallback only triggers
-        // on genuinely unparseable TS, mirroring the style block's fallback to
-        // trimmed content. (#1391)
-        let trimmed = block.content.trim();
-        let source_type =
-            script::source_type_for_script_lang(block.lang.as_ref().map(|lang| lang.as_ref()));
-        let formatted_content = script::format_sfc_script_content_stable(
-            trimmed,
-            self.options,
-            self.allocator,
-            source_type,
-        )
-        .unwrap_or_else(|_| trimmed.to_compact_string());
-
-        // Build the opening tag using byte operations
-        output.extend_from_slice(b"<script");
-        if block.setup {
-            write_attr(output, "setup", None);
-        }
-        if let Some(lang) = &block.lang {
-            write_attr(output, "lang", Some(lang));
-        }
-        write_remaining_attrs(output, &block.attrs, &["setup", "lang"]);
-        output.push(b'>');
-        output.extend_from_slice(self.options.newline_bytes());
-
-        // Add content with indentation if configured
-        if self.options.vue_indent_script_and_style {
-            block_indent::write_indented_block(
-                output,
-                &formatted_content,
-                self.options.indent_bytes(),
-                self.options.newline_bytes(),
-            );
-        } else {
-            output.extend_from_slice(formatted_content.as_bytes());
-            if !formatted_content.ends_with('\n') {
-                output.extend_from_slice(self.options.newline_bytes());
-            }
-        }
-
-        output.extend_from_slice(b"</script>");
-
-        Ok(())
-    }
-
-    /// Format a template block using byte operations
-    #[inline]
-    fn format_template_block_fast(
-        &self,
-        output: &mut Vec<u8>,
-        block: &vize_atelier_sfc::SfcTemplateBlock<'_>,
-    ) -> Result<(), FormatError> {
-        template_block::write_template_block(output, block, self.options)
-    }
-
-    /// Format a style block using lightningcss for CSS
-    #[inline]
-    fn format_style_block_fast(
-        &self,
-        output: &mut Vec<u8>,
-        block: &vize_atelier_sfc::SfcStyleBlock<'_>,
-    ) -> Result<(), FormatError> {
-        // Use lightningcss for plain CSS; for preprocessor languages, just trim
-        let is_plain_css = block.lang.as_ref().is_none_or(|l| l.as_ref() == "css");
-        let formatted_content = if is_plain_css {
-            style::format_style_content(&block.content, self.options)
-                .unwrap_or_else(|_| block.content.trim().to_compact_string())
-        } else {
-            block.content.trim().to_compact_string()
-        };
-        let formatted_content = formatted_content.as_str();
-
-        // Build the opening tag
-        output.extend_from_slice(b"<style");
-        if block.scoped {
-            write_attr(output, "scoped", None);
-        }
-        if let Some(lang) = &block.lang {
-            write_attr(output, "lang", Some(lang));
-        }
-        write_remaining_attrs(output, &block.attrs, &["scoped", "lang"]);
-        output.push(b'>');
-        output.extend_from_slice(self.options.newline_bytes());
-
-        // Add content with indentation if configured
-        if self.options.vue_indent_script_and_style {
-            block_indent::write_indented_block(
-                output,
-                formatted_content,
-                self.options.indent_bytes(),
-                self.options.newline_bytes(),
-            );
-        } else {
-            output.extend_from_slice(formatted_content.as_bytes());
-            if !formatted_content.ends_with('\n') {
-                output.extend_from_slice(self.options.newline_bytes());
-            }
-        }
-
-        output.extend_from_slice(b"</style>");
-
-        Ok(())
     }
 }
 

--- a/crates/vize_glyph/src/formatter/custom_block.rs
+++ b/crates/vize_glyph/src/formatter/custom_block.rs
@@ -4,17 +4,29 @@ pub(super) fn format(
     output: &mut Vec<u8>,
     block: &vize_atelier_sfc::SfcCustomBlock<'_>,
     options: &FormatOptions,
+    source: &str,
 ) -> Result<(), FormatError> {
-    output.push(b'<');
-    output.extend_from_slice(block.block_type.as_bytes());
-    super::write_remaining_attrs(output, &block.attrs, &[]);
-    output.push(b'>');
+    let opening_tag = super::opening_tag::raw_templated_opening_tag(source, &block.loc);
+    if let Some(opening_tag) = &opening_tag {
+        super::opening_tag::write_raw(output, opening_tag);
+    } else {
+        output.push(b'<');
+        output.extend_from_slice(block.block_type.as_bytes());
+        super::write_remaining_attrs(output, &block.attrs, &[]);
+        output.push(b'>');
+    }
     output.extend_from_slice(options.newline_bytes());
 
+    let content = super::opening_tag::content_after_opening_tag(
+        source,
+        &block.loc,
+        block.content.as_ref(),
+        opening_tag.as_ref(),
+    );
     if block.block_type.as_ref() == "art" {
-        write_art_content(output, block.content.as_ref(), options)?;
+        write_art_content(output, content, options)?;
     } else {
-        output.extend_from_slice(block.content.trim().as_bytes());
+        output.extend_from_slice(content.trim().as_bytes());
         output.extend_from_slice(options.newline_bytes());
     }
 

--- a/crates/vize_glyph/src/formatter/opening_tag.rs
+++ b/crates/vize_glyph/src/formatter/opening_tag.rs
@@ -1,0 +1,48 @@
+use vize_atelier_sfc::BlockLocation;
+
+pub(super) struct RawOpeningTag<'a> {
+    text: &'a str,
+    content_start: usize,
+}
+
+pub(super) fn raw_templated_opening_tag<'a>(
+    source: &'a str,
+    loc: &BlockLocation,
+) -> Option<RawOpeningTag<'a>> {
+    let raw_end = templated_opening_tag_end(source, loc)?;
+    Some(RawOpeningTag {
+        text: source.get(loc.tag_start..raw_end)?,
+        content_start: raw_end,
+    })
+}
+
+pub(super) fn content_after_opening_tag<'a>(
+    source: &'a str,
+    loc: &BlockLocation,
+    fallback: &'a str,
+    opening_tag: Option<&RawOpeningTag<'_>>,
+) -> &'a str {
+    let start = opening_tag.map_or(loc.start, |tag| tag.content_start);
+    source.get(start..loc.end).unwrap_or(fallback)
+}
+
+pub(super) fn write_raw(output: &mut Vec<u8>, opening_tag: &RawOpeningTag<'_>) {
+    output.extend_from_slice(opening_tag.text.as_bytes());
+}
+
+fn templated_opening_tag_end(source: &str, loc: &BlockLocation) -> Option<usize> {
+    let raw = source.get(loc.tag_start..loc.start)?;
+    let contains_marker = raw
+        .as_bytes()
+        .windows(2)
+        .any(|pair| pair == b"<%" || pair == b"%>");
+    contains_marker.then(|| {
+        loc.start
+            + usize::from(
+                source
+                    .as_bytes()
+                    .get(loc.start)
+                    .is_some_and(|byte| *byte == b'>'),
+            )
+    })
+}

--- a/crates/vize_glyph/src/formatter/script_block.rs
+++ b/crates/vize_glyph/src/formatter/script_block.rs
@@ -1,0 +1,57 @@
+use super::{block_indent, opening_tag, write_attr, write_remaining_attrs};
+use crate::{error::FormatError, options::FormatOptions, script};
+use vize_s0::{Allocator, ToCompactString};
+
+pub(super) fn write_script_block(
+    output: &mut Vec<u8>,
+    block: &vize_atelier_sfc::SfcScriptBlock<'_>,
+    options: &FormatOptions,
+    allocator: &Allocator,
+    source: &str,
+) -> Result<(), FormatError> {
+    let opening_tag = opening_tag::raw_templated_opening_tag(source, &block.loc);
+    let content = opening_tag::content_after_opening_tag(
+        source,
+        &block.loc,
+        block.content.as_ref(),
+        opening_tag.as_ref(),
+    );
+    let trimmed = content.trim();
+    let source_type =
+        script::source_type_for_script_lang(block.lang.as_ref().map(|lang| lang.as_ref()));
+    let formatted_content =
+        script::format_sfc_script_content_stable(trimmed, options, allocator, source_type)
+            .unwrap_or_else(|_| trimmed.to_compact_string());
+
+    if let Some(opening_tag) = &opening_tag {
+        opening_tag::write_raw(output, opening_tag);
+    } else {
+        output.extend_from_slice(b"<script");
+        if block.setup {
+            write_attr(output, "setup", None);
+        }
+        if let Some(lang) = &block.lang {
+            write_attr(output, "lang", Some(lang));
+        }
+        write_remaining_attrs(output, &block.attrs, &["setup", "lang"]);
+        output.push(b'>');
+    }
+    output.extend_from_slice(options.newline_bytes());
+
+    if options.vue_indent_script_and_style {
+        block_indent::write_indented_block(
+            output,
+            &formatted_content,
+            options.indent_bytes(),
+            options.newline_bytes(),
+        );
+    } else {
+        output.extend_from_slice(formatted_content.as_bytes());
+        if !formatted_content.ends_with('\n') {
+            output.extend_from_slice(options.newline_bytes());
+        }
+    }
+
+    output.extend_from_slice(b"</script>");
+    Ok(())
+}

--- a/crates/vize_glyph/src/formatter/style_block.rs
+++ b/crates/vize_glyph/src/formatter/style_block.rs
@@ -1,0 +1,60 @@
+use super::{block_indent, opening_tag, write_attr, write_remaining_attrs};
+use crate::{error::FormatError, options::FormatOptions, style};
+use vize_s0::ToCompactString;
+
+pub(super) fn write_style_block(
+    output: &mut Vec<u8>,
+    block: &vize_atelier_sfc::SfcStyleBlock<'_>,
+    options: &FormatOptions,
+    source: &str,
+) -> Result<(), FormatError> {
+    let is_plain_css = block
+        .lang
+        .as_ref()
+        .is_none_or(|lang| lang.as_ref() == "css");
+    let opening_tag = opening_tag::raw_templated_opening_tag(source, &block.loc);
+    let content = opening_tag::content_after_opening_tag(
+        source,
+        &block.loc,
+        block.content.as_ref(),
+        opening_tag.as_ref(),
+    );
+    let formatted_content = if is_plain_css {
+        style::format_style_content(content, options)
+            .unwrap_or_else(|_| content.trim().to_compact_string())
+    } else {
+        content.trim().to_compact_string()
+    };
+
+    if let Some(opening_tag) = &opening_tag {
+        opening_tag::write_raw(output, opening_tag);
+    } else {
+        output.extend_from_slice(b"<style");
+        if block.scoped {
+            write_attr(output, "scoped", None);
+        }
+        if let Some(lang) = &block.lang {
+            write_attr(output, "lang", Some(lang));
+        }
+        write_remaining_attrs(output, &block.attrs, &["scoped", "lang"]);
+        output.push(b'>');
+    }
+    output.extend_from_slice(options.newline_bytes());
+
+    if options.vue_indent_script_and_style {
+        block_indent::write_indented_block(
+            output,
+            formatted_content.as_str(),
+            options.indent_bytes(),
+            options.newline_bytes(),
+        );
+    } else {
+        output.extend_from_slice(formatted_content.as_bytes());
+        if !formatted_content.ends_with('\n') {
+            output.extend_from_slice(options.newline_bytes());
+        }
+    }
+
+    output.extend_from_slice(b"</style>");
+    Ok(())
+}

--- a/crates/vize_glyph/src/formatter/template_block.rs
+++ b/crates/vize_glyph/src/formatter/template_block.rs
@@ -5,7 +5,7 @@
 //! language is opaque: its bytes are preserved and only the common outer
 //! indentation is rebased.
 
-use super::{template_indent, write_attr, write_remaining_attrs};
+use super::{opening_tag, template_indent, write_attr, write_remaining_attrs};
 use crate::error::FormatError;
 use crate::options::FormatOptions;
 use crate::template;
@@ -14,6 +14,7 @@ pub(super) fn write_template_block(
     output: &mut Vec<u8>,
     block: &vize_atelier_sfc::SfcTemplateBlock<'_>,
     options: &FormatOptions,
+    source: &str,
 ) -> Result<(), FormatError> {
     // The HTML template formatter owns HTML syntax only. Feeding Pug,
     // Haml, Markdown, or another preprocessor language through it turns
@@ -23,17 +24,28 @@ pub(super) fn write_template_block(
         .lang
         .as_deref()
         .is_none_or(|lang| lang.eq_ignore_ascii_case("html"));
+    let opening_tag = opening_tag::raw_templated_opening_tag(source, &block.loc);
+    let content = opening_tag::content_after_opening_tag(
+        source,
+        &block.loc,
+        block.content.as_ref(),
+        opening_tag.as_ref(),
+    );
     let formatted_content = native_html
-        .then(|| template::format_template_content(&block.content, options))
+        .then(|| template::format_template_content(content, options))
         .transpose()?;
 
-    // Build the opening tag
-    output.extend_from_slice(b"<template");
-    if let Some(lang) = &block.lang {
-        write_attr(output, "lang", Some(lang));
+    if let Some(opening_tag) = &opening_tag {
+        opening_tag::write_raw(output, opening_tag);
+    } else {
+        // Build the opening tag
+        output.extend_from_slice(b"<template");
+        if let Some(lang) = &block.lang {
+            write_attr(output, "lang", Some(lang));
+        }
+        write_remaining_attrs(output, &block.attrs, &["lang"]);
+        output.push(b'>');
     }
-    write_remaining_attrs(output, &block.attrs, &["lang"]);
-    output.push(b'>');
     output.extend_from_slice(options.newline_bytes());
 
     let indent = options.indent_bytes();
@@ -52,7 +64,7 @@ pub(super) fn write_template_block(
         // relative indentation and all line content remain source-owned.
         template_indent::write_rebased_opaque_template(
             output,
-            &block.content,
+            content,
             indent,
             options.newline_bytes(),
         );

--- a/crates/vize_glyph/tests/sfc_templated_root_tags.rs
+++ b/crates/vize_glyph/tests/sfc_templated_root_tags.rs
@@ -1,0 +1,31 @@
+use vize_glyph::{FormatOptions, format_sfc};
+
+#[test]
+fn templated_script_opening_tag_is_source_owned() {
+    let source = r#"<script setup<%= useTs ? ' lang="ts"' : '' %>>
+import { useData } from 'vitepress'
+
+const { site, frontmatter } = useData()
+</script>
+
+<template>
+  <h1>{{ site.title }}</h1>
+</template>
+"#;
+    let options = FormatOptions::default();
+    let first = format_sfc(source, &options).expect("templated SFC must format");
+    let second = format_sfc(&first.code, &options).expect("formatted SFC must stay parseable");
+    let expected = r#"<script setup<%= useTs ? ' lang="ts"' : '' %>>
+import { useData } from "vitepress";
+
+const { site, frontmatter } = useData();
+</script>
+
+<template>
+  <h1>{{ site.title }}</h1>
+</template>
+"#;
+
+    assert_eq!(first.code, expected);
+    assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+}

--- a/tests/_fixtures/glyph-corpus-known-violations.json
+++ b/tests/_fixtures/glyph-corpus-known-violations.json
@@ -1,11 +1,1 @@
-[
-  {
-    "property": "parse-preservation",
-    "category": "semantic-diff",
-    "project": "vitepress",
-    "path": "template/.vitepress/theme/Layout.vue",
-    "reason": "Including hidden recursive formatter inputs exposes an existing VitePress fixture where formatting removes one Vue compiler parse error signature.",
-    "trackingIssue": 5723,
-    "expiryCondition": "Remove when the formatter preserves this file's parse-error signature without a waiver."
-  }
-]
+[]

--- a/tests/tooling/glyph-corpus-evidence.test.ts
+++ b/tests/tooling/glyph-corpus-evidence.test.ts
@@ -118,17 +118,14 @@ test("glyph corpus shard selection is bound to manifest project ids before hydra
   );
 });
 
-test("glyph waiver ledger validation is not narrowed to the selected shard", () => {
+test("glyph parse-preservation waiver ledger is empty after hidden VitePress passes", () => {
   const beforeIndex = process.env.FIXTURE_SHARD_INDEX;
   const beforeCount = process.env.FIXTURE_SHARD_COUNT;
   try {
     process.env.FIXTURE_SHARD_INDEX = "10";
     process.env.FIXTURE_SHARD_COUNT = "22";
     const violations = loadKnownViolations("parse-preservation");
-    assert.ok(
-      violations.some((entry: { project: string }) => entry.project === "vitepress"),
-      "the current VitePress waiver should remain valid outside its matrix shard",
-    );
+    assert.deepEqual(violations, []);
   } finally {
     restoreEnv("FIXTURE_SHARD_INDEX", beforeIndex);
     restoreEnv("FIXTURE_SHARD_COUNT", beforeCount);


### PR DESCRIPTION
## Summary
- Preserve templated SFC root opening tags when glyph formats malformed scaffold inputs.
- Keep the VitePress hidden Layout.vue parse-error signature unchanged.
- Remove the #5723 glyph corpus parse-preservation waiver.

Closes #5723.

## Validation
- cargo test -p vize_glyph
- cargo build --profile ci -p vize --features legacy
- VIZE_TEST_BIN=target/ci/vize node --test --test-concurrency=1 tests/tooling/glyph-corpus-parse-preservation.test.ts
- node --test tests/tooling/glyph-corpus-waivers.test.ts tests/tooling/glyph-corpus-hidden-inputs.test.ts
- cargo fmt --all --check
- git diff --check
- git diff --cached --check
- node --test tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791194569&installation_model_id=422833&pr_number=5746&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5746&signature=86ea95f415e85fba94ce7ed622e629cd7cc95c2b8df96397944a5d6a7f60dda4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved formatting for Vue single-file components with templated opening tags.
  - Preserves templated tags and their contents more accurately during formatting.
  - Enhanced handling of script, template, style, and custom blocks.
  - Improved formatting consistency and repeatability for affected files.

- **Tests**
  - Added coverage for templated script opening tags and idempotent formatting.
  - Removed a resolved known formatting violation from validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->