### PR TITLE
fix(patina): align valid-v-model expression parity

### DIFF
--- a/crates/vize_patina/src/rules/vue/valid_v_model.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_model.rs
@@ -80,10 +80,10 @@ impl Rule for ValidVModel {
             return;
         }
 
-        if let Some(expression_error_key) = model_expression_error_key(&directive.exp) {
+        if let Some((expression_error_key, loc)) = model_expression_error(&directive.exp) {
             ctx.error_with_help(
                 ctx.t(expression_error_key),
-                &directive.loc,
+                loc,
                 ctx.t("vue/valid-v-model.help"),
             );
         }
@@ -174,7 +174,9 @@ fn is_empty_expression(exp: &ExpressionNode) -> bool {
     }
 }
 
-fn model_expression_error_key(exp: &Option<ExpressionNode<'_>>) -> Option<&'static str> {
+fn model_expression_error<'a>(
+    exp: &'a Option<ExpressionNode<'a>>,
+) -> Option<(&'static str, &'a vize_relief::SourceLocation)> {
     let Some(ExpressionNode::Simple(simple)) = exp else {
         return None;
     };
@@ -182,16 +184,17 @@ fn model_expression_error_key(exp: &Option<ExpressionNode<'_>>) -> Option<&'stat
     let allocator = Allocator::default();
     let source_type = SourceType::default().with_typescript(true);
     let Ok(expression) = Parser::new(&allocator, source, source_type).parse_expression() else {
-        return Some("vue/valid-v-model.invalid_expression");
+        return Some(("vue/valid-v-model.invalid_expression", &simple.loc));
     };
 
     if expression.span().end as usize != source.len() {
-        return Some("vue/valid-v-model.invalid_expression");
+        return Some(("vue/valid-v-model.invalid_expression", &simple.loc));
     }
-    if expression_contains_optional_chain(&expression) {
-        return Some("vue/valid-v-model.optional_chain");
+    if is_optional_chaining_member_expression(&expression) {
+        return Some(("vue/valid-v-model.optional_chain", &simple.loc));
     }
-    (!is_assignable_model_target(&expression)).then_some("vue/valid-v-model.invalid_expression")
+    (!is_assignable_model_target(&expression))
+        .then_some(("vue/valid-v-model.invalid_expression", &simple.loc))
 }
 
 fn is_assignable_model_target(expression: &OxcExpression<'_>) -> bool {
@@ -217,37 +220,15 @@ fn is_assignable_model_target(expression: &OxcExpression<'_>) -> bool {
     }
 }
 
-fn expression_contains_optional_chain(expression: &OxcExpression<'_>) -> bool {
+fn is_optional_chaining_member_expression(expression: &OxcExpression<'_>) -> bool {
     match expression {
-        OxcExpression::ChainExpression(_) => true,
-        OxcExpression::StaticMemberExpression(member) => {
-            member.optional || expression_contains_optional_chain(&member.object)
-        }
-        OxcExpression::ComputedMemberExpression(member) => {
-            member.optional
-                || expression_contains_optional_chain(&member.object)
-                || expression_contains_optional_chain(&member.expression)
-        }
-        OxcExpression::PrivateFieldExpression(member) => {
-            member.optional || expression_contains_optional_chain(&member.object)
-        }
-        OxcExpression::CallExpression(call) => {
-            call.optional || expression_contains_optional_chain(&call.callee)
-        }
-        OxcExpression::ParenthesizedExpression(parenthesized) => {
-            expression_contains_optional_chain(&parenthesized.expression)
-        }
-        OxcExpression::TSNonNullExpression(ts_non_null) => {
-            expression_contains_optional_chain(&ts_non_null.expression)
-        }
-        OxcExpression::TSAsExpression(ts_as) => {
-            expression_contains_optional_chain(&ts_as.expression)
-        }
-        OxcExpression::TSSatisfiesExpression(ts_satisfies) => {
-            expression_contains_optional_chain(&ts_satisfies.expression)
-        }
-        OxcExpression::TSTypeAssertion(ts_assertion) => {
-            expression_contains_optional_chain(&ts_assertion.expression)
+        OxcExpression::ChainExpression(chain) => {
+            matches!(
+                &chain.expression,
+                oxc_ast::ast::ChainElement::StaticMemberExpression(_)
+                    | oxc_ast::ast::ChainElement::ComputedMemberExpression(_)
+                    | oxc_ast::ast::ChainElement::PrivateFieldExpression(_)
+            )
         }
         _ => false,
     }

--- a/crates/vize_patina/src/rules/vue/valid_v_model/assignment_target_tests.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_model/assignment_target_tests.rs
@@ -23,6 +23,32 @@ fn invalid_v_model_binary_expression() {
 }
 
 #[test]
+fn invalid_v_model_conditional_expression_reports_expression_range() {
+    let linter = create_linter();
+    let source = r#"<el-input v-model="multiple ? presentText : inputValue" />"#;
+    let result = linter.lint_template(source, "test.vue");
+    assert_eq!(result.error_count, 1);
+    let diagnostic = &result.diagnostics[0];
+    assert_eq!(
+        &source[diagnostic.start as usize..diagnostic.end as usize],
+        "multiple ? presentText : inputValue"
+    );
+}
+
+#[test]
+fn invalid_component_v_model_argument_reports_expression_range() {
+    let linter = create_linter();
+    let source = r#"<Dialog v-model:open="confirmDeleteKey !== null" />"#;
+    let result = linter.lint_template(source, "test.vue");
+    assert_eq!(result.error_count, 1);
+    let diagnostic = &result.diagnostics[0];
+    assert_eq!(
+        &source[diagnostic.start as usize..diagnostic.end as usize],
+        "confirmDeleteKey !== null"
+    );
+}
+
+#[test]
 fn invalid_v_model_optional_chain() {
     let linter = create_linter();
     let result = linter.lint_template(r#"<input v-model="foo?.bar">"#, "test.vue");
@@ -58,6 +84,7 @@ fn valid_v_model_member_targets() {
         r#"<input v-model="foo[bar]">"#,
         r#"<input v-model="foo().bar">"#,
         r#"<input v-model="(foo)">"#,
+        r#"<AppSelect v-model="(cell?.data as Permission).permission" />"#,
     ] {
         let result = linter.lint_template(source, "test.vue");
         assert_eq!(result.error_count, 0, "{source}");


### PR DESCRIPTION
## Summary
- report invalid `v-model` expression diagnostics at the expression range used by the eslint-plugin-vue baseline
- align optional-chain detection with upstream member-expression checks so TS-asserted member targets stay valid

## Tests
- `cargo fmt --check`
- `cargo test -p vize_patina valid_v_model -- --nocapture`
- `cargo build -p vize`
- `target/debug/vize lint` spot checks for dbx, element, and alexandrie valid-v-model cases
- `rust-script tools/commands/fixtures/lint-divergence-report.rs --project dbx,element,alexandrie --output-dir target/patina-valid-v-model-lint-divergence --budget-mode record-only --vize-bin target/debug/vize --preset ecosystem --timeout-ms 600000`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`
- `git diff --check`
- diff scope check: no `attribute_order`, `no_unused_components`, or `no_mutating_props` paths