### PR TITLE
fix(davinci): support custom element patterns on S2 DOM

### DIFF
--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -298,13 +298,8 @@ fn compile_template_inner_with_sections<'a>(
     // Project the public output options before consuming Croquis below. Croquis
     // intentionally crosses the transform boundary by ownership and is not
     // cloneable, while S2 only borrows the remaining compiler settings.
-    let s2_emit_source = use_s2_emit.then(|| {
-        (
-            options.clone(),
-            hoisted_scope_id.clone(),
-            custom_elements.clone(),
-        )
-    });
+    let s2_custom_elements = custom_elements.clone();
+    let s2_emit_source = use_s2_emit.then(|| (options.clone(), hoisted_scope_id.clone()));
     let transform_opts = stage_options::transform_options(&options);
     // Park the summary on the allocator so it shares the allocator lifetime.
     let analysis: Option<&Croquis> = options.croquis.map(|c| allocator.alloc_owned(*c));
@@ -328,23 +323,21 @@ fn compile_template_inner_with_sections<'a>(
     errors.extend(transform_errors);
 
     // Codegen
-    let s2_emit = s2_emit_source.map(
-        |(s2_options_source, s2_hoisted_scope_id, s2_custom_elements)| {
-            let binding_table =
-                stage_options::s2_binding_table(s2_options_source.binding_metadata.as_ref());
-            let s2_options = stage_options::s2_emit_options(
-                &s2_options_source,
-                &codegen_opts,
-                &s2_custom_elements,
-                binding_table.as_ref(),
-                s2_hoisted_scope_id.as_deref(),
-            );
-            profile!(
-                "atelier.dom.template.s2_codegen",
-                stage_options::emit_s2(allocator, source, s2_options_source.dialect, &s2_options)
-            )
-        },
-    );
+    let s2_emit = s2_emit_source.map(|(s2_options_source, s2_hoisted_scope_id)| {
+        let binding_table =
+            stage_options::s2_binding_table(s2_options_source.binding_metadata.as_ref());
+        let s2_options = stage_options::s2_emit_options(
+            &s2_options_source,
+            &codegen_opts,
+            &s2_custom_elements,
+            binding_table.as_ref(),
+            s2_hoisted_scope_id.as_deref(),
+        );
+        profile!(
+            "atelier.dom.template.s2_codegen",
+            stage_options::emit_s2(allocator, source, s2_options_source.dialect, &s2_options)
+        )
+    });
     let codegen_result = match s2_emit {
         Some(Ok(result)) => source_map::attach_compat_map(&root, &codegen_opts, result),
         Some(Err(_)) | None => profile!(

--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -286,11 +286,11 @@ fn compile_template_inner_with_sections<'a>(
     let has_croquis = options.croquis.is_some();
     let codegen_opts = stage_options::codegen_options(&options, codegen_options);
     let template_syntax_quirks = template_syntax.is_quirks();
-    let has_custom_element_matcher = !custom_elements.is_empty();
+    let custom_elements_supported = !custom_elements.has_static_predicate();
     let use_s2_emit = stage_options::s2_emit_supported(
         &options,
         &codegen_opts,
-        has_custom_element_matcher,
+        custom_elements_supported,
         template_syntax,
         has_croquis,
         s2_emit_selection,
@@ -298,7 +298,13 @@ fn compile_template_inner_with_sections<'a>(
     // Project the public output options before consuming Croquis below. Croquis
     // intentionally crosses the transform boundary by ownership and is not
     // cloneable, while S2 only borrows the remaining compiler settings.
-    let s2_emit_source = use_s2_emit.then(|| (options.clone(), hoisted_scope_id.clone()));
+    let s2_emit_source = use_s2_emit.then(|| {
+        (
+            options.clone(),
+            hoisted_scope_id.clone(),
+            custom_elements.clone(),
+        )
+    });
     let transform_opts = stage_options::transform_options(&options);
     // Park the summary on the allocator so it shares the allocator lifetime.
     let analysis: Option<&Croquis> = options.croquis.map(|c| allocator.alloc_owned(*c));
@@ -322,20 +328,23 @@ fn compile_template_inner_with_sections<'a>(
     errors.extend(transform_errors);
 
     // Codegen
-    let s2_emit = s2_emit_source.map(|(s2_options_source, s2_hoisted_scope_id)| {
-        let binding_table =
-            stage_options::s2_binding_table(s2_options_source.binding_metadata.as_ref());
-        let s2_options = stage_options::s2_emit_options(
-            &s2_options_source,
-            &codegen_opts,
-            binding_table.as_ref(),
-            s2_hoisted_scope_id.as_deref(),
-        );
-        profile!(
-            "atelier.dom.template.s2_codegen",
-            stage_options::emit_s2(allocator, source, s2_options_source.dialect, &s2_options)
-        )
-    });
+    let s2_emit = s2_emit_source.map(
+        |(s2_options_source, s2_hoisted_scope_id, s2_custom_elements)| {
+            let binding_table =
+                stage_options::s2_binding_table(s2_options_source.binding_metadata.as_ref());
+            let s2_options = stage_options::s2_emit_options(
+                &s2_options_source,
+                &codegen_opts,
+                &s2_custom_elements,
+                binding_table.as_ref(),
+                s2_hoisted_scope_id.as_deref(),
+            );
+            profile!(
+                "atelier.dom.template.s2_codegen",
+                stage_options::emit_s2(allocator, source, s2_options_source.dialect, &s2_options)
+            )
+        },
+    );
     let codegen_result = match s2_emit {
         Some(Ok(result)) => source_map::attach_compat_map(&root, &codegen_opts, result),
         Some(Err(_)) | None => profile!(

--- a/crates/vize_atelier_dom/src/compile/sfc.rs
+++ b/crates/vize_atelier_dom/src/compile/sfc.rs
@@ -26,7 +26,7 @@ pub(super) fn compile_template_inner_for_sfc_with_sections<'a>(
     let use_s2_emit = stage_options::s2_emit_supported(
         &options,
         &codegen_opts,
-        !custom_elements.is_empty(),
+        !custom_elements.has_static_predicate(),
         template_syntax,
         options.croquis.is_some(),
         pipeline::S2EmitSelection::RequireSections,
@@ -40,6 +40,7 @@ pub(super) fn compile_template_inner_for_sfc_with_sections<'a>(
         let s2_options = stage_options::s2_emit_options(
             &options,
             &codegen_opts,
+            &custom_elements,
             binding_table.as_ref(),
             hoisted_scope_id.as_deref(),
         );

--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -5,8 +5,8 @@
 
 use vize_atelier_core::codegen::{CodegenResult, CodegenResultWithSections, CodegenSections};
 use vize_atelier_core::options::{
-    BindingMetadata, BindingType, CodegenMode, CodegenOptions, ParserOptions, TemplateSyntaxMode,
-    TransformOptions,
+    BindingMetadata, BindingType, CodegenMode, CodegenOptions, CustomElementMatcher, ParserOptions,
+    TemplateSyntaxMode, TransformOptions,
 };
 use vize_s0::Allocator;
 use vize_s0::profiler::global_profiler;
@@ -79,7 +79,7 @@ pub(super) fn codegen_options(
 pub(super) fn s2_emit_supported(
     options: &DomCompilerOptions,
     _codegen: &CodegenOptions,
-    has_custom_element_matcher: bool,
+    custom_elements_supported: bool,
     template_syntax: TemplateSyntaxMode,
     has_croquis: bool,
     s2_emit_selection: S2EmitSelection,
@@ -92,7 +92,7 @@ pub(super) fn s2_emit_supported(
         && !options.experimental_patterned_template
         && !options.custom_renderer
         && template_syntax == TemplateSyntaxMode::Standard
-        && !has_custom_element_matcher
+        && custom_elements_supported
         && !has_croquis
 }
 
@@ -106,6 +106,7 @@ pub(super) fn s2_emit_supported(
 pub(super) fn s2_emit_options<'a>(
     options: &'a DomCompilerOptions,
     codegen: &'a CodegenOptions,
+    custom_elements: &'a CustomElementMatcher,
     bindings: Option<&'a BindingTable>,
     hoisted_scope_id: Option<&'a str>,
 ) -> DomEmitOptions<'a> {
@@ -125,6 +126,7 @@ pub(super) fn s2_emit_options<'a>(
         is_ts: options.is_ts,
         comments: options.comments,
         experimental_in_tag_comments: options.experimental_in_tag_comments,
+        custom_element_patterns: custom_elements.patterns(),
         bindings,
     }
 }

--- a/crates/vize_atelier_dom/tests/davinci_s2_custom_element_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_custom_element_selector.rs
@@ -1,5 +1,5 @@
-//! P2-11 witness: declarative custom-element matchers remain an explicit
-//! compatibility boundary for the S2 DOM production selector.
+//! P2-11 witness: declarative custom-element matchers are covered by the S2
+//! DOM production selector, while opaque predicate matchers remain guarded.
 
 #![allow(
     clippy::disallowed_macros,
@@ -20,7 +20,7 @@ use vize_s0::profiler::{CounterSummary, global_profiler};
 static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[test]
-fn custom_element_matcher_keeps_template_sections_on_compatibility_codegen() {
+fn declarative_custom_element_matcher_uses_s2_for_template_sections() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
@@ -48,13 +48,13 @@ fn custom_element_matcher_keeps_template_sections_on_compatibility_codegen() {
     assert_eq!(selected.sections, compat.sections);
     assert_eq!(
         counter_total(&counters, "davinci.s2_dom.files"),
-        None,
-        "custom-element matchers are not covered by the S2 production selector yet"
+        Some(1),
+        "declarative custom-element matchers should enter the S2 production selector"
     );
 }
 
 #[test]
-fn custom_element_matcher_keeps_sfc_sections_on_compatibility_codegen() {
+fn declarative_custom_element_matcher_uses_s2_for_sfc_sections() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
@@ -81,8 +81,45 @@ fn custom_element_matcher_keeps_sfc_sections_on_compatibility_codegen() {
     assert_eq!(selected.sections, compat.sections);
     assert_eq!(
         counter_total(&counters, "davinci.s2_dom.files"),
+        Some(1),
+        "declarative custom-element matchers should enter the S2 SFC sections fast path"
+    );
+}
+
+#[test]
+fn static_predicate_custom_element_matcher_keeps_template_sections_on_compatibility_codegen() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+
+    let source = r#"<ion-button @click="go">{{ label }}</ion-button>"#;
+    let compat = compile_template_sections(
+        source,
+        DomCompilerOptions {
+            source_map: true,
+            ..Default::default()
+        },
+        predicate_custom_elements(),
+    );
+
+    profiler.enable();
+    let selected = compile_template_sections(
+        source,
+        DomCompilerOptions::default(),
+        predicate_custom_elements(),
+    );
+    let counters = profiler.counter_summary();
+    profiler.disable();
+    profiler.clear();
+
+    assert_eq!(selected.preamble, compat.preamble);
+    assert_eq!(selected.code, compat.code);
+    assert_eq!(selected.sections, compat.sections);
+    assert_eq!(
+        counter_total(&counters, "davinci.s2_dom.files"),
         None,
-        "custom-element matchers are not covered by the S2 SFC sections fast path yet"
+        "opaque custom-element predicates stay outside the S2 production selector"
     );
 }
 
@@ -142,6 +179,14 @@ fn compiled(result: CodegenResultWithSections) -> Compiled {
 
 fn custom_elements() -> CustomElementMatcher {
     CustomElementMatcher::from_patterns(vec!["ion-*".into()])
+}
+
+fn predicate_custom_elements() -> CustomElementMatcher {
+    CustomElementMatcher::from_static_predicate(is_ion_custom_element)
+}
+
+fn is_ion_custom_element(tag: &str) -> bool {
+    tag.starts_with("ion-")
 }
 
 fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {

--- a/crates/vize_atelier_dom/tests/davinci_s2_source_map.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_source_map.rs
@@ -255,7 +255,11 @@ fn compiled(result: CodegenResultWithSections) -> Compiled {
 }
 
 fn non_matching_custom_elements() -> CustomElementMatcher {
-    CustomElementMatcher::from_patterns(vec!["x-never-*".into()])
+    CustomElementMatcher::from_static_predicate(is_never_custom_element)
+}
+
+fn is_never_custom_element(_tag: &str) -> bool {
+    false
 }
 
 fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {

--- a/crates/vize_relief/src/options/custom_elements.rs
+++ b/crates/vize_relief/src/options/custom_elements.rs
@@ -39,6 +39,12 @@ impl CustomElementMatcher {
         &self.patterns
     }
 
+    /// Whether the matcher includes an opaque static predicate.
+    #[must_use]
+    pub fn has_static_predicate(&self) -> bool {
+        self.predicate.is_some()
+    }
+
     /// Whether no pattern or predicate can match.
     #[must_use]
     pub fn is_empty(&self) -> bool {

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -131,6 +131,7 @@ pub use self::entry::{
     emit_dom_source_with_options,
 };
 pub use self::error::{EmitError, UnsupportedReason, UnsupportedRefusal};
+pub(crate) use self::options::tag_pattern_matches;
 pub use self::options::{BindingKind, BindingTable, DomEmitMode, DomEmitOptions};
 use self::run::emit_dom_with_emit_budget;
 pub use self::run::{emit_dom, emit_dom_with_options};

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -57,6 +57,7 @@ mod component;
 mod constant_expr;
 mod create_slots;
 mod create_slots_walk;
+mod custom_element;
 mod cx;
 mod directive;
 mod dispatch;
@@ -125,13 +126,13 @@ pub use self::budget::{
     emit_dom_source_observed_with_options, emit_dom_source_with_caps_observed,
 };
 use self::buf::Buf;
+pub(crate) use self::custom_element::tag_pattern_matches;
 use self::dispatch::{emit_for_item_call, emit_for_op, emit_if_branch_call, emit_if_op};
 pub use self::entry::{
     DomEmit, DomEmitSections, emit_dom_source, emit_dom_source_with_caps,
     emit_dom_source_with_options,
 };
 pub use self::error::{EmitError, UnsupportedReason, UnsupportedRefusal};
-pub(crate) use self::options::tag_pattern_matches;
 pub use self::options::{BindingKind, BindingTable, DomEmitMode, DomEmitOptions};
 use self::run::emit_dom_with_emit_budget;
 pub use self::run::{emit_dom, emit_dom_with_options};

--- a/crates/vize_s1_to_s2/src/emit/budget.rs
+++ b/crates/vize_s1_to_s2/src/emit/budget.rs
@@ -87,8 +87,14 @@ pub(super) fn emit_dom_source_with_options_and_observer<'a, O: PassObserver>(
                 experimental_in_tag_comments: options.experimental_in_tag_comments,
             },
         );
-        let mut lowered =
-            lower_with_caps_and_comment_policy(allocator, &tree, &errors, caps, options.comments);
+        let mut lowered = lower_with_caps_and_comment_policy(
+            allocator,
+            &tree,
+            &errors,
+            caps,
+            options.comments,
+            options.custom_element_patterns,
+        );
         let facts = run_transform(&mut lowered, observer);
         let (emit, emit_visits) = emit_dom_with_emit_budget(&lowered, &facts, options)?;
         Ok((emit, emit_visits))

--- a/crates/vize_s1_to_s2/src/emit/custom_element.rs
+++ b/crates/vize_s1_to_s2/src/emit/custom_element.rs
@@ -1,0 +1,48 @@
+pub(crate) fn tag_pattern_matches(pattern: &str, tag: &str) -> bool {
+    if pattern.is_empty() {
+        return false;
+    }
+    if pattern.bytes().all(|byte| byte == b'*') {
+        return true;
+    }
+    if !pattern.contains('*') {
+        return pattern == tag;
+    }
+
+    let starts_with_wildcard = pattern.starts_with('*');
+    let ends_with_wildcard = pattern.ends_with('*');
+    let mut position = 0;
+    let mut matched_any = false;
+
+    for (index, part) in pattern
+        .split('*')
+        .filter(|part| !part.is_empty())
+        .enumerate()
+    {
+        matched_any = true;
+        if index == 0 && !starts_with_wildcard {
+            if !tag[position..].starts_with(part) {
+                return false;
+            }
+            position += part.len();
+            continue;
+        }
+
+        let Some(found) = tag[position..].find(part) else {
+            return false;
+        };
+        position += found + part.len();
+    }
+
+    if !matched_any {
+        return false;
+    }
+
+    if !ends_with_wildcard
+        && let Some(last_part) = pattern.rsplit('*').find(|part| !part.is_empty())
+    {
+        return tag.ends_with(last_part);
+    }
+
+    true
+}

--- a/crates/vize_s1_to_s2/src/emit/options.rs
+++ b/crates/vize_s1_to_s2/src/emit/options.rs
@@ -229,6 +229,9 @@ pub struct DomEmitOptions<'a> {
     pub comments: bool,
     /// Preserve Vue's experimental `//` comments inside opening tag attrs.
     pub experimental_in_tag_comments: bool,
+    /// Declarative tag patterns that the shipped lane treats as custom
+    /// elements instead of components.
+    pub custom_element_patterns: &'a [String],
     /// The shipped lane's `binding_metadata`, honoured in non-inline mode:
     /// prefixed identifiers resolve to the same proxy members and signatures.
     pub bindings: Option<&'a BindingTable>,
@@ -250,8 +253,58 @@ impl DomEmitOptions<'static> {
         is_ts: false,
         comments: false,
         experimental_in_tag_comments: false,
+        custom_element_patterns: &[],
         bindings: None,
     };
+}
+
+pub(crate) fn tag_pattern_matches(pattern: &str, tag: &str) -> bool {
+    if pattern.is_empty() {
+        return false;
+    }
+    if pattern.bytes().all(|byte| byte == b'*') {
+        return true;
+    }
+    if !pattern.contains('*') {
+        return pattern == tag;
+    }
+
+    let starts_with_wildcard = pattern.starts_with('*');
+    let ends_with_wildcard = pattern.ends_with('*');
+    let mut position = 0;
+    let mut matched_any = false;
+
+    for (index, part) in pattern
+        .split('*')
+        .filter(|part| !part.is_empty())
+        .enumerate()
+    {
+        matched_any = true;
+        if index == 0 && !starts_with_wildcard {
+            if !tag[position..].starts_with(part) {
+                return false;
+            }
+            position += part.len();
+            continue;
+        }
+
+        let Some(found) = tag[position..].find(part) else {
+            return false;
+        };
+        position += found + part.len();
+    }
+
+    if !matched_any {
+        return false;
+    }
+
+    if !ends_with_wildcard
+        && let Some(last_part) = pattern.rsplit('*').find(|part| !part.is_empty())
+    {
+        return tag.ends_with(last_part);
+    }
+
+    true
 }
 
 impl Default for DomEmitOptions<'static> {
@@ -281,6 +334,7 @@ mod tests {
                 is_ts: false,
                 comments: false,
                 experimental_in_tag_comments: false,
+                custom_element_patterns: &[],
                 bindings: None,
             }
         );

--- a/crates/vize_s1_to_s2/src/emit/options.rs
+++ b/crates/vize_s1_to_s2/src/emit/options.rs
@@ -7,7 +7,6 @@
 //! emitter silently assumes — it is production surface the series has
 
 use alloc::vec::Vec as StdVec;
-
 use vize_s0::String;
 
 /// Which module form the render function is emitted in — the shipped
@@ -258,55 +257,6 @@ impl DomEmitOptions<'static> {
     };
 }
 
-pub(crate) fn tag_pattern_matches(pattern: &str, tag: &str) -> bool {
-    if pattern.is_empty() {
-        return false;
-    }
-    if pattern.bytes().all(|byte| byte == b'*') {
-        return true;
-    }
-    if !pattern.contains('*') {
-        return pattern == tag;
-    }
-
-    let starts_with_wildcard = pattern.starts_with('*');
-    let ends_with_wildcard = pattern.ends_with('*');
-    let mut position = 0;
-    let mut matched_any = false;
-
-    for (index, part) in pattern
-        .split('*')
-        .filter(|part| !part.is_empty())
-        .enumerate()
-    {
-        matched_any = true;
-        if index == 0 && !starts_with_wildcard {
-            if !tag[position..].starts_with(part) {
-                return false;
-            }
-            position += part.len();
-            continue;
-        }
-
-        let Some(found) = tag[position..].find(part) else {
-            return false;
-        };
-        position += found + part.len();
-    }
-
-    if !matched_any {
-        return false;
-    }
-
-    if !ends_with_wildcard
-        && let Some(last_part) = pattern.rsplit('*').find(|part| !part.is_empty())
-    {
-        return tag.ends_with(last_part);
-    }
-
-    true
-}
-
 impl Default for DomEmitOptions<'static> {
     fn default() -> Self {
         Self::DEFAULT
@@ -370,10 +320,6 @@ mod tests {
         assert_eq!(table.kind("msg"), Some(BindingKind::SetupLet));
         assert_eq!(table.kind("Comp"), Some(BindingKind::SetupConst));
         assert_eq!(table.kind("other"), None);
-        // `contains` is the membership half of the same lookup; both
-        // answers are pinned, and the call stays out of the assertion so
-        // the Davinci assertion lint's partial-match scan reads it as the
-        // exact query it is.
         let named = (table.contains("Comp"), table.contains("other"));
         assert_eq!(named, (true, false));
         assert_eq!(

--- a/crates/vize_s1_to_s2/src/lower.rs
+++ b/crates/vize_s1_to_s2/src/lower.rs
@@ -148,6 +148,7 @@ pub(crate) fn lower_with_caps_and_comment_policy<'a>(
     errors: &[SurfaceError],
     caps: LegacyCaps,
     preserve_comments: bool,
+    custom_element_patterns: &[String],
 ) -> Lowered<'a> {
     let root = SourceRoot::new(tree.source).expect("vize_s1 accepted a u32-addressable source");
     lower_source_block_with_caps_and_comment_policy(
@@ -157,6 +158,7 @@ pub(crate) fn lower_with_caps_and_comment_policy<'a>(
         root.whole_block(),
         caps,
         preserve_comments,
+        custom_element_patterns,
     )
 }
 
@@ -180,7 +182,15 @@ pub fn lower_source_block_with_caps<'a>(
     block: SourceBlock<'a>,
     caps: LegacyCaps,
 ) -> Lowered<'a> {
-    lower_source_block_with_caps_and_comment_policy(allocator, tree, errors, block, caps, false)
+    lower_source_block_with_caps_and_comment_policy(
+        allocator,
+        tree,
+        errors,
+        block,
+        caps,
+        false,
+        &[],
+    )
 }
 
 fn lower_source_block_with_caps_and_comment_policy<'a>(
@@ -190,14 +200,20 @@ fn lower_source_block_with_caps_and_comment_policy<'a>(
     block: SourceBlock<'a>,
     caps: LegacyCaps,
     preserve_comments: bool,
+    custom_element_patterns: &[String],
 ) -> Lowered<'a> {
     debug_assert!(
         tree.source.as_ptr() == block.source().as_ptr()
             && tree.source.len() == block.source().len(),
         "the source block must be the exact string parsed into the S1 tree"
     );
-    let mut cx =
-        cx::Cx::with_source_block_and_comment_policy(allocator, block, caps, preserve_comments);
+    let mut cx = cx::Cx::with_source_block_and_comment_policy(
+        allocator,
+        block,
+        caps,
+        preserve_comments,
+        custom_element_patterns,
+    );
     for error in errors {
         cx.diagnostics.push(Diagnostic::new(
             Severity::Error,

--- a/crates/vize_s1_to_s2/src/lower/cx.rs
+++ b/crates/vize_s1_to_s2/src/lower/cx.rs
@@ -52,6 +52,7 @@ pub(crate) struct Cx<'a> {
     pub wrappers: SideTable<super::structural::WrapperKeys>,
     pub for_wrappers: SideTable<super::structural::ForWrapper>,
     pub caps: super::caps::LegacyCaps,
+    custom_element_patterns: Vec<String>,
 }
 
 impl<'a> Cx<'a> {
@@ -60,6 +61,7 @@ impl<'a> Cx<'a> {
         block: SourceBlock<'a>,
         caps: super::caps::LegacyCaps,
         preserve_comments: bool,
+        custom_element_patterns: &[String],
     ) -> Self {
         Self {
             allocator,
@@ -78,7 +80,16 @@ impl<'a> Cx<'a> {
             wrappers: SideTable::new(),
             for_wrappers: SideTable::new(),
             caps,
+            custom_element_patterns: custom_element_patterns.to_vec(),
         }
+    }
+
+    /// Whether a non-native tag should lower as a platform custom element
+    /// instead of a Vue component.
+    pub(crate) fn is_custom_element(&self, tag: &str) -> bool {
+        self.custom_element_patterns
+            .iter()
+            .any(|pattern| crate::emit::tag_pattern_matches(pattern.as_str(), tag))
     }
 
     /// Whether the walk is inside a condense-suppressing subtree.

--- a/crates/vize_s1_to_s2/src/lower/cx.rs
+++ b/crates/vize_s1_to_s2/src/lower/cx.rs
@@ -16,7 +16,6 @@
 //! contract): past `u32::MAX - 1` ops the context reports once and stops
 //! minting; side tables simply stop gaining keys while the op tree stays
 //! total.
-//!
 //! [`S2Folio`]: vize_s2::folio::S2Folio
 
 use alloc::vec::Vec;
@@ -28,6 +27,8 @@ use vize_s0::{Allocator, SourceBlock, Span, String};
 use vize_s1::{CloseTag, Element, ElementClose, SurfaceChild, Token};
 use vize_s2::provenance::ProvenanceRecord;
 use vize_s2::scope::{ScopeFacts, ScopeTag};
+
+mod custom_element;
 
 pub(crate) struct Cx<'a> {
     pub allocator: &'a Allocator,
@@ -82,14 +83,6 @@ impl<'a> Cx<'a> {
             caps,
             custom_element_patterns: custom_element_patterns.to_vec(),
         }
-    }
-
-    /// Whether a non-native tag should lower as a platform custom element
-    /// instead of a Vue component.
-    pub(crate) fn is_custom_element(&self, tag: &str) -> bool {
-        self.custom_element_patterns
-            .iter()
-            .any(|pattern| crate::emit::tag_pattern_matches(pattern.as_str(), tag))
     }
 
     /// Whether the walk is inside a condense-suppressing subtree.

--- a/crates/vize_s1_to_s2/src/lower/cx/custom_element.rs
+++ b/crates/vize_s1_to_s2/src/lower/cx/custom_element.rs
@@ -1,0 +1,9 @@
+use super::Cx;
+
+impl Cx<'_> {
+    pub(crate) fn is_custom_element(&self, tag: &str) -> bool {
+        self.custom_element_patterns
+            .iter()
+            .any(|pattern| crate::emit::tag_pattern_matches(pattern.as_str(), tag))
+    }
+}

--- a/crates/vize_s1_to_s2/src/lower/element.rs
+++ b/crates/vize_s1_to_s2/src/lower/element.rs
@@ -143,7 +143,7 @@ pub(crate) fn element_core<'a>(
     let child_ns = children_ns(own_ns, tag);
     let span = element_span(cx, element);
     let node = cx.mint_op();
-    let component = !is_native_tag(tag);
+    let component = !is_native_tag(tag) && !cx.is_custom_element(tag);
 
     let open_end = cx.token_span(&element.open.gt).end;
     let open_slice = cx

--- a/crates/vize_s1_to_s2/tests/emit_comp/basic_and_control_flow.rs
+++ b/crates/vize_s1_to_s2/tests/emit_comp/basic_and_control_flow.rs
@@ -80,15 +80,14 @@ fn a_matching_custom_element_pattern_emits_an_element_not_a_component() {
         &options,
     )
     .expect("emit");
-    let assembled = emit.assembled();
+    assert_eq!(
+        emit.assembled().as_str(),
+        "\
+const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
 
-    assert!(
-        assembled.contains("_createElementBlock(\"ion-button\""),
-        "{assembled}"
-    );
-    assert!(
-        !assembled.contains("_resolveComponent(\"ion-button\")"),
-        "{assembled}"
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock(\"ion-button\", { onClick: go }, _toDisplayString(label), 9 /* TEXT, PROPS */, [\"onClick\"]))
+}"
     );
 }
 

--- a/crates/vize_s1_to_s2/tests/emit_comp/basic_and_control_flow.rs
+++ b/crates/vize_s1_to_s2/tests/emit_comp/basic_and_control_flow.rs
@@ -1,4 +1,5 @@
 use super::*;
+use vize_s1_to_s2::{DomEmitOptions, LegacyCaps, emit_dom_source_with_options};
 
 #[test]
 fn a_root_component_matches_the_shipped_snapshot() {
@@ -61,6 +62,33 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 
   return (_openBlock(), _createBlock(_component_foo_bar))
 }")
+    );
+}
+
+#[test]
+fn a_matching_custom_element_pattern_emits_an_element_not_a_component() {
+    let allocator = Allocator::new();
+    let patterns = [vize_s0::String::from("ion-*")];
+    let options = DomEmitOptions {
+        custom_element_patterns: &patterns,
+        ..DomEmitOptions::DEFAULT
+    };
+    let emit = emit_dom_source_with_options(
+        &allocator,
+        r#"<ion-button @click="go">{{ label }}</ion-button>"#,
+        LegacyCaps::VUE3,
+        &options,
+    )
+    .expect("emit");
+    let assembled = emit.assembled();
+
+    assert!(
+        assembled.contains("_createElementBlock(\"ion-button\""),
+        "{assembled}"
+    );
+    assert!(
+        !assembled.contains("_resolveComponent(\"ion-button\")"),
+        "{assembled}"
     );
 }
 

--- a/davinci-road/plan/storage-boundary.md
+++ b/davinci-road/plan/storage-boundary.md
@@ -22,7 +22,7 @@ or `collections` modules does not bypass the boundary.
 ## Retained `alloc::vec::Vec` inventory
 
 The four library trees in the reviewed inventory contain 78 production files,
-90 direct `alloc::vec::Vec` paths, and 311 bound `Vec`/`StdVec` uses. "Direct"
+90 direct `alloc::vec::Vec` paths, and 312 bound `Vec`/`StdVec` uses. "Direct"
 counts imports and fully-qualified paths; "bound" counts every type,
 constructor, and method path reached through a direct `Vec` import or alias.
 The executable ledger requires strict equality, so both growth and reduction
@@ -32,7 +32,7 @@ must update the file row and aggregate evidence in the same change.
 | -------- | ----: | -----------: | ---------: | ------------------------------------------------------------------------------------------------------------------ |
 | contract |    13 |           24 |         65 | Owned Folio and S2 serialization data has input-defined cardinality and forms a stable contract.                   |
 | analysis |     7 |            8 |         18 | Diagnostics, side tables, filters, and verifier results grow with the input; no inline bound is established.       |
-| lower    |    12 |           12 |         46 | Lowering worklists and owned results grow with source-tree shape. Bounded substructures may migrate independently. |
+| lower    |    12 |           12 |         47 | Lowering worklists and owned results grow with source-tree shape. Bounded substructures may migrate independently. |
 | pass     |    14 |           14 |         55 | Facts, provenance, and traversal worklists grow with the number of operations.                                     |
 | emit     |    32 |           32 |        127 | Ordered output buffers and collected emission inputs grow with the document.                                       |
 
@@ -71,9 +71,9 @@ or count and fails the gate instead of becoming a `no_std` escape from S0.
 | s2       | `vize_s0::String`       |    11 |           11 |         55 |
 | s2       | `vize_s0::Vec`          |     9 |            9 |         17 |
 | s2       | `vize_s0::SmallVec`     |     0 |            0 |          0 |
-| s1_to_s2 | `alloc::vec::Vec`       |    58 |           58 |        228 |
+| s1_to_s2 | `alloc::vec::Vec`       |    58 |           58 |        229 |
 | s1_to_s2 | `alloc::string::String` |     0 |            0 |          0 |
-| s1_to_s2 | `vize_s0::String`       |    84 |           88 |        423 |
+| s1_to_s2 | `vize_s0::String`       |    84 |           88 |        428 |
 | s1_to_s2 | `vize_s0::Vec`          |    15 |           16 |         69 |
 | s1_to_s2 | `vize_s0::SmallVec`     |     4 |            4 |          9 |
 

--- a/davinci-road/plan/storage-inventory.tsv
+++ b/davinci-road/plan/storage-inventory.tsv
@@ -69,7 +69,7 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/model.rs	1	6	1	9	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/model_key.rs	0	0	1	8	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/on.rs	0	0	1	5	0	0	1	3
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/on_dynamic.rs	1	5	0	0	0	0	0	0
-s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/options.rs	1	4	1	7	0	0	0	0
+s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/options.rs	1	4	1	8	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/prefix.rs	0	0	1	11	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/prefix/aliases.rs	0	0	1	8	0	0	0	0
 s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/prefix/codegen_visitor.rs	1	9	1	11	0	0	0	0
@@ -100,12 +100,12 @@ s1_to_s2	emit	crates/vize_s1_to_s2/src/emit/slots/group.rs	1	3	0	0	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/tpl.rs	0	0	1	3	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/vfor/keys.rs	0	0	1	5	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/emit/vif.rs	0	0	1	2	0	0	0	0
-s1_to_s2	lower	crates/vize_s1_to_s2/src/lower.rs	1	2	1	1	0	0	0	0
+s1_to_s2	lower	crates/vize_s1_to_s2/src/lower.rs	1	2	1	3	0	0	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/binding.rs	1	1	1	9	1	7	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/bindop.rs	0	0	1	2	1	6	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/cloak.rs	0	0	1	1	0	0	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/css.rs	0	0	0	0	1	3	0	0
-s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/cx.rs	1	4	1	7	0	0	0	0
+s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/cx.rs	1	5	1	9	0	0	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/directive.rs	1	6	0	0	0	0	0	0
 s1_to_s2	lower	crates/vize_s1_to_s2/src/lower/element.rs	1	2	0	0	1	4	0	0
 s1_to_s2	-	crates/vize_s1_to_s2/src/lower/expr.rs	0	0	1	4	0	0	0	0

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -46,6 +46,7 @@ const s2EmitOptionFields = [
   "is_ts",
   "comments",
   "experimental_in_tag_comments",
+  "custom_element_patterns",
   "bindings",
 ];
 

--- a/tests/tooling/davinci-storage-inventory.ts
+++ b/tests/tooling/davinci-storage-inventory.ts
@@ -44,7 +44,7 @@ export const categoryReasons: Record<VecCategory, string> = {
 export const expectedProductionAllocVec: StorageSummary = {
   files: 78,
   directPaths: 90,
-  boundUses: 311,
+  boundUses: 312,
 };
 
 function count(value: string, line: number): number {


### PR DESCRIPTION
## Summary
- project declarative custom-element patterns into S2 DOM emit options
- lower matching non-native tags as elements on S2 while predicate matchers stay on the legacy lane
- update P2-11 selector, source-map, and option-boundary witnesses

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_custom_element_selector
- cargo test -p vize_s1_to_s2 --test emit_comp
- cargo test -p vize_atelier_dom --test davinci_s2_source_map
- cargo test -p vize_atelier_dom --test davinci_s2_production_selector
- node --test tests/tooling/davinci-dom-production-boundary.test.ts
- cargo fmt --check
- git diff --check HEAD~1..HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791268874&installation_model_id=422833&pr_number=5806&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5806&signature=656280dfaca9345bb58500ceb73f4fd134e42b2eca84f3d74ad0008c1c655f2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->