### PR TITLE
fix(patina): honor options components registration

### DIFF
--- a/crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/require_component_registration.rs
@@ -45,7 +45,7 @@ use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_croquis::builtins::is_builtin_component;
 use vize_croquis::naming::{names_match, to_pascal_case};
-use vize_croquis::{Croquis, ScopeData};
+use vize_croquis::{Croquis, Scope, ScopeData, ScopeKind};
 use vize_relief::BindingType;
 use vize_relief::{ElementNode, RootNode};
 use vize_s0::String;
@@ -171,12 +171,7 @@ impl RequireComponentRegistration {
         analysis
             .scopes
             .iter()
-            .filter(|scope| {
-                matches!(
-                    scope.data(),
-                    ScopeData::ExternalModule(data) if !data.is_type_only
-                )
-            })
+            .filter(|scope| Self::is_script_setup_external_module(analysis, scope))
             .flat_map(|scope| scope.bindings())
             .any(|(name, binding)| {
                 matches!(
@@ -184,6 +179,26 @@ impl RequireComponentRegistration {
                     BindingType::SetupConst | BindingType::SetupMaybeRef
                 ) && component_name_matches(tag, name)
             })
+    }
+
+    fn is_script_setup_external_module(analysis: &Croquis, scope: &Scope) -> bool {
+        let ScopeData::ExternalModule(data) = scope.data() else {
+            return false;
+        };
+        if data.is_type_only {
+            return false;
+        }
+        scope
+            .parent()
+            .and_then(|id| analysis.scopes.get_scope(id))
+            .is_some_and(|parent| parent.kind == ScopeKind::ScriptSetup)
+    }
+
+    fn is_options_api_registered_component(&self, analysis: &Croquis, tag: &str) -> bool {
+        analysis
+            .component_registrations
+            .iter()
+            .any(|registration| component_name_matches(tag, registration.name.as_str()))
     }
 }
 
@@ -208,10 +223,10 @@ impl Rule for RequireComponentRegistration {
                     continue;
                 }
 
-                if ctx
-                    .analysis()
-                    .is_some_and(|analysis| self.is_script_setup_imported_component(analysis, &tag))
-                {
+                if ctx.analysis().is_some_and(|analysis| {
+                    self.is_script_setup_imported_component(analysis, &tag)
+                        || self.is_options_api_registered_component(analysis, &tag)
+                }) {
                     continue;
                 }
 

--- a/crates/vize_patina/src/rules/opinionated/vue/require_component_registration/tests.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/require_component_registration/tests.rs
@@ -56,6 +56,57 @@ import { LibraryWidget as RenamedWidget } from '@example/widgets'
 }
 
 #[test]
+fn test_allows_options_api_components_registration() {
+    let linter = create_linter();
+    let sfc = r#"<script lang="ts">
+import Child from './Child.vue'
+import LocalPanel from './LocalPanel.vue'
+
+export default {
+  components: {
+    Child,
+    RegisteredPanel: LocalPanel,
+  },
+}
+</script>
+
+<template>
+  <Child />
+  <registered-panel />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "ParentWidget.vue");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "Options API `components` registrations should count as registered: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn test_reports_normal_script_import_without_components_registration() {
+    let linter = create_linter();
+    let sfc = r#"<script lang="ts">
+import Child from './Child.vue'
+
+export default {}
+</script>
+
+<template>
+  <Child />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "ParentWidget.vue");
+
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(
+        result.diagnostics[0].rule_name,
+        "vue/require-component-registration"
+    );
+}
+
+#[test]
 fn test_reports_unimported_script_setup_component() {
     let linter = create_linter();
     let sfc = r#"<script setup lang="ts">


### PR DESCRIPTION
Summary:
- Count Options API components registrations for vue/require-component-registration.
- Stop treating normal script imports as auto-registered components.
- Add regression coverage for the false negative and false positive cases.

Validation:
- cargo test -p vize_patina require_component_registration --lib
- cargo test -p vize_patina --lib
- cargo clippy -p vize_patina --lib --tests -- -D warnings
- cargo fmt --all --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- git diff --check origin/main..HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791298113&installation_model_id=422833&pr_number=5837&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5837&signature=f920cf8666ce22ba4ecbbd6ef48d1894652da8ccf2cc49f2c7e80ca241c35fae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Vue component registration checks now recognize components registered through the Options API.
  - Imports in regular scripts continue to require explicit component registration.
  - Improved detection helps prevent incorrect warnings while preserving warnings for genuinely unregistered components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->