### PR TITLE
fix(davinci): guard DOM S2 legacy selection

### DIFF
--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -248,7 +248,6 @@ fn compile_template_inner_with_sections<'a>(
     } = pipeline_options;
     let parser_opts = stage_options::parser_options(&options);
 
-    // Parse
     let (mut root, errors) = profile!(
         "atelier.dom.template.parse",
         parse_with_options_custom_elements_and_template_syntax(
@@ -293,6 +292,7 @@ fn compile_template_inner_with_sections<'a>(
         custom_elements_supported,
         template_syntax,
         has_croquis,
+        stage_options::dom_lane_selection(),
         s2_emit_selection,
     );
     // Project the public output options before consuming Croquis below. Croquis

--- a/crates/vize_atelier_dom/src/compile/sfc.rs
+++ b/crates/vize_atelier_dom/src/compile/sfc.rs
@@ -23,12 +23,14 @@ pub(super) fn compile_template_inner_for_sfc_with_sections<'a>(
     codegen_options: CodegenOptions,
 ) -> (Vec<CompilerError>, CodegenResultWithSections) {
     let codegen_opts = stage_options::codegen_options(&options, codegen_options.clone());
+    let dom_lane = stage_options::dom_lane_selection();
     let use_s2_emit = stage_options::s2_emit_supported(
         &options,
         &codegen_opts,
         !custom_elements.has_static_predicate(),
         template_syntax,
         options.croquis.is_some(),
+        dom_lane,
         pipeline::S2EmitSelection::RequireSections,
     );
 

--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -18,6 +18,24 @@ use super::pipeline::S2EmitSelection;
 use crate::namespace::get_namespace;
 use crate::options::DomCompilerOptions;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DomLaneSelection {
+    S2,
+    Legacy,
+}
+
+pub(super) fn dom_lane_selection() -> DomLaneSelection {
+    let value = std::env::var(vize_s1_to_s2::DOM_LANE_FLAG);
+    dom_lane_selection_from_flag(value.as_deref().ok())
+}
+
+fn dom_lane_selection_from_flag(value: Option<&str>) -> DomLaneSelection {
+    match value {
+        Some("legacy") => DomLaneSelection::Legacy,
+        _ => DomLaneSelection::S2,
+    }
+}
+
 /// Parser options with DOM-specific settings.
 pub(super) fn parser_options(options: &DomCompilerOptions) -> ParserOptions {
     ParserOptions {
@@ -82,14 +100,18 @@ pub(super) fn s2_emit_supported(
     custom_elements_supported: bool,
     template_syntax: TemplateSyntaxMode,
     has_croquis: bool,
+    dom_lane: DomLaneSelection,
     s2_emit_selection: S2EmitSelection,
 ) -> bool {
-    matches!(
-        s2_emit_selection,
-        S2EmitSelection::Allowed | S2EmitSelection::RequireSections
-    ) && !options.ssr
+    dom_lane == DomLaneSelection::S2
+        && matches!(
+            s2_emit_selection,
+            S2EmitSelection::Allowed | S2EmitSelection::RequireSections
+        )
+        && !options.ssr
         && !options.experimental_patterned_template
         && !options.custom_renderer
+        && options.dialect == vize_s0::config::VueVersion::V3
         && template_syntax == TemplateSyntaxMode::Standard
         && custom_elements_supported
         && !has_croquis
@@ -226,3 +248,6 @@ const fn s2_binding_kind(kind: BindingType) -> BindingKind {
         BindingType::ExternalModule => BindingKind::ExternalModule,
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
@@ -1,0 +1,105 @@
+use super::{
+    DomLaneSelection, dom_lane_selection, dom_lane_selection_from_flag, s2_emit_supported,
+};
+use crate::DomCompilerOptions;
+use std::ffi::OsString;
+use vize_atelier_core::options::{CodegenOptions, TemplateSyntaxMode};
+use vize_s0::config::VueVersion;
+
+#[test]
+fn dom_lane_selection_maps_the_legacy_flag_value() {
+    assert_eq!(
+        dom_lane_selection_from_flag(Some("legacy")),
+        DomLaneSelection::Legacy
+    );
+    assert_eq!(
+        dom_lane_selection_from_flag(Some("s2")),
+        DomLaneSelection::S2
+    );
+    assert_eq!(dom_lane_selection_from_flag(None), DomLaneSelection::S2);
+}
+
+#[test]
+fn dom_lane_selection_reads_the_legacy_env_value() {
+    let _env_lock = lock_env();
+    let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "legacy");
+
+    assert_eq!(dom_lane_selection(), DomLaneSelection::Legacy);
+}
+
+#[test]
+fn the_dom_legacy_lane_flag_disarms_s2_selection() {
+    assert!(supported(
+        DomCompilerOptions::default(),
+        DomLaneSelection::S2
+    ));
+    assert!(!supported(
+        DomCompilerOptions::default(),
+        DomLaneSelection::Legacy
+    ));
+}
+
+#[test]
+fn legacy_dialects_stay_on_the_compatibility_lane() {
+    assert!(!supported(
+        DomCompilerOptions {
+            dialect: VueVersion::V2,
+            ..Default::default()
+        },
+        DomLaneSelection::S2
+    ));
+    assert!(!supported(
+        DomCompilerOptions {
+            dialect: VueVersion::V2_7,
+            ..Default::default()
+        },
+        DomLaneSelection::S2
+    ));
+}
+
+fn supported(options: DomCompilerOptions, dom_lane: DomLaneSelection) -> bool {
+    s2_emit_supported(
+        &options,
+        &CodegenOptions::default(),
+        true,
+        TemplateSyntaxMode::Standard,
+        false,
+        dom_lane,
+        super::S2EmitSelection::Allowed,
+    )
+}
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: This test holds the local environment lock for the full
+        // lifetime of the scoped override.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        // SAFETY: The guard is dropped before the local environment lock,
+        // restoring the process environment while mutations are serialized.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ENV_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}

--- a/crates/vize_atelier_dom/tests/davinci_s2_legacy_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_legacy_selector.rs
@@ -1,0 +1,174 @@
+//! P2-11 witness: legacy dialect compiles stay on compatibility until the DOM
+//! lane flag is deleted at the production switch exit gate.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use std::ffi::OsString;
+use vize_atelier_core::options::{CodegenOptions, TemplateSyntaxMode};
+use vize_atelier_dom::{
+    DomCompilerOptions,
+    compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+};
+use vize_s0::Allocator;
+use vize_s0::config::VueVersion;
+use vize_s0::profiler::{CounterSummary, global_profiler};
+
+#[test]
+fn legacy_dialect_stays_on_compatibility_until_flag_deletion() {
+    let _env_lock = lock_env();
+    let _profiler_lock = lock_profiler();
+    let (result, counters) = compile_with_s2_profiler(
+        r#"<button @click.native="go">{{ label | cap }}</button>"#,
+        DomCompilerOptions {
+            dialect: VueVersion::V2,
+            ..Default::default()
+        },
+    );
+
+    assert_compatibility_sections_without_s2_profile(
+        &result,
+        &counters,
+        "legacy dialect compiles must not enter the S2 production selector before flag deletion",
+    );
+}
+
+#[test]
+fn dom_legacy_lane_flag_keeps_vue3_on_compatibility_until_flag_deletion() {
+    let _env_lock = lock_env();
+    let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "legacy");
+    let _profiler_lock = lock_profiler();
+    let (result, counters) = compile_with_s2_profiler(
+        r#"<button @click="go">{{ label }}</button>"#,
+        DomCompilerOptions::default(),
+    );
+
+    assert_compatibility_sections_without_s2_profile(
+        &result,
+        &counters,
+        "the DOM legacy lane flag must keep Vue 3 compiles off the S2 production selector",
+    );
+}
+
+struct Compiled {
+    sections: Option<vize_atelier_core::CodegenSections>,
+}
+
+fn assert_compatibility_sections_without_s2_profile(
+    result: &Compiled,
+    counters: &CounterSummary,
+    s2_message: &str,
+) {
+    assert!(
+        result.sections.is_some(),
+        "the compatibility lane must keep codegen sections available"
+    );
+    assert_eq!(
+        counter_total(counters, "davinci.s2_dom.files"),
+        None,
+        "{s2_message}"
+    );
+}
+
+fn compile_with_s2_profiler(
+    source: &str,
+    options: DomCompilerOptions,
+) -> (Compiled, CounterSummary) {
+    let profiler = ScopedProfiler::enable();
+    let result = compile(source, options);
+    let counters = profiler.counter_summary();
+    (result, counters)
+}
+
+fn compile(source: &str, options: DomCompilerOptions) -> Compiled {
+    let allocator = Allocator::new();
+    let (_, errors, result) =
+        compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+            None,
+            CodegenOptions::default(),
+        );
+    assert!(errors.is_empty(), "compile errors: {errors:?}");
+    Compiled {
+        sections: result.sections,
+    }
+}
+
+fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
+    counters
+        .entries
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.total)
+}
+
+fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
+    static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    PROFILER_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ENV_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: This test holds the local environment lock for the full
+        // lifetime of the scoped override.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        // SAFETY: The guard is dropped before the local environment lock,
+        // restoring the process environment while mutations are serialized.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+struct ScopedProfiler;
+
+impl ScopedProfiler {
+    fn enable() -> Self {
+        let profiler = global_profiler();
+        profiler.clear();
+        profiler.enable();
+        Self
+    }
+
+    fn counter_summary(&self) -> CounterSummary {
+        global_profiler().counter_summary()
+    }
+}
+
+impl Drop for ScopedProfiler {
+    fn drop(&mut self) {
+        let profiler = global_profiler();
+        profiler.disable();
+        profiler.clear();
+    }
+}

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -48,6 +48,10 @@
 //! compatibility codegen; the old lane remains for unsupported option surfaces
 //! until the phase-exit deletion.
 
+/// Env flag that keeps DOM template compiles on the compatibility lane while
+/// the P2-11 production switch is still in phase.
+pub const DOM_LANE_FLAG: &str = "VIZE_DAVINCI_DOM";
+
 mod budget;
 mod buf;
 mod builtin;
@@ -229,4 +233,12 @@ struct EmitCx<'facts> {
     component_name: Option<&'facts str>,
     /// The transform scope and codegen slot params the prefixer consults.
     scope: prefix::PrefixScope<'facts>,
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn dom_lane_flag_name_is_stable() {
+        assert_eq!(super::DOM_LANE_FLAG, "VIZE_DAVINCI_DOM");
+    }
 }

--- a/crates/vize_s1_to_s2/src/lib.rs
+++ b/crates/vize_s1_to_s2/src/lib.rs
@@ -70,7 +70,7 @@ pub mod lower;
 pub mod pass;
 
 pub use emit::{
-    BindingKind, BindingTable, DomEmit, DomEmitBudget, DomEmitMode, DomEmitOptions,
+    BindingKind, BindingTable, DOM_LANE_FLAG, DomEmit, DomEmitBudget, DomEmitMode, DomEmitOptions,
     DomEmitSections, EmitError, ObservedDomEmit, UnsupportedReason, UnsupportedRefusal, emit_dom,
     emit_dom_source, emit_dom_source_observed, emit_dom_source_observed_with_options,
     emit_dom_source_with_caps, emit_dom_source_with_caps_observed, emit_dom_source_with_options,

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -24,13 +24,13 @@ const compilerOptionsProjectedToS2 = [
   "inline",
   "binding_metadata",
   "is_ts",
-  "dialect",
 ];
 const compilerOptionsHandledAroundS2 = ["source_map"];
 const compilerOptionsHeldAtDefault = [
   "ssr",
   "experimental_patterned_template",
   "custom_renderer",
+  "dialect",
   "croquis",
 ];
 const s2EmitOptionFields = [

--- a/tests/tooling/davinci-v-on-storage.test.ts
+++ b/tests/tooling/davinci-v-on-storage.test.ts
@@ -180,7 +180,7 @@ test("the natural committed v-on corpus fits the two-entry inline buckets", () =
     "the Mealie-shaped dynamic slot fixture keeps its natural modified v-on spelling",
   );
   assert.deepEqual(classify("@click.prevent"), { options: 0, event: 1, keys: 0 });
-  assert.equal(spellings.length, 224, "update the measured corpus evidence intentionally");
+  assert.equal(spellings.length, 225, "update the measured corpus evidence intentionally");
   assert.deepEqual(maxima, { options: 2, event: 2, keys: 2 });
 });
 


### PR DESCRIPTION
## Summary
- restore the DOM lane flag name in the S2 DOM emitter surface
- keep `VIZE_DAVINCI_DOM=legacy` and non-Vue 3 dialects on the compatibility selector
- classify `dialect` as held at default in the DOM production-boundary test

## Validation
- `cargo fmt --all --check`
- `cargo test -p vize_atelier_dom --lib stage_options -- --nocapture`
- `cargo test -p vize_s1_to_s2 --lib emit::tests::dom_lane_flag_name_is_stable -- --exact --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_legacy_selector`
- `cargo test -p vize_atelier_dom --test davinci_s2_production_selector`
- `cargo test -p vize_atelier_dom --test davinci_s2_custom_element_selector`
- `cargo test -p vize_atelier_dom --test davinci_s2_profile_unsupported`
- `node --test tests/tooling/davinci-dom-production-boundary.test.ts`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791288854&installation_model_id=422833&pr_number=5829&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5829&signature=5524ea863dffe9f79cedcb3edb25752025bf49796ee24a9a985e69de7b4ce343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable DOM compilation lane selection, with Vue 3 templates using the modern S2 pipeline by default.
  - Added support for routing templates through the legacy compatibility lane when the configured legacy setting is selected.
  - Vue 2 and Vue 2.7 templates continue to use compatibility processing.

- **Tests**
  - Added coverage for lane selection and compatibility output across supported template dialects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->