### PR TITLE
test(lsp): add signature help scorecard oracle

### DIFF
--- a/tests/_fixtures/maestro-vue-language-tools-scorecard.json
+++ b/tests/_fixtures/maestro-vue-language-tools-scorecard.json
@@ -109,6 +109,41 @@
       ]
     },
     {
+      "dimension": "signature-help",
+      "lspMethods": ["textDocument/signatureHelp"],
+      "mustInclude": [
+        {
+          "id": "template-call-signature",
+          "summary": "Template interpolation calls return TypeScript signature help on authored Vue positions.",
+          "evidence": [
+            {
+              "file": "tests/tooling/lsp-signature-help-capability.test.ts",
+              "contains": [
+                "vize lsp maps textDocument/signatureHelp from authored SFC template calls",
+                "signature help should answer the authored template call",
+                "precision: number"
+              ]
+            }
+          ]
+        }
+      ],
+      "mustExclude": [
+        {
+          "id": "non-call-position",
+          "summary": "Authored positions outside callable expressions return null instead of stale signature help.",
+          "evidence": [
+            {
+              "file": "tests/tooling/lsp-signature-help-capability.test.ts",
+              "contains": [
+                "nonCallHelp",
+                "signature help must not answer outside a callable authored expression"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
       "dimension": "hover",
       "lspMethods": ["textDocument/hover"],
       "mustInclude": [

--- a/tests/tooling/lsp-signature-help-capability.test.ts
+++ b/tests/tooling/lsp-signature-help-capability.test.ts
@@ -4,9 +4,13 @@ import path from "node:path";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
 import { isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
-import { testOutputRoot } from "./support/lsp/paths.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
 import type { ServerCapabilities } from "./support/lsp/protocol.ts";
 import { LspSession } from "./support/lsp/session.ts";
+import {
+  requireTypecheckDependency,
+  resolveTypecheckRuntime,
+} from "./support/typecheck-dependency.ts";
 
 const source = `<script setup lang="ts">
 function format(value: string, precision: number): string {
@@ -27,10 +31,36 @@ type SignatureHelp = {
   }>;
 };
 
-test("vize lsp maps textDocument/signatureHelp from authored SFC template calls", async () => {
+test("vize lsp maps textDocument/signatureHelp from authored SFC template calls", async (t) => {
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTypecheckRuntime(root),
+    "TypeScript 7/Corsa runtime for authored LSP signature help",
+    "TypeScript 7/Corsa runtime not found; skipping LSP signature-help test",
+  );
+  if (corsaPath == null) return;
+
   const testRootDir = path.join(testOutputRoot, "lsp-signature-help-capability");
   fs.mkdirSync(testRootDir, { recursive: true });
   const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  fs.writeFileSync(
+    path.join(workspaceDir, "vize.config.json"),
+    JSON.stringify(
+      {
+        lsp: {
+          lint: false,
+          signatureHelp: true,
+          typecheck: true,
+        },
+        typeChecker: {
+          corsaPath,
+        },
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
   fs.writeFileSync(
     path.join(workspaceDir, "tsconfig.json"),
     JSON.stringify(
@@ -56,6 +86,7 @@ test("vize lsp maps textDocument/signatureHelp from authored SFC template calls"
     const init = (await session.initialize(workspaceDir, {
       editor: true,
       lint: false,
+      signatureHelp: true,
       typecheck: true,
     })) as { capabilities?: ServerCapabilities };
     assert.deepEqual(init.capabilities?.signatureHelpProvider, {
@@ -90,6 +121,17 @@ test("vize lsp maps textDocument/signatureHelp from authored SFC template calls"
     assert.match(help.signatures[0].label ?? "", /value: string/);
     assert.match(help.signatures[0].label ?? "", /precision: number/);
     assert.equal(help.signatures[0].parameters?.length, 2, JSON.stringify(help));
+
+    const nonCallHelp = await session.request("textDocument/signatureHelp", {
+      textDocument: { uri },
+      position: offsetToPosition(source, source.indexOf("function format") + "function ".length),
+      context: { triggerKind: 1, isRetrigger: false },
+    });
+    assert.equal(
+      nonCallHelp,
+      null,
+      "signature help must not answer outside a callable authored expression",
+    );
   } finally {
     await session.shutdown();
     fs.rmSync(workspaceDir, { recursive: true, force: true });

--- a/tests/tooling/lsp-vue-language-tools-scorecard.test.ts
+++ b/tests/tooling/lsp-vue-language-tools-scorecard.test.ts
@@ -111,6 +111,7 @@ test("Maestro scorecard fixture covers every Vue Language Server parity dimensio
   const requiredDimensions = [
     "diagnostics",
     "completion",
+    "signature-help",
     "hover",
     "definition",
     "references",


### PR DESCRIPTION
## Summary
- harden the signature help LSP capability test with explicit Corsa runtime discovery and config
- assert the authored template call response shape and the null response outside callable authored expressions
- register signature-help as a Vue Language Server scorecard dimension

## Validation
- node --test tests/tooling/lsp-signature-help-capability.test.ts tests/tooling/lsp-vue-language-tools-scorecard.test.ts tests/tooling/lsp-vue-language-tools-oracles.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791280072&installation_model_id=422833&pr_number=5814&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5814&signature=bfd269316f86c0d8f85db335a1125adaf1fde3902bd4eab14dcc589bcc962534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->