### PR TITLE
test(davinci): pin source-map selector profiling

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
@@ -50,6 +50,41 @@ fn source_map_free_dom_compile_uses_s2_without_profiler() {
 }
 
 #[test]
+fn source_map_compiles_stay_on_compatibility_when_profiled() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+
+    let source = r#"<button @click="go">{{ label }}</button>"#;
+    let source_map_free = compile(source, DomCompilerOptions::default());
+
+    profiler.enable();
+    let mapped = compile(
+        source,
+        DomCompilerOptions {
+            source_map: true,
+            ..Default::default()
+        },
+    );
+    let counters = profiler.counter_summary();
+    profiler.disable();
+    profiler.clear();
+
+    assert_eq!(mapped.preamble, source_map_free.preamble);
+    assert_eq!(mapped.code, source_map_free.code);
+    assert!(
+        mapped.map.is_some(),
+        "source-map compiles must produce the compatibility map"
+    );
+    assert_eq!(
+        counter_total(&counters, "davinci.s2_dom.files"),
+        None,
+        "source-map compiles must stay on compatibility until S2 records map segments"
+    );
+}
+
+#[test]
 fn comments_stay_on_compatibility_without_profiler() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
@@ -155,6 +190,7 @@ fn sfc_sections_entry_uses_s2_once_sections_land() {
 struct Compiled {
     preamble: String,
     code: String,
+    map: Option<String>,
     sections: Option<vize_atelier_core::CodegenSections>,
 }
 
@@ -173,6 +209,7 @@ fn compile(source: &str, options: DomCompilerOptions) -> Compiled {
     Compiled {
         preamble: result.result.preamble.to_string(),
         code: result.result.code.to_string(),
+        map: result.result.map.map(|map| map.to_string()),
         sections: result.sections,
     }
 }
@@ -193,6 +230,7 @@ fn compile_sfc_sections_entry(source: &str, options: DomCompilerOptions) -> Comp
     Compiled {
         preamble: result.result.preamble.to_string(),
         code: result.result.code.to_string(),
+        map: result.result.map.map(|map| map.to_string()),
         sections: result.sections,
     }
 }


### PR DESCRIPTION
Summary:
- Add profiler-enabled selector coverage for source-map DOM compiles.
- Assert mapped compiles still produce a source map while staying on compatibility until S2 records map segments.

Checks:
- TMPDIR=$PWD/target/vize-tests/tmp TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp cargo test -p vize_atelier_dom --test davinci_s2_profile --test davinci_s2_production_selector -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-dom-production-boundary.test.ts
- rust-script tools/commands/davinci/assertion-lint.rs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791237255&installation_model_id=422833&pr_number=5772&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5772&signature=5f999c6753fb1258cc8c517b771ab27041705e4b01add6444d5ad0e5208e5981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify DOM compilation with source maps remains compatible when profiling is enabled.
  * Added checks confirming that S2 profiling counters are not created in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->