### PR TITLE
fix(davinci): admit bare static style merges

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_style_merge.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_style_merge.rs
@@ -16,8 +16,16 @@ const BATTERY: &[(&str, &str)] = &[
         r#"<div style="color: red" :style="s"></div>"#,
     ),
     (
+        "bare_static_then_dynamic",
+        r#"<div style :style="s"></div>"#,
+    ),
+    (
         "dynamic_then_static",
         r#"<div :style="s" style="color: red"></div>"#,
+    ),
+    (
+        "bare_dynamic_then_static",
+        r#"<div :style="s" style></div>"#,
     ),
     (
         "multiline_dynamic_then_static",

--- a/crates/vize_s1_to_s2/src/emit/props.rs
+++ b/crates/vize_s1_to_s2/src/emit/props.rs
@@ -42,17 +42,13 @@ pub(super) struct BindPropsOptions<'a> {
 }
 
 pub(super) fn admit_element_bindings(
-    attributes: &[Attribute<'_>],
+    _attributes: &[Attribute<'_>],
     bindings: &[BindingOp<'_>],
 ) -> Result<(), EmitError> {
-    admit_bindings_inner(attributes, bindings, true)
+    admit_bindings_inner(bindings, true)
 }
 
-fn admit_bindings_inner(
-    attributes: &[Attribute<'_>],
-    bindings: &[BindingOp<'_>],
-    allow_once: bool,
-) -> Result<(), EmitError> {
+fn admit_bindings_inner(bindings: &[BindingOp<'_>], allow_once: bool) -> Result<(), EmitError> {
     let mut class = false;
     let mut style = false;
     for binding in bindings.iter() {
@@ -103,16 +99,6 @@ fn admit_bindings_inner(
                 ));
             }
         }
-    }
-    if style
-        && let Some(attr) = attributes
-            .iter()
-            .find(|attr| attr.name == "style" && attr.value.is_none())
-    {
-        return Err(EmitError::unsupported_at(
-            Reason::BareStyleAttributeWithDynamicStyle,
-            attr.span,
-        ));
     }
     Ok(())
 }

--- a/crates/vize_s1_to_s2/tests/emit_static/static_props.rs
+++ b/crates/vize_s1_to_s2/tests/emit_static/static_props.rs
@@ -259,6 +259,12 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
 }
 
 #[test]
+fn bare_style_attribute_beside_dynamic_style_matches_the_shipped_lane() {
+    assert_shipped_parity(r#"<div style :style="s"></div>"#);
+    assert_shipped_parity(r#"<div :style="s" style></div>"#);
+}
+
+#[test]
 fn full_props_patch_flags_drop_class_and_style_bits() {
     assert_eq!(
         assembled(r#"<div :[foo]="bar" :class="c" :style="s"></div>"#),

--- a/crates/vize_s1_to_s2/tests/emit_unsupported_catalogue.rs
+++ b/crates/vize_s1_to_s2/tests/emit_unsupported_catalogue.rs
@@ -10,7 +10,6 @@ use vize_s1_to_s2::UnsupportedReason as Reason;
 
 const SOURCE: &[Reason] = &[
     Reason::ArrayBuiltinCannotUseSlotObject,
-    Reason::BareStyleAttributeWithDynamicStyle,
     Reason::BindNameNotJs,
     Reason::BindValueNotJs,
     Reason::CustomDirectiveExprNotJs,
@@ -71,6 +70,7 @@ const PREFIX_LANE: &[Reason] = &[
 const PORTABILITY: &[Reason] = &[Reason::TypeScriptLaneUnavailable];
 
 const RETIRED: &[Reason] = &[
+    Reason::BareStyleAttributeWithDynamicStyle,
     Reason::CreateSlotsMissingSlotTemplate,
     Reason::DynamicOnHasModifiers,
     Reason::ObjectBindHasModifiers,

--- a/crates/vize_s1_to_s2/tests/emit_unsupported_census.rs
+++ b/crates/vize_s1_to_s2/tests/emit_unsupported_census.rs
@@ -37,12 +37,6 @@ const SOURCE_CASES: &[Case] = &[
         Reason::ArrayBuiltinCannotUseSlotObject,
     ),
     case(
-        "bare_style_attr",
-        r#"<div style :style="s"></div>"#,
-        VUE3,
-        Reason::BareStyleAttributeWithDynamicStyle,
-    ),
-    case(
         "bad_bind_name",
         r#"<div :[a.]="x"></div>"#,
         VUE3,
@@ -197,7 +191,6 @@ fn committed_fixture_refusal_census_is_pinned() {
         counts.into_iter().collect::<Vec<_>>(),
         vec![
             ("array_builtin_cannot_use_slot_object", 1),
-            ("bare_style_attr_with_dynamic_style", 1),
             ("bind_name_not_js", 1),
             ("bind_value_not_js", 1),
             ("custom_directive_expr_not_js", 1),


### PR DESCRIPTION
## Summary
- admit empty static style attributes beside dynamic `:style` in S2 DOM emit
- add S2-vs-shipped parity coverage for both bare/static source orders
- move `bare_style_attr_with_dynamic_style` from source refusal census to retired accounting

## Validation
- `cargo test -p vize_s1_to_s2 --test emit_static --test emit_unsupported_census --test emit_unsupported_catalogue -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_style_merge -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791283526&installation_model_id=422833&pr_number=5821&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5821&signature=50a1c5aa1a2447fb0f9257903b69dbd31ac9e81403af19fbdd83f602f33407f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->