### PR TITLE
fix(davinci): pop html reentry closes case-insensitively

### DIFF
--- a/crates/vize_atelier_dom/src/compile/sfc/selector.rs
+++ b/crates/vize_atelier_dom/src/compile/sfc/selector.rs
@@ -74,7 +74,14 @@ fn find_byte(bytes: &[u8], start: usize, needle: u8) -> Option<usize> {
 }
 
 fn pop_closed_tag(tags: &mut Vec<SourceOpenTag<'_>>, name: &str) {
-    if tags.last().is_some_and(|tag| tag.name == name) {
+    let Some(tag) = tags.last() else {
+        return;
+    };
+    let closes = match tag.namespace {
+        SourceNamespace::Html => tag.name.eq_ignore_ascii_case(name),
+        SourceNamespace::Svg | SourceNamespace::MathMl => tag.name == name,
+    };
+    if closes {
         tags.pop();
     }
 }

--- a/crates/vize_atelier_dom/tests/davinci_s2_sfc_namespace_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_sfc_namespace_selector.rs
@@ -142,6 +142,38 @@ fn sfc_sections_entry_ignores_native_raw_text_bodies() {
 }
 
 #[test]
+fn sfc_sections_entry_pops_html_reentry_closes_case_insensitively() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+
+    let source = r#"<svg><foreignObject><div>label</DIV></foreignObject><path :d="path" /></svg>"#;
+    let compat = compile_sfc_sections_entry(
+        source,
+        DomCompilerOptions {
+            source_map: true,
+            ..Default::default()
+        },
+    );
+
+    profiler.enable();
+    let selected = compile_sfc_sections_entry(source, DomCompilerOptions::default());
+    let counters = profiler.counter_summary();
+    profiler.disable();
+    profiler.clear();
+
+    assert_eq!(selected.preamble, compat.preamble);
+    assert_eq!(selected.code, compat.code);
+    assert_eq!(selected.sections, compat.sections);
+    assert_eq!(
+        counter_total(&counters, "davinci.s2_dom.files"),
+        Some(1),
+        "case-insensitive HTML closes inside foreign re-entry must not poison the S2 selector"
+    );
+}
+
+#[test]
 fn sfc_sections_entry_keeps_root_html_title_on_compatibility() {
     let _guard = lock_profiler();
     let profiler = global_profiler();


### PR DESCRIPTION
## Summary
- pop HTML close tags case-insensitively while scanning SFC foreign-namespace re-entry state
- keep SVG and MathML close matching exact for the selector stack
- add an exact profiled S2/compat parity oracle for the recovered namespace case

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_sfc_namespace_selector sfc_sections_entry_pops_html_reentry_closes_case_insensitively -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_sfc_namespace_selector --test davinci_s2_production_selector --test davinci_s2_dom_namespace
- vp exec node --test tests/tooling/davinci-dom-production-boundary.test.ts
- cargo fmt --all -- --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of closing tags in mixed HTML, SVG, and MathML content.
  * HTML closing tags are now matched without case sensitivity, while SVG and MathML tags retain case-sensitive matching.
  * Fixed compilation behavior for uppercase HTML closing tags nested within SVG content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->