### PR TITLE
fix(lsp): ignore inactive imports in document links

### DIFF
--- a/crates/vize_maestro/src/ide/document_link.rs
+++ b/crates/vize_maestro/src/ide/document_link.rs
@@ -12,6 +12,8 @@ use tower_lsp::lsp_types::{DocumentLink, Position, Range, Url};
 
 use super::offset_to_position;
 
+mod imports;
+
 /// Document link service.
 pub struct DocumentLinkService;
 
@@ -40,7 +42,7 @@ impl DocumentLinkService {
                 links.push(Self::create_link(content, start, end, target));
             }
 
-            Self::collect_import_links(
+            imports::collect_import_links(
                 &script_setup.content,
                 script_setup.loc.start,
                 content,
@@ -58,7 +60,7 @@ impl DocumentLinkService {
                 links.push(Self::create_link(content, start, end, target));
             }
 
-            Self::collect_import_links(
+            imports::collect_import_links(
                 &script.content,
                 script.loc.start,
                 content,
@@ -113,117 +115,6 @@ impl DocumentLinkService {
         }
     }
 
-    /// Collect import statement links from script content.
-    fn collect_import_links(
-        script: &str,
-        base_offset: usize,
-        full_content: &str,
-        base_path: Option<&Path>,
-        links: &mut Vec<DocumentLink>,
-    ) {
-        // Match: import ... from "path" or import ... from 'path'
-        // Match: import "path" or import 'path' (side-effect imports)
-        // Match: export ... from "path" or export ... from 'path'
-        let mut pos = 0;
-        let bytes = script.as_bytes();
-
-        while pos < script.len() {
-            // Find "import" or "export"
-            let import_start = script[pos..].find("import");
-            let export_start = script[pos..].find("export");
-
-            let keyword_start = match (import_start, export_start) {
-                (Some(i), Some(e)) => Some(pos + i.min(e)),
-                (Some(i), None) => Some(pos + i),
-                (None, Some(e)) => Some(pos + e),
-                (None, None) => None,
-            };
-
-            let Some(start) = keyword_start else {
-                break;
-            };
-
-            // Check it's at word boundary
-            if start > 0 && Self::is_ident_char(bytes[start - 1] as char) {
-                pos = start + 1;
-                continue;
-            }
-
-            // Find the end of this statement (semicolon or newline)
-            let stmt_end = script[start..]
-                .find([';', '\n'])
-                .map(|i| start + i)
-                .unwrap_or(script.len());
-
-            let stmt = &script[start..stmt_end];
-
-            // Find string literal (the path)
-            if let Some((path, rel_start, rel_end)) = Self::extract_import_path(stmt) {
-                // Only link relative imports (start with . or /)
-                if (path.starts_with('.') || path.starts_with('/'))
-                    && let Some(target) = Self::resolve_path(&path, base_path)
-                {
-                    let abs_start = base_offset + start + rel_start;
-                    let abs_end = base_offset + start + rel_end;
-                    links.push(Self::create_link(full_content, abs_start, abs_end, target));
-                }
-            }
-
-            pos = stmt_end + 1;
-        }
-    }
-
-    /// Extract import path from an import/export statement.
-    /// Returns (path, start, end_offset) where offsets are relative to stmt start.
-    fn extract_import_path(stmt: &str) -> Option<(String, usize, usize)> {
-        // Look for 'from' keyword followed by string
-        if let Some(from_pos) = stmt.find(" from ") {
-            let after_from = &stmt[from_pos + 6..];
-            return Self::extract_string_literal(after_from)
-                .map(|(path, s, e)| (path, from_pos + 6 + s, from_pos + 6 + e));
-        }
-
-        // Side-effect import: import "path"
-        if stmt.starts_with("import ") || stmt.starts_with("import\t") {
-            let after_import = &stmt[7..];
-            // Check if it's a side-effect import (no identifier before the string)
-            let trimmed = after_import.trim_start();
-            if trimmed.starts_with('"') || trimmed.starts_with('\'') {
-                let ws_len = after_import.len() - trimmed.len();
-                return Self::extract_string_literal(trimmed)
-                    .map(|(path, s, e)| (path, 7 + ws_len + s, 7 + ws_len + e));
-            }
-        }
-
-        None
-    }
-
-    /// Extract string literal from text.
-    /// Returns (content, start, end_offset) where offsets include quotes.
-    fn extract_string_literal(text: &str) -> Option<(String, usize, usize)> {
-        let bytes = text.as_bytes();
-        if bytes.is_empty() {
-            return None;
-        }
-
-        let quote = bytes[0] as char;
-        if quote != '"' && quote != '\'' {
-            return None;
-        }
-
-        // Find closing quote
-        let mut i = 1;
-        while i < bytes.len() {
-            if bytes[i] == quote as u8 && (i == 1 || bytes[i - 1] != b'\\') {
-                let content = text[1..i].to_string();
-                return Some((content, 0, i + 1));
-            }
-            i += 1;
-        }
-
-        None
-    }
-
     /// Collect CSS @import links.
     fn collect_css_import_links(
         css: &str,
@@ -243,7 +134,9 @@ impl DocumentLinkService {
 
             // @import url("path") or @import url('path')
             if let Some(url_content) = trimmed.strip_prefix("url(") {
-                if let Some((path, s, e)) = Self::extract_string_literal(url_content.trim_start()) {
+                if let Some((path, s, e)) =
+                    imports::extract_string_literal(url_content.trim_start())
+                {
                     let inner_ws = url_content.len() - url_content.trim_start().len();
                     if (path.starts_with('.') || path.starts_with('/'))
                         && let Some(target) = Self::resolve_path(&path, base_path)
@@ -255,7 +148,7 @@ impl DocumentLinkService {
                 }
             }
             // @import "path" or @import 'path'
-            else if let Some((path, s, e)) = Self::extract_string_literal(trimmed)
+            else if let Some((path, s, e)) = imports::extract_string_literal(trimmed)
                 && (path.starts_with('.') || path.starts_with('/'))
                 && let Some(target) = Self::resolve_path(&path, base_path)
             {
@@ -355,10 +248,6 @@ impl DocumentLinkService {
             data: None,
         }
     }
-
-    fn is_ident_char(c: char) -> bool {
-        c.is_ascii_alphanumeric() || c == '_' || c == '$'
-    }
 }
 
 #[cfg(test)]
@@ -367,36 +256,6 @@ mod tests {
 
     use super::DocumentLinkService;
     use tower_lsp::lsp_types::Url;
-
-    #[test]
-    fn test_extract_import_path() {
-        // Regular import
-        let stmt = r#"import { ref } from "./utils""#;
-        let (path, _, _) = DocumentLinkService::extract_import_path(stmt).unwrap();
-        assert_eq!(path, "./utils");
-
-        // Side-effect import
-        let stmt = r#"import "./styles.css""#;
-        let (path, _, _) = DocumentLinkService::extract_import_path(stmt).unwrap();
-        assert_eq!(path, "./styles.css");
-
-        // Export from
-        let stmt = r#"export { foo } from './foo'"#;
-        let (path, _, _) = DocumentLinkService::extract_import_path(stmt).unwrap();
-        assert_eq!(path, "./foo");
-    }
-
-    #[test]
-    fn test_extract_string_literal() {
-        let (content, start, end) =
-            DocumentLinkService::extract_string_literal(r#""hello""#).unwrap();
-        assert_eq!(content, "hello");
-        assert_eq!(start, 0);
-        assert_eq!(end, 7);
-
-        let (content, _, _) = DocumentLinkService::extract_string_literal("'world'").unwrap();
-        assert_eq!(content, "world");
-    }
 
     #[test]
     fn test_define_art_source_link() {

--- a/crates/vize_maestro/src/ide/document_link.rs
+++ b/crates/vize_maestro/src/ide/document_link.rs
@@ -44,6 +44,7 @@ impl DocumentLinkService {
 
             imports::collect_import_links(
                 &script_setup.content,
+                imports::script_source_type(script_setup.lang.as_deref()),
                 script_setup.loc.start,
                 content,
                 base_path.as_deref(),
@@ -62,6 +63,7 @@ impl DocumentLinkService {
 
             imports::collect_import_links(
                 &script.content,
+                imports::script_source_type(script.lang.as_deref()),
                 script.loc.start,
                 content,
                 base_path.as_deref(),

--- a/crates/vize_maestro/src/ide/document_link/imports.rs
+++ b/crates/vize_maestro/src/ide/document_link/imports.rs
@@ -1,33 +1,35 @@
 use std::path::Path;
 
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Statement;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
 use tower_lsp::lsp_types::DocumentLink;
 
 use super::DocumentLinkService;
 
+#[derive(Debug, PartialEq)]
+struct ModuleSpecifier {
+    path: String,
+    start: usize,
+    end: usize,
+}
+
 /// Collect import statement links from script content.
 pub(super) fn collect_import_links(
     script: &str,
+    source_type: SourceType,
     base_offset: usize,
     full_content: &str,
     base_path: Option<&Path>,
     links: &mut Vec<DocumentLink>,
 ) {
-    let mut pos = 0;
-
-    while let Some(start) = next_module_keyword(script, pos) {
-        let stmt_end = script[start..]
-            .find([';', '\n'])
-            .map(|i| start + i)
-            .unwrap_or(script.len());
-
-        let stmt = &script[start..stmt_end];
-
-        if let Some((path, rel_start, rel_end)) = extract_import_path(stmt)
-            && (path.starts_with('.') || path.starts_with('/'))
-            && let Some(target) = DocumentLinkService::resolve_path(&path, base_path)
+    for specifier in collect_static_module_specifiers(script, source_type) {
+        if (specifier.path.starts_with('.') || specifier.path.starts_with('/'))
+            && let Some(target) = DocumentLinkService::resolve_path(&specifier.path, base_path)
         {
-            let abs_start = base_offset + start + rel_start;
-            let abs_end = base_offset + start + rel_end;
+            let abs_start = base_offset + specifier.start;
+            let abs_end = base_offset + specifier.end;
             links.push(DocumentLinkService::create_link(
                 full_content,
                 abs_start,
@@ -35,31 +37,54 @@ pub(super) fn collect_import_links(
                 target,
             ));
         }
-
-        pos = stmt_end + 1;
     }
 }
 
-/// Extract import path from an import/export statement.
-/// Returns (path, start, end_offset) where offsets are relative to stmt start.
-fn extract_import_path(stmt: &str) -> Option<(String, usize, usize)> {
-    if let Some(from_pos) = stmt.find(" from ") {
-        let after_from = &stmt[from_pos + 6..];
-        return extract_string_literal(after_from)
-            .map(|(path, s, e)| (path, from_pos + 6 + s, from_pos + 6 + e));
+pub(super) fn script_source_type(lang: Option<&str>) -> SourceType {
+    match lang.unwrap_or("js") {
+        "ts" => SourceType::ts().with_module(true),
+        "tsx" => SourceType::tsx().with_module(true),
+        "jsx" => SourceType::jsx().with_module(true),
+        _ => SourceType::mjs(),
+    }
+}
+
+fn collect_static_module_specifiers(script: &str, source_type: SourceType) -> Vec<ModuleSpecifier> {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, source_type).parse();
+    if parsed.panicked {
+        return Vec::new();
     }
 
-    if stmt.starts_with("import ") || stmt.starts_with("import\t") {
-        let after_import = &stmt[7..];
-        let trimmed = after_import.trim_start();
-        if trimmed.starts_with('"') || trimmed.starts_with('\'') {
-            let ws_len = after_import.len() - trimmed.len();
-            return extract_string_literal(trimmed)
-                .map(|(path, s, e)| (path, 7 + ws_len + s, 7 + ws_len + e));
-        }
-    }
+    parsed
+        .program
+        .body
+        .iter()
+        .filter_map(|statement| match statement {
+            Statement::ImportDeclaration(decl) => Some(module_specifier(
+                decl.source.value.as_str(),
+                decl.source.span.start,
+                decl.source.span.end,
+            )),
+            Statement::ExportNamedDeclaration(decl) => decl.source.as_ref().map(|source| {
+                module_specifier(source.value.as_str(), source.span.start, source.span.end)
+            }),
+            Statement::ExportAllDeclaration(decl) => Some(module_specifier(
+                decl.source.value.as_str(),
+                decl.source.span.start,
+                decl.source.span.end,
+            )),
+            _ => None,
+        })
+        .collect()
+}
 
-    None
+fn module_specifier(path: &str, start: u32, end: u32) -> ModuleSpecifier {
+    ModuleSpecifier {
+        path: path.to_string(),
+        start: start as usize,
+        end: end as usize,
+    }
 }
 
 /// Extract string literal from text.
@@ -87,91 +112,34 @@ pub(super) fn extract_string_literal(text: &str) -> Option<(String, usize, usize
     None
 }
 
-fn next_module_keyword(script: &str, mut pos: usize) -> Option<usize> {
-    let bytes = script.as_bytes();
-
-    while pos < bytes.len() {
-        match bytes[pos] {
-            b'/' if bytes.get(pos + 1) == Some(&b'/') => {
-                pos = skip_line_comment(bytes, pos + 2);
-            }
-            b'/' if bytes.get(pos + 1) == Some(&b'*') => {
-                pos = skip_block_comment(bytes, pos + 2);
-            }
-            b'\'' | b'"' | b'`' => {
-                pos = skip_quoted(bytes, pos, bytes[pos]);
-            }
-            b'i' if keyword_at(bytes, pos, b"import") => return Some(pos),
-            b'e' if keyword_at(bytes, pos, b"export") => return Some(pos),
-            _ => pos += 1,
-        }
-    }
-
-    None
-}
-
-fn skip_line_comment(bytes: &[u8], mut pos: usize) -> usize {
-    while pos < bytes.len() && bytes[pos] != b'\n' {
-        pos += 1;
-    }
-    pos.saturating_add(1).min(bytes.len())
-}
-
-fn skip_block_comment(bytes: &[u8], mut pos: usize) -> usize {
-    while pos + 1 < bytes.len() {
-        if bytes[pos] == b'*' && bytes[pos + 1] == b'/' {
-            return pos + 2;
-        }
-        pos += 1;
-    }
-    bytes.len()
-}
-
-fn skip_quoted(bytes: &[u8], mut pos: usize, quote: u8) -> usize {
-    pos += 1;
-
-    while pos < bytes.len() {
-        match bytes[pos] {
-            b'\\' => pos = pos.saturating_add(2).min(bytes.len()),
-            byte if byte == quote => return pos + 1,
-            _ => pos += 1,
-        }
-    }
-
-    bytes.len()
-}
-
-fn keyword_at(bytes: &[u8], pos: usize, keyword: &[u8]) -> bool {
-    bytes.get(pos..pos + keyword.len()) == Some(keyword)
-        && pos
-            .checked_sub(1)
-            .is_none_or(|prev| !is_ident_byte(bytes[prev]))
-        && bytes
-            .get(pos + keyword.len())
-            .is_none_or(|next| !is_ident_byte(*next))
-}
-
-fn is_ident_byte(byte: u8) -> bool {
-    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{extract_import_path, extract_string_literal, next_module_keyword};
+    use super::{collect_static_module_specifiers, extract_string_literal, script_source_type};
 
     #[test]
-    fn extracts_import_paths() {
-        let stmt = r#"import { ref } from "./utils""#;
-        let (path, _, _) = extract_import_path(stmt).unwrap();
-        assert_eq!(path, "./utils");
+    fn extracts_static_module_specifier_ranges() {
+        let source = concat!(
+            "import { ref } from \"./utils\"\n",
+            "import \"./styles.css\"\n",
+            "export { foo } from './foo'\n",
+            "export * from './all'\n",
+        );
 
-        let stmt = r#"import "./styles.css""#;
-        let (path, _, _) = extract_import_path(stmt).unwrap();
-        assert_eq!(path, "./styles.css");
-
-        let stmt = r#"export { foo } from './foo'"#;
-        let (path, _, _) = extract_import_path(stmt).unwrap();
-        assert_eq!(path, "./foo");
+        let specifiers = collect_static_module_specifiers(source, script_source_type(Some("ts")));
+        assert_eq!(
+            specifiers
+                .iter()
+                .map(|specifier| &specifier.path)
+                .collect::<Vec<_>>(),
+            vec!["./utils", "./styles.css", "./foo", "./all"]
+        );
+        assert_eq!(
+            specifiers
+                .iter()
+                .map(|specifier| &source[specifier.start..specifier.end])
+                .collect::<Vec<_>>(),
+            vec![r#""./utils""#, r#""./styles.css""#, "'./foo'", "'./all'"]
+        );
     }
 
     #[test]
@@ -186,14 +154,32 @@ mod tests {
     }
 
     #[test]
-    fn skips_keywords_inside_comments_and_strings() {
+    fn extracts_multiline_imports_and_skips_inactive_specifiers() {
         let script = concat!(
-            "// import Ghost from './ghost'\n",
+            "import {\n",
+            "  ref, /* from './ghost' */\n",
+            "} from './real'\n",
             "const note = \"export { Hidden } from './hidden'\"\n",
-            "const tpl = `import Other from './other'`\n",
-            "import Real from './real'\n",
+            "// export { Line } from './line'\n",
+            "export {\n",
+            "  ref as value,\n",
+            "} from './exported'\n",
         );
 
-        assert_eq!(next_module_keyword(script, 0), script.find("import Real"));
+        let specifiers = collect_static_module_specifiers(script, script_source_type(Some("ts")));
+        assert_eq!(
+            specifiers
+                .iter()
+                .map(|specifier| &specifier.path)
+                .collect::<Vec<_>>(),
+            vec!["./real", "./exported"]
+        );
+        assert_eq!(
+            specifiers
+                .iter()
+                .map(|specifier| &script[specifier.start..specifier.end])
+                .collect::<Vec<_>>(),
+            vec!["'./real'", "'./exported'"]
+        );
     }
 }

--- a/crates/vize_maestro/src/ide/document_link/imports.rs
+++ b/crates/vize_maestro/src/ide/document_link/imports.rs
@@ -1,0 +1,199 @@
+use std::path::Path;
+
+use tower_lsp::lsp_types::DocumentLink;
+
+use super::DocumentLinkService;
+
+/// Collect import statement links from script content.
+pub(super) fn collect_import_links(
+    script: &str,
+    base_offset: usize,
+    full_content: &str,
+    base_path: Option<&Path>,
+    links: &mut Vec<DocumentLink>,
+) {
+    let mut pos = 0;
+
+    while let Some(start) = next_module_keyword(script, pos) {
+        let stmt_end = script[start..]
+            .find([';', '\n'])
+            .map(|i| start + i)
+            .unwrap_or(script.len());
+
+        let stmt = &script[start..stmt_end];
+
+        if let Some((path, rel_start, rel_end)) = extract_import_path(stmt)
+            && (path.starts_with('.') || path.starts_with('/'))
+            && let Some(target) = DocumentLinkService::resolve_path(&path, base_path)
+        {
+            let abs_start = base_offset + start + rel_start;
+            let abs_end = base_offset + start + rel_end;
+            links.push(DocumentLinkService::create_link(
+                full_content,
+                abs_start,
+                abs_end,
+                target,
+            ));
+        }
+
+        pos = stmt_end + 1;
+    }
+}
+
+/// Extract import path from an import/export statement.
+/// Returns (path, start, end_offset) where offsets are relative to stmt start.
+fn extract_import_path(stmt: &str) -> Option<(String, usize, usize)> {
+    if let Some(from_pos) = stmt.find(" from ") {
+        let after_from = &stmt[from_pos + 6..];
+        return extract_string_literal(after_from)
+            .map(|(path, s, e)| (path, from_pos + 6 + s, from_pos + 6 + e));
+    }
+
+    if stmt.starts_with("import ") || stmt.starts_with("import\t") {
+        let after_import = &stmt[7..];
+        let trimmed = after_import.trim_start();
+        if trimmed.starts_with('"') || trimmed.starts_with('\'') {
+            let ws_len = after_import.len() - trimmed.len();
+            return extract_string_literal(trimmed)
+                .map(|(path, s, e)| (path, 7 + ws_len + s, 7 + ws_len + e));
+        }
+    }
+
+    None
+}
+
+/// Extract string literal from text.
+/// Returns (content, start, end_offset) where offsets include quotes.
+pub(super) fn extract_string_literal(text: &str) -> Option<(String, usize, usize)> {
+    let bytes = text.as_bytes();
+    if bytes.is_empty() {
+        return None;
+    }
+
+    let quote = bytes[0] as char;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+
+    let mut i = 1;
+    while i < bytes.len() {
+        if bytes[i] == quote as u8 && (i == 1 || bytes[i - 1] != b'\\') {
+            let content = text[1..i].to_string();
+            return Some((content, 0, i + 1));
+        }
+        i += 1;
+    }
+
+    None
+}
+
+fn next_module_keyword(script: &str, mut pos: usize) -> Option<usize> {
+    let bytes = script.as_bytes();
+
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'/' if bytes.get(pos + 1) == Some(&b'/') => {
+                pos = skip_line_comment(bytes, pos + 2);
+            }
+            b'/' if bytes.get(pos + 1) == Some(&b'*') => {
+                pos = skip_block_comment(bytes, pos + 2);
+            }
+            b'\'' | b'"' | b'`' => {
+                pos = skip_quoted(bytes, pos, bytes[pos]);
+            }
+            b'i' if keyword_at(bytes, pos, b"import") => return Some(pos),
+            b'e' if keyword_at(bytes, pos, b"export") => return Some(pos),
+            _ => pos += 1,
+        }
+    }
+
+    None
+}
+
+fn skip_line_comment(bytes: &[u8], mut pos: usize) -> usize {
+    while pos < bytes.len() && bytes[pos] != b'\n' {
+        pos += 1;
+    }
+    pos.saturating_add(1).min(bytes.len())
+}
+
+fn skip_block_comment(bytes: &[u8], mut pos: usize) -> usize {
+    while pos + 1 < bytes.len() {
+        if bytes[pos] == b'*' && bytes[pos + 1] == b'/' {
+            return pos + 2;
+        }
+        pos += 1;
+    }
+    bytes.len()
+}
+
+fn skip_quoted(bytes: &[u8], mut pos: usize, quote: u8) -> usize {
+    pos += 1;
+
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'\\' => pos = pos.saturating_add(2).min(bytes.len()),
+            byte if byte == quote => return pos + 1,
+            _ => pos += 1,
+        }
+    }
+
+    bytes.len()
+}
+
+fn keyword_at(bytes: &[u8], pos: usize, keyword: &[u8]) -> bool {
+    bytes.get(pos..pos + keyword.len()) == Some(keyword)
+        && pos
+            .checked_sub(1)
+            .is_none_or(|prev| !is_ident_byte(bytes[prev]))
+        && bytes
+            .get(pos + keyword.len())
+            .is_none_or(|next| !is_ident_byte(*next))
+}
+
+fn is_ident_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_import_path, extract_string_literal, next_module_keyword};
+
+    #[test]
+    fn extracts_import_paths() {
+        let stmt = r#"import { ref } from "./utils""#;
+        let (path, _, _) = extract_import_path(stmt).unwrap();
+        assert_eq!(path, "./utils");
+
+        let stmt = r#"import "./styles.css""#;
+        let (path, _, _) = extract_import_path(stmt).unwrap();
+        assert_eq!(path, "./styles.css");
+
+        let stmt = r#"export { foo } from './foo'"#;
+        let (path, _, _) = extract_import_path(stmt).unwrap();
+        assert_eq!(path, "./foo");
+    }
+
+    #[test]
+    fn extracts_string_literals() {
+        let (content, start, end) = extract_string_literal(r#""hello""#).unwrap();
+        assert_eq!(content, "hello");
+        assert_eq!(start, 0);
+        assert_eq!(end, 7);
+
+        let (content, _, _) = extract_string_literal("'world'").unwrap();
+        assert_eq!(content, "world");
+    }
+
+    #[test]
+    fn skips_keywords_inside_comments_and_strings() {
+        let script = concat!(
+            "// import Ghost from './ghost'\n",
+            "const note = \"export { Hidden } from './hidden'\"\n",
+            "const tpl = `import Other from './other'`\n",
+            "import Real from './real'\n",
+        );
+
+        assert_eq!(next_module_keyword(script, 0), script.find("import Real"));
+    }
+}

--- a/tests/tooling/lsp-document-link.test.ts
+++ b/tests/tooling/lsp-document-link.test.ts
@@ -207,11 +207,10 @@ export {
 
     assert.ok(Array.isArray(links), JSON.stringify(links));
     assert.deepEqual(links.map(basenameForTarget), ["Multi.vue", "Real.vue", "Exported.vue"]);
-    assert.deepEqual(links.map((link) => textAtLinkRange(source, link)), [
-      "'./Multi.vue'",
-      "'./Real.vue'",
-      "'./Exported.vue'",
-    ]);
+    assert.deepEqual(
+      links.map((link) => textAtLinkRange(source, link)),
+      ["'./Multi.vue'", "'./Real.vue'", "'./Exported.vue'"],
+    );
   } finally {
     await session.shutdown();
     fs.rmSync(workspaceDir, { recursive: true, force: true });

--- a/tests/tooling/lsp-document-link.test.ts
+++ b/tests/tooling/lsp-document-link.test.ts
@@ -144,7 +144,7 @@ const _x = ref(0)
   }
 });
 
-test("vize lsp documentLink ignores commented and string-literal imports", async () => {
+test("vize lsp documentLink handles multiline imports and ignores inactive specifiers", async () => {
   const testRootDir = path.join(testOutputRoot, "lsp-document-link-script-comments");
   fs.mkdirSync(testRootDir, { recursive: true });
   const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
@@ -157,18 +157,27 @@ test("vize lsp documentLink ignores commented and string-literal imports", async
       typecheck: false,
     });
 
-    fs.writeFileSync(
-      path.join(workspaceDir, "Real.vue"),
-      `<script setup lang="ts"></script>
+    for (const fileName of ["Multi.vue", "Real.vue", "Exported.vue"]) {
+      fs.writeFileSync(
+        path.join(workspaceDir, fileName),
+        `<script setup lang="ts"></script>
 <template><span /></template>
 `,
-      "utf8",
-    );
+        "utf8",
+      );
+    }
 
     const source = `<script setup lang="ts">
+/* import Block from './Block.vue' */
 // import Ghost from './Ghost.vue'
 const note = "import Hidden from './Hidden.vue'"
+import {
+  real /* from './CommentOnly.vue' */,
+} from './Multi.vue'
 import Real from './Real.vue'
+export {
+  default as Exported /* from './FakeExport.vue' */,
+} from './Exported.vue'
 </script>
 
 <template>
@@ -197,8 +206,12 @@ import Real from './Real.vue'
     })) as DocumentLink[] | null;
 
     assert.ok(Array.isArray(links), JSON.stringify(links));
-    assert.deepEqual(links.map(basenameForTarget), ["Real.vue"]);
-    assert.equal(textAtLinkRange(source, links[0]!), "'./Real.vue'");
+    assert.deepEqual(links.map(basenameForTarget), ["Multi.vue", "Real.vue", "Exported.vue"]);
+    assert.deepEqual(links.map((link) => textAtLinkRange(source, link)), [
+      "'./Multi.vue'",
+      "'./Real.vue'",
+      "'./Exported.vue'",
+    ]);
   } finally {
     await session.shutdown();
     fs.rmSync(workspaceDir, { recursive: true, force: true });

--- a/tests/tooling/lsp-document-link.test.ts
+++ b/tests/tooling/lsp-document-link.test.ts
@@ -144,6 +144,68 @@ const _x = ref(0)
   }
 });
 
+test("vize lsp documentLink ignores commented and string-literal imports", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-document-link-script-comments");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: false,
+    });
+
+    fs.writeFileSync(
+      path.join(workspaceDir, "Real.vue"),
+      `<script setup lang="ts"></script>
+<template><span /></template>
+`,
+      "utf8",
+    );
+
+    const source = `<script setup lang="ts">
+// import Ghost from './Ghost.vue'
+const note = "import Hidden from './Hidden.vue'"
+import Real from './Real.vue'
+</script>
+
+<template>
+  <Real />
+</template>
+`;
+    const filePath = path.join(workspaceDir, "Host.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        languageId: "vue",
+        version: 1,
+        text: source,
+      },
+    });
+
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    const links = (await session.request("textDocument/documentLink", {
+      textDocument: { uri },
+    })) as DocumentLink[] | null;
+
+    assert.ok(Array.isArray(links), JSON.stringify(links));
+    assert.deepEqual(links.map(basenameForTarget), ["Real.vue"]);
+    assert.equal(textAtLinkRange(source, links[0]!), "'./Real.vue'");
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
 test("vize lsp documentLink resolves SFC block src attributes and CSS imports", async (t) => {
   const testRootDir = path.join(testOutputRoot, "lsp-document-link-src-css");
   fs.mkdirSync(testRootDir, { recursive: true });


### PR DESCRIPTION
## Summary
- collect script import/export document links from OXC static module specifier spans
- ignore inactive import/export-looking text inside comments and quoted/template literals
- cover multiline imports/exports and fake inactive specifiers in unit and LSP tests

## Tests
- cargo fmt --all -- --check
- cargo test -p vize_maestro document_link
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 20
- git diff --check
- cargo build -p vize
- VIZE_LSP_BIN=$PWD/target/debug/vize node --test --test-concurrency=1 tests/tooling/lsp-document-link.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved document-link detection for multiline JavaScript and TypeScript imports and exports.
  - Links are now correctly provided for active relative paths while ignoring import-like text in comments, strings, and inactive specifiers.
  - Document links now support a broader range of script language variants, including TypeScript, TSX, and JSX.

- **Tests**
  - Added coverage for multiline imports, exports, comments, and string literals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->