### PR TITLE
fix(patina): allow target blank on relative links

### DIFF
--- a/crates/vize_patina/src/rules/vue/no_template_target_blank.rs
+++ b/crates/vize_patina/src/rules/vue/no_template_target_blank.rs
@@ -56,6 +56,27 @@ fn rel_is_safe(rel: &str) -> bool {
     has_noopener && has_noreferrer
 }
 
+fn is_external_href(value: &str) -> bool {
+    if value.starts_with("//") {
+        return true;
+    }
+    let Some(colon) = value.as_bytes().iter().position(|&byte| byte == b':') else {
+        return false;
+    };
+    colon > 0
+        && value.as_bytes()[..colon]
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || *byte == b'_')
+}
+
+fn markup_has_dangerous_href(element: &MarkupElement<'_>) -> bool {
+    element
+        .static_attribute("href")
+        .and_then(|attr| attr.value())
+        .is_some_and(is_external_href)
+        || element.has_bound_attribute("href")
+}
+
 impl MarkupRule for NoTemplateTargetBlank {
     fn name(&self) -> &'static str {
         META.name
@@ -71,8 +92,9 @@ impl MarkupRule for NoTemplateTargetBlank {
         if target.value().is_none_or(|value| value != "_blank") {
             return;
         }
-        // The reverse-tabnabbing risk only applies to links that navigate.
-        if !element.has_static_attribute("href") && !element.has_bound_attribute("href") {
+        // Match eslint-plugin-vue: static relative links are clean, while
+        // external static links and dynamic href bindings are checked.
+        if !markup_has_dangerous_href(element) {
             return;
         }
         let rel_is_safe = element
@@ -104,7 +126,7 @@ impl Rule for NoTemplateTargetBlank {
         if attribute_value(target) != "_blank" {
             return;
         }
-        if !has_attribute_or_binding(element, "href") {
+        if !has_dangerous_href(element) {
             return;
         }
         if static_attribute_value(element, "rel").is_some_and(rel_is_safe) {
@@ -138,13 +160,18 @@ fn static_attribute_value<'a>(element: &'a ElementNode<'a>, name: &str) -> Optio
     static_attribute(element, name).map(attribute_value)
 }
 
-/// Whether `element` has a static `name` attribute or a `v-bind:name` directive.
-fn has_attribute_or_binding(element: &ElementNode, name: &str) -> bool {
+fn has_dangerous_href(element: &ElementNode) -> bool {
     element.props.iter().any(|prop| match prop {
-        PropNode::Attribute(attr) => attr.name == name,
+        PropNode::Attribute(attr) => {
+            attr.name == "href"
+                && attr
+                    .value
+                    .as_ref()
+                    .is_some_and(|value| is_external_href(value.content))
+        }
         PropNode::Directive(dir) => {
             dir.name == "bind"
-                && matches!(&dir.arg, Some(ExpressionNode::Simple(s)) if s.content == name)
+                && matches!(&dir.arg, Some(ExpressionNode::Simple(s)) if s.content == "href")
         }
     })
 }
@@ -227,6 +254,14 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_relative_href() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r##"<a href="/guide" target="_blank">x</a>"##, "test.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
     fn test_invalid_missing_rel_reports_target_attribute_range() {
         // The non-ASCII label keeps the reported range honest about byte
         // offsets: a code-point or UTF-16 based span would drift here.
@@ -276,6 +311,17 @@ mod tests {
             JsxLang::Jsx,
         );
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_jsx_relative_href_is_clean() {
+        let linter = create_linter();
+        let result = linter.lint_jsx(
+            r#"const A = () => <a href="/guide" target="_blank">x</a>;"#,
+            "test.jsx",
+            JsxLang::Jsx,
+        );
+        assert_eq!(result.warning_count, 0);
     }
 
     #[test]

--- a/tests/snapshots/lint/__snapshots__/elk-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/elk-lint.snap
@@ -1313,17 +1313,6 @@
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
         "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener noreferrer\" is a security risk",
-        "line": 86,
-        "column": 42,
-        "endLine": 86,
-        "endColumn": 57,
-        "help": "Add rel=\"noopener noreferrer\" to links that open in a new tab: noopener protects window.opener, and noreferrer suppresses referrer data"
-      },
-      {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener noreferrer\" is a security risk",
         "line": 90,
         "column": 46,
         "endLine": 90,
@@ -1343,7 +1332,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 5
   },
   {
     "file": "app/components/nav/NavLogo.vue",

--- a/tests/snapshots/lint/__snapshots__/reka-ui-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/reka-ui-lint.snap
@@ -3967,21 +3967,9 @@
   },
   {
     "file": "packages/core/src/NavigationMenu/story/NavigationMenuAlignment.story.vue",
-    "messages": [
-      {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener noreferrer\" is a security risk",
-        "line": 52,
-        "column": 23,
-        "endLine": 52,
-        "endColumn": 38,
-        "help": "Add rel=\"noopener noreferrer\" to links that open in a new tab: noopener protects window.opener, and noreferrer suppresses referrer data"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "packages/core/src/NavigationMenu/story/NavigationMenuBasic.story.vue",
@@ -4067,21 +4055,10 @@
         "endLine": 30,
         "endColumn": 11,
         "help": "Rename the file to PascalCase or kebab-case:\n  myComponent.vue  -> MyComponent.vue\n  my-Component.vue -> my-component.vue"
-      },
-      {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener noreferrer\" is a security risk",
-        "line": 55,
-        "column": 19,
-        "endLine": 55,
-        "endColumn": 34,
-        "help": "Add rel=\"noopener noreferrer\" to links that open in a new tab: noopener protects window.opener, and noreferrer suppresses referrer data"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "packages/core/src/NavigationMenu/story/_NavigationMenuListItem.vue",
@@ -6727,21 +6704,9 @@
   },
   {
     "file": "packages/core/src/Toolbar/story/Toolbar.story.vue",
-    "messages": [
-      {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener noreferrer\" is a security risk",
-        "line": 86,
-        "column": 11,
-        "endLine": 86,
-        "endColumn": 26,
-        "help": "Add rel=\"noopener noreferrer\" to links that open in a new tab: noopener protects window.opener, and noreferrer suppresses referrer data"
-      }
-    ],
+    "messages": [],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 0
   },
   {
     "file": "packages/core/src/Toolbar/story/_Toolbar.vue",
@@ -6756,21 +6721,10 @@
         "endLine": 17,
         "endColumn": 11,
         "help": "Rename the file to PascalCase or kebab-case:\n  myComponent.vue  -> MyComponent.vue\n  my-Component.vue -> my-component.vue"
-      },
-      {
-        "ruleId": "vue/no-template-target-blank",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 1,
-        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener noreferrer\" is a security risk",
-        "line": 81,
-        "column": 7,
-        "endLine": 81,
-        "endColumn": 22,
-        "help": "Add rel=\"noopener noreferrer\" to links that open in a new tab: noopener protects window.opener, and noreferrer suppresses referrer data"
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 1
   },
   {
     "file": "packages/core/src/Tooltip/TooltipArrow.vue",


### PR DESCRIPTION
## Summary
- allow vue/no-template-target-blank to skip static relative href values
- keep external static hrefs and dynamic href bindings reportable in template and JSX paths
- add regression tests for relative template and JSX links

## Verification
- cargo test -p vize_patina no_template_target_blank --lib
- cargo test -p vize_patina eslint_vue_rule_map --lib
- cargo fmt --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791249582&installation_model_id=422833&pr_number=5789&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5789&signature=96eddb8aba9395a0e1a048ce89af08cac0994b27ded48721a8d83b40b84df5fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of links that open in a new tab.
  - Relative links are no longer flagged unnecessarily.
  - External links and dynamic link destinations continue to receive safety checks.
  - Added coverage for relative links in Vue and JSX scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->