### PR TITLE
fix(tools): pair prefixed lint location anchors

### DIFF
--- a/tests/tooling/lint-divergence-report-runner.test.ts
+++ b/tests/tooling/lint-divergence-report-runner.test.ts
@@ -183,3 +183,96 @@ test("the Rust runner pairs prefixed unused-component location divergences", () 
     fs.rmSync(outputDir, { recursive: true, force: true });
   }
 });
+
+test("the Rust runner keeps embedded brackets in unused-component messages", () => {
+  fs.mkdirSync(path.join(repoRoot, "target"), { recursive: true });
+  const fixtureDir = fs.mkdtempSync(path.join(repoRoot, "target", "lint-unused-bracket-fixture-"));
+  const outputDir = fs.mkdtempSync(path.join(repoRoot, "target", "lint-unused-bracket-report-"));
+  try {
+    fs.writeFileSync(
+      path.join(fixtureDir, "App.vue"),
+      [
+        "<template>",
+        "  <main />",
+        "</template>",
+        "<script>",
+        "import UploaderFile from './UploaderFile.vue';",
+        "export default {",
+        "  components: {",
+        "    UploaderFile,",
+        "  },",
+        "};",
+        "</script>",
+        "",
+      ].join("\n"),
+    );
+    const fakeVize = path.join(fixtureDir, "fake-vize.mjs");
+    fs.writeFileSync(
+      fakeVize,
+      [
+        "#!/usr/bin/env node",
+        "if (process.argv[2] !== 'lint') process.exit(2);",
+        "process.stdout.write(JSON.stringify([{",
+        '  file: "App.vue",',
+        "  messages: [",
+        "    {",
+        '      ruleId: "vue/no-unused-components",',
+        '      severity: "warning",',
+        "      line: 1, column: 11, endLine: 2, endColumn: 12,",
+        "      message: \"debug ] Component 'UploaderFile' is registered but never used in template\",",
+        "    },",
+        "  ],",
+        "}]));",
+        "",
+      ].join("\n"),
+    );
+    fs.chmodSync(fakeVize, 0o755);
+    const registryPath = path.join(fixtureDir, "registry.json");
+    fs.writeFileSync(
+      registryPath,
+      JSON.stringify({
+        projects: [
+          {
+            id: "lint-unused-bracket-fixture",
+            revision: "0".repeat(40),
+            fixturePath: path.relative(repoRoot, fixtureDir),
+            vueGlobs: ["App.vue"],
+            coverage: ["linter"],
+          },
+        ],
+      }),
+    );
+
+    const result = spawnSync(
+      "rust-script",
+      [
+        "tools/commands/fixtures/lint-divergence-report.rs",
+        "--registry",
+        registryPath,
+        "--output-dir",
+        outputDir,
+        "--vize-bin",
+        fakeVize,
+        "--budget-mode",
+        "record-only",
+        "--timeout-ms",
+        "30000",
+      ],
+      { cwd: repoRoot, encoding: "utf8", env: { ...process.env, LANG: "C", LC_ALL: "C" } },
+    );
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    const artifact = JSON.parse(
+      fs.readFileSync(
+        path.join(outputDir, "lint-unused-bracket-fixture-lint-divergence.json"),
+        "utf8",
+      ),
+    );
+    assert.equal(artifact.divergence.summary.falsePositiveCount, 1);
+    assert.equal(artifact.divergence.summary.falseNegativeCount, 1);
+    assert.equal(artifact.divergence.summary.ruleLocationDivergenceCount, 0);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});

--- a/tests/tooling/lint-divergence-report-runner.test.ts
+++ b/tests/tooling/lint-divergence-report-runner.test.ts
@@ -78,3 +78,108 @@ test("the Rust runner counts the same ignore-filtered files as vize lint", () =>
     fs.rmSync(outputDir, { recursive: true, force: true });
   }
 });
+
+test("the Rust runner pairs prefixed unused-component location divergences", () => {
+  fs.mkdirSync(path.join(repoRoot, "target"), { recursive: true });
+  const fixtureDir = fs.mkdtempSync(path.join(repoRoot, "target", "lint-unused-fixture-"));
+  const outputDir = fs.mkdtempSync(path.join(repoRoot, "target", "lint-unused-report-"));
+  try {
+    fs.writeFileSync(
+      path.join(fixtureDir, "App.vue"),
+      [
+        "<template>",
+        "  <main />",
+        "</template>",
+        "<script>",
+        "import UploaderFile from './UploaderFile.vue';",
+        "import UploaderFiles from './UploaderFiles.vue';",
+        "export default {",
+        "  components: {",
+        "    UploaderFile,",
+        "    UploaderFiles,",
+        "  },",
+        "};",
+        "</script>",
+        "",
+      ].join("\n"),
+    );
+    const fakeVize = path.join(fixtureDir, "fake-vize.mjs");
+    fs.writeFileSync(
+      fakeVize,
+      [
+        "#!/usr/bin/env node",
+        "if (process.argv[2] !== 'lint') process.exit(2);",
+        "process.stdout.write(JSON.stringify([{",
+        '  file: "App.vue",',
+        "  messages: [",
+        "    {",
+        '      ruleId: "vue/no-unused-components",',
+        '      severity: "warning",',
+        "      line: 1, column: 11, endLine: 2, endColumn: 12,",
+        "      message: \"[vize:vue/no-unused-components] Component 'UploaderFile' is registered but never used in template\",",
+        "    },",
+        "    {",
+        '      ruleId: "vue/no-unused-components",',
+        '      severity: "warning",',
+        "      line: 1, column: 11, endLine: 2, endColumn: 12,",
+        "      message: \"[vize:vue/no-unused-components] Component 'UploaderFiles' is registered but never used in template\",",
+        "    },",
+        "  ],",
+        "}]));",
+        "",
+      ].join("\n"),
+    );
+    fs.chmodSync(fakeVize, 0o755);
+    const registryPath = path.join(fixtureDir, "registry.json");
+    fs.writeFileSync(
+      registryPath,
+      JSON.stringify({
+        projects: [
+          {
+            id: "lint-unused-fixture",
+            revision: "0".repeat(40),
+            fixturePath: path.relative(repoRoot, fixtureDir),
+            vueGlobs: ["App.vue"],
+            coverage: ["linter"],
+          },
+        ],
+      }),
+    );
+
+    const result = spawnSync(
+      "rust-script",
+      [
+        "tools/commands/fixtures/lint-divergence-report.rs",
+        "--registry",
+        registryPath,
+        "--output-dir",
+        outputDir,
+        "--vize-bin",
+        fakeVize,
+        "--budget-mode",
+        "enforce",
+        "--timeout-ms",
+        "30000",
+      ],
+      { cwd: repoRoot, encoding: "utf8", env: { ...process.env, LANG: "C", LC_ALL: "C" } },
+    );
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    const artifact = JSON.parse(
+      fs.readFileSync(path.join(outputDir, "lint-unused-fixture-lint-divergence.json"), "utf8"),
+    );
+    assert.equal(artifact.divergence.summary.falsePositiveCount, 0);
+    assert.equal(artifact.divergence.summary.falseNegativeCount, 0);
+    assert.equal(artifact.divergence.summary.ruleLocationDivergenceCount, 2);
+    assert.deepEqual(
+      artifact.divergence.ruleLocationDivergences.map(
+        (entry: { subject: string }) => entry.subject,
+      ),
+      ["component:UploaderFile", "component:UploaderFiles"],
+    );
+    assert.equal(artifact.budget.passed, true);
+  } finally {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+});

--- a/tools/commands/fixtures/lint-divergence-report.rs
+++ b/tools/commands/fixtures/lint-divergence-report.rs
@@ -1680,8 +1680,9 @@ fn contains_span(outer: &LintRecord, inner: &LintRecord) -> bool {
 
 fn unused_component_name(message: &str) -> Option<String> {
     let message = message
-        .split_once("] ")
-        .map_or(message, |(_, stripped)| stripped);
+        .strip_prefix("[")
+        .and_then(|rest| rest.split_once("] ").map(|(_, stripped)| stripped))
+        .unwrap_or(message);
     let prefix = "Component '";
     if let Some(rest) = message.strip_prefix(prefix) {
         if let Some((name, _)) = rest.split_once("' is registered but never used") {

--- a/tools/commands/fixtures/lint-divergence-report.rs
+++ b/tools/commands/fixtures/lint-divergence-report.rs
@@ -1679,6 +1679,9 @@ fn contains_span(outer: &LintRecord, inner: &LintRecord) -> bool {
 }
 
 fn unused_component_name(message: &str) -> Option<String> {
+    let message = message
+        .split_once("] ")
+        .map_or(message, |(_, stripped)| stripped);
     let prefix = "Component '";
     if let Some(rest) = message.strip_prefix(prefix) {
         if let Some((name, _)) = rest.split_once("' is registered but never used") {


### PR DESCRIPTION
## Summary
- pair Patina-prefixed no-unused-components messages with eslint-plugin-vue anchors in the Rust lint divergence runner
- add a runner regression that exercises the prefixed message shape against a real eslint baseline

## Validation
- vp install --frozen-lockfile --prefer-offline
- node --test tests/tooling/lint-divergence-report-runner.test.ts tests/tooling/lint-divergence-rule-location.test.ts tests/tooling/lint-divergence-budget.test.ts
- rustfmt --check tools/commands/fixtures/lint-divergence-report.rs
- vp exec oxfmt --check tests/tooling/lint-divergence-report-runner.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791280525&installation_model_id=422833&pr_number=5815&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5815&signature=bfacb15b70e28412b702f7c37fbf20c1ec9c2009d681568804489b9235a0fef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved lint divergence reporting for unused-component warnings with bracketed rule prefixes or embedded brackets.
  - Component names are now correctly associated with their reported warning locations.
  - Budget enforcement and record-only reporting now produce more accurate divergence results.

- **Tests**
  - Added coverage for prefixed and bracket-containing warning messages.
  - Added validation for divergence counts, component matching, and successful budget enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->