### PR TITLE
fix(typecheck): remove converged reka-ui ledger rows

### DIFF
--- a/tests/_fixtures/compat-documented-differences.json
+++ b/tests/_fixtures/compat-documented-differences.json
@@ -63,20 +63,6 @@
     },
     {
       "project": "reka-ui",
-      "file": "packages/core/src/Checkbox/CheckboxRoot.vue",
-      "severity": "error",
-      "line": 155,
-      "column": 12,
-      "vize": {
-        "code": 2367,
-        "message": "This comparison appears to be unintentional because the types 'Exclude<__DefineProps<Props<T>, \"asChild\" | \"disabled\" | \"required\" | ([\"indeterminate\" | T | undefined] extends [boolean | undefined] ? \"defaultValue\" : never) | ([T | undefined] extends [...] ? \"falseValue\" : never) | ... | ...>[\"as\"], undefined>' and 'string' have no overlap."
-      },
-      "baseline": null,
-      "issue": 5722,
-      "reason": "Vize preserves this stricter real-project diagnostic while vue-tsc accepts the same source; the exact row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
       "file": "packages/core/src/Combobox/ComboboxRoot.vue",
       "severity": "error",
       "line": 110,
@@ -273,20 +259,6 @@
     },
     {
       "project": "reka-ui",
-      "file": "packages/core/src/Select/SelectRoot.vue",
-      "severity": "error",
-      "line": 96,
-      "column": 3,
-      "vize": {
-        "code": 2578,
-        "message": "Unused '@ts-expect-error' directive."
-      },
-      "baseline": null,
-      "issue": 5722,
-      "reason": "Vize preserves this stricter real-project diagnostic while vue-tsc accepts the same source; the exact row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
       "file": "packages/core/src/Select/story/_Select.vue",
       "severity": "error",
       "line": 34,
@@ -410,20 +382,6 @@
       },
       "issue": 5722,
       "reason": "vue-tsc applies the Histoire Story layout prop surface differently for this story file; the exact baseline-only row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/Switch/SwitchRoot.vue",
-      "severity": "error",
-      "line": 105,
-      "column": 12,
-      "vize": {
-        "code": 2367,
-        "message": "This comparison appears to be unintentional because the types 'Exclude<__DefineProps<Props<T>, \"asChild\" | \"disabled\" | \"required\" | ([T | undefined] extends [boolean | undefined] ? \"defaultValue\" : never) | ([T | undefined] extends [...] ? \"falseValue\" : never) | ... | ...>[\"as\"], undefined>' and 'string' have no overlap."
-      },
-      "baseline": null,
-      "issue": 5722,
-      "reason": "Vize preserves this stricter real-project diagnostic while vue-tsc accepts the same source; the exact row is tracked for follow-up under issue 5722."
     },
     {
       "project": "reka-ui",


### PR DESCRIPTION
## Summary
- remove three `reka-ui` documented typecheck divergence rows that no longer reproduce
- keep the issue 5722 ledger fail-closed by dropping only rows reported as converged by the v0.397.0 matrix shard

## Evidence
- Real Project Matrix run 33964192753, job 101301245811 reported stale rows for `CheckboxRoot.vue:155:12`, `SelectRoot.vue:96:3`, and `SwitchRoot.vue:105:12`

## Verification
- vp install --frozen-lockfile --prefer-offline
- node --test tests/tooling/typecheck-divergence-ledger.test.ts tests/tooling/typecheck-divergence-report-ledger.test.ts tests/tooling/typecheck-divergence-report-rejections.test.ts tests/tooling/compat-ratchet.test.ts
- cargo fmt --all --check
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791201403&installation_model_id=422833&pr_number=5754&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5754&signature=746846bb5de4c04f0f9dec551a5cf83478e4ac8702d0909c3b8daeac1605695f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated compatibility tracking to remove three previously documented discrepancies related to checkbox, select, and switch components.
  - All other compatibility entries remain unchanged.
  - No changes were made to exported or public-facing APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->