### PR TITLE
test(tooling): require authored LSP anchor evidence

### DIFF
--- a/tests/tooling/real-project-lsp.test.ts
+++ b/tests/tooling/real-project-lsp.test.ts
@@ -44,14 +44,38 @@ test("LSP report summarizes authored feature coverage from project evidence", ()
   );
 
   assert.equal(report.summary.projectCount, 3);
-  assert.equal(report.version, 4);
+  assert.equal(report.version, 5);
   assert.equal(report.commitSha, "0".repeat(40));
   assert.equal(report.evidence.commitSha, "0".repeat(40));
   assert.deepEqual(report.evidence.runtime, { name: "node", version: process.versions.node });
   assert.equal(report.summary.authoredFeatureProjectCount, 1);
+  assert.equal(report.summary.authoredAnchorCount, 6);
   assert.deepEqual(report.summary.missingAuthoredFeatureProjectIds, [
     "missing-oracle",
     "also-missing-oracle",
+  ]);
+});
+
+test("LSP report refuses to count incomplete authored feature evidence", () => {
+  const missingAnchorEvidence = authoredEvidence();
+  missingAnchorEvidence.authoredAnchors = { count: 0, sha256: "1".repeat(64) };
+  const missingHoverEvidence = authoredEvidence();
+  missingHoverEvidence.hover = { count: 0, durationMs: 0, sha256: "2".repeat(64) };
+  const report = createLspReport(
+    { enforced: true, projects: [], shardCount: 1, shardIndex: 0 },
+    [
+      projectEvidence("complete-oracle", authoredEvidence()),
+      projectEvidence("missing-anchor-evidence", missingAnchorEvidence),
+      projectEvidence("missing-hover-evidence", missingHoverEvidence),
+    ],
+    { GITHUB_SHA: "0".repeat(40) },
+  );
+
+  assert.equal(report.summary.authoredFeatureProjectCount, 1);
+  assert.equal(report.summary.authoredAnchorCount, 6);
+  assert.deepEqual(report.summary.missingAuthoredFeatureProjectIds, [
+    "missing-anchor-evidence",
+    "missing-hover-evidence",
   ]);
 });
 
@@ -267,12 +291,13 @@ function projectEvidence(
 
 function authoredEvidence(): AuthoredLspEvidence {
   const diagnostic = { count: 0, sha256: "0".repeat(64) };
-  const response = { count: 1, durationMs: 0, sha256: "0".repeat(64) };
+  const response = () => ({ count: 1, durationMs: 0, sha256: "0".repeat(64) });
   return {
-    completion: response,
-    componentDefinition: response,
+    authoredAnchors: { count: 6, sha256: "0".repeat(64) },
+    completion: response(),
+    componentDefinition: response(),
     componentFile: "FeatureChild.vue",
-    definition: response,
+    definition: response(),
     dependencyCompletion: {
       baselineContainsProbe: false,
       changedContainsProbe: true,
@@ -280,25 +305,25 @@ function authoredEvidence(): AuthoredLspEvidence {
     },
     fileLifecycle: {
       copiedFile: "Copied.vue",
-      createdDefinition: response,
-      createdWorkspaceSymbols: response,
-      deletedDefinition: { ...response, count: 0 },
-      deletedDocumentSymbols: { ...response, count: 0 },
+      createdDefinition: response(),
+      createdWorkspaceSymbols: response(),
+      deletedDefinition: { ...response(), count: 0 },
+      deletedDocumentSymbols: { ...response(), count: 0 },
       deletedImporterDiagnostics: diagnostic,
-      deletedWorkspaceSymbols: { ...response, count: 0 },
+      deletedWorkspaceSymbols: { ...response(), count: 0 },
       repairedDiagnostics: diagnostic,
-      renameEdit: response,
-      renamedDefinition: response,
+      renameEdit: response(),
+      renamedDefinition: response(),
       renamedFile: "Renamed.vue",
-      renamedWorkspaceSymbols: response,
-      restoredDefinition: response,
-      staleCopiedDocumentSymbols: { ...response, count: 0 },
+      renamedWorkspaceSymbols: response(),
+      restoredDefinition: response(),
+      staleCopiedDocumentSymbols: { ...response(), count: 0 },
     },
-    hover: response,
+    hover: response(),
     importerFile: "FeatureParent.vue",
-    prepareRename: response,
-    references: response,
-    rename: response,
+    prepareRename: response(),
+    references: response(),
+    rename: response(),
     templateBindingFile: "Binding.vue",
   };
 }

--- a/tests/tooling/real-project-matrix-summary.test.ts
+++ b/tests/tooling/real-project-matrix-summary.test.ts
@@ -70,6 +70,7 @@ test("shard summary script records every surface, present or missing", () => {
     /summary\.md/,
     /lsp-lifecycle-summary\.json/,
     /authoredFeatureProjectCount/,
+    /authoredAnchorCount/,
     /missingAuthoredFeatureProjectIds/,
     /actualFileCount/,
     /No LSP lifecycle report was produced/,

--- a/tests/tooling/support/real-project-lsp-authored-oracle.ts
+++ b/tests/tooling/support/real-project-lsp-authored-oracle.ts
@@ -32,6 +32,7 @@ import type {
   FixtureProject,
   LspAuthoredOracle,
 } from "./real-project-lsp-report.ts";
+import { authoredAnchorEvidence } from "./real-project-lsp-report-authored.ts";
 import { exerciseAuthoredFileLifecycle } from "./real-project-lsp-file-lifecycle.ts";
 
 const diagnosticsTimeoutMs = 120_000;
@@ -292,6 +293,7 @@ export async function exerciseAuthoredLspOracle(
       responseEvidence(response, count, workspaceDir, request.durationMs);
 
     return {
+      authoredAnchors: authoredAnchorEvidence(oracle),
       completion: evidence(completionRequest, baselineLabels, baselineLabels.length),
       componentDefinition: evidence(componentDefinitionRequest, componentDefinition, 1),
       componentFile: boundary.componentFile,

--- a/tests/tooling/support/real-project-lsp-report-authored.ts
+++ b/tests/tooling/support/real-project-lsp-report-authored.ts
@@ -1,0 +1,111 @@
+import { createHash } from "node:crypto";
+
+import type {
+  LspAuthoredOracle,
+  LspProjectEvidence,
+  LspResponseEvidence,
+} from "./real-project-lsp-report.ts";
+
+export function authoredAnchorEvidence(oracle: LspAuthoredOracle) {
+  const anchors = [
+    {
+      anchor: oracle.templateBinding.usageAnchor,
+      file: oracle.templateBinding.file,
+      kind: "template-binding-usage",
+      symbol: oracle.templateBinding.symbol,
+    },
+    {
+      anchor: oracle.templateBinding.declarationAnchor,
+      file: oracle.templateBinding.file,
+      kind: "template-binding-declaration",
+      symbol: oracle.templateBinding.symbol,
+    },
+    {
+      anchor: oracle.componentBoundary.tagAnchor,
+      file: oracle.componentBoundary.importerFile,
+      kind: "component-boundary-tag",
+      symbol: oracle.componentBoundary.tagName,
+    },
+    {
+      anchor: oracle.componentBoundary.dependencyEdit.anchor,
+      file: oracle.componentBoundary.componentFile,
+      kind: "dependency-edit",
+      symbol: oracle.componentBoundary.dependencyEdit.completionLabel,
+    },
+    {
+      anchor: oracle.fileLifecycle.originalImportSpecifier,
+      file: oracle.componentBoundary.importerFile,
+      kind: "file-lifecycle-import",
+      symbol: oracle.componentBoundary.tagName,
+    },
+    {
+      anchor: oracle.fileLifecycle.markerInsertionAnchor,
+      file: oracle.componentBoundary.componentFile,
+      kind: "file-lifecycle-marker-insertion",
+      symbol: oracle.fileLifecycle.markerSymbol,
+    },
+  ];
+  return {
+    count: anchors.length,
+    sha256: createHash("sha256")
+      .update(`${JSON.stringify(anchors)}\n`)
+      .digest("hex"),
+  };
+}
+
+export function hasCompleteAuthoredFeatureEvidence(project: LspProjectEvidence): boolean {
+  const authored = project.authoredFeatures;
+  if (authored == null) return false;
+  return (
+    authored.authoredAnchors != null &&
+    authored.authoredAnchors.count > 0 &&
+    isSha256(authored.authoredAnchors.sha256) &&
+    authored.templateBindingFile.length > 0 &&
+    authored.importerFile.length > 0 &&
+    authored.componentFile.length > 0 &&
+    hasPositiveResponse(authored.completion) &&
+    hasPositiveResponse(authored.componentDefinition) &&
+    hasPositiveResponse(authored.definition) &&
+    hasPositiveResponse(authored.hover) &&
+    hasPositiveResponse(authored.prepareRename) &&
+    hasPositiveResponse(authored.references) &&
+    hasPositiveResponse(authored.rename) &&
+    authored.dependencyCompletion.baselineContainsProbe === false &&
+    authored.dependencyCompletion.changedContainsProbe === true &&
+    authored.dependencyCompletion.repairedContainsProbe === false &&
+    hasPositiveResponse(authored.fileLifecycle.createdDefinition) &&
+    hasPositiveResponse(authored.fileLifecycle.createdWorkspaceSymbols) &&
+    hasPositiveResponse(authored.fileLifecycle.renameEdit) &&
+    hasPositiveResponse(authored.fileLifecycle.renamedDefinition) &&
+    hasPositiveResponse(authored.fileLifecycle.renamedWorkspaceSymbols) &&
+    hasPositiveResponse(authored.fileLifecycle.restoredDefinition) &&
+    hasZeroResponse(authored.fileLifecycle.deletedDefinition) &&
+    hasZeroResponse(authored.fileLifecycle.deletedDocumentSymbols) &&
+    hasZeroResponse(authored.fileLifecycle.deletedWorkspaceSymbols) &&
+    hasZeroResponse(authored.fileLifecycle.staleCopiedDocumentSymbols)
+  );
+}
+
+function hasPositiveResponse(evidence: LspResponseEvidence | undefined): boolean {
+  return (
+    evidence != null &&
+    evidence.count > 0 &&
+    Number.isFinite(evidence.durationMs) &&
+    evidence.durationMs >= 0 &&
+    isSha256(evidence.sha256)
+  );
+}
+
+function hasZeroResponse(evidence: LspResponseEvidence | undefined): boolean {
+  return (
+    evidence != null &&
+    evidence.count === 0 &&
+    Number.isFinite(evidence.durationMs) &&
+    evidence.durationMs >= 0 &&
+    isSha256(evidence.sha256)
+  );
+}
+
+function isSha256(value: string | undefined): boolean {
+  return value != null && /^[0-9a-f]{64}$/.test(value);
+}

--- a/tests/tooling/support/real-project-lsp-report.ts
+++ b/tests/tooling/support/real-project-lsp-report.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveVizeLaunchCommand } from "./lsp/launch.ts";
+import { hasCompleteAuthoredFeatureEvidence } from "./real-project-lsp-report-authored.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 const reportName = "lsp-lifecycle-summary.json";
@@ -65,6 +66,11 @@ export type LspResponseEvidence = {
   sha256: string;
 };
 
+export type AuthoredAnchorEvidence = {
+  count: number;
+  sha256: string;
+};
+
 export type LspReportEvidence = {
   commitSha: string;
   runtime: { name: "node"; version: string };
@@ -93,6 +99,7 @@ export type AuthoredFileLifecycleEvidence = {
 };
 
 export type AuthoredLspEvidence = {
+  authoredAnchors: AuthoredAnchorEvidence;
   completion: LspResponseEvidence;
   componentDefinition: LspResponseEvidence;
   componentFile: string;
@@ -161,19 +168,23 @@ export function createLspReport(
   } = {},
 ) {
   const evidence = createReportEvidence(environment, dependencies);
+  const completeAuthoredProjects = projects.filter(hasCompleteAuthoredFeatureEvidence);
   return {
     schema: "vize.realProjectLspLifecycle",
-    version: 4,
+    version: 5,
     commitSha: evidence.commitSha,
     evidence,
     shard: { count: selection.shardCount, index: selection.shardIndex },
     summary: {
       projectCount: projects.length,
       actualFileCount: projects.filter((project) => project.actualFile != null).length,
-      authoredFeatureProjectCount: projects.filter((project) => project.authoredFeatures != null)
-        .length,
+      authoredFeatureProjectCount: completeAuthoredProjects.length,
+      authoredAnchorCount: completeAuthoredProjects.reduce(
+        (total, project) => total + project.authoredFeatures!.authoredAnchors.count,
+        0,
+      ),
       missingAuthoredFeatureProjectIds: projects
-        .filter((project) => project.authoredFeatures == null)
+        .filter((project) => !hasCompleteAuthoredFeatureEvidence(project))
         .map((project) => project.id),
       vueFileCount: projects.reduce((total, project) => total + project.vueFileCount, 0),
       failedProjectCount: projects.filter((project) => project.status === "failed").length,

--- a/tools/commands/ci/github/publish-real-project-shard-summary.rs
+++ b/tools/commands/ci/github/publish-real-project-shard-summary.rs
@@ -274,10 +274,11 @@ fn string_array(json: &Value, pointer: &str) -> Result<String, String> {
 
 fn lsp_summary(json: &Value) -> Result<String, String> {
     Ok(format!(
-        "LSP lifecycle: {} project(s), {} actual file(s), {} authored feature oracle(s), {} Vue file(s), {} failed project(s); missing authored oracles: {}",
+        "LSP lifecycle: {} project(s), {} actual file(s), {} authored feature oracle(s), {} authored anchor(s), {} Vue file(s), {} failed project(s); missing authored oracles: {}",
         number(json, "/summary/projectCount")?,
         number(json, "/summary/actualFileCount")?,
         number(json, "/summary/authoredFeatureProjectCount")?,
+        number(json, "/summary/authoredAnchorCount")?,
         number(json, "/summary/vueFileCount")?,
         number(json, "/summary/failedProjectCount")?,
         string_array(json, "/summary/missingAuthoredFeatureProjectIds")?


### PR DESCRIPTION
## Summary
- require the real-project LSP report to prove that probes opened authored files
- publish authored-feature evidence in shard summaries so missing LSP coverage fails closed
- cover incomplete authored evidence and shard-summary reporting with focused tooling tests

## Verification
- node --test tests/tooling/real-project-lsp.test.ts tests/tooling/real-project-matrix-summary.test.ts
- vp exec oxlint tests/tooling/real-project-lsp.test.ts tests/tooling/real-project-matrix-summary.test.ts tests/tooling/support/real-project-lsp-authored-oracle.ts tests/tooling/support/real-project-lsp-report-authored.ts tests/tooling/support/real-project-lsp-report.ts
- vp exec oxfmt --check tests/tooling/real-project-lsp.test.ts tests/tooling/real-project-matrix-summary.test.ts tests/tooling/support/real-project-lsp-authored-oracle.ts tests/tooling/support/real-project-lsp-report-authored.ts tests/tooling/support/real-project-lsp-report.ts tools/commands/ci/github/publish-real-project-shard-summary.rs
- cargo fmt --all -- --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5841"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791304356&installation_model_id=422833&pr_number=5841&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5841&signature=8b832ce51344cf212a8d61111c8092b2dd8dd3d96ca35ac13fea7768cde9b296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->