### PR TITLE
fix(vscode): declare extension sources as ESM

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -15,6 +15,7 @@
     "directory": "editors/vscode"
   },
   "publisher": "ubugeeei",
+  "type": "module",
   "main": "./dist/extension.cjs",
   "scripts": {
     "vscode:prepublish": "vp pack",

--- a/editors/vscode/src/auto-insert.ts
+++ b/editors/vscode/src/auto-insert.ts
@@ -1,6 +1,6 @@
 import { SnippetString, window, type TextDocumentChangeEvent, type TextEditor } from "vscode";
-import type { LanguageClient, Middleware } from "vscode-languageclient/node";
-import type { VizeConfigurationLike } from "./extension-core";
+import type { LanguageClient, Middleware } from "vscode-languageclient/node.js";
+import type { VizeConfigurationLike } from "./extension-core.js";
 
 export const AUTO_INSERT_METHOD = "volar/client/autoInsert";
 

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -24,7 +24,7 @@ import {
   ServerOptions,
   Trace,
   TransportKind,
-} from "vscode-languageclient/node";
+} from "vscode-languageclient/node.js";
 import {
   LINT_ONLY_CONFIGURATION_UPDATES,
   createDocumentSelector,
@@ -35,11 +35,11 @@ import {
   parseVizeVersion,
   shouldStartFromConfiguration,
   type LspInitializationOptions,
-} from "./extension-core";
-import { registerHostTestCommands } from "./host-test-commands";
-import { registerTypeScriptContentMapperDiscovery } from "./content-mapper-discovery";
-import { createAutoInsertMiddleware } from "./auto-insert";
-import { downloadFile } from "./release-download";
+} from "./extension-core.js";
+import { registerHostTestCommands } from "./host-test-commands.js";
+import { registerTypeScriptContentMapperDiscovery } from "./content-mapper-discovery.js";
+import { createAutoInsertMiddleware } from "./auto-insert.js";
+import { downloadFile } from "./release-download.js";
 
 const execFileAsync = promisify(execFile);
 let client: LanguageClient | undefined;

--- a/editors/vscode/src/host-test-commands.ts
+++ b/editors/vscode/src/host-test-commands.ts
@@ -4,7 +4,7 @@ import {
   bindHostTestCommands,
   type HostTestLanguageClient,
   type HostTestServerInfo,
-} from "./host-test-core";
+} from "./host-test-core.js";
 
 /**
  * Binds the environment-gated host smoke commands to the VS Code command

--- a/editors/vscode/tsconfig.json
+++ b/editors/vscode/tsconfig.json
@@ -9,6 +9,7 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "types": ["node"],
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "declarationMap": true,

--- a/tests/tooling/vscode-release-download.test.ts
+++ b/tests/tooling/vscode-release-download.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import path from "node:path";
 import { test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { isTrustedReleaseDownloadUrl } from "../../editors/vscode/src/release-download.ts";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 test("vscode release downloads stay on GitHub HTTPS hosts", () => {
   assert.equal(
@@ -28,4 +33,16 @@ test("vscode release downloads stay on GitHub HTTPS hosts", () => {
   assert.equal(isTrustedReleaseDownloadUrl("https://github.com.evil.example/vize.tar.gz"), false);
   assert.equal(isTrustedReleaseDownloadUrl("https://attacker@github.com/vize.tar.gz"), false);
   assert.equal(isTrustedReleaseDownloadUrl("https://github.com:8443/vize.tar.gz"), false);
+});
+
+test("vscode release download source imports without package module warnings", () => {
+  const source = pathToFileURL(path.join(root, "editors/vscode/src/release-download.ts")).href;
+  const result = spawnSync(
+    process.execPath,
+    ["--input-type=module", "--eval", `await import(${JSON.stringify(source)});`],
+    { cwd: root, encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stderr, /MODULE_TYPELESS_PACKAGE_JSON|Reparsing as ES module/);
 });

--- a/tests/tooling/vscode-vsix-policy.test.ts
+++ b/tests/tooling/vscode-vsix-policy.test.ts
@@ -15,12 +15,17 @@ function readJson(relativePath: string): unknown {
 }
 
 test("VSIX package policy keeps the production CJS host entrypoint shippable", () => {
-  const manifest = readJson("editors/vscode/package.json") as { main?: string };
+  const manifest = readJson("editors/vscode/package.json") as { main?: string; type?: string };
+  const tsconfig = readJson("editors/vscode/tsconfig.json") as {
+    compilerOptions?: { types?: string[] };
+  };
   const packConfig = readText("editors/vscode/vite.config.ts");
   const ignore = readText("editors/vscode/.vscodeignore");
   const smoke = readText("tools/commands/editors/vscode/assert-vsix-package.rs");
 
+  assert.equal(manifest.type, "module");
   assert.equal(manifest.main, "./dist/extension.cjs");
+  assert.deepEqual(tsconfig.compilerOptions?.types, ["node"]);
   assert.match(packConfig, /entry:\s*\["src\/extension\.ts"\]/);
   assert.match(packConfig, /outDir:\s*"dist"/);
   assert.match(packConfig, /format:\s*"cjs"/);


### PR DESCRIPTION
## Summary
- mark the VS Code extension workspace as ESM so source-only imports do not trigger module-type warnings
- add explicit .js suffixes for extension source imports while keeping the shipped CJS entrypoint unchanged
- cover release-download dynamic import and VSIX packaging policy with tooling tests

## Verification
- node --test tests/tooling/vscode-release-download.test.ts tests/tooling/vscode-vsix-policy.test.ts
- vp exec oxlint editors/vscode/src/auto-insert.ts editors/vscode/src/extension.ts editors/vscode/src/host-test-commands.ts tests/tooling/vscode-release-download.test.ts tests/tooling/vscode-vsix-policy.test.ts
- vp exec oxfmt --check editors/vscode/package.json editors/vscode/src/auto-insert.ts editors/vscode/src/extension.ts editors/vscode/src/host-test-commands.ts editors/vscode/tsconfig.json tests/tooling/vscode-release-download.test.ts tests/tooling/vscode-vsix-policy.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791304192&installation_model_id=422833&pr_number=5840&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5840&signature=344149405d99c86ef9e530e0ae943fea8506953df22c4b70c150034748c78ebc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VS Code extension compatibility with modern Node.js module resolution.
  * Prevented module-type warnings when loading extension tooling.
  * Preserved the production CommonJS entry point for reliable VSIX packaging.

* **Tests**
  * Added coverage to verify warning-free module loading and required extension packaging settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->