### PR TITLE
fix(patina): allow v-model on lowercase custom components

### DIFF
--- a/crates/vize_patina/src/rules/vue/valid_v_model.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_model.rs
@@ -31,7 +31,7 @@ use oxc_ast::ast::Expression as OxcExpression;
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
 use vize_relief::{DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode};
-use vize_s0::is_html_tag;
+use vize_s0::is_native_tag;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/valid-v-model",
@@ -146,7 +146,7 @@ fn is_component_like_tag(element: &ElementNode<'_>) -> bool {
     }
 
     let tag = element.tag;
-    tag == "component" || (tag.contains('-') && !is_html_tag(tag))
+    tag == "component" || !is_native_tag(tag)
 }
 
 fn is_static_file_input(element: &ElementNode<'_>) -> bool {
@@ -300,6 +300,13 @@ mod tests {
     fn test_valid_v_model_on_custom_element_like_component() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<my-widget v-model="value"></my-widget>"#, "test.vue");
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_valid_v_model_on_lowercase_custom_component() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<multiselect v-model="selected" />"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 


### PR DESCRIPTION
Summary
- Treat non-native tags as custom components for vue/valid-v-model so lowercase real-project components such as multiselect and draggable do not report invalid-element diagnostics.
- Keep native element checks for div, file inputs, and native arguments intact.

Validation
- cargo fmt --check
- cargo test -p vize_patina valid_v_model
- cargo test -p vize_patina
- cargo test -p vize --test lint_rule_execution_cli

Artifact impact
- /tmp/vize-real-matrix-33981711065: 241 vue/valid-v-model false positives were invalid-element custom-tag findings targeted by this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791225544&installation_model_id=422833&pr_number=5766&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5766&signature=63341702d2a07c737920d36a821e2a277d05378b239916a7db5fcd8e9b036a7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `v-model` validation for custom components, including lowercase custom element names such as `<multiselect>`.
  - Non-native tags are now correctly treated as component-like elements during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->