### PR TITLE
fix(vscode): keep typescript plugin staging atomic

### DIFF
--- a/tests/tooling/vscode-typescript-plugin-staging.test.ts
+++ b/tests/tooling/vscode-typescript-plugin-staging.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const syncCommand = path.join(
+  root,
+  "tools",
+  "commands",
+  "editors",
+  "vscode",
+  "sync-typescript-plugin.rs",
+);
+const pluginFiles = ["index.cjs", "package.json", "virtual-modules.cjs"] as const;
+
+test("TypeScript Vue plugin staging refuses partial source packages without touching target", () => {
+  const fixture = createFixture();
+  const source = path.join(fixture.root, "editors/vscode/typescript-vue-plugin");
+  const target = path.join(
+    fixture.root,
+    "editors/vscode/node_modules/@vizejs/typescript-vue-plugin",
+  );
+  fs.mkdirSync(source, { recursive: true });
+  fs.mkdirSync(target, { recursive: true });
+  fs.writeFileSync(path.join(source, "index.cjs"), "new index\n");
+  fs.writeFileSync(path.join(source, "package.json"), "{}\n");
+  for (const file of pluginFiles) {
+    fs.writeFileSync(path.join(target, file), `previous ${file}\n`);
+  }
+
+  try {
+    const result = runStage(fixture.root);
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /virtual-modules\.cjs/);
+    for (const file of pluginFiles) {
+      assert.equal(fs.readFileSync(path.join(target, file), "utf8"), `previous ${file}\n`);
+    }
+  } finally {
+    fs.rmSync(fixture.root, { force: true, recursive: true });
+  }
+});
+
+test("TypeScript Vue plugin staging atomically replaces the target package", () => {
+  const fixture = createFixture();
+  const source = path.join(fixture.root, "editors/vscode/typescript-vue-plugin");
+  const target = path.join(
+    fixture.root,
+    "editors/vscode/node_modules/@vizejs/typescript-vue-plugin",
+  );
+  fs.mkdirSync(source, { recursive: true });
+  fs.mkdirSync(target, { recursive: true });
+  for (const file of pluginFiles) {
+    fs.writeFileSync(path.join(source, file), `new ${file}\n`);
+    fs.writeFileSync(path.join(target, file), `previous ${file}\n`);
+  }
+
+  try {
+    const result = runStage(fixture.root);
+
+    assert.equal(result.status, 0, result.stderr);
+    for (const file of pluginFiles) {
+      assert.equal(fs.readFileSync(path.join(target, file), "utf8"), `new ${file}\n`);
+    }
+    assert.deepEqual(
+      fs.readdirSync(path.dirname(target)).filter((entry) => entry.startsWith(".")),
+      [],
+    );
+  } finally {
+    fs.rmSync(fixture.root, { force: true, recursive: true });
+  }
+});
+
+function createFixture(): { root: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "vize-typescript-plugin-stage-"));
+  fs.writeFileSync(path.join(root, "Cargo.toml"), "[workspace]\n");
+  fs.writeFileSync(path.join(root, "pnpm-workspace.yaml"), "packages: []\n");
+  return { root };
+}
+
+function runStage(repoRoot: string): ReturnType<typeof spawnSync> {
+  return spawnSync("rust-script", [syncCommand, "stage"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, VIZE_REPO_ROOT: repoRoot },
+  });
+}

--- a/tools/commands/editors/vscode/sync-typescript-plugin.rs
+++ b/tools/commands/editors/vscode/sync-typescript-plugin.rs
@@ -52,11 +52,46 @@ fn run() -> Result<(), String> {
 }
 
 fn stage_plugin(source_dir: &Path, target_dir: &Path) -> Result<(), String> {
-    if target_dir.exists() {
-        fs::remove_dir_all(target_dir)
-            .map_err(|error| format!("cannot remove {}: {error}", target_dir.display()))?;
+    validate_plugin_files(source_dir)?;
+    let parent = target_dir
+        .parent()
+        .ok_or_else(|| format!("{} has no parent directory", target_dir.display()))?;
+    common::mkdir(parent)?;
+    let temp_dir = unique_sibling_dir(parent, ".typescript-vue-plugin-stage")?;
+    let backup_dir = unique_sibling_dir(parent, ".typescript-vue-plugin-backup")?;
+    common::mkdir(&temp_dir)?;
+
+    let result = (|| {
+        copy_plugin_files(source_dir, &temp_dir)?;
+        replace_staged_plugin(&temp_dir, target_dir, &backup_dir)
+    })();
+
+    if result.is_err() {
+        let _ = fs::remove_dir_all(&temp_dir);
     }
-    common::mkdir(target_dir)?;
+    result
+}
+
+fn validate_plugin_files(source_dir: &Path) -> Result<(), String> {
+    if !source_dir.is_dir() {
+        return Err(format!(
+            "TypeScript Vue plugin source directory does not exist: {}",
+            source_dir.display()
+        ));
+    }
+    for file in PLUGIN_FILES {
+        let path = source_dir.join(file);
+        if !path.is_file() {
+            return Err(format!(
+                "TypeScript Vue plugin source file is missing: {}",
+                path.display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn copy_plugin_files(source_dir: &Path, target_dir: &Path) -> Result<(), String> {
     for file in PLUGIN_FILES {
         fs::copy(source_dir.join(file), target_dir.join(file)).map_err(|error| {
             format!(
@@ -67,6 +102,47 @@ fn stage_plugin(source_dir: &Path, target_dir: &Path) -> Result<(), String> {
         })?;
     }
     Ok(())
+}
+
+fn replace_staged_plugin(
+    temp_dir: &Path,
+    target_dir: &Path,
+    backup_dir: &Path,
+) -> Result<(), String> {
+    if target_dir.exists() {
+        fs::rename(target_dir, backup_dir).map_err(|error| {
+            format!(
+                "cannot move {} to {}: {error}",
+                target_dir.display(),
+                backup_dir.display()
+            )
+        })?;
+    }
+
+    if let Err(error) = fs::rename(temp_dir, target_dir) {
+        if backup_dir.exists() {
+            let _ = fs::rename(backup_dir, target_dir);
+        }
+        return Err(format!(
+            "cannot move staged plugin {} to {}: {error}",
+            temp_dir.display(),
+            target_dir.display()
+        ));
+    }
+
+    if backup_dir.exists() {
+        fs::remove_dir_all(backup_dir)
+            .map_err(|error| format!("cannot remove {}: {error}", backup_dir.display()))?;
+    }
+    Ok(())
+}
+
+fn unique_sibling_dir(parent: &Path, prefix: &str) -> Result<PathBuf, String> {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|error| error.to_string())?
+        .as_nanos();
+    Ok(parent.join(format!("{prefix}-{}-{nanos}", std::process::id())))
 }
 
 fn inject_plugin(source_dir: &Path, vsix_path: &Path) -> Result<(), String> {


### PR DESCRIPTION
## Summary
- validate required TypeScript Vue plugin source files before staging
- stage into a sibling temporary directory before replacing the package target
- add a temp-repo regression test for missing plugin files and successful replacement

## Verification
- `mkdir -p target/vize-tests/tmp && TMPDIR=$PWD/target/vize-tests/tmp TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp node --test tests/tooling/vscode-typescript-plugin-staging.test.ts tests/tooling/vscode-vsix-policy.test.ts tests/tooling/editor-package-tasks.test.ts tests/tooling/source-file-lengths.test.ts`
- `rustfmt --edition 2024 tools/commands/editors/vscode/sync-typescript-plugin.rs --check`
- `git diff --cached --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791247554&installation_model_id=422833&pr_number=5785&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5785&signature=f898f36068203da4f54e5e3a61601f6d1c8edbdc547d077f33f5566d12bdc37c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->