### PR TITLE
test(vscode): require configured server in host smoke

### DIFF
--- a/editors/vscode/test/pinned-create-vue-host-result.mjs
+++ b/editors/vscode/test/pinned-create-vue-host-result.mjs
@@ -19,20 +19,27 @@ const expectedResult = {
   schemaVersion: 1,
 };
 
-export function readPinnedCreateVueHostResult(resultPath) {
+export function readPinnedCreateVueHostResult(resultPath, expectedServerPath) {
   assert.ok(fs.existsSync(resultPath), `packaged host did not write its result: ${resultPath}`);
   const actual = JSON.parse(fs.readFileSync(resultPath, "utf8"));
-  assertServerInfo(actual.serverInfo);
+  assertServerInfo(actual.serverInfo, expectedServerPath);
   assert.deepEqual(actual, { ...expectedResult, serverInfo: actual.serverInfo });
   return actual;
 }
 
-function assertServerInfo(serverInfo) {
+function assertServerInfo(serverInfo, expectedServerPath) {
   assert.equal(serverInfo?.source, "configured");
   assert.equal(serverInfo?.status, "ready");
   assert.equal(typeof serverInfo?.path, "string");
   assert.ok(path.isAbsolute(serverInfo.path), "selected server path must be absolute");
   assert.ok(fs.existsSync(serverInfo.path), `selected server path must exist: ${serverInfo.path}`);
+  assert.equal(typeof expectedServerPath, "string", "configured real server path must be recorded");
+  assert.ok(path.isAbsolute(expectedServerPath), "configured real server path must be absolute");
+  assert.equal(
+    fs.realpathSync(serverInfo.path),
+    fs.realpathSync(expectedServerPath),
+    "selected server path must match the configured real server",
+  );
   assert.deepEqual(Object.keys(serverInfo).sort(), [
     "extensionVersion",
     "path",

--- a/editors/vscode/test/run-extension-host-real.mjs
+++ b/editors/vscode/test/run-extension-host-real.mjs
@@ -89,7 +89,7 @@ await withPinnedFixtureWorkspace(
         vsixPath,
         workspacePath: fixture.workspaceDir,
       });
-      readPinnedCreateVueHostResult(resultPath);
+      readPinnedCreateVueHostResult(resultPath, serverPath);
     } finally {
       fs.rmSync(profilePath, { force: true, recursive: true });
     }

--- a/tests/tooling/vscode-packaged-host-result.test.ts
+++ b/tests/tooling/vscode-packaged-host-result.test.ts
@@ -15,13 +15,13 @@ test("packaged host result proves the pinned create-vue diagnostic transition", 
   try {
     fs.writeFileSync(serverPath, "");
     fs.writeFileSync(resultPath, JSON.stringify(passingResult));
-    assert.deepEqual(readPinnedCreateVueHostResult(resultPath), passingResult);
+    assert.deepEqual(readPinnedCreateVueHostResult(resultPath, serverPath), passingResult);
 
     fs.writeFileSync(
       resultPath,
       JSON.stringify({ ...passingResult, documentDirty: false, extensionActive: false }),
     );
-    assert.throws(() => readPinnedCreateVueHostResult(resultPath));
+    assert.throws(() => readPinnedCreateVueHostResult(resultPath, serverPath));
 
     fs.writeFileSync(
       resultPath,
@@ -30,7 +30,21 @@ test("packaged host result proves the pinned create-vue diagnostic transition", 
         brokenDiagnostics: [{ ...passingResult.brokenDiagnostics[0], range: [1, 7, 1, 12] }],
       }),
     );
-    assert.throws(() => readPinnedCreateVueHostResult(resultPath));
+    assert.throws(() => readPinnedCreateVueHostResult(resultPath, serverPath));
+
+    const otherServerPath = path.join(resultDirectory, "other-vize");
+    fs.writeFileSync(otherServerPath, "");
+    fs.writeFileSync(
+      resultPath,
+      JSON.stringify({
+        ...passingResult,
+        serverInfo: { ...passingResult.serverInfo, path: otherServerPath },
+      }),
+    );
+    assert.throws(
+      () => readPinnedCreateVueHostResult(resultPath, serverPath),
+      /selected server path must match the configured real server/,
+    );
 
     fs.writeFileSync(
       resultPath,
@@ -40,7 +54,7 @@ test("packaged host result proves the pinned create-vue diagnostic transition", 
       }),
     );
     assert.throws(
-      () => readPinnedCreateVueHostResult(resultPath),
+      () => readPinnedCreateVueHostResult(resultPath, serverPath),
       /selected server version must match extension version/,
     );
   } finally {


### PR DESCRIPTION
## Summary
- pass the configured real server path into packaged host result validation
- reject pinned create-vue host evidence if VS Code selected any other server binary

## Validation
- vp install --frozen-lockfile --prefer-offline
- node --test tests/tooling/vscode-packaged-host-result.test.ts
- node --test tests/tooling/vscode-packaged-host-smoke.test.ts
- vp check tests/tooling/vscode-packaged-host-result.test.ts editors/vscode/test/pinned-create-vue-host-result.mjs editors/vscode/test/run-extension-host-real.mjs
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved validation to ensure the selected server matches the configured server and resolves to a valid absolute path.
  - Added coverage for mismatched server configurations, helping detect incorrect server selection earlier.

- **Tests**
  - Expanded validation coverage for invalid diagnostics, version mismatches, inactive extensions, and dirty documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->