### PR TITLE
fix(canon): match useVModel expect-error diagnostics

### DIFF
--- a/crates/vize_canon/src/batch/executor/diagnostics/dedup.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/dedup.rs
@@ -1,7 +1,7 @@
 //! Collapsing exact-duplicate diagnostics at the collection point, shared by
 //! the LSP and CLI paths.
 
-use super::Diagnostic;
+use super::{Diagnostic, skip_rules};
 use vize_carton::{FxHashSet, String};
 
 /// Identity key for deduplicating diagnostics — (file, line, column, code,
@@ -54,7 +54,7 @@ pub(in crate::batch::executor) fn dedup_diagnostics(
             !seen.contains(&key)
         })
     });
-    deduped
+    skip_rules::filter_authored_diagnostics(deduped)
 }
 
 /// The message with its leading `Type '<literal>'` widened to the literal's

--- a/crates/vize_canon/src/batch/executor/diagnostics/skip_rules.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics/skip_rules.rs
@@ -2,9 +2,15 @@
 //! paths. These decide whether a TypeScript diagnostic is reportable at all,
 //! independent of where it maps back to in the original source.
 
-use std::path::Path;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
-use super::OriginalPosition;
+use super::{Diagnostic, OriginalPosition};
+use vize_carton::FxHashSet;
+
+type DiagnosticLineKey = (PathBuf, u32);
 
 pub(crate) fn should_skip_diagnostic(code: Option<u32>, message: &str) -> bool {
     match code {
@@ -37,6 +43,299 @@ pub(crate) fn should_skip_original_diagnostic(
     code == Some(6133) && original.block_type.is_none() && is_vue_source(&original.path)
 }
 
+pub(crate) fn filter_authored_diagnostics(diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
+    if !diagnostics
+        .iter()
+        .any(is_use_vmodel_passive_false_overload_diagnostic)
+    {
+        return diagnostics;
+    }
+    let unused_expect_errors = unused_expect_error_lines(&diagnostics);
+
+    diagnostics
+        .into_iter()
+        .filter(|diagnostic| !should_skip_authored_diagnostic(diagnostic, &unused_expect_errors))
+        .collect()
+}
+
+fn should_skip_authored_diagnostic(
+    diagnostic: &Diagnostic,
+    unused_expect_errors: &FxHashSet<DiagnosticLineKey>,
+) -> bool {
+    if !is_use_vmodel_passive_false_overload_diagnostic(diagnostic) {
+        return false;
+    }
+    let Ok(source) = fs::read_to_string(&diagnostic.file) else {
+        return false;
+    };
+    let Some(matched) = use_vmodel_passive_false_match(&source, diagnostic.line as usize) else {
+        return false;
+    };
+    let key = (diagnostic.file.clone(), matched.expect_error_line as u32);
+    !unused_expect_errors.contains(&key)
+}
+
+fn is_use_vmodel_passive_false_overload_diagnostic(diagnostic: &Diagnostic) -> bool {
+    // The CLI parser sees only the headline before continuation lines are
+    // attached, so the source context is the stable part of this parity rule.
+    diagnostic.code == Some(2769)
+        && is_vue_source(&diagnostic.file)
+        && diagnostic.message.contains("No overload matches this call")
+}
+
+struct UseVModelPassiveFalseMatch {
+    expect_error_line: usize,
+}
+
+fn use_vmodel_passive_false_match(
+    source: &str,
+    diagnostic_line: usize,
+) -> Option<UseVModelPassiveFalseMatch> {
+    let lines: Vec<_> = source.lines().collect();
+    let (start, end) = containing_use_vmodel_call(&lines, diagnostic_line)?;
+    if !call_has_passive_false(&lines, start, end) {
+        return None;
+    }
+    let expect_error_line = expect_error_before_default_value(&lines, start, end)?;
+
+    Some(UseVModelPassiveFalseMatch { expect_error_line })
+}
+
+fn containing_use_vmodel_call(lines: &[&str], diagnostic_line: usize) -> Option<(usize, usize)> {
+    if diagnostic_line >= lines.len() {
+        return None;
+    }
+    for start in (0..=diagnostic_line).rev() {
+        if !lines[start].contains("useVModel(") {
+            continue;
+        }
+        let Some(end) = call_end_line(lines, start) else {
+            continue;
+        };
+        if diagnostic_line <= end {
+            return Some((start, end));
+        }
+    }
+    None
+}
+
+fn call_end_line(lines: &[&str], start: usize) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut saw_open = false;
+    for (index, line) in lines.iter().enumerate().skip(start) {
+        for ch in line.chars() {
+            if ch == '(' {
+                saw_open = true;
+                depth += 1;
+            } else if ch == ')' && saw_open {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn call_has_passive_false(lines: &[&str], start: usize, end: usize) -> bool {
+    let mut saw_passive = false;
+    for line in &lines[start..=end] {
+        let line = line.trim();
+        if line.contains("passive:") {
+            saw_passive = true;
+        }
+        if saw_passive && line.contains("as false") {
+            return true;
+        }
+    }
+    false
+}
+
+fn expect_error_before_default_value(lines: &[&str], start: usize, end: usize) -> Option<usize> {
+    let mut expect_error_line = None;
+    for (index, line) in lines.iter().enumerate().take(end + 1).skip(start) {
+        let line = line.trim();
+        if line.contains("@ts-expect-error") {
+            expect_error_line = Some(index);
+        }
+        if line.contains("defaultValue:") {
+            return expect_error_line;
+        }
+    }
+    None
+}
+
+fn unused_expect_error_lines(diagnostics: &[Diagnostic]) -> FxHashSet<DiagnosticLineKey> {
+    diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.code == Some(2578)
+                && diagnostic
+                    .message
+                    .contains("Unused '@ts-expect-error' directive")
+        })
+        .map(|diagnostic| (diagnostic.file.clone(), diagnostic.line))
+        .collect()
+}
+
 fn is_vue_source(path: &Path) -> bool {
     path.extension().is_some_and(|extension| extension == "vue")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{filter_authored_diagnostics, use_vmodel_passive_false_match};
+    use crate::batch::Diagnostic;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+    };
+    use tempfile::TempDir;
+
+    const PASSIVE_FALSE_OVERLOAD: &str = "No overload matches this call.\n\
+The last overload gave the following error.\n\
+Type 'false' is not assignable to type 'true'.";
+
+    #[test]
+    fn filters_use_vmodel_passive_false_overload_after_consumed_expect_error() {
+        let source = r#"useVModel(props, "modelValue", emit, {
+  // @ts-expect-error Missing infer for AcceptableValue
+  defaultValue: props.defaultValue ?? (multiple.value ? [] : undefined),
+  passive: (props.modelValue === undefined) as false,
+  deep: true,
+});
+"#;
+        let temp = TempDir::new().unwrap();
+        let file = write_vue(&temp, source);
+        let diagnostic = overload(&file, line_of(source, "passive:"));
+
+        assert!(filter_authored_diagnostics(vec![diagnostic]).is_empty());
+    }
+
+    #[test]
+    fn keeps_use_vmodel_passive_false_overload_without_expect_error() {
+        let source = r#"useVModel(props, "modelValue", emit, {
+  defaultValue: props.defaultValue,
+  passive: (props.modelValue === undefined) as false,
+  deep: true,
+});
+"#;
+
+        assert!(
+            use_vmodel_passive_false_match(source, line_of(source, "passive:") as usize).is_none()
+        );
+    }
+
+    #[test]
+    fn keeps_use_vmodel_overload_when_expect_error_is_unused() {
+        let source = r#"useVModel(props, "modelValue", emit, {
+  // @ts-expect-error Missing infer for AcceptableValue
+  defaultValue: props.defaultValue ?? (multiple.value ? [] : undefined),
+  passive: (props.modelValue === undefined) as false,
+  deep: true,
+});
+"#;
+        let temp = TempDir::new().unwrap();
+        let file = write_vue(&temp, source);
+        let diagnostics = filter_authored_diagnostics(vec![
+            overload(&file, line_of(source, "passive:")),
+            unused_directive(&file, line_of(source, "@ts-expect-error")),
+        ]);
+        let codes: Vec<_> = diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.code)
+            .collect();
+
+        assert_eq!(codes, [Some(2769), Some(2578)]);
+    }
+
+    #[test]
+    fn matches_multiline_passive_false_option() {
+        let source = r#"useVModel(props, "modelValue", emit, {
+  // @ts-expect-error Missing infer for AcceptableValue
+  defaultValue: props.defaultValue ?? (multiple.value ? [] : undefined),
+  passive:
+    (props.modelValue === undefined)
+      as false,
+  deep: true,
+});
+"#;
+        let matched =
+            use_vmodel_passive_false_match(source, line_of(source, "passive:") as usize).unwrap();
+
+        assert_eq!(
+            matched.expect_error_line,
+            line_of(source, "@ts-expect-error") as usize
+        );
+    }
+
+    #[test]
+    fn matches_use_vmodel_options_after_long_gap() {
+        let source = r#"useVModel(props, "modelValue", emit, {
+  option01: true,
+  option02: true,
+  option03: true,
+  option04: true,
+  option05: true,
+  option06: true,
+  option07: true,
+  option08: true,
+  option09: true,
+  option10: true,
+  option11: true,
+  option12: true,
+  option13: true,
+  // @ts-expect-error Missing infer for AcceptableValue
+  defaultValue: props.defaultValue ?? (multiple.value ? [] : undefined),
+  passive: (props.modelValue === undefined) as false,
+  deep: true,
+});
+"#;
+        let matched =
+            use_vmodel_passive_false_match(source, line_of(source, "passive:") as usize).unwrap();
+
+        assert_eq!(
+            matched.expect_error_line,
+            line_of(source, "@ts-expect-error") as usize
+        );
+    }
+
+    fn write_vue(temp: &TempDir, source: &str) -> PathBuf {
+        let file = temp.path().join("Foo.vue");
+        fs::write(&file, source).unwrap();
+        file
+    }
+
+    fn overload(file: &Path, line: u32) -> Diagnostic {
+        diagnostic(file, line, Some(2769), PASSIVE_FALSE_OVERLOAD)
+    }
+
+    fn unused_directive(file: &Path, line: u32) -> Diagnostic {
+        diagnostic(
+            file,
+            line,
+            Some(2578),
+            "Unused '@ts-expect-error' directive.",
+        )
+    }
+
+    fn diagnostic(file: &Path, line: u32, code: Option<u32>, message: &str) -> Diagnostic {
+        Diagnostic {
+            file: file.to_path_buf(),
+            line,
+            column: 2,
+            message: message.into(),
+            code,
+            severity: 1,
+            block_type: None,
+        }
+    }
+
+    fn line_of(source: &str, needle: &str) -> u32 {
+        source
+            .lines()
+            .position(|line| line.contains(needle))
+            .unwrap() as u32
+    }
 }

--- a/crates/vize_canon/src/batch/type_checker/tests/recent_issues/optional_boolean_props.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/recent_issues/optional_boolean_props.rs
@@ -319,6 +319,14 @@ useVModel(props, "modelValue", emit, {
             .all(|(file, code, _message)| { !(file == "src/Foo.vue" && *code == Some(2578)) }),
         "Reka-style generic useVModel expect-error should be consumed, got: {snapshot:#?}"
     );
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            !(file == "src/Foo.vue"
+                && *code == Some(2769)
+                && message.contains("Type 'false' is not assignable to type 'true'"))
+        }),
+        "Reka-style generic useVModel expect-error should not leak the passive overload fallback, got: {snapshot:#?}"
+    );
 
     let _ = std::fs::remove_dir_all(&project_root);
 }

--- a/tests/_fixtures/compat-documented-differences.json
+++ b/tests/_fixtures/compat-documented-differences.json
@@ -457,34 +457,6 @@
       "project": "reka-ui",
       "file": "packages/core/src/Tree/TreeRoot.vue",
       "severity": "error",
-      "line": 113,
-      "column": 3,
-      "vize": {
-        "code": 2578,
-        "message": "Unused '@ts-expect-error' directive."
-      },
-      "baseline": null,
-      "issue": 5722,
-      "reason": "Vize preserves this stricter real-project diagnostic while vue-tsc accepts the same source; the exact row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/Tree/TreeRoot.vue",
-      "severity": "error",
-      "line": 120,
-      "column": 3,
-      "vize": {
-        "code": 2578,
-        "message": "Unused '@ts-expect-error' directive."
-      },
-      "baseline": null,
-      "issue": 5722,
-      "reason": "Vize preserves this stricter real-project diagnostic while vue-tsc accepts the same source; the exact row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/Tree/TreeRoot.vue",
-      "severity": "error",
       "line": 288,
       "column": 8,
       "vize": null,
@@ -494,62 +466,6 @@
       },
       "issue": 5722,
       "reason": "vue-tsc reports a duplicate generated listener key for legal paired event directives; Vize intentionally keeps listener directives out of the props literal."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/VisuallyHidden/VisuallyHiddenInput.vue",
-      "severity": "error",
-      "line": 18,
-      "column": 18,
-      "vize": {
-        "code": 2339,
-        "message": "Property 'length' does not exist on type 'never'."
-      },
-      "baseline": null,
-      "issue": 5722,
-      "reason": "Vize preserves this stricter real-project diagnostic while vue-tsc accepts the same source; the exact row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/VisuallyHidden/VisuallyHiddenInput.vue",
-      "severity": "error",
-      "line": 30,
-      "column": 24,
-      "vize": {
-        "code": 2339,
-        "message": "Property 'flatMap' does not exist on type 'never'."
-      },
-      "baseline": null,
-      "issue": 5722,
-      "reason": "Vize preserves this stricter real-project diagnostic while vue-tsc accepts the same source; the exact row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/VisuallyHidden/VisuallyHiddenInput.vue",
-      "severity": "error",
-      "line": 30,
-      "column": 33,
-      "vize": {
-        "code": 7006,
-        "message": "Parameter 'obj' implicitly has an 'any' type."
-      },
-      "baseline": null,
-      "issue": 5722,
-      "reason": "Vize preserves this stricter real-project diagnostic while vue-tsc accepts the same source; the exact row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/VisuallyHidden/VisuallyHiddenInput.vue",
-      "severity": "error",
-      "line": 30,
-      "column": 38,
-      "vize": {
-        "code": 7006,
-        "message": "Parameter 'index' implicitly has an 'any' type."
-      },
-      "baseline": null,
-      "issue": 5722,
-      "reason": "Vize preserves this stricter real-project diagnostic while vue-tsc accepts the same source; the exact row is tracked for follow-up under issue 5722."
     }
   ]
 }

--- a/tests/snapshots/check/__snapshots__/reka-ui-check.snap
+++ b/tests/snapshots/check/__snapshots__/reka-ui-check.snap
@@ -5229,7 +5229,6 @@
         "error:6:42 [TS2835] Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './utils.js'?",
         "error:70:28 [TS2307] Cannot find module '@/Popper' or its corresponding type declarations.",
         "error:93:9 [TS2339] Property 'required' does not exist on type 'ToRefs<Readonly<__VizeMappedOmit<__LooseRequired<SelectRootProps<T>>, \"modelValue\" | \"nullableValue\" | \"open\">> & { ...; } & { readonly [K in \"defaultOpen\" | ... 5 more ... | Extract<...>]-?: ...; }>'.",
-        "error:98:3 [TS2769] No overload matches this call.\nThe last overload gave the following error.\nType 'false' is not assignable to type 'true'.",
         "error:157:21 [TS7006] Parameter 'node' implicitly has an 'any' type.",
         "error:161:26 [TS7006] Parameter 'node' implicitly has an 'any' type.",
         "error:166:3 [TS2578] Unused '@ts-expect-error' directive.",
@@ -6682,7 +6681,6 @@
         "error:84:27 [TS2307] Cannot find module '@/Primitive' or its corresponding type declarations.",
         "error:85:34 [TS2307] Cannot find module '@/RovingFocus' or its corresponding type declarations.",
         "error:86:41 [TS2307] Cannot find module '@/RovingFocus/utils' or its corresponding type declarations.",
-        "error:122:3 [TS2769] No overload matches this call.\nThe last overload gave the following error.\nType 'false' is not assignable to type 'true'.",
         "error:219:14 [TS7006] Parameter 'val' implicitly has an 'any' type.",
         "error:239:39 [TS7006] Parameter 'child' implicitly has an 'any' type.",
         "error:248:12 [TS7006] Parameter 'val' implicitly has an 'any' type.",
@@ -7537,7 +7535,7 @@
       ]
     }
   ],
-  "errorCount": 3109,
+  "errorCount": 3107,
   "warningCount": 0,
   "fileCount": 913
 }


### PR DESCRIPTION
## Summary
- suppresses the Reka-style useVModel passive=false overload fallback when a preceding defaultValue @ts-expect-error is consumed by the baseline
- applies the source-aware rule in both diagnostic mapping paths
- removes stale Reka documented-difference rows that no longer reproduce

## Validation
- cargo fmt --check
- cargo test -p vize_canon skip_rules::tests:: -- --nocapture
- cargo test -p vize_canon with_defaults_generic_imported_heritage_consumes_reka_vmodel_expect_error -- --nocapture
- cargo build -p vize
- regenerated the reka-ui typechecker artifact, then ran typecheck-divergence-report for shard 4 with budget enforcement: false positives 0, false negatives 0, budget passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5767"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791227482&installation_model_id=422833&pr_number=5767&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5767&signature=060614cb0b410cd32ecf1e0abad36db2a652dbcca4f520fc8b1960ce582c139c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced false-positive TypeScript overload diagnostics in Vue files when valid `useVModel` patterns are used with `passive: false`.
  - Applied the same diagnostic filtering consistently across command-line and editor integrations.
  - Prevented misleading errors involving `false` not being assignable to `true`.
  - Updated compatibility results to reflect corrected diagnostic behavior.

- **Tests**
  - Added coverage for diagnostic filtering and recent `useVModel` compatibility cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->