### PR TITLE
fix(davinci): guard custom element projection

### DIFF
--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -285,11 +285,10 @@ fn compile_template_inner_with_sections<'a>(
     let has_croquis = options.croquis.is_some();
     let codegen_opts = stage_options::codegen_options(&options, codegen_options);
     let template_syntax_quirks = template_syntax.is_quirks();
-    let custom_elements_supported = !custom_elements.has_static_predicate();
     let use_s2_emit = stage_options::s2_emit_supported(
         &options,
         &codegen_opts,
-        custom_elements_supported,
+        &custom_elements,
         template_syntax,
         has_croquis,
         stage_options::dom_lane_selection(),
@@ -323,7 +322,7 @@ fn compile_template_inner_with_sections<'a>(
     errors.extend(transform_errors);
 
     // Codegen
-    let s2_emit = s2_emit_source.map(|(s2_options_source, s2_hoisted_scope_id)| {
+    let s2_emit = s2_emit_source.and_then(|(s2_options_source, s2_hoisted_scope_id)| {
         let binding_table =
             stage_options::s2_binding_table(s2_options_source.binding_metadata.as_ref());
         let s2_options = stage_options::s2_emit_options(
@@ -332,11 +331,11 @@ fn compile_template_inner_with_sections<'a>(
             &s2_custom_elements,
             binding_table.as_ref(),
             s2_hoisted_scope_id.as_deref(),
-        );
-        profile!(
+        )?;
+        Some(profile!(
             "atelier.dom.template.s2_codegen",
             stage_options::emit_s2(allocator, source, s2_options_source.dialect, &s2_options)
-        )
+        ))
     });
     let codegen_result = match s2_emit {
         Some(Ok(result)) => source_map::attach_compat_map(&root, &codegen_opts, result),

--- a/crates/vize_atelier_dom/src/compile/sfc.rs
+++ b/crates/vize_atelier_dom/src/compile/sfc.rs
@@ -27,7 +27,7 @@ pub(super) fn compile_template_inner_for_sfc_with_sections<'a>(
     let use_s2_emit = stage_options::s2_emit_supported(
         &options,
         &codegen_opts,
-        !custom_elements.has_static_predicate(),
+        &custom_elements,
         template_syntax,
         options.croquis.is_some(),
         dom_lane,
@@ -46,10 +46,12 @@ pub(super) fn compile_template_inner_for_sfc_with_sections<'a>(
             binding_table.as_ref(),
             hoisted_scope_id.as_deref(),
         );
-        if let Ok(result) = profile!(
-            "atelier.dom.template.s2_codegen_sfc_fast",
-            stage_options::emit_s2(allocator, source, options.dialect, &s2_options)
-        ) {
+        if let Some(s2_options) = s2_options
+            && let Ok(result) = profile!(
+                "atelier.dom.template.s2_codegen_sfc_fast",
+                stage_options::emit_s2(allocator, source, options.dialect, &s2_options)
+            )
+        {
             return (Vec::new(), result);
         }
         force_compat_sections = true;

--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -97,7 +97,7 @@ pub(super) fn codegen_options(
 pub(super) fn s2_emit_supported(
     options: &DomCompilerOptions,
     codegen: &CodegenOptions,
-    custom_elements_supported: bool,
+    custom_elements: &CustomElementMatcher,
     template_syntax: TemplateSyntaxMode,
     has_croquis: bool,
     dom_lane: DomLaneSelection,
@@ -113,7 +113,7 @@ pub(super) fn s2_emit_supported(
         && !options.custom_renderer
         && options.dialect == vize_s0::config::VueVersion::V3
         && template_syntax == TemplateSyntaxMode::Standard
-        && custom_elements_supported
+        && custom_elements.projectable_patterns().is_some()
         && !has_croquis
         && !codegen.optimize_imports
 }
@@ -131,8 +131,9 @@ pub(super) fn s2_emit_options<'a>(
     custom_elements: &'a CustomElementMatcher,
     bindings: Option<&'a BindingTable>,
     hoisted_scope_id: Option<&'a str>,
-) -> DomEmitOptions<'a> {
-    DomEmitOptions {
+) -> Option<DomEmitOptions<'a>> {
+    let custom_element_patterns = custom_elements.projectable_patterns()?;
+    Some(DomEmitOptions {
         mode: match options.mode {
             CodegenMode::Function => DomEmitMode::Function,
             CodegenMode::Module => DomEmitMode::Module,
@@ -149,9 +150,9 @@ pub(super) fn s2_emit_options<'a>(
         is_ts: options.is_ts,
         comments: options.comments,
         experimental_in_tag_comments: options.experimental_in_tag_comments,
-        custom_element_patterns: custom_elements.patterns(),
+        custom_element_patterns,
         bindings,
-    }
+    })
 }
 
 pub(super) fn s2_binding_table(metadata: Option<&BindingMetadata>) -> Option<BindingTable> {

--- a/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use crate::DomCompilerOptions;
 use std::ffi::OsString;
-use vize_atelier_core::options::{CodegenOptions, TemplateSyntaxMode};
+use vize_atelier_core::options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode};
 use vize_s0::config::VueVersion;
 
 #[test]
@@ -65,7 +65,20 @@ fn ssr_optimize_imports_codegen_option_stays_on_the_compatibility_lane() {
             optimize_imports: true,
             ..Default::default()
         },
-        true,
+        &CustomElementMatcher::default(),
+        TemplateSyntaxMode::Standard,
+        false,
+        DomLaneSelection::S2,
+        super::S2EmitSelection::Allowed,
+    ));
+}
+
+#[test]
+fn opaque_custom_element_predicates_stay_on_the_compatibility_lane() {
+    assert!(!s2_emit_supported(
+        &DomCompilerOptions::default(),
+        &CodegenOptions::default(),
+        &CustomElementMatcher::from_static_predicate(is_custom_element),
         TemplateSyntaxMode::Standard,
         false,
         DomLaneSelection::S2,
@@ -77,12 +90,16 @@ fn supported(options: DomCompilerOptions, dom_lane: DomLaneSelection) -> bool {
     s2_emit_supported(
         &options,
         &CodegenOptions::default(),
-        true,
+        &CustomElementMatcher::default(),
         TemplateSyntaxMode::Standard,
         false,
         dom_lane,
         super::S2EmitSelection::Allowed,
     )
+}
+
+fn is_custom_element(tag: &str) -> bool {
+    tag.starts_with("x-")
 }
 
 struct ScopedEnvVar {

--- a/crates/vize_atelier_dom/tests/davinci_s2_custom_element_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_custom_element_selector.rs
@@ -123,6 +123,43 @@ fn static_predicate_custom_element_matcher_keeps_template_sections_on_compatibil
     );
 }
 
+#[test]
+fn static_predicate_custom_element_matcher_keeps_sfc_sections_on_compatibility_codegen() {
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+    profiler.disable();
+    profiler.clear();
+
+    let source = r#"<ion-button @click="go">{{ label }}</ion-button>"#;
+    let compat = compile_sfc_sections(
+        source,
+        DomCompilerOptions {
+            source_map: true,
+            ..Default::default()
+        },
+        predicate_custom_elements(),
+    );
+
+    profiler.enable();
+    let selected = compile_sfc_sections(
+        source,
+        DomCompilerOptions::default(),
+        predicate_custom_elements(),
+    );
+    let counters = profiler.counter_summary();
+    profiler.disable();
+    profiler.clear();
+
+    assert_eq!(selected.preamble, compat.preamble);
+    assert_eq!(selected.code, compat.code);
+    assert_eq!(selected.sections, compat.sections);
+    assert_eq!(
+        counter_total(&counters, "davinci.s2_dom.files"),
+        None,
+        "opaque custom-element predicates stay outside the S2 SFC sections selector"
+    );
+}
+
 struct Compiled {
     preamble: String,
     code: String,

--- a/crates/vize_relief/src/options/custom_elements.rs
+++ b/crates/vize_relief/src/options/custom_elements.rs
@@ -39,6 +39,12 @@ impl CustomElementMatcher {
         &self.patterns
     }
 
+    /// Return patterns only when this matcher has no opaque predicate branch.
+    #[must_use]
+    pub fn projectable_patterns(&self) -> Option<&[String]> {
+        (!self.has_static_predicate()).then_some(self.patterns())
+    }
+
     /// Whether the matcher includes an opaque static predicate.
     #[must_use]
     pub fn has_static_predicate(&self) -> bool {
@@ -116,6 +122,10 @@ mod tests {
     use super::CustomElementMatcher;
     use vize_s0::String;
 
+    fn is_tres(tag: &str) -> bool {
+        tag.starts_with("Tres")
+    }
+
     #[test]
     fn custom_element_matcher_supports_exact_and_wildcard_patterns() {
         let matcher = CustomElementMatcher::from_patterns(vec![
@@ -145,6 +155,26 @@ mod tests {
         assert!(matcher.matches("TresMaterial"));
         assert!(!matcher.matches("TresMaterialX"));
         assert!(!matcher.matches("MyTresBasicMaterial"));
+    }
+
+    #[test]
+    fn custom_element_matcher_projects_only_declarative_patterns() {
+        let matcher = CustomElementMatcher::from_patterns(vec![
+            String::from("Tres*"),
+            String::from("primitive"),
+        ]);
+
+        assert_eq!(
+            matcher.projectable_patterns().unwrap(),
+            [String::from("Tres*"), String::from("primitive")]
+        );
+
+        let opaque = CustomElementMatcher {
+            patterns: vec![String::from("Tres*")],
+            predicate: Some(is_tres),
+        };
+        assert!(opaque.matches("TresMesh"));
+        assert!(opaque.projectable_patterns().is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- project declarative custom element patterns into Davinci S2 stage options
- keep opaque custom element predicates on the compatibility lane
- cover template and SFC section selection for both declarative and predicate matchers

## Verification
- cargo test -p vize_relief custom_element_matcher --lib
- cargo test -p vize_atelier_dom --test davinci_s2_custom_element_selector
- cargo test -p vize_atelier_dom custom_element --lib
- cargo fmt --all -- --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --max-lines 350 --limit 5 --base-ref origin/main
- git diff --check origin/main..HEAD

## Release impact
- moves another custom element selector surface onto S2 while preserving compatibility behavior for non-projectable predicates

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791305593&installation_model_id=422833&pr_number=5842&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5842&signature=81cad54e0561a326917987768f409bc3c416eaeb5f75cdfc197deda09b4b8ce4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of custom-element matching during template compilation.
  * Templates using opaque custom-element predicates now consistently use the compatibility compilation path, avoiding unsupported optimized output.
  * Compilation gracefully falls back when optimized emission options are unavailable.

* **Tests**
  * Added coverage confirming generated sections remain consistent across source-map configurations.
  * Expanded validation for custom-element matching and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->