### PR TITLE
fix(davinci): preserve S2 DOM comments

### DIFF
--- a/crates/vize_atelier_core/tests/s2_support/hoist.rs
+++ b/crates/vize_atelier_core/tests/s2_support/hoist.rs
@@ -271,7 +271,7 @@ pub fn shape_of_s2(ops: &[FolioOp], out: &mut vize_s0::String) {
                 shape_of_s2(&for_op.ops, out);
                 out.push(')');
             }
-            FolioOp::Text(_) | FolioOp::Interpolation(_) => {}
+            FolioOp::Text(_) | FolioOp::Interpolation(_) | FolioOp::Comment(_) => {}
         }
     }
 }

--- a/crates/vize_atelier_core/tests/s2_support/hoist_owner.rs
+++ b/crates/vize_atelier_core/tests/s2_support/hoist_owner.rs
@@ -330,7 +330,7 @@ pub fn advance_ops(ops: &[FolioOp], next: &mut u32) {
                 *next += 1;
                 advance_ops(&for_op.ops, next);
             }
-            FolioOp::Text(_) | FolioOp::Interpolation(_) => *next += 1,
+            FolioOp::Text(_) | FolioOp::Interpolation(_) | FolioOp::Comment(_) => *next += 1,
         }
     }
 }

--- a/crates/vize_atelier_core/tests/s2_support/hoist_walk.rs
+++ b/crates/vize_atelier_core/tests/s2_support/hoist_walk.rs
@@ -76,7 +76,10 @@ pub fn walk_level(
     let mut cursor = 0usize;
     for op in s2 {
         // Leaf ops between structural positions still consume ids.
-        if matches!(op, FolioOp::Text(_) | FolioOp::Interpolation(_)) {
+        if matches!(
+            op,
+            FolioOp::Text(_) | FolioOp::Interpolation(_) | FolioOp::Comment(_)
+        ) {
             *next += 1;
             continue;
         }
@@ -243,7 +246,10 @@ fn walk_branch_roots(
     );
     let mut cursor = 0usize;
     for op in ops {
-        if matches!(op, FolioOp::Text(_) | FolioOp::Interpolation(_)) {
+        if matches!(
+            op,
+            FolioOp::Text(_) | FolioOp::Interpolation(_) | FolioOp::Comment(_)
+        ) {
             *next += 1;
             continue;
         }

--- a/crates/vize_atelier_core/tests/s2_support/s2_lane.rs
+++ b/crates/vize_atelier_core/tests/s2_support/s2_lane.rs
@@ -247,6 +247,7 @@ fn walk(
                     },
                 });
             }
+            FolioOp::Comment(_) => *next += 1,
             FolioOp::If(if_op) => {
                 let id = NodeId::from_index(*next).expect("page-order ids fit");
                 *next += 1;

--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -90,7 +90,6 @@ pub(super) fn s2_emit_supported(
     ) && !codegen.source_map
         && options.hoist_static
         && !options.ssr
-        && !options.comments
         && !options.experimental_in_tag_comments
         && !options.experimental_patterned_template
         && !options.custom_renderer
@@ -125,6 +124,7 @@ pub(super) fn s2_emit_options<'a>(
         hoisted_scope_id,
         scope_id: options.scope_id.as_deref(),
         is_ts: options.is_ts,
+        comments: options.comments,
         bindings,
     }
 }

--- a/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
@@ -85,30 +85,6 @@ fn source_map_compiles_stay_on_compatibility_when_profiled() {
 }
 
 #[test]
-fn comments_use_s2_when_profiled() {
-    let _guard = lock_profiler();
-    let profiler = global_profiler();
-    profiler.disable();
-    profiler.clear();
-
-    let source = "<div><!--kept--><span>probe</span></div>";
-    profiler.enable();
-    let result = compile(
-        source,
-        DomCompilerOptions {
-            comments: true,
-            ..Default::default()
-        },
-    );
-    let counters = profiler.counter_summary();
-    profiler.disable();
-    profiler.clear();
-
-    assert!(result.code.contains(r#"_createCommentVNode("kept")"#));
-    assert_eq!(counter_total(&counters, "davinci.s2_dom.files"), Some(1));
-}
-
-#[test]
 fn unsupported_options_stay_on_compatibility_without_profiler() {
     let _guard = lock_profiler();
     let profiler = global_profiler();

--- a/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
@@ -85,30 +85,27 @@ fn source_map_compiles_stay_on_compatibility_when_profiled() {
 }
 
 #[test]
-fn comments_stay_on_compatibility_without_profiler() {
+fn comments_use_s2_when_profiled() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
     profiler.clear();
 
     let source = "<div><!--kept--><span>probe</span></div>";
-    let options = DomCompilerOptions {
-        comments: true,
-        ..Default::default()
-    };
-
-    let result = compile(source, options);
+    profiler.enable();
+    let result = compile(
+        source,
+        DomCompilerOptions {
+            comments: true,
+            ..Default::default()
+        },
+    );
     let counters = profiler.counter_summary();
+    profiler.disable();
+    profiler.clear();
 
-    assert!(
-        result.sections.is_some(),
-        "comment-preserving compiles must keep compatibility sections"
-    );
-    assert_eq!(
-        counter_total(&counters, "davinci.s2_dom.files"),
-        None,
-        "compatibility compiles must not instantiate the profiling observer"
-    );
+    assert!(result.code.contains(r#"_createCommentVNode("kept")"#));
+    assert_eq!(counter_total(&counters, "davinci.s2_dom.files"), Some(1));
 }
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
@@ -234,7 +234,7 @@ fn source_map_disabled_runtime_global_name_stays_on_s2_codegen() {
 }
 
 #[test]
-fn source_map_disabled_comments_use_compatibility_codegen() {
+fn source_map_disabled_comments_use_s2_codegen() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
@@ -264,9 +264,9 @@ fn source_map_disabled_comments_use_compatibility_codegen() {
     assert_eq!(result.preamble, compat.preamble);
     assert_eq!(result.code, compat.code);
     assert_eq!(
-        counter_total(&counters, "davinci.s2_dom.files"),
-        None,
-        "comment-preserving compiles must stay on compatibility codegen"
+        counter(&counters, "davinci.s2_dom.files"),
+        1,
+        "comment-preserving source-map-free compiles are covered by the S2 production option surface"
     );
 }
 

--- a/crates/vize_atelier_dom/tests/davinci_s2_sfc_comment_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_sfc_comment_selector.rs
@@ -1,5 +1,5 @@
-//! P2-11 witness: SFC section selection keeps comment-preserving DOM compiles
-//! on the compatibility path until S2 preserves authored comments.
+//! P2-11 witness: SFC section selection routes comment-preserving DOM compiles
+//! through S2 while retaining exact authored comment output.
 
 #![allow(
     clippy::disallowed_macros,
@@ -16,7 +16,7 @@ use vize_s0::Allocator;
 use vize_s0::profiler::{CounterSummary, global_profiler};
 
 #[test]
-fn comment_preserving_sfc_sections_stay_on_compatibility_when_profiled() {
+fn comment_preserving_sfc_sections_use_s2_when_profiled() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
@@ -59,8 +59,8 @@ fn comment_preserving_sfc_sections_stay_on_compatibility_when_profiled() {
     );
     assert_eq!(
         counter_total(&counters, "davinci.s2_dom.files"),
-        None,
-        "comment-preserving SFC sections must stay on compatibility until S2 preserves comments"
+        Some(1),
+        "comment-preserving SFC sections must use S2 once S2 preserves comments"
     );
 }
 

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -32,8 +32,9 @@
 //! **dynamic `v-if` keys** (`:key="expr"`), foreign namespace boundaries,
 //! template refs, Vue 2 `.native` event sugar, static+dynamic `style`,
 //! dynamic `v-on` keys, native-element `v-once` / `v-memo`, `v-html` /
-//! `v-text`, `v-bind` modifiers, dynamic `v-bind` keys / modifiers, and
-//! Vue 2 pipe filters legalized by `legacy-sugar`, and **module mode**
+//! `v-text`, ordinary template comments, `v-bind` modifiers, dynamic
+//! `v-bind` keys / modifiers, and Vue 2 pipe filters legalized by
+//! `legacy-sugar`, and **module mode**
 //! ([`DomEmitOptions`]: `import { … } from "vue"` + `export function
 //! render(_ctx, _cache)`, custom runtime module / global names), and
 //! **`cache_handlers`** (`_cache[n] || (_cache[n] = …)` around a `v-on`
@@ -43,8 +44,8 @@
 //! every props object — inline, hoisted and component alike, and once as a
 //! trailing `mergeProps` argument rather than per spread segment). `atelier_dom`
 //! selects this lane for supported source-map-free DOM compiles; the old lane
-//! remains for source maps and unsupported option surfaces until the phase-exit
-//! deletion.
+//! remains for source maps, experimental in-tag comments and unsupported
+//! option surfaces until the phase-exit deletion.
 
 mod budget;
 mod buf;

--- a/crates/vize_s1_to_s2/src/emit/budget.rs
+++ b/crates/vize_s1_to_s2/src/emit/budget.rs
@@ -2,7 +2,7 @@ use vize_davinci::pass::{BudgetObserver, PassObserver};
 use vize_s0::{Allocator, ensure_sufficient_stack};
 use vize_s1::parse;
 
-use crate::lower::{LegacyCaps, lower_with_caps};
+use crate::lower::{LegacyCaps, lower_with_caps_and_comment_policy};
 use crate::pass::run_transform;
 
 use super::{DomEmit, DomEmitOptions, EmitError, emit_dom_with_emit_budget};
@@ -81,7 +81,8 @@ pub(super) fn emit_dom_source_with_options_and_observer<'a, O: PassObserver>(
 ) -> Result<(DomEmit, u32), EmitError> {
     ensure_sufficient_stack(|| {
         let (tree, errors) = parse(allocator, source);
-        let mut lowered = lower_with_caps(allocator, &tree, &errors, caps);
+        let mut lowered =
+            lower_with_caps_and_comment_policy(allocator, &tree, &errors, caps, options.comments);
         let facts = run_transform(&mut lowered, observer);
         let (emit, emit_visits) = emit_dom_with_emit_budget(&lowered, &facts, options)?;
         Ok((emit, emit_visits))

--- a/crates/vize_s1_to_s2/src/emit/children.rs
+++ b/crates/vize_s1_to_s2/src/emit/children.rs
@@ -7,7 +7,7 @@ pub(super) use slot_text::{emit_slot_text_child, emit_slot_text_run};
 use vize_davinci::id::NodeId;
 use vize_s0::Span;
 use vize_s2::expr::{ExprRef, JsExpr, OpaqueReason};
-use vize_s2::op::{InterpolationOp, Op, Region};
+use vize_s2::op::{CommentOp, InterpolationOp, Op, Region};
 
 use super::EmitCx;
 use super::EmitError;
@@ -26,7 +26,12 @@ pub(super) fn emit_text_like(cx: &mut EmitCx<'_>, ops: &[Op<'_>]) -> Result<(), 
         match op {
             Op::Text(text) => emit_quoted_text(cx, text.content),
             Op::Interpolation(interp) => emit_interpolation(cx, interp, id)?,
-            Op::Element(_) | Op::Component(_) | Op::If(_) | Op::For(_) | Op::Slot(_) => {
+            Op::Element(_)
+            | Op::Component(_)
+            | Op::Comment(_)
+            | Op::If(_)
+            | Op::For(_)
+            | Op::Slot(_) => {
                 return Err(EmitError::unsupported_op(
                     Reason::TextRunContainsNonText,
                     op,
@@ -56,6 +61,7 @@ pub(super) fn children_need_text_flag(cx: &EmitCx<'_>, children: &Region<'_>) ->
                 all_constant &= interpolation_is_constant(cx, interp, id);
             }
             Op::Text(_) => {}
+            Op::Comment(_) => return false,
             _ => return false,
         }
     }
@@ -217,6 +223,14 @@ pub(super) fn emit_plain_text_vnode(cx: &mut EmitCx<'_>, content: &str) {
     }
     cx.buf.push("(\"");
     cx.buf.push(escape_js_string(content).as_str());
+    cx.buf.push("\")");
+}
+
+pub(super) fn emit_comment_vnode(cx: &mut EmitCx<'_>, comment: &CommentOp<'_>) {
+    cx.buf.use_create_comment();
+    cx.buf.push(Buf::create_comment_alias());
+    cx.buf.push("(\"");
+    cx.buf.push(escape_js_string(comment.content).as_str());
     cx.buf.push("\")");
 }
 

--- a/crates/vize_s1_to_s2/src/emit/children/slot_text.rs
+++ b/crates/vize_s1_to_s2/src/emit/children/slot_text.rs
@@ -106,7 +106,12 @@ fn emit_slot_text_like(cx: &mut EmitCx<'_>, ops: &[Op<'_>]) -> Result<(), EmitEr
         match op {
             Op::Text(text) => emit_quoted_text(cx, text.content),
             Op::Interpolation(interp) => emit_slot_interpolation(cx, interp, id)?,
-            Op::Element(_) | Op::Component(_) | Op::If(_) | Op::For(_) | Op::Slot(_) => {
+            Op::Element(_)
+            | Op::Component(_)
+            | Op::Comment(_)
+            | Op::If(_)
+            | Op::For(_)
+            | Op::Slot(_) => {
                 return Err(EmitError::unsupported_op(
                     Reason::TextRunContainsNonText,
                     op,

--- a/crates/vize_s1_to_s2/src/emit/component/call_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props.rs
@@ -171,7 +171,7 @@ fn has_nested_component_key(region: &Region<'_>) -> bool {
             .any(|branch| has_nested_component_key(&branch.region)),
         Op::For(for_op) => has_nested_component_key(&for_op.region),
         Op::Slot(slot) => has_nested_component_key(&slot.fallback),
-        Op::Text(_) | Op::Interpolation(_) => false,
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => false,
     })
 }
 

--- a/crates/vize_s1_to_s2/src/emit/component/call_props/scans.rs
+++ b/crates/vize_s1_to_s2/src/emit/component/call_props/scans.rs
@@ -28,7 +28,7 @@ pub(super) fn has_nested_for_component_static_bind_props(
             }
             Op::For(for_op) => region_has_component_static_bind_props(&for_op.region, is_ts)?,
             Op::Slot(slot) => has_nested_for_component_static_bind_props(&slot.fallback, is_ts)?,
-            Op::Text(_) | Op::Interpolation(_) => false,
+            Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => false,
         };
         if found {
             return Ok(true);
@@ -59,7 +59,7 @@ fn region_has_component_static_bind_props(
             }
             Op::For(for_op) => region_has_component_static_bind_props(&for_op.region, is_ts)?,
             Op::Slot(slot) => region_has_component_static_bind_props(&slot.fallback, is_ts)?,
-            Op::Text(_) | Op::Interpolation(_) => false,
+            Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => false,
         };
         if found {
             return Ok(true);

--- a/crates/vize_s1_to_s2/src/emit/create_slots/branch_keys.rs
+++ b/crates/vize_s1_to_s2/src/emit/create_slots/branch_keys.rs
@@ -90,7 +90,7 @@ fn op_branch_key_count(cx: &EmitCx<'_>, op: &Op<'_>, walk: &mut PageWalk) -> u32
             walk.skip(slot.bindings.len());
             region_branch_key_count(cx, &slot.fallback, walk)
         }
-        Op::Text(_) | Op::Interpolation(_) => 0,
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => 0,
     }
 }
 

--- a/crates/vize_s1_to_s2/src/emit/create_slots_walk.rs
+++ b/crates/vize_s1_to_s2/src/emit/create_slots_walk.rs
@@ -68,7 +68,7 @@ pub(super) fn advance_after_op(walk: &mut PageWalk, op: &Op<'_>) {
             walk.skip(slot.bindings.len());
             advance_after_ops(walk, &slot.fallback.ops);
         }
-        Op::Text(_) | Op::Interpolation(_) => {}
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
     }
 }
 
@@ -145,6 +145,6 @@ fn skip_op(cx: &mut EmitCx<'_>, op: &Op<'_>) {
             cx.walk.skip(slot.bindings.len());
             skip_ops(cx, &slot.fallback.ops);
         }
-        Op::Text(_) | Op::Interpolation(_) => {}
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/directive.rs
+++ b/crates/vize_s1_to_s2/src/emit/directive.rs
@@ -278,7 +278,7 @@ fn collect_from_guarded<'a>(region: &'a Region<'a>, names: &mut StdVec<&'a str>)
                 }
             }
             Op::For(for_op) => collect_from(&for_op.region, names),
-            Op::Text(_) | Op::Interpolation(_) => {}
+            Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
         }
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/error.rs
+++ b/crates/vize_s1_to_s2/src/emit/error.rs
@@ -294,6 +294,7 @@ fn op_span(op: &Op<'_>) -> Span {
         Op::Component(op) => op.span,
         Op::Text(op) => op.span,
         Op::Interpolation(op) => op.span,
+        Op::Comment(op) => op.span,
         Op::If(op) => op.span,
         Op::For(op) => op.span,
         Op::Slot(op) => op.span,

--- a/crates/vize_s1_to_s2/src/emit/fragment.rs
+++ b/crates/vize_s1_to_s2/src/emit/fragment.rs
@@ -12,8 +12,9 @@ use super::EmitError;
 use super::UnsupportedReason as Reason;
 use super::buf::Buf;
 use super::children::{
-    emit_create_text_vnode, emit_dynamic_part, emit_interpolation, emit_plain_text_vnode,
-    emit_raw_interpolation_or_refuse, emit_to_display_string, is_empty_interpolation,
+    emit_comment_vnode, emit_create_text_vnode, emit_dynamic_part, emit_interpolation,
+    emit_plain_text_vnode, emit_raw_interpolation_or_refuse, emit_to_display_string,
+    is_empty_interpolation,
 };
 use super::helper::Helper;
 use super::prefix::Site;
@@ -85,6 +86,11 @@ fn emit_unique(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> {
         Op::Interpolation(interp) => {
             let id = cx.walk.mint();
             emit_interpolation(cx, interp, id)
+        }
+        Op::Comment(comment) => {
+            let _id = cx.walk.mint();
+            emit_comment_vnode(cx, comment);
+            Ok(())
         }
         Op::Element(element) => {
             let _id = cx.walk.mint();
@@ -159,6 +165,12 @@ fn emit_units(cx: &mut EmitCx<'_>, op: &Op<'_>, first: &mut bool) -> Result<(), 
             emit_create_text_vnode(cx, core::slice::from_ref(op))
         }
         Op::Interpolation(interp) => emit_interp(cx, interp, first),
+        Op::Comment(comment) => {
+            start_item(cx, first);
+            let _id = cx.walk.mint();
+            emit_comment_vnode(cx, comment);
+            Ok(())
+        }
         Op::Element(element) => {
             start_item(cx, first);
             let id = cx.walk.mint();

--- a/crates/vize_s1_to_s2/src/emit/helper_preference.rs
+++ b/crates/vize_s1_to_s2/src/emit/helper_preference.rs
@@ -173,6 +173,7 @@ fn prefer_op_helpers(
             );
         }
         Op::Text(_) => buf.prefer(Helper::CreateText),
+        Op::Comment(_) => buf.prefer(Helper::CreateComment),
         Op::Interpolation(_) => {
             buf.prefer(Helper::ToDisplayString);
             if id

--- a/crates/vize_s1_to_s2/src/emit/helper_preference/slot_order.rs
+++ b/crates/vize_s1_to_s2/src/emit/helper_preference/slot_order.rs
@@ -56,7 +56,8 @@ fn conditional_slot_template_has_direct_v_for(region: &Region<'_>) -> bool {
         | Op::Slot(_)
         | Op::For(_)
         | Op::Text(_)
-        | Op::Interpolation(_) => false,
+        | Op::Interpolation(_)
+        | Op::Comment(_) => false,
     })
 }
 
@@ -92,7 +93,7 @@ fn op_has_transition(op: &Op<'_>) -> bool {
             .any(|branch| region_has_transition(&branch.region)),
         Op::For(for_op) => region_has_transition(&for_op.region),
         Op::Slot(slot) => region_has_transition(&slot.fallback),
-        Op::Text(_) | Op::Interpolation(_) => false,
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => false,
     }
 }
 
@@ -109,7 +110,7 @@ fn op_has_transition_group(op: &Op<'_>) -> bool {
             .any(|branch| region_has_transition_group(&branch.region)),
         Op::For(for_op) => region_has_transition_group(&for_op.region),
         Op::Slot(slot) => region_has_transition_group(&slot.fallback),
-        Op::Text(_) | Op::Interpolation(_) => false,
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => false,
     }
 }
 
@@ -125,9 +126,12 @@ fn dynamic_slot_carrier_has_slot_outlet(region: &Region<'_>) -> bool {
         Op::For(for_op) => {
             first_slot_template(&for_op.region).is_some() && has_slot_outlet(&for_op.region)
         }
-        Op::Element(_) | Op::Component(_) | Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => {
-            false
-        }
+        Op::Element(_)
+        | Op::Component(_)
+        | Op::Slot(_)
+        | Op::Text(_)
+        | Op::Interpolation(_)
+        | Op::Comment(_) => false,
     })
 }
 
@@ -168,7 +172,7 @@ fn first_op_slot_order_marker(op: &Op<'_>) -> Option<SlotOrderMarker> {
             .iter()
             .find_map(|branch| first_slot_order_marker(&branch.region)),
         Op::For(for_op) => first_slot_order_marker(&for_op.region),
-        Op::Text(_) | Op::Interpolation(_) => None,
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => None,
     }
 }
 
@@ -180,7 +184,9 @@ pub(super) fn op_is_direct_slot_carrier(op: &Op<'_>) -> bool {
             .iter()
             .any(|branch| direct_slot_carrier_precedes_slot_outlet(&branch.region)),
         Op::For(for_op) => direct_slot_carrier_precedes_slot_outlet(&for_op.region),
-        Op::Component(_) | Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => false,
+        Op::Component(_) | Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {
+            false
+        }
     }
 }
 
@@ -204,7 +210,7 @@ fn op_has_direct_slot_carrier(op: &Op<'_>) -> bool {
             .iter()
             .any(|branch| region_has_direct_slot_carrier(&branch.region)),
         Op::For(for_op) => region_has_direct_slot_carrier(&for_op.region),
-        Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => false,
+        Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => false,
     }
 }
 
@@ -220,7 +226,7 @@ fn component_tree_has_slot_carrier(region: &Region<'_>) -> bool {
             .iter()
             .any(|branch| component_tree_has_slot_carrier(&branch.region)),
         Op::For(for_op) => component_tree_has_slot_carrier(&for_op.region),
-        Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => false,
+        Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => false,
     })
 }
 
@@ -238,6 +244,6 @@ fn op_has_slot_outlet(op: &Op<'_>) -> bool {
             .any(|branch| has_slot_outlet(&branch.region)),
         Op::For(for_op) => has_slot_outlet(&for_op.region),
         Op::Slot(_) => true,
-        Op::Text(_) | Op::Interpolation(_) => false,
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => false,
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/namespace.rs
+++ b/crates/vize_s1_to_s2/src/emit/namespace.rs
@@ -60,7 +60,9 @@ fn structural_children_cross_boundary(
             })
         }),
         Op::For(for_op) => ensure_sufficient_stack(|| children_cross_boundary(ns, &for_op.region)),
-        Op::Component(_) | Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => false,
+        Op::Component(_) | Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {
+            false
+        }
     })
 }
 
@@ -88,7 +90,9 @@ fn child_crosses(ns: Namespace, child: &Op<'_>) -> bool {
             .iter()
             .any(|branch| ensure_sufficient_stack(|| children_cross_boundary(ns, &branch.region))),
         Op::For(for_op) => ensure_sufficient_stack(|| children_cross_boundary(ns, &for_op.region)),
-        Op::Component(_) | Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) => false,
+        Op::Component(_) | Op::Slot(_) | Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {
+            false
+        }
     }
 }
 

--- a/crates/vize_s1_to_s2/src/emit/options.rs
+++ b/crates/vize_s1_to_s2/src/emit/options.rs
@@ -195,11 +195,9 @@ impl BindingTable {
 pub struct DomEmitOptions<'a> {
     /// Module or function output.
     pub mode: DomEmitMode,
-    /// The module the helper imports name in [`DomEmitMode::Module`]
-    /// (`"vue"` by default).
+    /// Module name imported in [`DomEmitMode::Module`] (`"vue"` by default).
     pub runtime_module_name: &'a str,
-    /// The global the helper destructure reads in
-    /// [`DomEmitMode::Function`] (`"Vue"` by default).
+    /// Global read in [`DomEmitMode::Function`] (`"Vue"` by default).
     pub runtime_global_name: &'a str,
     /// The shipped lane's `prefix_identifiers`: free identifiers become
     /// member accesses (`emit::prefix`).
@@ -218,10 +216,7 @@ pub struct DomEmitOptions<'a> {
     /// is created once instead of on every render. Turned on with
     /// [`DomEmitOptions::inline`] by `compile_template_block`.
     pub cache_handlers: bool,
-    /// SFC scoped-style attr for module-level static VNode hoists. The DOM
-    /// SFC wrapper passes this separately from `scope_id` because runtime
-    /// VNodes receive scope attrs from Vue; only import-time hoists need it
-    /// baked into generated props.
+    /// SFC scoped-style attr for module-level static VNode hoists.
     pub hoisted_scope_id: Option<&'a str>,
     /// The shipped lane's `scope_id`: `<style scoped>` gives the SFC an
     /// attribute name (`data-v-abc123`) that every element's props object
@@ -231,6 +226,8 @@ pub struct DomEmitOptions<'a> {
     /// so each one is type-erased (`emit::prefix::typescript`) before the
     /// identifier pass reads it.
     pub is_ts: bool,
+    /// Preserve ordinary template comments as `_createCommentVNode(...)`.
+    pub comments: bool,
     /// The shipped lane's `binding_metadata`, honoured in non-inline mode:
     /// prefixed identifiers resolve to `$setup.` / `$props.` / `$data.` /
     /// `$options.`, components and directives resolve to `$setup` members,
@@ -252,6 +249,7 @@ impl DomEmitOptions<'static> {
         hoisted_scope_id: None,
         scope_id: None,
         is_ts: false,
+        comments: false,
         bindings: None,
     };
 }
@@ -281,6 +279,7 @@ mod tests {
                 hoisted_scope_id: None,
                 scope_id: None,
                 is_ts: false,
+                comments: false,
                 bindings: None,
             }
         );

--- a/crates/vize_s1_to_s2/src/emit/outlet.rs
+++ b/crates/vize_s1_to_s2/src/emit/outlet.rs
@@ -4,7 +4,7 @@
 //! branch shapes. Static prop keys are camelized.
 
 use vize_s2::expr::{ExprRef, OpaqueReason};
-use vize_s2::op::{BindingOp, DynamicName, InterpolationOp, Op, Region, SlotOp};
+use vize_s2::op::{BindingOp, CommentOp, DynamicName, InterpolationOp, Op, Region, SlotOp};
 
 use super::EmitCx;
 use super::EmitError;
@@ -35,7 +35,7 @@ fn op_forwards(op: &Op<'_>) -> bool {
             .iter()
             .any(|branch| has_forwarded_outlet(&branch.region)),
         Op::For(for_op) => has_forwarded_outlet(&for_op.region),
-        Op::Text(_) | Op::Interpolation(_) => false,
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => false,
     }
 }
 
@@ -178,6 +178,7 @@ fn emit_fallback_units(
             emit_create_text_vnode(cx, core::slice::from_ref(op))
         }
         Op::Interpolation(interp) => emit_fallback_interp(cx, interp, compact, first),
+        Op::Comment(comment) => emit_fallback_comment(cx, comment, compact, first),
         Op::Element(element) if is_hoistable(element, cx.is_ts) => {
             start_fallback_item(cx, compact, first);
             emit_hoisted_element(cx, element)
@@ -199,6 +200,18 @@ fn emit_fallback_element(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitErr
     let result = emit_array_child(cx, op, false, false);
     cx.static_cache = previous;
     result
+}
+
+fn emit_fallback_comment(
+    cx: &mut EmitCx<'_>,
+    comment: &CommentOp<'_>,
+    compact: bool,
+    first: &mut bool,
+) -> Result<(), EmitError> {
+    start_fallback_item(cx, compact, first);
+    let _id = cx.walk.mint();
+    super::children::emit_comment_vnode(cx, comment);
+    Ok(())
 }
 
 /// Slot fallback walks each S1 child (`generate_node`), so a merged
@@ -281,6 +294,6 @@ fn skip_op(cx: &mut EmitCx<'_>, op: &Op<'_>) {
             cx.walk.skip(slot.bindings.len());
             skip_region(cx, &slot.fallback);
         }
-        Op::Text(_) | Op::Interpolation(_) => {}
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/slots.rs
+++ b/crates/vize_s1_to_s2/src/emit/slots.rs
@@ -108,7 +108,7 @@ pub(super) fn admit_default(children: &Region<'_>) -> Result<(), EmitError> {
 fn walk_admit(region: &Region<'_>) -> Result<(), EmitError> {
     for op in region.ops.iter() {
         match op {
-            Op::Text(_) | Op::Interpolation(_) => {}
+            Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
             Op::Element(element) if is_slot_template(element) => {
                 if element.bindings.iter().any(|b| !is_inert_slot_binding(b)) {
                     return Err(EmitError::unsupported_at(

--- a/crates/vize_s1_to_s2/src/emit/slots/capture.rs
+++ b/crates/vize_s1_to_s2/src/emit/slots/capture.rs
@@ -90,9 +90,12 @@ fn emit_slot_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> {
         Op::Element(element) if is_static_element_tree(element, cx.is_ts) => {
             emit_hoisted_element(cx, element)
         }
-        Op::Element(_) | Op::Component(_) | Op::If(_) | Op::For(_) | Op::Slot(_) => {
-            emit_array_child(cx, op, false, false)
-        }
+        Op::Element(_)
+        | Op::Component(_)
+        | Op::Comment(_)
+        | Op::If(_)
+        | Op::For(_)
+        | Op::Slot(_) => emit_array_child(cx, op, false, false),
     }
 }
 

--- a/crates/vize_s1_to_s2/src/emit/slots/group.rs
+++ b/crates/vize_s1_to_s2/src/emit/slots/group.rs
@@ -184,7 +184,7 @@ fn op_branch_key_count(cx: &EmitCx<'_>, op: &Op<'_>, walk: &mut PageWalk) -> u32
             walk.skip(slot.bindings.len());
             region_branch_key_count(cx, &slot.fallback, walk)
         }
-        Op::Text(_) | Op::Interpolation(_) => 0,
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => 0,
     }
 }
 

--- a/crates/vize_s1_to_s2/src/emit/static_cache.rs
+++ b/crates/vize_s1_to_s2/src/emit/static_cache.rs
@@ -101,7 +101,7 @@ fn op_has_legacy_hoist(
             skip_region(walk, &slot.fallback.ops);
             false
         }
-        Op::Text(_) | Op::Interpolation(_) => false,
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => false,
     }
 }
 
@@ -285,6 +285,6 @@ fn skip_op_after_mint(walk: &mut PageWalk, op: &Op<'_>) {
             walk.skip(slot.bindings.len());
             ensure_sufficient_stack(|| skip_region(walk, &slot.fallback.ops));
         }
-        Op::Text(_) | Op::Interpolation(_) => {}
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
     }
 }

--- a/crates/vize_s1_to_s2/src/emit/static_cache/foreign_props.rs
+++ b/crates/vize_s1_to_s2/src/emit/static_cache/foreign_props.rs
@@ -90,7 +90,7 @@ pub(super) fn region_has_non_branch_foreign_props_hoist(
                     return true;
                 }
             }
-            Op::Text(_) | Op::Interpolation(_) => {}
+            Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
         }
     }
     false

--- a/crates/vize_s1_to_s2/src/emit/tpl/fragment.rs
+++ b/crates/vize_s1_to_s2/src/emit/tpl/fragment.rs
@@ -3,9 +3,9 @@ use vize_s2::op::{InterpolationOp, Op};
 
 use super::super::buf::Buf;
 use super::super::children::{
-    emit_create_text_vnode, emit_dynamic_part, emit_interpolation, emit_js_to_display_string,
-    emit_plain_text_vnode, emit_raw_interpolation_or_refuse, emit_to_display_string,
-    is_empty_interpolation,
+    emit_comment_vnode, emit_create_text_vnode, emit_dynamic_part, emit_interpolation,
+    emit_js_to_display_string, emit_plain_text_vnode, emit_raw_interpolation_or_refuse,
+    emit_to_display_string, is_empty_interpolation,
 };
 use super::super::hoist::{emit_hoisted_element, is_hoistable};
 use super::super::js::{escape_js_string, is_valid_js_identifier};
@@ -227,6 +227,11 @@ fn emit_generate_node(cx: &mut EmitCx<'_>, ops: &[Op<'_>]) -> Result<(), EmitErr
             Op::Interpolation(interp) => {
                 emit_gen_interp(cx, interp, &mut first)?;
             }
+            Op::Comment(comment) => {
+                start_item(cx, &mut first);
+                let _id = cx.walk.mint();
+                emit_comment_vnode(cx, comment);
+            }
             _ => {
                 start_item(cx, &mut first);
                 emit_node_child(cx, op)?;
@@ -301,6 +306,11 @@ fn emit_inline_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> 
         Op::Interpolation(interp) => {
             let id = cx.walk.mint();
             emit_interpolation(cx, interp, id)
+        }
+        Op::Comment(comment) => {
+            let _id = cx.walk.mint();
+            emit_comment_vnode(cx, comment);
+            Ok(())
         }
         _ => emit_node_child(cx, op),
     }

--- a/crates/vize_s1_to_s2/src/emit/vnode/array_child.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode/array_child.rs
@@ -56,6 +56,10 @@ pub(in crate::emit) fn emit_array_child(
                 cx.walk.skip(slot.bindings.len());
                 super::super::outlet::emit_outlet(cx, slot, None, false)
             }
+            Op::Comment(comment) => {
+                super::super::children::emit_comment_vnode(cx, comment);
+                Ok(())
+            }
             Op::Text(_) | Op::Interpolation(_) => {
                 Err(EmitError::unsupported_op(Reason::ArrayChildTextRun, op))
             }

--- a/crates/vize_s1_to_s2/src/emit/vnode/checks.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode/checks.rs
@@ -56,7 +56,7 @@ fn op_has_interpolation_descendant(op: &Op<'_>) -> bool {
             .any(|branch| region_has_interpolation_descendant(&branch.region.ops)),
         Op::For(for_op) => region_has_interpolation_descendant(&for_op.region.ops),
         Op::Slot(slot) => region_has_interpolation_descendant(&slot.fallback.ops),
-        Op::Text(_) => false,
+        Op::Text(_) | Op::Comment(_) => false,
     }
 }
 

--- a/crates/vize_s1_to_s2/src/emit/vnode_children.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_children.rs
@@ -2,7 +2,7 @@
 
 use vize_s2::op::{Op, Region};
 
-use super::children::{emit_create_text_vnode, emit_text_like};
+use super::children::{emit_comment_vnode, emit_create_text_vnode, emit_text_like};
 use super::{EmitCx, EmitError};
 
 pub(super) fn emit_children(
@@ -68,7 +68,18 @@ fn emit_children_inner(
         }
         cx.buf.newline();
         first = false;
-        super::vnode::emit_array_child(cx, &ops[i], hoist_static_children, cache_static_children)?;
+        match &ops[i] {
+            Op::Comment(comment) => {
+                let _id = cx.walk.mint();
+                emit_comment_vnode(cx, comment);
+            }
+            op => super::vnode::emit_array_child(
+                cx,
+                op,
+                hoist_static_children,
+                cache_static_children,
+            )?,
+        }
         i += 1;
     }
     cx.buf.deindent();

--- a/crates/vize_s1_to_s2/src/lower.rs
+++ b/crates/vize_s1_to_s2/src/lower.rs
@@ -142,6 +142,24 @@ pub fn lower_with_caps<'a>(
     lower_source_block_with_caps(allocator, tree, errors, root.whole_block(), caps)
 }
 
+pub(crate) fn lower_with_caps_and_comment_policy<'a>(
+    allocator: &'a Allocator,
+    tree: &SurfaceTree<'a>,
+    errors: &[SurfaceError],
+    caps: LegacyCaps,
+    preserve_comments: bool,
+) -> Lowered<'a> {
+    let root = SourceRoot::new(tree.source).expect("vize_s1 accepted a u32-addressable source");
+    lower_source_block_with_caps_and_comment_policy(
+        allocator,
+        tree,
+        errors,
+        root.whole_block(),
+        caps,
+        preserve_comments,
+    )
+}
+
 /// Lower a parsed S1 source block while preserving file-absolute S0 spans.
 #[must_use]
 pub fn lower_source_block<'a>(
@@ -162,12 +180,24 @@ pub fn lower_source_block_with_caps<'a>(
     block: SourceBlock<'a>,
     caps: LegacyCaps,
 ) -> Lowered<'a> {
+    lower_source_block_with_caps_and_comment_policy(allocator, tree, errors, block, caps, false)
+}
+
+fn lower_source_block_with_caps_and_comment_policy<'a>(
+    allocator: &'a Allocator,
+    tree: &SurfaceTree<'a>,
+    errors: &[SurfaceError],
+    block: SourceBlock<'a>,
+    caps: LegacyCaps,
+    preserve_comments: bool,
+) -> Lowered<'a> {
     debug_assert!(
         tree.source.as_ptr() == block.source().as_ptr()
             && tree.source.len() == block.source().len(),
         "the source block must be the exact string parsed into the S1 tree"
     );
-    let mut cx = cx::Cx::with_source_block(allocator, block, caps);
+    let mut cx =
+        cx::Cx::with_source_block_and_comment_policy(allocator, block, caps, preserve_comments);
     for error in errors {
         cx.diagnostics.push(Diagnostic::new(
             Severity::Error,

--- a/crates/vize_s1_to_s2/src/lower/cx.rs
+++ b/crates/vize_s1_to_s2/src/lower/cx.rs
@@ -43,6 +43,8 @@ pub(crate) struct Cx<'a> {
     /// How many `v-pre` ancestors the walk is inside; interpolations are
     /// inert authored text for those subtrees.
     v_pre_depth: u32,
+    /// Whether ordinary comments lower to `ui.comment`.
+    preserve_comments: bool,
     pub diagnostics: Vec<Diagnostic>,
     pub provenance: Vec<ProvenanceRecord>,
     pub scopes: SideTable<ScopeFacts>,
@@ -53,10 +55,11 @@ pub(crate) struct Cx<'a> {
 }
 
 impl<'a> Cx<'a> {
-    pub(crate) fn with_source_block(
+    pub(crate) fn with_source_block_and_comment_policy(
         allocator: &'a Allocator,
         block: SourceBlock<'a>,
         caps: super::caps::LegacyCaps,
+        preserve_comments: bool,
     ) -> Self {
         Self {
             allocator,
@@ -67,6 +70,7 @@ impl<'a> Cx<'a> {
             next_scope: 0,
             condense_depth: 0,
             v_pre_depth: 0,
+            preserve_comments,
             diagnostics: Vec::new(),
             provenance: Vec::new(),
             scopes: SideTable::new(),
@@ -85,6 +89,11 @@ impl<'a> Cx<'a> {
     /// Whether the walk is inside a `v-pre` subtree.
     pub(crate) fn v_pre_suppressed(&self) -> bool {
         self.v_pre_depth > 0
+    }
+
+    /// Whether ordinary comments are lowered as `ui.comment` ops.
+    pub(crate) fn preserve_comments(&self) -> bool {
+        self.preserve_comments
     }
 
     /// Enter/leave a condense-suppressing `<pre>` around its children.

--- a/crates/vize_s1_to_s2/src/lower/leaf.rs
+++ b/crates/vize_s1_to_s2/src/lower/leaf.rs
@@ -1,5 +1,5 @@
-//! Leaf children: text, interpolations, and the S1 node kinds S2 does
-//! not carry (comments, processing instructions, `Unexpected` holes).
+//! Leaf children: text, interpolations, comments, and the S1 node kinds S2 does
+//! not carry (processing instructions, `Unexpected` holes).
 //!
 //! Dropping is never silent: every non-lowered node leaves a provenance
 //! record (the survival law), and the bytes stay recoverable through S1.
@@ -11,7 +11,7 @@
 use vize_s0::{Box, Span, String, Vec, cstr};
 use vize_s1::{Interpolation, SurfaceChild, Token};
 
-use vize_s2::op::{InterpolationOp, Op, TextOp};
+use vize_s2::op::{CommentOp, InterpolationOp, Op, TextOp};
 
 use super::cx::Cx;
 use super::expr::{desc, filter_expr_at};
@@ -26,8 +26,12 @@ pub(crate) fn lower_leaf<'a>(cx: &mut Cx<'a>, child: &SurfaceChild<'a>, out: &mu
         SurfaceChild::Text(token) => lower_text(cx, token, token.text, out),
         SurfaceChild::Interpolation(node) => lower_interpolation(cx, node, out),
         SurfaceChild::Comment(token) => {
-            let span = cx.token_span(token);
-            cx.record("drop.comment", None, token.text, String::default(), span);
+            if cx.preserve_comments() {
+                lower_comment(cx, token, out);
+            } else {
+                let span = cx.token_span(token);
+                cx.record("drop.comment", None, token.text, String::default(), span);
+            }
         }
         SurfaceChild::Cdata(token) => lower_cdata(cx, token, out),
         SurfaceChild::ProcessingInstruction(token) => {
@@ -89,6 +93,31 @@ fn lower_interpolation<'a>(cx: &mut Cx<'a>, node: &Interpolation<'a>, out: &mut 
         InterpolationOp { expression, span },
         &cx.allocator,
     )));
+}
+
+fn lower_comment<'a>(cx: &mut Cx<'a>, token: &Token<'a>, out: &mut Vec<'a, Op<'a>>) {
+    let node = cx.mint_op();
+    let span = cx.token_span(token);
+    cx.record(
+        "lower.comment",
+        node,
+        token.text,
+        String::from("ui.comment"),
+        span,
+    );
+    out.push(Op::Comment(Box::new_in(
+        CommentOp {
+            content: comment_content(token.text),
+            span,
+        },
+        &cx.allocator,
+    )));
+}
+
+fn comment_content(text: &str) -> &str {
+    text.strip_prefix("<!--")
+        .and_then(|inner| inner.strip_suffix("-->"))
+        .unwrap_or(text)
 }
 
 /// A CDATA section's content is text (the foreign-namespace reading);

--- a/crates/vize_s1_to_s2/src/lower/text.rs
+++ b/crates/vize_s1_to_s2/src/lower/text.rs
@@ -15,11 +15,13 @@
 //! for one decisive reason: **comments**. Both computations read comment
 //! positions — a comment is a non-text-like neighbour for the
 //! remove-vs-condense rule and a hard boundary for run merging — and
-//! comments exist only in S1 (the lowering drops them under
-//! `drop.comment`). A post-lowering pass would be comment-blind and
-//! wrong on real shapes (`a<!--c-->\n<!--d-->b` must lose its
-//! whitespace, `a<!--c-->b` must stay two text units); the lowering is
-//! the last stage that can compute the legacy answers. P2-5b's record
+//! comments exist only in S1 unless the DOM comment-preserving route asks
+//! the lowering to keep them as `ui.comment` (the default lowering still
+//! drops them under `drop.comment`). A post-lowering pass would be
+//! comment-blind and wrong on real shapes (`a<!--c-->\n<!--d-->b` must
+//! lose its whitespace, `a<!--c-->b` must stay two text units); the
+//! lowering is the last stage that can compute the legacy answers.
+//! P2-5b's record
 //! independently requires it: the position-classified opaque reasons —
 //! [`OpaqueReason::Compound`] included — "are assignable only by the
 //! S1→S2 lowering".

--- a/crates/vize_s1_to_s2/src/pass/hoist/lattice.rs
+++ b/crates/vize_s1_to_s2/src/pass/hoist/lattice.rs
@@ -134,6 +134,11 @@ fn visit_region_guarded(
                 nested: true,
                 native: true,
             },
+            Op::Comment(_) => Contribution {
+                level: ChildLevel::Dynamic,
+                nested: false,
+                native: true,
+            },
             Op::If(if_op) => {
                 for branch in if_op.branches.iter() {
                     visit_region(walk, &branch.region.ops, ns, provenance, facts);

--- a/crates/vize_s1_to_s2/src/pass/legacy/filter.rs
+++ b/crates/vize_s1_to_s2/src/pass/legacy/filter.rs
@@ -119,7 +119,7 @@ fn rewrite_ops<'a>(
                     facts,
                 );
             }
-            Op::Text(_) => {}
+            Op::Text(_) | Op::Comment(_) => {}
         }
     }
 }

--- a/crates/vize_s1_to_s2/src/pass/legacy/ids.rs
+++ b/crates/vize_s1_to_s2/src/pass/legacy/ids.rs
@@ -40,7 +40,7 @@ fn collect_ops(walk: &mut PageWalk, ops: &[Op<'_>], ids: &mut StdVec<NodeId>) {
                 }
             }
             Op::For(for_op) => collect_ops(walk, &for_op.region.ops, ids),
-            Op::Text(_) | Op::Interpolation(_) => {}
+            Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
         }
     }
 }

--- a/crates/vize_s1_to_s2/src/pass/legacy/tree.rs
+++ b/crates/vize_s1_to_s2/src/pass/legacy/tree.rs
@@ -30,7 +30,7 @@ pub(super) fn map_binding_lists<'a>(
                 }
             }
             Op::For(for_op) => map_binding_lists(&mut for_op.region.ops, visit),
-            Op::Text(_) | Op::Interpolation(_) => {}
+            Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
         }
     }
 }

--- a/crates/vize_s1_to_s2/src/pass/text.rs
+++ b/crates/vize_s1_to_s2/src/pass/text.rs
@@ -203,7 +203,7 @@ fn visit_region_guarded(
                 }
                 visit_region(walk, &component.children.ops, texts, provenance, facts);
             }
-            Op::Text(_) => {}
+            Op::Text(_) | Op::Comment(_) => {}
             Op::Interpolation(interpolation) => {
                 consume_compound(
                     texts,

--- a/crates/vize_s1_to_s2/src/pass/vif/keys.rs
+++ b/crates/vize_s1_to_s2/src/pass/vif/keys.rs
@@ -64,6 +64,7 @@ fn carrier_surface<'w, 'a>(
         | Op::Component(_)
         | Op::Slot(_)
         | Op::Text(_)
+        | Op::Comment(_)
         | Op::Interpolation(_)
         | Op::If(_)
         | Op::For(_) => None,

--- a/crates/vize_s1_to_s2/src/pass/vmodel.rs
+++ b/crates/vize_s1_to_s2/src/pass/vmodel.rs
@@ -224,7 +224,7 @@ fn visit<'a>(
                 region(walk, channels, env, &component.children.ops);
             });
         }
-        Op::Text(_) | Op::Interpolation(_) => {}
+        Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
         Op::If(if_op) => {
             for branch in if_op.branches.iter() {
                 region(walk, channels, env, &branch.region.ops);

--- a/crates/vize_s1_to_s2/src/pass/vslot/consume.rs
+++ b/crates/vize_s1_to_s2/src/pass/vslot/consume.rs
@@ -112,6 +112,17 @@ pub(super) enum ChildKind {
     },
 }
 
+fn implicit_default_content(id: Option<NodeId>, span: Span) -> ChildView {
+    ChildView {
+        id,
+        span,
+        kind: ChildKind::Content {
+            implicit: true,
+            default_slot: true,
+        },
+    }
+}
+
 /// Whether any view in a region carries implicit content (the legacy
 /// `any_implicit_child`), plus unwrapped wrappers that hold nested
 /// `#slot` templates. Kept `#slot v-if` / `#slot v-for` carriers stay
@@ -254,26 +265,14 @@ fn visit<'a>(walk: &mut PageWalk, channels: &mut Channels<'_>, op: &Op<'a>) -> C
                 },
             }
         }
-        Op::Text(text) => ChildView {
+        Op::Text(text) if crate::lower::legacy_slot_filler_text(text.content) => ChildView {
             id,
             span: text.span,
-            kind: if crate::lower::legacy_slot_filler_text(text.content) {
-                ChildKind::Filler
-            } else {
-                ChildKind::Content {
-                    implicit: true,
-                    default_slot: true,
-                }
-            },
+            kind: ChildKind::Filler,
         },
-        Op::Interpolation(interpolation) => ChildView {
-            id,
-            span: interpolation.span,
-            kind: ChildKind::Content {
-                implicit: true,
-                default_slot: true,
-            },
-        },
+        Op::Text(text) => implicit_default_content(id, text.span),
+        Op::Interpolation(interpolation) => implicit_default_content(id, interpolation.span),
+        Op::Comment(comment) => implicit_default_content(id, comment.span),
         Op::If(if_op) => {
             let wrapper = id.and_then(|id| channels.wrappers.get(id));
             let mut implicit = false;

--- a/crates/vize_s1_to_s2/src/pass/walk.rs
+++ b/crates/vize_s1_to_s2/src/pass/walk.rs
@@ -113,7 +113,7 @@ fn visit_ops_guarded<'a>(
                 walk.skip(component.bindings.len());
                 visit_ops(walk, &mut component.children.ops, visit);
             }
-            Op::Text(_) | Op::Interpolation(_) => {}
+            Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
             Op::If(if_op) => {
                 for branch in if_op.branches.iter_mut() {
                     visit_ops(walk, &mut branch.region.ops, visit);

--- a/crates/vize_s1_to_s2/tests/emit_comments.rs
+++ b/crates/vize_s1_to_s2/tests/emit_comments.rs
@@ -1,0 +1,86 @@
+//! Ordinary template comments in the S2 DOM emitter.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+use vize_s0::Allocator;
+use vize_s1_to_s2::{DomEmitOptions, LegacyCaps, emit_dom_source, emit_dom_source_with_options};
+
+fn assembled_with_comments(source: &str, comments: bool) -> String {
+    let allocator = Allocator::new();
+    emit_dom_source_with_options(
+        &allocator,
+        source,
+        LegacyCaps::VUE3,
+        &DomEmitOptions {
+            comments,
+            ..DomEmitOptions::DEFAULT
+        },
+    )
+    .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
+    .assembled()
+    .to_string()
+}
+
+#[test]
+fn ordinary_template_comments_emit_comment_vnodes_when_enabled() {
+    let output = assembled_with_comments("<div><!--kept--><span>ok</span></div>", true);
+
+    assert!(
+        output.contains("createCommentVNode: _createCommentVNode"),
+        "expected comment helper in output:\n{output}"
+    );
+    assert!(
+        output.contains("_createCommentVNode(\"kept\")"),
+        "expected preserved comment vnode in output:\n{output}"
+    );
+    assert!(
+        output.contains("_createElementVNode(\"span\", null, \"ok\")"),
+        "expected sibling vnode to stay emitted in output:\n{output}"
+    );
+}
+
+#[test]
+fn ordinary_template_comments_stay_dropped_by_default() {
+    let allocator = Allocator::new();
+    let output = emit_dom_source(&allocator, "<div><!--kept--><span>ok</span></div>")
+        .unwrap_or_else(|error| panic!("emit refused default comments=false case: {error:?}"))
+        .assembled()
+        .to_string();
+
+    assert!(
+        !output.contains("_createCommentVNode"),
+        "expected default lowering to drop comments:\n{output}"
+    );
+}
+
+#[test]
+fn component_default_slots_preserve_comment_children_when_enabled() {
+    let output = assembled_with_comments("<Foo><!--slot--><span>ok</span></Foo>", true);
+
+    assert!(
+        output.contains("_createCommentVNode(\"slot\")"),
+        "expected component default slot comment vnode in output:\n{output}"
+    );
+    assert!(
+        output.contains("_createElementVNode(\"span\", null, \"ok\")"),
+        "expected component default slot sibling vnode in output:\n{output}"
+    );
+}
+
+#[test]
+fn slot_outlet_fallbacks_preserve_comment_children_when_enabled() {
+    let output = assembled_with_comments("<slot><!--fallback--><span>ok</span></slot>", true);
+
+    assert!(
+        output.contains("_createCommentVNode(\"fallback\")"),
+        "expected slot fallback comment vnode in output:\n{output}"
+    );
+    assert!(
+        output.contains("_createElementVNode(\"span\", null, \"ok\")"),
+        "expected slot fallback sibling vnode in output:\n{output}"
+    );
+}

--- a/crates/vize_s1_to_s2/tests/emit_comments.rs
+++ b/crates/vize_s1_to_s2/tests/emit_comments.rs
@@ -25,62 +25,82 @@ fn assembled_with_comments(source: &str, comments: bool) -> String {
     .to_string()
 }
 
+fn pin(visual: &str) -> String {
+    visual.replace(")\n\n  return", ")\n  \n  return")
+}
+
 #[test]
 fn ordinary_template_comments_emit_comment_vnodes_when_enabled() {
-    let output = assembled_with_comments("<div><!--kept--><span>ok</span></div>", true);
+    assert_eq!(
+        assembled_with_comments("<div><!--kept--><span>ok</span></div>", true),
+        "\
+const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode } = Vue
 
-    assert!(
-        output.contains("createCommentVNode: _createCommentVNode"),
-        "expected comment helper in output:\n{output}"
-    );
-    assert!(
-        output.contains("_createCommentVNode(\"kept\")"),
-        "expected preserved comment vnode in output:\n{output}"
-    );
-    assert!(
-        output.contains("_createElementVNode(\"span\", null, \"ok\")"),
-        "expected sibling vnode to stay emitted in output:\n{output}"
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", null, [
+    _createCommentVNode(\"kept\"),
+    _createElementVNode(\"span\", null, \"ok\")
+  ]))
+}"
     );
 }
 
 #[test]
 fn ordinary_template_comments_stay_dropped_by_default() {
     let allocator = Allocator::new();
-    let output = emit_dom_source(&allocator, "<div><!--kept--><span>ok</span></div>")
-        .unwrap_or_else(|error| panic!("emit refused default comments=false case: {error:?}"))
-        .assembled()
-        .to_string();
+    assert_eq!(
+        emit_dom_source(&allocator, "<div><!--kept--><span>ok</span></div>")
+            .unwrap_or_else(|error| panic!("emit refused default comments=false case: {error:?}"))
+            .assembled()
+            .to_string(),
+        "\
+const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
 
-    assert!(
-        !output.contains("_createCommentVNode"),
-        "expected default lowering to drop comments:\n{output}"
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"div\", null, [
+    _createElementVNode(\"span\", null, \"ok\")
+  ]))
+}"
     );
 }
 
 #[test]
 fn component_default_slots_preserve_comment_children_when_enabled() {
-    let output = assembled_with_comments("<Foo><!--slot--><span>ok</span></Foo>", true);
+    assert_eq!(
+        assembled_with_comments("<Foo><!--slot--><span>ok</span></Foo>", true),
+        pin("\
+const { resolveComponent: _resolveComponent, createElementVNode: _createElementVNode, openBlock: _openBlock, createBlock: _createBlock, createCommentVNode: _createCommentVNode, withCtx: _withCtx } = Vue
 
-    assert!(
-        output.contains("_createCommentVNode(\"slot\")"),
-        "expected component default slot comment vnode in output:\n{output}"
-    );
-    assert!(
-        output.contains("_createElementVNode(\"span\", null, \"ok\")"),
-        "expected component default slot sibling vnode in output:\n{output}"
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode(\"span\", null, \"ok\")
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Foo = _resolveComponent(\"Foo\")
+
+  return (_openBlock(), _createBlock(_component_Foo, null, {
+    default: _withCtx(() => [
+      _createCommentVNode(\"slot\"),
+      _hoisted_1
+    ]),
+    _: 1 /* STABLE */
+  }))
+}")
     );
 }
 
 #[test]
 fn slot_outlet_fallbacks_preserve_comment_children_when_enabled() {
-    let output = assembled_with_comments("<slot><!--fallback--><span>ok</span></slot>", true);
+    assert_eq!(
+        assembled_with_comments("<slot><!--fallback--><span>ok</span></slot>", true),
+        "\
+const { renderSlot: _renderSlot, createElementVNode: _createElementVNode, createCommentVNode: _createCommentVNode } = Vue
 
-    assert!(
-        output.contains("_createCommentVNode(\"fallback\")"),
-        "expected slot fallback comment vnode in output:\n{output}"
-    );
-    assert!(
-        output.contains("_createElementVNode(\"span\", null, \"ok\")"),
-        "expected slot fallback sibling vnode in output:\n{output}"
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode(\"span\", null, \"ok\")
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return _renderSlot(_ctx.$slots, \"default\", {}, () => [
+    _createCommentVNode(\"fallback\"),
+    _hoisted_1
+  ])
+}"
     );
 }

--- a/crates/vize_s1_to_s2/tests/metamorphic/normalize.rs
+++ b/crates/vize_s1_to_s2/tests/metamorphic/normalize.rs
@@ -82,7 +82,7 @@ fn walk_region(ops: &mut [FolioOp]) {
                 sort_binding_attrs(&mut slot.bindings);
                 walk_region(&mut slot.fallback);
             }
-            FolioOp::Text(_) | FolioOp::Interpolation(_) => {}
+            FolioOp::Text(_) | FolioOp::Interpolation(_) | FolioOp::Comment(_) => {}
         }
     }
 }

--- a/crates/vize_s1_to_s2/tests/support/authored.rs
+++ b/crates/vize_s1_to_s2/tests/support/authored.rs
@@ -61,6 +61,7 @@ fn assert_op(source: &str, root: SourceRoot<'_>, op: &Op<'_>) {
             assert_region(source, root, &component.children);
         }
         Op::Text(text) => assert_span(source, root, text.span, "text"),
+        Op::Comment(comment) => assert_span(source, root, comment.span, "comment"),
         Op::Interpolation(interpolation) => {
             assert_span(source, root, interpolation.span, "interpolation");
             assert_expr(source, root, interpolation.expression);

--- a/crates/vize_s1_to_s2/tests/support/folio_spans.rs
+++ b/crates/vize_s1_to_s2/tests/support/folio_spans.rs
@@ -29,6 +29,7 @@ fn assert_op(source: &str, root: SourceRoot<'_>, op: &FolioOp, context: &str) {
             assert_ops(source, root, &component.children, context);
         }
         FolioOp::Text(text) => assert_span(source, root, text.span, "text", context),
+        FolioOp::Comment(comment) => assert_span(source, root, comment.span, "comment", context),
         FolioOp::Interpolation(interpolation) => {
             assert_span(source, root, interpolation.span, "interpolation", context);
             assert_expr(source, root, &interpolation.expression, context);

--- a/crates/vize_s1_to_s2/tests/vfor_pass.rs
+++ b/crates/vize_s1_to_s2/tests/vfor_pass.rs
@@ -20,7 +20,7 @@ fn count_fors(ops: &[FolioOp]) -> usize {
         .map(|op| match op {
             FolioOp::Element(element) => count_fors(&element.children),
             FolioOp::Component(component) => count_fors(&component.children),
-            FolioOp::Text(_) | FolioOp::Interpolation(_) => 0,
+            FolioOp::Text(_) | FolioOp::Interpolation(_) | FolioOp::Comment(_) => 0,
             FolioOp::If(if_op) => if_op
                 .branches
                 .iter()

--- a/crates/vize_s2/src/folio.rs
+++ b/crates/vize_s2/src/folio.rs
@@ -35,9 +35,9 @@ mod parse;
 mod print;
 
 pub use owned::{
-    FolioAttribute, FolioBind, FolioBinding, FolioBranch, FolioComponent, FolioContract,
-    FolioElement, FolioExpr, FolioFor, FolioForBinding, FolioIf, FolioInterpolation, FolioModel,
-    FolioName, FolioOn, FolioOp, FolioSlot, FolioSlotContent, FolioText, FolioVueCloak,
+    FolioAttribute, FolioBind, FolioBinding, FolioBranch, FolioComment, FolioComponent,
+    FolioContract, FolioElement, FolioExpr, FolioFor, FolioForBinding, FolioIf, FolioInterpolation,
+    FolioModel, FolioName, FolioOn, FolioOp, FolioSlot, FolioSlotContent, FolioText, FolioVueCloak,
     FolioVueCssBind, FolioVueDirective, FolioVueHtml, FolioVueMemo, FolioVueOnce, FolioVueShow,
     FolioVueSlotScope, FolioVueSync, FolioVueText,
 };

--- a/crates/vize_s2/src/folio/owned.rs
+++ b/crates/vize_s2/src/folio/owned.rs
@@ -39,6 +39,8 @@ pub enum FolioOp {
     Text(FolioText),
     /// `ui.interpolation`.
     Interpolation(FolioInterpolation),
+    /// `ui.comment`.
+    Comment(FolioComment),
     /// `ui.if`.
     If(FolioIf),
     /// `ui.for`.
@@ -113,6 +115,15 @@ pub struct FolioText {
 pub struct FolioInterpolation {
     /// The rendered expression.
     pub expression: FolioExpr,
+    /// Source range.
+    pub span: Span,
+}
+
+/// Mirror of [`crate::op::CommentOp`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FolioComment {
+    /// The comment body.
+    pub content: String,
     /// Source range.
     pub span: Span,
 }
@@ -217,6 +228,10 @@ fn own_op_guarded(op: &Op<'_>) -> FolioOp {
             expression: own_expr(&interpolation.expression),
             span: interpolation.span,
         }),
+        Op::Comment(comment) => FolioOp::Comment(FolioComment {
+            content: String::from(comment.content),
+            span: comment.span,
+        }),
         Op::If(if_op) => FolioOp::If(FolioIf {
             branches: if_op
                 .branches
@@ -277,7 +292,7 @@ fn count_op_guarded(op: &FolioOp) -> u64 {
             1 + component.bindings.len() as u64
                 + component.children.iter().map(count_op).sum::<u64>()
         }
-        FolioOp::Text(_) | FolioOp::Interpolation(_) => 1,
+        FolioOp::Text(_) | FolioOp::Interpolation(_) | FolioOp::Comment(_) => 1,
         FolioOp::If(if_op) => {
             1 + if_op
                 .branches

--- a/crates/vize_s2/src/folio/parse.rs
+++ b/crates/vize_s2/src/folio/parse.rs
@@ -230,7 +230,9 @@ impl Parser {
                     FolioOp::If(if_op) => self.stack.push(Frame::If(if_op)),
                     FolioOp::For(for_op) => self.stack.push(Frame::For(for_op)),
                     FolioOp::Slot(slot) => self.stack.push(Frame::Slot(slot, Phase::Attrs)),
-                    FolioOp::Text(_) | FolioOp::Interpolation(_) => self.attach_op(op),
+                    FolioOp::Text(_) | FolioOp::Interpolation(_) | FolioOp::Comment(_) => {
+                        self.attach_op(op)
+                    }
                 }
                 Ok(())
             }

--- a/crates/vize_s2/src/folio/parse/line.rs
+++ b/crates/vize_s2/src/folio/parse/line.rs
@@ -12,7 +12,7 @@ use vize_davinci::folio::FolioError;
 use vize_s0::{Span, String, cstr};
 
 use super::super::owned::{
-    FolioAttribute, FolioBind, FolioBranch, FolioComponent, FolioElement, FolioFor,
+    FolioAttribute, FolioBind, FolioBranch, FolioComment, FolioComponent, FolioElement, FolioFor,
     FolioForBinding, FolioIf, FolioInterpolation, FolioModel, FolioName, FolioOn, FolioOp,
     FolioSlot, FolioSlotContent, FolioText, FolioVueCloak, FolioVueCssBind, FolioVueDirective,
     FolioVueHtml, FolioVueMemo, FolioVueOnce, FolioVueShow, FolioVueSlotScope, FolioVueSync,
@@ -110,6 +110,7 @@ pub(in super::super) fn parse_item(content: &str, line_no: usize) -> Result<Item
         "ui.component" => component(rest, line_no),
         "ui.text" => text(rest, line_no),
         "ui.interpolation" => interpolation(rest, line_no),
+        "ui.comment" => comment(rest, line_no),
         "ui.if" => Ok(Item::Op(FolioOp::If(FolioIf {
             branches: alloc::vec::Vec::new(),
             span: final_span(rest, line_no)?,
@@ -219,6 +220,14 @@ fn interpolation(rest: &str, line_no: usize) -> Result<Item, FolioError> {
     let (expression, tail) = take_expr(rest, line_no)?;
     Ok(Item::Op(FolioOp::Interpolation(FolioInterpolation {
         expression,
+        span: tail_span(tail, line_no)?,
+    })))
+}
+
+fn comment(rest: &str, line_no: usize) -> Result<Item, FolioError> {
+    let (content, tail) = take_quoted(rest, line_no)?;
+    Ok(Item::Op(FolioOp::Comment(FolioComment {
+        content,
         span: tail_span(tail, line_no)?,
     })))
 }

--- a/crates/vize_s2/src/folio/print.rs
+++ b/crates/vize_s2/src/folio/print.rs
@@ -164,6 +164,12 @@ fn print_op_guarded<W: Write>(w: &mut W, op: &FolioOp, depth: usize, mode: Folio
             print_expr(w, &interpolation.expression, mode)?;
             end_line(w, interpolation.span, mode)
         }
+        FolioOp::Comment(comment) => {
+            indent(w, depth)?;
+            w.write_str("ui.comment ")?;
+            quoted(w, comment.content.as_str())?;
+            end_line(w, comment.span, mode)
+        }
         FolioOp::If(if_op) => {
             indent(w, depth)?;
             w.write_str("ui.if")?;

--- a/crates/vize_s2/src/op.rs
+++ b/crates/vize_s2/src/op.rs
@@ -51,7 +51,7 @@ pub use control::{ForBinding, ForOp, IfBranch, IfOp};
 pub use element::{Attribute, ComponentOp, ElementOp, Namespace};
 pub use model::{BindingContract, ModelOp};
 pub use slot::{DynamicName, SlotContentOp, SlotOp};
-pub use text::{InterpolationOp, TextOp};
+pub use text::{CommentOp, InterpolationOp, TextOp};
 pub use vue::{
     VueCloakOp, VueCssBindOp, VueDirectiveOp, VueHtmlOp, VueMemoOp, VueOnceOp, VueShowOp,
     VueSlotScopeOp, VueSyncOp, VueTextOp,
@@ -77,6 +77,8 @@ pub enum Op<'a> {
     Text(Box<'a, TextOp<'a>>),
     /// `ui.interpolation` - an expression rendered as text.
     Interpolation(Box<'a, InterpolationOp<'a>>),
+    /// `ui.comment` - an authored template comment preserved for DOM output.
+    Comment(Box<'a, CommentOp<'a>>),
     /// `ui.if` - structured conditional; every branch owns its region.
     If(Box<'a, IfOp<'a>>),
     /// `ui.for` - structured iteration; the repeated content is one owned
@@ -96,6 +98,7 @@ impl Op<'_> {
             Self::Component(_) => "ui.component",
             Self::Text(_) => "ui.text",
             Self::Interpolation(_) => "ui.interpolation",
+            Self::Comment(_) => "ui.comment",
             Self::If(_) => "ui.if",
             Self::For(_) => "ui.for",
             Self::Slot(_) => "ui.slot",

--- a/crates/vize_s2/src/op/text.rs
+++ b/crates/vize_s2/src/op/text.rs
@@ -1,4 +1,4 @@
-//! `ui.text` / `ui.interpolation` payloads.
+//! `ui.text` / `ui.interpolation` / `ui.comment` payloads.
 
 use vize_s0::Span;
 
@@ -23,9 +23,19 @@ pub struct InterpolationOp<'a> {
     pub span: Span,
 }
 
+/// `ui.comment` - an authored template comment kept for DOM output.
+#[derive(Debug)]
+pub struct CommentOp<'a> {
+    /// The comment body, without the `<!--` / `-->` delimiters.
+    pub content: &'a str,
+    /// The comment's full source range.
+    pub span: Span,
+}
+
 /// See [`crate::op`] for the guard rationale.
 #[cfg(target_pointer_width = "64")]
 const _: () = {
     assert!(core::mem::size_of::<TextOp<'_>>() == 24);
     assert!(core::mem::size_of::<InterpolationOp<'_>>() == 24);
+    assert!(core::mem::size_of::<CommentOp<'_>>() == 24);
 };

--- a/crates/vize_s2/src/verify/walk.rs
+++ b/crates/vize_s2/src/verify/walk.rs
@@ -37,6 +37,7 @@ fn keyword(op: &FolioOp) -> &'static str {
         FolioOp::Component(_) => "ui.component",
         FolioOp::Text(_) => "ui.text",
         FolioOp::Interpolation(_) => "ui.interpolation",
+        FolioOp::Comment(_) => "ui.comment",
         FolioOp::If(_) => "ui.if",
         FolioOp::For(_) => "ui.for",
         FolioOp::Slot(_) => "ui.slot",
@@ -50,6 +51,7 @@ fn op_span(op: &FolioOp) -> Span {
         FolioOp::Component(component) => component.span,
         FolioOp::Text(text) => text.span,
         FolioOp::Interpolation(interpolation) => interpolation.span,
+        FolioOp::Comment(comment) => comment.span,
         FolioOp::If(if_op) => if_op.span,
         FolioOp::For(for_op) => for_op.span,
         FolioOp::Slot(slot) => slot.span,
@@ -105,7 +107,7 @@ fn visit_op(op: &FolioOp, owner: Owner, rigor: Rigor, out: &mut Vec<Violation>) 
             rigor,
             out,
         ),
-        FolioOp::Text(_) | FolioOp::Interpolation(_) => {}
+        FolioOp::Text(_) | FolioOp::Interpolation(_) | FolioOp::Comment(_) => {}
         FolioOp::If(if_op) => visit_if(if_op, rigor, out),
         FolioOp::For(for_op) => {
             for child in &for_op.ops {

--- a/crates/vize_s2/tests/fixtures/reference.folio
+++ b/crates/vize_s2/tests/fixtures/reference.folio
@@ -1,5 +1,5 @@
 [disegno]
-ops=12
+ops=13
 
 [disegno.ops]
 ui.element form @0:99
@@ -10,6 +10,7 @@ ui.element form @0:99
   ui.if @61:90
     branch js("open" @65:69) @61:75
       ui.text "a\"b\\c" @66:70
+      ui.comment "kept" @70:74
     branch @75:90
       ui.interpolation opaque(nesting-refused "((((x))))" @82:88) @80:88
 ui.for source=opaque(for-value "a in b in c" @110:121) value=js("a" @105:106) key=js("i" @108:109) @100:161

--- a/crates/vize_s2/tests/folio_laws.rs
+++ b/crates/vize_s2/tests/folio_laws.rs
@@ -1,24 +1,17 @@
-//! TS-16 for the disegno folio (P2-5a; expression payloads P2-5b).
-//!
-//! `Full` mode: `print(parse(t)) == t` byte-exact for canonical text and
-//! `parse(print(v)) == v` structurally, with normalization by the first
-//! print for non-canonical input. `Display` explicitly carries **no**
-//! round-trip law - here it elides every span (line tails and the spans
-//! inside expression payloads) and nothing else. The committed reference
-//! page (`tests/fixtures/reference.folio`) covers every op kind, both
-//! binding kinds, escapes, a namespace, static and dynamic names,
-//! optional `ui.for` positions, and all three expression payload kinds;
-//! `tests/folio_mirror.rs` builds the same tree in a live arena, and the
-//! remaining opaque-reason spellings are pinned by
-//! `every_opaque_reason_spelling_round_trips` below.
+//! TS-16 for the disegno folio (P2-5a; expression payloads P2-5b). Full mode
+//! round-trips byte-exact canonical text and parse/print structure; Display
+//! elides spans and carries no round-trip law. The committed reference page
+//! covers every op and binding kind; `tests/folio_mirror.rs` builds the same
+//! tree in a live arena, and this file pins all opaque-reason spellings.
 
 use vize_davinci::folio::{Folio, FolioMode};
 use vize_s0::{Span, String};
 use vize_s2::expr::OpaqueReason;
 use vize_s2::folio::{
-    DisegnoFolio, FolioAttribute, FolioBind, FolioBinding, FolioBranch, FolioComponent,
-    FolioContract, FolioElement, FolioExpr, FolioFor, FolioForBinding, FolioIf, FolioInterpolation,
-    FolioModel, FolioName, FolioOn, FolioOp, FolioSlot, FolioText, FolioVueDirective,
+    DisegnoFolio, FolioAttribute, FolioBind, FolioBinding, FolioBranch, FolioComment,
+    FolioComponent, FolioContract, FolioElement, FolioExpr, FolioFor, FolioForBinding, FolioIf,
+    FolioInterpolation, FolioModel, FolioName, FolioOn, FolioOp, FolioSlot, FolioText,
+    FolioVueDirective,
 };
 use vize_s2::op::Namespace;
 
@@ -28,7 +21,7 @@ const CANONICAL: &str = include_str!("fixtures/reference.folio");
 /// `Display` output for the same tree: every span elided, nothing else.
 const DISPLAY: &str = "\
 [disegno]
-ops=12
+ops=13
 
 [disegno.ops]
 ui.element form
@@ -39,6 +32,7 @@ ui.element form
   ui.if
     branch js(\"open\")
       ui.text \"a\\\"b\\\\c\"
+      ui.comment \"kept\"
     branch
       ui.interpolation opaque(nesting-refused \"((((x))))\")
 ui.for source=opaque(for-value \"a in b in c\") value=js(\"a\") key=js(\"i\")
@@ -109,10 +103,16 @@ fn hand_built() -> DisegnoFolio {
                     branches: vec![
                         FolioBranch {
                             condition: Some(js("open", 65, 69)),
-                            ops: vec![FolioOp::Text(FolioText {
-                                content: String::from("a\"b\\c"),
-                                span: Span::new(66, 70),
-                            })],
+                            ops: vec![
+                                FolioOp::Text(FolioText {
+                                    content: String::from("a\"b\\c"),
+                                    span: Span::new(66, 70),
+                                }),
+                                FolioOp::Comment(FolioComment {
+                                    content: String::from("kept"),
+                                    span: Span::new(70, 74),
+                                }),
+                            ],
                             span: Span::new(61, 75),
                         },
                         FolioBranch {

--- a/crates/vize_s2/tests/folio_mirror.rs
+++ b/crates/vize_s2/tests/folio_mirror.rs
@@ -11,9 +11,9 @@ use vize_s0::{Allocator, Box, Span, Vec as ArenaVec};
 use vize_s2::expr::{ExprRef, ForeignExpr, JsExpr, OpaqueExpr, OpaqueReason};
 use vize_s2::folio::DisegnoFolio;
 use vize_s2::op::{
-    Attribute, BindOp, BindingContract, BindingOp, ComponentOp, DynamicName, ElementOp, ForBinding,
-    ForOp, IfBranch, IfOp, InterpolationOp, ModelOp, Namespace, OnOp, Op, Region, SlotOp, TextOp,
-    VueDirectiveOp,
+    Attribute, BindOp, BindingContract, BindingOp, CommentOp, ComponentOp, DynamicName, ElementOp,
+    ForBinding, ForOp, IfBranch, IfOp, InterpolationOp, ModelOp, Namespace, OnOp, Op, Region,
+    SlotOp, TextOp, VueDirectiveOp,
 };
 
 /// Canonical text of the reference tree.
@@ -54,13 +54,22 @@ fn arena_built<'a>(allocator: &'a Allocator) -> ArenaVec<'a, Op<'a>> {
                         condition: Some(js(allocator, "open", 65, 69)),
                         region: Region {
                             ops: ArenaVec::from_iter_in(
-                                [Op::Text(Box::new_in(
-                                    TextOp {
-                                        content: "a\"b\\c",
-                                        span: Span::new(66, 70),
-                                    },
-                                    &allocator,
-                                ))],
+                                [
+                                    Op::Text(Box::new_in(
+                                        TextOp {
+                                            content: "a\"b\\c",
+                                            span: Span::new(66, 70),
+                                        },
+                                        &allocator,
+                                    )),
+                                    Op::Comment(Box::new_in(
+                                        CommentOp {
+                                            content: "kept",
+                                            span: Span::new(70, 74),
+                                        },
+                                        &allocator,
+                                    )),
+                                ],
                                 &allocator,
                             ),
                         },
@@ -250,7 +259,7 @@ fn an_arena_tree_mirrors_into_the_same_folio() {
     let allocator = Allocator::default();
     let ops = arena_built(&allocator);
     let mirrored = DisegnoFolio::of(&ops);
-    assert_eq!(mirrored.op_count(), 12);
+    assert_eq!(mirrored.op_count(), 13);
     assert_eq!(
         mirrored.print_to_string(FolioMode::Full).as_str(),
         CANONICAL

--- a/crates/vize_s2/tests/op_family.rs
+++ b/crates/vize_s2/tests/op_family.rs
@@ -10,10 +10,10 @@
 use vize_s0::{Allocator, Box, Span, Vec};
 use vize_s2::expr::{ExprRef, OpaqueExpr, OpaqueReason};
 use vize_s2::op::{
-    Attribute, BindOp, BindingContract, BindingOp, ComponentOp, DynamicName, ElementOp, ForBinding,
-    ForOp, IfBranch, IfOp, InterpolationOp, ModelOp, Namespace, OnOp, Op, Region, SlotContentOp,
-    SlotOp, TextOp, VueCloakOp, VueCssBindOp, VueDirectiveOp, VueHtmlOp, VueMemoOp, VueOnceOp,
-    VueShowOp, VueSlotScopeOp, VueSyncOp, VueTextOp,
+    Attribute, BindOp, BindingContract, BindingOp, CommentOp, ComponentOp, DynamicName, ElementOp,
+    ForBinding, ForOp, IfBranch, IfOp, InterpolationOp, ModelOp, Namespace, OnOp, Op, Region,
+    SlotContentOp, SlotOp, TextOp, VueCloakOp, VueCssBindOp, VueDirectiveOp, VueHtmlOp, VueMemoOp,
+    VueOnceOp, VueShowOp, VueSlotScopeOp, VueSyncOp, VueTextOp,
 };
 
 /// The escape payload standing in for "some expression" wherever the op
@@ -34,6 +34,7 @@ fn op_keyword(op: &Op<'_>) -> &'static str {
         Op::Component(_) => "ui.component",
         Op::Text(_) => "ui.text",
         Op::Interpolation(_) => "ui.interpolation",
+        Op::Comment(_) => "ui.comment",
         Op::If(_) => "ui.if",
         Op::For(_) => "ui.for",
         Op::Slot(_) => "ui.slot",
@@ -120,6 +121,13 @@ fn every_op<'a>(allocator: &'a Allocator) -> Vec<'a, Op<'a>> {
             Op::Interpolation(Box::new_in(
                 InterpolationOp {
                     expression: expr,
+                    span,
+                },
+                &allocator,
+            )),
+            Op::Comment(Box::new_in(
+                CommentOp {
+                    content: "kept",
                     span,
                 },
                 &allocator,
@@ -280,6 +288,7 @@ fn every_region_op_variant_is_matched_without_a_wildcard() {
             "ui.component",
             "ui.text",
             "ui.interpolation",
+            "ui.comment",
             "ui.if",
             "ui.for",
             "ui.slot",

--- a/davinci-road/plan/phase-2-records/p2-11.md
+++ b/davinci-road/plan/phase-2-records/p2-11.md
@@ -287,12 +287,13 @@ The patch-site program remains explicit for `v-memo`, `v-once`, slot outlet and
 required Rust test job. #5387 is still the corpus-runnable entry; it widens to
 the hydrated fixture tree with `VIZE_DAVINCI_DIFFERENTIAL_CORPUS`.
 
-The series is not done. Waiver budget remains zero, and the old DOM lane remains
-the compatibility path for source maps, comments, unsupported option shapes and
-the explicit legacy flag. The canonical hydrated zero-divergence evidence is now
-recorded below; the remaining blocker is the full production-lane switch / flag
-deletion, which still needs installment 40's release-graph decision rather than
-an accidental dependency edge.
+The series is not done. Waiver budget remains zero. Ordinary template comments
+now have a source-map-free S2 route, and the old DOM lane remains the
+compatibility path for source maps, experimental in-tag comments, unsupported
+option shapes and the explicit legacy flag. The canonical hydrated
+zero-divergence evidence is now recorded below; the remaining blocker is the
+full production-lane switch / flag deletion, which still needs installment 40's
+release-graph decision rather than an accidental dependency edge.
 
 ## Hydrated corpus differential count contract
 

--- a/davinci-road/plan/phase-2-tasks.md
+++ b/davinci-road/plan/phase-2-tasks.md
@@ -233,9 +233,9 @@ late directive and patch-site witnesses, residual component and hoist-order
 witnesses, and the corpus-runnable plus CI DOM lanes. Real Project Matrix run `33531193323`
 recorded canonical hydrated zero-divergence evidence over 146 gitlinks,
 142 ecosystem projects, 42,668 files and 42,279 compared templates. The task
-remains blocked on the full production-lane switch because source-map, comment,
-unsupported-option and explicit legacy-flag compiles still require the
-compatibility path. See the
+remains blocked on the full production-lane switch because source-map,
+experimental in-tag comment, unsupported-option and explicit legacy-flag
+compiles still require the compatibility path. See the
 [series record](./phase-2-records/p2-11.md).
 
 **Steps:**

--- a/davinci-road/plan/phase-2.md
+++ b/davinci-road/plan/phase-2.md
@@ -102,8 +102,8 @@ counts or fixture availability changes.
   zero-divergence evidence over 146 gitlinks and 142 ecosystem projects:
   42,668 files, 42,279 compared templates, zero S2 refusals and zero
   divergences. The full production-lane switch remains open for source maps,
-  comments, unsupported option shapes and the explicit legacy flag; the old DOM
-  lane remains the compatibility path.
+  experimental in-tag comments, unsupported option shapes and the explicit
+  legacy flag; the old DOM lane remains the compatibility path.
 - **Open and dependency-blocked: 4 of 22 — P2-12b, P2-16, P2-17 and
   P2-20.** P2-12b depends on P2-12a, P2-11 and P2-3; TS-22 groundwork now
   exposes `emit_dom_source_observed` and `emit_budget_observer` for the one

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -68,13 +68,13 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s1       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
 | s2       | `alloc::vec::Vec`       |    10 |           22 |         44 |
 | s2       | `alloc::string::String` |     0 |            0 |          0 |
-| s2       | `vize_s0::String`       |    11 |           11 |         53 |
+| s2       | `vize_s0::String`       |    11 |           11 |         55 |
 | s2       | `vize_s0::Vec`          |     9 |            9 |         17 |
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
 | s1_to_s2 | `alloc::vec::Vec`       |    58 |           58 |        228 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    84 |           88 |        422 |
-| s1_to_s2 | `vize_s0::Vec`          |    15 |           16 |         68 |
+| s1_to_s2 | `vize_s0::String`       |    84 |           88 |        423 |
+| s1_to_s2 | `vize_s0::Vec`          |    15 |           16 |         69 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     4 |            4 |          9 |
 
 `tests/tooling/davinci-storage-policy.test.ts` masks comments, literals, and

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -20,7 +20,7 @@ s1	-	crates/vize_s1/src/surface.rs	0	0	0	0	1	3	0	0
 s2	analysis	crates/vize_s2/src/expr/filter.rs	2	0	0	0	1	2	0	0
 s2	-	crates/vize_s2/src/expr/foreign.rs	0	0	0	0	1	1	0	0
 s2	contract	crates/vize_s2/src/folio.rs	1	1	0	0	0	0	0	0
-s2	contract	crates/vize_s2/src/folio/owned.rs	1	14	1	12	0	0	0	0
+s2	contract	crates/vize_s2/src/folio/owned.rs	1	14	1	14	0	0	0	0
 s2	contract	crates/vize_s2/src/folio/owned/binding.rs	1	7	1	13	0	0	0	0
 s2	-	crates/vize_s2/src/folio/owned/expr.rs	0	0	1	10	0	0	0	0
 s2	contract	crates/vize_s2/src/folio/parse.rs	1	4	0	0	0	0	0	0
@@ -111,7 +111,7 @@ s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/element.rs	1	2	0	0	1	4	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/expr.rs	0	0	1	4	0	0	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/forop.rs	1	2	1	5	1	2	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/html.rs	0	0	1	2	0	0	0	0
-s1_to_s2	-	crates/vize_s1_to_s2/src/lower/leaf.rs	0	0	1	5	1	4	0	0
+s1_to_s2	-	crates/vize_s1_to_s2/src/lower/leaf.rs	0	0	1	6	1	5	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/once_memo.rs	0	0	1	3	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/show.rs	0	0	1	2	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/slot.rs	0	0	1	4	1	4	0	0

--- a/davinci-road/roadmap.md
+++ b/davinci-road/roadmap.md
@@ -132,8 +132,8 @@ earlier increments pin the late directive, patch-site, component, hoist-order
 and residual DOM corpus witnesses. Real Project Matrix run
 `33531193323` recorded canonical hydrated zero-divergence evidence over 146
 gitlinks, 142 ecosystem projects, 42,668 files and 42,279 compared templates;
-the full production-lane switch is still open for source maps, comments,
-unsupported option shapes and the explicit legacy flag.
+the full production-lane switch is still open for source maps, experimental
+in-tag comments, unsupported option shapes and the explicit legacy flag.
 The executable fixture inventory is 146 gitlinks / 142 ecosystem projects;
 fixture checkout hydration is deliberately not a project-count source.
 

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -17,6 +17,7 @@ const compilerOptionsProjectedToS2 = [
   "prefix_identifiers",
   "cache_handlers",
   "scope_id",
+  "comments",
   "component_name",
   "inline",
   "binding_metadata",
@@ -27,7 +28,6 @@ const compilerOptionsHeldAtDefault = [
   "hoist_static",
   "ssr",
   "source_map",
-  "comments",
   "experimental_in_tag_comments",
   "experimental_patterned_template",
   "custom_renderer",
@@ -44,6 +44,7 @@ const s2EmitOptionFields = [
   "hoisted_scope_id",
   "scope_id",
   "is_ts",
+  "comments",
   "bindings",
 ];
 


### PR DESCRIPTION
## Summary
- preserve ordinary template comments as `ui.comment` in the S2 DOM path
- route source-map-free `comments: true` DOM compiles through S2 while source maps and experimental in-tag comments stay on compatibility
- cover root children, component default slots, slot outlet fallbacks, SFC selection, folio round trips, and P2-11 records

## Validation
- `cargo test -p vize_s2`
- `cargo test -p vize_s1_to_s2`
- `cargo test -p vize_s1_to_s2 --test emit_comments`
- `cargo test -p vize_atelier_core`
- `cargo test -p vize_atelier_dom`
- `cargo test -p vize_atelier_dom --test davinci_s2_sfc_comment_selector`
- `cargo test -p vize_atelier_dom --test davinci_s2_production_selector`
- `cargo test -p vize_atelier_dom --test davinci_s2_profile`
- `cargo test -p vize_atelier_dom davinci_s2`
- `cargo build -p vize`
- `cargo fmt --all -- --check`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - S2 compilation can preserve ordinary template comments when comment preservation is enabled.
  - Preserved comments are emitted as comment VNodes in slots, fallbacks, fragments, and conditional content.
  - Comment-preserving templates can use the S2 production path without source maps.

- **Bug Fixes**
  - Comments now remain correctly positioned and accounted for across generated DOM structures.

- **Documentation**
  - Clarified compatibility requirements for experimental in-tag comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->