### PR TITLE
test(davinci): pin SFC comment selector boundary

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_sfc_comment_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_sfc_comment_selector.rs
@@ -1,0 +1,106 @@
+//! P2-11 witness: SFC section selection keeps comment-preserving DOM compiles
+//! on the compatibility path until S2 preserves authored comments.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use vize_atelier_core::options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode};
+use vize_atelier_dom::{
+    DomCompilerOptions,
+    compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+};
+use vize_s0::Allocator;
+use vize_s0::profiler::{CounterSummary, global_profiler};
+
+#[test]
+fn comment_preserving_sfc_sections_stay_on_compatibility_when_profiled() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+
+    let source = "<div><!--kept--><span>probe</span></div>";
+    let compat = compile_sfc_sections_entry(
+        source,
+        DomCompilerOptions {
+            comments: true,
+            source_map: true,
+            ..Default::default()
+        },
+    );
+
+    profiler.enable();
+    let selected = compile_sfc_sections_entry(
+        source,
+        DomCompilerOptions {
+            comments: true,
+            ..Default::default()
+        },
+    );
+    let counters = profiler.counter_summary();
+    profiler.disable();
+    profiler.clear();
+
+    assert_eq!(selected.preamble, compat.preamble);
+    assert_eq!(selected.code, compat.code);
+    assert_eq!(selected.sections, compat.sections);
+    assert_eq!(
+        selected.code,
+        r#"function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    _createCommentVNode("kept"),
+    _createElementVNode("span", null, "probe")
+  ]))
+}"#,
+        "comment-preserving SFC compiles must keep the exact comment vnode output"
+    );
+    assert_eq!(
+        counter_total(&counters, "davinci.s2_dom.files"),
+        None,
+        "comment-preserving SFC sections must stay on compatibility until S2 preserves comments"
+    );
+}
+
+struct Compiled {
+    preamble: String,
+    code: String,
+    sections: Option<vize_atelier_core::CodegenSections>,
+}
+
+fn compile_sfc_sections_entry(source: &str, options: DomCompilerOptions) -> Compiled {
+    let allocator = Allocator::new();
+    let (errors, result) =
+        compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+            None,
+            CustomElementMatcher::default(),
+            CodegenOptions::default(),
+        );
+    assert!(errors.is_empty(), "compile errors: {errors:?}");
+    Compiled {
+        preamble: result.result.preamble.to_string(),
+        code: result.result.code.to_string(),
+        sections: result.sections,
+    }
+}
+
+fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
+    counters
+        .entries
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.total)
+}
+
+fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
+    static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    PROFILER_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}


### PR DESCRIPTION
## Summary

- add a P2-11 witness for the SFC sections entry with `comments: true`
- assert comment-vnode parity with the source-map compatibility lane
- assert profiled comment-preserving SFC compiles do not enter the S2 DOM selector until S2 preserves comments

## Verification

- `cargo fmt --check`
- `cargo test -p vize_atelier_dom --test davinci_s2_sfc_comment_selector`
- `cargo test -p vize_atelier_dom --test davinci_s2_production_selector`
- `node --test tests/tooling/davinci-phase2-ledger.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791247554&installation_model_id=422833&pr_number=5784&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5784&signature=d6343199146e1b31beaab36c9589c91e9ba7aede1060cd75227d7271952f1991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for preserving authored comments during SFC section selection.
  - Verified that profiled and unprofiled compilation produce identical output, including comment nodes.
  - Confirmed the compatibility behavior remains active for this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->