### PR TITLE
fix(maestro): evict tracked vue descendants on directory events

### DIFF
--- a/crates/vize_maestro/src/server/workspace_files/dependents.rs
+++ b/crates/vize_maestro/src/server/workspace_files/dependents.rs
@@ -40,6 +40,7 @@ pub(super) fn affected_vue_source_paths<'a>(
         if is_vue_file(&path) {
             sources.push(path.clone());
         }
+        sources.extend(tracked_vue_descendant_paths(state, &path));
         sources.extend(
             importers::indexed_dependency_paths(state, &path)
                 .into_iter()
@@ -49,6 +50,15 @@ pub(super) fn affected_vue_source_paths<'a>(
     sources.sort();
     sources.dedup();
     sources
+}
+
+fn tracked_vue_descendant_paths(state: &ServerState, root: &Path) -> Vec<PathBuf> {
+    state
+        .workspace_vue_file_uris()
+        .into_iter()
+        .filter_map(|uri| uri.to_file_path().ok())
+        .filter(|path| path.starts_with(root) && is_vue_file(path))
+        .collect()
 }
 
 /// Mark the on-disk project view cached by the reusable Corsa editor session stale.
@@ -95,7 +105,7 @@ mod tests {
     use tower_lsp::lsp_types::Url;
     use vize_s0::cstr;
 
-    use super::{ServerState, versioned_open_typecheck_dependents};
+    use super::{ServerState, affected_vue_source_paths, versioned_open_typecheck_dependents};
 
     #[test]
     fn package_manifest_event_reindexes_the_retargeted_vue_source() {
@@ -131,6 +141,33 @@ mod tests {
             versioned_open_typecheck_dependents(&state, [renamed_uri.as_str()].into_iter()),
             [(parent_uri, 1)],
             "the manifest refresh must index the new physical target",
+        );
+    }
+
+    #[test]
+    fn directory_events_evict_tracked_vue_descendants_without_disk_scan() {
+        let root = tempfile::tempdir().unwrap();
+        let components = root.path().join("components");
+        let child = components.join("nested/Child.vue");
+        let sibling_dir = root.path().join("components-old");
+        let sibling = sibling_dir.join("Sibling.vue");
+        std::fs::create_dir_all(child.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(&sibling_dir).unwrap();
+        std::fs::write(&child, "<template />\n").unwrap();
+        std::fs::write(&sibling, "<template />\n").unwrap();
+        let components_uri = Url::from_file_path(&components).unwrap();
+        let sibling_uri = Url::from_file_path(&sibling_dir).unwrap();
+        let state = ServerState::new();
+
+        assert!(state.track_workspace_vue_files(components_uri.as_str()));
+        assert!(state.track_workspace_vue_files(sibling_uri.as_str()));
+
+        std::fs::rename(&components, root.path().join("renamed-components")).unwrap();
+
+        assert_eq!(
+            affected_vue_source_paths(&state, [components_uri.as_str()].into_iter()),
+            [child],
+            "directory rename/delete events must retire old tracked Vue virtual documents"
         );
     }
 


### PR DESCRIPTION
## Summary
- include tracked workspace Vue descendants when LSP file events evict Corsa virtual docs
- add a regression for directory rename/delete events after the directory disappears from disk

## Tests
- cargo test -p vize_maestro directory_events_evict_tracked_vue_descendants_without_disk_scan
- cargo test -p vize_maestro workspace_files
- cargo fmt --check
- cargo clippy -p vize_maestro --tests -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791288677&installation_model_id=422833&pr_number=5828&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5828&signature=d35e058a4019bba1866806c621022000ec4e39927f0c7d681a69a4f82871afad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Vue files affected by directory renames or deletions.
  - Retired outdated tracked Vue documents more reliably when their containing directories change.
  - Improved workspace tracking for Vue files located within affected directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->