### PR TITLE
fix(lsp): locate workspace emit symbols at declarations

### DIFF
--- a/crates/vize_maestro/src/ide/workspace_symbols.rs
+++ b/crates/vize_maestro/src/ide/workspace_symbols.rs
@@ -7,6 +7,8 @@
 
 #[cfg(feature = "native")]
 mod disk;
+#[cfg(test)]
+mod tests;
 
 use tower_lsp::lsp_types::{Location, Position, Range, SymbolInformation, SymbolKind, Url};
 
@@ -166,10 +168,8 @@ impl WorkspaceSymbolsService {
 
         let container = Self::extract_component_name(uri);
 
-        // Range pointing at the start of the script setup block. Symbols
-        // discovered through Croquis don't yet carry their declaration span,
-        // so we anchor them at the block start as a follow-up improvement
-        // on top of the line-0-character-0 placeholder from #715.
+        // Fallback for Croquis symbols that do not yet carry a declaration
+        // span, on top of the line-0-character-0 placeholder from #715.
         let script_setup_position =
             Self::offset_to_position(descriptor.source.as_ref(), script_setup.loc.start);
         let placeholder_range = Range {
@@ -185,6 +185,13 @@ impl WorkspaceSymbolsService {
             if !query.is_empty() && !name.to_lowercase().contains(query) {
                 continue;
             }
+            let range = Self::macro_declaration_range(
+                descriptor.source.as_ref(),
+                script_setup.content.as_ref(),
+                script_setup.loc.start,
+                croquis.macros.emit_declaration(name),
+                placeholder_range,
+            );
             symbols.push(SymbolInformation {
                 name: name.to_string(),
                 kind: SymbolKind::EVENT,
@@ -192,7 +199,7 @@ impl WorkspaceSymbolsService {
                 deprecated: None,
                 location: Location {
                     uri: uri.clone(),
-                    range: placeholder_range,
+                    range,
                 },
                 container_name: container.clone(),
             });
@@ -217,6 +224,57 @@ impl WorkspaceSymbolsService {
                 },
                 container_name: container.clone(),
             });
+        }
+    }
+
+    fn macro_declaration_range(
+        source: &str,
+        script: &str,
+        script_start: usize,
+        declaration: Option<(u32, u32)>,
+        fallback: Range,
+    ) -> Range {
+        let Some((start, end)) = declaration else {
+            return fallback;
+        };
+        let start = start as usize;
+        let end = end as usize;
+        if start >= end || script.get(start..end).is_none() {
+            return fallback;
+        }
+
+        let (start, end) = Self::trim_paired_quotes(script, start, end);
+        let (Some(source_start), Some(source_end)) = (
+            script_start.checked_add(start),
+            script_start.checked_add(end),
+        ) else {
+            return fallback;
+        };
+        if source_start > source_end || source.get(source_start..source_end).is_none() {
+            return fallback;
+        }
+
+        Range {
+            start: Self::offset_to_position(source, source_start),
+            end: Self::offset_to_position(source, source_end),
+        }
+    }
+
+    fn trim_paired_quotes(source: &str, start: usize, end: usize) -> (usize, usize) {
+        let Some(raw) = source.get(start..end) else {
+            return (start, end);
+        };
+        let bytes = raw.as_bytes();
+        if bytes.len() < 2 {
+            return (start, end);
+        }
+        let Some(last) = bytes.last() else {
+            return (start, end);
+        };
+        if matches!(bytes[0], b'\'' | b'"') && *last == bytes[0] {
+            (start + 1, end - 1)
+        } else {
+            (start, end)
         }
     }
 
@@ -563,64 +621,5 @@ impl WorkspaceSymbolsService {
 
     fn is_ident_char(c: char) -> bool {
         c.is_ascii_alphanumeric() || c == '_' || c == '$'
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::WorkspaceSymbolsService;
-    use tower_lsp::lsp_types::SymbolKind;
-
-    #[test]
-    fn test_to_pascal_case() {
-        assert_eq!(
-            WorkspaceSymbolsService::to_pascal_case("hello-world"),
-            "HelloWorld"
-        );
-        assert_eq!(
-            WorkspaceSymbolsService::to_pascal_case("my_component"),
-            "MyComponent"
-        );
-        assert_eq!(WorkspaceSymbolsService::to_pascal_case("Button"), "Button");
-    }
-
-    #[test]
-    fn test_extract_identifier() {
-        assert_eq!(
-            WorkspaceSymbolsService::extract_identifier("count = 0"),
-            Some("count".to_string())
-        );
-        assert_eq!(
-            WorkspaceSymbolsService::extract_identifier("MyClass extends Base"),
-            Some("MyClass".to_string())
-        );
-        assert_eq!(
-            WorkspaceSymbolsService::extract_identifier("{ a, b } = obj"),
-            None
-        );
-    }
-
-    #[test]
-    fn test_extract_css_classes() {
-        let classes = WorkspaceSymbolsService::extract_css_classes(".container .item-active { }");
-        assert_eq!(classes, vec!["container", "item-active"]);
-    }
-
-    #[test]
-    fn test_extract_css_ids() {
-        let ids = WorkspaceSymbolsService::extract_css_ids("#app #main-content { }");
-        assert_eq!(ids, vec!["app", "main-content"]);
-    }
-
-    #[test]
-    fn test_parse_declaration() {
-        let (name, kind) = WorkspaceSymbolsService::parse_declaration("count = ref(0)").unwrap();
-        assert_eq!(name, "count");
-        assert_eq!(kind, SymbolKind::VARIABLE);
-
-        let (name, kind) =
-            WorkspaceSymbolsService::parse_declaration("handleClick = () => {}").unwrap();
-        assert_eq!(name, "handleClick");
-        assert_eq!(kind, SymbolKind::FUNCTION);
     }
 }

--- a/crates/vize_maestro/src/ide/workspace_symbols/tests.rs
+++ b/crates/vize_maestro/src/ide/workspace_symbols/tests.rs
@@ -1,0 +1,94 @@
+use super::WorkspaceSymbolsService;
+use tower_lsp::lsp_types::{Position, Range, SymbolKind};
+
+#[test]
+fn test_to_pascal_case() {
+    assert_eq!(
+        WorkspaceSymbolsService::to_pascal_case("hello-world"),
+        "HelloWorld"
+    );
+    assert_eq!(
+        WorkspaceSymbolsService::to_pascal_case("my_component"),
+        "MyComponent"
+    );
+    assert_eq!(WorkspaceSymbolsService::to_pascal_case("Button"), "Button");
+}
+
+#[test]
+fn test_extract_identifier() {
+    assert_eq!(
+        WorkspaceSymbolsService::extract_identifier("count = 0"),
+        Some("count".to_string())
+    );
+    assert_eq!(
+        WorkspaceSymbolsService::extract_identifier("MyClass extends Base"),
+        Some("MyClass".to_string())
+    );
+    assert_eq!(
+        WorkspaceSymbolsService::extract_identifier("{ a, b } = obj"),
+        None
+    );
+}
+
+#[test]
+fn test_extract_css_classes() {
+    let classes = WorkspaceSymbolsService::extract_css_classes(".container .item-active { }");
+    assert_eq!(classes, vec!["container", "item-active"]);
+}
+
+#[test]
+fn test_extract_css_ids() {
+    let ids = WorkspaceSymbolsService::extract_css_ids("#app #main-content { }");
+    assert_eq!(ids, vec!["app", "main-content"]);
+}
+
+#[test]
+fn test_parse_declaration() {
+    let (name, kind) = WorkspaceSymbolsService::parse_declaration("count = ref(0)").unwrap();
+    assert_eq!(name, "count");
+    assert_eq!(kind, SymbolKind::VARIABLE);
+
+    let (name, kind) =
+        WorkspaceSymbolsService::parse_declaration("handleClick = () => {}").unwrap();
+    assert_eq!(name, "handleClick");
+    assert_eq!(kind, SymbolKind::FUNCTION);
+}
+
+#[test]
+fn macro_declaration_range_targets_quoted_name_content() {
+    let source = "<script setup>\nconst emit = defineEmits(['save-item'])\n</script>\n";
+    let script_start = source.find("const emit").unwrap();
+    let script_end = source.find("\n</script>").unwrap();
+    let script = &source[script_start..script_end];
+    let quoted_start = script.find("'save-item'").unwrap();
+    let quoted_end = quoted_start + "'save-item'".len();
+    let name_start = source.find("save-item").unwrap();
+    let name_end = name_start + "save-item".len();
+    let fallback = Range {
+        start: Position {
+            line: 0,
+            character: 0,
+        },
+        end: Position {
+            line: 0,
+            character: 0,
+        },
+    };
+
+    let range = WorkspaceSymbolsService::macro_declaration_range(
+        source,
+        script,
+        script_start,
+        Some((quoted_start as u32, quoted_end as u32)),
+        fallback,
+    );
+
+    assert_eq!(
+        range.start,
+        WorkspaceSymbolsService::offset_to_position(source, name_start)
+    );
+    assert_eq!(
+        range.end,
+        WorkspaceSymbolsService::offset_to_position(source, name_end)
+    );
+}

--- a/tests/tooling/lsp-workspace-symbol-emits.test.ts
+++ b/tests/tooling/lsp-workspace-symbol-emits.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+type SymbolInformation = {
+  name: string;
+  kind: number;
+  containerName?: string;
+  location: {
+    uri: string;
+    range: {
+      start: { line: number; character: number };
+      end: { line: number; character: number };
+    };
+  };
+};
+
+test("vize lsp workspaceSymbol locates defineEmits event declarations", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-workspace-symbol-emits");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: false,
+    });
+
+    const source = `<script setup lang="ts">
+const emit = defineEmits<{
+  (event: "update:modelValue", value: string): void
+}>()
+</script>
+
+<template>
+  <button @click="emit('update:modelValue', 'next')" />
+</template>
+`;
+    const filePath = path.join(workspaceDir, "Emitter.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        languageId: "vue",
+        version: 1,
+        text: source,
+      },
+    });
+
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    const symbols = (await session.request("workspace/symbol", {
+      query: "update:modelValue",
+    })) as SymbolInformation[] | null;
+    assert.equal(symbols?.length, 1, JSON.stringify(symbols));
+
+    const [symbol] = symbols;
+    assert.equal(symbol.name, "update:modelValue");
+    assert.equal(symbol.kind, 24);
+    assert.equal(symbol.containerName, "Emitter");
+    assert.equal(symbol.location.uri, uri);
+
+    const eventNameOffset = source.indexOf('"update:modelValue"') + 1;
+    assert.deepEqual(symbol.location.range.start, offsetToPosition(source, eventNameOffset));
+    assert.deepEqual(
+      symbol.location.range.end,
+      offsetToPosition(source, eventNameOffset + "update:modelValue".length),
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- use Croquis macro declaration spans for defineEmits workspace symbols
- trim quoted event names so workspace/symbol returns authored event-name ranges
- cover the LSP workspaceSymbol response with a real server test

## Validation
- cargo test -p vize_maestro workspace_symbols -- --nocapture
- node --test tests/tooling/lsp-workspace-symbol-emits.test.ts
- cargo fmt --all --check
- git diff --cached --check
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791206078&installation_model_id=422833&pr_number=5758&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5758&signature=548a60e4abfbd4ae14062b31fb10dbf9845f63da1cf86abd903a193d5a1e1bc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace symbol results now report precise source ranges for declarations, improving navigation and highlighting.
  - Event declarations defined with `defineEmits` are now correctly discovered through workspace symbol search.

- **Tests**
  - Added coverage for declaration parsing, CSS selectors, identifier extraction, macro ranges, and end-to-end workspace symbol results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->