### PR TITLE
test(lsp): add naive-ui authored oracle

### DIFF
--- a/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
+++ b/legacy-tools/fixtures/fixture-compatibility-ledger.mjs
@@ -320,7 +320,7 @@ function validateRatchets(oracles, fixtureMap, context) {
   for (const kind of ["compiler", "formatter-idempotency", "linter", "typechecker"]) {
     equal(oracles.get(kind).size, 142, `${kind} oracle count drifted`);
   }
-  equal(oracles.get("authored-lsp").size, 30, "authored LSP oracle count drifted");
+  equal(oracles.get("authored-lsp").size, 31, "authored LSP oracle count drifted");
   equal(oracles.get("vue-tsc-parity").size, 11, "vue-tsc parity count drifted");
   deepEqual(
     [...oracles.get("authored-lsp")].sort(compareCodepoints),

--- a/tests/_fixtures/fixture-compatibility-ledger.json
+++ b/tests/_fixtures/fixture-compatibility-ledger.json
@@ -771,6 +771,7 @@
           "tests/_fixtures/_git/hoppscotch",
           "tests/_fixtures/_git/inspira-ui",
           "tests/_fixtures/_git/reka-ui",
+          "tests/_fixtures/_git/naive-ui",
           "tests/_fixtures/_git/elk",
           "tests/_fixtures/_git/misskey",
           "tests/_fixtures/_git/motion-vue",

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -2,7 +2,7 @@
   "schemaVersion": 8,
   "requiredToolCoverage": ["compiler", "linter", "typechecker", "formatter", "syntax-highlighter", "lsp"],
   "lspAuthoredOracleGate": {
-    "minimumProjectCount": 30,
+    "minimumProjectCount": 31,
     "trackingIssue": 3952
   },
   "projects": [
@@ -682,7 +682,73 @@
         "syntax-highlighter",
         "lsp"
       ],
-      "diff": "curator-compare"
+      "diff": "curator-compare",
+      "lspAuthoredOracle": {
+        "templateBinding": {
+          "file": "src/switch/demos/enUS/event.demo.vue",
+          "symbol": "active",
+          "usageAnchor": "v-model:value=\"active\"",
+          "declarationAnchor": "const active = ref(false)",
+          "hoverContains": ["const active: boolean"],
+          "renameTo": "__vizeRenamedActive"
+        },
+        "componentBoundary": {
+          "importerFile": "demo/utils/ComponentDemo.vue",
+          "componentFile": "demo/utils/CopyCodeButton.vue",
+          "tagName": "CopyCodeButton",
+          "tagAnchor": "<CopyCodeButton\n            ",
+          "completionItemCount": 33,
+          "completionItems": [
+            { "label": "v-if", "rank": 0 },
+            { "label": "v-else-if", "rank": 1 },
+            { "label": "v-else", "rank": 2 },
+            { "label": "v-for", "rank": 3 },
+            { "label": "v-on", "rank": 4 },
+            { "label": "v-bind", "rank": 5 },
+            { "label": "v-model", "rank": 6 },
+            { "label": "v-slot", "rank": 7 },
+            { "label": "v-show", "rank": 8 },
+            { "label": "v-pre", "rank": 9 },
+            { "label": "v-once", "rank": 10 },
+            { "label": "v-memo", "rank": 11 },
+            { "label": "v-cloak", "rank": 12 },
+            { "label": "v-text", "rank": 13 },
+            { "label": "v-html", "rank": 14 },
+            { "label": "@", "rank": 15 },
+            { "label": ":", "rank": 16 },
+            { "label": "#", "rank": 17 },
+            { "label": "@click", "rank": 18 },
+            { "label": "@input", "rank": 19 },
+            { "label": "@change", "rank": 20 },
+            { "label": "@submit", "rank": 21 },
+            { "label": "@keydown", "rank": 22 },
+            { "label": "@keyup", "rank": 23 },
+            { "label": "@focus", "rank": 24 },
+            { "label": "@blur", "rank": 25 },
+            { "label": "@mouseenter", "rank": 26 },
+            { "label": "@mouseleave", "rank": 27 },
+            { "label": "text", "rank": 28 },
+            { "label": "code", "rank": 29 },
+            { "label": "size", "rank": 30 },
+            { "label": "success-text", "rank": 31 },
+            { "label": "depth", "rank": 32 }
+          ],
+          "dependencyEdit": {
+            "anchor": "    depth: String\n",
+            "replacement": "    depth: String,\n    vizeOracleProbe: Boolean\n",
+            "completionLabel": "vize-oracle-probe"
+          }
+        },
+        "fileLifecycle": {
+          "copiedFile": "demo/utils/__VizeOracleCopyCodeButton.vue",
+          "renamedFile": "demo/utils/__VizeOracleRenamedCopyCodeButton.vue",
+          "originalImportSpecifier": "./CopyCodeButton.vue",
+          "copiedImportSpecifier": "./__VizeOracleCopyCodeButton.vue",
+          "renamedImportSpecifier": "./__VizeOracleRenamedCopyCodeButton.vue",
+          "markerInsertionAnchor": "import { defineComponent } from 'vue'\n\n",
+          "markerSymbol": "__vizeNaiveUiCopyCodeButtonMarker__"
+        }
+      }
     },
     {
       "id": "voicevox",

--- a/tests/tooling/fixture-compatibility-ledger.test.ts
+++ b/tests/tooling/fixture-compatibility-ledger.test.ts
@@ -63,7 +63,7 @@ test("report keeps present, exercised, and runtime evidence separate", () => {
       linter: 142,
       typechecker: 142,
       "production-build": 4,
-      "authored-lsp": 30,
+      "authored-lsp": 31,
       "vue-tsc-parity": 11,
       ssr: 3,
       hydration: 4,


### PR DESCRIPTION
## Summary
- add a Naive UI authored LSP oracle covering template binding hover, definition, references, and rename
- pin the ComponentDemo to CopyCodeButton component boundary completion order and file lifecycle behavior
- raise the authored LSP oracle ratchet to 31 projects

## Validation
- git submodule update --init --depth 1 -- tests/_fixtures/_git/naive-ui
- vp install --frozen-lockfile --prefer-offline
- cargo build --profile ci -p vize
- node --test tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/typed-dx-roadmap.test.ts tests/tooling/lsp-vue-language-tools-scorecard.test.ts
- node --test --test-concurrency=1 tests/tooling/real-project-lsp.test.ts with only naive-ui hydrated locally
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791277688&installation_model_id=422833&pr_number=5813&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5813&signature=818069fe7750fc199e6b59f3d691bf82896b85ccfec229a44474b04cf9fdd89f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded validation coverage for the Vue ecosystem, including template bindings, component boundaries, and file lifecycle scenarios.
  - Increased the minimum project coverage threshold to maintain broader compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->