### PR TITLE
feat(patina): add no-static-inline-styles rule

### DIFF
--- a/crates/vize_patina/src/linter/category_rules.rs
+++ b/crates/vize_patina/src/linter/category_rules.rs
@@ -60,6 +60,7 @@ fn is_style_rule_name(rule_name: &str) -> bool {
             | "vue/mustache-interpolation-spacing"
             | "vue/no-inline-style"
             | "vue/no-multi-spaces"
+            | "vue/no-static-inline-styles"
             | "vue/prefer-props-shorthand"
             | "vue/prefer-true-attribute-shorthand"
             | "vue/prop-name-casing"

--- a/crates/vize_patina/src/preset/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/preset/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -654,6 +654,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "vue/no-deprecated-router-link-tag-prop",
     "vue/no-deprecated-filter",
     "vue/no-bare-strings-in-template",
+    "vue/no-static-inline-styles",
     "ecosystem/pinia-prefer-store-to-refs",
     "ecosystem/vue-router-prefer-named-push",
     "ecosystem/vue-test-utils-no-html-snapshot",

--- a/crates/vize_patina/src/rules/vue.rs
+++ b/crates/vize_patina/src/rules/vue.rs
@@ -29,6 +29,7 @@ mod no_dupe_v_else_if;
 mod no_duplicate_attributes;
 mod no_invalid_html_attribute;
 mod no_reserved_component_names;
+mod no_static_inline_styles;
 mod no_template_key;
 mod no_textarea_mustache;
 mod no_unused_vars;
@@ -151,6 +152,7 @@ pub use html_quotes::{HtmlQuotes, HtmlQuotesOption};
 pub use mustache_interpolation_spacing::MustacheInterpolationSpacing;
 pub use no_multi_spaces::NoMultiSpaces;
 pub use no_multiple_template_root::NoMultipleTemplateRoot;
+pub use no_static_inline_styles::NoStaticInlineStyles;
 pub use prop_name_casing::PropNameCasing;
 pub use v_on_style::{VOnStyle, VOnStyleOption};
 pub use v_slot_style::VSlotStyle;
@@ -284,5 +286,8 @@ pub(crate) fn register_opt_in(registry: &mut crate::rule::RuleRegistry) {
     }
     if !registry.has_rule("vue/no-bare-strings-in-template") {
         registry.register(Box::new(NoBareStringsInTemplate));
+    }
+    if !registry.has_rule("vue/no-static-inline-styles") {
+        registry.register(Box::new(NoStaticInlineStyles));
     }
 }

--- a/crates/vize_patina/src/rules/vue/no_static_inline_styles.rs
+++ b/crates/vize_patina/src/rules/vue/no_static_inline_styles.rs
@@ -1,0 +1,122 @@
+//! vue/no-static-inline-styles
+//!
+//! Disallow static inline `style` attributes.
+//!
+//! This follows eslint-plugin-vue's `vue/no-static-inline-styles` surface:
+//! literal `style="..."` attributes are reported, while dynamic style bindings
+//! such as `:style="..."` remain valid.
+
+use crate::context::LintContext;
+use crate::diagnostic::Severity;
+use crate::markup::{MarkupBinding, MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
+use crate::rule::{Rule, RuleCategory, RuleMeta};
+use vize_relief::ElementNode;
+
+static META: RuleMeta = RuleMeta {
+    name: "vue/no-static-inline-styles",
+    description: "Disallow static inline style attributes",
+    category: RuleCategory::Recommended,
+    fixable: false,
+    default_severity: Severity::Warning,
+};
+
+#[derive(Default)]
+pub struct NoStaticInlineStyles;
+
+impl NoStaticInlineStyles {
+    fn check_binding(ctx: &mut LintContext<'_>, binding: &MarkupBinding<'_>) {
+        if binding.kind() != MarkupBindingKind::Attribute
+            || !binding.is_unqualified_arg_exact("style")
+            || binding.static_value().is_none()
+        {
+            return;
+        }
+
+        ctx.warn_at_with_help(
+            "Static inline style attributes are not allowed.",
+            binding.range(),
+            "Move the style to a class, CSS module, or dynamic style binding.",
+        );
+    }
+
+    fn check_element(ctx: &mut LintContext<'_>, element: &MarkupElement<'_>) {
+        element.walk_bindings(&mut |binding| Self::check_binding(ctx, &binding));
+    }
+}
+
+impl MarkupRule for NoStaticInlineStyles {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_binding<'a>(
+        &self,
+        ctx: &mut MarkupContext<'_, 'a>,
+        _element: &MarkupElement<'a>,
+        binding: &MarkupBinding<'a>,
+    ) {
+        Self::check_binding(ctx.lint(), binding);
+    }
+}
+
+impl Rule for NoStaticInlineStyles {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        Self::check_element(ctx, &MarkupElement::new(element));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NoStaticInlineStyles;
+    use crate::linter::Linter;
+    use crate::rule::RuleRegistry;
+
+    fn create_linter() -> Linter {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(NoStaticInlineStyles));
+        Linter::with_registry(registry)
+    }
+
+    #[test]
+    fn reports_static_style_attribute() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div style="color: red">text</div>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+        assert_eq!(
+            result.diagnostics[0].rule_name,
+            "vue/no-static-inline-styles"
+        );
+    }
+
+    #[test]
+    fn allows_dynamic_style_binding() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div :style="{ color: theme.color }">text</div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn allows_v_bind_style_binding() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div v-bind:style="styles">text</div>"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn allows_class_attribute() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div class="text-red">text</div>"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+}

--- a/npm/cli/src/types/rules.ts
+++ b/npm/cli/src/types/rules.ts
@@ -190,6 +190,7 @@ export const LINT_RULE_NAMES = [
   "vue/no-root-v-if",
   "vue/no-script-non-standard-lang",
   "vue/no-src-attribute",
+  "vue/no-static-inline-styles",
   "vue/no-template-key",
   "vue/no-template-lang",
   "vue/no-template-shadow",

--- a/tests/_fixtures/davinci-fpfn/expected/suppression-report.json
+++ b/tests/_fixtures/davinci-fpfn/expected/suppression-report.json
@@ -7,7 +7,7 @@
   },
   "ruleMap": {
     "fixture": "tests/_fixtures/patina-eslint-vue-rule-map.json",
-    "mappedRules": 122,
+    "mappedRules": 123,
     "coreSidecarRules": 0
   },
   "scope": {

--- a/tests/_fixtures/patina-eslint-vue-rule-map.json
+++ b/tests/_fixtures/patina-eslint-vue-rule-map.json
@@ -821,8 +821,10 @@
       "status": "unimplemented"
     },
     "vue/no-static-inline-styles": {
-      "issue": 3223,
-      "status": "unimplemented"
+      "patinaPresets": [],
+      "patinaRule": "vue/no-static-inline-styles",
+      "patinaSeverity": "warning",
+      "status": "mapped"
     },
     "vue/no-template-key": {
       "patinaPresets": [
@@ -1676,8 +1678,8 @@
   "schemaVersion": 1,
   "summary": {
     "intentionalDivergence": 2,
-    "mapped": 122,
-    "unimplemented": 128
+    "mapped": 123,
+    "unimplemented": 127
   },
   "upstream": {
     "package": "eslint-plugin-vue",

--- a/tests/tooling/davinci-fpfn-pilots.test.ts
+++ b/tests/tooling/davinci-fpfn-pilots.test.ts
@@ -274,6 +274,6 @@ test("suppression telemetry reports the mapped FP candidate and the unmapped nam
   assert.equal(
     lines[1],
     "scope-proof: files-scanned=4 suppression-comments=2 named=2 bare=0 " +
-      "rules-mapped=122 mapped-seen=1 unmapped-seen=1 fp-candidates=1",
+      "rules-mapped=123 mapped-seen=1 unmapped-seen=1 fp-candidates=1",
   );
 });

--- a/tests/tooling/patina-eslint-vue-rule-map.test.ts
+++ b/tests/tooling/patina-eslint-vue-rule-map.test.ts
@@ -7,7 +7,7 @@ test("the Patina scorecard exhaustively maps the pinned eslint-plugin-vue rule s
 
   assert.equal(ruleMap.upstream.version, "10.9.2");
   assert.equal(ruleMap.upstream.ruleCount, 252);
-  assert.deepEqual(ruleMap.summary, { mapped: 122, unimplemented: 128, intentionalDivergence: 2 });
+  assert.deepEqual(ruleMap.summary, { mapped: 123, unimplemented: 127, intentionalDivergence: 2 });
   assert.deepEqual(ruleMap.entries["vue/component-definition-name-casing"], {
     status: "intentional-divergence",
     reason:


### PR DESCRIPTION
## Summary
- add the Patina implementation for `vue/no-static-inline-styles`
- wire style category membership and opt-in rule registration
- update the eslint-plugin-vue parity fixture, rule-map test count, and preset snapshot

## Validation
- `cargo fmt --all -- --check`
- `node_modules/node/bin/node --test tests/tooling/patina-eslint-vue-rule-map.test.ts`
- `cargo test -p vize_patina -- --nocapture`
- `cargo clippy -p vize_patina --all-targets -- -D warnings -D clippy::wildcard_imports`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791305779&installation_model_id=422833&pr_number=5844&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5844&signature=c469c9096f21280ff0074336ce9a5ebf1f1faa41c3472b9e0cf2d73f7f6fe271"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->