### PR TITLE
test(canon): cover Corsa LSP declaration and implementation

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -9,7 +9,7 @@ use vize_carton::cstr;
 use vize_carton::profiler::{CacheStats, Profiler};
 
 use super::session::build_client;
-use super::types::{CorsaBridgeConfig, CorsaBridgeError};
+use super::types::{CorsaBridgeConfig, CorsaBridgeError, LspDefinitionResponse, LspLocation};
 use super::worker::{BoundedWorker, WorkerError};
 use crate::corsa_client::CorsaProjectClient;
 
@@ -227,4 +227,40 @@ where
     serde_json::from_value(value).map_err(|e| {
         CorsaBridgeError::CommunicationError(cstr!("Failed to parse Corsa result: {e}"))
     })
+}
+
+pub(super) fn parse_lsp_locations(value: Value) -> Result<Vec<LspLocation>, CorsaBridgeError> {
+    Ok(parse_json_value::<LspDefinitionResponse>(value)?.into_locations())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_lsp_locations;
+
+    #[test]
+    fn declaration_and_implementation_location_links_normalize_to_locations() {
+        let locations = parse_lsp_locations(serde_json::json!([{
+            "targetUri": "file:///workspace/src/service.ts",
+            "targetRange": {
+                "start": { "line": 3, "character": 0 },
+                "end": { "line": 5, "character": 1 }
+            },
+            "targetSelectionRange": {
+                "start": { "line": 3, "character": 6 },
+                "end": { "line": 3, "character": 21 }
+            },
+            "originSelectionRange": {
+                "start": { "line": 0, "character": 10 },
+                "end": { "line": 0, "character": 17 }
+            }
+        }]))
+        .expect("location-link response");
+
+        assert_eq!(locations.len(), 1);
+        assert_eq!(locations[0].uri, "file:///workspace/src/service.ts");
+        assert_eq!(locations[0].range.start.line, 3);
+        assert_eq!(locations[0].range.start.character, 6);
+        assert_eq!(locations[0].range.end.line, 3);
+        assert_eq!(locations[0].range.end.character, 21);
+    }
 }

--- a/crates/vize_canon/src/corsa_bridge/bridge/declaration.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge/declaration.rs
@@ -1,7 +1,7 @@
 //! Declaration-location editor query forwarded through the Corsa session.
 
-use super::{CorsaBridge, parse_json_value};
-use crate::corsa_bridge::types::{CorsaBridgeError, LspDefinitionResponse, LspLocation};
+use super::{CorsaBridge, parse_lsp_locations};
+use crate::corsa_bridge::types::{CorsaBridgeError, LspLocation};
 
 #[allow(clippy::disallowed_types)]
 impl CorsaBridge {
@@ -27,7 +27,7 @@ impl CorsaBridge {
         }
 
         if let Some(value) = result {
-            return Ok(parse_json_value::<LspDefinitionResponse>(value)?.into_locations());
+            return parse_lsp_locations(value);
         }
 
         Ok(Vec::new())

--- a/crates/vize_canon/src/corsa_bridge/bridge/implementation.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge/implementation.rs
@@ -1,7 +1,7 @@
 //! Implementation-location editor query forwarded through the Corsa session.
 
-use super::{CorsaBridge, parse_json_value};
-use crate::corsa_bridge::types::{CorsaBridgeError, LspDefinitionResponse, LspLocation};
+use super::{CorsaBridge, parse_lsp_locations};
+use crate::corsa_bridge::types::{CorsaBridgeError, LspLocation};
 
 #[allow(clippy::disallowed_types)]
 impl CorsaBridge {
@@ -27,7 +27,7 @@ impl CorsaBridge {
         }
 
         if let Some(value) = result {
-            return Ok(parse_json_value::<LspDefinitionResponse>(value)?.into_locations());
+            return parse_lsp_locations(value);
         }
 
         Ok(Vec::new())

--- a/crates/vize_canon/src/corsa_bridge/bridge/language_features.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge/language_features.rs
@@ -3,10 +3,10 @@
 use serde_json::Value;
 use vize_carton::String;
 
-use super::{CorsaBridge, parse_json_value};
+use super::{CorsaBridge, parse_json_value, parse_lsp_locations};
 use crate::corsa_bridge::types::{
-    CorsaBridgeError, LspCompletionItem, LspCompletionResponse, LspDefinitionResponse, LspHover,
-    LspLocation, LspSignatureHelp,
+    CorsaBridgeError, LspCompletionItem, LspCompletionResponse, LspHover, LspLocation,
+    LspSignatureHelp,
 };
 
 #[allow(clippy::disallowed_types)]
@@ -57,7 +57,7 @@ impl CorsaBridge {
         }
 
         if let Some(value) = result {
-            return Ok(parse_json_value::<LspDefinitionResponse>(value)?.into_locations());
+            return parse_lsp_locations(value);
         }
 
         Ok(Vec::new())
@@ -97,9 +97,7 @@ impl CorsaBridge {
         results
             .into_iter()
             .map(|result| match result {
-                Some(value) => {
-                    Ok(parse_json_value::<LspDefinitionResponse>(value)?.into_locations())
-                }
+                Some(value) => parse_lsp_locations(value),
                 None => Ok(Vec::new()),
             })
             .collect()
@@ -127,7 +125,7 @@ impl CorsaBridge {
         }
 
         if let Some(value) = result {
-            return Ok(parse_json_value::<LspDefinitionResponse>(value)?.into_locations());
+            return parse_lsp_locations(value);
         }
 
         Ok(Vec::new())

--- a/crates/vize_canon/src/lsp_client/editor_lsp/declaration.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/declaration.rs
@@ -2,7 +2,10 @@ use corsa::runtime::block_on;
 use serde_json::Value;
 use vize_s0::{String, cstr};
 
-use super::{EditorLspSession, requests::RawDeclarationRequest};
+use super::{
+    EditorLspSession,
+    requests::{RawDeclarationRequest, positional_text_document_request_params},
+};
 
 impl EditorLspSession {
     pub(super) fn declaration(
@@ -12,13 +15,9 @@ impl EditorLspSession {
         character: u32,
     ) -> Result<Option<Value>, String> {
         let uri = self.ready_document_uri(document_uri)?;
-        block_on(
-            self.client
-                .request::<RawDeclarationRequest>(serde_json::json!({
-                    "textDocument": { "uri": uri },
-                    "position": { "line": line, "character": character },
-                })),
-        )
+        block_on(self.client.request::<RawDeclarationRequest>(
+            positional_text_document_request_params(&uri, line, character),
+        ))
         .map_err(|error| cstr!("Failed to request editor LSP declaration: {error}"))
     }
 }

--- a/crates/vize_canon/src/lsp_client/editor_lsp/implementation.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/implementation.rs
@@ -2,7 +2,10 @@ use corsa::runtime::block_on;
 use serde_json::Value;
 use vize_s0::{String, cstr};
 
-use super::{EditorLspSession, requests::RawImplementationRequest};
+use super::{
+    EditorLspSession,
+    requests::{RawImplementationRequest, positional_text_document_request_params},
+};
 
 impl EditorLspSession {
     pub(super) fn implementation(
@@ -12,13 +15,9 @@ impl EditorLspSession {
         character: u32,
     ) -> Result<Option<Value>, String> {
         let uri = self.ready_document_uri(document_uri)?;
-        block_on(
-            self.client
-                .request::<RawImplementationRequest>(serde_json::json!({
-                    "textDocument": { "uri": uri },
-                    "position": { "line": line, "character": character },
-                })),
-        )
+        block_on(self.client.request::<RawImplementationRequest>(
+            positional_text_document_request_params(&uri, line, character),
+        ))
         .map_err(|error| cstr!("Failed to request editor LSP implementation: {error}"))
     }
 }

--- a/crates/vize_canon/src/lsp_client/editor_lsp/requests.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/requests.rs
@@ -118,6 +118,17 @@ impl lsp_types::request::Request for RawWillRenameFilesRequest {
     const METHOD: &'static str = "workspace/willRenameFiles";
 }
 
+pub(super) fn positional_text_document_request_params(
+    uri: &Uri,
+    line: u32,
+    character: u32,
+) -> Value {
+    serde_json::json!({
+        "textDocument": { "uri": uri },
+        "position": { "line": line, "character": character },
+    })
+}
+
 pub(super) fn signature_help_request_params(
     uri: &Uri,
     line: u32,

--- a/crates/vize_canon/src/lsp_client/editor_lsp/tests.rs
+++ b/crates/vize_canon/src/lsp_client/editor_lsp/tests.rs
@@ -1,6 +1,32 @@
 use super::*;
 
 #[test]
+fn declaration_and_implementation_requests_use_standard_lsp_methods() {
+    assert_eq!(
+        <requests::RawDeclarationRequest as lsp_types::request::Request>::METHOD,
+        "textDocument/declaration"
+    );
+    assert_eq!(
+        <requests::RawImplementationRequest as lsp_types::request::Request>::METHOD,
+        "textDocument/implementation"
+    );
+}
+
+#[test]
+fn positional_language_feature_params_use_lsp_text_document_position_shape() {
+    let uri = Uri::from_str("file:///workspace/src/App.vue.ts").unwrap();
+    let params = requests::positional_text_document_request_params(&uri, 12, 34);
+
+    assert_eq!(
+        params,
+        serde_json::json!({
+            "textDocument": { "uri": "file:///workspace/src/App.vue.ts" },
+            "position": { "line": 12, "character": 34 }
+        })
+    );
+}
+
+#[test]
 fn prepare_call_hierarchy_uses_editor_lsp_runtime_items() {
     if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
         return;

--- a/crates/vize_canon/tests/lsp_declaration_implementation.rs
+++ b/crates/vize_canon/tests/lsp_declaration_implementation.rs
@@ -1,0 +1,118 @@
+use std::path::{Path, PathBuf};
+
+use vize_canon::{CorsaBridge, CorsaBridgeConfig, LspLocation};
+use vize_s0::ToCompactString;
+
+#[test]
+fn bridge_requests_implementation_from_corsa_tsgo() {
+    let Some(corsa_path) = resolve_tsgo_binary() else {
+        return;
+    };
+    let source = "interface Service {\n  run(): string;\n}\nclass ConcreteService implements Service {\n  run(): string { return 'ok'; }\n}\n";
+    let (_project, project_root, source_path) = write_ts_project("service.ts", source);
+    let (line, character) = position(source, "interface ".len() + 1);
+    let (uri, locations) = request_locations(
+        &corsa_path,
+        &project_root,
+        &source_path,
+        source,
+        line,
+        character,
+    );
+
+    assert_contains_location(&locations, &uri, 3, "class ".len() as u32);
+}
+
+fn request_locations(
+    corsa_path: &Path,
+    project_root: &Path,
+    source_path: &Path,
+    source: &str,
+    line: u32,
+    character: u32,
+) -> (String, Vec<LspLocation>) {
+    let bridge = CorsaBridge::with_config(CorsaBridgeConfig {
+        corsa_path: Some(corsa_path.to_path_buf()),
+        working_dir: Some(project_root.to_path_buf()),
+        timeout_ms: 30_000,
+        ..Default::default()
+    });
+
+    corsa::runtime::block_on(async {
+        bridge.spawn().await.expect("tsgo session");
+        let uri = source_path.display().to_compact_string();
+        let uri = bridge
+            .open_or_update_virtual_document(uri.as_str(), source)
+            .await
+            .expect("open source");
+        let locations = bridge
+            .implementation(&uri, line, character)
+            .await
+            .expect("implementation request");
+        bridge.shutdown().await.expect("shutdown");
+        (uri.into(), locations)
+    })
+}
+
+fn write_ts_project(file_name: &str, source: &str) -> (tempfile::TempDir, PathBuf, PathBuf) {
+    let project = tempfile::TempDir::new().expect("temp project");
+    let project_root = project.path().to_path_buf();
+    let src = project_root.join("src");
+    std::fs::create_dir_all(&src).expect("src");
+    std::fs::create_dir(project_root.join("node_modules")).expect("node_modules");
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .expect("tsconfig");
+    let source_path = src.join(file_name);
+    std::fs::write(&source_path, source).expect("source");
+    (project, project_root, source_path)
+}
+
+fn assert_contains_location(
+    locations: &[LspLocation],
+    uri: &str,
+    start_line: u32,
+    start_character: u32,
+) {
+    assert!(
+        locations.iter().any(|location| location.uri == uri
+            && location.range.start.line == start_line
+            && location.range.start.character == start_character),
+        "expected {uri}:{start_line}:{start_character}, got {locations:#?}",
+    );
+}
+
+fn position(source: &str, offset: usize) -> (u32, u32) {
+    let prefix = &source[..offset];
+    let line = prefix.bytes().filter(|byte| *byte == b'\n').count() as u32;
+    let line_start = prefix.rfind('\n').map_or(0, |index| index + 1);
+    let character = prefix[line_start..].encode_utf16().count() as u32;
+    (line, character)
+}
+
+fn resolve_tsgo_binary() -> Option<PathBuf> {
+    if std::env::var_os("VIZE_TEST_DISABLE_TSGO").is_some() {
+        return None;
+    }
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)?;
+    vize_s0::corsa_resolver::resolve_corsa_executable(
+        vize_s0::corsa_resolver::CorsaResolveRequest {
+            project_root: Some(workspace_root),
+            ..Default::default()
+        },
+    )
+    .ok()
+}


### PR DESCRIPTION
## Summary
- add exact editor-LSP method and textDocument/position request-shape coverage for declaration and implementation
- share Corsa bridge LSP location-response normalization across definition, typeDefinition, declaration, and implementation
- add a focused CorsaBridge implementation request test against the tsgo-backed editor LSP path

## Validation
- cargo fmt --all --check
- cargo test -p vize_canon --lib declaration_and_implementation
- cargo test -p vize_canon --lib positional_language_feature_params_use_lsp_text_document_position_shape
- cargo test -p vize_canon --test lsp_declaration_implementation -- --nocapture
- git diff --check origin/main...HEAD

Refs #3953

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791230978&installation_model_id=422833&pr_number=5770&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5770&signature=9d06a45253e1b9fd860b3dfb04e8eb0d099ab3d64471b2e2758b1f6adf0f0f7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->