### PR TITLE
fix(release): dehydrate matrix fixtures before cleanup

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -339,7 +339,7 @@ jobs:
         if: ${{ always() }}
         env:
           VIZE_DAVINCI_DOM_CORPUS_OUTCOME: ${{ steps.davinci_dom_corpus.outcome }}
-        run: rust-script tools/commands/fixtures/davinci-dom-corpus-workflow.rs finalize
+        run: rust-script tools/commands/fixtures/davinci-dom-corpus-workflow.rs finalize-and-dehydrate
       - name: Upload S2 DOM corpus evidence
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/legacy-tools/fixtures/davinci-dom-corpus-workflow.mjs
+++ b/legacy-tools/fixtures/davinci-dom-corpus-workflow.mjs
@@ -272,6 +272,27 @@ export function hydrateCorpus({ artifact = artifactDir, runCommand = run } = {})
   return 0;
 }
 
+export function dehydrateCorpus({ artifact = artifactDir, runCommand = run } = {}) {
+  const fixturePaths = readOptional(`${artifact}/selected-gitlinks.txt`)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (fixturePaths.length === 0) return 0;
+  runCommand("git", ["submodule", "deinit", "--force", "--", ...fixturePaths]);
+  return 0;
+}
+
+export async function finalizeAndDehydrateCorpus(environment = process.env) {
+  const finalizeStatus = await finalizeCorpus(environment);
+  try {
+    const dehydrateStatus = dehydrateCorpus();
+    return finalizeStatus === 0 ? dehydrateStatus : finalizeStatus;
+  } catch (error) {
+    console.error(errorMessage(error));
+    return 1;
+  }
+}
+
 export async function runCorpus() {
   mkdirSync(artifactDir, { recursive: true });
   const log = createWriteStream(`${artifactDir}/dom-corpus.log`, { flags: "w" });
@@ -397,7 +418,11 @@ async function main() {
   if (command === "hydrate") return hydrateCorpus();
   if (command === "run") return await runCorpus();
   if (command === "finalize") return await finalizeCorpus();
-  console.error("usage: davinci-dom-corpus-workflow.mjs hydrate|run|finalize");
+  if (command === "finalize-and-dehydrate") return await finalizeAndDehydrateCorpus();
+  if (command === "dehydrate") return dehydrateCorpus();
+  console.error(
+    "usage: davinci-dom-corpus-workflow.mjs hydrate|run|finalize|finalize-and-dehydrate|dehydrate",
+  );
   return 1;
 }
 

--- a/tests/tooling/davinci-dom-corpus-dehydrate.test.ts
+++ b/tests/tooling/davinci-dom-corpus-dehydrate.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import { dehydrateCorpus } from "../../legacy-tools/fixtures/davinci-dom-corpus-workflow.mjs";
+
+test("S2 DOM corpus dehydrate unregisters selected fixture gitlinks", () => {
+  const artifact = mkdtempSync(join(tmpdir(), "vize-dom-corpus-"));
+  const calls = [];
+  const runCommand = (command, args) => {
+    calls.push([command, args]);
+    return "";
+  };
+  try {
+    writeFileSync(
+      join(artifact, "selected-gitlinks.txt"),
+      "tests/_fixtures/_git/element\ntests/_fixtures/_git/primevue\n",
+    );
+    assert.equal(dehydrateCorpus({ artifact, runCommand }), 0);
+    assert.deepEqual(calls, [
+      [
+        "git",
+        [
+          "submodule",
+          "deinit",
+          "--force",
+          "--",
+          "tests/_fixtures/_git/element",
+          "tests/_fixtures/_git/primevue",
+        ],
+      ],
+    ]);
+  } finally {
+    rmSync(artifact, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
+++ b/tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts
@@ -81,7 +81,7 @@ test("real-project workflow carries a full-canonical S2 DOM corpus job", () => {
   });
   assert.equal(
     finalize.run,
-    "rust-script tools/commands/fixtures/davinci-dom-corpus-workflow.rs finalize",
+    "rust-script tools/commands/fixtures/davinci-dom-corpus-workflow.rs finalize-and-dehydrate",
   );
   assert.match(helperSource, /"record-only"/);
   assert.match(helperSource, /EXPECTED_DOM_OUTPUT_COMPARISONS: usize = 144/);
@@ -94,6 +94,10 @@ test("real-project workflow carries a full-canonical S2 DOM corpus job", () => {
   assert.match(helperSource, /line\.contains\("davinci DOM corpus sweep"\)/);
   assert.match(helperSource, /davinci DOM corpus old-lane error reasons/);
   assert.match(helperSource, /Davinci S2 DOM corpus failed/);
+  assert.match(helperSource, /fn finalize_and_dehydrate_corpus/);
+  assert.match(helperSource, /fn dehydrate_corpus/);
+  assert.match(helperSource, /selected-gitlinks\.txt/);
+  assert.match(helperSource, /"submodule", "deinit", "--force", "--"/);
 
   const upload = findStep(steps, "Upload S2 DOM corpus evidence");
   assert.equal(upload.if, "${{ always() }}");

--- a/tests/tooling/real-project-matrix-summary.test.ts
+++ b/tests/tooling/real-project-matrix-summary.test.ts
@@ -86,6 +86,9 @@ test("shard summary script records every surface, present or missing", () => {
     /append_unique_typecheck_divergence/,
     /glyph-waiver-issues\.json/,
     /surface-verdict\.json/,
+    /dehydrate_selected_fixture_shard/,
+    /selected-fixtures\.txt/,
+    /"submodule", "deinit", "--force", "--"/,
   ]) {
     assert.match(script, pattern);
   }

--- a/tools/commands/ci/github/publish-real-project-shard-summary.rs
+++ b/tools/commands/ci/github/publish-real-project-shard-summary.rs
@@ -13,14 +13,21 @@ use std::{
     fs::OpenOptions,
     io::Write,
     path::{Path, PathBuf},
-    process::ExitCode,
+    process::{Command, ExitCode, Stdio},
 };
 
 fn main() -> ExitCode {
-    match publish() {
-        Ok(()) => ExitCode::SUCCESS,
-        Err(error) => {
+    let publish_result = publish();
+    let cleanup_result = dehydrate_selected_fixture_shard();
+    match (publish_result, cleanup_result) {
+        (Ok(()), Ok(())) => ExitCode::SUCCESS,
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => {
             eprintln!("{error}");
+            ExitCode::from(1)
+        }
+        (Err(publish_error), Err(cleanup_error)) => {
+            eprintln!("{publish_error}");
+            eprintln!("{cleanup_error}");
             ExitCode::from(1)
         }
     }
@@ -84,6 +91,39 @@ fn publish() -> Result<(), String> {
         surface_summary,
         true,
     )
+}
+
+fn dehydrate_selected_fixture_shard() -> Result<(), String> {
+    let Some(report_dir) = env::var_os("FIXTURE_REPORT_DIR") else {
+        return Ok(());
+    };
+    let selected_path = PathBuf::from(report_dir).join("selected-fixtures.txt");
+    if !is_nonempty(&selected_path) {
+        return Ok(());
+    }
+    let selected = fs::read_to_string(&selected_path)
+        .map_err(|error| format!("failed to read {}: {error}", selected_path.display()))?;
+    let fixture_paths = selected
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    if fixture_paths.is_empty() {
+        return Ok(());
+    }
+    let status = Command::new("git")
+        .args(["submodule", "deinit", "--force", "--"])
+        .args(fixture_paths)
+        .stdin(Stdio::null())
+        .status()
+        .map_err(|error| format!("failed to run git submodule deinit: {error}"))?;
+    if !status.success() {
+        return Err(format!(
+            "git submodule deinit failed with exit code {}",
+            status.code().unwrap_or(1)
+        ));
+    }
+    Ok(())
 }
 
 fn append_file_or_line(out: &mut fs::File, path: &Path, fallback: &str) -> Result<(), String> {

--- a/tools/commands/fixtures/davinci-dom-corpus-workflow.rs
+++ b/tools/commands/fixtures/davinci-dom-corpus-workflow.rs
@@ -14,7 +14,7 @@ mod common;
 
 use regex::Regex;
 use serde::Serialize;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use std::{
     collections::BTreeMap,
     env, fs,
@@ -47,8 +47,12 @@ fn run() -> Result<u8, String> {
         [command] if command == "hydrate" => hydrate_corpus(ARTIFACT_DIR),
         [command] if command == "run" => run_corpus(),
         [command] if command == "finalize" => finalize_corpus(ARTIFACT_DIR),
+        [command] if command == "finalize-and-dehydrate" => {
+            finalize_and_dehydrate_corpus(ARTIFACT_DIR)
+        }
+        [command] if command == "dehydrate" => dehydrate_corpus(ARTIFACT_DIR),
         _ => Err(
-            "usage: rust-script tools/commands/fixtures/davinci-dom-corpus-workflow.rs hydrate|run|finalize"
+            "usage: rust-script tools/commands/fixtures/davinci-dom-corpus-workflow.rs hydrate|run|finalize|finalize-and-dehydrate|dehydrate"
                 .to_string(),
         ),
     }
@@ -129,6 +133,43 @@ fn hydrate_fixture_serially(fixture_path: &str) -> Result<(), String> {
         .map(str::to_string),
     )?;
     Ok(())
+}
+
+fn dehydrate_corpus(artifact: &str) -> Result<u8, String> {
+    let selected_path = Path::new(artifact).join("selected-gitlinks.txt");
+    if !selected_path.exists() {
+        return Ok(0);
+    }
+    let selected = common::read_text(&selected_path)?;
+    let fixture_paths = selected
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    if fixture_paths.is_empty() {
+        return Ok(0);
+    }
+    let mut args = vec!["submodule", "deinit", "--force", "--"]
+        .into_iter()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    args.extend(fixture_paths);
+    run_git(&args)?;
+    Ok(0)
+}
+
+fn finalize_and_dehydrate_corpus(artifact: &str) -> Result<u8, String> {
+    let finalize_result = finalize_corpus(artifact);
+    let dehydrate_result = dehydrate_corpus(artifact);
+    match (finalize_result, dehydrate_result) {
+        (Ok(code), Ok(_)) => Ok(code),
+        (Err(error), Ok(_)) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Err(finalize_error), Err(dehydrate_error)) => Err(format!(
+            "{finalize_error}\nfailed to dehydrate Davinci DOM corpus fixtures: {dehydrate_error}"
+        )),
+    }
 }
 
 fn run_corpus() -> Result<u8, String> {
@@ -451,10 +492,7 @@ fn expected_old_error_reasons() -> BTreeMap<String, usize> {
     .collect()
 }
 
-fn same_reason_counts(
-    left: &BTreeMap<String, usize>,
-    right: &BTreeMap<String, usize>,
-) -> bool {
+fn same_reason_counts(left: &BTreeMap<String, usize>, right: &BTreeMap<String, usize>) -> bool {
     left == right
 }
 


### PR DESCRIPTION
## Summary
- dehydrate selected real-project fixture submodules from the shard summary helper before checkout post-cleanup
- finalize and dehydrate the full Davinci DOM corpus through one release-gate command
- cover the cleanup contract in workflow and helper tests

## Verification
- node --test tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/real-project-matrix-summary.test.ts tests/tooling/davinci-dom-corpus-real-project-workflow.test.ts tests/tooling/davinci-dom-corpus-dehydrate.test.ts
- cargo fmt --all --check
- rustfmt --check tools/commands/fixtures/davinci-dom-corpus-workflow.rs tools/commands/ci/github/publish-real-project-shard-summary.rs
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20
- GITHUB_STEP_SUMMARY=/tmp/vize-shard-summary-smoke/summary.md FIXTURE_REPORT_DIR=/tmp/vize-shard-summary-smoke/report rust-script tools/commands/ci/github/publish-real-project-shard-summary.rs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791198902&installation_model_id=422833&pr_number=5752&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5752&signature=3a8564288662bffda3645890932ce9788a72e3009d1e448dd530227602bc3ccb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workflow support for dehydrating selected fixture repositories after processing.
  * Added combined finalize-and-dehydrate and standalone dehydrate commands.
  * Updated shard publishing to clean up selected fixtures and report cleanup failures.

* **Bug Fixes**
  * Real-project workflows now perform fixture cleanup during finalization.

* **Tests**
  * Added coverage for fixture dehydration, selected-fixture tracking, forced submodule cleanup, and related workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->