### PR TITLE
fix(typecheck): reject stale divergence ledger rows

### DIFF
--- a/tests/tooling/typecheck-divergence-report-ledger.test.ts
+++ b/tests/tooling/typecheck-divergence-report-ledger.test.ts
@@ -76,3 +76,23 @@ test("typecheck divergence report rejects a stale documented difference", () => 
     cleanup(fixture);
   }
 });
+
+test("typecheck divergence report rejects stale documented differences in record-only mode", () => {
+  const fixture = setup();
+  try {
+    const result = run(fixture, {}, [
+      "--budget-mode",
+      "record-only",
+      "--documented-differences",
+      writeDocumentedDifferences(fixture),
+    ]);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Documented typecheck difference ledger is stale for fixture/);
+    assert.equal(
+      fs.existsSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json")),
+      false,
+    );
+  } finally {
+    cleanup(fixture);
+  }
+});

--- a/tools/commands/fixtures/typecheck-divergence-report.rs
+++ b/tools/commands/fixtures/typecheck-divergence-report.rs
@@ -210,13 +210,6 @@ fn write_project_artifact(root: &Path, args: &Args, project: &Value) -> Result<V
         &typecheck_source_roots,
         &documented_differences,
     )?;
-    if args.budget_mode == "enforce" {
-        reject_stale_documented_differences(
-            &project_id,
-            &expected_documented_differences,
-            &divergence,
-        )?;
-    }
     let coverage = if let Some(reason) = baseline
         .run_error
         .as_deref()
@@ -252,6 +245,12 @@ fn write_project_artifact(root: &Path, args: &Args, project: &Value) -> Result<V
         baseline_args: &baseline_args,
         documented_differences: &documented_differences,
     })?;
+    reject_stale_documented_differences(
+        &project_id,
+        &expected_documented_differences,
+        &divergence,
+        &mutation_oracle,
+    )?;
     let budget = evaluate_budget(
         performance,
         &divergence,
@@ -1612,6 +1611,11 @@ fn summarize_mutation_observations(
         && states[2].get("falsePositiveCount").and_then(Value::as_u64) == Some(0)
         && states[2].get("falseNegativeCount").and_then(Value::as_u64) == Some(0)
         && !repaired_expected;
+    let documented_differences = observed_documented_differences(&[
+        &clean.comparison,
+        &broken.comparison,
+        &repaired.comparison,
+    ]);
     Ok(json!({
         "schema": "vize.fixtureTypecheckSeededMutationOracle",
         "version": 1,
@@ -1626,8 +1630,23 @@ fn summarize_mutation_observations(
         "cleanExpectedDiagnosticPresent": clean_expected,
         "expectedDiagnosticMatched": expected_matched,
         "repairedExpectedDiagnosticPresent": repaired_expected,
+        "documentedDifferences": documented_differences,
         "states": states,
     }))
+}
+
+fn observed_documented_differences(comparisons: &[&Value]) -> Vec<Value> {
+    let mut observed = BTreeMap::new();
+    for comparison in comparisons {
+        for difference in comparison
+            .get("documentedDifferences")
+            .and_then(Value::as_array)
+            .unwrap_or(&Vec::new())
+        {
+            observed.insert(documented_key(difference), difference.clone());
+        }
+    }
+    observed.into_values().collect()
 }
 
 fn mutation_state_json(
@@ -1899,18 +1918,26 @@ fn reject_stale_documented_differences(
     project_id: &str,
     expected: &[DocumentedDifference],
     divergence: &Value,
+    mutation_oracle: &Value,
 ) -> Result<(), String> {
     if expected.is_empty() {
         return Ok(());
     }
-    let observed = divergence
+    let divergence_observed = divergence
         .get("documentedDifferences")
         .and_then(Value::as_array)
         .ok_or_else(|| divergence_error("comparison is missing documented differences"))?;
-    if observed.len() == expected.len() {
-        return Ok(());
-    }
-    let observed_keys = observed.iter().map(documented_key).collect::<BTreeSet<_>>();
+    let empty_mutation_observed = Vec::new();
+    let mutation_observed = mutation_oracle
+        .get("documentedDifferences")
+        .and_then(Value::as_array)
+        .unwrap_or(&empty_mutation_observed)
+        .iter();
+    let observed_keys = divergence_observed
+        .iter()
+        .chain(mutation_observed)
+        .map(documented_key)
+        .collect::<BTreeSet<_>>();
     let stale = expected
         .iter()
         .filter(|difference| {


### PR DESCRIPTION
## Summary

- reject stale documented typecheck divergence rows even when the report runs in record-only mode
- cover the #5722 ledger path so refreshed evidence cannot keep converged rows alive

## Verification

- node --test tests/tooling/typecheck-divergence-report-ledger.test.ts
- node --test tests/tooling/typecheck-divergence-budget.test.ts tests/tooling/typecheck-divergence-baseline.test.ts
- cargo fmt --all --check
- git diff --check
- node --test tests/tooling/source-file-lengths.test.ts

Refs #5722

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791196690&installation_model_id=422833&pr_number=5749&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5749&signature=f70276d32f0aad56413ea38d8d19f09baf344b3538f422fac0762c0c563e8d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->