### PR TITLE
fix(canon): map typecheck diagnostics with utf16 columns

### DIFF
--- a/crates/vize_canon/src/typecheck_service.rs
+++ b/crates/vize_canon/src/typecheck_service.rs
@@ -349,24 +349,6 @@ impl TypeCheckService {
     }
 }
 
-/// Convert line and column to offset in the given content.
-fn line_col_to_offset(content: &str, line: u32, col: u32) -> u32 {
-    let mut offset = 0;
-    let mut current_line = 0;
-
-    for (i, ch) in content.char_indices() {
-        if current_line == line {
-            return (i as u32) + col;
-        }
-        if ch == '\n' {
-            current_line += 1;
-        }
-        offset = i as u32 + 1;
-    }
-
-    offset + col
-}
-
 fn add_script_parse_diagnostics(
     diagnostics: Vec<ScriptParseDiagnostic>,
     result: &mut SfcTypeCheckResult,
@@ -401,8 +383,13 @@ fn map_position_to_sfc(
     _template_offset: u32,
 ) -> (u32, u32) {
     // Convert line/col to offset in generated content
-    let gen_start_offset = line_col_to_offset(&virtual_ts.code, start_line, start_char) as usize;
-    let gen_end_offset = line_col_to_offset(&virtual_ts.code, end_line, end_char) as usize;
+    let line_index = vize_carton::line_index::LineIndex::new(&virtual_ts.code);
+    let (Some(gen_start_offset), Some(gen_end_offset)) = (
+        line_index.line_col_to_offset(start_line, start_char),
+        line_index.line_col_to_offset(end_line, end_char),
+    ) else {
+        return fallback_position_to_sfc(start_line, start_char, end_line, end_char, script_offset);
+    };
 
     if let Some((src_start, src_end)) = crate::virtual_ts::mapping::map_generated_range_to_source(
         &virtual_ts.mappings,
@@ -414,27 +401,24 @@ fn map_position_to_sfc(
 
     // Fallback: estimate based on line numbers
     // This is a rough approximation when source map mapping is not found
-    let start = script_offset + start_line * 80 + start_char;
-    let end = script_offset + end_line * 80 + end_char;
+    fallback_position_to_sfc(start_line, start_char, end_line, end_char, script_offset)
+}
+
+fn fallback_position_to_sfc(
+    start_line: u32,
+    start_char: u32,
+    end_line: u32,
+    end_char: u32,
+    script_offset: u32,
+) -> (u32, u32) {
+    let start = script_offset
+        .saturating_add(start_line.saturating_mul(80))
+        .saturating_add(start_char);
+    let end = script_offset
+        .saturating_add(end_line.saturating_mul(80))
+        .saturating_add(end_char);
     (start, end)
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{SfcDiagnosticSeverity, TypeCheckServiceOptions};
-
-    #[test]
-    fn test_sfc_diagnostic_severity() {
-        assert_eq!(SfcDiagnosticSeverity::Error, SfcDiagnosticSeverity::Error);
-        assert_ne!(SfcDiagnosticSeverity::Error, SfcDiagnosticSeverity::Warning);
-    }
-
-    #[test]
-    fn test_type_check_service_options_default() {
-        let opts = TypeCheckServiceOptions::default();
-        assert!(opts.project_root.is_none());
-        assert!(opts.tsconfig_path.is_none());
-        assert!(!opts.check_cross_component);
-        assert!(!opts.check_template);
-    }
-}
+mod tests;

--- a/crates/vize_canon/src/typecheck_service/tests.rs
+++ b/crates/vize_canon/src/typecheck_service/tests.rs
@@ -1,0 +1,42 @@
+use super::{
+    SfcDiagnosticSeverity, TypeCheckServiceOptions, fallback_position_to_sfc, map_position_to_sfc,
+};
+use crate::virtual_ts::{VirtualTsOutput, VizeMapping};
+
+#[test]
+fn test_sfc_diagnostic_severity() {
+    assert_eq!(SfcDiagnosticSeverity::Error, SfcDiagnosticSeverity::Error);
+    assert_ne!(SfcDiagnosticSeverity::Error, SfcDiagnosticSeverity::Warning);
+}
+
+#[test]
+fn test_type_check_service_options_default() {
+    let opts = TypeCheckServiceOptions::default();
+    assert!(opts.project_root.is_none());
+    assert!(opts.tsconfig_path.is_none());
+    assert!(!opts.check_cross_component);
+    assert!(!opts.check_template);
+}
+
+#[test]
+fn maps_generated_utf16_columns_before_non_bmp_text() {
+    let virtual_ts = VirtualTsOutput {
+        code: "\u{1F600}missing;\n".into(),
+        mappings: vec![VizeMapping {
+            gen_range: 4..11,
+            src_range: 100..107,
+            sub_spans: Vec::new(),
+        }],
+        semantic_links: Vec::new(),
+    };
+
+    assert_eq!(
+        map_position_to_sfc(&virtual_ts, 0, 2, 0, 9, 0, 0),
+        (100, 107)
+    );
+}
+
+#[test]
+fn invalid_generated_positions_keep_the_fallback_mapping() {
+    assert_eq!(fallback_position_to_sfc(1, 2, 1, 7, 40), (122, 127));
+}


### PR DESCRIPTION
## Summary
- replace the single-file typecheck diagnostic line/column conversion with the shared UTF-16 line index
- keep invalid generated positions on the existing fallback path
- move typecheck service unit tests into a normal test module and add a non-BMP regression

## Verification
- `cargo fmt --all --check`
- `cargo test -p vize_canon typecheck_service -- --nocapture`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20`
- `node --test tests/tooling/davinci-module-layout.test.ts`
- `git diff --cached --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791249535&installation_model_id=422833&pr_number=5788&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5788&signature=a36b539414470610d57a826f9ff1332bf63e3687076938388ee1949a7877f5a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->