### PR TITLE
test(davinci): guard phase 2 ledger current pin

### DIFF
--- a/tests/tooling/support/davinci-phase2-ledger.ts
+++ b/tests/tooling/support/davinci-phase2-ledger.ts
@@ -33,6 +33,7 @@ export function requiredLine(source: string, pattern: RegExp, label: string): st
 }
 
 export function assertCurrentP2_11Installment(source: string, label: string): void {
+  assertP2_11CurrentPin();
   const record = currentP2_11InstallmentRecord(source, label);
   const current = P2_11_CURRENT.number;
   assert.ok(
@@ -49,7 +50,22 @@ export function assertCurrentP2_11Installment(source: string, label: string): vo
     new RegExp(`#${P2_11_CURRENT.pr}`, "u"),
     `${label} current record must cite #${P2_11_CURRENT.pr}`,
   );
+  if (label === "p2_11")
+    assert.match(
+      record,
+      new RegExp(P2_11_CURRENT.sha, "u"),
+      `${label} current record must cite ${P2_11_CURRENT.sha}`,
+    );
   assert.doesNotMatch(record, /\bpending\b/iu, `${label} current record must not be pending`);
+}
+
+function assertP2_11CurrentPin(): void {
+  const currentRow = p2_11TableRows[p2_11TableRows.length - 1];
+  assert.deepEqual(
+    currentRow,
+    [P2_11_CURRENT.number, P2_11_CURRENT.pr, P2_11_CURRENT.sha],
+    "P2-11 current pin must match the final installment table row",
+  );
 }
 
 function currentP2_11InstallmentRecord(source: string, label: string): string {


### PR DESCRIPTION
## Summary
- assert the P2-11 current pin matches the final landed installment row
- require the P2-11 current record row to cite the pinned main-line SHA

## Verification
- node --test tests/tooling/davinci-phase2-ledger.test.ts
- rust-script tools/commands/davinci/assertion-lint.rs
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791249489&installation_model_id=422833&pr_number=5786&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5786&signature=82c9cf1fc4162bdbe24627fb37198a9769e14ee5aa41428ef5860cfc8efffe23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded validation for P2-11 installment records to confirm the final ledger row matches the current pin values.
  * Added conditional verification that records labeled “p2_11” reference the current SHA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->