### PR TITLE
test(lsp): assert authored oracle diagnostic evidence

### DIFF
--- a/tests/tooling/real-project-lsp-authored-oracle.test.ts
+++ b/tests/tooling/real-project-lsp-authored-oracle.test.ts
@@ -28,6 +28,10 @@ test("real-project LSP exercises authored binding and component boundary feature
     assert.equal(result.hover.count, 1);
     assert.equal(result.references.count, 2);
     assert.equal(result.rename.count, 2);
+    assert.deepEqual(result.templateBindingDiagnostics, {
+      count: 0,
+      sha256: "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b",
+    });
     for (const evidence of [
       result.completion,
       result.componentDefinition,

--- a/tests/tooling/support/real-project-lsp-authored-oracle.ts
+++ b/tests/tooling/support/real-project-lsp-authored-oracle.ts
@@ -27,7 +27,11 @@ import {
   requestCompletion,
   waitForDiagnostics,
 } from "./real-project-lsp-authored-oracle-session.ts";
-import type { FixtureProject, LspAuthoredOracle } from "./real-project-lsp-report.ts";
+import type {
+  AuthoredLspExerciseEvidence,
+  FixtureProject,
+  LspAuthoredOracle,
+} from "./real-project-lsp-report.ts";
 import { exerciseAuthoredFileLifecycle } from "./real-project-lsp-file-lifecycle.ts";
 
 const diagnosticsTimeoutMs = 120_000;
@@ -37,7 +41,7 @@ export async function exerciseAuthoredLspOracle(
   workspaceDir: string,
   oracle: LspAuthoredOracle,
   timeoutMs: () => number = () => diagnosticsTimeoutMs,
-) {
+): Promise<AuthoredLspExerciseEvidence> {
   const openUris: string[] = [];
   const binding = oracle.templateBinding;
   const boundary = oracle.componentBoundary;

--- a/tests/tooling/support/real-project-lsp-report.ts
+++ b/tests/tooling/support/real-project-lsp-report.ts
@@ -111,6 +111,10 @@ export type AuthoredLspEvidence = {
   templateBindingFile: string;
 };
 
+export type AuthoredLspExerciseEvidence = AuthoredLspEvidence & {
+  templateBindingDiagnostics: DiagnosticEvidence;
+};
+
 export type LspProjectEvidence = {
   actualFile: string | null;
   actualFileDiagnostics: DiagnosticEvidence | null;


### PR DESCRIPTION
## Summary
- make authored real-project LSP exercise evidence explicitly carry template-binding diagnostics
- assert the fake authored LSP oracle records a clean template-binding diagnostic baseline before feature evidence is serialized

Refs #3952.

## Validation
- node --test tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp.test.ts
- node --test tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/real-project-lsp-file-lifecycle.test.ts tests/tooling/real-project-lsp-authored-registry.test.ts tests/tooling/real-project-lsp.test.ts
- node --test tests/tooling/lsp-incremental-budgets.test.ts
- vp check tests/tooling/real-project-lsp-authored-oracle.test.ts tests/tooling/support/real-project-lsp-authored-oracle.ts tests/tooling/support/real-project-lsp-report.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791284279&installation_model_id=422833&pr_number=5823&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5823&signature=78961e38b037addd45c83af84777bd2d02c771640bb946c3b7e1dbd372d72569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation that authored language-service checks produce no template-binding diagnostics.
  * Added verification of the diagnostics payload against an expected integrity hash.
  * Improved type clarity for language-service exercise evidence used in test reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->