### PR TITLE
test(typecheck): prove clean divergence probes are live

### DIFF
--- a/tests/_helpers/compat-nonvacuity.ts
+++ b/tests/_helpers/compat-nonvacuity.ts
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import { compareTypecheckDiagnostics } from "../../legacy-tools/fixtures/typecheck-divergence.mjs";
+import {
+  buildSeededMutation,
+  seededMutationDiagnostic,
+} from "../../legacy-tools/fixtures/typecheck-divergence-mutation-source.mjs";
+import type { CompatProbe, CompatSummary } from "./compat-ratchet.ts";
+import type { PinnedFixtureWorkspace } from "./realworld-patch.ts";
+import { runVizeCheck, runVueTsc } from "./realworld-typecheck.ts";
+
+export type CompatNonVacuity = {
+  file: string | null;
+  passed: boolean;
+  reason: string | null;
+  summary: CompatSummary | null;
+};
+
+export function assertCompatNonVacuity(
+  fixtureId: string,
+  summary: CompatSummary,
+  nonVacuity: CompatNonVacuity | null,
+): void {
+  if (!isDiagnosticFreeSummary(summary)) return;
+  assert.equal(
+    nonVacuity?.passed,
+    true,
+    `${fixtureId}: the compat result is diagnostic-free on both tools, so ` +
+      `the ratchet must prove the checked sources are live with a seeded TypeScript ` +
+      `mutation (${nonVacuity?.reason ?? "probe was not run"})`,
+  );
+}
+
+export function isDiagnosticFreeSummary(summary: CompatSummary): boolean {
+  return summary.vizeDiagnosticCount === 0 && summary.baselineDiagnosticCount === 0;
+}
+
+export type TypecheckDivergence = {
+  summary: CompatSummary & Record<string, number>;
+  shared?: Array<{ code?: unknown; file?: unknown; severity?: unknown }>;
+};
+
+export function compatSummaryFromDivergence(
+  summary: TypecheckDivergence["summary"],
+): CompatSummary {
+  return {
+    vizeDiagnosticCount: summary.vizeDiagnosticCount,
+    baselineDiagnosticCount: summary.baselineDiagnosticCount,
+    sharedCount: summary.sharedCount,
+    messageMismatchCount: summary.messageMismatchCount,
+    documentedDifferenceCount: summary.documentedDifferenceCount,
+    falsePositiveCount: summary.falsePositiveCount,
+    falseNegativeCount: summary.falseNegativeCount,
+    falsePositiveRatio: summary.falsePositiveRatio,
+    falseNegativeRatio: summary.falseNegativeRatio,
+  };
+}
+
+export function runCompatNonVacuityProbe({
+  probe,
+  fixture,
+  corsaPath,
+  vueTscPath,
+  documentedDifferences,
+}: {
+  probe: CompatProbe;
+  fixture: PinnedFixtureWorkspace;
+  corsaPath: string;
+  vueTscPath: string;
+  documentedDifferences: unknown[];
+}): CompatNonVacuity {
+  let failed: CompatNonVacuity | null = null;
+  for (const file of listVueFiles(fixture.workspaceDir)) {
+    const cleanSource = fixture.read(file);
+    const mutation = buildSeededMutation(cleanSource);
+    if (mutation == null) continue;
+
+    try {
+      fixture.write(file, mutation.brokenSource);
+      const vize = runVizeCheck(fixture.workspaceDir, corsaPath, []);
+      assert.ok(
+        vize.status === 0 || vize.status === 1,
+        `${probe.fixtureId}: Vize non-vacuity probe must complete: exit ${vize.status}\n${vize.stderr}`,
+      );
+      const vueTsc = runVueTsc(fixture.workspaceDir, vueTscPath);
+      assert.ok(
+        vueTsc.status === 0 || vueTsc.status === 1 || vueTsc.status === 2,
+        `${probe.fixtureId}: vue-tsc non-vacuity probe must complete: exit ${vueTsc.status}\n${vueTsc.stderr}`,
+      );
+      const divergence = compareTypecheckDiagnostics({
+        projectId: probe.fixtureId,
+        cwd: fixture.workspaceDir,
+        vizeReport: vize.report,
+        vueTscOutput: `${vueTsc.stdout}\n${vueTsc.stderr}`,
+        documentedDifferences,
+      }) as TypecheckDivergence;
+      const summary = compatSummaryFromDivergence(divergence.summary);
+      const expectedMatched = divergence.shared?.some(
+        (record) =>
+          record.file === file &&
+          record.severity === seededMutationDiagnostic.severity &&
+          record.code === seededMutationDiagnostic.code,
+      );
+      const passed =
+        expectedMatched === true &&
+        summary.sharedCount >= 1 &&
+        summary.messageMismatchCount === 0 &&
+        summary.documentedDifferenceCount === 0 &&
+        summary.falseNegativeCount === 0;
+      const reason = passed
+        ? null
+        : `seeded mutation produced shared=${summary.sharedCount}, messageMismatches=${summary.messageMismatchCount}, documented=${summary.documentedDifferenceCount}, falsePositives=${summary.falsePositiveCount}, falseNegatives=${summary.falseNegativeCount}`;
+      const observed = { file, passed, reason, summary };
+      if (passed) return observed;
+      failed = observed;
+    } catch (error) {
+      failed = {
+        file,
+        passed: false,
+        reason: error instanceof Error ? error.message : String(error),
+        summary: null,
+      };
+    } finally {
+      fixture.write(file, cleanSource);
+    }
+  }
+
+  return (
+    failed ?? {
+      file: null,
+      passed: false,
+      reason: "no copied authored Vue file accepted a seeded TypeScript probe",
+      summary: null,
+    }
+  );
+}
+
+function listVueFiles(root: string, relativeDir = ""): string[] {
+  const dir = path.join(root, relativeDir);
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules") continue;
+    const relativePath = relativeDir === "" ? entry.name : `${relativeDir}/${entry.name}`;
+    if (entry.isDirectory()) files.push(...listVueFiles(root, relativePath));
+    else if (entry.isFile() && relativePath.endsWith(".vue")) files.push(relativePath);
+  }
+  return files.sort();
+}

--- a/tests/_helpers/compat-ratchet.ts
+++ b/tests/_helpers/compat-ratchet.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { compareTypecheckDiagnostics } from "../../legacy-tools/fixtures/typecheck-divergence.mjs";
+import * as compatNonVacuity from "./compat-nonvacuity.ts";
+import type { CompatNonVacuity } from "./compat-nonvacuity.ts";
 import { repoRoot, symlinkDirectory, withPinnedFixtureWorkspace } from "./realworld-patch.ts";
 import {
   resolveTsgoBinary,
@@ -75,6 +77,7 @@ export type CompatProbeResult = {
   revision: string;
   summary: CompatSummary;
   accepted: boolean;
+  nonVacuity: CompatNonVacuity | null;
   vizeDurationMs: number;
   vueTscDurationMs: number;
 };
@@ -226,29 +229,30 @@ export async function runCompatProbe(probe: CompatProbe): Promise<CompatProbeRes
         `vue-tsc must complete for ${probe.fixtureId}: exit ${vueTsc.status}\n${vueTsc.stderr}`,
       );
 
+      const documentedDifferences = readCompatDocumentedDifferences().differences;
       const divergence = compareTypecheckDiagnostics({
         projectId: probe.fixtureId,
         cwd: fixture.workspaceDir,
         vizeReport: vize.report,
         vueTscOutput: `${vueTsc.stdout}\n${vueTsc.stderr}`,
-        documentedDifferences: readCompatDocumentedDifferences().differences,
+        documentedDifferences,
       }) as { summary: CompatSummary & Record<string, number> };
 
-      const summary: CompatSummary = {
-        vizeDiagnosticCount: divergence.summary.vizeDiagnosticCount,
-        baselineDiagnosticCount: divergence.summary.baselineDiagnosticCount,
-        sharedCount: divergence.summary.sharedCount,
-        messageMismatchCount: divergence.summary.messageMismatchCount,
-        documentedDifferenceCount: divergence.summary.documentedDifferenceCount,
-        falsePositiveCount: divergence.summary.falsePositiveCount,
-        falseNegativeCount: divergence.summary.falseNegativeCount,
-        falsePositiveRatio: divergence.summary.falsePositiveRatio,
-        falseNegativeRatio: divergence.summary.falseNegativeRatio,
-      };
+      const summary = compatNonVacuity.compatSummaryFromDivergence(divergence.summary);
+      const nonVacuity = compatNonVacuity.isDiagnosticFreeSummary(summary)
+        ? compatNonVacuity.runCompatNonVacuityProbe({
+            probe,
+            fixture,
+            corsaPath,
+            vueTscPath,
+            documentedDifferences,
+          })
+        : null;
       return {
         revision: fixture.entry.revision,
         summary,
         accepted: isAcceptedByRegistryBudget(probe.fixtureId, summary),
+        nonVacuity,
         vizeDurationMs,
         vueTscDurationMs,
       };

--- a/tests/tooling/compat-nonvacuity.test.ts
+++ b/tests/tooling/compat-nonvacuity.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { assertCompatNonVacuity } from "../_helpers/compat-nonvacuity.ts";
+import type { CompatSummary } from "../_helpers/compat-ratchet.ts";
+
+const exactParity: CompatSummary = {
+  vizeDiagnosticCount: 0,
+  baselineDiagnosticCount: 0,
+  sharedCount: 0,
+  messageMismatchCount: 0,
+  documentedDifferenceCount: 0,
+  falsePositiveCount: 0,
+  falseNegativeCount: 0,
+  falsePositiveRatio: 0,
+  falseNegativeRatio: 0,
+};
+
+test("compat non-vacuity requires seeded proof for diagnostic-free summaries", () => {
+  assertCompatNonVacuity("fixture", exactParity, {
+    file: "src/App.vue",
+    passed: true,
+    reason: null,
+    summary: { ...exactParity, vizeDiagnosticCount: 1, baselineDiagnosticCount: 1, sharedCount: 1 },
+  });
+  assert.throws(
+    () => assertCompatNonVacuity("fixture", exactParity, null),
+    /diagnostic-free on both tools/,
+  );
+});
+
+test("compat non-vacuity allows mutation-induced false positives after shared proof", () => {
+  assertCompatNonVacuity("fixture", exactParity, {
+    file: "src/App.vue",
+    passed: true,
+    reason: null,
+    summary: {
+      ...exactParity,
+      vizeDiagnosticCount: 3,
+      baselineDiagnosticCount: 1,
+      sharedCount: 1,
+      falsePositiveCount: 2,
+      falsePositiveRatio: 2,
+    },
+  });
+});
+
+test("compat non-vacuity allows diagnostic-bearing summaries to use the normal ratchet", () => {
+  assert.doesNotThrow(() =>
+    assertCompatNonVacuity(
+      "fixture",
+      { ...exactParity, vizeDiagnosticCount: 1, baselineDiagnosticCount: 1, sharedCount: 1 },
+      null,
+    ),
+  );
+});

--- a/tests/tooling/compat-ratchet.test.ts
+++ b/tests/tooling/compat-ratchet.test.ts
@@ -27,6 +27,7 @@ import os from "node:os";
 import path from "node:path";
 import { after, test } from "node:test";
 
+import { assertCompatNonVacuity } from "../_helpers/compat-nonvacuity.ts";
 import {
   type CompatBaseline,
   type CompatBaselineEntry,
@@ -114,6 +115,7 @@ for (const probe of compatProbes) {
           ` falseNegatives=${summary.falseNegativeCount} (${summary.falseNegativeRatio.toFixed(4)})` +
           ` vize=${result.vizeDurationMs}ms vue-tsc=${result.vueTscDurationMs}ms`,
       );
+      assertCompatNonVacuity(probe.fixtureId, summary, result.nonVacuity);
 
       if (updateBaseline) {
         updatedEntries.set(probe.fixtureId, {


### PR DESCRIPTION
Summary:
- add a seeded mutation proof for diagnostic-free compatibility probes
- keep zero-diagnostic divergence summaries from passing vacuously
- cover both non-vacuity and ratchet helper behavior

Validation:
- node --test tests/tooling/compat-nonvacuity.test.ts tests/tooling/compat-ratchet.test.ts
- vp exec oxfmt --check tests/_helpers/compat-nonvacuity.ts tests/_helpers/compat-ratchet.ts tests/tooling/compat-nonvacuity.test.ts tests/tooling/compat-ratchet.test.ts
- vp exec oxlint tests/_helpers/compat-nonvacuity.ts tests/_helpers/compat-ratchet.ts tests/tooling/compat-nonvacuity.test.ts tests/tooling/compat-ratchet.test.ts
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check origin/main..HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791300409&installation_model_id=422833&pr_number=5838&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5838&signature=99ef85261c98ed87ac320a1e109e4e3e83d083359dbfddb6f47f077c7b6da949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added compatibility checks that verify diagnostic-free results are backed by a seeded, detectable type error.
  * Extended compatibility ratchet tests to validate non-vacuous probe execution across authored Vue files.
  * Added coverage for successful and failing non-vacuity assertions, while preserving normal behavior when diagnostics are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->