### PR TITLE
fix(patina): allow v-for slot templates without keys

### DIFF
--- a/crates/vize_patina/src/rules/vue/require_v_for_key.rs
+++ b/crates/vize_patina/src/rules/vue/require_v_for_key.rs
@@ -74,6 +74,9 @@ fn has_markup_key(element: &MarkupElement<'_>) -> bool {
 }
 
 fn has_markup_template_v_for_key(element: &MarkupElement<'_>) -> bool {
+    if element.has_directive("slot") {
+        return true;
+    }
     if has_markup_key(element) {
         return true;
     }
@@ -186,7 +189,8 @@ fn relief_directive_is_bound_key(directive: &DirectiveNode<'_>) -> bool {
 }
 
 fn relief_template_v_for_has_key(element: &ElementNode<'_>) -> bool {
-    relief_element_has_key(element)
+    relief_template_has_slot_directive(element)
+        || relief_element_has_key(element)
         || element.children.iter().any(|child| {
             matches!(
                 child,
@@ -196,6 +200,15 @@ fn relief_template_v_for_has_key(element: &ElementNode<'_>) -> bool {
                     .any(|prop| matches!(prop, PropNode::Directive(dir) if relief_directive_is_bound_key(dir)))
             )
         })
+}
+
+fn relief_template_has_slot_directive(element: &ElementNode<'_>) -> bool {
+    element.props.iter().any(|prop| {
+        matches!(
+            prop,
+            PropNode::Directive(directive) if directive.name == "slot"
+        )
+    })
 }
 
 /// Markup-IR entry point for `vue/require-v-for-key`.

--- a/crates/vize_patina/src/rules/vue/require_v_for_key/tests.rs
+++ b/crates/vize_patina/src/rules/vue/require_v_for_key/tests.rs
@@ -97,3 +97,17 @@ fn test_template_v_for_child_key_is_not_missing_key() {
     );
     assert_eq!(result.error_count, 0);
 }
+
+#[test]
+fn test_template_v_for_dynamic_slot_forwarder_is_not_missing_key() {
+    let linter = create_linter();
+    let result = linter.lint_template(
+        r#"<Component>
+  <template v-for="header in headers" #[`header.${header.value}`]>
+    <slot :name="`header.${header.value}`" :header="header" />
+  </template>
+</Component>"#,
+        "test.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}

--- a/tests/snapshots/lint/__snapshots__/npmx.dev-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/npmx.dev-lint.snap
@@ -3706,17 +3706,6 @@
         "help": "Use kebab-case for attribute names"
       },
       {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 1028,
-        "column": 19,
-        "endLine": 1028,
-        "endColumn": 60,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
         "ruleId": "vue/attribute-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -3770,20 +3759,9 @@
         "endLine": 1102,
         "endColumn": 23,
         "help": "Use kebab-case for attribute names"
-      },
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 1136,
-        "column": 19,
-        "endLine": 1136,
-        "endColumn": 60,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
       }
     ],
-    "errorCount": 2,
+    "errorCount": 0,
     "warningCount": 17
   },
   {

--- a/tests/snapshots/lint/__snapshots__/nuxt-ui-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/nuxt-ui-lint.snap
@@ -67,20 +67,8 @@
   },
   {
     "file": "src/runtime/components/BlogPosts.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 73,
-        "column": 19,
-        "endLine": 73,
-        "endColumn": 55,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
@@ -133,20 +121,8 @@
   },
   {
     "file": "src/runtime/components/ChangelogVersions.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 101,
-        "column": 21,
-        "endLine": 101,
-        "endColumn": 57,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
@@ -159,17 +135,6 @@
     "file": "src/runtime/components/ChatMessages.vue",
     "messages": [
       {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 343,
-        "column": 21,
-        "endLine": 343,
-        "endColumn": 57,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      },
-      {
         "ruleId": "a11y/aria-role",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 2,
@@ -181,7 +146,7 @@
         "help": "Why: Invalid ARIA roles prevent assistive technologies from conveying the intended meaning to users.\nValid ARIA roles are defined in the WAI-ARIA specification:\nhttps://www.w3.org/TR/wai-aria/#role_definitions\nCommon roles:\n  <!-- Widget roles -->\n  <div role=\"button\">Click me</div>\n  <div role=\"dialog\">Modal content</div>\n  <div role=\"checkbox\">Toggle</div>\n  \n  <!-- Landmark roles -->\n  <nav role=\"navigation\">...</nav>\n  <main role=\"main\">...</main>\n  <aside role=\"complementary\">...</aside>\n  \n  <!-- Document structure roles -->\n  <div role=\"heading\" aria-level=\"2\">Title</div>\n  <div role=\"list\">...</div>"
       }
     ],
-    "errorCount": 2,
+    "errorCount": 1,
     "warningCount": 0
   },
   {
@@ -192,38 +157,14 @@
   },
   {
     "file": "src/runtime/components/ChatPrompt.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 168,
-        "column": 19,
-        "endLine": 168,
-        "endColumn": 55,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
     "file": "src/runtime/components/ChatPromptSubmit.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 171,
-        "column": 15,
-        "endLine": 171,
-        "endColumn": 41,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
@@ -252,20 +193,8 @@
   },
   {
     "file": "src/runtime/components/CheckboxGroup.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 200,
-        "column": 19,
-        "endLine": 200,
-        "endColumn": 55,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
@@ -334,38 +263,14 @@
   },
   {
     "file": "src/runtime/components/ContextMenu.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 169,
-        "column": 17,
-        "endLine": 169,
-        "endColumn": 53,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
     "file": "src/runtime/components/ContextMenuContent.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 160,
-        "column": 29,
-        "endLine": 160,
-        "endColumn": 65,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
@@ -394,38 +299,14 @@
   },
   {
     "file": "src/runtime/components/DashboardSearch.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 219,
-        "column": 21,
-        "endLine": 219,
-        "endColumn": 57,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
     "file": "src/runtime/components/DashboardSearchButton.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 118,
-        "column": 17,
-        "endLine": 118,
-        "endColumn": 53,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
@@ -460,38 +341,14 @@
   },
   {
     "file": "src/runtime/components/DropdownMenu.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 211,
-        "column": 17,
-        "endLine": 211,
-        "endColumn": 53,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
     "file": "src/runtime/components/DropdownMenuContent.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 225,
-        "column": 29,
-        "endLine": 225,
-        "endColumn": 65,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
@@ -862,20 +719,8 @@
   },
   {
     "file": "src/runtime/components/PricingPlans.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 100,
-        "column": 19,
-        "endLine": 100,
-        "endColumn": 55,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
@@ -1185,56 +1030,20 @@
   },
   {
     "file": "src/runtime/components/content/ContentNavigation.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 247,
-        "column": 25,
-        "endLine": 247,
-        "endColumn": 51,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
     "file": "src/runtime/components/content/ContentSearch.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 376,
-        "column": 21,
-        "endLine": 376,
-        "endColumn": 57,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {
     "file": "src/runtime/components/content/ContentSearchButton.vue",
-    "messages": [
-      {
-        "ruleId": "vue/require-v-for-key",
-        "ruleDocsPath": "docs/content/rules/vue.md",
-        "severity": 2,
-        "message": "[vize:vue/require-v-for-key] Elements in iteration expect to have 'v-bind:key' directives. Element: <template>",
-        "line": 118,
-        "column": 17,
-        "endLine": 118,
-        "endColumn": 53,
-        "help": "Why: The :key attribute helps Vue's virtual DOM efficiently track and update list items.\nFix: Add a unique identifier as the key:\n  <li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n  </li>\nBest practices:\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)"
-      }
-    ],
-    "errorCount": 1,
+    "messages": [],
+    "errorCount": 0,
     "warningCount": 0
   },
   {


### PR DESCRIPTION
## Summary
- treat `<template v-for>` slot templates as slot forwarding rather than keyed DOM list nodes
- add a Directus-derived regression for dynamic slot forwarding with `#[...]`

## Routing Evidence
- `/tmp/vize-matrix-34025327157-current-20260906-1004/real-project-matrix-13/directus-lint-divergence.json` reported `vue/require-v-for-key` false positives on Directus dynamic slot templates
- reproduced against latest `origin/main` before the fix with `cargo run -p vize -- lint --no-config --preset ecosystem --format json --help-level none tests/_fixtures/_git/directus/app/src/components/v-table/v-table.vue`

## Validation
- `cargo test -p vize_patina rules::vue::require_v_for_key::tests::test_template_v_for_dynamic_slot_forwarder_is_not_missing_key -- --nocapture`
- `cargo test -p vize_patina --test require_v_for_key_object_bind`
- `cargo test -p vize_patina require_v_for_key`
- `cargo run -p vize -- lint --no-config --preset ecosystem --format json --help-level none tests/_fixtures/_git/directus/app/src/components/v-table/v-table.vue`
- `cargo fmt --check`
- `cargo test -p vize_patina --lib rules::vue::require_v_for_key`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791283536&installation_model_id=422833&pr_number=5822&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5822&signature=56aa6c5afd492e8f67a05c195eaafcbf787b0dd339d4d1582d8445846549bede"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->