### PR TITLE
fix(davinci): route source maps through S2 DOM emit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3590,6 +3590,7 @@ dependencies = [
  "insta",
  "phf 0.13.1",
  "serde",
+ "serde_json",
  "thiserror 2.0.20",
  "vize_atelier_core",
  "vize_carton",

--- a/crates/vize_atelier_dom/Cargo.toml
+++ b/crates/vize_atelier_dom/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = { workspace = true }
 criterion = { workspace = true }
 davinci_harness = { workspace = true }
 insta = { workspace = true }
+serde_json = { workspace = true }
 
 # S2 test and benchmark fixtures still use the stage diagnostics/types.
 vize_davinci = { workspace = true }

--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -15,6 +15,7 @@ use vize_s0::{Allocator, String, profile};
 
 mod pipeline;
 mod sfc;
+mod source_map;
 mod stage_options;
 
 use crate::options::DomCompilerOptions;
@@ -336,7 +337,7 @@ fn compile_template_inner_with_sections<'a>(
         )
     });
     let codegen_result = match s2_emit {
-        Some(Ok(result)) => result,
+        Some(Ok(result)) => source_map::attach_compat_map(&root, &codegen_opts, result),
         Some(Err(_)) | None => profile!(
             "atelier.dom.template.codegen_compat",
             generate_with_sections(&root, codegen_opts)

--- a/crates/vize_atelier_dom/src/compile/sfc.rs
+++ b/crates/vize_atelier_dom/src/compile/sfc.rs
@@ -33,8 +33,9 @@ pub(super) fn compile_template_inner_for_sfc_with_sections<'a>(
     );
 
     let mut force_compat_sections = false;
+    let fast_path_supported = selector::s2_sfc_fast_path_supported_source(source);
 
-    if use_s2_emit && selector::s2_sfc_fast_path_supported_source(source) {
+    if use_s2_emit && fast_path_supported && !codegen_opts.source_map {
         let binding_table = stage_options::s2_binding_table(options.binding_metadata.as_ref());
         let s2_options = stage_options::s2_emit_options(
             &options,
@@ -49,7 +50,7 @@ pub(super) fn compile_template_inner_for_sfc_with_sections<'a>(
             return (Vec::new(), result);
         }
         force_compat_sections = true;
-    } else if use_s2_emit {
+    } else if use_s2_emit && !fast_path_supported {
         force_compat_sections = true;
     }
 

--- a/crates/vize_atelier_dom/src/compile/source_map.rs
+++ b/crates/vize_atelier_dom/src/compile/source_map.rs
@@ -1,0 +1,40 @@
+//! Source-map bridging for the S2 DOM production selector.
+//!
+//! The S2 DOM emitter owns the selected render code. Until S4 carries mapping
+//! spans through a structured emitter, source-map requests borrow the existing
+//! compatibility map only after the compatibility generator proves it would
+//! have emitted the same render module bytes and section boundaries.
+
+use vize_atelier_core::{
+    RootNode,
+    codegen::{CodegenResultWithSections, generate_with_sections},
+    options::CodegenOptions,
+};
+use vize_s0::profile;
+
+pub(super) fn attach_compat_map(
+    root: &RootNode<'_>,
+    codegen_options: &CodegenOptions,
+    mut s2: CodegenResultWithSections,
+) -> CodegenResultWithSections {
+    if !codegen_options.source_map {
+        return s2;
+    }
+
+    let compat = profile!(
+        "atelier.dom.template.codegen_sourcemap_compat",
+        generate_with_sections(root, codegen_options.clone())
+    );
+    if same_generated_output(&s2, &compat) {
+        s2.result.map = compat.result.map;
+        s2
+    } else {
+        compat
+    }
+}
+
+fn same_generated_output(a: &CodegenResultWithSections, b: &CodegenResultWithSections) -> bool {
+    a.result.preamble == b.result.preamble
+        && a.result.code == b.result.code
+        && a.sections == b.sections
+}

--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -78,7 +78,7 @@ pub(super) fn codegen_options(
 
 pub(super) fn s2_emit_supported(
     options: &DomCompilerOptions,
-    codegen: &CodegenOptions,
+    _codegen: &CodegenOptions,
     has_custom_element_matcher: bool,
     template_syntax: TemplateSyntaxMode,
     has_croquis: bool,
@@ -87,8 +87,7 @@ pub(super) fn s2_emit_supported(
     matches!(
         s2_emit_selection,
         S2EmitSelection::Allowed | S2EmitSelection::RequireSections
-    ) && !codegen.source_map
-        && options.hoist_static
+    ) && options.hoist_static
         && !options.ssr
         && !options.experimental_in_tag_comments
         && !options.experimental_patterned_template
@@ -102,8 +101,9 @@ pub(super) fn s2_emit_supported(
 ///
 /// Keep this conversion beside the legacy parse/transform wiring: the public
 /// compiler still returns its AST and diagnostics, while S2 owns the supported
-/// source-map-free traversal surface. A field missing here must stay on the
-/// compatibility path rather than becoming an accidental S2 default.
+/// traversal surface. Source-map requests attach a verified compatibility map
+/// in `compile::source_map`; a field missing here must stay on the compatibility
+/// path rather than becoming an accidental S2 default.
 pub(super) fn s2_emit_options<'a>(
     options: &'a DomCompilerOptions,
     codegen: &'a CodegenOptions,

--- a/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
@@ -50,7 +50,7 @@ fn source_map_free_dom_compile_uses_s2_without_profiler() {
 }
 
 #[test]
-fn source_map_compiles_stay_on_compatibility_when_profiled() {
+fn source_map_compiles_use_s2_with_the_compatibility_map_when_profiled() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
@@ -75,12 +75,12 @@ fn source_map_compiles_stay_on_compatibility_when_profiled() {
     assert_eq!(mapped.code, source_map_free.code);
     assert!(
         mapped.map.is_some(),
-        "source-map compiles must produce the compatibility map"
+        "source-map compiles must keep producing a map"
     );
     assert_eq!(
         counter_total(&counters, "davinci.s2_dom.files"),
-        None,
-        "source-map compiles must stay on compatibility until S2 records map segments"
+        Some(1),
+        "source-map compiles must use S2 once the map is verified against compatibility codegen"
     );
 }
 

--- a/crates/vize_atelier_dom/tests/davinci_s2_source_map.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_source_map.rs
@@ -1,5 +1,5 @@
-//! P2-11 witness: source-map requests retain their compatibility contract
-//! while profiled source-map-free DOM templates can use the S2 backend.
+//! P2-11 witness: source-map requests can use S2 DOM output while retaining
+//! the shipped source-map contract.
 
 #![allow(
     clippy::disallowed_macros,
@@ -7,23 +7,249 @@
     clippy::disallowed_methods
 )]
 
-use vize_atelier_dom::{DomCompilerOptions, compile_template_with_options};
+use vize_atelier_core::{
+    CodegenSections,
+    codegen::CodegenResultWithSections,
+    options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode},
+};
+use vize_atelier_dom::{
+    DomCompilerOptions,
+    compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+    compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+    compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+};
+use vize_s0::{
+    Allocator,
+    profiler::{CounterSummary, global_profiler},
+};
 
 #[test]
-fn source_maps_keep_the_documented_compatibility_contract() {
-    let allocator = vize_s0::Allocator::new();
-    let (_, errors, result) = compile_template_with_options(
-        &allocator,
-        "<div>{{ msg }}</div>",
+fn source_map_template_compile_uses_s2_with_the_compatibility_map() {
+    let source = r#"<section id="app">{{ msg }}<span :title="title">ok</span></section>"#;
+    let codegen = CodegenOptions {
+        filename: "MappedTemplate.vue".into(),
+        ..Default::default()
+    };
+    let compat = compile_template_compat(
+        source,
         DomCompilerOptions {
             source_map: true,
             ..Default::default()
         },
+        codegen.clone(),
+    );
+    let (selected, counters) = compile_template_selected_with_profile(
+        source,
+        DomCompilerOptions {
+            source_map: true,
+            ..Default::default()
+        },
+        codegen,
     );
 
-    assert!(errors.is_empty());
+    assert_selected_source_map_matches_compat(selected, compat, counters);
+}
+
+#[test]
+fn source_map_sfc_sections_compile_uses_s2_with_the_compatibility_map() {
+    let source = r#"<section id="app">{{ msg }}<span :title="title">ok</span></section>"#;
+    let codegen = CodegenOptions {
+        filename: "MappedSfcTemplate.vue".into(),
+        ..Default::default()
+    };
+    let compat = compile_sfc_compat(
+        source,
+        DomCompilerOptions {
+            source_map: true,
+            ..Default::default()
+        },
+        codegen.clone(),
+    );
+    let (selected, counters) = compile_sfc_selected_with_profile(
+        source,
+        DomCompilerOptions {
+            source_map: true,
+            ..Default::default()
+        },
+        codegen,
+    );
+
+    assert_selected_source_map_matches_compat(selected, compat, counters);
+}
+
+fn assert_selected_source_map_matches_compat(
+    selected: Compiled,
+    compat: Compiled,
+    counters: CounterSummary,
+) {
+    assert_eq!(selected.preamble, compat.preamble);
+    assert_eq!(selected.code, compat.code);
+    assert_eq!(selected.sections, compat.sections);
+    assert_eq!(selected.map, compat.map);
+
     assert!(
-        result.map.is_some(),
+        selected.map.is_some(),
         "source-map requests must remain additive"
     );
+    assert_eq!(
+        counter_total(&counters, "davinci.s2_dom.files"),
+        Some(1),
+        "source-map requests must enter the S2 DOM production selector"
+    );
+
+    let map = selected.map.expect("source map");
+    let parsed: serde_json::Value = serde_json::from_str(&map).expect("map must be valid JSON");
+    assert_eq!(parsed["version"], 3);
+    assert!(
+        parsed["mappings"].as_str().is_some_and(|m| !m.is_empty()),
+        "the selected source map must keep non-empty mappings"
+    );
+}
+
+struct Compiled {
+    preamble: String,
+    code: String,
+    map: Option<String>,
+    sections: Option<CodegenSections>,
+}
+
+fn compile_template_selected_with_profile(
+    source: &str,
+    options: DomCompilerOptions,
+    codegen: CodegenOptions,
+) -> (Compiled, CounterSummary) {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+    profiler.enable();
+    let selected = compile_template_selected(source, options, codegen);
+    let counters = profiler.counter_summary();
+    profiler.disable();
+    profiler.clear();
+    (selected, counters)
+}
+
+fn compile_sfc_selected_with_profile(
+    source: &str,
+    options: DomCompilerOptions,
+    codegen: CodegenOptions,
+) -> (Compiled, CounterSummary) {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+    profiler.enable();
+    let selected = compile_sfc_selected(source, options, codegen);
+    let counters = profiler.counter_summary();
+    profiler.disable();
+    profiler.clear();
+    (selected, counters)
+}
+
+fn compile_template_selected(
+    source: &str,
+    options: DomCompilerOptions,
+    codegen: CodegenOptions,
+) -> Compiled {
+    let allocator = Allocator::new();
+    let (_, errors, result) =
+        compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+            None,
+            codegen,
+        );
+    assert!(errors.is_empty(), "compile errors: {errors:?}");
+    compiled(result)
+}
+
+fn compile_template_compat(
+    source: &str,
+    options: DomCompilerOptions,
+    codegen: CodegenOptions,
+) -> Compiled {
+    let allocator = Allocator::new();
+    let (_, errors, result) =
+        compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+            None,
+            non_matching_custom_elements(),
+            codegen,
+        );
+    assert!(errors.is_empty(), "compile errors: {errors:?}");
+    compiled(result)
+}
+
+fn compile_sfc_selected(
+    source: &str,
+    options: DomCompilerOptions,
+    codegen: CodegenOptions,
+) -> Compiled {
+    let allocator = Allocator::new();
+    let (errors, result) =
+        compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+            None,
+            CustomElementMatcher::default(),
+            codegen,
+        );
+    assert!(errors.is_empty(), "compile errors: {errors:?}");
+    compiled(result)
+}
+
+fn compile_sfc_compat(
+    source: &str,
+    options: DomCompilerOptions,
+    codegen: CodegenOptions,
+) -> Compiled {
+    let allocator = Allocator::new();
+    let (errors, result) =
+        compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+            None,
+            non_matching_custom_elements(),
+            codegen,
+        );
+    assert!(errors.is_empty(), "compile errors: {errors:?}");
+    compiled(result)
+}
+
+fn compiled(result: CodegenResultWithSections) -> Compiled {
+    Compiled {
+        preamble: result.result.preamble.to_string(),
+        code: result.result.code.to_string(),
+        map: result.result.map.map(|map| map.to_string()),
+        sections: result.sections,
+    }
+}
+
+fn non_matching_custom_elements() -> CustomElementMatcher {
+    CustomElementMatcher::from_patterns(vec!["x-never-*".into()])
+}
+
+fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
+    counters
+        .entries
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.total)
+}
+
+fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
+    static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    PROFILER_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -43,9 +43,10 @@
 //! and **`scope_id`** (`<style scoped>`'s `"data-v-abc123": ""` pair on
 //! every props object — inline, hoisted and component alike, and once as a
 //! trailing `mergeProps` argument rather than per spread segment). `atelier_dom`
-//! selects this lane for supported source-map-free DOM compiles; the old lane
-//! remains for source maps, experimental in-tag comments and unsupported
-//! option surfaces until the phase-exit deletion.
+//! selects this lane for supported DOM compiles, including source-map requests
+//! whose maps are verified against compatibility codegen; the old lane remains
+//! for experimental in-tag comments and unsupported option surfaces until the
+//! phase-exit deletion.
 
 mod budget;
 mod buf;

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -24,10 +24,10 @@ const compilerOptionsProjectedToS2 = [
   "is_ts",
   "dialect",
 ];
+const compilerOptionsHandledAroundS2 = ["source_map"];
 const compilerOptionsHeldAtDefault = [
   "hoist_static",
   "ssr",
-  "source_map",
   "experimental_in_tag_comments",
   "experimental_patterned_template",
   "custom_renderer",
@@ -121,7 +121,11 @@ test("DOM S2 production switch classifies every compiler option", () => {
   );
 
   assert.deepEqual(
-    sortedUnique([...compilerOptionsProjectedToS2, ...compilerOptionsHeldAtDefault]),
+    sortedUnique([
+      ...compilerOptionsProjectedToS2,
+      ...compilerOptionsHandledAroundS2,
+      ...compilerOptionsHeldAtDefault,
+    ]),
     [...fields].sort(),
   );
 });


### PR DESCRIPTION
## Summary
- route source_map=true DOM compiles through S2 emit, then attach the compatibility map only when generated bytes and section boundaries match
- cover direct template and SFC sections compiles with byte/map equality witnesses
- classify source_map as bridge-handled in the DOM production boundary test

## Validation
- cargo fmt --all -- --check
- cargo test -p vize_atelier_dom --test davinci_s2_source_map --test davinci_s2_production_selector
- cargo test -p vize_atelier_dom --tests
- cargo test -p vize_atelier_sfc source_map
- cargo build -p vize
- node --test tests/tooling/davinci-dom-production-boundary.test.ts
- node --test tests/tooling/davinci-storage-policy.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main
- git diff --check

## Notes
- based on main after #5796 merged
- local full test:scripts was attempted after vp install; it reached unrelated local Corepack shim drift in config-generation, while the focused gates above passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Source maps are now supported for eligible S2 DOM compilations.
  * Generated source maps are validated for compatibility and preserved in compiled template and SFC output.
  * Profiling now records S2 production compilation for supported source-map requests.

* **Bug Fixes**
  * Unsupported SFC fast-path cases now correctly use the compatibility compilation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->