### PR TITLE
fix(patina): align no-mutating-props mutation parity

### DIFF
--- a/crates/vize_patina/src/rules/vue/no_mutating_props.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props.rs
@@ -12,8 +12,8 @@
 //! bindings returned by `defineProps` (including destructured bindings and
 //! `withDefaults`). In templates, two positions mutate a prop directly:
 //! `v-model` bound to a prop, and an assignment (or `++` / `--`) inside a
-//! `v-on` inline handler. Both script and handler checks resolve real oxc
-//! syntax rather than scanning source text.
+//! `v-on` inline handler. Assignments, updates, deletes, and mutating calls are
+//! checked with real oxc syntax rather than scanning source text.
 //!
 //! ## Examples
 //!
@@ -97,22 +97,19 @@ impl NoMutatingProps {
         if !scope.is_mutation(content) {
             return;
         }
+        let span = exp.loc().span;
         ctx.report(
             crate::diagnostic::LintDiagnostic::error(
                 ctx.current_rule,
                 format!("Unexpected mutation of prop '{}' via v-model", content),
-                directive.loc.span.start,
-                directive.loc.span.end,
+                span.start,
+                span.end,
             )
             .with_help("Use a local ref or emit an event instead of mutating props directly"),
         );
     }
 
-    /// Check whether a `v-on` inline handler assigns to a prop.
-    ///
-    /// Reported at the directive, matching the `v-model` half of this rule.
-    /// Upstream highlights the mutated expression instead; that is a location
-    /// divergence for the parity ledger, not a coverage one.
+    /// Check whether a `v-on` inline handler mutates a prop.
     fn check_handler_mutation<'a>(
         &self,
         ctx: &mut LintContext<'a>,
@@ -125,23 +122,37 @@ impl NoMutatingProps {
         let Some(exp) = directive.exp.as_ref() else {
             return;
         };
-        let mut mutated: Vec<String> = Vec::new();
-        handlers::for_each_mutation_target(expression_source(exp, ctx.source), |target| {
-            let target = target.trim();
-            if scope.is_mutation(target) && !mutated.iter().any(|seen| seen == target) {
-                mutated.push(String::new(target));
+        let expression_start = exp.loc().span.start;
+        let mut mutated: Vec<TemplateMutation> = Vec::new();
+        handlers::for_each_mutation_target(expression_source(exp, ctx.source), |mutation| {
+            let target = mutation.target.trim();
+            if !scope.is_mutation(target) {
+                return;
             }
+            let start = expression_start + mutation.span.start;
+            let end = expression_start + mutation.span.end;
+            if mutated
+                .iter()
+                .any(|seen| seen.target == target && seen.start == start && seen.end == end)
+            {
+                return;
+            }
+            mutated.push(TemplateMutation {
+                target: String::new(target),
+                start,
+                end,
+            });
         });
-        for target in mutated {
+        for mutation in mutated {
             ctx.report(
                 crate::diagnostic::LintDiagnostic::error(
                     ctx.current_rule,
                     format!(
                         "Unexpected mutation of prop '{}' in an inline handler",
-                        target
+                        mutation.target
                     ),
-                    directive.loc.span.start,
-                    directive.loc.span.end,
+                    mutation.start,
+                    mutation.end,
                 )
                 .with_help("Use a local ref or emit an event instead of mutating props directly"),
             );
@@ -236,6 +247,12 @@ impl NoMutatingProps {
         self.check_children(ctx, &element.children, scope);
         scope.shadowed.truncate(depth);
     }
+}
+
+struct TemplateMutation {
+    target: String,
+    start: u32,
+    end: u32,
 }
 
 impl Rule for NoMutatingProps {

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/handlers.rs
@@ -35,21 +35,42 @@
 //!   The one deliberate imprecision is shadowing (a `v-for` alias or a slot
 //!   variable that reuses a prop name), and it errs towards *not* reporting.
 //! * **Under-match** loses a report: a body oxc cannot parse is skipped, as is
-//!   a destructuring target (`[props.msg] = list`) and a mutation performed
-//!   through a call (`@click="props.items.push(1)"`, which upstream reports
-//!   and this does not). All three leave a real bug unreported, which is the
-//!   tolerable direction.
+//!   a destructuring target (`[props.msg] = list`) or a mutating call whose
+//!   method is not statically named (`@click="props.items[method](1)"`). These
+//!   leave a real bug unreported, which is the tolerable direction.
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
-    AssignmentExpression, AssignmentTarget, SimpleAssignmentTarget, UpdateExpression,
+    Argument, AssignmentExpression, AssignmentTarget, CallExpression, Expression,
+    SimpleAssignmentTarget, UnaryExpression, UpdateExpression,
 };
 use oxc_ast_visit::{
     Visit,
-    walk::{walk_assignment_expression, walk_update_expression},
+    walk::{
+        walk_assignment_expression, walk_call_expression, walk_unary_expression,
+        walk_update_expression,
+    },
 };
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType, Span};
+use oxc_syntax::operator::UnaryOperator;
+
+const MUTATING_ARRAY_METHODS: &[&str] = &[
+    "push",
+    "pop",
+    "shift",
+    "unshift",
+    "reverse",
+    "splice",
+    "sort",
+    "copyWithin",
+    "fill",
+];
+
+pub(super) struct HandlerMutationTarget<'a> {
+    pub(super) target: &'a str,
+    pub(super) span: Span,
+}
 
 /// Call `visit` with the source slice of every assignment / update target in
 /// `source`, a `v-on` inline handler body.
@@ -58,10 +79,13 @@ use oxc_span::{GetSpan, SourceType, Span};
 /// (`@click="a = 1; b = 2"` is valid), so it is parsed as a program. Bodies
 /// oxc rejects are skipped: a report invented from a mis-parse would be a
 /// false positive, and a template that does not compile has larger problems.
-pub(super) fn for_each_mutation_target(source: &str, mut visit: impl FnMut(&str)) {
+pub(super) fn for_each_mutation_target(
+    source: &str,
+    mut visit: impl FnMut(HandlerMutationTarget<'_>),
+) {
     // Cheap reject for the overwhelmingly common handler (`@click="submit"`,
     // `@click="emit('x')"`): no mutation operator, nothing to parse.
-    if !source.contains('=') && !source.contains("++") && !source.contains("--") {
+    if !may_mutate(source) {
         return;
     }
     let allocator = Allocator::default();
@@ -74,23 +98,33 @@ pub(super) fn for_each_mutation_target(source: &str, mut visit: impl FnMut(&str)
     if parsed.panicked || !parsed.diagnostics.is_empty() {
         return;
     }
-    let mut collector = MutationTargetCollector { spans: Vec::new() };
+    let mut collector = MutationTargetCollector {
+        targets: Vec::new(),
+    };
     collector.visit_program(&parsed.program);
-    for span in collector.spans {
-        if let Some(text) = source.get(span.start as usize..span.end as usize) {
-            visit(text);
+    for target in collector.targets {
+        if let Some(text) = source.get(target.target.start as usize..target.target.end as usize) {
+            visit(HandlerMutationTarget {
+                target: text,
+                span: target.mutation,
+            });
         }
     }
 }
 
 struct MutationTargetCollector {
-    spans: Vec<Span>,
+    targets: Vec<MutationTargetSpan>,
+}
+
+struct MutationTargetSpan {
+    target: Span,
+    mutation: Span,
 }
 
 impl<'a> Visit<'a> for MutationTargetCollector {
     fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
         if let Some(span) = assignment_target_span(&it.left) {
-            self.spans.push(span);
+            self.push(span, it.span);
         }
         // Keep walking: the right-hand side can hold further assignments
         // (`a = (props.msg = 'x')`).
@@ -99,9 +133,29 @@ impl<'a> Visit<'a> for MutationTargetCollector {
 
     fn visit_update_expression(&mut self, it: &UpdateExpression<'a>) {
         if let Some(span) = simple_assignment_target_span(&it.argument) {
-            self.spans.push(span);
+            self.push(span, it.span);
         }
         walk_update_expression(self, it);
+    }
+
+    fn visit_unary_expression(&mut self, it: &UnaryExpression<'a>) {
+        if it.operator == UnaryOperator::Delete {
+            self.push(it.argument.get_inner_expression().span(), it.span);
+        }
+        walk_unary_expression(self, it);
+    }
+
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        if let Some(target) = mutating_call_target(it) {
+            self.push(target.get_inner_expression().span(), it.span);
+        }
+        walk_call_expression(self, it);
+    }
+}
+
+impl MutationTargetCollector {
+    fn push(&mut self, target: Span, mutation: Span) {
+        self.targets.push(MutationTargetSpan { target, mutation });
     }
 }
 
@@ -115,6 +169,58 @@ fn assignment_target_span(target: &AssignmentTarget<'_>) -> Option<Span> {
         AssignmentTarget::AssignmentTargetIdentifier(identifier) => Some(identifier.span),
         other => other.as_member_expression().map(GetSpan::span),
     }
+}
+
+fn mutating_call_target<'a>(call: &'a CallExpression<'a>) -> Option<&'a Expression<'a>> {
+    let (object, property) = static_call_member(&call.callee)?;
+
+    if MUTATING_ARRAY_METHODS.contains(&property) {
+        return Some(object);
+    }
+
+    if property == "assign"
+        && is_identifier_named(object, "Object")
+        && let Some(argument) = call.arguments.first().and_then(Argument::as_expression)
+    {
+        return Some(argument);
+    }
+
+    None
+}
+
+fn static_call_member<'a>(callee: &'a Expression<'a>) -> Option<(&'a Expression<'a>, &'a str)> {
+    match callee.get_inner_expression() {
+        Expression::StaticMemberExpression(member) => {
+            Some((&member.object, member.property.name.as_str()))
+        }
+        Expression::ComputedMemberExpression(member) => match member
+            .expression
+            .get_inner_expression()
+        {
+            Expression::StringLiteral(property) => Some((&member.object, property.value.as_str())),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn is_identifier_named(expression: &Expression<'_>, expected: &str) -> bool {
+    matches!(
+        expression.get_inner_expression(),
+        Expression::Identifier(identifier) if identifier.name.as_str() == expected
+    )
+}
+
+fn may_mutate(source: &str) -> bool {
+    source.contains('=')
+        || source.contains("++")
+        || source.contains("--")
+        || source.contains("delete")
+        || source.contains("Object.assign")
+        || source.contains("assign")
+        || MUTATING_ARRAY_METHODS
+            .iter()
+            .any(|method| source.contains(method))
 }
 
 fn simple_assignment_target_span(target: &SimpleAssignmentTarget<'_>) -> Option<Span> {

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/script_mutations.rs
@@ -8,18 +8,34 @@
 use crate::rules::script::script_source_type;
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
-    AssignmentExpression, CallExpression, Expression, IdentifierReference, Program,
-    SimpleAssignmentTarget, Statement, UpdateExpression,
+    Argument, AssignmentExpression, CallExpression, Expression, IdentifierReference, Program,
+    SimpleAssignmentTarget, Statement, UnaryExpression, UpdateExpression,
 };
 use oxc_ast_visit::{
     Visit,
-    walk::{walk_assignment_expression, walk_update_expression},
+    walk::{
+        walk_assignment_expression, walk_call_expression, walk_unary_expression,
+        walk_update_expression,
+    },
 };
 use oxc_parser::Parser;
 use oxc_semantic::{Scoping, SemanticBuilder};
 use oxc_span::{GetSpan, Span};
+use oxc_syntax::operator::UnaryOperator;
 use oxc_syntax::symbol::SymbolId;
 use vize_s0::{FxHashSet, String};
+
+const MUTATING_ARRAY_METHODS: &[&str] = &[
+    "push",
+    "pop",
+    "shift",
+    "unshift",
+    "reverse",
+    "splice",
+    "sort",
+    "copyWithin",
+    "fill",
+];
 
 pub(super) struct ScriptPropMutation {
     pub(super) target: String,
@@ -124,10 +140,27 @@ struct MutationCollector<'s> {
 }
 
 impl MutationCollector<'_> {
-    fn record(&mut self, target: &SimpleAssignmentTarget<'_>) {
+    fn record(&mut self, target: &SimpleAssignmentTarget<'_>, mutation_span: Span) {
         let Some(reference) = target_reference(target) else {
             return;
         };
+        self.record_reference(reference, target.span(), mutation_span);
+    }
+
+    fn record_expression(&mut self, target: &Expression<'_>, mutation_span: Span) {
+        let target = target.get_inner_expression();
+        let Some(reference) = root_reference(target) else {
+            return;
+        };
+        self.record_reference(reference, target.span(), mutation_span);
+    }
+
+    fn record_reference(
+        &mut self,
+        reference: &IdentifierReference<'_>,
+        target_span: Span,
+        mutation_span: Span,
+    ) {
         let Some(reference_id) = reference.reference_id.get() else {
             return;
         };
@@ -138,13 +171,15 @@ impl MutationCollector<'_> {
             return;
         }
 
-        let span = target.span();
-        let Some(target) = self.source.get(span.start as usize..span.end as usize) else {
+        let Some(target) = self
+            .source
+            .get(target_span.start as usize..target_span.end as usize)
+        else {
             return;
         };
         self.mutations.push(ScriptPropMutation {
             target: String::from(target),
-            span,
+            span: mutation_span,
         });
     }
 }
@@ -152,14 +187,28 @@ impl MutationCollector<'_> {
 impl<'a> Visit<'a> for MutationCollector<'_> {
     fn visit_assignment_expression(&mut self, expression: &AssignmentExpression<'a>) {
         if let Some(target) = expression.left.as_simple_assignment_target() {
-            self.record(target);
+            self.record(target, expression.span);
         }
         walk_assignment_expression(self, expression);
     }
 
     fn visit_update_expression(&mut self, expression: &UpdateExpression<'a>) {
-        self.record(&expression.argument);
+        self.record(&expression.argument, expression.span);
         walk_update_expression(self, expression);
+    }
+
+    fn visit_unary_expression(&mut self, expression: &UnaryExpression<'a>) {
+        if expression.operator == UnaryOperator::Delete {
+            self.record_expression(&expression.argument, expression.span);
+        }
+        walk_unary_expression(self, expression);
+    }
+
+    fn visit_call_expression(&mut self, expression: &CallExpression<'a>) {
+        if let Some(target) = mutating_call_target(expression) {
+            self.record_expression(target, expression.span);
+        }
+        walk_call_expression(self, expression);
     }
 }
 
@@ -183,4 +232,44 @@ fn root_reference<'a>(expression: &'a Expression<'a>) -> Option<&'a IdentifierRe
         }
         _ => None,
     }
+}
+
+fn mutating_call_target<'a>(call: &'a CallExpression<'a>) -> Option<&'a Expression<'a>> {
+    let (object, property) = static_call_member(&call.callee)?;
+
+    if MUTATING_ARRAY_METHODS.contains(&property) {
+        return Some(object);
+    }
+
+    if property == "assign"
+        && is_identifier_named(object, "Object")
+        && let Some(argument) = call.arguments.first().and_then(Argument::as_expression)
+    {
+        return Some(argument);
+    }
+
+    None
+}
+
+fn static_call_member<'a>(callee: &'a Expression<'a>) -> Option<(&'a Expression<'a>, &'a str)> {
+    match callee.get_inner_expression() {
+        Expression::StaticMemberExpression(member) => {
+            Some((&member.object, member.property.name.as_str()))
+        }
+        Expression::ComputedMemberExpression(member) => match member
+            .expression
+            .get_inner_expression()
+        {
+            Expression::StringLiteral(property) => Some((&member.object, property.value.as_str())),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn is_identifier_named(expression: &Expression<'_>, expected: &str) -> bool {
+    matches!(
+        expression.get_inner_expression(),
+        Expression::Identifier(identifier) if identifier.name.as_str() == expected
+    )
 }

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/tests.rs
@@ -4,6 +4,7 @@ use crate::linter::{LintResult, Linter};
 use crate::rule::{Rule, RuleCategory};
 
 mod script_mutations;
+mod template_handlers;
 
 /// Lint a full SFC with only this rule enabled.
 ///
@@ -36,150 +37,22 @@ fn none() -> Vec<(&'static str, Severity, u32, u32, &'static str)> {
     Vec::new()
 }
 
+fn span_for(sfc: &str, needle: &str) -> (u32, u32) {
+    let start = sfc.find(needle).expect("expected source span");
+    (start as u32, (start + needle.len()) as u32)
+}
+
+fn last_span_for(sfc: &str, needle: &str) -> (u32, u32) {
+    let start = sfc.rfind(needle).expect("expected source span");
+    (start as u32, (start + needle.len()) as u32)
+}
+
 #[test]
 fn test_meta() {
     let rule = NoMutatingProps;
     assert_eq!(rule.meta().name, "vue/no-mutating-props");
     assert_eq!(rule.meta().category, RuleCategory::Essential);
     assert_eq!(rule.meta().default_severity, Severity::Error);
-}
-
-// --- The recovered case: an assignment inside an inline handler ------------
-
-#[test]
-fn reports_prop_assignment_in_an_inline_handler() {
-    let sfc = r#"<script setup lang="ts">
-const props = defineProps<{ msg: string }>();
-</script>
-
-<template>
-  <button @click="props.msg = 'x'">{{ props.msg }}</button>
-</template>
-"#;
-    let directive = sfc.find("@click=").expect("handler directive");
-    let directive_end = sfc.find(">{{").expect("end of the start tag");
-    assert_eq!(
-        findings(&lint_sfc(sfc)),
-        vec![(
-            "vue/no-mutating-props",
-            Severity::Error,
-            directive as u32,
-            directive_end as u32,
-            "Unexpected mutation of prop 'props.msg' in an inline handler",
-        )]
-    );
-}
-
-#[test]
-fn reports_bare_prop_assignment_in_an_inline_handler() {
-    let sfc = r#"<script setup lang="ts">
-defineProps<{ msg: string }>();
-</script>
-
-<template>
-  <button @click="msg = 'x'">go</button>
-</template>
-"#;
-    let directive = sfc.find("@click=").expect("handler directive");
-    let directive_end = sfc.find(">go").expect("end of the start tag");
-    assert_eq!(
-        findings(&lint_sfc(sfc)),
-        vec![(
-            "vue/no-mutating-props",
-            Severity::Error,
-            directive as u32,
-            directive_end as u32,
-            "Unexpected mutation of prop 'msg' in an inline handler",
-        )]
-    );
-}
-
-#[test]
-fn reports_a_prop_update_expression() {
-    let sfc = r#"<script setup lang="ts">
-const props = defineProps<{ count: number }>();
-</script>
-
-<template>
-  <button @click="props.count++">go</button>
-</template>
-"#;
-    let directive = sfc.find("@click=").expect("handler directive");
-    let directive_end = sfc.find(">go").expect("end of the start tag");
-    assert_eq!(
-        findings(&lint_sfc(sfc)),
-        vec![(
-            "vue/no-mutating-props",
-            Severity::Error,
-            directive as u32,
-            directive_end as u32,
-            "Unexpected mutation of prop 'props.count' in an inline handler",
-        )]
-    );
-}
-
-#[test]
-fn reports_each_distinct_prop_of_a_multi_statement_handler_once() {
-    let sfc = r#"<script setup lang="ts">
-defineProps<{ msg: string; count: number }>();
-</script>
-
-<template>
-  <button @click="msg = 'x'; count = 1; msg = 'y'">go</button>
-</template>
-"#;
-    let directive = sfc.find("@click=").expect("handler directive");
-    let directive_end = sfc.find(">go").expect("end of the start tag");
-    assert_eq!(
-        findings(&lint_sfc(sfc)),
-        vec![
-            (
-                "vue/no-mutating-props",
-                Severity::Error,
-                directive as u32,
-                directive_end as u32,
-                "Unexpected mutation of prop 'msg' in an inline handler",
-            ),
-            (
-                "vue/no-mutating-props",
-                Severity::Error,
-                directive as u32,
-                directive_end as u32,
-                "Unexpected mutation of prop 'count' in an inline handler",
-            ),
-        ]
-    );
-}
-
-// --- The template does not mutate a prop: exactly zero findings ------------
-
-#[test]
-fn ignores_a_handler_that_reads_a_prop() {
-    let sfc = r#"<script setup lang="ts">
-const props = defineProps<{ msg: string }>();
-const emit = defineEmits<{ go: [string] }>();
-</script>
-
-<template>
-  <button @click="emit('go', props.msg)">{{ props.msg }}</button>
-</template>
-"#;
-    assert_eq!(findings(&lint_sfc(sfc)), none());
-}
-
-#[test]
-fn ignores_an_assignment_to_local_state() {
-    let sfc = r#"<script setup lang="ts">
-import { ref } from 'vue';
-defineProps<{ msg: string }>();
-const draft = ref('');
-</script>
-
-<template>
-  <button @click="draft = 'x'">go</button>
-</template>
-"#;
-    assert_eq!(findings(&lint_sfc(sfc)), none());
 }
 
 // --- Over-match probes: none of these may manufacture a finding ------------
@@ -212,34 +85,6 @@ defineProps<{ msg: string }>();
 }
 
 #[test]
-fn ignores_a_prop_assignment_inside_a_string_literal() {
-    let sfc = r#"<script setup lang="ts">
-defineProps<{ msg: string }>();
-</script>
-
-<template>
-  <button @click="console.log('msg = 1')">go</button>
-</template>
-"#;
-    assert_eq!(findings(&lint_sfc(sfc)), none());
-}
-
-#[test]
-fn ignores_an_identifier_that_merely_starts_with_a_prop_name() {
-    let sfc = r#"<script setup lang="ts">
-import { ref } from 'vue';
-defineProps<{ msg: string }>();
-const msgExtra = ref('');
-</script>
-
-<template>
-  <button @click="msgExtra = 'x'">go</button>
-</template>
-"#;
-    assert_eq!(findings(&lint_sfc(sfc)), none());
-}
-
-#[test]
 fn ignores_a_prop_assignment_inside_a_v_pre_region() {
     let sfc = r#"<script setup lang="ts">
 defineProps<{ msg: string }>();
@@ -250,67 +95,6 @@ defineProps<{ msg: string }>();
 </template>
 "#;
     assert_eq!(findings(&lint_sfc(sfc)), none());
-}
-
-#[test]
-fn ignores_a_v_for_alias_that_shadows_a_prop_name() {
-    let sfc = r#"<script setup lang="ts">
-defineProps<{ msg: string; rows: string[] }>();
-</script>
-
-<template>
-  <ul>
-    <li v-for="msg in rows" :key="msg">
-      <button @click="msg = 'x'">go</button>
-    </li>
-  </ul>
-</template>
-"#;
-    assert_eq!(findings(&lint_sfc(sfc)), none());
-}
-
-#[test]
-fn ignores_a_slot_variable_that_shadows_a_prop_name() {
-    let sfc = r#"<script setup lang="ts">
-defineProps<{ msg: string }>();
-</script>
-
-<template>
-  <Child v-slot="{ msg }">
-    <button @click="msg = 'x'">go</button>
-  </Child>
-</template>
-"#;
-    assert_eq!(findings(&lint_sfc(sfc)), none());
-}
-
-#[test]
-fn still_reports_a_prop_after_a_shadowing_subtree_ends() {
-    let sfc = r#"<script setup lang="ts">
-defineProps<{ msg: string; rows: string[] }>();
-</script>
-
-<template>
-  <ul>
-    <li v-for="msg in rows" :key="msg">
-      <button @click="msg = 'x'">shadowed</button>
-    </li>
-  </ul>
-  <button @click="msg = 'y'">not shadowed</button>
-</template>
-"#;
-    let directive = sfc.rfind("@click=").expect("handler directive");
-    let directive_end = sfc.rfind(">not").expect("end of the start tag");
-    assert_eq!(
-        findings(&lint_sfc(sfc)),
-        vec![(
-            "vue/no-mutating-props",
-            Severity::Error,
-            directive as u32,
-            directive_end as u32,
-            "Unexpected mutation of prop 'msg' in an inline handler",
-        )]
-    );
 }
 
 // --- The pre-existing v-model half must keep working ----------------------
@@ -325,14 +109,14 @@ defineProps<{ msg: string }>();
   <input v-model="msg" />
 </template>
 "#;
-    let directive = sfc.find("v-model=").expect("model directive");
+    let (start, end) = last_span_for(sfc, "msg");
     assert_eq!(
         findings(&lint_sfc(sfc)),
         vec![(
             "vue/no-mutating-props",
             Severity::Error,
-            directive as u32,
-            (directive + "v-model=\"msg\"".len()) as u32,
+            start,
+            end,
             "Unexpected mutation of prop 'msg' via v-model",
         )]
     );

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/tests/script_mutations.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/tests/script_mutations.rs
@@ -5,10 +5,11 @@ use vize_s0::String;
 fn expected_script_finding<'a>(
     sfc: &'a str,
     target: &'a str,
+    mutation: &'a str,
     occurrence: usize,
 ) -> (&'static str, Severity, u32, u32, String) {
     let start = sfc
-        .match_indices(target)
+        .match_indices(mutation)
         .nth(occurrence)
         .map(|(start, _)| start)
         .expect("mutation target");
@@ -16,7 +17,7 @@ fn expected_script_finding<'a>(
         "vue/no-mutating-props",
         Severity::Error,
         start as u32,
-        (start + target.len()) as u32,
+        (start + mutation.len()) as u32,
         String::new(format!(
             "Unexpected mutation of prop '{target}' in <script setup>"
         )),
@@ -36,10 +37,10 @@ props.profile.name = 'Ada'
     let result = lint_sfc(sfc);
     let actual = findings(&result);
     let expected = [
-        expected_script_finding(sfc, "props.count", 0),
-        expected_script_finding(sfc, "props.count", 1),
-        expected_script_finding(sfc, "props.count", 2),
-        expected_script_finding(sfc, "props.profile.name", 0),
+        expected_script_finding(sfc, "props.count", "props.count = 1", 0),
+        expected_script_finding(sfc, "props.count", "props.count += 1", 0),
+        expected_script_finding(sfc, "props.count", "props.count++", 0),
+        expected_script_finding(sfc, "props.profile.name", "props.profile.name = 'Ada'", 0),
     ];
 
     assert_eq!(actual.len(), expected.len());
@@ -66,8 +67,8 @@ isEnabled--
     let result = lint_sfc(sfc);
     let actual = findings(&result);
     let expected = [
-        expected_script_finding(sfc, "count", 2),
-        expected_script_finding(sfc, "isEnabled", 1),
+        expected_script_finding(sfc, "count", "count = 1", 0),
+        expected_script_finding(sfc, "isEnabled", "isEnabled--", 0),
     ];
 
     assert_eq!(actual.len(), expected.len());
@@ -86,9 +87,87 @@ const props = withDefaults(defineProps<{ count?: number }>(), { count: 0 })
 props.count *= 2
 </script>
 "#;
-    let expected = expected_script_finding(sfc, "props.count", 0);
+    let expected = expected_script_finding(sfc, "props.count", "props.count *= 2", 0);
     let result = lint_sfc(sfc);
     let actual = findings(&result);
+
+    assert_eq!(actual.len(), 1);
+    assert_eq!(
+        (actual[0].2, actual[0].3, actual[0].4),
+        (expected.2, expected.3, expected.4.as_str())
+    );
+}
+
+#[test]
+fn reports_delete_and_mutating_calls_on_props() {
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{
+  items: string[]
+  profile: { name?: string }
+  options: Record<string, boolean>
+}>()
+props.items.push('x')
+props.items.splice(0, 1)
+props.items["push"]('y')
+Object.assign(props.options, { enabled: true })
+Object["assign"](props.options, { archived: false })
+delete props.profile.name
+</script>
+"#;
+    let result = lint_sfc(sfc);
+    let actual = findings(&result);
+    let expected = [
+        expected_script_finding(sfc, "props.items", "props.items.push('x')", 0),
+        expected_script_finding(sfc, "props.items", "props.items.splice(0, 1)", 0),
+        expected_script_finding(sfc, "props.items", "props.items[\"push\"]('y')", 0),
+        expected_script_finding(
+            sfc,
+            "props.options",
+            "Object.assign(props.options, { enabled: true })",
+            0,
+        ),
+        expected_script_finding(
+            sfc,
+            "props.options",
+            "Object[\"assign\"](props.options, { archived: false })",
+            0,
+        ),
+        expected_script_finding(sfc, "props.profile.name", "delete props.profile.name", 0),
+    ];
+
+    assert_eq!(actual.len(), expected.len());
+    for (actual, expected) in actual.iter().zip(expected.iter()) {
+        assert_eq!(
+            (actual.2, actual.3, actual.4),
+            (expected.2, expected.3, expected.4.as_str())
+        );
+    }
+}
+
+#[test]
+fn ignores_non_literal_computed_mutating_calls_on_props() {
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ items: string[]; options: Record<string, boolean> }>()
+const method = 'push'
+const assign = 'assign'
+props.items[method]('x')
+Object[assign](props.options, { enabled: true })
+</script>
+"#;
+
+    assert!(findings(&lint_sfc(sfc)).is_empty());
+}
+
+#[test]
+fn reports_mutating_calls_on_destructured_props() {
+    let sfc = r#"<script setup lang="ts">
+const { items } = defineProps<{ items: string[] }>()
+items.sort()
+</script>
+"#;
+    let result = lint_sfc(sfc);
+    let actual = findings(&result);
+    let expected = expected_script_finding(sfc, "items", "items.sort()", 0);
 
     assert_eq!(actual.len(), 1);
     assert_eq!(

--- a/crates/vize_patina/src/rules/vue/no_mutating_props/tests/template_handlers.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props/tests/template_handlers.rs
@@ -1,0 +1,316 @@
+use super::{findings, last_span_for, lint_sfc, none, span_for};
+use crate::diagnostic::Severity;
+
+// --- The recovered case: an assignment inside an inline handler ------------
+
+#[test]
+fn reports_prop_assignment_in_an_inline_handler() {
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <button @click="props.msg = 'x'">{{ props.msg }}</button>
+</template>
+"#;
+    let (start, end) = span_for(sfc, "props.msg = 'x'");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "vue/no-mutating-props",
+            Severity::Error,
+            start,
+            end,
+            "Unexpected mutation of prop 'props.msg' in an inline handler",
+        )]
+    );
+}
+
+#[test]
+fn reports_bare_prop_assignment_in_an_inline_handler() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <button @click="msg = 'x'">go</button>
+</template>
+"#;
+    let (start, end) = span_for(sfc, "msg = 'x'");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "vue/no-mutating-props",
+            Severity::Error,
+            start,
+            end,
+            "Unexpected mutation of prop 'msg' in an inline handler",
+        )]
+    );
+}
+
+#[test]
+fn reports_a_prop_update_expression() {
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ count: number }>();
+</script>
+
+<template>
+  <button @click="props.count++">go</button>
+</template>
+"#;
+    let (start, end) = span_for(sfc, "props.count++");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "vue/no-mutating-props",
+            Severity::Error,
+            start,
+            end,
+            "Unexpected mutation of prop 'props.count' in an inline handler",
+        )]
+    );
+}
+
+#[test]
+fn reports_each_prop_mutation_of_a_multi_statement_handler() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string; count: number }>();
+</script>
+
+<template>
+  <button @click="msg = 'x'; count = 1; msg = 'y'">go</button>
+</template>
+"#;
+    let (first_msg_start, first_msg_end) = span_for(sfc, "msg = 'x'");
+    let (count_start, count_end) = span_for(sfc, "count = 1");
+    let (second_msg_start, second_msg_end) = span_for(sfc, "msg = 'y'");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![
+            (
+                "vue/no-mutating-props",
+                Severity::Error,
+                first_msg_start,
+                first_msg_end,
+                "Unexpected mutation of prop 'msg' in an inline handler",
+            ),
+            (
+                "vue/no-mutating-props",
+                Severity::Error,
+                count_start,
+                count_end,
+                "Unexpected mutation of prop 'count' in an inline handler",
+            ),
+            (
+                "vue/no-mutating-props",
+                Severity::Error,
+                second_msg_start,
+                second_msg_end,
+                "Unexpected mutation of prop 'msg' in an inline handler",
+            ),
+        ]
+    );
+}
+
+#[test]
+fn reports_delete_and_mutating_calls_in_an_inline_handler() {
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ items: string[]; profile: { name?: string } }>();
+</script>
+
+<template>
+  <button @click="items.push('x'); items['push']('y'); props.items.splice(0, 1); props.items['splice'](0, 1); Object['assign'](props.profile, { name: 'Ada' }); delete props.profile.name">go</button>
+</template>
+"#;
+    let (push_start, push_end) = span_for(sfc, "items.push('x')");
+    let (bracket_push_start, bracket_push_end) = span_for(sfc, "items['push']('y')");
+    let (splice_start, splice_end) = span_for(sfc, "props.items.splice(0, 1)");
+    let (bracket_splice_start, bracket_splice_end) = span_for(sfc, "props.items['splice'](0, 1)");
+    let (assign_start, assign_end) =
+        span_for(sfc, "Object['assign'](props.profile, { name: 'Ada' })");
+    let (delete_start, delete_end) = span_for(sfc, "delete props.profile.name");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![
+            (
+                "vue/no-mutating-props",
+                Severity::Error,
+                push_start,
+                push_end,
+                "Unexpected mutation of prop 'items' in an inline handler",
+            ),
+            (
+                "vue/no-mutating-props",
+                Severity::Error,
+                bracket_push_start,
+                bracket_push_end,
+                "Unexpected mutation of prop 'items' in an inline handler",
+            ),
+            (
+                "vue/no-mutating-props",
+                Severity::Error,
+                splice_start,
+                splice_end,
+                "Unexpected mutation of prop 'props.items' in an inline handler",
+            ),
+            (
+                "vue/no-mutating-props",
+                Severity::Error,
+                bracket_splice_start,
+                bracket_splice_end,
+                "Unexpected mutation of prop 'props.items' in an inline handler",
+            ),
+            (
+                "vue/no-mutating-props",
+                Severity::Error,
+                assign_start,
+                assign_end,
+                "Unexpected mutation of prop 'props.profile' in an inline handler",
+            ),
+            (
+                "vue/no-mutating-props",
+                Severity::Error,
+                delete_start,
+                delete_end,
+                "Unexpected mutation of prop 'props.profile.name' in an inline handler",
+            ),
+        ]
+    );
+}
+
+#[test]
+fn ignores_non_literal_computed_calls_in_an_inline_handler() {
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ items: string[]; options: Record<string, boolean> }>();
+const method = 'push';
+const assign = 'assign';
+</script>
+
+<template>
+  <button @click="props.items[method]('x'); Object[assign](props.options, { enabled: true })">go</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- The template does not mutate a prop: exactly zero findings ------------
+
+#[test]
+fn ignores_a_handler_that_reads_a_prop() {
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ msg: string }>();
+const emit = defineEmits<{ go: [string] }>();
+</script>
+
+<template>
+  <button @click="emit('go', props.msg)">{{ props.msg }}</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_assignment_to_local_state() {
+    let sfc = r#"<script setup lang="ts">
+import { ref } from 'vue';
+defineProps<{ msg: string }>();
+const draft = ref('');
+</script>
+
+<template>
+  <button @click="draft = 'x'">go</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+// --- Over-match probes: none of these may manufacture a finding ------------
+
+#[test]
+fn ignores_a_prop_assignment_inside_a_string_literal() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <button @click="console.log('msg = 1')">go</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_an_identifier_that_merely_starts_with_a_prop_name() {
+    let sfc = r#"<script setup lang="ts">
+import { ref } from 'vue';
+defineProps<{ msg: string }>();
+const msgExtra = ref('');
+</script>
+
+<template>
+  <button @click="msgExtra = 'x'">go</button>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_v_for_alias_that_shadows_a_prop_name() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string; rows: string[] }>();
+</script>
+
+<template>
+  <ul>
+    <li v-for="msg in rows" :key="msg">
+      <button @click="msg = 'x'">go</button>
+    </li>
+  </ul>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn ignores_a_slot_variable_that_shadows_a_prop_name() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string }>();
+</script>
+
+<template>
+  <Child v-slot="{ msg }">
+    <button @click="msg = 'x'">go</button>
+  </Child>
+</template>
+"#;
+    assert_eq!(findings(&lint_sfc(sfc)), none());
+}
+
+#[test]
+fn still_reports_a_prop_after_a_shadowing_subtree_ends() {
+    let sfc = r#"<script setup lang="ts">
+defineProps<{ msg: string; rows: string[] }>();
+</script>
+
+<template>
+  <ul>
+    <li v-for="msg in rows" :key="msg">
+      <button @click="msg = 'x'">shadowed</button>
+    </li>
+  </ul>
+  <button @click="msg = 'y'">not shadowed</button>
+</template>
+"#;
+    let (start, end) = last_span_for(sfc, "msg = 'y'");
+    assert_eq!(
+        findings(&lint_sfc(sfc)),
+        vec![(
+            "vue/no-mutating-props",
+            Severity::Error,
+            start,
+            end,
+            "Unexpected mutation of prop 'msg' in an inline handler",
+        )]
+    );
+}

--- a/tests/snapshots/lint/__snapshots__/misskey-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/misskey-lint.snap
@@ -4355,7 +4355,7 @@
         "line": 151,
         "column": 27,
         "endLine": 151,
-        "endColumn": 66,
+        "endColumn": 75,
         "help": "Use a local ref or emit an event instead of mutating props directly"
       },
       {
@@ -4366,7 +4366,7 @@
         "line": 321,
         "column": 4,
         "endLine": 321,
-        "endColumn": 43,
+        "endColumn": 52,
         "help": "Use a local ref or emit an event instead of mutating props directly"
       }
     ],
@@ -5729,7 +5729,7 @@
         "line": 76,
         "column": 2,
         "endLine": 76,
-        "endColumn": 29,
+        "endColumn": 43,
         "help": "Use a local ref or emit an event instead of mutating props directly"
       },
       {
@@ -5740,7 +5740,7 @@
         "line": 77,
         "column": 2,
         "endLine": 77,
-        "endColumn": 34,
+        "endColumn": 81,
         "help": "Use a local ref or emit an event instead of mutating props directly"
       },
       {
@@ -5751,7 +5751,7 @@
         "line": 82,
         "column": 2,
         "endLine": 82,
-        "endColumn": 29,
+        "endColumn": 42,
         "help": "Use a local ref or emit an event instead of mutating props directly"
       },
       {
@@ -5762,7 +5762,7 @@
         "line": 87,
         "column": 2,
         "endLine": 87,
-        "endColumn": 35,
+        "endColumn": 45,
         "help": "Use a local ref or emit an event instead of mutating props directly"
       }
     ],


### PR DESCRIPTION
## Summary
- Align `vue/no-mutating-props` reports with upstream mutation expression ranges.
- Detect script and inline-handler deletes, mutating array methods, literal computed method names, and `Object.assign` targets.
- Preserve dynamic computed method calls as no-report cases unless another exact mutation target is present.
- Refresh focused lint snapshots for the wider mutation spans.

## Validation
- `cargo test -p vize_patina no_mutating_props`
- `cargo fmt --package vize_patina --check`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 50`
- `node --test tests/tooling/source-file-lengths.test.ts tests/tooling/lint-divergence.test.ts tests/tooling/lint-divergence-rule-location.test.ts`
- `git diff --check`
