### PR TITLE
test(davinci): cover conditional forwarded slot outlets

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_outlets.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_outlets.rs
@@ -126,6 +126,10 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<Bar v-slot="{ row }"><Foo><slot @[row.event]="row.handler"></slot></Foo></Bar>"#,
     ),
     (
+        "conditional_forwarded_dynamic_event",
+        r#"<Foo><slot v-if="ok" @[event]="handler"></slot></Foo>"#,
+    ),
+    (
         "scoped_forwarded",
         r#"<Bar v-slot="p"><Foo><slot></slot></Foo></Bar>"#,
     ),
@@ -222,6 +226,11 @@ const PATCH_SITE_CASES: &[Case] = &[
             "1024 /* DYNAMIC_SLOTS */",
             "3 /* FORWARDED */",
         ],
+    },
+    Case {
+        name: "conditional_forwarded_dynamic_event",
+        src: r#"<Foo><slot v-if="ok" @[event]="handler"></slot></Foo>"#,
+        sites: &["3 /* FORWARDED */"],
     },
     Case {
         name: "named_mixed_props",


### PR DESCRIPTION
## Summary

- add a conditional forwarded slot outlet case to the S2 DOM outlet battery
- pin the patch-site contract for dynamic event forwarding to the forwarded-only flag

## Validation

- `cargo test -p vize_atelier_dom --test davinci_s2_outlets -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check origin/main..HEAD && git diff --check`
- `node --test tests/tooling/davinci-phase2-ledger.test.ts`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791207153&installation_model_id=422833&pr_number=5759&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5759&signature=d3aa55819ff7485ccfaf61edf1429ee688079f63b98819115bec1f9800c55bee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->