### PR TITLE
fix(fixtures): close inherited stdio children after checker exit

### DIFF
--- a/tests/tooling/typecheck-divergence-report-timeout.test.ts
+++ b/tests/tooling/typecheck-divergence-report-timeout.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 
@@ -16,6 +17,20 @@ const outerHarnessTimeoutMs = 20_000;
 
 function artifactPath(fixture: ReturnType<typeof setup>) {
   return path.join(fixture.reportDir, "fixture-typecheck-divergence.json");
+}
+
+function killPidFileIfPresent(pidPath: string) {
+  if (!fs.existsSync(pidPath)) return;
+
+  const rawPid = fs.readFileSync(pidPath, "utf8").trim();
+  const pid = Number.parseInt(rawPid, 10);
+  if (!Number.isSafeInteger(pid) || pid <= 0 || String(pid) !== rawPid) return;
+
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch (error) {
+    if ((error as { code?: unknown }).code !== "ESRCH") throw error;
+  }
 }
 
 test("typecheck divergence report bounds a vue-tsc baseline that ignores SIGTERM", () => {
@@ -59,6 +74,55 @@ setInterval(() => {}, 1000);`,
     assert.equal(artifact.budget.verdict, "unusable");
     assert.equal(artifact.budget.passed, false);
   } finally {
+    cleanup(fixture);
+  }
+});
+
+test("typecheck divergence report closes inherited stdio children after checker exit", () => {
+  if (process.platform === "win32") return;
+
+  const fixture = setup();
+  const childPidPath = path.join(fixture.fakeDir, "stdio-child.pid");
+  try {
+    fs.writeFileSync(
+      fixture.vueTsc,
+      `#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000);"], { stdio: "inherit" });
+if (typeof child.pid === "number") fs.writeFileSync(${JSON.stringify(childPidPath)}, String(child.pid));
+
+if (process.argv.includes("--version")) {
+  console.log("3.3.4");
+  process.exit(0);
+}
+
+if (process.argv.includes("--listFilesOnly")) {
+  console.log(path.join(process.cwd(), "src/App.vue"));
+  process.exit(0);
+}
+
+process.stdout.write("src/App.vue(1,1): error TS2322: shared\\n");
+process.exit(2);
+`,
+    );
+    fs.chmodSync(fixture.vueTsc, 0o755);
+
+    const startedAt = Date.now();
+    const result = run(fixture, {}, ["--budget-mode", "record-only"], { timeoutMs: 8_000 });
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(
+      Date.now() - startedAt < 8_000,
+      "checker output capture must not wait for inherited stdio children after exit",
+    );
+    assert.equal(
+      fs.existsSync(path.join(fixture.reportDir, "fixture-typecheck-divergence.json")),
+      true,
+    );
+  } finally {
+    killPidFileIfPresent(childPidPath);
     cleanup(fixture);
   }
 });

--- a/tools/commands/fixtures/typecheck-divergence-report.rs
+++ b/tools/commands/fixtures/typecheck-divergence-report.rs
@@ -2880,6 +2880,7 @@ fn run_capture_limited(
         thread::sleep(Duration::from_millis(5));
     };
     let status = status.code().unwrap_or(1);
+    kill_child_process_group(child.id());
     let stdout = join_output_reader(stdout_reader, label, "stdout")?;
     let stderr = join_output_reader(stderr_reader, label, "stderr")?;
     if !allowed_statuses.contains(&status) {
@@ -2921,14 +2922,32 @@ fn timeout_error(label: &str, timeout_ms: u64) -> String {
 }
 
 fn kill_child_group(child: &mut std::process::Child) {
-    #[cfg(unix)]
-    {
-        let _ = Command::new("kill")
-            .args(["-KILL", &format!("-{}", child.id())])
-            .status();
-    }
+    kill_child_process_group(child.id());
     let _ = child.kill();
     let _ = child.wait();
+}
+
+#[cfg(unix)]
+fn kill_child_process_group(child_id: u32) {
+    let Ok(child_pid) = i32::try_from(child_id) else {
+        return;
+    };
+    // SAFETY: `child_pid` came from `Child::id`, and a negative pid asks the OS
+    // to signal the process group created by `process_group(0)` above.
+    unsafe {
+        let _ = kill(-child_pid, SIGKILL);
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_child_process_group(_child_id: u32) {}
+
+#[cfg(unix)]
+const SIGKILL: i32 = 9;
+
+#[cfg(unix)]
+unsafe extern "C" {
+    fn kill(pid: i32, sig: i32) -> i32;
 }
 
 fn mutation_run_error(error: String) -> String {


### PR DESCRIPTION
## Summary
- clean up checker process groups after the parent exits before joining output readers
- keep process-group cleanup quiet so timeout evidence remains stable
- add a timeout regression for inherited stdio children that outlive the checker parent

## Validation
- vp install --frozen-lockfile --prefer-offline
- vp check --fix tools/commands/fixtures/typecheck-divergence-report.rs tests/tooling/typecheck-divergence-report-timeout.test.ts
- vp check tools/commands/fixtures/typecheck-divergence-report.rs tests/tooling/typecheck-divergence-report-timeout.test.ts
- cargo fmt --all --check
- node --test tests/tooling/typecheck-divergence-report-timeout.test.ts tests/tooling/typecheck-divergence-mutation-oracle.test.ts tests/tooling/typecheck-divergence-report.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791292170&installation_model_id=422833&pr_number=5831&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5831&signature=abd72c558a65185d7e202a15f05bd5e76a02f1d0089d56cb69024f04ecf71f80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Typecheck divergence reports now complete promptly even when a checker leaves background processes running.
  - Improved process cleanup prevents lingering child processes from delaying report generation.
  - Process termination is handled more reliably across supported platforms.

- **Tests**
  - Added coverage to verify that reports finish within the expected timeout when checker subprocesses remain active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->