### PR TITLE
feat(lsp): resolve call hierarchy calls

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/bridge/call_hierarchy.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge/call_hierarchy.rs
@@ -23,4 +23,30 @@ impl CorsaBridge {
         })
         .await
     }
+
+    /// Resolve callers for a prepared call-hierarchy item.
+    pub async fn call_hierarchy_incoming_calls(
+        &self,
+        item: Value,
+    ) -> Result<Option<Value>, CorsaBridgeError> {
+        self.with_client(move |client| {
+            client
+                .call_hierarchy_incoming_calls_raw(item)
+                .map_err(CorsaBridgeError::CommunicationError)
+        })
+        .await
+    }
+
+    /// Resolve callees for a prepared call-hierarchy item.
+    pub async fn call_hierarchy_outgoing_calls(
+        &self,
+        item: Value,
+    ) -> Result<Option<Value>, CorsaBridgeError> {
+        self.with_client(move |client| {
+            client
+                .call_hierarchy_outgoing_calls_raw(item)
+                .map_err(CorsaBridgeError::CommunicationError)
+        })
+        .await
+    }
 }

--- a/crates/vize_canon/src/lsp_client/editor_lsp.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp.rs
@@ -29,6 +29,7 @@ use std::{
 };
 use vize_s0::{FxHashMap, FxHashSet, String, cstr};
 
+mod call_hierarchy;
 mod client;
 mod declaration;
 mod file_rename;
@@ -43,9 +44,9 @@ mod tests;
 mod type_definition;
 
 use requests::{
-    RawCompletionRequest, RawDefinitionRequest, RawHoverRequest, RawPrepareCallHierarchyRequest,
-    RawPrepareRenameRequest, RawReferencesRequest, RawRenameRequest, RawSignatureHelpRequest,
-    RawWillRenameFilesRequest, signature_help_request_params, will_rename_files_request_params,
+    RawCompletionRequest, RawDefinitionRequest, RawHoverRequest, RawPrepareRenameRequest,
+    RawReferencesRequest, RawRenameRequest, RawSignatureHelpRequest, RawWillRenameFilesRequest,
+    signature_help_request_params, will_rename_files_request_params,
 };
 use responder::spawn_responder;
 
@@ -181,23 +182,6 @@ impl EditorLspSession {
                 })),
         )
         .map_err(|error| cstr!("Failed to request editor LSP definition: {error}"))
-    }
-
-    fn prepare_call_hierarchy(
-        &mut self,
-        document_uri: &str,
-        line: u32,
-        character: u32,
-    ) -> Result<Option<Value>, String> {
-        let uri = self.ready_document_uri(document_uri)?;
-        block_on(
-            self.client
-                .request::<RawPrepareCallHierarchyRequest>(serde_json::json!({
-                    "textDocument": { "uri": uri },
-                    "position": { "line": line, "character": character },
-                })),
-        )
-        .map_err(|error| cstr!("Failed to request editor LSP call hierarchy: {error}"))
     }
 
     fn references(

--- a/crates/vize_canon/src/lsp_client/editor_lsp/call_hierarchy.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/call_hierarchy.rs
@@ -1,0 +1,58 @@
+use corsa::runtime::block_on;
+use serde_json::Value;
+use vize_s0::{String, cstr};
+
+use super::{
+    EditorLspSession,
+    requests::{
+        RawCallHierarchyIncomingCallsRequest, RawCallHierarchyOutgoingCallsRequest,
+        RawPrepareCallHierarchyRequest,
+    },
+};
+
+impl EditorLspSession {
+    pub(super) fn prepare_call_hierarchy(
+        &mut self,
+        document_uri: &str,
+        line: u32,
+        character: u32,
+    ) -> Result<Option<Value>, String> {
+        let uri = self.ready_document_uri(document_uri)?;
+        block_on(
+            self.client
+                .request::<RawPrepareCallHierarchyRequest>(serde_json::json!({
+                    "textDocument": { "uri": uri },
+                    "position": { "line": line, "character": character },
+                })),
+        )
+        .map_err(|error| cstr!("Failed to request editor LSP call hierarchy: {error}"))
+    }
+
+    pub(super) fn call_hierarchy_incoming_calls(
+        &mut self,
+        item: Value,
+    ) -> Result<Option<Value>, String> {
+        self.ready_workspace_request()?;
+        block_on(
+            self.client
+                .request::<RawCallHierarchyIncomingCallsRequest>(serde_json::json!({
+                    "item": item,
+                })),
+        )
+        .map_err(|error| cstr!("Failed to request editor LSP incoming call hierarchy: {error}"))
+    }
+
+    pub(super) fn call_hierarchy_outgoing_calls(
+        &mut self,
+        item: Value,
+    ) -> Result<Option<Value>, String> {
+        self.ready_workspace_request()?;
+        block_on(
+            self.client
+                .request::<RawCallHierarchyOutgoingCallsRequest>(serde_json::json!({
+                    "item": item,
+                })),
+        )
+        .map_err(|error| cstr!("Failed to request editor LSP outgoing call hierarchy: {error}"))
+    }
+}

--- a/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/client.rs
@@ -102,6 +102,24 @@ impl CorsaProjectClient {
         })
     }
 
+    pub(in crate::lsp_client) fn call_hierarchy_incoming_calls_via_editor_lsp(
+        &mut self,
+        item: Value,
+    ) -> Result<Option<Value>, String> {
+        self.request_with_editor_lsp_recovery(|session| {
+            session.call_hierarchy_incoming_calls(item.clone())
+        })
+    }
+
+    pub(in crate::lsp_client) fn call_hierarchy_outgoing_calls_via_editor_lsp(
+        &mut self,
+        item: Value,
+    ) -> Result<Option<Value>, String> {
+        self.request_with_editor_lsp_recovery(|session| {
+            session.call_hierarchy_outgoing_calls(item.clone())
+        })
+    }
+
     pub(in crate::lsp_client) fn references_via_editor_lsp(
         &mut self,
         uri: &str,

--- a/crates/vize_canon/src/lsp_client/editor_lsp/requests.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/requests.rs
@@ -62,6 +62,22 @@ impl lsp_types::request::Request for RawPrepareCallHierarchyRequest {
     const METHOD: &'static str = "textDocument/prepareCallHierarchy";
 }
 
+pub(super) struct RawCallHierarchyIncomingCallsRequest;
+
+impl lsp_types::request::Request for RawCallHierarchyIncomingCallsRequest {
+    type Params = Value;
+    type Result = Option<Value>;
+    const METHOD: &'static str = "callHierarchy/incomingCalls";
+}
+
+pub(super) struct RawCallHierarchyOutgoingCallsRequest;
+
+impl lsp_types::request::Request for RawCallHierarchyOutgoingCallsRequest {
+    type Params = Value;
+    type Result = Option<Value>;
+    const METHOD: &'static str = "callHierarchy/outgoingCalls";
+}
+
 pub(super) struct RawReferencesRequest;
 
 impl lsp_types::request::Request for RawReferencesRequest {

--- a/crates/vize_canon/src/lsp_client/editor_lsp/tests.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/tests.rs
@@ -51,6 +51,86 @@ fn prepare_call_hierarchy_uses_editor_lsp_runtime_items() {
 }
 
 #[test]
+fn call_hierarchy_incoming_and_outgoing_use_editor_lsp_runtime_items() {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return;
+    }
+    let Some(corsa_path) = resolve_tsgo_binary() else {
+        return;
+    };
+
+    let project = tempfile::TempDir::new().expect("temp project");
+    std::fs::write(
+        project.path().join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .expect("tsconfig");
+    let src = project.path().join("src");
+    std::fs::create_dir_all(&src).expect("src");
+    let source = "export function leaf(value: string): string { return value }\n\
+export function caller(): string { return leaf('x') }\n\
+caller()\n";
+    let path = src.join("call-hierarchy.ts");
+    std::fs::write(&path, source).expect("source");
+    let uri = format!("file://{}", path.display());
+    let mut documents = FxHashMap::default();
+    documents.insert(uri.clone().into(), source.into());
+
+    let mut session = EditorLspSession::spawn(
+        corsa_path.to_str().expect("utf8 path"),
+        project.path(),
+        project.path(),
+    )
+    .expect("editor LSP session");
+    session.synchronize(&documents).expect("synchronize source");
+    let leaf_items = session
+        .prepare_call_hierarchy(&uri, 0, "export function ".len() as u32)
+        .expect("prepare leaf")
+        .expect("leaf call hierarchy items");
+    let caller_items = session
+        .prepare_call_hierarchy(&uri, 1, "export function ".len() as u32)
+        .expect("prepare caller")
+        .expect("caller call hierarchy items");
+    let incoming = session
+        .call_hierarchy_incoming_calls(leaf_items[0].clone())
+        .expect("incoming calls request")
+        .expect("leaf incoming calls");
+    let outgoing = session
+        .call_hierarchy_outgoing_calls(caller_items[0].clone())
+        .expect("outgoing calls request")
+        .expect("caller outgoing calls");
+    session.shutdown().expect("shutdown");
+
+    assert!(
+        incoming
+            .as_array()
+            .expect("incoming calls array")
+            .iter()
+            .any(|call| call["from"]["name"] == "caller"
+                && !call["fromRanges"].as_array().unwrap().is_empty()),
+        "leaf should have caller incoming call: {incoming:#?}",
+    );
+    assert!(
+        outgoing
+            .as_array()
+            .expect("outgoing calls array")
+            .iter()
+            .any(|call| call["to"]["name"] == "leaf"
+                && !call["fromRanges"].as_array().unwrap().is_empty()),
+        "caller should have leaf outgoing call: {outgoing:#?}",
+    );
+}
+
+#[test]
 fn signature_help_request_defaults_to_manual_invocation() {
     let uri = Uri::from_str("file:///workspace/App.vue.ts").unwrap();
     let params = signature_help_request_params(&uri, 4, 7, None);

--- a/crates/vize_canon/src/lsp_client/queries.rs
+++ b/crates/vize_canon/src/lsp_client/queries.rs
@@ -109,6 +109,20 @@ impl CorsaProjectClient {
         self.prepare_call_hierarchy_via_editor_lsp(uri, line, character)
     }
 
+    pub(crate) fn call_hierarchy_incoming_calls_raw(
+        &mut self,
+        item: Value,
+    ) -> Result<Option<Value>, String> {
+        self.call_hierarchy_incoming_calls_via_editor_lsp(item)
+    }
+
+    pub(crate) fn call_hierarchy_outgoing_calls_raw(
+        &mut self,
+        item: Value,
+    ) -> Result<Option<Value>, String> {
+        self.call_hierarchy_outgoing_calls_via_editor_lsp(item)
+    }
+
     pub(crate) fn references_raw(
         &mut self,
         uri: &str,

--- a/crates/vize_maestro/src/ide/call_hierarchy.rs
+++ b/crates/vize_maestro/src/ide/call_hierarchy.rs
@@ -6,7 +6,11 @@
 use std::sync::Arc;
 
 #[cfg(feature = "native")]
-use tower_lsp::lsp_types::{CallHierarchyItem, Location, Range};
+use serde_json::Value;
+#[cfg(feature = "native")]
+use tower_lsp::lsp_types::{
+    CallHierarchyIncomingCall, CallHierarchyItem, CallHierarchyOutgoingCall, Location, Range,
+};
 #[cfg(feature = "native")]
 use vize_canon::{CorsaBridge, LspLocation, LspPosition, LspRange};
 
@@ -17,6 +21,9 @@ use crate::virtual_code::BlockType;
 
 /// Checker-backed call-hierarchy service.
 pub struct CallHierarchyService;
+
+#[cfg(feature = "native")]
+const RAW_CALL_HIERARCHY_ITEM_DATA_KEY: &str = "vizeCorsaRawCallHierarchyItem";
 
 #[cfg(feature = "native")]
 impl CallHierarchyService {
@@ -56,25 +63,99 @@ impl CallHierarchyService {
             .prepare_call_hierarchy(&document.request_uri, line, character)
             .await
             .ok()??;
-        let items = serde_json::from_value::<Vec<CallHierarchyItem>>(items).ok()?;
+        let items = items.as_array()?.clone();
         let items = items
             .into_iter()
-            .filter_map(|item| Self::map_canonical_item(ctx, &document, item))
+            .filter_map(|raw_item| {
+                let item = serde_json::from_value::<CallHierarchyItem>(raw_item.clone()).ok()?;
+                Self::map_canonical_item(ctx, &document, item, Some(raw_item))
+            })
             .collect::<Vec<_>>();
 
         (!items.is_empty()).then_some(items)
     }
 
+    /// Resolve incoming calls for a prepared item and keep every visible span
+    /// source-faithful.
+    pub async fn incoming_calls_with_corsa(
+        ctx: &IdeContext<'_>,
+        item: &CallHierarchyItem,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> Option<Vec<CallHierarchyIncomingCall>> {
+        let bridge = corsa_bridge?;
+        if !bridge.is_initialized() {
+            return None;
+        }
+
+        match ctx.block_type? {
+            BlockType::Template | BlockType::Script | BlockType::ScriptSetup
+                if !ctx.uri.path().ends_with(".art.vue") =>
+            {
+                let document =
+                    corsa_support::open_canonical_virtual_project_document(ctx, &bridge).await?;
+                let raw_item = Self::raw_item(item)?;
+                let calls = bridge
+                    .call_hierarchy_incoming_calls(raw_item)
+                    .await
+                    .ok()??;
+                Self::map_incoming_calls(ctx, &document, calls)
+            }
+            BlockType::Template
+            | BlockType::Script
+            | BlockType::ScriptSetup
+            | BlockType::Style(_)
+            | BlockType::Art(_) => None,
+        }
+    }
+
+    /// Resolve outgoing calls for a prepared item and keep call-site ranges on
+    /// authored Vue text.
+    pub async fn outgoing_calls_with_corsa(
+        ctx: &IdeContext<'_>,
+        item: &CallHierarchyItem,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> Option<Vec<CallHierarchyOutgoingCall>> {
+        let bridge = corsa_bridge?;
+        if !bridge.is_initialized() {
+            return None;
+        }
+
+        match ctx.block_type? {
+            BlockType::Template | BlockType::Script | BlockType::ScriptSetup
+                if !ctx.uri.path().ends_with(".art.vue") =>
+            {
+                let document =
+                    corsa_support::open_canonical_virtual_project_document(ctx, &bridge).await?;
+                let raw_item = Self::raw_item(item)?;
+                let origin_uri = raw_item.get("uri")?.as_str()?.to_owned();
+                let calls = bridge
+                    .call_hierarchy_outgoing_calls(raw_item)
+                    .await
+                    .ok()??;
+                Self::map_outgoing_calls(ctx, &document, &origin_uri, calls)
+            }
+            BlockType::Template
+            | BlockType::Script
+            | BlockType::ScriptSetup
+            | BlockType::Style(_)
+            | BlockType::Art(_) => None,
+        }
+    }
+
     fn map_canonical_item(
         ctx: &IdeContext<'_>,
         document: &corsa_support::CanonicalVirtualDocument,
-        item: CallHierarchyItem,
+        mut item: CallHierarchyItem,
+        raw_item: Option<Value>,
     ) -> Option<CallHierarchyItem> {
         let selection =
             Self::map_canonical_item_range(ctx, document, &item.uri, item.selection_range)?;
         let range = Self::map_canonical_item_range(ctx, document, &item.uri, item.range)
             .filter(|range| range.uri == selection.uri)
             .unwrap_or_else(|| selection.clone());
+        if let Some(raw_item) = raw_item {
+            item.data = Some(Self::raw_item_data(raw_item));
+        }
 
         Some(CallHierarchyItem {
             uri: selection.uri,
@@ -82,6 +163,85 @@ impl CallHierarchyService {
             selection_range: selection.range,
             ..item
         })
+    }
+
+    fn map_incoming_calls(
+        ctx: &IdeContext<'_>,
+        document: &corsa_support::CanonicalVirtualDocument,
+        calls: Value,
+    ) -> Option<Vec<CallHierarchyIncomingCall>> {
+        let calls = calls.as_array()?.clone();
+        let calls = calls
+            .into_iter()
+            .filter_map(|raw_call| {
+                let call =
+                    serde_json::from_value::<CallHierarchyIncomingCall>(raw_call.clone()).ok()?;
+                let raw_from = raw_call.get("from").cloned();
+                let raw_from_uri = call.from.uri.clone();
+                let from = Self::map_canonical_item(ctx, document, call.from, raw_from)?;
+                let from_ranges = Self::map_call_ranges(
+                    ctx,
+                    document,
+                    &raw_from_uri,
+                    &from.uri,
+                    call.from_ranges,
+                );
+                Some(CallHierarchyIncomingCall { from, from_ranges })
+            })
+            .collect::<Vec<_>>();
+        Some(calls)
+    }
+
+    fn map_outgoing_calls(
+        ctx: &IdeContext<'_>,
+        document: &corsa_support::CanonicalVirtualDocument,
+        origin_uri: &str,
+        calls: Value,
+    ) -> Option<Vec<CallHierarchyOutgoingCall>> {
+        let calls = calls.as_array()?.clone();
+        let origin_uri = tower_lsp::lsp_types::Url::parse(origin_uri).ok()?;
+        let calls = calls
+            .into_iter()
+            .filter_map(|raw_call| {
+                let call =
+                    serde_json::from_value::<CallHierarchyOutgoingCall>(raw_call.clone()).ok()?;
+                let raw_to = raw_call.get("to").cloned();
+                let to = Self::map_canonical_item(ctx, document, call.to, raw_to)?;
+                let from_ranges =
+                    Self::map_call_ranges(ctx, document, &origin_uri, ctx.uri, call.from_ranges);
+                Some(CallHierarchyOutgoingCall { to, from_ranges })
+            })
+            .collect::<Vec<_>>();
+        Some(calls)
+    }
+
+    fn map_call_ranges(
+        ctx: &IdeContext<'_>,
+        document: &corsa_support::CanonicalVirtualDocument,
+        raw_uri: &tower_lsp::lsp_types::Url,
+        expected_uri: &tower_lsp::lsp_types::Url,
+        ranges: Vec<Range>,
+    ) -> Vec<Range> {
+        ranges
+            .into_iter()
+            .filter_map(|range| Self::map_canonical_item_range(ctx, document, raw_uri, range))
+            .filter(|location| location.uri == *expected_uri)
+            .map(|location| location.range)
+            .collect()
+    }
+
+    fn raw_item(item: &CallHierarchyItem) -> Option<Value> {
+        item.data
+            .as_ref()
+            .and_then(|data| data.get(RAW_CALL_HIERARCHY_ITEM_DATA_KEY))
+            .cloned()
+            .or_else(|| serde_json::to_value(item).ok())
+    }
+
+    fn raw_item_data(raw_item: Value) -> Value {
+        let mut data = serde_json::Map::new();
+        data.insert(RAW_CALL_HIERARCHY_ITEM_DATA_KEY.to_string(), raw_item);
+        Value::Object(data)
     }
 
     fn map_canonical_item_range(

--- a/crates/vize_maestro/src/ide/call_hierarchy/tests.rs
+++ b/crates/vize_maestro/src/ide/call_hierarchy/tests.rs
@@ -76,6 +76,124 @@ function run(value: string): string {
     });
 }
 
+#[test]
+fn incoming_and_outgoing_call_hierarchy_maps_call_sites_to_authored_source() {
+    crate::runtime::block_on(async {
+        let Some(corsa_path) = resolve_tsgo_binary() else {
+            return;
+        };
+        let project = tempfile::TempDir::new().expect("temp project");
+        let src = project.path().join("src");
+        std::fs::create_dir_all(&src).expect("src");
+        std::fs::write(
+            project.path().join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+        )
+        .expect("tsconfig");
+
+        let source = r#"<script setup lang="ts">
+function leaf(value: string): string {
+  return value
+}
+function caller(): string {
+  return leaf('setup')
+}
+</script>
+<template>
+  <button @click="caller()">{{ leaf('template') }}</button>
+</template>
+"#;
+        let path = src.join("App.vue");
+        std::fs::write(&path, source).expect("source");
+        let uri = Url::from_file_path(&path).expect("source uri");
+        let state = ServerState::new();
+        state.set_workspace_root(project.path().to_path_buf());
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+        let bridge = Arc::new(CorsaBridge::with_config(CorsaBridgeConfig {
+            corsa_path: Some(corsa_path),
+            working_dir: Some(project.path().to_path_buf()),
+            timeout_ms: 30_000,
+            ..Default::default()
+        }));
+        bridge.spawn().await.expect("tsgo session");
+
+        let leaf = prepare_item(source, &uri, &state, &bridge, "leaf(value").await;
+        let caller = prepare_item(source, &uri, &state, &bridge, "caller():").await;
+        let caller_ctx = context_at(source, &uri, &state, "caller():");
+        let outgoing = CallHierarchyService::outgoing_calls_with_corsa(
+            &caller_ctx,
+            &caller,
+            Some(bridge.clone()),
+        )
+        .await
+        .expect("caller outgoing calls");
+        assert!(
+            outgoing.iter().any(|call| {
+                call.to.name == "leaf"
+                    && call
+                        .from_ranges
+                        .iter()
+                        .any(|range| authored_text(source, *range) == "leaf")
+            }),
+            "caller should expose the authored leaf call site: {outgoing:#?}",
+        );
+
+        let leaf_ctx = context_at(source, &uri, &state, "leaf(value");
+        let incoming =
+            CallHierarchyService::incoming_calls_with_corsa(&leaf_ctx, &leaf, Some(bridge.clone()))
+                .await
+                .expect("leaf incoming calls");
+        assert!(
+            incoming.iter().any(|call| {
+                call.from.name == "caller"
+                    && call
+                        .from_ranges
+                        .iter()
+                        .any(|range| authored_text(source, *range) == "leaf")
+            }),
+            "leaf should expose caller through authored ranges: {incoming:#?}",
+        );
+
+        bridge.shutdown().await.expect("shutdown");
+    });
+}
+
+async fn prepare_item(
+    source: &str,
+    uri: &Url,
+    state: &ServerState,
+    bridge: &Arc<CorsaBridge>,
+    marker: &str,
+) -> CallHierarchyItem {
+    let ctx = context_at(source, uri, state, marker);
+    let items = CallHierarchyService::prepare_with_corsa(&ctx, Some(bridge.clone()))
+        .await
+        .expect("call hierarchy items");
+    single_item(items)
+}
+
+fn context_at<'a>(
+    source: &'a str,
+    uri: &'a Url,
+    state: &'a ServerState,
+    marker: &str,
+) -> IdeContext<'a> {
+    let offset = source.find(marker).expect("marker") + 1;
+    IdeContext::new(state, uri, offset).expect("context")
+}
+
 fn single_item(mut items: Vec<CallHierarchyItem>) -> CallHierarchyItem {
     assert_eq!(items.len(), 1, "{items:#?}");
     items.remove(0)

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -262,13 +262,11 @@ impl LanguageServer for MaestroServer {
     }
 
     async fn incoming_calls(&self, params: CHIncomingParams) -> Result<Option<CHIncomingResponse>> {
-        let _ = params;
-        Ok(None)
+        call_hierarchy::incoming(self, params).await
     }
 
     async fn outgoing_calls(&self, params: CHOutgoingParams) -> Result<Option<CHOutgoingResponse>> {
-        let _ = params;
-        Ok(None)
+        call_hierarchy::outgoing(self, params).await
     }
 
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {

--- a/crates/vize_maestro/src/server/handlers/call_hierarchy.rs
+++ b/crates/vize_maestro/src/server/handlers/call_hierarchy.rs
@@ -52,3 +52,80 @@ pub(super) async fn prepare(
         Ok(None)
     }
 }
+
+pub(super) async fn incoming(
+    server: &MaestroServer,
+    params: CHIncomingParams,
+) -> Result<Option<CHIncomingResponse>> {
+    if !server.state.lsp_features().definition || !server.state.lsp_features().typecheck {
+        return Ok(None);
+    }
+
+    #[cfg(feature = "native")]
+    {
+        let Some(ctx) = context_for_item(server, &params.item) else {
+            return Ok(None);
+        };
+        let corsa_bridge = server.state.get_corsa_bridge().await;
+        return Ok(CallHierarchyService::incoming_calls_with_corsa(
+            &ctx,
+            &params.item,
+            corsa_bridge,
+        )
+        .await);
+    }
+
+    #[cfg(not(feature = "native"))]
+    {
+        let _ = params;
+        Ok(None)
+    }
+}
+
+pub(super) async fn outgoing(
+    server: &MaestroServer,
+    params: CHOutgoingParams,
+) -> Result<Option<CHOutgoingResponse>> {
+    if !server.state.lsp_features().definition || !server.state.lsp_features().typecheck {
+        return Ok(None);
+    }
+
+    #[cfg(feature = "native")]
+    {
+        let Some(ctx) = context_for_item(server, &params.item) else {
+            return Ok(None);
+        };
+        let corsa_bridge = server.state.get_corsa_bridge().await;
+        return Ok(CallHierarchyService::outgoing_calls_with_corsa(
+            &ctx,
+            &params.item,
+            corsa_bridge,
+        )
+        .await);
+    }
+
+    #[cfg(not(feature = "native"))]
+    {
+        let _ = params;
+        Ok(None)
+    }
+}
+
+#[cfg(feature = "native")]
+fn context_for_item<'a>(
+    server: &'a MaestroServer,
+    item: &'a CallHierarchyItem,
+) -> Option<IdeContext<'a>> {
+    let content = server.state.documents.text(&item.uri)?;
+    let offset = position_to_offset(
+        &content,
+        item.selection_range.start.line,
+        item.selection_range.start.character,
+    )?;
+    Some(IdeContext::with_content(
+        &server.state,
+        &item.uri,
+        offset,
+        content,
+    ))
+}


### PR DESCRIPTION
## Summary
- route callHierarchy incoming/outgoing requests through the Corsa editor LSP transport
- round-trip raw prepared call hierarchy items while returning authored Vue items to clients
- map caller/callee ranges and call-site ranges back to authored .vue files

Refs #3953.

## Verification
- cargo fmt --all --check
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20
- TMPDIR=/tmp/vize-lsp-callhier TEMP=/tmp/vize-lsp-callhier TMP=/tmp/vize-lsp-callhier cargo test -p vize_canon lsp_client::editor_lsp::tests -- --nocapture
- TMPDIR=/tmp/vize-lsp-callhier TEMP=/tmp/vize-lsp-callhier TMP=/tmp/vize-lsp-callhier cargo test -p vize_maestro ide::call_hierarchy::tests --features native -- --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791196571&installation_model_id=422833&pr_number=5748&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5748&signature=a0128226ddd21a895355d709c3ad467dc492e29bbc1f476be9c7622a926d4589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for incoming and outgoing call hierarchy queries.
  - Call relationships can now be resolved across authored Vue source and generated code.
  - Call-site ranges are mapped back to their corresponding authored source locations.
  - Call hierarchy requests now return meaningful results when the required language features are enabled.

- **Tests**
  - Added coverage for incoming and outgoing calls, including setup-script and template call sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->