### PR TITLE
test(davinci): pin profiled unsupported option routing

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_profile_unsupported.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_profile_unsupported.rs
@@ -1,0 +1,95 @@
+//! P2-11 witness: profiling must not make unsupported DOM option shapes look
+//! like S2 production-selector coverage.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use vize_atelier_dom::{DomCompilerOptions, compile_template_with_options};
+use vize_s0::Allocator;
+use vize_s0::profiler::{CounterSummary, global_profiler};
+
+static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[test]
+fn profiled_unsupported_options_stay_on_compatibility_codegen() {
+    let _guard = lock_profiler();
+    for (label, options) in [
+        (
+            "ssr",
+            DomCompilerOptions {
+                ssr: true,
+                ..Default::default()
+            },
+        ),
+        (
+            "patterned_template",
+            DomCompilerOptions {
+                experimental_patterned_template: true,
+                ..Default::default()
+            },
+        ),
+        (
+            "custom_renderer",
+            DomCompilerOptions {
+                custom_renderer: true,
+                ..Default::default()
+            },
+        ),
+    ] {
+        let profile = ProfileScope::enable();
+        let allocator = Allocator::new();
+        let (_, errors, result) =
+            compile_template_with_options(&allocator, "<div>{{ msg }}</div>", options);
+        let counters = profile.finish();
+
+        assert!(errors.is_empty(), "{label} compile errors: {errors:?}");
+        assert!(!result.code.is_empty(), "{label} must still emit code");
+        assert_eq!(
+            counter_total(&counters, "davinci.s2_dom.files"),
+            None,
+            "{label} must stay on compatibility even when profiling is enabled"
+        );
+    }
+}
+
+fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
+    counters
+        .entries
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.total)
+}
+
+struct ProfileScope;
+
+impl ProfileScope {
+    fn enable() -> Self {
+        let profiler = global_profiler();
+        profiler.clear();
+        profiler.enable();
+        Self
+    }
+
+    fn finish(self) -> CounterSummary {
+        let profiler = global_profiler();
+        profiler.disable();
+        profiler.counter_summary()
+    }
+}
+
+impl Drop for ProfileScope {
+    fn drop(&mut self) {
+        let profiler = global_profiler();
+        profiler.disable();
+        profiler.clear();
+    }
+}
+
+fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
+    PROFILER_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}


### PR DESCRIPTION
Summary:
- add a P2-11 regression test for unsupported DOM option shapes under profiling
- assert ssr, patterned template, and custom renderer compiles still emit through compatibility
- ensure profiling does not record S2 DOM file counters for those unsupported shapes

Validation:
- TMPDIR=$PWD/target/vize-tests/tmp TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp cargo test -p vize_atelier_dom --test davinci_s2_profile_unsupported -- --nocapture
- cargo fmt --all -- --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- rust-script tools/commands/davinci/assertion-lint.rs
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791238935&installation_model_id=422833&pr_number=5775&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5775&signature=c017a92cf709c0681ca1ad2189b5325488d1f86a009393cbc7e9e01ded2c3120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring unsupported DOM compiler options do not appear as production-selector profiling results.
  * Verified compilation succeeds, generates output, and continues using the compatibility code-generation path for unsupported configurations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->