### PR TITLE
test(davinci): guard in-tag DOM option routing

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
@@ -132,6 +132,13 @@ fn unsupported_options_stay_on_compatibility_without_profiler() {
             },
         ),
         (
+            "in_tag_comments",
+            DomCompilerOptions {
+                experimental_in_tag_comments: true,
+                ..Default::default()
+            },
+        ),
+        (
             "custom_renderer",
             DomCompilerOptions {
                 custom_renderer: true,
@@ -144,7 +151,12 @@ fn unsupported_options_stay_on_compatibility_without_profiler() {
         profiler.disable();
         profiler.clear();
 
-        let result = compile(r#"<button @click="go">{{ label }}</button>"#, options);
+        let source = if label == "in_tag_comments" {
+            "<button // keep the parse extension covered\n  @click=\"go\">{{ label }}</button>"
+        } else {
+            r#"<button @click="go">{{ label }}</button>"#
+        };
+        let result = compile(source, options);
         let counters = profiler.counter_summary();
 
         assert!(

--- a/crates/vize_atelier_dom/tests/davinci_s2_profile_unsupported.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_profile_unsupported.rs
@@ -32,6 +32,13 @@ fn profiled_unsupported_options_stay_on_compatibility_codegen() {
             },
         ),
         (
+            "in_tag_comments",
+            DomCompilerOptions {
+                experimental_in_tag_comments: true,
+                ..Default::default()
+            },
+        ),
+        (
             "custom_renderer",
             DomCompilerOptions {
                 custom_renderer: true,
@@ -41,8 +48,12 @@ fn profiled_unsupported_options_stay_on_compatibility_codegen() {
     ] {
         let profile = ProfileScope::enable();
         let allocator = Allocator::new();
-        let (_, errors, result) =
-            compile_template_with_options(&allocator, "<div>{{ msg }}</div>", options);
+        let source = if label == "in_tag_comments" {
+            "<div // keep the parse extension covered\n  id=\"x\">{{ msg }}</div>"
+        } else {
+            "<div>{{ msg }}</div>"
+        };
+        let (_, errors, result) = compile_template_with_options(&allocator, source, options);
         let counters = profile.finish();
 
         assert!(errors.is_empty(), "{label} compile errors: {errors:?}");


### PR DESCRIPTION
## Summary
- add `experimental_in_tag_comments` to the unsupported DOM production-selector witness
- cover both profiled and unprofiled compatibility-routing paths

## Tests
- `cargo fmt --check`
- `TMPDIR=$PWD/target/vize-tests/tmp TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp cargo test -p vize_atelier_dom --test davinci_s2_production_selector --test davinci_s2_profile_unsupported`
- `vp install --frozen-lockfile --prefer-offline`
- `vp exec node --test tests/tooling/davinci-dom-production-boundary.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791240769&installation_model_id=422833&pr_number=5777&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5777&signature=8b7fa3067227698048cbbb9d16f7c293e0d981bdb360078d31768c1ecc972dbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->