### PR TITLE
test(carton): cover top-level vue version config

### DIFF
--- a/crates/vize_carton/src/config/loader/tests.rs
+++ b/crates/vize_carton/src/config/loader/tests.rs
@@ -100,6 +100,7 @@ fn load_config_defaults_dialect_to_unset() {
     assert_eq!(loaded.config.dialect, None);
 }
 
+#[test]
 fn load_compiler_vue_version_reads_vue_version_key() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("vize.config.json");


### PR DESCRIPTION
Summary:
- enable the existing top-level `vue.version` config loader regression as a real Rust test
- keep the rescue worktree untouched while extracting the focused carton coverage slice

Validation:
- git diff --check
- cargo fmt --all -- --check
- cargo test -p vize_carton load_compiler_vue_version_reads_vue_version_key -- --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791263597&installation_model_id=422833&pr_number=5802&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5802&signature=3ff7f792570f8ee5831e182899449e696efe4f0c15fd40fdcbe13b02335140e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated test coverage for loading the Vue version configuration key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->