### PR TITLE
fix(release): reject observed typecheck mutation drift

### DIFF
--- a/legacy-tools/github/release-preflight-typecheck-evidence.mjs
+++ b/legacy-tools/github/release-preflight-typecheck-evidence.mjs
@@ -199,6 +199,7 @@ function assertReleaseMutationOracle(artifactName, mutationOracle) {
 function hasMutationStateEvidence(state) {
   return (
     hasSummaryEvidence(state.observed) &&
+    hasObservedMutationParity(state.observed) &&
     hasRunEvidence(state.vize) &&
     hasRunEvidence(state.baseline)
   );
@@ -214,6 +215,14 @@ function hasSummaryEvidence(summary) {
     "falsePositiveCount",
     "falseNegativeCount",
   ].every((key) => Number.isSafeInteger(summary?.[key]) && summary[key] >= 0);
+}
+
+function hasObservedMutationParity(summary) {
+  return (
+    summary?.messageMismatchCount === 0 &&
+    summary?.falsePositiveCount === 0 &&
+    summary?.falseNegativeCount === 0
+  );
 }
 
 function hasRunEvidence(run) {

--- a/tests/tooling/release-preflight-matrix-evidence-rejections.test.ts
+++ b/tests/tooling/release-preflight-matrix-evidence-rejections.test.ts
@@ -51,6 +51,15 @@ test("release preflight requires same-corpus coverage, mutation oracle, and prep
       /seeded mutation oracle/,
     ],
     [
+      "observed mutation false positive",
+      (entries: Record<string, string>) =>
+        mutateDivergence(
+          entries,
+          (artifact) => (artifact.mutationOracle.states[1].observed.falsePositiveCount = 1),
+        ),
+      /seeded mutation oracle/,
+    ],
+    [
       "unrestored repaired mutation state",
       (entries: Record<string, string>) =>
         mutateDivergence(

--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../legacy-tools/github/release-preflight.mjs";
 import { workspaceVersionFromCargoToml } from "../../legacy-tools/github/release-preflight-core.mjs";
 import { repoRoot } from "./_helpers/moonbit.ts";
+import { mutateDivergence } from "./_helpers/release-preflight-matrix-evidence-fixture.ts";
 import { writeFakeCommand } from "./support/fake-command.ts";
 import { createReleasePreflightVerifyOnlyFixture } from "./support/release-preflight-runner-fixture.ts";
 
@@ -180,6 +181,39 @@ test("verify-only mode accepts flat job evidence returned by pagination", () => 
     assert.ifError(result.error);
     assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`.trim());
     assert.match(result.stdout, new RegExp(`Release preflight passed for ${fixture.tag}`));
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("verify-only mode rejects mutation states with observed typecheck drift", () => {
+  const tempDir = fs.mkdtempSync(path.join(tmpdir(), "vize-release-mutation-drift-"));
+  try {
+    const fixture = createReleasePreflightVerifyOnlyFixture(tempDir, {
+      mutateShardEntries(shard, entries) {
+        if (shard !== 0) return;
+        mutateDivergence(
+          entries,
+          (artifact) => (artifact.mutationOracle.states[1].observed.falseNegativeCount = 1),
+        );
+      },
+    });
+    const result = spawnSync(
+      "rust-script",
+      ["tools/commands/ci/github/release-preflight.rs", "--verify-only"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          ...fixture.env,
+        },
+      },
+    );
+    assert.ifError(result.error);
+    assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`.trim());
+    assert.match(result.stderr, /seeded mutation oracle/);
   } finally {
     fs.rmSync(tempDir, { recursive: true, force: true });
   }

--- a/tests/tooling/support/release-preflight-runner-fixture.ts
+++ b/tests/tooling/support/release-preflight-runner-fixture.ts
@@ -16,7 +16,12 @@ import { writeFakeCommand } from "./fake-command.ts";
 const releaseSha = "a".repeat(40);
 const baseSha = "b".repeat(40);
 
-export function createReleasePreflightVerifyOnlyFixture(tempDir: string) {
+export function createReleasePreflightVerifyOnlyFixture(
+  tempDir: string,
+  options: {
+    mutateShardEntries?: (shard: number, entries: Record<string, string>) => void;
+  } = {},
+) {
   const binDir = path.join(tempDir, "bin");
   const dataDir = path.join(tempDir, "github-api");
   const artifactDir = path.join(tempDir, "artifacts");
@@ -35,14 +40,11 @@ export function createReleasePreflightVerifyOnlyFixture(tempDir: string) {
   fs.mkdirSync(dataDir, { recursive: true });
   fs.mkdirSync(artifactDir, { recursive: true });
   for (const shard of artifacts.keys()) {
-    fs.writeFileSync(
-      path.join(artifactDir, `${shard}.zip`),
-      storedZip(
-        Object.entries(
-          shardEntries(shard, { typecheckProject: typecheckProjectIds()[shard] ?? null }),
-        ),
-      ),
-    );
+    const entries = shardEntries(shard, {
+      typecheckProject: typecheckProjectIds()[shard] ?? null,
+    });
+    options.mutateShardEntries?.(shard, entries);
+    fs.writeFileSync(path.join(artifactDir, `${shard}.zip`), storedZip(Object.entries(entries)));
   }
   writeJson(path.join(dataDir, "runs.json"), runs);
   writeJson(path.join(dataDir, "artifacts.json"), artifacts);

--- a/tools/support/release/preflight_matrix_evidence.rs
+++ b/tools/support/release/preflight_matrix_evidence.rs
@@ -564,7 +564,9 @@ fn assert_release_mutation_oracle(
 }
 
 fn has_mutation_state_evidence(state: &Value) -> bool {
-    has_summary_evidence(nested(state, &["observed"]))
+    let observed = nested(state, &["observed"]);
+    has_summary_evidence(observed)
+        && has_observed_mutation_parity(observed)
         && has_run_evidence(nested(state, &["vize"]))
         && has_run_evidence(nested(state, &["baseline"]))
 }
@@ -581,6 +583,12 @@ fn has_summary_evidence(summary: &Value) -> bool {
     ]
     .into_iter()
     .all(|key| integer_field(summary, key).is_some_and(|value| value >= 0))
+}
+
+fn has_observed_mutation_parity(summary: &Value) -> bool {
+    integer_field(summary, "messageMismatchCount") == Some(0)
+        && integer_field(summary, "falsePositiveCount") == Some(0)
+        && integer_field(summary, "falseNegativeCount") == Some(0)
 }
 
 fn has_run_evidence(run: &Value) -> bool {


### PR DESCRIPTION
## Summary
- reject release typecheck mutation oracle states when their observed summary still has message mismatches, false positives, or false negatives
- keep JS and Rust release-preflight checkers aligned
- add direct helper and verify-only runner regressions for forged shard artifacts

## Validation
- node --test tests/tooling/release-preflight-matrix-evidence-rejections.test.ts tests/tooling/release-preflight-runner.test.ts
- node --test tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/release-preflight-matrix-evidence-rejections.test.ts
- rustfmt --check tools/support/release/preflight_matrix_evidence.rs tools/commands/ci/github/release-preflight.rs
- git diff --check

Refs #5722

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791290751&installation_model_id=422833&pr_number=5830&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5830&signature=5a268a008388cbd3f269ec2071acc7c62df39b561295560b0fbd2a585e1aae6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->