### PR TITLE
test(tooling): add vue-data-ui authored lsp oracle

### DIFF
--- a/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 27, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 28, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -787,6 +787,7 @@
           "tests/_fixtures/_git/splitpanes",
           "tests/_fixtures/_git/layoutit-grid",
           "tests/_fixtures/_git/lew-ui",
+          "tests/_fixtures/_git/vue-data-ui",
           "tests/_fixtures/_git/vue-charts",
           "tests/_fixtures/_git/vue-datepicker",
           "tests/_fixtures/_git/vue-flow",

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 27,
+    "minimumProjectCount": 28,
     "trackingIssue": 3952
   },
   "projects": [
@@ -3845,6 +3845,70 @@
         "syntax-highlighter",
         "lsp"
       ],
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "ts-playground/src/components/HelloWorld.vue",
+          "symbol": "msg",
+          "usageAnchor": "{{ msg }}",
+          "declarationAnchor": "    msg: string;",
+          "hoverContains": ["const msg: string"],
+          "renameTo": "__vizeRenamedMsg"
+        },
+        "componentBoundary": {
+          "importerFile": "manual-testing/src/views/HomeView.vue",
+          "componentFile": "manual-testing/src/components/TheWelcome.vue",
+          "tagName": "TheWelcome",
+          "tagAnchor": "<TheWelcome ",
+          "completionItemCount": 28,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 }
+          ],
+          "dependencyEdit": {
+            "file": "manual-testing/src/components/TheWelcome.vue",
+            "anchor": "import BaseIcon from '../../../src/atoms/BaseIcon.vue';\n",
+            "replacement": "import BaseIcon from '../../../src/atoms/BaseIcon.vue';\ndefineProps<{ vizeOracleProbe?: boolean }>();\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "sourceFile": "manual-testing/src/components/TheWelcome.vue",
+          "importerFile": "manual-testing/src/views/HomeView.vue",
+          "copiedFile": "manual-testing/src/components/__VizeOracleTheWelcome.vue",
+          "renamedFile": "manual-testing/src/components/__VizeOracleRenamedTheWelcome.vue",
+          "originalImportSpecifier": "../components/TheWelcome.vue",
+          "copiedImportSpecifier": "../components/__VizeOracleTheWelcome.vue",
+          "renamedImportSpecifier": "../components/__VizeOracleRenamedTheWelcome.vue",
+          "markerInsertionAnchor": "<script setup lang=\"ts\">\n",
+          "markerSymbol": "__vizeVueDataUiTheWelcomeMarker__"
+        }
+      },
       "diff": "curator-compare"
     },
     {

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 27,
+      "authored-lsp": 28,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,


### PR DESCRIPTION
## Summary
- add Vue Data UI as authored real-project LSP oracle coverage
- pin script-setup `msg` binding and `HomeView` to `TheWelcome` completion/lifecycle behavior
- raise authored LSP registry and compatibility ledger ratchets to 28

## Validation
- `cargo build --profile ci -p vize`
- `node --test --test-concurrency=1 tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts`
- `TMPDIR=$PWD/target/vize-tests/tmp TEMP=$PWD/target/vize-tests/tmp TMP=$PWD/target/vize-tests/tmp CORSA_PATH=node_modules/@typescript/typescript-darwin-arm64/lib/tsc VIZE_LSP_BIN=target/ci/vize FIXTURE_REPORT_DIR=target/vize-tests/lsp-authored-oracle FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=109 REAL_PROJECT_LSP_TIMEOUT_MS=600000 node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts`
- `node --test --test-concurrency=1 tests/tooling/real-project-matrix-summary.test.ts`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`
- `vp check tests/_fixtures/vue-ecosystem-fixtures.json tests/_fixtures/fixture-compatibility-ledger.json legacy-tools/fixtures/fixture-compatibility-ledger.mjs tests/tooling/fixture-compatibility-ledger.test.ts`
- `git diff --check`

Refs #3952

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791254805&installation_model_id=422833&pr_number=5795&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5795&signature=e1028ad725e46faa30c0e9f36a0e0d01649ad13bafe7ad838d7d835f3786a43e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded compatibility coverage to include the Vue Data UI fixture.
  - Added scenarios covering template bindings, component boundaries, dependency edits, and file lifecycle changes.
  - Updated fixture validation to account for the expanded test set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->