### PR TITLE
test(vscode): pin LSP feature switch forwarding

### DIFF
--- a/tests/tooling/lsp-editor-feature-matrix.test.ts
+++ b/tests/tooling/lsp-editor-feature-matrix.test.ts
@@ -159,6 +159,27 @@ test("feature setting keys are backed by the VS Code manifest", () => {
   }
 });
 
+test("every direct VS Code feature switch forwards explicit LSP option values", () => {
+  for (const key of FEATURE_SETTING_KEYS) {
+    if (key === "diagnostics.enable") {
+      continue;
+    }
+
+    const option = key.slice(0, -".enable".length);
+
+    assert.deepEqual(
+      getInitializationOptions(new FakeConfig({ enable: true, [key]: true })),
+      { [option]: true },
+      `${key} should enable ${option}`,
+    );
+    assert.deepEqual(
+      getInitializationOptions(new FakeConfig({ enable: true, [key]: false })),
+      { [option]: false },
+      `${key} should disable ${option}`,
+    );
+  }
+});
+
 test("document selector covers supported language and URI scheme product", () => {
   assert.deepEqual(createDocumentSelector(), [
     { scheme: "file", language: "vue" },


### PR DESCRIPTION
## Summary

- add a VS Code extension matrix regression that checks every direct feature switch forwards explicit true and false values to `vize lsp`
- keep the diagnostics alias separate so lint precedence remains covered by the existing alias test

Refs #3953.
Refs #3957.

## Validation

- `node --test tests/tooling/lsp-editor-feature-matrix.test.ts`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`
- `cargo build -p vize --locked`
- `node --test tests/tooling/lsp-capabilities.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791237257&installation_model_id=422833&pr_number=5773&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5773&signature=c77f96615af58a87ab50daa5f364b03f145b7c620959f70d40b21f09a38dff58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->