### PR TITLE
fix(bench): fail closed on invalid check median

### DIFF
--- a/.github/workflows/check-bench.yml
+++ b/.github/workflows/check-bench.yml
@@ -32,6 +32,7 @@ on:
       - tools/benchmarks/scripts/check-gate-env.mjs
       - tools/benchmarks/scripts/check-gate-plants.mjs
       - tools/benchmarks/scripts/check-gate-report.mjs
+      - tools/benchmarks/scripts/check-gate-report.test.mjs
       - .github/workflows/check-bench.yml
   schedule:
     # Weekly report cadence; the plants correctness gate itself runs on every
@@ -79,6 +80,9 @@ jobs:
           node-version-file: "package.json"
           cache: true
           run-install: false
+
+      - name: Test check benchmark report helpers
+        run: node --test tools/benchmarks/scripts/check-gate-report.test.mjs
 
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline

--- a/tools/benchmarks/scripts/check-gate-report.mjs
+++ b/tools/benchmarks/scripts/check-gate-report.mjs
@@ -75,6 +75,9 @@ export function measureRows(variants, { runs, warmups }) {
 
 /** Pure budget rule so tests can exercise it without re-measuring. */
 export function evaluateBudget(headMedianMs, baseline, thresholdPercent) {
+  if (!Number.isFinite(headMedianMs) || headMedianMs <= 0) {
+    return { status: "invalid-head-median", headMedianMs, thresholdPercent };
+  }
   if (baseline == null) return { status: "no-baseline", thresholdPercent };
   const baseMedianMs = baseline?.rows?.find((row) => row.id === "vize-check-max")?.medianMs;
   if (!Number.isFinite(baseMedianMs) || baseMedianMs <= 0) {

--- a/tools/benchmarks/scripts/check-gate-report.test.mjs
+++ b/tools/benchmarks/scripts/check-gate-report.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { evaluateBudget } from "./check-gate-report.mjs";
+
+const baseline = {
+  rows: [{ id: "vize-check-max", medianMs: 100 }],
+};
+
+void test("evaluateBudget fails closed when the head median is invalid", () => {
+  for (const headMedianMs of [Number.NaN, Number.POSITIVE_INFINITY, 0, -1]) {
+    assert.deepEqual(evaluateBudget(headMedianMs, baseline, 10), {
+      status: "invalid-head-median",
+      headMedianMs,
+      thresholdPercent: 10,
+    });
+  }
+});
+
+void test("evaluateBudget keeps the no-baseline report state for valid head timings", () => {
+  assert.deepEqual(evaluateBudget(90, null, 10), {
+    status: "no-baseline",
+    thresholdPercent: 10,
+  });
+});
+
+void test("evaluateBudget reports an invalid stored baseline separately", () => {
+  assert.deepEqual(evaluateBudget(90, { rows: [] }, 10), {
+    status: "invalid-baseline",
+    thresholdPercent: 10,
+  });
+});
+
+void test("evaluateBudget fails only when the threshold is reached", () => {
+  assert.deepEqual(evaluateBudget(109.99, baseline, 10), {
+    status: "passed",
+    baseMedianMs: 100,
+    headMedianMs: 109.99,
+    changePercent: 9.99,
+    thresholdPercent: 10,
+  });
+  assert.deepEqual(evaluateBudget(110, baseline, 10), {
+    status: "failed",
+    baseMedianMs: 100,
+    headMedianMs: 110,
+    changePercent: 10,
+    thresholdPercent: 10,
+  });
+});

--- a/tools/benchmarks/scripts/check-gate.mjs
+++ b/tools/benchmarks/scripts/check-gate.mjs
@@ -268,7 +268,11 @@ export async function main(argv = process.argv.slice(2)) {
   if (args.out) writeFileSync(resolve(args.out), markdown);
   else process.stdout.write(markdown);
   if (args.json) writeFileSync(resolve(args.json), `${JSON.stringify(data, null, 2)}\n`);
-  if (budget.status === "failed" || budget.status === "invalid-baseline") {
+  if (
+    budget.status === "failed" ||
+    budget.status === "invalid-baseline" ||
+    budget.status === "invalid-head-median"
+  ) {
     throw new Error(`check-gate: budget ${budget.status} (${JSON.stringify(budget)})`);
   }
 }


### PR DESCRIPTION
Summary:
- Reject invalid check benchmark head medians before ratio evaluation.
- Make check-gate exit nonzero for invalid head median reports.
- Run the check-gate report unit test from the benchmark workflow.

Validation:
- node --test tools/benchmarks/scripts/check-gate-report.test.mjs
- vp exec oxfmt --check tools/benchmarks/scripts/check-gate-report.mjs tools/benchmarks/scripts/check-gate-report.test.mjs tools/benchmarks/scripts/check-gate.mjs .github/workflows/check-bench.yml
- vp exec oxlint tools/benchmarks/scripts/check-gate-report.mjs tools/benchmarks/scripts/check-gate-report.test.mjs tools/benchmarks/scripts/check-gate.mjs
- rust-script tools/commands/ci/verify-tool-layout.rs
- git diff --check origin/main..HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791298104&installation_model_id=422833&pr_number=5836&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5836&signature=252c22e31d5857d8051c2a7d23d9b4000ecc4f920fe7cdf2417b5b370bfdaf1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Benchmark budget checks now reject invalid or non-positive performance measurements instead of producing misleading comparisons.
  - Invalid benchmark results now correctly cause budget checks to fail.
  - Threshold handling remains precise, including distinctions between just-below and exactly-at-limit changes.

- **Tests**
  - Added coverage for invalid measurements, missing or invalid baselines, and budget threshold boundaries.
  - Benchmark report tests now run automatically during pull request validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->