### PR TITLE
test(fixtures): retire stale reka-ui typecheck rows

### DIFF
--- a/tests/_fixtures/compat-documented-differences.json
+++ b/tests/_fixtures/compat-documented-differences.json
@@ -259,34 +259,6 @@
     },
     {
       "project": "reka-ui",
-      "file": "packages/core/src/Select/story/_Select.vue",
-      "severity": "error",
-      "line": 34,
-      "column": 5,
-      "vize": {
-        "code": 2353,
-        "message": "Object literal may only specify known properties, and '\"ariaLabel\"' does not exist in type 'Partial<Props<string>> & { autocomplete?: unknown; by?: unknown; defaultOpen?: unknown; defaultValue?: unknown; dir?: unknown; disabled?: unknown; modelValue?: unknown; multiple?: unknown; name?: unknown; nullableValue?: unknown; open?: unknown; required?: unknown; } & VNodeProps & AllowedComponentProps & ComponentC...'."
-      },
-      "baseline": null,
-      "issue": 5722,
-      "reason": "Vize preserves this stricter real-project diagnostic while vue-tsc accepts the same source; the exact row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
-      "file": "packages/core/src/Select/story/_SelectTest.vue",
-      "severity": "error",
-      "line": 33,
-      "column": 7,
-      "vize": {
-        "code": 2353,
-        "message": "Object literal may only specify known properties, and '\"ariaLabel\"' does not exist in type 'Partial<Props<string | number | bigint | Record<string, any> | null>> & { autocomplete?: unknown; by?: unknown; defaultOpen?: unknown; defaultValue?: unknown; dir?: unknown; disabled?: unknown; modelValue?: unknown; multiple?: unknown; name?: unknown; nullableValue?: unknown; open?: unknown; required?: unknown; } & ...'."
-      },
-      "baseline": null,
-      "issue": 5722,
-      "reason": "Vize preserves this stricter real-project diagnostic while vue-tsc accepts the same source; the exact row is tracked for follow-up under issue 5722."
-    },
-    {
-      "project": "reka-ui",
       "file": "packages/core/src/Splitter/story/SplitterAction.story.vue",
       "severity": "error",
       "line": 18,


### PR DESCRIPTION
## Summary
- remove the two stale Reka UI Select story typecheck differences that no longer reproduce
- keep the rest of the issue #5722 Reka UI documented differences intact
- restore the shard 4 typecheck-divergence report path so Reka UI emits its divergence artifact

## Validation
- cargo build --profile ci -p vize
- cargo test --profile ci -p vize_canon issue_4966_strict_surface_accepts_global_html_attrs_on_closed_components
- node --test tests/tooling/typecheck-divergence-ledger.test.ts tests/tooling/typecheck-divergence-budget.test.ts tests/tooling/typecheck-divergence-report-ledger.test.ts
- GITHUB_SHA=f303c514db2691e9cfa0eb3fe920b6ae7d42c664 rust-script tools/commands/fixtures/typecheck-dependency-prepare.rs --output-dir target/typecheck-divergence-5722/reka-ui-f303-1788689983 --shard-count 144 --shard-index 4 --timeout-ms 600000
- rust-script tools/commands/fixtures/tool-matrix-report.rs --project reka-ui --tool typechecker --vize-bin target/ci/vize --timeout-ms 600000 --output-dir target/typecheck-divergence-5722/reka-ui-f303-1788689983
- GITHUB_SHA=f303c514db2691e9cfa0eb3fe920b6ae7d42c664 VIZE_TYPECHECK_DIVERGENCE_PROGRESS=1 rust-script tools/commands/fixtures/typecheck-divergence-report.rs --report-dir target/typecheck-divergence-5722/reka-ui-f303-1788689983 --vize-bin target/ci/vize --vue-tsc-bin tests/node_modules/.bin/vue-tsc --shard-count 144 --shard-index 4 --budget-mode enforce
- VIZE_TEST_BIN=target/ci/vize node --test tests/tooling/compat-ratchet.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791282201&installation_model_id=422833&pr_number=5817&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5817&signature=bf80cbf5ce424a16f8794781927ad559db9f6a3f0f331a07483cb1c0df0c3693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Removed two outdated compatibility fixture entries related to TS2353 diagnostics for the `ariaLabel` property.
  - All remaining documented compatibility differences are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->