### PR TITLE
test(fixtures): update vue-storefront file count

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2168,7 +2168,7 @@
       "revision": "220341f4c15d9f6ddb8d5e4c2fd225f5dd4d6f76",
       "license": { "spdx": "MIT", "files": ["LICENSE.md"] },
       "vueGlobs": ["**/*.vue"],
-      "expectedVueFileCount": 45,
+      "expectedVueFileCount": 48,
       "coverage": ["compiler","linter","typechecker","formatter","syntax-highlighter","lsp"],
       "diff": "e2e-vrt"
     },

--- a/tests/tooling/vue-ecosystem-fixtures.test.ts
+++ b/tests/tooling/vue-ecosystem-fixtures.test.ts
@@ -201,7 +201,7 @@ test("fixtures with exact Vue SFC expectations stay explicit", () => {
     projects.map((project) => ({ id: project.id, count: project.expectedVueFileCount })),
     [
       { id: "docsify", count: 0 },
-      { id: "vue-storefront", count: 45 },
+      { id: "vue-storefront", count: 48 },
       { id: "vue-native-core", count: 0 },
       { id: "vuefes-japan-speakers", count: 15 },
       { id: "wakapi", count: 0 },


### PR DESCRIPTION
## Summary
- update the Vue Storefront fixture expected Vue file count from 45 to 48
- keep the explicit fixture registry coverage assertion aligned with the pinned fixture

## Verification
- node --test --test-concurrency=1 tests/tooling/vue-ecosystem-fixtures.test.ts
- git diff --check origin/main..HEAD && git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 50

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791212681&installation_model_id=422833&pr_number=5762&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5762&signature=cf243b2e727d38e4e25612bbe1bd2afbb1d96ae4d7ab8185c49c8d2b90dfa779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Vue Storefront fixture expectations to reflect the current count of Vue files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->