### PR TITLE
test(vscode): route real host hover through lsp command

### DIFF
--- a/editors/vscode/test/real-host-lsp-request-oracle.mjs
+++ b/editors/vscode/test/real-host-lsp-request-oracle.mjs
@@ -1,3 +1,47 @@
+import assert from "node:assert/strict";
+
 // Mirrors `HOST_TEST_LSP_REQUEST_COMMAND` in `src/host-test-core.ts`; the
 // tooling tests assert both stay in sync.
 export const HOST_TEST_LSP_REQUEST_COMMAND = "vize.test.executeLspRequest";
+
+export function assertRealHostTemplateBindingHover(actual) {
+  const markdown = hoverToMarkdown(actual);
+
+  assert.match(markdown, /^```typescript\n/);
+  assert.ok(
+    markdown.includes('const label: "hello from vize"'),
+    `raw LSP hover must report the backend type of the binding: ${JSON.stringify(markdown)}`,
+  );
+  assert.doesNotMatch(
+    markdown,
+    /TypeScript quick info|Template binding from script|Ref<unknown>|ComputedRef<unknown>|MaybeRef<unknown>/,
+  );
+
+  return markdown;
+}
+
+function hoverToMarkdown(hover) {
+  assert.ok(
+    hover?.contents,
+    `real host raw LSP hover must include contents: ${JSON.stringify(hover)}`,
+  );
+
+  return markupToMarkdown(hover.contents);
+}
+
+function markupToMarkdown(markup) {
+  if (typeof markup === "string") {
+    return markup;
+  }
+  if (Array.isArray(markup)) {
+    return markup.map(markupToMarkdown).join("\n");
+  }
+  if (typeof markup?.value === "string") {
+    if (typeof markup.language === "string") {
+      return `\`\`\`${markup.language}\n${markup.value}\n\`\`\``;
+    }
+    return markup.value;
+  }
+
+  assert.fail(`unsupported real host hover contents: ${JSON.stringify(markup)}`);
+}

--- a/editors/vscode/test/suite/extension-host-real.cjs
+++ b/editors/vscode/test/suite/extension-host-real.cjs
@@ -126,37 +126,18 @@ async function runRealReferencesSmoke(mismatchDocument) {
 }
 
 async function runRealHoverSmoke(mismatchDocument) {
+  const { HOST_TEST_LSP_REQUEST_COMMAND, assertRealHostTemplateBindingHover } =
+    await import("../real-host-lsp-request-oracle.mjs");
   const position = positionAfter(mismatchDocument, "{{ label }}", "{{ la");
-  const hovers = await vscode.commands.executeCommand(
-    "vscode.executeHoverProvider",
-    mismatchDocument.uri,
-    position,
-  );
-  assert.ok(hovers?.length >= 1, "expected a hover for the template binding");
+  const hover = await vscode.commands.executeCommand(HOST_TEST_LSP_REQUEST_COMMAND, {
+    method: "textDocument/hover",
+    params: {
+      position: { character: position.character, line: position.line },
+      textDocument: { uri: mismatchDocument.uri.toString() },
+    },
+  });
 
-  const markdown = hovers
-    .flatMap((hover) => hover.contents)
-    .map((content) => (typeof content === "string" ? content : content.value))
-    .join("\n");
-  // This profile enables typechecking, so the hover type text comes from the
-  // live backend (#3321): the real literal type of the const, not the
-  // script-binding heuristic that used to answer here.
-  //
-  // The hover opens with the signature code block, like Volar and tsserver:
-  // no implementation-detail preamble ahead of it (#3894).
-  assert.match(markdown, /^```typescript\n/);
-  assert.ok(
-    markdown.includes('const label: "hello from vize"'),
-    `hover must report the backend type of the binding: ${JSON.stringify(markdown)}`,
-  );
-  assert.ok(
-    !markdown.includes("TypeScript quick info"),
-    `hover must not restore the removed preamble: ${JSON.stringify(markdown)}`,
-  );
-  assert.ok(
-    !markdown.includes("Template binding from script"),
-    `hover must not fall back to the script-binding heuristic: ${JSON.stringify(markdown)}`,
-  );
+  assertRealHostTemplateBindingHover(hover);
 }
 
 async function runRealDidChangeRepairSmoke(mismatchDocument, extension) {

--- a/tests/_fixtures/maestro-vue-language-tools-scorecard.json
+++ b/tests/_fixtures/maestro-vue-language-tools-scorecard.json
@@ -133,10 +133,10 @@
           "summary": "Type-aware VS Code hover does not fall back to removed heuristic preambles.",
           "evidence": [
             {
-              "file": "editors/vscode/test/suite/extension-host-real.cjs",
+              "file": "editors/vscode/test/real-host-lsp-request-oracle.mjs",
               "contains": [
-                "!markdown.includes(\"TypeScript quick info\")",
-                "!markdown.includes(\"Template binding from script\")"
+                "assert.doesNotMatch",
+                "TypeScript quick info|Template binding from script|Ref<unknown>|ComputedRef<unknown>|MaybeRef<unknown>"
               ]
             }
           ]

--- a/tests/tooling/vscode-host-lsp-request-command.test.ts
+++ b/tests/tooling/vscode-host-lsp-request-command.test.ts
@@ -8,7 +8,10 @@ import {
   type HostTestLanguageClient,
   type TestLspRequest,
 } from "../../editors/vscode/src/host-test-core.ts";
-import { HOST_TEST_LSP_REQUEST_COMMAND as suiteHostLspRequestCommand } from "../../editors/vscode/test/real-host-lsp-request-oracle.mjs";
+import {
+  HOST_TEST_LSP_REQUEST_COMMAND as suiteHostLspRequestCommand,
+  assertRealHostTemplateBindingHover,
+} from "../../editors/vscode/test/real-host-lsp-request-oracle.mjs";
 
 test("the generic host LSP request command only exists for the host smoke", () => {
   const client = createFakeClientResponse(null);
@@ -64,6 +67,28 @@ test("the generic host LSP request command validates request shape", async () =>
 
 test("the real host LSP request oracle keeps the command id in sync", () => {
   assert.equal(HOST_TEST_LSP_REQUEST_COMMAND, suiteHostLspRequestCommand);
+});
+
+test("the real host LSP request oracle pins backend typed hover content", () => {
+  const hover = {
+    contents: {
+      kind: "markdown",
+      value: ["```typescript", 'const label: "hello from vize"', "```"].join("\n"),
+    },
+  };
+
+  assert.equal(
+    assertRealHostTemplateBindingHover(hover),
+    '```typescript\nconst label: "hello from vize"\n```',
+  );
+  assert.throws(
+    () =>
+      assertRealHostTemplateBindingHover({
+        contents: "Template binding from script: Ref<unknown>",
+      }),
+    /Template binding from script/,
+  );
+  assert.throws(() => assertRealHostTemplateBindingHover(null), /must include contents/);
 });
 
 function hasLspRequestCommand(behavior: Parameters<typeof createHostTestCommands>[0]): boolean {


### PR DESCRIPTION
## Summary

- route the packaged VS Code real-host hover smoke through the hidden raw LSP request command
- share the hover oracle with tooling tests so the command id and backend typed hover contract stay pinned together
- reject fallback hover text and unknown ref/computed types in the real-host oracle

## Validation

- `node --test tests/tooling/vscode-host-lsp-request-command.test.ts tests/tooling/vscode-packaged-host-smoke.test.ts`
- `node --test tests/tooling/vscode-host-test-commands.test.ts tests/tooling/vscode-host-references-oracle.test.ts tests/tooling/vscode-host-lsp-request-command.test.ts`
- `node --test tests/tooling/lsp-vue-language-tools-scorecard.test.ts`
- `../../node_modules/.pnpm/node_modules/.bin/tsc --noEmit` in `editors/vscode`
- `../../node_modules/.bin/vp check src vite.config.ts` in `editors/vscode`
- `cargo fmt --all --check`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20`
- `git diff --check origin/main..HEAD && git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved validation of editor hover information to ensure template bindings display precise backend types.
  - Added coverage for raw language-server hover responses and malformed hover data.
  - Added safeguards against misleading generic TypeScript quick-info and unknown reference types appearing in hover results.
  - Updated compatibility checks to reflect the refined hover validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->