### PR TITLE
test(vscode): cover packaged host install failure

### DIFF
--- a/tests/tooling/vscode-packaged-host-smoke.test.ts
+++ b/tests/tooling/vscode-packaged-host-smoke.test.ts
@@ -281,6 +281,64 @@ test("real host runner refuses to launch without a packaged VSIX", async () => {
   }
 });
 
+test("real host runner stops when installing the VSIX fails", async () => {
+  const profilePath = fs.mkdtempSync(path.join(os.tmpdir(), "vize-packaged-host-install-"));
+  const extensionsPath = path.join(profilePath, "extensions");
+  const userDataPath = path.join(profilePath, "user-data");
+  const vsixPath = path.join(profilePath, "vize.vsix");
+  fs.mkdirSync(extensionsPath);
+  fs.writeFileSync(vsixPath, "");
+
+  try {
+    const installFailure = new Error("install failed");
+    const invocations: string[][] = [];
+    let outputCount = 0;
+
+    await assert.rejects(
+      runPackagedExtensionHost(
+        async (args) => {
+          invocations.push(args);
+          if (!args.includes("--install-extension")) {
+            assert.fail(`unexpected host launch: ${args.join(" ")}`);
+          }
+          throw installFailure;
+        },
+        {
+          extensionId: "ubugeeei.vize",
+          extensionsPath,
+          extensionTestsPath: path.join(profilePath, "extension-host-real.cjs"),
+          hostEnvironment: {},
+          hostTimeoutMs: 1000,
+          installEnvironment: {},
+          installTimeoutMs: 1000,
+          onOutput: () => {
+            outputCount += 1;
+          },
+          userDataPath,
+          vscodeVersion: "1.107.1",
+          vsixPath,
+          workspacePath: path.join(profilePath, "workspace"),
+        },
+      ),
+      (error) => {
+        assert.strictEqual(error, installFailure);
+        return true;
+      },
+    );
+
+    assert.equal(outputCount, 0);
+    assert.deepEqual(invocations, [
+      createPackagedHostInstallArgs({
+        extensionsPath,
+        userDataPath,
+        vsixPath,
+      }),
+    ]);
+  } finally {
+    fs.rmSync(profilePath, { force: true, recursive: true });
+  }
+});
+
 function taskShape(value: unknown): { command: string } {
   return value as { command: string };
 }


### PR DESCRIPTION
## Summary
- add a packaged VS Code host oracle for failed VSIX installation
- assert install failures propagate before launch or output handling

## Verification
- `TMPDIR=$PWD/target/vize-tests/tmp TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp node --test tests/tooling/vscode-packaged-host-smoke.test.ts tests/tooling/vscode-vsix-policy.test.ts tests/tooling/editor-package-tasks.test.ts tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791249518&installation_model_id=422833&pr_number=5787&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5787&signature=813efa4d4430691095ca6d52ff8dad662f5ef1111d32436191b936cea0ccc475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->