### PR TITLE
fix(davinci): gate unsupported DOM codegen options

### DIFF
--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -96,7 +96,7 @@ pub(super) fn codegen_options(
 
 pub(super) fn s2_emit_supported(
     options: &DomCompilerOptions,
-    _codegen: &CodegenOptions,
+    codegen: &CodegenOptions,
     custom_elements_supported: bool,
     template_syntax: TemplateSyntaxMode,
     has_croquis: bool,
@@ -115,6 +115,7 @@ pub(super) fn s2_emit_supported(
         && template_syntax == TemplateSyntaxMode::Standard
         && custom_elements_supported
         && !has_croquis
+        && !codegen.optimize_imports
 }
 
 /// The published DOM option surface projected onto the S2 emitter.

--- a/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
@@ -57,6 +57,22 @@ fn legacy_dialects_stay_on_the_compatibility_lane() {
     ));
 }
 
+#[test]
+fn ssr_optimize_imports_codegen_option_stays_on_the_compatibility_lane() {
+    assert!(!s2_emit_supported(
+        &DomCompilerOptions::default(),
+        &CodegenOptions {
+            optimize_imports: true,
+            ..Default::default()
+        },
+        true,
+        TemplateSyntaxMode::Standard,
+        false,
+        DomLaneSelection::S2,
+        super::S2EmitSelection::Allowed,
+    ));
+}
+
 fn supported(options: DomCompilerOptions, dom_lane: DomLaneSelection) -> bool {
     s2_emit_supported(
         &options,

--- a/crates/vize_atelier_dom/tests/davinci_s2_codegen_option_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_codegen_option_selector.rs
@@ -1,0 +1,68 @@
+//! P2-11 witness: backend-only codegen options stay on the compatibility lane
+//! until the DOM S2 selector owns their semantics.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use vize_atelier_core::options::{CodegenOptions, TemplateSyntaxMode};
+use vize_atelier_dom::{
+    DomCompilerOptions,
+    compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+};
+use vize_s0::Allocator;
+use vize_s0::profiler::{CounterSummary, global_profiler};
+
+#[test]
+fn optimize_imports_stays_on_compatibility_when_profiled() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+    profiler.enable();
+
+    let allocator = Allocator::new();
+    let (_, errors, result) =
+        compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            r#"<button @click="go">{{ label }}</button>"#,
+            DomCompilerOptions::default(),
+            TemplateSyntaxMode::Standard,
+            None,
+            CodegenOptions {
+                optimize_imports: true,
+                ..Default::default()
+            },
+        );
+    let counters = profiler.counter_summary();
+    profiler.disable();
+    profiler.clear();
+
+    assert!(errors.is_empty(), "compile errors: {errors:?}");
+    assert!(
+        result.sections.is_some(),
+        "unsupported backend-only codegen options must keep compatibility sections"
+    );
+    assert_eq!(
+        counter_total(&counters, "davinci.s2_dom.files"),
+        None,
+        "unsupported backend-only codegen options must not enter the S2 production selector"
+    );
+}
+
+fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
+    counters
+        .entries
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.total)
+}
+
+fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
+    static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    PROFILER_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -50,6 +50,21 @@ const s2EmitOptionFields = [
   "custom_element_patterns",
   "bindings",
 ];
+const codegenOptionsOwnedByDomCompiler = [
+  "mode",
+  "prefix_identifiers",
+  "source_map",
+  "component_name",
+  "scope_id",
+  "ssr",
+  "is_ts",
+  "inline",
+  "binding_metadata",
+  "cache_handlers",
+];
+const codegenOptionsProjectedToS2 = ["runtime_module_name", "runtime_global_name"];
+const codegenOptionsHandledAroundS2 = ["filename"];
+const codegenOptionsUnsupportedForS2 = ["optimize_imports"];
 
 test("DOM compiler keeps the published S2 renderer available for profiling", () => {
   const dependencies = workspacePackage(metadata, "vize_atelier_dom").dependencies;
@@ -142,6 +157,23 @@ test("DOM S2 emit options stay scoped to the supported switch surface", () => {
       ),
     ].sort(),
     [...s2EmitOptionFields].sort(),
+  );
+});
+
+test("DOM S2 production switch classifies every adapter codegen option", () => {
+  const fields = publicStructFieldNames(
+    readRepoFile("crates", "vize_relief", "src", "options.rs"),
+    "CodegenOptions",
+  );
+
+  assert.deepEqual(
+    sortedUnique([
+      ...codegenOptionsOwnedByDomCompiler,
+      ...codegenOptionsProjectedToS2,
+      ...codegenOptionsHandledAroundS2,
+      ...codegenOptionsUnsupportedForS2,
+    ]),
+    [...fields].sort(),
   );
 });
 


### PR DESCRIPTION
## Summary
- Keep backend-only `CodegenOptions::optimize_imports` on the DOM compatibility lane until S2 owns it.
- Add behavior coverage for the profiled production selector and a tooling inventory guard for adapter codegen options.

## Validation
- `cargo fmt --check`
- `cargo test -p vize_atelier_dom compile::stage_options::tests`
- `cargo test -p vize_atelier_dom --test davinci_s2_production_selector`
- `vp exec node --test tests/tooling/davinci-dom-production-boundary.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791293436&installation_model_id=422833&pr_number=5834&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5834&signature=475a8dbe6218a18a4b4313efb9932ae18297eb443bc76790f82afebbb470cad3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enabling import optimization during code generation now keeps compilation on the compatibility path instead of selecting the S2 production path.
  - Compatibility sections are preserved when this unsupported S2 option is enabled.

- **Tests**
  - Added regression coverage for import optimization behavior and S2 lane selection.
  - Added validation ensuring code generation options are consistently classified across compilation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->