### PR TITLE
docs(davinci): align phase ledger anchors

### DIFF
--- a/davinci-road/plan/phase-2-records.md
+++ b/davinci-road/plan/phase-2-records.md
@@ -12,7 +12,7 @@
 > not exempt from. A record grows with its task, and 22 of them cannot share a
 > page.
 
-## Current completion evidence (2026-09-05)
+## Current completion evidence (2026-09-06)
 
 This table is the current ledger. The task files below remain historical
 records of what was measured at landing time; current task counts, suite range

--- a/davinci-road/plan/phase-2.md
+++ b/davinci-road/plan/phase-2.md
@@ -73,7 +73,7 @@ Each ID links to its contract in [phase-2-tasks.md](./phase-2-tasks.md); what a 
 - [x] [P2-19](./phase-2-tasks-later.md#p2-19--devtool-protocol-spike) DevTool protocol spike — landed 2026-08-21; decided **document over JSON-RPC**: the P2-18 feed document stays the unit on every surface — C-7's local server speaks content-mapper-style JSON-RPC whose `initialize` negotiates the feed `schema_version` before any payload is serialized (the only candidate that negotiates rather than refusing after the producer wrote everything), served files stay the at-rest form, the wasm playground keeps the P2-18 embedding, JSON-lines rejected (every named consumer reassembles the document anyway); spike deleted deliberately, measurements and reproduction recipe in the record ([record](./phase-2-records/p2-19.md))
 - [ ] [P2-20](./phase-2-tasks-later.md#p2-20--phase-exit) Phase exit
 
-## Current execution ledger (2026-09-05)
+## Current execution ledger (2026-09-06)
 
 This is the current snapshot. The phase re-cut above and the per-installment
 records are historical evidence and are not silently rewritten when current
@@ -82,7 +82,7 @@ counts or fixture availability changes.
 - **Complete: 17 of 22 — P2-1, P2-2, P2-3, P2-4, P2-5a, P2-5b, P2-6,
   P2-7, P2-8, P2-9, P2-10, P2-12a, P2-13, P2-14, P2-15, P2-18 and P2-19.**
   Each completion is joined to its merged PR and current evidence in the
-  [evidence index](./phase-2-records.md#current-completion-evidence-2026-09-05);
+  [evidence index](./phase-2-records.md#current-completion-evidence-2026-09-06);
   review-only evidence is labeled there rather than presented as executable.
 - **Active and blocked: 1 of 22 — P2-11.** P2-11 has 115 landed installments
   through

--- a/davinci-road/roadmap.md
+++ b/davinci-road/roadmap.md
@@ -113,7 +113,7 @@ holds or improves — this phase should be a measurable win, not a wash.
   timing, remark emission) land with the pass manager itself, so the DevTool's
   data feed exists from the first S2 build.
 
-**Current execution ledger (2026-09-06):** [17 of 22 tasks are complete](./plan/phase-2.md#current-execution-ledger-2026-09-05).
+**Current execution ledger (2026-09-06):** [17 of 22 tasks are complete](./plan/phase-2.md#current-execution-ledger-2026-09-06).
 P2-9 is now complete: the hydrated corpus run compiled 41,580 files at zero
 divergence and measured the retained-`None` residual at 11.73%. P2-11 remains
 the active blocked series; P2-12b, P2-16, P2-17 and P2-20 remain open because


### PR DESCRIPTION
## Summary
- align the Phase 2 ledger and current evidence date anchors with the 2026-09-06 installment
- update the roadmap link to the refreshed ledger anchor

## Validation
- node --test tests/tooling/davinci-phase2-ledger.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791270562&installation_model_id=422833&pr_number=5807&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5807&signature=3d3af87222c6b9397d011a78e92d0d0e63086bb1fb757d9cf6bbe5e9496de9fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->