### PR TITLE
fix(davinci): route in-tag comments through S2 DOM

### DIFF
--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -89,7 +89,6 @@ pub(super) fn s2_emit_supported(
         S2EmitSelection::Allowed | S2EmitSelection::RequireSections
     ) && options.hoist_static
         && !options.ssr
-        && !options.experimental_in_tag_comments
         && !options.experimental_patterned_template
         && !options.custom_renderer
         && template_syntax == TemplateSyntaxMode::Standard
@@ -125,6 +124,7 @@ pub(super) fn s2_emit_options<'a>(
         scope_id: options.scope_id.as_deref(),
         is_ts: options.is_ts,
         comments: options.comments,
+        experimental_in_tag_comments: options.experimental_in_tag_comments,
         bindings,
     }
 }

--- a/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
@@ -105,13 +105,6 @@ fn unsupported_options_stay_on_compatibility_without_profiler() {
             },
         ),
         (
-            "in_tag_comments",
-            DomCompilerOptions {
-                experimental_in_tag_comments: true,
-                ..Default::default()
-            },
-        ),
-        (
             "custom_renderer",
             DomCompilerOptions {
                 custom_renderer: true,
@@ -124,12 +117,7 @@ fn unsupported_options_stay_on_compatibility_without_profiler() {
         profiler.disable();
         profiler.clear();
 
-        let source = if label == "in_tag_comments" {
-            "<button // keep the parse extension covered\n  @click=\"go\">{{ label }}</button>"
-        } else {
-            r#"<button @click="go">{{ label }}</button>"#
-        };
-        let result = compile(source, options);
+        let result = compile(r#"<button @click="go">{{ label }}</button>"#, options);
         let counters = profiler.counter_summary();
 
         assert!(
@@ -142,6 +130,29 @@ fn unsupported_options_stay_on_compatibility_without_profiler() {
             "{label} compatibility compiles must not instantiate the profiling observer"
         );
     }
+}
+
+#[test]
+fn in_tag_comment_compiles_use_s2_codegen() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+    profiler.enable();
+
+    let selected = compile(
+        "<button // keep the parse extension covered\n  @click=\"go\">{{ label }}</button>",
+        DomCompilerOptions {
+            experimental_in_tag_comments: true,
+            ..Default::default()
+        },
+    );
+    let counters = profiler.counter_summary();
+    profiler.disable();
+    profiler.clear();
+
+    assert!(selected.sections.is_some());
+    assert_eq!(counter_total(&counters, "davinci.s2_dom.files"), Some(1));
 }
 
 #[test]

--- a/crates/vize_atelier_dom/tests/davinci_s2_profile_unsupported.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_profile_unsupported.rs
@@ -32,13 +32,6 @@ fn profiled_unsupported_options_stay_on_compatibility_codegen() {
             },
         ),
         (
-            "in_tag_comments",
-            DomCompilerOptions {
-                experimental_in_tag_comments: true,
-                ..Default::default()
-            },
-        ),
-        (
             "custom_renderer",
             DomCompilerOptions {
                 custom_renderer: true,
@@ -48,12 +41,8 @@ fn profiled_unsupported_options_stay_on_compatibility_codegen() {
     ] {
         let profile = ProfileScope::enable();
         let allocator = Allocator::new();
-        let source = if label == "in_tag_comments" {
-            "<div // keep the parse extension covered\n  id=\"x\">{{ msg }}</div>"
-        } else {
-            "<div>{{ msg }}</div>"
-        };
-        let (_, errors, result) = compile_template_with_options(&allocator, source, options);
+        let (_, errors, result) =
+            compile_template_with_options(&allocator, "<div>{{ msg }}</div>", options);
         let counters = profile.finish();
 
         assert!(errors.is_empty(), "{label} compile errors: {errors:?}");

--- a/crates/vize_atelier_dom/tests/davinci_s2_source_map.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_source_map.rs
@@ -77,6 +77,25 @@ fn source_map_sfc_sections_compile_uses_s2_with_the_compatibility_map() {
     assert_selected_source_map_matches_compat(selected, compat, counters);
 }
 
+#[test]
+fn in_tag_comment_source_map_compile_uses_s2_with_the_compatibility_map() {
+    let source =
+        "<button // keep the parse extension covered\n  @click=\"go\">{{ label }}</button>";
+    let options = DomCompilerOptions {
+        source_map: true,
+        experimental_in_tag_comments: true,
+        ..Default::default()
+    };
+    let codegen = CodegenOptions {
+        filename: "InTagComment.vue".into(),
+        ..Default::default()
+    };
+    let compat = compile_template_compat(source, options.clone(), codegen.clone());
+    let (selected, counters) = compile_template_selected_with_profile(source, options, codegen);
+
+    assert_selected_source_map_matches_compat(selected, compat, counters);
+}
+
 fn assert_selected_source_map_matches_compat(
     selected: Compiled,
     compat: Compiled,

--- a/crates/vize_s1/src/lib.rs
+++ b/crates/vize_s1/src/lib.rs
@@ -70,7 +70,7 @@ pub mod surface;
 mod build;
 mod event;
 
-pub use parse::{SurfaceError, parse};
+pub use parse::{SurfaceError, SurfaceParseOptions, parse, parse_with_options};
 pub use render::{HoleCounts, check_fidelity, hole_counts, render};
 pub use surface::{
     AttrValue, Attribute, CloseTag, Element, ElementClose, Interpolation, OpenTag, SurfaceChild,

--- a/crates/vize_s1/src/parse.rs
+++ b/crates/vize_s1/src/parse.rs
@@ -10,6 +10,13 @@ use crate::event::{Event, Recorder};
 use crate::render::check_fidelity;
 use crate::surface::SurfaceTree;
 
+/// Parse-time switches S1 owns for the S2 consumers.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SurfaceParseOptions {
+    /// Accept Vue's experimental `//` comments inside opening tag attrs.
+    pub experimental_in_tag_comments: bool,
+}
+
 /// A recoverable tokenizer diagnostic, by code and byte offset. S1 keeps
 /// armature's codes verbatim; rendering them through the P2-1
 /// `Diagnostic` channel is the S1→S2 lowering's job (P2-8).
@@ -37,6 +44,15 @@ pub fn parse<'a>(
     allocator: &'a Allocator,
     source: &'a str,
 ) -> (SurfaceTree<'a>, Vec<'a, SurfaceError>) {
+    parse_with_options(allocator, source, SurfaceParseOptions::default())
+}
+
+/// [`parse`] with explicit S1 parse switches.
+pub fn parse_with_options<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    options: SurfaceParseOptions,
+) -> (SurfaceTree<'a>, Vec<'a, SurfaceError>) {
     assert!(
         u32::try_from(source.len()).is_ok(),
         "S1 sources are u32-addressed"
@@ -49,6 +65,7 @@ pub fn parse<'a>(
             errors: &mut errors,
         };
         let mut tokenizer = Tokenizer::new(source, recorder);
+        tokenizer.set_in_tag_comments(options.experimental_in_tag_comments);
         tokenizer.tokenize();
     }
     let tree = build(allocator, source, &events);

--- a/crates/vize_s1/tests/surface_fidelity.rs
+++ b/crates/vize_s1/tests/surface_fidelity.rs
@@ -10,7 +10,8 @@ use davinci_test_support::surface_fixture as common;
 use vize_relief::ErrorCode;
 use vize_s0::{Allocator, String};
 use vize_s1::{
-    ElementClose, HoleCounts, SurfaceChild, SurfaceTree, check_fidelity, hole_counts, parse, render,
+    ElementClose, HoleCounts, SurfaceChild, SurfaceParseOptions, SurfaceTree, check_fidelity,
+    hole_counts, parse, parse_with_options, render,
 };
 
 fn rendered(tree: &SurfaceTree<'_>) -> String {
@@ -299,4 +300,35 @@ fn in_tag_junk_rides_in_leading_under_a_diagnostic() {
     assert_eq!(element.open.attrs[0].name.leading, " / ");
     assert_eq!(errors.len(), 1);
     assert!(matches!(errors[0].code, ErrorCode::UnexpectedSolidusInTag));
+}
+
+#[test]
+fn experimental_in_tag_comments_ride_in_leading_without_holes() {
+    let source = concat!(
+        "<LegacySelect\n",
+        "  :options=\"options\"\n",
+        "  // @vue-expect-error legacy API\n",
+        "  :selected-id=\"selectedId\"\n",
+        "/>",
+    );
+    let allocator = Allocator::new();
+    let (tree, errors) = parse_with_options(
+        &allocator,
+        source,
+        SurfaceParseOptions {
+            experimental_in_tag_comments: true,
+        },
+    );
+
+    assert!(errors.is_empty());
+    assert_eq!(rendered(&tree), source);
+    assert_eq!(hole_counts(&tree), HoleCounts::default());
+    let SurfaceChild::Element(element) = &tree.children[0] else {
+        panic!("one element");
+    };
+    assert_eq!(element.open.attrs.len(), 2);
+    assert_eq!(
+        element.open.attrs[1].name.leading,
+        "\n  // @vue-expect-error legacy API\n  "
+    );
 }

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -42,11 +42,11 @@
 //! handler from the patch flag; suppressed under `v-for` / slot params),
 //! and **`scope_id`** (`<style scoped>`'s `"data-v-abc123": ""` pair on
 //! every props object — inline, hoisted and component alike, and once as a
-//! trailing `mergeProps` argument rather than per spread segment). `atelier_dom`
-//! selects this lane for supported DOM compiles, including source-map requests
-//! whose maps are verified against compatibility codegen; the old lane remains
-//! for experimental in-tag comments and unsupported option surfaces until the
-//! phase-exit deletion.
+//! trailing `mergeProps` argument rather than per spread segment), and
+//! experimental in-tag comments. `atelier_dom` selects this lane for supported
+//! DOM compiles, including source-map requests whose maps are verified against
+//! compatibility codegen; the old lane remains for unsupported option surfaces
+//! until the phase-exit deletion.
 
 mod budget;
 mod buf;

--- a/crates/vize_s1_to_s2/src/emit/budget.rs
+++ b/crates/vize_s1_to_s2/src/emit/budget.rs
@@ -1,6 +1,6 @@
 use vize_davinci::pass::{BudgetObserver, PassObserver};
 use vize_s0::{Allocator, ensure_sufficient_stack};
-use vize_s1::parse;
+use vize_s1::{SurfaceParseOptions, parse_with_options};
 
 use crate::lower::{LegacyCaps, lower_with_caps_and_comment_policy};
 use crate::pass::run_transform;
@@ -80,7 +80,13 @@ pub(super) fn emit_dom_source_with_options_and_observer<'a, O: PassObserver>(
     observer: &mut O,
 ) -> Result<(DomEmit, u32), EmitError> {
     ensure_sufficient_stack(|| {
-        let (tree, errors) = parse(allocator, source);
+        let (tree, errors) = parse_with_options(
+            allocator,
+            source,
+            SurfaceParseOptions {
+                experimental_in_tag_comments: options.experimental_in_tag_comments,
+            },
+        );
         let mut lowered =
             lower_with_caps_and_comment_policy(allocator, &tree, &errors, caps, options.comments);
         let facts = run_transform(&mut lowered, observer);

--- a/crates/vize_s1_to_s2/src/emit/options.rs
+++ b/crates/vize_s1_to_s2/src/emit/options.rs
@@ -5,7 +5,6 @@
 //! the atelier_dom dual-run can pin each option against the shipped lane
 //! one at a time. A field missing from this struct is not a default the
 //! emitter silently assumes — it is production surface the series has
-//! not reached yet, and the witness for it does not exist.
 
 use alloc::vec::Vec as StdVec;
 
@@ -228,10 +227,10 @@ pub struct DomEmitOptions<'a> {
     pub is_ts: bool,
     /// Preserve ordinary template comments as `_createCommentVNode(...)`.
     pub comments: bool,
+    /// Preserve Vue's experimental `//` comments inside opening tag attrs.
+    pub experimental_in_tag_comments: bool,
     /// The shipped lane's `binding_metadata`, honoured in non-inline mode:
-    /// prefixed identifiers resolve to `$setup.` / `$props.` / `$data.` /
-    /// `$options.`, components and directives resolve to `$setup` members,
-    /// and the render signature carries all six arguments.
+    /// prefixed identifiers resolve to the same proxy members and signatures.
     pub bindings: Option<&'a BindingTable>,
 }
 
@@ -250,6 +249,7 @@ impl DomEmitOptions<'static> {
         scope_id: None,
         is_ts: false,
         comments: false,
+        experimental_in_tag_comments: false,
         bindings: None,
     };
 }
@@ -280,6 +280,7 @@ mod tests {
                 scope_id: None,
                 is_ts: false,
                 comments: false,
+                experimental_in_tag_comments: false,
                 bindings: None,
             }
         );

--- a/crates/vize_s1_to_s2/tests/emit_comments.rs
+++ b/crates/vize_s1_to_s2/tests/emit_comments.rs
@@ -25,6 +25,14 @@ fn assembled_with_comments(source: &str, comments: bool) -> String {
     .to_string()
 }
 
+fn assembled_with_options(source: &str, options: DomEmitOptions<'_>) -> String {
+    let allocator = Allocator::new();
+    emit_dom_source_with_options(&allocator, source, LegacyCaps::VUE3, &options)
+        .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
+        .assembled()
+        .to_string()
+}
+
 fn pin(visual: &str) -> String {
     visual.replace(")\n\n  return", ")\n  \n  return")
 }
@@ -62,6 +70,21 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
   ]))
 }"
     );
+}
+
+#[test]
+fn in_tag_comments_are_parse_options_not_comment_vnodes() {
+    let with_in_tag_comment = assembled_with_options(
+        "<div // keep the parse extension covered\n  id=\"x\">{{ msg }}</div>",
+        DomEmitOptions {
+            experimental_in_tag_comments: true,
+            ..DomEmitOptions::DEFAULT
+        },
+    );
+    let without_in_tag_comment =
+        assembled_with_options("<div id=\"x\">{{ msg }}</div>", Default::default());
+
+    assert_eq!(with_in_tag_comment, without_in_tag_comment);
 }
 
 #[test]

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -64,7 +64,7 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s1       | `alloc::vec::Vec`       |     0 |            0 |          0 |
 | s1       | `alloc::string::String` |     0 |            0 |          0 |
 | s1       | `vize_s0::String`       |     0 |            0 |          0 |
-| s1       | `vize_s0::Vec`          |     5 |            5 |         21 |
+| s1       | `vize_s0::Vec`          |     5 |            5 |         22 |
 | s1       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
 | s2       | `alloc::vec::Vec`       |    10 |           22 |         44 |
 | s2       | `alloc::string::String` |     0 |            0 |          0 |

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -15,7 +15,7 @@ infra	analysis	crates/vize_davinci/src/side_table.rs	1	2	0	0	0	0	0	0
 s1	-	crates/vize_s1/src/build.rs	0	0	0	0	1	7	0	0
 s1	-	crates/vize_s1/src/build/tag.rs	0	0	0	0	1	4	0	0
 s1	-	crates/vize_s1/src/event.rs	0	0	0	0	1	2	0	0
-s1	-	crates/vize_s1/src/parse.rs	0	0	0	0	1	5	0	0
+s1	-	crates/vize_s1/src/parse.rs	0	0	0	0	1	6	0	0
 s1	-	crates/vize_s1/src/surface.rs	0	0	0	0	1	3	0	0
 s2	analysis	crates/vize_s2/src/expr/filter.rs	2	0	0	0	1	2	0	0
 s2	-	crates/vize_s2/src/expr/foreign.rs	0	0	0	0	1	1	0	0

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -19,6 +19,7 @@ const compilerOptionsProjectedToS2 = [
   "scope_id",
   "comments",
   "component_name",
+  "experimental_in_tag_comments",
   "inline",
   "binding_metadata",
   "is_ts",
@@ -28,7 +29,6 @@ const compilerOptionsHandledAroundS2 = ["source_map"];
 const compilerOptionsHeldAtDefault = [
   "hoist_static",
   "ssr",
-  "experimental_in_tag_comments",
   "experimental_patterned_template",
   "custom_renderer",
   "croquis",
@@ -45,6 +45,7 @@ const s2EmitOptionFields = [
   "scope_id",
   "is_ts",
   "comments",
+  "experimental_in_tag_comments",
   "bindings",
 ];
 


### PR DESCRIPTION
## Summary
- add S1 parse options for experimental in-tag comments
- pass the option through S2 DOM emit and allow the DOM selector to choose S2
- update selector, source-map, profile, and direct emitter witnesses

## Validation
- cargo test -p vize_s1 --test surface_fidelity -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_comments -- --nocapture
- cargo test -p vize_s1_to_s2 default_options_project_the_shipped_codegen_defaults -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_production_selector -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_source_map -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_profile_unsupported -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_option_audit -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_option_matrix -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_profile -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791263940&installation_model_id=422833&pr_number=5803&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5803&signature=3c9edefb0b80970c74ee2067c8368422bbe48ef4189999f7520b17d29ec8bfd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for experimental `//` comments inside opening-tag attributes.
  * Comments are preserved during parsing without creating rendered comment nodes.
  * The feature now works with optimized S2 DOM code generation and source maps.
  * Added parsing options for enabling experimental in-tag comments.

* **Bug Fixes**
  * Ensured the in-tag comment option is correctly passed through compilation and code generation.
  * Preserved compatibility output and source-map accuracy when the feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->