### PR TITLE
fix(patina): align no-unused-components registration parity

### DIFF
--- a/crates/vize_patina/src/linter/tests/no_unused_components.rs
+++ b/crates/vize_patina/src/linter/tests/no_unused_components.rs
@@ -316,5 +316,5 @@ export default defineComponent({
 
     assert_eq!(result.warning_count, 1);
     assert_eq!(result.diagnostics[0].rule_name, "vue/no-unused-components");
-    assert!(result.diagnostics[0].message.contains("Style"));
+    assert!(result.diagnostics[0].message.contains("FourStyle"));
 }

--- a/crates/vize_patina/src/rules/vue/no_unused_components.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_components.rs
@@ -29,23 +29,20 @@
 #![allow(clippy::disallowed_macros)]
 
 mod dynamic_is;
+mod script_setup_refs;
 #[cfg(test)]
 mod tests;
 
 use self::dynamic_is::has_dynamic_is_binding;
+use self::script_setup_refs::script_setup_component_import_references;
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use oxc_allocator::Allocator;
-use oxc_ast::ast::{IdentifierReference, ImportDeclaration, ImportDeclarationSpecifier, TSType};
-use oxc_ast_visit::{Visit, walk::walk_ts_type};
-use oxc_parser::Parser;
-use oxc_span::SourceType;
 use vize_croquis::naming::{is_pascal_case, to_pascal_case};
-use vize_croquis::{Croquis, ScopeData};
+use vize_croquis::{Croquis, Scope, ScopeData, ScopeKind};
 use vize_relief::BindingType;
 use vize_relief::RootNode;
-use vize_s0::{CompactString, FxHashSet, String, ToCompactString};
+use vize_s0::{CompactString, String, ToCompactString};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-unused-components",
@@ -60,6 +57,13 @@ static META: RuleMeta = RuleMeta {
 pub struct NoUnusedComponents {
     /// Pattern for components to ignore (e.g., starts with '_')
     pub ignore_pattern: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ComponentCandidate {
+    name: CompactString,
+    local_name: CompactString,
+    is_script_setup_import: bool,
 }
 
 impl NoUnusedComponents {
@@ -91,46 +95,51 @@ impl NoUnusedComponents {
         matches!(binding_type, BindingType::SetupConst)
     }
 
-    fn imported_component_names(analysis: &Croquis) -> Vec<&str> {
-        let mut names: Vec<_> = analysis
+    fn component_candidates(analysis: &Croquis) -> Vec<ComponentCandidate> {
+        let mut candidates = Vec::new();
+
+        for scope in analysis
             .scopes
             .iter()
-            .filter(|scope| {
-                matches!(
-                    scope.data(),
-                    ScopeData::ExternalModule(data)
-                        if !data.is_type_only
-                            && Self::is_component_import_source(data.source.as_str())
-                )
-            })
-            .flat_map(|scope| {
-                scope.bindings().filter_map(|(name, binding)| {
-                    if Self::is_component_binding(binding.binding_type) && is_pascal_case(name) {
-                        Some(name)
-                    } else {
-                        None
-                    }
-                })
-            })
-            .collect();
+            .filter(|scope| Self::is_script_setup_component_import(analysis, scope))
+        {
+            for (name, binding) in scope.bindings() {
+                if Self::is_component_binding(binding.binding_type) && is_pascal_case(name) {
+                    push_component_candidate(&mut candidates, name, name, true);
+                }
+            }
+        }
 
-        names.sort_unstable();
-        names.dedup();
-        names
+        for registration in &analysis.component_registrations {
+            push_component_candidate(
+                &mut candidates,
+                registration.name.as_str(),
+                registration.local_name.as_str(),
+                false,
+            );
+        }
+
+        candidates.sort_unstable_by(|left, right| left.name.as_str().cmp(right.name.as_str()));
+        candidates
+    }
+
+    fn is_script_setup_component_import(analysis: &Croquis, scope: &Scope) -> bool {
+        let ScopeData::ExternalModule(data) = scope.data() else {
+            return false;
+        };
+        if data.is_type_only || !Self::is_component_import_source(data.source.as_str()) {
+            return false;
+        }
+        scope
+            .parent()
+            .and_then(|id| analysis.scopes.get_scope(id))
+            .is_some_and(|parent| parent.kind == ScopeKind::ScriptSetup)
     }
 
     fn component_name_matches(used: &str, registered: &str) -> bool {
         used == registered
             || vize_croquis::naming::names_match(used, registered)
             || to_pascal_case(used).as_str() == registered
-    }
-
-    fn matches_registered_alias(analysis: &Croquis, used: &str, local_name: &str) -> bool {
-        analysis
-            .component_registrations
-            .iter()
-            .filter(|registration| registration.local_name == local_name)
-            .any(|registration| Self::component_name_matches(used, registration.name.as_str()))
     }
 }
 
@@ -149,12 +158,15 @@ impl Rule for NoUnusedComponents {
         }
 
         // Collect template-unused components first (to avoid borrow conflicts)
-        let (template_unused_components, import_statement_ranges): (Vec<String>, Vec<(u32, u32)>) = {
+        let (template_unused_components, import_statement_ranges): (
+            Vec<ComponentCandidate>,
+            Vec<(u32, u32)>,
+        ) = {
             let Some(analysis) = ctx.analysis() else {
                 return;
             };
 
-            let registered_components = Self::imported_component_names(analysis);
+            let registered_components = Self::component_candidates(analysis);
 
             let import_statement_ranges = analysis
                 .import_statements
@@ -164,35 +176,44 @@ impl Rule for NoUnusedComponents {
 
             let template_unused_components = registered_components
                 .into_iter()
-                .filter(|name| {
+                .filter(|component| {
+                    let name = component.name.as_str();
                     if self.should_ignore(name) {
                         return false;
                     }
 
                     // Check if used in template (case-insensitive matching for kebab-case)
-                    !analysis.used_components.iter().any(|used| {
-                        Self::component_name_matches(used.as_str(), name)
-                            || Self::matches_registered_alias(analysis, used.as_str(), name)
-                    })
+                    !analysis
+                        .used_components
+                        .iter()
+                        .any(|used| Self::component_name_matches(used.as_str(), name))
                 })
-                .map(|name| name.to_compact_string())
                 .collect();
 
             (template_unused_components, import_statement_ranges)
         };
 
+        let script_setup_candidate_names: Vec<_> = template_unused_components
+            .iter()
+            .filter(|component| component.is_script_setup_import)
+            .map(|component| component.local_name.clone())
+            .collect();
         let script_used_components = script_setup_component_import_references(
             ctx,
-            &template_unused_components,
+            &script_setup_candidate_names,
             &import_statement_ranges,
         );
-        let unused_components: Vec<String> = template_unused_components
+        let unused_components: Vec<_> = template_unused_components
             .into_iter()
-            .filter(|name| !script_used_components.contains(name.as_str()))
+            .filter(|component| {
+                !component.is_script_setup_import
+                    || !script_used_components.contains(component.local_name.as_str())
+            })
             .collect();
 
         // Report unused components
-        for name in unused_components {
+        for component in unused_components {
+            let name = component.name.as_str();
             ctx.report(
                 crate::diagnostic::LintDiagnostic::warn(
                     ctx.current_rule,
@@ -209,144 +230,21 @@ impl Rule for NoUnusedComponents {
     }
 }
 
-fn script_setup_component_import_references(
-    ctx: &LintContext<'_>,
-    candidate_names: &[String],
-    import_statement_ranges: &[(u32, u32)],
-) -> FxHashSet<CompactString> {
-    if candidate_names.is_empty() {
-        return FxHashSet::default();
-    }
-
-    let Some(script_setup) = ctx
-        .sfc_descriptor()
-        .and_then(|descriptor| descriptor.script_setup.as_ref())
-    else {
-        return FxHashSet::default();
-    };
-
-    let source = script_setup.content.as_ref();
-    if !candidate_names.iter().any(|name| {
-        has_non_import_identifier_reference(source, name.as_str(), import_statement_ranges)
-    }) {
-        return FxHashSet::default();
-    }
-
-    let allocator = Allocator::default();
-    let source_type = SourceType::from_path("component.ts").unwrap_or_else(|_| SourceType::ts());
-    let parsed = Parser::new(&allocator, source, source_type).parse();
-    if parsed.panicked || !parsed.diagnostics.is_empty() {
-        return FxHashSet::default();
-    }
-
-    let mut visitor = ScriptSetupComponentImportVisitor {
-        component_imports: FxHashSet::default(),
-        referenced_imports: FxHashSet::default(),
-        scopes: Vec::new(),
-        type_depth: 0,
-    };
-    visitor.visit_program(&parsed.program);
-    visitor.referenced_imports
-}
-
-fn has_non_import_identifier_reference(
-    source: &str,
+fn push_component_candidate(
+    candidates: &mut Vec<ComponentCandidate>,
     name: &str,
-    import_statement_ranges: &[(u32, u32)],
-) -> bool {
-    source.match_indices(name).any(|(index, _)| {
-        let start = index as u32;
-        let end = (index + name.len()) as u32;
-        !import_statement_ranges
-            .iter()
-            .any(|(import_start, import_end)| start >= *import_start && end <= *import_end)
-            && is_identifier_boundary(source.as_bytes().get(index.wrapping_sub(1)).copied())
-            && is_identifier_boundary(source.as_bytes().get(index + name.len()).copied())
-    })
-}
-
-fn is_identifier_boundary(byte: Option<u8>) -> bool {
-    !byte.is_some_and(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$')
-}
-
-struct ScriptSetupComponentImportVisitor {
-    component_imports: FxHashSet<CompactString>,
-    referenced_imports: FxHashSet<CompactString>,
-    scopes: Vec<FxHashSet<CompactString>>,
-    type_depth: usize,
-}
-
-impl<'a> Visit<'a> for ScriptSetupComponentImportVisitor {
-    fn enter_scope(
-        &mut self,
-        _flags: oxc_syntax::scope::ScopeFlags,
-        _scope_id: &std::cell::Cell<Option<oxc_syntax::scope::ScopeId>>,
-    ) {
-        self.scopes.push(FxHashSet::default());
+    local_name: &str,
+    is_script_setup_import: bool,
+) {
+    if candidates
+        .iter()
+        .any(|candidate| candidate.name.as_str() == name)
+    {
+        return;
     }
-
-    fn leave_scope(&mut self) {
-        self.scopes.pop();
-    }
-
-    fn visit_import_declaration(&mut self, it: &ImportDeclaration<'a>) {
-        if it.import_kind.is_type()
-            || !NoUnusedComponents::is_component_import_source(it.source.value.as_str())
-        {
-            return;
-        }
-
-        let Some(specifiers) = &it.specifiers else {
-            return;
-        };
-
-        for specifier in specifiers {
-            match specifier {
-                ImportDeclarationSpecifier::ImportSpecifier(specifier)
-                    if !specifier.import_kind.is_type() =>
-                {
-                    self.component_imports
-                        .insert(CompactString::new(specifier.local.name.as_str()));
-                }
-                ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => {
-                    self.component_imports
-                        .insert(CompactString::new(specifier.local.name.as_str()));
-                }
-                ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => {
-                    self.component_imports
-                        .insert(CompactString::new(specifier.local.name.as_str()));
-                }
-                _ => {}
-            }
-        }
-    }
-
-    fn visit_binding_identifier(&mut self, it: &oxc_ast::ast::BindingIdentifier<'a>) {
-        if let Some(scope) = self.scopes.last_mut() {
-            scope.insert(CompactString::new(it.name.as_str()));
-        }
-    }
-
-    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
-        if self.type_depth > 0 {
-            return;
-        }
-
-        let name = it.name.as_str();
-        if self.component_imports.contains(name) && !self.is_shadowed(name) {
-            self.referenced_imports.insert(CompactString::new(name));
-        }
-    }
-
-    fn visit_ts_type(&mut self, it: &TSType<'a>) {
-        self.type_depth += 1;
-        walk_ts_type(self, it);
-        self.type_depth -= 1;
-    }
-}
-
-impl ScriptSetupComponentImportVisitor {
-    fn is_shadowed(&self, name: &str) -> bool {
-        self.scopes.iter().rev().any(|scope| scope.contains(name))
-    }
+    candidates.push(ComponentCandidate {
+        name: name.to_compact_string(),
+        local_name: local_name.to_compact_string(),
+        is_script_setup_import,
+    });
 }

--- a/crates/vize_patina/src/rules/vue/no_unused_components/script_setup_refs.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_components/script_setup_refs.rs
@@ -1,0 +1,150 @@
+use super::NoUnusedComponents;
+use crate::context::LintContext;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{IdentifierReference, ImportDeclaration, ImportDeclarationSpecifier, TSType};
+use oxc_ast_visit::{Visit, walk::walk_ts_type};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_s0::{CompactString, FxHashSet};
+
+pub(super) fn script_setup_component_import_references(
+    ctx: &LintContext<'_>,
+    candidate_names: &[CompactString],
+    import_statement_ranges: &[(u32, u32)],
+) -> FxHashSet<CompactString> {
+    if candidate_names.is_empty() {
+        return FxHashSet::default();
+    }
+
+    let Some(script_setup) = ctx
+        .sfc_descriptor()
+        .and_then(|descriptor| descriptor.script_setup.as_ref())
+    else {
+        return FxHashSet::default();
+    };
+
+    let source = script_setup.content.as_ref();
+    if !candidate_names.iter().any(|name| {
+        has_non_import_identifier_reference(source, name.as_str(), import_statement_ranges)
+    }) {
+        return FxHashSet::default();
+    }
+
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path("component.ts").unwrap_or_else(|_| SourceType::ts());
+    let parsed = Parser::new(&allocator, source, source_type).parse();
+    if parsed.panicked || !parsed.diagnostics.is_empty() {
+        return FxHashSet::default();
+    }
+
+    let mut visitor = ScriptSetupComponentImportVisitor {
+        component_imports: FxHashSet::default(),
+        referenced_imports: FxHashSet::default(),
+        scopes: Vec::new(),
+        type_depth: 0,
+    };
+    visitor.visit_program(&parsed.program);
+    visitor.referenced_imports
+}
+
+fn has_non_import_identifier_reference(
+    source: &str,
+    name: &str,
+    import_statement_ranges: &[(u32, u32)],
+) -> bool {
+    source.match_indices(name).any(|(index, _)| {
+        let start = index as u32;
+        let end = (index + name.len()) as u32;
+        !import_statement_ranges
+            .iter()
+            .any(|(import_start, import_end)| start >= *import_start && end <= *import_end)
+            && is_identifier_boundary(source.as_bytes().get(index.wrapping_sub(1)).copied())
+            && is_identifier_boundary(source.as_bytes().get(index + name.len()).copied())
+    })
+}
+
+fn is_identifier_boundary(byte: Option<u8>) -> bool {
+    !byte.is_some_and(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$')
+}
+
+struct ScriptSetupComponentImportVisitor {
+    component_imports: FxHashSet<CompactString>,
+    referenced_imports: FxHashSet<CompactString>,
+    scopes: Vec<FxHashSet<CompactString>>,
+    type_depth: usize,
+}
+
+impl<'a> Visit<'a> for ScriptSetupComponentImportVisitor {
+    fn enter_scope(
+        &mut self,
+        _flags: oxc_syntax::scope::ScopeFlags,
+        _scope_id: &std::cell::Cell<Option<oxc_syntax::scope::ScopeId>>,
+    ) {
+        self.scopes.push(FxHashSet::default());
+    }
+
+    fn leave_scope(&mut self) {
+        self.scopes.pop();
+    }
+
+    fn visit_import_declaration(&mut self, it: &ImportDeclaration<'a>) {
+        if it.import_kind.is_type()
+            || !NoUnusedComponents::is_component_import_source(it.source.value.as_str())
+        {
+            return;
+        }
+
+        let Some(specifiers) = &it.specifiers else {
+            return;
+        };
+
+        for specifier in specifiers {
+            match specifier {
+                ImportDeclarationSpecifier::ImportSpecifier(specifier)
+                    if !specifier.import_kind.is_type() =>
+                {
+                    self.component_imports
+                        .insert(CompactString::new(specifier.local.name.as_str()));
+                }
+                ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => {
+                    self.component_imports
+                        .insert(CompactString::new(specifier.local.name.as_str()));
+                }
+                ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => {
+                    self.component_imports
+                        .insert(CompactString::new(specifier.local.name.as_str()));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn visit_binding_identifier(&mut self, it: &oxc_ast::ast::BindingIdentifier<'a>) {
+        if let Some(scope) = self.scopes.last_mut() {
+            scope.insert(CompactString::new(it.name.as_str()));
+        }
+    }
+
+    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+        if self.type_depth > 0 {
+            return;
+        }
+
+        let name = it.name.as_str();
+        if self.component_imports.contains(name) && !self.is_shadowed(name) {
+            self.referenced_imports.insert(CompactString::new(name));
+        }
+    }
+
+    fn visit_ts_type(&mut self, it: &TSType<'a>) {
+        self.type_depth += 1;
+        walk_ts_type(self, it);
+        self.type_depth -= 1;
+    }
+}
+
+impl ScriptSetupComponentImportVisitor {
+    fn is_shadowed(&self, name: &str) -> bool {
+        self.scopes.iter().rev().any(|scope| scope.contains(name))
+    }
+}

--- a/crates/vize_patina/src/rules/vue/no_unused_components/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_components/tests.rs
@@ -1,4 +1,5 @@
 use super::NoUnusedComponents;
+use crate::linter::Linter;
 use crate::rule::{Rule, RuleCategory};
 
 #[test]
@@ -13,4 +14,82 @@ fn test_should_ignore() {
     let rule = NoUnusedComponents::default();
     assert!(rule.should_ignore("_Internal"));
     assert!(!rule.should_ignore("MyComponent"));
+}
+
+fn lint_messages(sfc: &str) -> Vec<String> {
+    Linter::new()
+        .with_enabled_rules(Some(vec!["vue/no-unused-components".into()]))
+        .lint_sfc(sfc, "test.vue")
+        .diagnostics
+        .into_iter()
+        .map(|diagnostic| diagnostic.message.to_string())
+        .collect()
+}
+
+#[test]
+fn test_plain_script_component_value_is_not_registration() {
+    let sfc = r#"<template>
+  <DocSections :docs="docs" />
+</template>
+
+<script>
+import DocApiTable from './DocApiTable.vue'
+
+export default {
+  data() {
+    return {
+      docs: [{ component: DocApiTable }]
+    }
+  }
+}
+</script>
+"#;
+
+    assert_eq!(lint_messages(sfc), Vec::<String>::new());
+}
+
+#[test]
+fn test_options_api_registration_reports_public_alias() {
+    let sfc = r#"<script>
+import Style from './style.vue'
+
+export default {
+  components: {
+    FourStyle: Style,
+  },
+}
+</script>
+
+<template>
+  <div />
+</template>
+"#;
+
+    assert_eq!(
+        lint_messages(sfc),
+        vec!["Component 'FourStyle' is registered but never used in template"]
+    );
+}
+
+#[test]
+fn test_registered_library_component_reports_unused() {
+    let sfc = r#"<script>
+import { SfButton } from '@storefront-ui/vue'
+
+export default {
+  components: {
+    SfButton,
+  },
+}
+</script>
+
+<template>
+  <div />
+</template>
+"#;
+
+    assert_eq!(
+        lint_messages(sfc),
+        vec!["Component 'SfButton' is registered but never used in template"]
+    );
 }


### PR DESCRIPTION
## Summary
- restrict `vue/no-unused-components` candidates to script-setup `.vue` imports and explicit Options API registrations
- report unused Options API registrations by public registration name
- keep script-setup import reference handling in a dedicated helper module

## Evidence
- Real Project Matrix run 33981711065 showed 4,496 Patina-only `vue/no-unused-components` rows and 126 baseline-only rows.
- Dominant false-positive pattern was PrimeVue and PrimeVue Showcase docs importing values such as `DocApiTable` and using them as plain JS values (`component: DocApiTable`) rather than registering them.

## Validation
- `cargo test -p vize_patina no_unused_components`
- `cargo test -p vize_patina --lib --quiet`
- `cargo clippy -p vize_patina --lib -- -D warnings`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 10`
- `node --test tests/tooling/source-file-lengths.test.ts tests/tooling/lint-divergence-rule-location.test.ts tests/tooling/lint-divergence.test.ts tests/tooling/lint-divergence-ledger.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791272798&installation_model_id=422833&pr_number=5809&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5809&signature=0e34c4c31b8bb43897f8770190a4d19628c537710edcb5f020d8dbbbd293363c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Vue `no-unused-components` lint rule to correctly recognize component usage in `<script setup>` blocks.
  * Prevented false positives when components are referenced as data values or through registered aliases.
  * Improved detection of unused local and library components registered through the Options API.
  * Diagnostic messages now identify registered component aliases more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->