### PR TITLE
test(maestro): cover authored signature help routing

### DIFF
--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -274,12 +274,14 @@ test("vize lsp per-feature init flags toggle individual providers independently"
     {
       editor: true,
       completion: false,
+      signatureHelp: false,
       hover: false,
       definition: false,
       references: false,
     },
     (capabilities) => {
       assert.equal(capabilities.completionProvider, undefined);
+      assert.equal(capabilities.signatureHelpProvider, undefined);
       assert.equal(capabilities.hoverProvider, undefined);
       assert.equal(capabilities.definitionProvider, undefined);
       assert.equal(capabilities.typeDefinitionProvider, undefined);

--- a/tests/tooling/lsp-editor-feature-routing.test.ts
+++ b/tests/tooling/lsp-editor-feature-routing.test.ts
@@ -25,6 +25,7 @@ const ALL_EDITOR_FEATURES_OFF: LspInitializationOptions = {
   references: false,
   rename: false,
   semanticTokens: false,
+  signatureHelp: false,
   typecheck: false,
   workspaceSymbols: false,
 };
@@ -66,6 +67,14 @@ const DISABLED_REQUESTS: RequestCase[] = [
   {
     method: "textDocument/completion",
     params: (uri) => ({ textDocument: { uri }, position }),
+  },
+  {
+    method: "textDocument/signatureHelp",
+    params: (uri) => ({
+      textDocument: { uri },
+      position,
+      context: { triggerKind: 1, isRetrigger: false },
+    }),
   },
   {
     method: "textDocument/documentSymbol",

--- a/tests/tooling/lsp-signature-help-capability.test.ts
+++ b/tests/tooling/lsp-signature-help-capability.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { ServerCapabilities } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+const source = `<script setup lang="ts">
+function format(value: string, precision: number): string {
+  return value.repeat(precision)
+}
+</script>
+
+<template>
+  <span>{{ format('hello', ) }}</span>
+</template>
+`;
+
+type SignatureHelp = {
+  activeParameter?: number;
+  signatures?: Array<{
+    label?: string;
+    parameters?: unknown[];
+  }>;
+};
+
+test("vize lsp maps textDocument/signatureHelp from authored SFC template calls", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-signature-help-capability");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  fs.writeFileSync(
+    path.join(workspaceDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          target: "ES2022",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+        },
+        include: ["**/*"],
+      },
+      null,
+      2,
+    ),
+  );
+  const filePath = path.join(workspaceDir, "Formatter.vue");
+  const uri = pathToFileURL(filePath).href;
+  const session = new LspSession();
+
+  try {
+    const init = (await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: true,
+    })) as { capabilities?: ServerCapabilities };
+    assert.deepEqual(init.capabilities?.signatureHelpProvider, {
+      triggerCharacters: ["(", ",", "<"],
+      retriggerCharacters: [")"],
+    });
+
+    fs.writeFileSync(filePath, source, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "vue", version: 1, text: source },
+    });
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri),
+      60_000,
+    );
+
+    const position = offsetToPosition(
+      source,
+      source.indexOf("format('hello', ") + "format('hello', ".length,
+    );
+    const help = (await session.request("textDocument/signatureHelp", {
+      textDocument: { uri },
+      position,
+      context: { triggerKind: 1, isRetrigger: false },
+    })) as SignatureHelp | null;
+
+    assert.ok(help, "signature help should answer the authored template call");
+    assert.equal(help.activeParameter, 1);
+    assert.equal(help.signatures?.length, 1, JSON.stringify(help));
+    assert.match(help.signatures[0].label ?? "", /format/);
+    assert.match(help.signatures[0].label ?? "", /value: string/);
+    assert.match(help.signatures[0].label ?? "", /precision: number/);
+    assert.equal(help.signatures[0].parameters?.length, 2, JSON.stringify(help));
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/support/lsp/protocol.ts
+++ b/tests/tooling/support/lsp/protocol.ts
@@ -29,6 +29,7 @@ export type LspInitializationOptions = {
   references?: boolean;
   rename?: boolean;
   semanticTokens?: boolean;
+  signatureHelp?: boolean;
   typecheck?: boolean;
   workspaceSymbols?: boolean;
   autoInsert?: boolean;


### PR DESCRIPTION
## Summary
- add a live LSP oracle for authored Vue template signature help
- include signatureHelp in feature routing and capability disable coverage
- type the shared LSP initialization option used by tooling tests

Refs #3953.

## Validation
- node --test --test-concurrency=1 tests/tooling/lsp-signature-help-capability.test.ts tests/tooling/lsp-editor-feature-routing.test.ts tests/tooling/lsp-capabilities.test.ts
- cargo fmt --all --check
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 50

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791196815&installation_model_id=422833&pr_number=5750&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5750&signature=dbf3089f0df005ce2935cbdf51f84ec6959a82576c06d0f14d8219b909874f51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->