### PR TITLE
test(patina): assert unused alias diagnostic range

### DIFF
--- a/crates/vize_patina/src/linter/tests/v_for_unused_vars.rs
+++ b/crates/vize_patina/src/linter/tests/v_for_unused_vars.rs
@@ -99,5 +99,11 @@ fn test_lint_template_reports_outer_alias_shadowed_by_event_parameter() {
     let result = linter.lint_sfc(source, "test.vue");
 
     assert_eq!(result.warning_count, 1, "{:?}", result.diagnostics);
-    assert!(result.diagnostics[0].message.contains("'event'"));
+    let alias_start = source.find(r#"v-for="event"#).unwrap() as u32 + "v-for=\"".len() as u32;
+    let diagnostic = &result.diagnostics[0];
+    assert!(diagnostic.message.contains("'event'"));
+    assert_eq!(
+        (diagnostic.start, diagnostic.end),
+        (alias_start, alias_start + "event".len() as u32)
+    );
 }

--- a/tests/tooling/patina-no-unused-vars-oracle.test.ts
+++ b/tests/tooling/patina-no-unused-vars-oracle.test.ts
@@ -12,6 +12,24 @@ const pluginVue = requireFromBench("eslint-plugin-vue");
 const vueParser = requireFromBench("vue-eslint-parser");
 const typescriptParser = requireFromBench("@typescript-eslint/parser");
 
+function rangeAt(source: string, offset: number, text: string) {
+  assert.equal(source.slice(offset, offset + text.length), text);
+  return {
+    line: 1,
+    column: offset + 1,
+    endLine: 1,
+    endColumn: offset + text.length + 1,
+  };
+}
+
+function aliasRange(source: string, directive: string, alias: string) {
+  const offset = source.indexOf(directive);
+  assert.notEqual(offset, -1, `missing expected range target: ${directive}${alias}`);
+  return rangeAt(source, offset + directive.length, alias);
+}
+
+const eventParameterShadowSource = `<template><button v-for="event in events" @click="(event) => handle(event)"></button></template>`;
+
 const cases = [
   {
     id: "leading-value-alias-needed-for-index",
@@ -35,8 +53,9 @@ const cases = [
   },
   {
     id: "event-parameter-shadows-outer-alias",
-    source: `<template><button v-for="event in events" @click="(event) => handle(event)"></button></template>`,
+    source: eventParameterShadowSource,
     diagnostics: ["'event' is defined but never used."],
+    ranges: [aliasRange(eventParameterShadowSource, `v-for="`, "event")],
   },
 ] as const;
 
@@ -71,10 +90,23 @@ test("no-unused-vars v-for tuple boundary stays pinned to eslint-plugin-vue 10.9
     });
     const diagnostics = result.messages
       .filter((message) => message.ruleId === "vue/no-unused-vars")
-      .map((message) => message.message);
+      .map((message) => ({
+        message: message.message,
+        range: {
+          line: message.line,
+          column: message.column,
+          endLine: message.endLine,
+          endColumn: message.endColumn,
+        },
+      }));
     const parserErrors = result.messages.filter((message) => message.ruleId == null);
+    const messages = diagnostics.map((diagnostic) => diagnostic.message);
+    const ranges = diagnostics.map((diagnostic) => diagnostic.range);
 
     assert.deepEqual(parserErrors, [], `${fixture.id}: parser errors`);
-    assert.deepEqual(diagnostics, fixture.diagnostics, fixture.id);
+    assert.deepEqual(messages, fixture.diagnostics, fixture.id);
+    if ("ranges" in fixture) {
+      assert.deepEqual(ranges, fixture.ranges, `${fixture.id}: diagnostic ranges`);
+    }
   }
 });


### PR DESCRIPTION
Summary:
- strengthen the Patina regression for vue/no-unused-vars event-parameter shadowing
- assert both Vize byte spans and the eslint-plugin-vue oracle range point at the outer v-for alias

Tests:
- TMPDIR=$PWD/target/vize-tests/tmp TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp cargo test -p vize_patina v_for_unused_vars -- --nocapture
- vp exec node --test tests/tooling/patina-no-unused-vars-oracle.test.ts
- cargo fmt --all --check
- vp exec oxfmt --check tests/tooling/patina-no-unused-vars-oracle.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791252966&installation_model_id=422833&pr_number=5793&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5793&signature=09160ca5c970d6e667bd8ca2c829c36f5338e91bc20112fa5ac205f92106818d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->