### PR TITLE
fix(maestro): gate implementation requests on type checking

### DIFF
--- a/crates/vize_maestro/src/server/capabilities/tests/feature_gating.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests/feature_gating.rs
@@ -52,7 +52,7 @@ fn individual_feature_flags_gate_matching_providers() {
             |features| features.references = false,
             |capabilities| {
                 capabilities.references_provider.is_some()
-                    && capabilities.document_highlight_provider.is_some()
+                    || capabilities.document_highlight_provider.is_some()
             },
         ),
         (
@@ -68,7 +68,10 @@ fn individual_feature_flags_gate_matching_providers() {
         (
             "rename",
             |features| features.rename = false,
-            |capabilities| capabilities.rename_provider.is_some(),
+            |capabilities| {
+                capabilities.rename_provider.is_some()
+                    || capabilities.linked_editing_range_provider.is_some()
+            },
         ),
         (
             "formatting",
@@ -77,8 +80,8 @@ fn individual_feature_flags_gate_matching_providers() {
             // formatter scoped to the document, to a selection, and to a line.
             |capabilities| {
                 capabilities.document_formatting_provider.is_some()
-                    && capabilities.document_range_formatting_provider.is_some()
-                    && capabilities.document_on_type_formatting_provider.is_some()
+                    || capabilities.document_range_formatting_provider.is_some()
+                    || capabilities.document_on_type_formatting_provider.is_some()
             },
         ),
         (
@@ -94,12 +97,18 @@ fn individual_feature_flags_gate_matching_providers() {
         (
             "document_links",
             |features| features.document_links = false,
-            |capabilities| capabilities.document_link_provider.is_some(),
+            |capabilities| {
+                capabilities.document_link_provider.is_some()
+                    || capabilities.color_provider.is_some()
+            },
         ),
         (
             "folding_ranges",
             |features| features.folding_ranges = false,
-            |capabilities| capabilities.folding_range_provider.is_some(),
+            |capabilities| {
+                capabilities.folding_range_provider.is_some()
+                    || capabilities.selection_range_provider.is_some()
+            },
         ),
         (
             "inlay_hints",

--- a/crates/vize_maestro/src/server/handlers/navigation.rs
+++ b/crates/vize_maestro/src/server/handlers/navigation.rs
@@ -159,7 +159,7 @@ pub(super) async fn goto_implementation(
     server: &MaestroServer,
     params: GotoImplementationParams,
 ) -> Result<Option<GotoImplementationResponse>> {
-    if !server.state.lsp_features().definition {
+    if !server.state.lsp_features().definition || !server.state.lsp_features().typecheck {
         return Ok(None);
     }
 

--- a/crates/vize_maestro/src/server/handlers/tests/requests.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests.rs
@@ -184,6 +184,21 @@ enabled_missing_doc_request_returns_none!(
     |server, uri| server.goto_declaration(declaration_params(&uri))
 );
 disabled_open_doc_request_returns_none!(
+    implementation_disabled_returns_none,
+    &[("definition", false), ("typecheck", true)],
+    |server, uri| server.goto_implementation(implementation_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
+    implementation_disabled_when_typecheck_is_off_returns_none,
+    &[("definition", true), ("typecheck", false)],
+    |server, uri| server.goto_implementation(implementation_params(&uri))
+);
+enabled_missing_doc_request_returns_none!(
+    implementation_missing_document_returns_none,
+    &[("definition", true), ("typecheck", true)],
+    |server, uri| server.goto_implementation(implementation_params(&uri))
+);
+disabled_open_doc_request_returns_none!(
     references_disabled_returns_none,
     &[("references", false)],
     |server, uri| server.references(references_params(&uri))

--- a/crates/vize_maestro/src/server/handlers/tests/requests/params.rs
+++ b/crates/vize_maestro/src/server/handlers/tests/requests/params.rs
@@ -107,6 +107,14 @@ pub(super) fn declaration_params(uri: &Url) -> DeclParams {
     }
 }
 
+pub(super) fn implementation_params(uri: &Url) -> ImplParams {
+    ImplParams {
+        text_document_position_params: text_pos(uri),
+        work_done_progress_params: WorkDoneProgressParams::default(),
+        partial_result_params: PartialResultParams::default(),
+    }
+}
+
 pub(super) fn references_params(uri: &Url) -> ReferenceParams {
     ReferenceParams {
         text_document_position: text_pos(uri),


### PR DESCRIPTION
## Summary
- gate `textDocument/implementation` on both definition and typecheck feature flags
- add request-guard coverage for implementation requests
- harden grouped capability-gate assertions so companion providers cannot leak

## Tests
- `cargo fmt --all --check`
- `cargo test -p vize_maestro server::handlers::tests::requests --all-features`
- `cargo test -p vize_maestro server::capabilities::tests --all-features`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791293347&installation_model_id=422833&pr_number=5833&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5833&signature=bd9fceceff38918e8fb1b5e6c17df07e0939450f9af162f9460de5cc53640b95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->