### PR TITLE
fix(davinci): route disabled static hoists through s2

### DIFF
--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -87,8 +87,7 @@ pub(super) fn s2_emit_supported(
     matches!(
         s2_emit_selection,
         S2EmitSelection::Allowed | S2EmitSelection::RequireSections
-    ) && options.hoist_static
-        && !options.ssr
+    ) && !options.ssr
         && !options.experimental_patterned_template
         && !options.custom_renderer
         && template_syntax == TemplateSyntaxMode::Standard
@@ -118,6 +117,7 @@ pub(super) fn s2_emit_options<'a>(
         runtime_module_name: codegen.runtime_module_name.as_str(),
         runtime_global_name: codegen.runtime_global_name.as_str(),
         prefix_identifiers: options.prefix_identifiers,
+        hoist_static: options.hoist_static,
         inline: options.inline,
         component_name: options.component_name.as_deref(),
         cache_handlers: options.cache_handlers,

--- a/crates/vize_atelier_dom/tests/davinci_s2_hoist_static_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_hoist_static_selector.rs
@@ -1,0 +1,138 @@
+//! S2 production selector coverage for disabled static hoists.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use vize_atelier_core::options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode};
+use vize_atelier_dom::{
+    DomCompilerOptions,
+    compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+    compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+};
+use vize_s0::Allocator;
+use vize_s0::profiler::{CounterSummary, global_profiler};
+
+#[test]
+fn disabled_static_hoists_use_s2_codegen() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+
+    for (label, source) in [
+        (
+            "static_tree",
+            r#"<section><span class="badge">ok</span><strong>{{ label }}</strong></section>"#,
+        ),
+        (
+            "component_slot",
+            r#"<Card><span class="badge">ok</span></Card>"#,
+        ),
+        (
+            "slot_fallback",
+            r#"<slot><span class="badge">ok</span></slot>"#,
+        ),
+        (
+            "template_if",
+            r#"<template v-if="ok"><span class="badge">ok</span></template>"#,
+        ),
+        (
+            "v_once_nested",
+            r#"<Card v-once><span class="badge">ok</span></Card>"#,
+        ),
+    ] {
+        profiler.disable();
+        profiler.clear();
+
+        let options = DomCompilerOptions {
+            hoist_static: false,
+            ..Default::default()
+        };
+        let compat = compile_compat(source, options.clone());
+
+        profiler.enable();
+        let selected = compile(source, options);
+        let counters = profiler.counter_summary();
+        profiler.disable();
+        profiler.clear();
+
+        assert_eq!(selected.preamble, compat.preamble, "{label} preamble");
+        assert_eq!(selected.code, compat.code, "{label} code");
+        assert_eq!(selected.sections, compat.sections, "{label} sections");
+        assert_eq!(
+            selected.preamble.matches("_hoisted_").count(),
+            0,
+            "{label}: disabled static hoists must not synthesize hoist declarations"
+        );
+        assert_eq!(
+            counter_total(&counters, "davinci.s2_dom.files"),
+            Some(1),
+            "{label}: disabled static hoists are a supported S2 production option"
+        );
+    }
+}
+
+struct Compiled {
+    preamble: String,
+    code: String,
+    sections: Option<vize_atelier_core::CodegenSections>,
+}
+
+fn compile(source: &str, options: DomCompilerOptions) -> Compiled {
+    let allocator = Allocator::new();
+    let (_, errors, result) =
+        compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+            None,
+            CodegenOptions::default(),
+        );
+    assert!(errors.is_empty(), "compile errors: {errors:?}");
+    Compiled {
+        preamble: result.result.preamble.to_string(),
+        code: result.result.code.to_string(),
+        sections: result.sections,
+    }
+}
+
+fn compile_compat(source: &str, options: DomCompilerOptions) -> Compiled {
+    let allocator = Allocator::new();
+    let (_, errors, result) =
+        compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+            None,
+            CustomElementMatcher::from_static_predicate(is_never_custom_element),
+            CodegenOptions::default(),
+        );
+    assert!(errors.is_empty(), "compat compile errors: {errors:?}");
+    Compiled {
+        preamble: result.result.preamble.to_string(),
+        code: result.result.code.to_string(),
+        sections: result.sections,
+    }
+}
+
+fn is_never_custom_element(_tag: &str) -> bool {
+    false
+}
+
+fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
+    counters
+        .entries
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.total)
+}
+
+fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
+    static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    PROFILER_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}

--- a/crates/vize_atelier_dom/tests/davinci_s2_option_matrix.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_option_matrix.rs
@@ -210,6 +210,23 @@ fn cached_handlers_and_scope_id_agree_with_the_shipped_lane() {
     );
 }
 
+#[test]
+fn disabled_static_hoists_agree_with_the_shipped_lane() {
+    let battery = production_option_battery();
+    support::assert_s2_matches_shipped_with_options(
+        &battery,
+        &DomCompilerOptions {
+            hoist_static: false,
+            ..Default::default()
+        },
+        &CodegenOptions::default(),
+        &DomEmitOptions {
+            hoist_static: false,
+            ..DomEmitOptions::DEFAULT
+        },
+    );
+}
+
 /// The configuration a real `<script setup>` SFC with `<style scoped>`
 /// compiles under: module mode, prefixed identifiers, binding metadata,
 /// cached handlers and a scope id, all at once.

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -196,6 +196,9 @@ struct EmitCx<'facts> {
     /// `prefix_identifiers`: expressions go through [`prefix`] on their
     /// way out instead of being pushed verbatim.
     prefix_identifiers: bool,
+    /// `hoist_static`: static props and static VNode declarations are emitted
+    /// only when the public transform option enabled them.
+    hoist_static: bool,
     /// The shipped lane's `is_ts`: expressions are type-erased first.
     is_ts: bool,
     /// The shipped lane's `cache_handlers`.

--- a/crates/vize_s1_to_s2/src/emit/component.rs
+++ b/crates/vize_s1_to_s2/src/emit/component.rs
@@ -88,7 +88,7 @@ pub(super) fn emit_call(
     let hoist_attrs = rendered_hoist_attrs(component, skip_is);
     let static_nested = builtin::has_static_nested(&component.children);
     let builtin_helper = builtin::helper(component.name).is_some();
-    let hoistable_static_props = if cx.hoisted_scope_id.is_some() {
+    let hoistable_static_props = if !cx.hoist_static || cx.hoisted_scope_id.is_some() {
         None
     } else {
         call_props::hoistable_static_props(component, skip_is, &hoist_attrs, cx.is_ts, cx.scope_id)?

--- a/crates/vize_s1_to_s2/src/emit/cx.rs
+++ b/crates/vize_s1_to_s2/src/emit/cx.rs
@@ -57,7 +57,7 @@ impl EmitCx<'_> {
         write: impl FnOnce(&mut Self) -> Result<T, EmitError>,
     ) -> Result<T, EmitError> {
         let previous = self.hoist_static_vnodes;
-        self.hoist_static_vnodes = previous || enabled;
+        self.hoist_static_vnodes = self.hoist_static && (previous || enabled);
         let result = write(self);
         self.hoist_static_vnodes = previous;
         result
@@ -69,7 +69,7 @@ impl EmitCx<'_> {
         write: impl FnOnce(&mut Self) -> Result<T, EmitError>,
     ) -> Result<T, EmitError> {
         let previous = self.hoist_static_vnodes;
-        self.hoist_static_vnodes = enabled;
+        self.hoist_static_vnodes = self.hoist_static && enabled;
         let result = write(self);
         self.hoist_static_vnodes = previous;
         result

--- a/crates/vize_s1_to_s2/src/emit/once.rs
+++ b/crates/vize_s1_to_s2/src/emit/once.rs
@@ -81,7 +81,9 @@ fn emit_component_target(
 fn skip_or_hoist_component_children(cx: &mut EmitCx<'_>, component: &ComponentOp<'_>) {
     for op in component.children.ops.iter() {
         match op {
-            Op::Element(element) if super::hoist::is_hoistable(element, cx.is_ts) => {
+            Op::Element(element)
+                if cx.hoist_static && super::hoist::is_hoistable(element, cx.is_ts) =>
+            {
                 let _id = cx.walk.mint();
                 cx.walk.skip(element.bindings.len());
                 let _alias = super::hoist::hoist_static_element(cx, element);
@@ -99,7 +101,9 @@ fn skip_or_hoist_component_children(cx: &mut EmitCx<'_>, component: &ComponentOp
 fn skip_or_hoist_once_element_children(cx: &mut EmitCx<'_>, element: &ElementOp<'_>) {
     for op in element.children.ops.iter() {
         match op {
-            Op::Element(child) if super::hoist::is_hoistable(child, cx.is_ts) => {
+            Op::Element(child)
+                if cx.hoist_static && super::hoist::is_hoistable(child, cx.is_ts) =>
+            {
                 let _id = cx.walk.mint();
                 cx.walk.skip(child.bindings.len());
                 let _alias = super::hoist::hoist_static_element(cx, child);
@@ -153,7 +157,7 @@ pub(super) fn emit_hoisted_child(
     cx: &mut EmitCx<'_>,
     element: &ElementOp<'_>,
 ) -> Result<bool, EmitError> {
-    if cx.once_depth == 0 || !is_hoistable(element, cx.is_ts) {
+    if cx.once_depth == 0 || !cx.hoist_static || !is_hoistable(element, cx.is_ts) {
         return Ok(false);
     }
     let alias = super::hoist::hoist_static_element(cx, element);

--- a/crates/vize_s1_to_s2/src/emit/options.rs
+++ b/crates/vize_s1_to_s2/src/emit/options.rs
@@ -197,22 +197,18 @@ pub struct DomEmitOptions<'a> {
     pub runtime_module_name: &'a str,
     /// Global read in [`DomEmitMode::Function`] (`"Vue"` by default).
     pub runtime_global_name: &'a str,
-    /// The shipped lane's `prefix_identifiers`: free identifiers become
-    /// member accesses (`emit::prefix`).
+    /// Free identifiers become member accesses (`emit::prefix`) when enabled.
     pub prefix_identifiers: bool,
-    /// The shipped lane's `inline`: the render function is inlined into
-    /// `setup()`, so setup bindings are read straight from the closure —
-    /// refs through `.value`, `let`/maybe-ref bindings through `_unref`,
-    /// props through `__props.` — instead of the `$setup` proxy.
+    /// Static props and static VNode declarations are emitted only when enabled.
+    pub hoist_static: bool,
+    /// Inline render functions read setup bindings from closure locals instead
+    /// of the `$setup` proxy.
     pub inline: bool,
     /// The shipped lane's `component_name`: the SFC's own name (its file
     /// stem). A component tag that resolves to it is a self-reference, and
     /// the shipped lane asks the runtime to resolve it as one.
     pub component_name: Option<&'a str>,
-    /// The shipped lane's `cache_handlers`: an inline `v-on` handler is
-    /// hoisted into the render function's `_cache` array, so the closure
-    /// is created once instead of on every render. Turned on with
-    /// [`DomEmitOptions::inline`] by `compile_template_block`.
+    /// Cache inline `v-on` handlers in `_cache` when safe for scopes.
     pub cache_handlers: bool,
     /// SFC scoped-style attr for module-level static VNode hoists.
     pub hoisted_scope_id: Option<&'a str>,
@@ -244,6 +240,7 @@ impl DomEmitOptions<'static> {
         runtime_module_name: "vue",
         runtime_global_name: "Vue",
         prefix_identifiers: false,
+        hoist_static: true,
         inline: false,
         component_name: None,
         cache_handlers: false,
@@ -276,6 +273,7 @@ mod tests {
                 runtime_module_name: "vue",
                 runtime_global_name: "Vue",
                 prefix_identifiers: false,
+                hoist_static: true,
                 inline: false,
                 component_name: None,
                 cache_handlers: false,

--- a/crates/vize_s1_to_s2/src/emit/outlet.rs
+++ b/crates/vize_s1_to_s2/src/emit/outlet.rs
@@ -179,7 +179,7 @@ fn emit_fallback_units(
         }
         Op::Interpolation(interp) => emit_fallback_interp(cx, interp, compact, first),
         Op::Comment(comment) => emit_fallback_comment(cx, comment, compact, first),
-        Op::Element(element) if is_hoistable(element, cx.is_ts) => {
+        Op::Element(element) if cx.hoist_static && is_hoistable(element, cx.is_ts) => {
             start_fallback_item(cx, compact, first);
             emit_hoisted_element(cx, element)
         }

--- a/crates/vize_s1_to_s2/src/emit/props_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/props_static.rs
@@ -34,6 +34,9 @@ pub(super) fn should_hoist(
     id: Option<NodeId>,
     position: PropHoistPosition,
 ) -> bool {
+    if !cx.hoist_static {
+        return false;
+    }
     let Some(fact) = id.and_then(|id| cx.facts.static_facts.get(id)) else {
         return false;
     };
@@ -76,13 +79,17 @@ pub(super) fn inline_root_hoist(
     id: Option<NodeId>,
     position: PropHoistPosition,
 ) -> bool {
-    matches!(position, PropHoistPosition::Root)
+    cx.hoist_static
+        && matches!(position, PropHoistPosition::Root)
         && id
             .and_then(|id| cx.facts.static_facts.get(id))
             .is_some_and(|fact| fact.props_hoistable && inline_root_arm(cx, fact))
 }
 
 pub(super) fn props_hoistable(cx: &EmitCx<'_>, id: Option<NodeId>) -> bool {
+    if !cx.hoist_static {
+        return false;
+    }
     id.and_then(|id| cx.facts.static_facts.get(id))
         .is_some_and(|fact| fact.props_hoistable)
 }

--- a/crates/vize_s1_to_s2/src/emit/run.rs
+++ b/crates/vize_s1_to_s2/src/emit/run.rs
@@ -53,9 +53,10 @@ pub(super) fn emit_dom_with_emit_budget<'f>(
     {
         return Err(EmitError::Diagnostics);
     }
-    // `static_cache = inline || !hoists.is_empty()`.
-    let static_cache =
-        options.inline || static_cache::enabled(&lowered.root, facts, &lowered.wrappers);
+    // `static_cache = inline || !hoists.is_empty()`, with `hoists` empty
+    // when `hoist_static` disables the transform's static hoist pass.
+    let static_cache = options.inline
+        || (options.hoist_static && static_cache::enabled(&lowered.root, facts, &lowered.wrappers));
     let mut cx = EmitCx {
         buf: Buf::new(options.inline),
         source: lowered.source,
@@ -83,6 +84,7 @@ pub(super) fn emit_dom_with_emit_budget<'f>(
         static_cache,
         parent_ns: Namespace::Html,
         prefix_identifiers: options.prefix_identifiers,
+        hoist_static: options.hoist_static,
         is_ts: options.is_ts,
         cache_handlers: options.cache_handlers,
         hoisted_scope_id: options.hoisted_scope_id,

--- a/crates/vize_s1_to_s2/src/emit/slots/capture.rs
+++ b/crates/vize_s1_to_s2/src/emit/slots/capture.rs
@@ -87,7 +87,7 @@ fn emit_slot_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> {
     }
     match op {
         Op::Text(_) | Op::Interpolation(_) => emit_slot_text_child(cx, op),
-        Op::Element(element) if is_static_element_tree(element, cx.is_ts) => {
+        Op::Element(element) if cx.hoist_static && is_static_element_tree(element, cx.is_ts) => {
             emit_hoisted_element(cx, element)
         }
         Op::Element(_)

--- a/crates/vize_s1_to_s2/src/emit/tpl.rs
+++ b/crates/vize_s1_to_s2/src/emit/tpl.rs
@@ -50,7 +50,7 @@ pub(super) fn emit_if_template_branch(
     branch: &IfBranch<'_>,
     key: &str,
 ) -> Result<(), EmitError> {
-    if should_unwrap_if(&branch.region.ops, cx.is_ts) {
+    if should_unwrap_if(&branch.region.ops, cx.is_ts, cx.hoist_static) {
         return unwrap_if(cx, branch, key);
     }
     emit_inner_fragment(
@@ -63,9 +63,9 @@ pub(super) fn emit_if_template_branch(
     )
 }
 
-fn should_unwrap_if(ops: &[Op<'_>], is_ts: bool) -> bool {
+fn should_unwrap_if(ops: &[Op<'_>], is_ts: bool, hoist_static: bool) -> bool {
     match ops {
-        [Op::Element(element)] => !is_hoistable(element, is_ts),
+        [Op::Element(element)] => !hoist_static || !is_hoistable(element, is_ts),
         [Op::Component(_)] | [Op::Slot(_)] | [Op::For(_)] => true,
         _ => false,
     }

--- a/crates/vize_s1_to_s2/src/emit/tpl/fragment.rs
+++ b/crates/vize_s1_to_s2/src/emit/tpl/fragment.rs
@@ -293,7 +293,7 @@ fn emit_gen_interp(
 
 fn emit_node_child(cx: &mut EmitCx<'_>, op: &Op<'_>) -> Result<(), EmitError> {
     match op {
-        Op::Element(element) if is_hoistable(element, cx.is_ts) => {
+        Op::Element(element) if cx.hoist_static && is_hoistable(element, cx.is_ts) => {
             emit_hoisted_element(cx, element)
         }
         _ => vnode::emit_array_child(cx, op, false, false),

--- a/crates/vize_s1_to_s2/src/emit/vnode/array_child.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode/array_child.rs
@@ -11,6 +11,7 @@ pub(in crate::emit) fn emit_array_child(
 ) -> Result<(), EmitError> {
     let hoist_static_children = hoist_static_children || cx.hoist_static_vnodes;
     if hoist_static_children
+        && cx.hoist_static
         && let Op::Element(element) = op
         && super::super::hoist::is_hoistable(element, cx.is_ts)
     {

--- a/crates/vize_s1_to_s2/src/emit/vnode_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_static.rs
@@ -15,6 +15,9 @@ pub(super) fn should_hoist_static_children(
     branch_root: bool,
     for_item: bool,
 ) -> bool {
+    if !cx.hoist_static {
+        return false;
+    }
     if cx.conditional_v_for_item {
         return false;
     }

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -15,6 +15,7 @@ const domStageDeps = new Set(["vize_davinci", "vize_s1_to_s2", "vize_s2"]);
 const compilerOptionsProjectedToS2 = [
   "mode",
   "prefix_identifiers",
+  "hoist_static",
   "cache_handlers",
   "scope_id",
   "comments",
@@ -27,7 +28,6 @@ const compilerOptionsProjectedToS2 = [
 ];
 const compilerOptionsHandledAroundS2 = ["source_map"];
 const compilerOptionsHeldAtDefault = [
-  "hoist_static",
   "ssr",
   "experimental_patterned_template",
   "custom_renderer",
@@ -38,6 +38,7 @@ const s2EmitOptionFields = [
   "runtime_module_name",
   "runtime_global_name",
   "prefix_identifiers",
+  "hoist_static",
   "inline",
   "component_name",
   "cache_handlers",


### PR DESCRIPTION
## Summary
- project the public hoist_static flag into the S2 DOM emitter
- gate static props and static VNode hoists when that option is disabled
- add production selector and option matrix parity witnesses for disabled static hoists

## Validation
- vp install
- cargo fmt --all --check
- cargo test -p vize_atelier_dom --test davinci_s2_option_matrix -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_production_selector -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_profile_unsupported -- --nocapture
- cargo test -p vize_s1_to_s2 --lib emit::options -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_static_hoist -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_static_vnode_hoist -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_option_audit -- --nocapture
- cargo test -p vize_atelier_dom --tests --no-run
- cargo test -p vize_s1_to_s2 --tests --no-run
- node --test tests/tooling/davinci-dom-production-boundary.test.ts
- node --test tests/tooling/davinci-phase2-ledger.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791282396&installation_model_id=422833&pr_number=5818&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5818&signature=7777d9e5820b6489a9e78c5303258158a6935499101632ef5eb2e39487f2a846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for disabling static hoisting during template compilation.
  - Static props, VNodes, elements, slots, fallbacks, and `v-once` content now respect the static-hoisting setting.
  - The setting is forwarded through the compilation pipeline for consistent behavior.

- **Bug Fixes**
  - Prevented static content from being hoisted when hoisting is disabled.
  - Preserved output compatibility with the shipped compilation path across supported template scenarios.

- **Tests**
  - Added coverage for disabled static hoisting across production options and template patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->