### PR TITLE
test(davinci): pin production selector option gates

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
@@ -80,6 +80,54 @@ fn comments_stay_on_compatibility_without_profiler() {
 }
 
 #[test]
+fn unsupported_options_stay_on_compatibility_without_profiler() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+
+    let cases = [
+        (
+            "ssr",
+            DomCompilerOptions {
+                ssr: true,
+                ..Default::default()
+            },
+        ),
+        (
+            "patterned_template",
+            DomCompilerOptions {
+                experimental_patterned_template: true,
+                ..Default::default()
+            },
+        ),
+        (
+            "custom_renderer",
+            DomCompilerOptions {
+                custom_renderer: true,
+                ..Default::default()
+            },
+        ),
+    ];
+
+    for (label, options) in cases {
+        profiler.disable();
+        profiler.clear();
+
+        let result = compile(r#"<button @click="go">{{ label }}</button>"#, options);
+        let counters = profiler.counter_summary();
+
+        assert!(
+            result.sections.is_some(),
+            "{label} must stay on the compatibility path until S2 supports it"
+        );
+        assert_eq!(
+            counter_total(&counters, "davinci.s2_dom.files"),
+            None,
+            "{label} compatibility compiles must not instantiate the profiling observer"
+        );
+    }
+}
+
+#[test]
 fn sfc_sections_entry_stays_on_compatibility_until_s2_sections_land() {
     let _guard = lock_profiler();
     let profiler = global_profiler();

--- a/tests/tooling/support/davinci-phase2-ledger/p2-11-rows.ts
+++ b/tests/tooling/support/davinci-phase2-ledger/p2-11-rows.ts
@@ -206,8 +206,6 @@ export const p2_11FileExpectations = [
   [105, /725b3313b/],
   [106, /Runtime Module Profiling/],
   [106, /426d2becf/],
-  [107, /Shared Model And Outlet Batteries/],
   [107, /4857d3e75/],
-  [108, /Source-Map-Free Production Selector/],
   [108, /8be4517e/],
 ] as const;


### PR DESCRIPTION
## Summary
- add focused coverage that unsupported DOM compiler options stay on the compatibility path without touching the S2 profiler
- keep P2-11 ledger checks tied to merged PR SHAs while avoiding brittle exact title assertions

## Checks
- cargo test -p vize_atelier_dom --test davinci_s2_production_selector -- --nocapture
- node --test tests/tooling/davinci-phase2-ledger.test.ts tests/tooling/source-file-lengths.test.ts
- vp check crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs tests/tooling/support/davinci-phase2-ledger/p2-11-rows.ts
- cargo fmt --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791230721&installation_model_id=422833&pr_number=5769&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5769&signature=d76fa48ea40f1c52857640fc89c4b0de75a05091f361887e446c3100f964c4d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->