### PR TITLE
fix(release): report failed matrix shard jobs

### DIFF
--- a/legacy-tools/github/release-preflight-evidence.mjs
+++ b/legacy-tools/github/release-preflight-evidence.mjs
@@ -151,6 +151,7 @@ export function selectRequiredWorkflowRuns(
   required = requiredReleaseWorkflows,
   qualifiers = new Map(),
   evidenceShas = new Map(),
+  jobFailureSummaries = new Map(),
 ) {
   const selected = new Map();
   const failures = [];
@@ -172,7 +173,7 @@ export function selectRequiredWorkflowRuns(
       );
     } else if (current.status !== "completed" || current.conclusion !== "success") {
       failures.push(
-        `${workflowName}: ${current.status}/${current.conclusion ?? "no conclusion"} (${current.html_url ?? "no URL"})`,
+        `${workflowName}: ${current.status}/${current.conclusion ?? "no conclusion"} (${current.html_url ?? "no URL"})${formatJobFailureSummary(jobFailureSummaries.get(workflowName))}`,
       );
     } else {
       selected.set(workflowName, current);
@@ -188,8 +189,37 @@ export function selectRequiredWorkflowRuns(
   return selected;
 }
 
+function formatJobFailureSummary(summary) {
+  return summary == null || summary === "" ? "" : `; ${summary}`;
+}
+
 export function workflowRequiresJobEvidence(workflowName) {
   return requiredJobNames.has(workflowName);
+}
+
+export function summarizeRequiredWorkflowJobFailures(workflowName, jobs) {
+  const failures = [];
+  for (const jobName of requiredJobNames.get(workflowName) ?? []) {
+    const matching = jobs.filter((job) => job.name === jobName);
+    if (matching.length === 0) {
+      failures.push(`${jobName}=missing`);
+      continue;
+    }
+    if (matching.length > 1) {
+      failures.push(`${jobName}=duplicate(${matching.length})`);
+      continue;
+    }
+    const job = matching[0];
+    if (job.status !== "completed" || job.conclusion !== "success") {
+      failures.push(`${jobName}=${job.status}/${job.conclusion ?? "no conclusion"}`);
+    }
+  }
+  if (failures.length === 0) return null;
+  const maxReportedJobs = 8;
+  const reported = failures.slice(0, maxReportedJobs);
+  const omitted = failures.length - reported.length;
+  if (omitted > 0) reported.push(`and ${omitted} more`);
+  return `required jobs: ${reported.join(", ")}`;
 }
 
 export function assertRequiredWorkflowJobs(workflowName, jobs) {

--- a/tests/tooling/release-preflight-evidence.test.ts
+++ b/tests/tooling/release-preflight-evidence.test.ts
@@ -6,6 +6,7 @@ import {
   requiredReleaseWorkflowEvidence,
   requiredReleaseWorkflows,
   selectRequiredWorkflowRuns,
+  summarizeRequiredWorkflowJobFailures,
 } from "../../legacy-tools/github/release-preflight-evidence.mjs";
 import { requiredRealProjectMatrixShardCount } from "../../legacy-tools/github/release-preflight-matrix-evidence.mjs";
 import { readRepoFile } from "./support/github-workflows.ts";
@@ -171,6 +172,39 @@ test("matrix-sensitive release gates require every successful job", () => {
       ]),
     new RegExp(
       `real projects \\(0\\/${requiredRealProjectMatrixShardCount}\\) is completed\\/failure`,
+    ),
+  );
+});
+
+test("required workflow selection can report failed release jobs inline", () => {
+  const runs = requiredReleaseWorkflows.map((name, index) => successfulReleaseRun(name, index + 1));
+  const matrix = runs.find((run) => run.name === "Real Project Matrix");
+  assert.ok(matrix);
+  matrix.conclusion = "cancelled";
+
+  const matrixJobs = Array.from({ length: requiredRealProjectMatrixShardCount }, (_, shard) =>
+    successfulReleaseJob(`real projects (${shard}/${requiredRealProjectMatrixShardCount})`),
+  );
+  matrixJobs[0] = { ...matrixJobs[0], conclusion: "cancelled" };
+  matrixJobs[12] = { ...matrixJobs[12], conclusion: "failure" };
+
+  const summary = summarizeRequiredWorkflowJobFailures("Real Project Matrix", matrixJobs);
+  assert.equal(
+    summary,
+    `required jobs: real projects (0/${requiredRealProjectMatrixShardCount})=completed/cancelled, real projects (12/${requiredRealProjectMatrixShardCount})=completed/failure`,
+  );
+  assert.throws(
+    () =>
+      selectRequiredWorkflowRuns(
+        runs,
+        releaseSha,
+        requiredReleaseWorkflows,
+        new Map(),
+        new Map(),
+        new Map([["Real Project Matrix", summary]]),
+      ),
+    new RegExp(
+      `Real Project Matrix: completed\\/cancelled[\\s\\S]*required jobs: real projects \\(0\\/${requiredRealProjectMatrixShardCount}\\)=completed\\/cancelled, real projects \\(12\\/${requiredRealProjectMatrixShardCount}\\)=completed\\/failure`,
     ),
   );
 });

--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -186,6 +186,49 @@ test("verify-only mode accepts flat job evidence returned by pagination", () => 
   }
 });
 
+test("verify-only mode reports failed matrix shard jobs for red release evidence", () => {
+  const tempDir = fs.mkdtempSync(path.join(tmpdir(), "vize-release-red-matrix-"));
+  try {
+    const fixture = createReleasePreflightVerifyOnlyFixture(tempDir, {
+      requireJobTimeoutArgs: true,
+      mutateRuns(runs) {
+        const matrix = runs.find((run) => run.name === "Real Project Matrix");
+        assert.ok(matrix);
+        matrix.conclusion = "cancelled";
+      },
+      mutateJobs(jobs) {
+        const matrixJobs = jobs[106];
+        assert.ok(matrixJobs);
+        matrixJobs[0] = { ...matrixJobs[0], conclusion: "cancelled" };
+        matrixJobs[12] = { ...matrixJobs[12], conclusion: "failure" };
+      },
+    });
+    const result = spawnSync(
+      "rust-script",
+      ["tools/commands/ci/github/release-preflight.rs", "--verify-only"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          ...fixture.env,
+        },
+      },
+    );
+
+    assert.ifError(result.error);
+    assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`.trim());
+    assert.match(result.stderr, /Real Project Matrix: completed\/cancelled/);
+    assert.match(
+      result.stderr,
+      /required jobs: real projects \(0\/22\)=completed\/cancelled, real projects \(12\/22\)=completed\/failure/,
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("verify-only mode rejects mutation states with observed typecheck drift", () => {
   const tempDir = fs.mkdtempSync(path.join(tmpdir(), "vize-release-mutation-drift-"));
   try {

--- a/tests/tooling/support/release-preflight-runner-fixture.ts
+++ b/tests/tooling/support/release-preflight-runner-fixture.ts
@@ -19,7 +19,10 @@ const baseSha = "b".repeat(40);
 export function createReleasePreflightVerifyOnlyFixture(
   tempDir: string,
   options: {
+    mutateJobs?: (jobs: ReturnType<typeof releaseWorkflowJobs>) => void;
+    mutateRuns?: (runs: ReturnType<typeof releaseWorkflowRuns>) => void;
     mutateShardEntries?: (shard: number, entries: Record<string, string>) => void;
+    requireJobTimeoutArgs?: boolean;
   } = {},
 ) {
   const binDir = path.join(tempDir, "bin");
@@ -35,6 +38,8 @@ export function createReleasePreflightVerifyOnlyFixture(
   assert.ok(matrixRun);
   const artifacts = realProjectArtifacts(matrixRun);
   const jobs = releaseWorkflowJobs();
+  options.mutateRuns?.(runs);
+  options.mutateJobs?.(jobs);
 
   fs.mkdirSync(binDir, { recursive: true });
   fs.mkdirSync(dataDir, { recursive: true });
@@ -70,6 +75,7 @@ export function createReleasePreflightVerifyOnlyFixture(
       TEST_MAIN_CARGO_TOML: `[workspace.package]\nversion = "${version}"\n`,
       TEST_PACKAGE_MANIFESTS: JSON.stringify(trackedManifests),
       TEST_RELEASE_SHA: releaseSha,
+      TEST_REQUIRE_JOB_TIMEOUT_ARGS: options.requireJobTimeoutArgs === true ? "1" : "0",
       TEST_RUNS_FILE: path.join(dataDir, "runs.json"),
       TEST_TAG: tag,
       TEST_TAG_SHA: releaseSha,
@@ -182,6 +188,13 @@ function writeFlatJobEvidenceCurlCommand(binDir: string): void {
       "const args = process.argv.slice(2);",
       "const read = (file) => JSON.parse(fs.readFileSync(file, 'utf8'));",
       "const send = (value) => process.stdout.write(JSON.stringify(value));",
+      "const isJobsRequest = url.includes('/actions/runs/') && url.includes('/jobs');",
+      "if (process.env.TEST_REQUIRE_JOB_TIMEOUT_ARGS === '1' && isJobsRequest) {",
+      "  if (!args.includes('--connect-timeout') || !args.includes('--max-time')) {",
+      "    console.error('jobs request is missing bounded curl timeout flags');",
+      "    process.exit(22);",
+      "  }",
+      "}",
       "if (url.includes('/actions/runs?')) send({ workflow_runs: read(process.env.TEST_RUNS_FILE) });",
       "else if (url.includes('/actions/runs/') && url.includes('/artifacts')) send({ artifacts: read(process.env.TEST_ARTIFACTS_FILE) });",
       "else if (url.startsWith('https://example.test/artifacts/')) {",
@@ -189,7 +202,7 @@ function writeFlatJobEvidenceCurlCommand(binDir: string): void {
       "  const shard = url.match(/\\/artifacts\\/(\\d+)\\.zip$/)?.[1];",
       "  if (output == null || shard == null) process.exit(22);",
       "  fs.copyFileSync(path.join(process.env.TEST_ARTIFACT_DIR, `${shard}.zip`), output);",
-      "} else if (url.includes('/actions/runs/')) {",
+      "} else if (isJobsRequest) {",
       "  const id = url.match(/\\/actions\\/runs\\/(\\d+)\\/jobs/)?.[1];",
       "  send({ jobs: read(process.env.TEST_JOBS_FILE)[id] ?? [] });",
       "} else if (url.includes('/issues?')) send([]);",

--- a/tools/commands/ci/github/release-preflight.rs
+++ b/tools/commands/ci/github/release-preflight.rs
@@ -46,6 +46,10 @@ const PARENT_EVIDENCE_REUSABLE_WORKFLOWS: &[&str] = &[
 ];
 const RELEASE_PACKAGE_ROOTS: &[&str] = &["editors", "npm"];
 const RELEASE_BLOCKING_LABELS: &[&str] = &["priority:p0", "priority:p1"];
+const FAILURE_DETAIL_GITHUB_TIMEOUTS: GitHubApiTimeouts = GitHubApiTimeouts {
+    connect: Duration::from_secs(5),
+    total: Duration::from_secs(20),
+};
 
 #[derive(Clone, Debug)]
 struct PackageManifest {
@@ -58,6 +62,12 @@ struct GitOutput {
     status: i32,
     stdout: String,
     stderr: String,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct GitHubApiTimeouts {
+    connect: Duration,
+    total: Duration,
 }
 
 #[derive(Clone, Debug)]
@@ -151,7 +161,15 @@ fn verify_release_preflight(bootstrap: bool) -> Result<(), String> {
             &mut runs,
         )?
     } else {
-        select_required_workflow_runs(&runs, &target.sha, &evidence_shas, &dispatch_plans)?
+        select_required_workflow_runs_with_failure_details(
+            &api_url,
+            &repository,
+            &token,
+            &runs,
+            &target.sha,
+            &evidence_shas,
+            &dispatch_plans,
+        )?
     };
 
     let issues = github_api_pages(&api_url, &repository, &token, "issues", Some("state=open"))?;
@@ -615,16 +633,46 @@ fn bootstrap_required_workflow_runs(
             }
         }
         if failed || (missing.is_empty() && pending.is_empty()) {
-            return select_required_workflow_runs(runs, &target.sha, evidence_shas, dispatch_plans);
+            let failure_details = collect_required_workflow_failure_details(
+                api_url,
+                repository,
+                token,
+                runs,
+                &target.sha,
+                evidence_shas,
+                dispatch_plans,
+            );
+            return select_required_workflow_runs(
+                runs,
+                &target.sha,
+                evidence_shas,
+                dispatch_plans,
+                Some(&failure_details),
+            );
         }
         if started.elapsed() >= timeout {
-            return select_required_workflow_runs(runs, &target.sha, evidence_shas, dispatch_plans)
-                .map_err(|error| {
-                    format!(
-                        "Timed out after {}ms waiting for release gates.\n{error}",
-                        timeout.as_millis()
-                    )
-                });
+            let failure_details = collect_required_workflow_failure_details(
+                api_url,
+                repository,
+                token,
+                runs,
+                &target.sha,
+                evidence_shas,
+                dispatch_plans,
+            );
+            return select_required_workflow_runs(
+                runs,
+                &target.sha,
+                evidence_shas,
+                dispatch_plans,
+                Some(&failure_details),
+            )
+            .map_err(|error| {
+                format!(
+                    "Timed out after {}ms waiting for release gates.\n{error}",
+                    timeout.as_millis()
+                )
+            });
         }
         let wait_state = format!("missing={missing:?};pending={pending:?}");
         if wait_state != previous_wait_state {
@@ -647,6 +695,33 @@ fn bootstrap_required_workflow_runs(
     }
 }
 
+fn select_required_workflow_runs_with_failure_details(
+    api_url: &str,
+    repository: &str,
+    token: &str,
+    runs: &[Value],
+    sha: &str,
+    evidence_shas: &BTreeMap<&'static str, Vec<String>>,
+    dispatch_plans: &[DispatchPlan],
+) -> Result<BTreeMap<String, Value>, String> {
+    let failure_details = collect_required_workflow_failure_details(
+        api_url,
+        repository,
+        token,
+        runs,
+        sha,
+        evidence_shas,
+        dispatch_plans,
+    );
+    select_required_workflow_runs(
+        runs,
+        sha,
+        evidence_shas,
+        dispatch_plans,
+        Some(&failure_details),
+    )
+}
+
 fn dispatch_workflow(
     api_url: &str,
     repository: &str,
@@ -666,6 +741,7 @@ fn select_required_workflow_runs(
     sha: &str,
     evidence_shas: &BTreeMap<&'static str, Vec<String>>,
     dispatch_plans: &[DispatchPlan],
+    failure_details: Option<&BTreeMap<String, String>>,
 ) -> Result<BTreeMap<String, Value>, String> {
     let mut selected = BTreeMap::new();
     let mut failures = Vec::new();
@@ -686,14 +762,19 @@ fn select_required_workflow_runs(
             if status == Some("completed") && conclusion == Some("success") {
                 selected.insert((*workflow_name).to_string(), current.clone());
             } else {
+                let detail = failure_details
+                    .and_then(|details| details.get(*workflow_name))
+                    .map(|detail| format!("; {detail}"))
+                    .unwrap_or_default();
                 failures.push(format!(
-                    "{workflow_name}: {}/{} ({})",
+                    "{workflow_name}: {}/{} ({}){}",
                     status.unwrap_or("unknown"),
                     conclusion.unwrap_or("no conclusion"),
                     current
                         .get("html_url")
                         .and_then(Value::as_str)
-                        .unwrap_or("no URL")
+                        .unwrap_or("no URL"),
+                    detail
                 ));
             }
         } else {
@@ -716,6 +797,55 @@ fn select_required_workflow_runs(
         ));
     }
     Ok(selected)
+}
+
+fn collect_required_workflow_failure_details(
+    api_url: &str,
+    repository: &str,
+    token: &str,
+    runs: &[Value],
+    sha: &str,
+    evidence_shas: &BTreeMap<&'static str, Vec<String>>,
+    dispatch_plans: &[DispatchPlan],
+) -> BTreeMap<String, String> {
+    let mut details = BTreeMap::new();
+    for workflow_name in REQUIRED_RELEASE_WORKFLOWS {
+        if !workflow_requires_job_evidence(workflow_name) {
+            continue;
+        }
+        let Ok(Some(run)) = latest_required_workflow_run(
+            runs,
+            &accepted_evidence_shas(evidence_shas, workflow_name, sha),
+            workflow_name,
+            dispatch_plans
+                .iter()
+                .find(|plan| plan.workflow_name == *workflow_name),
+        ) else {
+            continue;
+        };
+        if run.get("status").and_then(Value::as_str) == Some("completed")
+            && run.get("conclusion").and_then(Value::as_str) == Some("success")
+        {
+            continue;
+        }
+        let Some(run_id) = run.get("id").and_then(Value::as_i64) else {
+            continue;
+        };
+        let detail = github_api_pages_with_timeouts(
+            api_url,
+            repository,
+            token,
+            &format!("actions/runs/{run_id}/jobs"),
+            None,
+            FAILURE_DETAIL_GITHUB_TIMEOUTS,
+        )
+        .ok()
+        .and_then(|jobs| summarize_required_workflow_job_failures(workflow_name, &jobs));
+        if let Some(detail) = detail {
+            details.insert((*workflow_name).to_string(), detail);
+        }
+    }
+    details
 }
 
 fn latest_required_workflow_run<'a>(
@@ -839,11 +969,8 @@ fn workflow_requires_job_evidence(workflow_name: &str) -> bool {
     )
 }
 
-fn assert_required_workflow_jobs(
-    workflow_name: &str,
-    jobs_response: &[Value],
-) -> Result<(), String> {
-    let job_names = match workflow_name {
+fn required_workflow_job_names(workflow_name: &str) -> Vec<String> {
+    match workflow_name {
         "Check" => vec!["test-scripts".to_string()],
         "Benchmark" => vec!["pr-benchmark-budget".to_string()],
         "Fuzz" => vec![
@@ -862,7 +989,14 @@ fn assert_required_workflow_jobs(
             })
             .collect(),
         _ => Vec::new(),
-    };
+    }
+}
+
+fn assert_required_workflow_jobs(
+    workflow_name: &str,
+    jobs_response: &[Value],
+) -> Result<(), String> {
+    let job_names = required_workflow_job_names(workflow_name);
     let mut jobs = flatten_collection(jobs_response, "jobs");
     if jobs.is_empty() && jobs_response.iter().all(Value::is_object) {
         jobs.extend(jobs_response);
@@ -895,6 +1029,57 @@ fn assert_required_workflow_jobs(
         }
     }
     Ok(())
+}
+
+fn summarize_required_workflow_job_failures(
+    workflow_name: &str,
+    jobs_response: &[Value],
+) -> Option<String> {
+    let job_names = required_workflow_job_names(workflow_name);
+    if job_names.is_empty() {
+        return None;
+    }
+    let mut jobs = flatten_collection(jobs_response, "jobs");
+    if jobs.is_empty() && jobs_response.iter().all(Value::is_object) {
+        jobs.extend(jobs_response);
+    }
+    let mut failures = Vec::new();
+    for name in job_names {
+        let matching = jobs
+            .iter()
+            .filter(|job| job.get("name").and_then(Value::as_str) == Some(name.as_str()))
+            .collect::<Vec<_>>();
+        match matching.as_slice() {
+            [] => failures.push(format!("{name}=missing")),
+            [job] => {
+                let status = job
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown");
+                let conclusion = job
+                    .get("conclusion")
+                    .and_then(Value::as_str)
+                    .unwrap_or("no conclusion");
+                if status != "completed" || conclusion != "success" {
+                    failures.push(format!("{name}={status}/{conclusion}"));
+                }
+            }
+            _ => failures.push(format!("{name}=duplicate({})", matching.len())),
+        }
+    }
+    if failures.is_empty() {
+        return None;
+    }
+    const MAX_REPORTED_JOBS: usize = 8;
+    let omitted = failures.len().saturating_sub(MAX_REPORTED_JOBS);
+    let mut reported = failures
+        .into_iter()
+        .take(MAX_REPORTED_JOBS)
+        .collect::<Vec<_>>();
+    if omitted > 0 {
+        reported.push(format!("and {omitted} more"));
+    }
+    Some(format!("required jobs: {}", reported.join(", ")))
 }
 
 fn find_release_blockers(issues: &[Value], tag: Option<&str>) -> Result<Vec<Value>, String> {
@@ -1019,6 +1204,28 @@ fn github_api_pages(
     resource: &str,
     query: Option<&str>,
 ) -> Result<Vec<Value>, String> {
+    github_api_pages_inner(api_url, repository, token, resource, query, None)
+}
+
+fn github_api_pages_with_timeouts(
+    api_url: &str,
+    repository: &str,
+    token: &str,
+    resource: &str,
+    query: Option<&str>,
+    timeouts: GitHubApiTimeouts,
+) -> Result<Vec<Value>, String> {
+    github_api_pages_inner(api_url, repository, token, resource, query, Some(timeouts))
+}
+
+fn github_api_pages_inner(
+    api_url: &str,
+    repository: &str,
+    token: &str,
+    resource: &str,
+    query: Option<&str>,
+    timeouts: Option<GitHubApiTimeouts>,
+) -> Result<Vec<Value>, String> {
     let mut page = 1;
     let mut items = Vec::new();
     loop {
@@ -1032,7 +1239,11 @@ fn github_api_pages(
             separator,
             page
         );
-        let response = github_api_raw(token, &url)?;
+        let response = if let Some(timeouts) = timeouts {
+            github_api_raw_with_timeouts(token, &url, Some(timeouts))?
+        } else {
+            github_api_raw(token, &url)?
+        };
         let value: Value = serde_json::from_str(&response)
             .map_err(|error| format!("GitHub API returned invalid JSON for {resource}: {error}"))?;
         let page_items = flatten_collection(std::slice::from_ref(&value), collection_for(resource));
@@ -1109,7 +1320,16 @@ fn github_api_request(
 }
 
 fn github_api_raw(token: &str, url: &str) -> Result<String, String> {
-    let output = Command::new("curl")
+    github_api_raw_with_timeouts(token, url, None)
+}
+
+fn github_api_raw_with_timeouts(
+    token: &str,
+    url: &str,
+    timeouts: Option<GitHubApiTimeouts>,
+) -> Result<String, String> {
+    let mut command = Command::new("curl");
+    command
         .args([
             "--fail-with-body",
             "--silent",
@@ -1120,15 +1340,27 @@ fn github_api_raw(token: &str, url: &str) -> Result<String, String> {
             "X-GitHub-Api-Version: 2022-11-28",
             "--header",
             &format!("Authorization: Bearer {token}"),
-            url,
         ])
-        .stdin(Stdio::null())
+        .stdin(Stdio::null());
+    if let Some(timeouts) = timeouts {
+        command
+            .arg("--connect-timeout")
+            .arg(curl_timeout_arg(timeouts.connect))
+            .arg("--max-time")
+            .arg(curl_timeout_arg(timeouts.total));
+    }
+    let output = command
+        .arg(url)
         .output()
         .map_err(|error| format!("failed to run curl: {error}"))?;
     if !output.status.success() {
         return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
     }
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn curl_timeout_arg(duration: Duration) -> String {
+    duration.as_secs().max(1).to_string()
 }
 
 fn collection_for(resource: &str) -> &'static str {


### PR DESCRIPTION
## Summary
- include non-success required job names when release preflight reports a red required gate
- keep the legacy evidence helper aligned with the Rust script
- cover cancelled Real Project Matrix shard evidence in selector and verify-only tests

## Validation
- `TMPDIR="$PWD/target/vize-tests/tmp" TEMP="$PWD/target/vize-tests/tmp" TMP="$PWD/target/vize-tests/tmp" vp exec node --test tests/tooling/release-preflight-evidence.test.ts tests/tooling/release-preflight-runner.test.ts tests/tooling/release-preflight-bootstrap.test.ts tests/tooling/release-preflight-bootstrap-budget.test.ts tests/tooling/github-workflows-docs.test.ts`
- `rustfmt --check tools/commands/ci/github/release-preflight.rs`
- `git diff --check origin/main...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5835"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791294229&installation_model_id=422833&pr_number=5835&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5835&signature=5122886fab8726c77b4a8fa5b31345cada049e36333d4ee1dbbceec092a84ee3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release preflight failure messages with detailed required-job information.
  - Reports missing, duplicate, failed, cancelled, or otherwise unsuccessful jobs by workflow.
  - Applies the enhanced diagnostics during both verify-only checks and release readiness polling.
  - Limits lengthy job lists while indicating how many additional failures were found.
  - Provides clearer command-line output when required workflow runs or jobs do not complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->