### PR TITLE
fix(davinci): harden SFC namespace selection

### DIFF
--- a/crates/vize_atelier_dom/src/compile/sfc.rs
+++ b/crates/vize_atelier_dom/src/compile/sfc.rs
@@ -97,8 +97,8 @@ fn source_contains_non_void_native_self_closing_tag(source: &str) -> bool {
     let mut tags = Vec::new();
     let mut index = 0;
 
-    while let Some(offset) = source[index..].find('<') {
-        let name_start = index + offset + 1;
+    while let Some(tag_start) = find_byte(bytes, index, b'<') {
+        let name_start = tag_start + 1;
         if name_start >= bytes.len() {
             break;
         }
@@ -108,13 +108,13 @@ fn source_contains_non_void_native_self_closing_tag(source: &str) -> bool {
             let closing_name_end = scan_tag_name(bytes, closing_name_start);
             if closing_name_end > closing_name_start {
                 pop_closed_tag(&mut tags, &source[closing_name_start..closing_name_end]);
-                index = closing_name_end;
+                index = scan_tag_end(bytes, closing_name_end);
                 continue;
             }
         }
 
         if matches!(bytes[name_start], b'!' | b'?') {
-            index = name_start + 1;
+            index = scan_special_tag_end(bytes, name_start);
             continue;
         }
 
@@ -126,7 +126,8 @@ fn source_contains_non_void_native_self_closing_tag(source: &str) -> bool {
 
         let name = &source[name_start..name_end];
         let namespace = tag_namespace(name, tags.last().copied());
-        let self_closing = tag_closes_self_closing(bytes, name_end);
+        let tag_end = scan_tag_end(bytes, name_end);
+        let self_closing = tag_closes_self_closing(bytes, name_end, tag_end);
         if namespace == SourceNamespace::Html
             && is_plain_native_html_tag_name(name)
             && !is_html_void_tag_name(name)
@@ -137,17 +138,24 @@ fn source_contains_non_void_native_self_closing_tag(source: &str) -> bool {
         }
 
         if !self_closing {
-            tags.push(name);
+            tags.push(SourceOpenTag { name, namespace });
         }
 
-        index = name_end;
+        index = tag_end;
     }
 
     false
 }
 
-fn pop_closed_tag(tags: &mut Vec<&str>, name: &str) {
-    if tags.last().is_some_and(|tag| *tag == name) {
+fn find_byte(bytes: &[u8], start: usize, needle: u8) -> Option<usize> {
+    bytes[start..]
+        .iter()
+        .position(|byte| *byte == needle)
+        .map(|offset| start + offset)
+}
+
+fn pop_closed_tag(tags: &mut Vec<SourceOpenTag<'_>>, name: &str) {
+    if tags.last().is_some_and(|tag| tag.name == name) {
         tags.pop();
     }
 }
@@ -155,32 +163,52 @@ fn pop_closed_tag(tags: &mut Vec<&str>, name: &str) {
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum SourceNamespace {
     Html,
-    Foreign,
+    Svg,
+    MathMl,
 }
 
-fn tag_namespace(tag: &str, parent: Option<&str>) -> SourceNamespace {
-    if vize_s0::is_svg_tag(tag) || vize_s0::is_math_ml_tag(tag) {
-        return SourceNamespace::Foreign;
+#[derive(Clone, Copy)]
+struct SourceOpenTag<'source> {
+    name: &'source str,
+    namespace: SourceNamespace,
+}
+
+fn tag_namespace(tag: &str, parent: Option<SourceOpenTag<'_>>) -> SourceNamespace {
+    match parent {
+        None => html_child_namespace(tag),
+        Some(parent) if parent.namespace == SourceNamespace::Html => html_child_namespace(tag),
+        Some(parent)
+            if parent.namespace == SourceNamespace::Svg
+                && is_svg_html_integration_point(parent.name) =>
+        {
+            html_child_namespace(tag)
+        }
+        Some(parent)
+            if parent.namespace == SourceNamespace::MathMl
+                && is_mathml_html_integration_point(parent.name) =>
+        {
+            html_child_namespace(tag)
+        }
+        Some(parent) => parent.namespace,
     }
+}
 
-    let Some(parent) = parent else {
-        return SourceNamespace::Html;
-    };
-
-    let svg_to_html = matches!(parent, "foreignObject" | "desc" | "title");
-    if vize_s0::is_svg_tag(parent) && !svg_to_html {
-        return SourceNamespace::Foreign;
+fn html_child_namespace(tag: &str) -> SourceNamespace {
+    if tag.eq_ignore_ascii_case("svg") {
+        SourceNamespace::Svg
+    } else if tag.eq_ignore_ascii_case("math") {
+        SourceNamespace::MathMl
+    } else {
+        SourceNamespace::Html
     }
+}
 
-    let mathml_to_html = matches!(
-        parent,
-        "annotation-xml" | "mi" | "mo" | "mn" | "ms" | "mtext"
-    );
-    if vize_s0::is_math_ml_tag(parent) && !mathml_to_html {
-        return SourceNamespace::Foreign;
-    }
+fn is_svg_html_integration_point(tag: &str) -> bool {
+    matches!(tag, "foreignObject" | "desc" | "title")
+}
 
-    SourceNamespace::Html
+fn is_mathml_html_integration_point(tag: &str) -> bool {
+    matches!(tag, "annotation-xml" | "mi" | "mo" | "mn" | "ms" | "mtext")
 }
 
 fn scan_tag_name(bytes: &[u8], start: usize) -> usize {
@@ -224,12 +252,58 @@ fn is_allowed_self_closing_special_tag_name(name: &str) -> bool {
     matches!(name, "component" | "slot")
 }
 
-fn tag_closes_self_closing(bytes: &[u8], start: usize) -> bool {
+fn scan_special_tag_end(bytes: &[u8], start: usize) -> usize {
+    if bytes.get(start..start + 3) == Some(b"!--") {
+        return scan_comment_end(bytes, start + 3);
+    }
+
+    scan_tag_end(bytes, start + 1)
+}
+
+fn scan_comment_end(bytes: &[u8], start: usize) -> usize {
+    let mut index = start;
+    while index + 2 < bytes.len() {
+        if &bytes[index..index + 3] == b"-->" {
+            return index + 3;
+        }
+        index += 1;
+    }
+    bytes.len()
+}
+
+fn scan_tag_end(bytes: &[u8], start: usize) -> usize {
+    let mut index = start;
+    let mut quote = None;
+
+    while index < bytes.len() {
+        let byte = bytes[index];
+
+        if let Some(quote_byte) = quote {
+            if byte == quote_byte {
+                quote = None;
+            }
+            index += 1;
+            continue;
+        }
+
+        match byte {
+            b'\'' | b'"' => quote = Some(byte),
+            b'>' => return index + 1,
+            _ => {}
+        }
+
+        index += 1;
+    }
+
+    bytes.len()
+}
+
+fn tag_closes_self_closing(bytes: &[u8], start: usize, end: usize) -> bool {
     let mut index = start;
     let mut quote = None;
     let mut last_non_whitespace = None;
 
-    while index < bytes.len() {
+    while index < end {
         let byte = bytes[index];
 
         if let Some(quote_byte) = quote {

--- a/crates/vize_atelier_dom/tests/davinci_s2_sfc_namespace_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_sfc_namespace_selector.rs
@@ -1,0 +1,176 @@
+//! P2-11 witness: SFC section selection keeps HTML and foreign namespace
+//! self-closing guards distinct while admitting SVG and MathML fast paths.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use vize_atelier_core::options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode};
+use vize_atelier_dom::{
+    DomCompilerOptions,
+    compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+};
+use vize_s0::Allocator;
+use vize_s0::profiler::{CounterSummary, global_profiler};
+
+#[test]
+fn sfc_sections_entry_keeps_custom_foreign_descendants_on_s2() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+
+    for (label, source) in [
+        (
+            "svg_custom_descendant",
+            r#"<svg><g><my-node><div /></my-node></g></svg>"#,
+        ),
+        (
+            "mathml_custom_descendant",
+            r#"<math><mrow><my-node><div /></my-node></mrow></math>"#,
+        ),
+    ] {
+        let compat = compile_sfc_sections_entry(
+            source,
+            DomCompilerOptions {
+                source_map: true,
+                ..Default::default()
+            },
+        );
+
+        profiler.enable();
+        let selected = compile_sfc_sections_entry(source, DomCompilerOptions::default());
+        let counters = profiler.counter_summary();
+        profiler.disable();
+        profiler.clear();
+
+        assert_eq!(selected.preamble, compat.preamble, "{label} preamble");
+        assert_eq!(selected.code, compat.code, "{label} code");
+        assert_eq!(selected.sections, compat.sections, "{label} sections");
+        assert_eq!(
+            counter_total(&counters, "davinci.s2_dom.files"),
+            Some(1),
+            "{label} must keep the S2 SFC sections fast path"
+        );
+    }
+}
+
+#[test]
+fn sfc_sections_entry_ignores_lt_inside_foreign_attributes() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+
+    for (label, source) in [
+        (
+            "svg_attribute",
+            r#"<svg data-probe="<é"><circle :r="radius" /></svg>"#,
+        ),
+        (
+            "mathml_attribute",
+            r#"<math data-probe="<é"><msub :data-depth="depth"><mi>x</mi></msub></math>"#,
+        ),
+    ] {
+        let compat = compile_sfc_sections_entry(
+            source,
+            DomCompilerOptions {
+                source_map: true,
+                ..Default::default()
+            },
+        );
+
+        profiler.enable();
+        let selected = compile_sfc_sections_entry(source, DomCompilerOptions::default());
+        let counters = profiler.counter_summary();
+        profiler.disable();
+        profiler.clear();
+
+        assert_eq!(selected.preamble, compat.preamble, "{label} preamble");
+        assert_eq!(selected.code, compat.code, "{label} code");
+        assert_eq!(selected.sections, compat.sections, "{label} sections");
+        assert_eq!(
+            counter_total(&counters, "davinci.s2_dom.files"),
+            Some(1),
+            "{label} must use the S2 SFC sections fast path"
+        );
+    }
+}
+
+#[test]
+fn sfc_sections_entry_keeps_root_html_title_on_compatibility() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.clear();
+    profiler.enable();
+
+    let (_, result) =
+        compile_sfc_sections_entry_with_errors(r#"<title />"#, DomCompilerOptions::default());
+    let counters = profiler.counter_summary();
+    profiler.disable();
+    profiler.clear();
+
+    assert!(
+        result.sections.is_some(),
+        "root HTML title must keep compatibility sections"
+    );
+    assert_eq!(
+        counter_total(&counters, "davinci.s2_dom.files"),
+        None,
+        "root HTML title must not be treated as a foreign self-closing tag"
+    );
+}
+
+struct Compiled {
+    preamble: String,
+    code: String,
+    sections: Option<vize_atelier_core::CodegenSections>,
+}
+
+fn compile_sfc_sections_entry(source: &str, options: DomCompilerOptions) -> Compiled {
+    let (error_count, compiled) = compile_sfc_sections_entry_with_errors(source, options);
+    assert_eq!(error_count, 0, "compile errors");
+    compiled
+}
+
+fn compile_sfc_sections_entry_with_errors(
+    source: &str,
+    options: DomCompilerOptions,
+) -> (usize, Compiled) {
+    let allocator = Allocator::new();
+    let (errors, result) =
+        compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+            None,
+            CustomElementMatcher::default(),
+            CodegenOptions::default(),
+        );
+    (
+        errors.len(),
+        Compiled {
+            preamble: result.result.preamble.to_string(),
+            code: result.result.code.to_string(),
+            sections: result.sections,
+        },
+    )
+}
+
+fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
+    counters
+        .entries
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.total)
+}
+
+fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
+    static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    PROFILER_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}

--- a/crates/vize_s1_to_s2/src/emit/run.rs
+++ b/crates/vize_s1_to_s2/src/emit/run.rs
@@ -128,9 +128,10 @@ pub(super) fn emit_dom_with_emit_budget<'f>(
         filter::emit_resolves(&mut cx, filters);
         resolved_assets = true;
     }
-    let assets_end = cx.buf.code.len();
+    let mut assets_end = cx.buf.code.len();
     if resolved_assets {
         cx.buf.newline();
+        assets_end = cx.buf.code.len();
     }
     cx.buf.push("return ");
     let return_expr_start = cx.buf.code.len();


### PR DESCRIPTION
## Summary
- keep SFC fast-path namespace scanning on byte indexes so quoted foreign attributes cannot move onto invalid UTF-8 boundaries
- store resolved HTML/SVG/MathML namespace on the open-tag stack for nested foreign descendants
- align S2 asset section boundaries with the compatibility emitter when component assets are present

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_sfc_namespace_selector --test davinci_s2_production_selector --test davinci_s2_profile --test davinci_s2_dom_namespace -- --nocapture
- cargo test -p vize_s1_to_s2
- cargo clippy -p vize_s1_to_s2 --lib -- -D warnings
- cargo clippy -p vize_atelier_dom --tests -- -D warnings
- cargo fmt --all -- --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20
- rust-script tools/commands/davinci/assertion-lint.rs
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791242339&installation_model_id=422833&pr_number=5779&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5779&signature=33ea012c23c86c7df2bb3d2ea64b76c2f998c46334be7d66414d838af9f86f6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->