### PR TITLE
fix(davinci): admit SFC namespace templates on S2

### DIFF
--- a/crates/vize_atelier_dom/src/compile/sfc.rs
+++ b/crates/vize_atelier_dom/src/compile/sfc.rs
@@ -89,44 +89,12 @@ pub(super) fn compile_template_inner_for_sfc<'a>(
 }
 
 fn s2_sfc_fast_path_supported_source(source: &str) -> bool {
-    !source_contains_foreign_namespace_tag(source)
-        && !source_contains_non_void_native_self_closing_tag(source)
-}
-
-fn source_contains_foreign_namespace_tag(source: &str) -> bool {
-    let bytes = source.as_bytes();
-    let mut index = 0;
-
-    while let Some(offset) = source[index..].find('<') {
-        let name_start = index + offset + 1;
-        if name_start >= bytes.len() {
-            break;
-        }
-
-        if matches!(bytes[name_start], b'/' | b'!' | b'?') {
-            index = name_start + 1;
-            continue;
-        }
-
-        let name_end = scan_tag_name(bytes, name_start);
-        if name_end == name_start {
-            index = name_start + 1;
-            continue;
-        }
-
-        let name = &source[name_start..name_end];
-        if name.eq_ignore_ascii_case("svg") || name.eq_ignore_ascii_case("math") {
-            return true;
-        }
-
-        index = name_end;
-    }
-
-    false
+    !source_contains_non_void_native_self_closing_tag(source)
 }
 
 fn source_contains_non_void_native_self_closing_tag(source: &str) -> bool {
     let bytes = source.as_bytes();
+    let mut tags = Vec::new();
     let mut index = 0;
 
     while let Some(offset) = source[index..].find('<') {
@@ -135,7 +103,17 @@ fn source_contains_non_void_native_self_closing_tag(source: &str) -> bool {
             break;
         }
 
-        if matches!(bytes[name_start], b'/' | b'!' | b'?') {
+        if bytes[name_start] == b'/' {
+            let closing_name_start = name_start + 1;
+            let closing_name_end = scan_tag_name(bytes, closing_name_start);
+            if closing_name_end > closing_name_start {
+                pop_closed_tag(&mut tags, &source[closing_name_start..closing_name_end]);
+                index = closing_name_end;
+                continue;
+            }
+        }
+
+        if matches!(bytes[name_start], b'!' | b'?') {
             index = name_start + 1;
             continue;
         }
@@ -147,18 +125,62 @@ fn source_contains_non_void_native_self_closing_tag(source: &str) -> bool {
         }
 
         let name = &source[name_start..name_end];
-        if is_plain_native_html_tag_name(name)
+        let namespace = tag_namespace(name, tags.last().copied());
+        let self_closing = tag_closes_self_closing(bytes, name_end);
+        if namespace == SourceNamespace::Html
+            && is_plain_native_html_tag_name(name)
             && !is_html_void_tag_name(name)
             && !is_allowed_self_closing_special_tag_name(name)
-            && tag_closes_self_closing(bytes, name_end)
+            && self_closing
         {
             return true;
+        }
+
+        if !self_closing {
+            tags.push(name);
         }
 
         index = name_end;
     }
 
     false
+}
+
+fn pop_closed_tag(tags: &mut Vec<&str>, name: &str) {
+    if tags.last().is_some_and(|tag| *tag == name) {
+        tags.pop();
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SourceNamespace {
+    Html,
+    Foreign,
+}
+
+fn tag_namespace(tag: &str, parent: Option<&str>) -> SourceNamespace {
+    if vize_s0::is_svg_tag(tag) || vize_s0::is_math_ml_tag(tag) {
+        return SourceNamespace::Foreign;
+    }
+
+    let Some(parent) = parent else {
+        return SourceNamespace::Html;
+    };
+
+    let svg_to_html = matches!(parent, "foreignObject" | "desc" | "title");
+    if vize_s0::is_svg_tag(parent) && !svg_to_html {
+        return SourceNamespace::Foreign;
+    }
+
+    let mathml_to_html = matches!(
+        parent,
+        "annotation-xml" | "mi" | "mo" | "mn" | "ms" | "mtext"
+    );
+    if vize_s0::is_math_ml_tag(parent) && !mathml_to_html {
+        return SourceNamespace::Foreign;
+    }
+
+    SourceNamespace::Html
 }
 
 fn scan_tag_name(bytes: &[u8], start: usize) -> usize {

--- a/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
@@ -187,6 +187,85 @@ fn sfc_sections_entry_uses_s2_once_sections_land() {
     );
 }
 
+#[test]
+fn sfc_sections_entry_uses_s2_for_foreign_namespace_templates() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+
+    for (label, source) in [
+        ("svg", r#"<svg><circle :r="radius" /></svg>"#),
+        (
+            "mathml",
+            r#"<math><msub :data-depth="depth"><mi>x</mi></msub></math>"#,
+        ),
+    ] {
+        let compat = compile_sfc_sections_entry(
+            source,
+            DomCompilerOptions {
+                source_map: true,
+                ..Default::default()
+            },
+        );
+
+        profiler.enable();
+        let selected = compile_sfc_sections_entry(source, DomCompilerOptions::default());
+        let counters = profiler.counter_summary();
+        profiler.disable();
+        profiler.clear();
+
+        assert_eq!(selected.preamble, compat.preamble, "{label} preamble");
+        assert_eq!(selected.code, compat.code, "{label} code");
+        assert_eq!(selected.sections, compat.sections, "{label} sections");
+        assert_eq!(
+            counter_total(&counters, "davinci.s2_dom.files"),
+            Some(1),
+            "{label} must use the S2 SFC sections fast path"
+        );
+    }
+}
+
+#[test]
+fn sfc_sections_entry_keeps_html_self_closing_native_tags_on_compatibility() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+
+    for (label, source) in [
+        ("html_root", r#"<div />"#),
+        (
+            "svg_html_reentry",
+            r#"<svg><foreignObject><div /></foreignObject></svg>"#,
+        ),
+        (
+            "mathml_html_reentry",
+            r#"<math><annotation-xml><div /></annotation-xml></math>"#,
+        ),
+    ] {
+        profiler.clear();
+        profiler.enable();
+        let (error_count, result) =
+            compile_sfc_sections_entry_with_errors(source, DomCompilerOptions::default());
+        let counters = profiler.counter_summary();
+        profiler.disable();
+        profiler.clear();
+
+        assert!(
+            error_count > 0,
+            "{label} must surface the compatibility parser diagnostic"
+        );
+        assert!(
+            result.sections.is_some(),
+            "{label} must keep compatibility sections"
+        );
+        assert_eq!(
+            counter_total(&counters, "davinci.s2_dom.files"),
+            None,
+            "{label} must stay on compatibility until native self-closing is admitted"
+        );
+    }
+}
+
 struct Compiled {
     preamble: String,
     code: String,
@@ -215,6 +294,15 @@ fn compile(source: &str, options: DomCompilerOptions) -> Compiled {
 }
 
 fn compile_sfc_sections_entry(source: &str, options: DomCompilerOptions) -> Compiled {
+    let (error_count, compiled) = compile_sfc_sections_entry_with_errors(source, options);
+    assert_eq!(error_count, 0, "compile errors");
+    compiled
+}
+
+fn compile_sfc_sections_entry_with_errors(
+    source: &str,
+    options: DomCompilerOptions,
+) -> (usize, Compiled) {
     let allocator = Allocator::new();
     let (errors, result) =
         compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
@@ -226,13 +314,15 @@ fn compile_sfc_sections_entry(source: &str, options: DomCompilerOptions) -> Comp
             CustomElementMatcher::default(),
             CodegenOptions::default(),
         );
-    assert!(errors.is_empty(), "compile errors: {errors:?}");
-    Compiled {
-        preamble: result.result.preamble.to_string(),
-        code: result.result.code.to_string(),
-        map: result.result.map.map(|map| map.to_string()),
-        sections: result.sections,
-    }
+    (
+        errors.len(),
+        Compiled {
+            preamble: result.result.preamble.to_string(),
+            code: result.result.code.to_string(),
+            map: result.result.map.map(|map| map.to_string()),
+            sections: result.sections,
+        },
+    )
 }
 
 fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {


### PR DESCRIPTION
## Summary
- let the SFC sections fast path use S2 for SVG and MathML templates instead of rejecting every foreign namespace source up front
- make the self-closing native tag guard namespace-aware so HTML integration points still stay on compatibility
- pin the production selector with profiled SFC-section coverage for SVG/MathML and compatibility coverage for HTML self-closing native tags

## Verification
- cargo test -p vize_atelier_dom --test davinci_s2_production_selector -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_production_selector --test davinci_s2_dom_namespace --test davinci_s2_profile -- --nocapture
- cargo clippy -p vize_atelier_dom --tests -- -D warnings
- cargo fmt --all -- --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10
- rust-script tools/commands/davinci/assertion-lint.rs
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved compilation handling for SVG and MathML templates by enabling the optimized SFC compilation path where supported.
  - Preserved compatibility processing for native self-closing HTML tags, including HTML elements nested within SVG or MathML.

- **Bug Fixes**
  - Maintained appropriate parser diagnostics for unsupported native self-closing HTML syntax.
  - Improved handling of mixed HTML, SVG, and MathML nesting during SFC compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->