### PR TITLE
docs(davinci): pin P2-17 witness ledger

### DIFF
--- a/davinci-road/plan/phase-2.md
+++ b/davinci-road/plan/phase-2.md
@@ -117,12 +117,16 @@ counts or fixture availability changes.
   must not replace this inventory.
 - **P2-17/P2-20 pre-exit blocker map:** P2-17 cannot be signed off until
   P2-11's S2 DOM lane, P2-12b's traversal-budget swap and P2-13's failure
-  provenance contract are all available to review together; its mechanical
-  span-resolution and `schema_version` negotiation checks still need to land as
-  tests. P2-20 cannot evaluate the exit gate until every P2-1..P2-19
-  dependency is closed. Until then the exit gate below stays unticked: P2-20's
-  acceptance rule is to tick a line only with evidence, or leave it unticked
-  with its blocker named during the phase-exit evaluation.
+  provenance contract are all available to review together. Its mechanical
+  span-resolution witness now runs in
+  [`ir_contract_spans.rs`](../../crates/vize_s1_to_s2/tests/ir_contract_spans.rs),
+  and its `schema_version` negotiation witness now runs in
+  [`spolvero_feed.rs`](../../crates/vize_davinci/tests/spolvero_feed.rs); those
+  tests are pre-signoff evidence, not a P2-17 completion. P2-20 cannot evaluate
+  the exit gate until every P2-1..P2-19 dependency is closed. Until then the
+  exit gate below stays unticked: P2-20's acceptance rule is to tick a line only
+  with evidence, or leave it unticked with its blocker named during the
+  phase-exit evaluation.
 
 ## Davinci describes the shipped pipeline — and cannot yet consume it (2026-08-19)
 

--- a/tests/tooling/support/davinci-phase2-ledger.ts
+++ b/tests/tooling/support/davinci-phase2-ledger.ts
@@ -201,9 +201,12 @@ export function assertP2_17P2_20ExitBlockers(
   assert.match(phaseLedger, /P2-11's S2 DOM lane/);
   assert.match(phaseLedger, /P2-12b's traversal-budget swap/);
   assert.match(phaseLedger, /P2-13's failure\s+provenance contract/);
-  assert.match(phaseLedger, /span-resolution and `schema_version` negotiation checks/);
-  assert.match(phaseLedger, /P2-20 cannot evaluate the exit gate until every P2-1\.\.P2-19/);
-  assert.match(phaseLedger, /tick a line only with evidence/);
+  assert.match(phaseLedger, /ir_contract_spans\.rs/);
+  assert.match(phaseLedger, /spolvero_feed\.rs/);
+  assert.match(phaseLedger, /pre-signoff evidence, not a P2-17 completion/);
+  assert.match(phaseLedger, /P2-20 cannot evaluate\s+the exit gate until every P2-1\.\.P2-19/);
+  assert.match(phaseLedger, /tick a line only\s+with evidence/);
+  assertP2_17MechanicalWitnesses();
 
   assert.equal(gateItems.length, 12, "the P2 exit gate item count changed");
   assert.deepEqual(
@@ -228,4 +231,22 @@ export function assertP2_17P2_20ExitBlockers(
     ),
     "P2-20 must continue to gate the C-16 waiver-ledger review",
   );
+}
+
+function assertP2_17MechanicalWitnesses(): void {
+  const spanWitness = fs.readFileSync(
+    new URL("../../../crates/vize_s1_to_s2/tests/ir_contract_spans.rs", import.meta.url),
+    "utf8",
+  );
+  assert.match(spanWitness, /P2-17 mechanical span gate/);
+  assert.match(spanWitness, /owned_folio_spans_resolve_for_optional_corpus/);
+  assert.match(spanWitness, /assert_folio_spans_resolve/);
+
+  const schemaWitness = fs.readFileSync(
+    new URL("../../../crates/vize_davinci/tests/spolvero_feed.rs", import.meta.url),
+    "utf8",
+  );
+  assert.match(schemaWitness, /consumers_negotiate_schema_version_before_reading_pages/);
+  assert.match(schemaWitness, /not read until the version is accepted/);
+  assert.match(schemaWitness, /SchemaGateError::VersionMismatch/);
 }


### PR DESCRIPTION
## Summary
- record the landed P2-17 span and schema-version witness tests in the current Phase 2 ledger
- keep P2-17 unticked by naming the remaining dependency and review blockers
- make the ledger test read the witness files so the references stay executable

## Verification
- node --test tests/tooling/davinci-phase2-ledger.test.ts
- cargo test -p vize_s1_to_s2 --test ir_contract_spans
- cargo test -p vize_davinci --test spolvero_feed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791246208&installation_model_id=422833&pr_number=5783&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5783&signature=d995f8b43a8db6af1182635867fcffdebc7623a497549fc5f0187dc71bb73c0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Phase 2 execution ledger to reflect completed pre-signoff evidence for span resolution and schema-version negotiation checks.
  - Clarified that these checks support sign-off evaluation but do not indicate completion of the related phase work.
  - Maintained the requirement to resolve all dependencies before evaluating the Phase 2 exit gate.

- **Tests**
  - Updated validation to verify the documented pre-signoff evidence and associated exit-blocker wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->