### PR TITLE
test(tooling): add directus authored lsp oracle

### DIFF
--- a/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 28, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 29, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -767,6 +767,7 @@
           "tests/_fixtures/_git/ant-design-vue",
           "tests/_fixtures/_git/element-plus",
           "tests/_fixtures/_git/epic-spinners",
+          "tests/_fixtures/_git/directus",
           "tests/_fixtures/_git/hoppscotch",
           "tests/_fixtures/_git/inspira-ui",
           "tests/_fixtures/_git/reka-ui",

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 28,
+    "minimumProjectCount": 29,
     "trackingIssue": 3952
   },
   "projects": [
@@ -972,7 +972,69 @@
       "vueGlobs": ["app/src/**/*.vue"],
       "tsconfig": "app/tsconfig.json",
       "coverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
-      "diff": "e2e-vrt"
+      "diff": "e2e-vrt",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "app/src/interfaces/input-multiline/input-multiline.vue",
+          "symbol": "charsRemaining",
+          "usageAnchor": "{{ charsRemaining }}",
+          "declarationAnchor": "const charsRemaining = computed(() => {",
+          "hoverContains": ["**charsRemaining**", "Binding from `<script setup>`."],
+          "renameTo": "__vizeRenamedCharsRemaining"
+        },
+        "componentBoundary": {
+          "importerFile": "app/src/interfaces/presentation-header/header.vue",
+          "componentFile": "app/src/interfaces/presentation-header/helper-text.vue",
+          "tagName": "HelperText",
+          "tagAnchor": "\t\t\t\t\t<HelperText ",
+          "completionItemCount": 29,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "content", "rank": 28 }
+          ],
+          "dependencyEdit": {
+            "anchor": "\tcontent: string;",
+            "replacement": "\tcontent: string;\n\tvizeOracleProbe?: boolean;",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "app/src/interfaces/presentation-header/__VizeOracleHelperText.vue",
+          "renamedFile": "app/src/interfaces/presentation-header/__VizeOracleRenamedHelperText.vue",
+          "originalImportSpecifier": "./helper-text.vue",
+          "copiedImportSpecifier": "./__VizeOracleHelperText.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedHelperText.vue",
+          "markerInsertionAnchor": "import { computed } from 'vue';\n",
+          "markerSymbol": "__vizeDirectusHelperTextMarker__"
+        }
+      }
     },
     {
       "id": "motion-vue",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 28,
+      "authored-lsp": 29,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,


### PR DESCRIPTION
## Summary
- add a Directus authored real-project LSP oracle for template binding hover, definition, references, and rename
- cover a relative component boundary through completion, unsaved dependency edits, and file create, rename, and delete lifecycle
- ratchet authored LSP fixture coverage from 28 to 29 projects

## Validation
- cargo fmt --all -- --check
- cargo build --profile ci -p vize
- node --test --test-concurrency=1 tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts
- REAL_PROJECT_LSP_TIMEOUT_MS=600000 FIXTURE_SHARD_COUNT=144 FIXTURE_SHARD_INDEX=13 VIZE_LSP_BIN=$PWD/target/ci/vize node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts
- node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts tests/tooling/real-project-matrix-summary.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/fixture-compatibility-ledger.test.ts tests/tooling/vue-ecosystem-fixtures.test.ts
- NODE_OPTIONS="--disable-warning=DEP0040 --disable-warning=DEP0169" vp run --workspace-root check:ci
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791258036&installation_model_id=422833&pr_number=5797&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5797&signature=8b95101518276b9eb1737bb92b6eb3f8825fdc51b04fb111fdf0899dd2962e18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->