### PR TITLE
feat(davinci): return S2 DOM section boundaries

### DIFF
--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -94,7 +94,7 @@ pub struct CodegenContext {
 /// hoisted consts / asset preamble / render body. Recording the boundaries
 /// while the code is written lets the caller slice the buffer directly
 /// instead of re-scanning the output line by line.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CodegenSections {
     /// Byte length of the import statement section at the start of
     /// `preamble`. Hoisted declarations (when present) follow after a single

--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -14,6 +14,7 @@ use vize_croquis::Croquis;
 use vize_s0::{Allocator, String, profile};
 
 mod pipeline;
+mod sfc;
 mod stage_options;
 
 use crate::options::DomCompilerOptions;

--- a/crates/vize_atelier_dom/src/compile/custom_elements.rs
+++ b/crates/vize_atelier_dom/src/compile/custom_elements.rs
@@ -1,6 +1,7 @@
 use super::{
     compile_template_inner, compile_template_inner_with_sections,
     pipeline::DomCompilePipelineOptions,
+    sfc::{compile_template_inner_for_sfc, compile_template_inner_for_sfc_with_sections},
 };
 use crate::DomCompilerOptions;
 use vize_atelier_core::{
@@ -51,5 +52,59 @@ pub fn compile_template_with_custom_elements_and_template_syntax_and_hoisted_sco
         template_syntax,
         hoisted_scope_id,
         DomCompilePipelineOptions::require_sections(custom_elements, codegen_options),
+    )
+}
+
+/// Compile with declarative custom-element patterns and an SFC hoisted scope ID.
+#[doc(hidden)]
+pub fn compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_and_codegen_options<
+    'a,
+>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    options: DomCompilerOptions,
+    template_syntax: TemplateSyntaxMode,
+    hoisted_scope_id: Option<String>,
+    custom_elements: CustomElementMatcher,
+    codegen_options: CodegenOptions,
+) -> (RootNode<'a>, Vec<CompilerError>, CodegenResult) {
+    compile_template_inner_for_sfc(
+        allocator,
+        source,
+        options,
+        template_syntax,
+        hoisted_scope_id,
+        custom_elements,
+        codegen_options,
+    )
+}
+
+/// Compile an SFC template block with section metadata and custom-element patterns.
+///
+/// This entry returns only diagnostics and codegen because SFC assembly does
+/// not consume the DOM `RootNode`. That lets the fully supported S2 sections
+/// lane avoid constructing the legacy transformed AST solely to throw it away;
+/// unsupported or diagnostic inputs still fall back to the ordinary section
+/// path so warning/error behavior stays with the shipped compiler.
+#[doc(hidden)]
+pub fn compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options<
+    'a,
+>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    options: DomCompilerOptions,
+    template_syntax: TemplateSyntaxMode,
+    hoisted_scope_id: Option<String>,
+    custom_elements: CustomElementMatcher,
+    codegen_options: CodegenOptions,
+) -> (Vec<CompilerError>, CodegenResultWithSections) {
+    compile_template_inner_for_sfc_with_sections(
+        allocator,
+        source,
+        options,
+        template_syntax,
+        hoisted_scope_id,
+        custom_elements,
+        codegen_options,
     )
 }

--- a/crates/vize_atelier_dom/src/compile/pipeline.rs
+++ b/crates/vize_atelier_dom/src/compile/pipeline.rs
@@ -4,6 +4,7 @@ use vize_atelier_core::options::{CodegenOptions, CustomElementMatcher};
 pub(super) enum S2EmitSelection {
     Allowed,
     RequireSections,
+    Disabled,
 }
 
 pub(super) struct DomCompilePipelineOptions {
@@ -32,6 +33,17 @@ impl DomCompilePipelineOptions {
             custom_elements,
             codegen_options,
             s2_emit_selection: S2EmitSelection::RequireSections,
+        }
+    }
+
+    pub(super) fn require_sections_compat(
+        custom_elements: CustomElementMatcher,
+        codegen_options: CodegenOptions,
+    ) -> Self {
+        Self {
+            custom_elements,
+            codegen_options,
+            s2_emit_selection: S2EmitSelection::Disabled,
         }
     }
 }

--- a/crates/vize_atelier_dom/src/compile/sfc.rs
+++ b/crates/vize_atelier_dom/src/compile/sfc.rs
@@ -1,0 +1,232 @@
+use super::{
+    compile_template_inner_with_sections,
+    pipeline::{self, DomCompilePipelineOptions},
+    stage_options,
+};
+use crate::options::DomCompilerOptions;
+use vize_atelier_core::{
+    CompilerError, RootNode,
+    codegen::{CodegenResult, CodegenResultWithSections},
+    options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode},
+};
+use vize_s0::{Allocator, String, profile};
+
+pub(super) fn compile_template_inner_for_sfc_with_sections<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    options: DomCompilerOptions,
+    template_syntax: TemplateSyntaxMode,
+    hoisted_scope_id: Option<String>,
+    custom_elements: CustomElementMatcher,
+    codegen_options: CodegenOptions,
+) -> (Vec<CompilerError>, CodegenResultWithSections) {
+    let codegen_opts = stage_options::codegen_options(&options, codegen_options.clone());
+    let use_s2_emit = stage_options::s2_emit_supported(
+        &options,
+        &codegen_opts,
+        !custom_elements.is_empty(),
+        template_syntax,
+        options.croquis.is_some(),
+        pipeline::S2EmitSelection::RequireSections,
+    );
+
+    let mut force_compat_sections = false;
+
+    if use_s2_emit && s2_sfc_fast_path_supported_source(source) {
+        let binding_table = stage_options::s2_binding_table(options.binding_metadata.as_ref());
+        let s2_options = stage_options::s2_emit_options(
+            &options,
+            &codegen_opts,
+            binding_table.as_ref(),
+            hoisted_scope_id.as_deref(),
+        );
+        if let Ok(result) = profile!(
+            "atelier.dom.template.s2_codegen_sfc_fast",
+            stage_options::emit_s2(allocator, source, options.dialect, &s2_options)
+        ) {
+            return (Vec::new(), result);
+        }
+        force_compat_sections = true;
+    } else if use_s2_emit {
+        force_compat_sections = true;
+    }
+
+    let pipeline_options = if force_compat_sections {
+        DomCompilePipelineOptions::require_sections_compat(custom_elements, codegen_options)
+    } else {
+        DomCompilePipelineOptions::require_sections(custom_elements, codegen_options)
+    };
+
+    let (_, errors, result) = compile_template_inner_with_sections(
+        allocator,
+        source,
+        options,
+        template_syntax,
+        hoisted_scope_id,
+        pipeline_options,
+    );
+    (errors, result)
+}
+
+pub(super) fn compile_template_inner_for_sfc<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    options: DomCompilerOptions,
+    template_syntax: TemplateSyntaxMode,
+    hoisted_scope_id: Option<String>,
+    custom_elements: CustomElementMatcher,
+    codegen_options: CodegenOptions,
+) -> (RootNode<'a>, Vec<CompilerError>, CodegenResult) {
+    let (root, errors, result) = compile_template_inner_with_sections(
+        allocator,
+        source,
+        options,
+        template_syntax,
+        hoisted_scope_id,
+        DomCompilePipelineOptions::require_sections_compat(custom_elements, codegen_options),
+    );
+    (root, errors, result.into_result())
+}
+
+fn s2_sfc_fast_path_supported_source(source: &str) -> bool {
+    !source_contains_foreign_namespace_tag(source)
+        && !source_contains_non_void_native_self_closing_tag(source)
+}
+
+fn source_contains_foreign_namespace_tag(source: &str) -> bool {
+    let bytes = source.as_bytes();
+    let mut index = 0;
+
+    while let Some(offset) = source[index..].find('<') {
+        let name_start = index + offset + 1;
+        if name_start >= bytes.len() {
+            break;
+        }
+
+        if matches!(bytes[name_start], b'/' | b'!' | b'?') {
+            index = name_start + 1;
+            continue;
+        }
+
+        let name_end = scan_tag_name(bytes, name_start);
+        if name_end == name_start {
+            index = name_start + 1;
+            continue;
+        }
+
+        let name = &source[name_start..name_end];
+        if name.eq_ignore_ascii_case("svg") || name.eq_ignore_ascii_case("math") {
+            return true;
+        }
+
+        index = name_end;
+    }
+
+    false
+}
+
+fn source_contains_non_void_native_self_closing_tag(source: &str) -> bool {
+    let bytes = source.as_bytes();
+    let mut index = 0;
+
+    while let Some(offset) = source[index..].find('<') {
+        let name_start = index + offset + 1;
+        if name_start >= bytes.len() {
+            break;
+        }
+
+        if matches!(bytes[name_start], b'/' | b'!' | b'?') {
+            index = name_start + 1;
+            continue;
+        }
+
+        let name_end = scan_tag_name(bytes, name_start);
+        if name_end == name_start {
+            index = name_start + 1;
+            continue;
+        }
+
+        let name = &source[name_start..name_end];
+        if is_plain_native_html_tag_name(name)
+            && !is_html_void_tag_name(name)
+            && !is_allowed_self_closing_special_tag_name(name)
+            && tag_closes_self_closing(bytes, name_end)
+        {
+            return true;
+        }
+
+        index = name_end;
+    }
+
+    false
+}
+
+fn scan_tag_name(bytes: &[u8], start: usize) -> usize {
+    let mut end = start;
+    while end < bytes.len() && is_tag_name_byte(bytes[end]) {
+        end += 1;
+    }
+    end
+}
+
+fn is_tag_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b':')
+}
+
+fn is_plain_native_html_tag_name(name: &str) -> bool {
+    name.bytes()
+        .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
+}
+
+fn is_html_void_tag_name(name: &str) -> bool {
+    matches!(
+        name,
+        "area"
+            | "base"
+            | "br"
+            | "col"
+            | "embed"
+            | "hr"
+            | "img"
+            | "input"
+            | "link"
+            | "meta"
+            | "param"
+            | "source"
+            | "track"
+            | "wbr"
+    )
+}
+
+fn is_allowed_self_closing_special_tag_name(name: &str) -> bool {
+    matches!(name, "component" | "slot")
+}
+
+fn tag_closes_self_closing(bytes: &[u8], start: usize) -> bool {
+    let mut index = start;
+    let mut quote = None;
+    let mut last_non_whitespace = None;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+
+        if let Some(quote_byte) = quote {
+            if byte == quote_byte {
+                quote = None;
+            }
+            index += 1;
+            continue;
+        }
+
+        match byte {
+            b'\'' | b'"' => quote = Some(byte),
+            b'>' => return last_non_whitespace == Some(b'/'),
+            b if b.is_ascii_whitespace() => {}
+            _ => last_non_whitespace = Some(byte),
+        }
+
+        index += 1;
+    }
+
+    false
+}

--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -3,7 +3,7 @@
 //! Keeps the parse/transform option wiring out of `compile.rs` so that entry
 //! point stays focused on pipeline flow.
 
-use vize_atelier_core::codegen::{CodegenResult, CodegenResultWithSections};
+use vize_atelier_core::codegen::{CodegenResult, CodegenResultWithSections, CodegenSections};
 use vize_atelier_core::options::{
     BindingMetadata, BindingType, CodegenMode, CodegenOptions, ParserOptions, TemplateSyntaxMode,
     TransformOptions,
@@ -11,7 +11,7 @@ use vize_atelier_core::options::{
 use vize_s0::Allocator;
 use vize_s0::profiler::global_profiler;
 use vize_s1_to_s2::{
-    BindingKind, BindingTable, DomEmitMode, DomEmitOptions, EmitError, LegacyCaps,
+    BindingKind, BindingTable, DomEmitMode, DomEmitOptions, DomEmitSections, EmitError, LegacyCaps,
 };
 
 use super::pipeline::S2EmitSelection;
@@ -84,8 +84,10 @@ pub(super) fn s2_emit_supported(
     has_croquis: bool,
     s2_emit_selection: S2EmitSelection,
 ) -> bool {
-    s2_emit_selection == S2EmitSelection::Allowed
-        && !codegen.source_map
+    matches!(
+        s2_emit_selection,
+        S2EmitSelection::Allowed | S2EmitSelection::RequireSections
+    ) && !codegen.source_map
         && options.hoist_static
         && !options.ssr
         && !options.comments
@@ -185,11 +187,20 @@ pub(super) fn emit_s2(
             preamble: emit.preamble,
             map: None,
         },
-        // S2 does not retain emission offsets yet. SFC assembly keeps its
-        // established scanner fallback until the source-map/section work
-        // moves into the S2 backend.
-        sections: None,
+        // S2 records the same structural render-module boundaries as the
+        // shipped emitter so SFC assembly can slice either lane identically.
+        sections: Some(s2_codegen_sections(emit.sections)),
     })
+}
+
+const fn s2_codegen_sections(sections: DomEmitSections) -> CodegenSections {
+    CodegenSections {
+        imports_len: sections.imports_len,
+        assets_start: sections.assets_start,
+        assets_end: sections.assets_end,
+        return_expr_start: sections.return_expr_start,
+        return_expr_end: sections.return_expr_end,
+    }
 }
 
 const fn s2_binding_kind(kind: BindingType) -> BindingKind {

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -26,7 +26,9 @@ pub mod steps;
 mod tests;
 
 pub use compile::custom_elements::{
+    compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
     compile_template_with_custom_elements_and_template_syntax_and_codegen_options,
+    compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_and_codegen_options,
     compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
 };
 pub use compile::{

--- a/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
@@ -10,7 +10,7 @@
 use vize_atelier_core::options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode};
 use vize_atelier_dom::{
     DomCompilerOptions,
-    compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+    compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
     compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
 };
 use vize_s0::Allocator;
@@ -41,10 +41,7 @@ fn source_map_free_dom_compile_uses_s2_without_profiler() {
 
     assert_eq!(selected.preamble, compat.preamble);
     assert_eq!(selected.code, compat.code);
-    assert!(
-        selected.sections.is_none(),
-        "source-map-free supported DOM compiles should come from the S2 selector"
-    );
+    assert_eq!(selected.sections, compat.sections);
     assert_eq!(
         counter_total(&counters, "davinci.s2_dom.files"),
         None,
@@ -128,26 +125,30 @@ fn unsupported_options_stay_on_compatibility_without_profiler() {
 }
 
 #[test]
-fn sfc_sections_entry_stays_on_compatibility_until_s2_sections_land() {
+fn sfc_sections_entry_uses_s2_once_sections_land() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
     profiler.clear();
 
-    let result = compile_sfc_sections_entry(
-        r#"<button @click="go">{{ label }}</button>"#,
-        DomCompilerOptions::default(),
+    let source = r#"<button @click="go">{{ label }}</button>"#;
+    let compat = compile_sfc_sections_entry(
+        source,
+        DomCompilerOptions {
+            source_map: true,
+            ..Default::default()
+        },
     );
+    let selected = compile_sfc_sections_entry(source, DomCompilerOptions::default());
     let counters = profiler.counter_summary();
 
-    assert!(
-        result.sections.is_some(),
-        "SFC template assembly needs compatibility sections until S2 records them"
-    );
+    assert_eq!(selected.preamble, compat.preamble);
+    assert_eq!(selected.code, compat.code);
+    assert_eq!(selected.sections, compat.sections);
     assert_eq!(
         counter_total(&counters, "davinci.s2_dom.files"),
         None,
-        "compatibility compiles must not instantiate the profiling observer"
+        "the SFC sections entry must not instantiate the profiling observer"
     );
 }
 
@@ -178,8 +179,8 @@ fn compile(source: &str, options: DomCompilerOptions) -> Compiled {
 
 fn compile_sfc_sections_entry(source: &str, options: DomCompilerOptions) -> Compiled {
     let allocator = Allocator::new();
-    let (_, errors, result) =
-        compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+    let (errors, result) =
+        compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
             &allocator,
             source,
             options,

--- a/crates/vize_atelier_sfc/src/compile_template.rs
+++ b/crates/vize_atelier_sfc/src/compile_template.rs
@@ -194,18 +194,40 @@ pub(crate) fn compile_template_block(
     }
 
     // Compile template
-    let (_, errors, result) = profile!(
-        "atelier.sfc.template.dom",
-        vize_atelier_dom::compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
-            allocator,
-            &template.content,
-            dom_opts,
-            template_syntax,
-            hoisted_scope_attr,
-            custom_elements.clone(),
-            codegen_options.clone(),
+    let (errors, result) = if inline {
+        profile!(
+            "atelier.sfc.template.dom",
+            vize_atelier_dom::compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+                allocator,
+                &template.content,
+                dom_opts,
+                template_syntax,
+                hoisted_scope_attr,
+                custom_elements.clone(),
+                codegen_options.clone(),
+            )
         )
-    );
+    } else {
+        let (_, errors, result) = profile!(
+            "atelier.sfc.template.dom",
+            vize_atelier_dom::compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_and_codegen_options(
+                allocator,
+                &template.content,
+                dom_opts,
+                template_syntax,
+                hoisted_scope_attr,
+                custom_elements.clone(),
+                codegen_options.clone(),
+            )
+        );
+        (
+            errors,
+            vize_atelier_core::codegen::CodegenResultWithSections {
+                result,
+                sections: None,
+            },
+        )
+    };
 
     // See above — drop recoverable parser diagnostics from the gating
     // check so duplicate-attribute SFCs still produce valid render code. (#958)

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -125,7 +125,8 @@ pub use self::budget::{
 use self::buf::Buf;
 use self::dispatch::{emit_for_item_call, emit_for_op, emit_if_branch_call, emit_if_op};
 pub use self::entry::{
-    DomEmit, emit_dom_source, emit_dom_source_with_caps, emit_dom_source_with_options,
+    DomEmit, DomEmitSections, emit_dom_source, emit_dom_source_with_caps,
+    emit_dom_source_with_options,
 };
 pub use self::error::{EmitError, UnsupportedReason, UnsupportedRefusal};
 pub use self::options::{BindingKind, BindingTable, DomEmitMode, DomEmitOptions};

--- a/crates/vize_s1_to_s2/src/emit/buf/preamble.rs
+++ b/crates/vize_s1_to_s2/src/emit/buf/preamble.rs
@@ -11,10 +11,18 @@ impl Buf {
     /// destructure or the module-mode import, per `options.mode` — then
     /// any root static-props hoist (the shipped codegen appends hoists to
     /// the helper preamble in both modes).
+    #[cfg(test)]
     pub(in crate::emit) fn preamble(&self, options: &DomEmitOptions<'_>) -> String {
+        self.preamble_with_imports_len(options).0
+    }
+
+    pub(in crate::emit) fn preamble_with_imports_len(
+        &self,
+        options: &DomEmitOptions<'_>,
+    ) -> (String, usize) {
         let listed = self.ordered_helpers();
         if listed.is_empty() {
-            return String::default();
+            return (String::default(), 0);
         }
         let mut preamble = String::default();
         match options.mode {
@@ -47,6 +55,7 @@ impl Buf {
                 preamble.push_str("\"\n");
             }
         }
+        let imports_len = preamble.len();
         if !self.hoists.is_empty() {
             preamble.push('\n');
             for (i, rhs) in self.hoists.iter().enumerate() {
@@ -57,6 +66,6 @@ impl Buf {
                 preamble.push('\n');
             }
         }
-        preamble
+        (preamble, imports_len)
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/entry.rs
+++ b/crates/vize_s1_to_s2/src/emit/entry.rs
@@ -19,6 +19,23 @@ pub struct DomEmit {
     pub preamble: String,
     /// The `function render(…)` body, no trailing newline after `}`.
     pub code: String,
+    /// Emission-recorded section boundaries in the same buffers.
+    pub sections: DomEmitSections,
+}
+
+/// Byte offsets of the structural sections of one S2 DOM render module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DomEmitSections {
+    /// Byte length of the import/destructure section at the start of
+    /// [`DomEmit::preamble`]. Hoisted declarations, when present, follow it.
+    pub imports_len: usize,
+    /// Byte range in [`DomEmit::code`] covering component/directive/filter
+    /// resolution statements inside the render function.
+    pub assets_start: usize,
+    pub assets_end: usize,
+    /// Byte range in [`DomEmit::code`] covering the root `return` expression.
+    pub return_expr_start: usize,
+    pub return_expr_end: usize,
 }
 
 impl DomEmit {

--- a/crates/vize_s1_to_s2/src/emit/run.rs
+++ b/crates/vize_s1_to_s2/src/emit/run.rs
@@ -16,8 +16,8 @@ use super::buf::Buf;
 use super::fragment::emit_root;
 use super::helper::Helper;
 use super::{
-    DomEmit, DomEmitOptions, EmitCx, EmitError, UnsupportedReason, cache_slots, component,
-    directive, filter, fragment, helper_preference, prefix, static_cache,
+    DomEmit, DomEmitOptions, DomEmitSections, EmitCx, EmitError, UnsupportedReason, cache_slots,
+    component, directive, filter, fragment, helper_preference, prefix, static_cache,
 };
 
 /// Emit a DOM render function from an already-lowered (and typically
@@ -114,6 +114,7 @@ pub(super) fn emit_dom_with_emit_budget<'f>(
         .push(options.mode.render_signature(options.bindings.is_some()));
     cx.buf.indent();
     cx.buf.newline();
+    let assets_start = cx.buf.code.len();
     let names = component::collect_names(&lowered.root);
     let dirs = directive::collect_names(&lowered.root);
     let mut resolved_assets = false;
@@ -127,11 +128,14 @@ pub(super) fn emit_dom_with_emit_budget<'f>(
         filter::emit_resolves(&mut cx, filters);
         resolved_assets = true;
     }
+    let assets_end = cx.buf.code.len();
     if resolved_assets {
         cx.buf.newline();
     }
     cx.buf.push("return ");
+    let return_expr_start = cx.buf.code.len();
     emit_root(&mut cx, &lowered.root)?;
+    let return_expr_end = cx.buf.code.len();
     cx.buf.deindent();
     cx.buf.newline();
     cx.buf.push("}");
@@ -145,7 +149,20 @@ pub(super) fn emit_dom_with_emit_budget<'f>(
     }
     cache_slots::renumber(&mut cx);
     let emit_visits = cx.walk.visits();
-    let preamble = cx.buf.preamble(options);
+    let (preamble, imports_len) = cx.buf.preamble_with_imports_len(options);
     let code = cx.buf.code;
-    Ok((DomEmit { preamble, code }, emit_visits))
+    Ok((
+        DomEmit {
+            preamble,
+            code,
+            sections: DomEmitSections {
+                imports_len,
+                assets_start,
+                assets_end,
+                return_expr_start,
+                return_expr_end,
+            },
+        },
+        emit_visits,
+    ))
 }

--- a/crates/vize_s1_to_s2/src/lib.rs
+++ b/crates/vize_s1_to_s2/src/lib.rs
@@ -70,10 +70,11 @@ pub mod lower;
 pub mod pass;
 
 pub use emit::{
-    BindingKind, BindingTable, DomEmit, DomEmitBudget, DomEmitMode, DomEmitOptions, EmitError,
-    ObservedDomEmit, UnsupportedReason, UnsupportedRefusal, emit_dom, emit_dom_source,
-    emit_dom_source_observed, emit_dom_source_observed_with_options, emit_dom_source_with_caps,
-    emit_dom_source_with_caps_observed, emit_dom_source_with_options, emit_dom_with_options,
+    BindingKind, BindingTable, DomEmit, DomEmitBudget, DomEmitMode, DomEmitOptions,
+    DomEmitSections, EmitError, ObservedDomEmit, UnsupportedReason, UnsupportedRefusal, emit_dom,
+    emit_dom_source, emit_dom_source_observed, emit_dom_source_observed_with_options,
+    emit_dom_source_with_caps, emit_dom_source_with_caps_observed, emit_dom_source_with_options,
+    emit_dom_with_options,
 };
 pub use lower::{
     LegacyCaps, Lowered, lower, lower_source_block, lower_source_block_with_caps,


### PR DESCRIPTION
Summary:
- Expose S2 DOM emit section offsets for imports, asset resolution, and the returned root expression.
- Use S2 for section-aware DOM compile entries while preserving compatibility fallback for unsupported options.
- Pin production selector coverage for section equality and unsupported option gates.

Checks:
- cargo fmt --check
- git diff --check
- cargo test -p vize_atelier_dom --test davinci_s2_production_selector --test davinci_s2_profile -- --nocapture
- cargo test -p vize_s1_to_s2 --tests
- node --test tests/tooling/davinci-dom-production-boundary.test.ts tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791231592&installation_model_id=422833&pr_number=5771&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5771&signature=e6d7dd6ac01eff3d81e22a03f25ccc7236157f395fe4e7e68bc1030acddcefae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved template compilation with a faster path for supported templates.
  - Automatically uses compatibility processing for templates with unsupported syntax or markup.

- **Compilation Output**
  - Added structural information to generated output for more precise handling of imports, assets, and returned expressions.
  - SFC compilation now preserves this information for inline templates.

- **Reliability**
  - Ensured optimized compilation results remain consistent with compatibility output.
  - Added safeguards for special markup and unsupported self-closing elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->