### PR TITLE
fix(typecheck): mirror workspace package output dependencies

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -236,17 +236,16 @@ pub(super) fn collect_transitive_local_imports_with_resolver(
             if let Some(route) = package_route
                 && needs_registration
             {
+                if !package_graph && registered.insert(file.clone()) {
+                    registrations.push(file.clone());
+                }
                 let (_, invalidation_paths, mode, context, _) = package_lookup
                     .as_ref()
                     .expect("a positive package route came from a package lookup");
                 let mut route = route.clone();
-                // Re-sort only when the extension actually added something. The
-                // route arrives sorted and deduped, and most occurrences in a
-                // workspace resolve to a package whose sources are already all
-                // known, so the common case is appending nothing and then paying
-                // a full sort of the package's whole dependency list — with
-                // `Path`'s component-wise comparison, over long pnpm paths, once
-                // per import occurrence (#4426).
+                // Re-sort only when the extension actually added something; most
+                // workspace packages arrive sorted and deduped, so the common case
+                // avoids a component-wise path sort over long pnpm paths (#4426).
                 let before = route.dependency_paths.len();
                 route.dependency_paths.extend(
                     discovery

--- a/crates/vize/src/commands/check/imports_aliases_tests.rs
+++ b/crates/vize/src/commands/check/imports_aliases_tests.rs
@@ -62,6 +62,84 @@ fn exact_alias_does_not_match_prefix() {
 }
 
 #[test]
+#[cfg(unix)]
+fn wildcard_alias_js_type_import_registers_sources_that_need_package_shadows() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempfile::tempdir().unwrap();
+    let entry = write(
+        root.path(),
+        "src/App.vue",
+        "<script setup lang=\"ts\">\nimport type { Form } from '@/utility/form.js'\ndefineProps<{ form: Form }>()\n</script>\n",
+    );
+    let form = write(
+        root.path(),
+        "src/utility/form.ts",
+        "import * as Misskey from 'misskey-js';\nexport interface Form { file: Misskey.entities.DriveFile }\n",
+    );
+    let package = root.path().join("packages/misskey-js");
+    let package_source = write(
+        root.path(),
+        "packages/misskey-js/src/index.ts",
+        "export * as entities from './entities.js';\n",
+    );
+    write(
+        root.path(),
+        "packages/misskey-js/src/entities.ts",
+        "export interface DriveFile { id: string }\n",
+    );
+    write(
+        root.path(),
+        "packages/misskey-js/package.json",
+        r#"{
+  "type": "module",
+  "name": "misskey-js",
+  "exports": {
+    ".": {
+      "import": "./built/index.js",
+      "types": "./built/index.d.ts"
+    }
+  }
+}
+"#,
+    );
+    std::fs::write(
+        root.path().join("tsconfig.json"),
+        r#"{"compilerOptions":{"paths":{"@/*":["./src/*"]}}}"#,
+    )
+    .unwrap();
+    let link = root.path().join("node_modules/misskey-js");
+    std::fs::create_dir_all(link.parent().unwrap()).unwrap();
+    symlink(&package, &link).unwrap();
+    let resolver =
+        PathAliasResolver::from_tsconfig(Some(root.path().join("tsconfig.json").as_path()));
+
+    let mut package_resolver = vize_canon::PackageRouteResolver::default();
+    let discovered = super::super::imports::collect_transitive_local_imports_with_resolver(
+        std::slice::from_ref(&entry),
+        root.path(),
+        &mut CanonicalPathCache::default(),
+        false,
+        Some(&resolver),
+        &mut package_resolver,
+    );
+
+    assert_eq!(discovered.registrations, vec![form.canonicalize().unwrap()]);
+    assert!(
+        discovered
+            .authored
+            .contains(&package_source.canonicalize().unwrap())
+    );
+    assert_eq!(discovered.package_routes.len(), 1);
+    assert!(
+        discovered.package_routes[0]
+            .route
+            .as_ref()
+            .is_some_and(vize_canon::PackageRoute::requires_workspace_source_shadow)
+    );
+}
+
+#[test]
 fn missing_alias_target_retains_every_probed_candidate() {
     let root = tempfile::tempdir().unwrap();
     std::fs::write(

--- a/crates/vize_canon/src/batch/virtual_project/package_shadow.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_shadow.rs
@@ -206,7 +206,46 @@ impl VirtualProject {
             topology
                 .files
                 .entry(shadow_root.join(relative_probe))
-                .or_insert(canonical_virtual);
+                .or_insert_with(|| canonical_virtual.clone());
+            if let Some(relative_target) =
+                source.declaration_target_relative_path(&route.package_root)
+            {
+                topology
+                    .files
+                    .entry(shadow_root.join(relative_target))
+                    .or_insert_with(|| canonical_virtual.clone());
+            }
+            self.collect_workspace_dependency_target_shadows(route, source, shadow_root, topology);
+        }
+    }
+
+    fn collect_workspace_dependency_target_shadows(
+        &self,
+        route: &crate::PackageRoute,
+        source: &crate::PackageRouteSource,
+        shadow_root: &Path,
+        topology: &mut PackageShadowTopology,
+    ) {
+        let normalized_root = vize_carton::path::canonicalize_non_verbatim(&route.package_root);
+        let Some(indexed_sources) = self.package_source_index.get(&normalized_root) else {
+            return;
+        };
+        let mut sources = indexed_sources
+            .iter()
+            .map(|(source_path, (_, virtual_path))| (source_path, virtual_path))
+            .collect::<Vec<_>>();
+        sources.sort_by(|left, right| left.0.cmp(right.0));
+
+        for (dependency, canonical_virtual) in sources {
+            let Some(relative_probe) =
+                source.workspace_dependency_probe_relative_path(&route.package_root, dependency)
+            else {
+                continue;
+            };
+            topology
+                .files
+                .entry(shadow_root.join(relative_probe))
+                .or_insert_with(|| canonical_virtual.clone());
         }
     }
 

--- a/crates/vize_canon/src/batch/virtual_project/package_shadow_runtime.rs
+++ b/crates/vize_canon/src/batch/virtual_project/package_shadow_runtime.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use vize_carton::{FxHashSet, String as CompactString, cstr};
 
+use crate::batch::declaration_path::is_declaration_file;
 use crate::batch::error::CorsaResult;
 
 use super::VirtualProject;
@@ -25,6 +26,11 @@ impl VirtualProject {
             .extension()
             .is_none_or(|extension| extension != "vue")
         {
+            if !is_declaration_file(&file.original_path)
+                && let Some(forwarder) = declaration_shadow_forwarder(shadow_path)
+            {
+                return Ok(forwarder);
+            }
             // Package TS/declaration modules keep their authored spelling in
             // the importer-local mirror. Native TypeScript can then apply
             // `allowArbitraryExtensions` to `./Widget.vue` and select the
@@ -131,4 +137,17 @@ impl VirtualProject {
         links.dedup();
         links
     }
+}
+
+fn declaration_shadow_forwarder(shadow_path: &Path) -> Option<CompactString> {
+    let name = shadow_path.file_name()?.to_str()?;
+    let target = if let Some(stem) = name.strip_suffix(".d.mts") {
+        cstr!("{stem}.mjs")
+    } else if let Some(stem) = name.strip_suffix(".d.cts") {
+        cstr!("{stem}.cjs")
+    } else {
+        let stem = name.strip_suffix(".d.ts")?;
+        cstr!("{stem}.js")
+    };
+    Some(cstr!("export * from \"./{target}\";\n"))
 }

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -17,6 +17,7 @@ mod source_types;
 mod tsconfig_extends;
 mod tsconfig_native_options;
 mod windows_paths;
+mod workspace_package_dependency_shadows;
 mod workspace_package_routes;
 fn unique_case_dir(name: &str) -> PathBuf {
     static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
@@ -45,7 +46,6 @@ fn assert_tsx_parses(source: &str) {
         parsed.diagnostics
     );
 }
-
 #[derive(Debug)]
 #[allow(dead_code)]
 struct DiagnosticSnapshot<'a> {

--- a/crates/vize_canon/src/batch/virtual_project/tests/workspace_package_dependency_shadows.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/workspace_package_dependency_shadows.rs
@@ -1,0 +1,136 @@
+use std::{fs, path::PathBuf};
+
+use crate::{PackageResolutionContext, PackageRoute, PackageRouteBinding};
+
+use super::{VirtualProject, unique_case_dir};
+
+#[test]
+fn workspace_build_shadow_mirrors_source_dependency_tree() {
+    let project_root = unique_case_dir("workspace-build-shadow-deps");
+    let package_root = project_root.parent().unwrap().join(format!(
+        "{}-package",
+        project_root.file_name().unwrap().to_string_lossy()
+    ));
+    let _ = fs::remove_dir_all(&project_root);
+    let _ = fs::remove_dir_all(&package_root);
+    fs::create_dir_all(project_root.join("src")).unwrap();
+    fs::create_dir_all(package_root.join("src/autogen")).unwrap();
+    fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{"compilerOptions":{"module":"ESNext","moduleResolution":"Bundler","strict":true}}"#,
+    )
+    .unwrap();
+    let entry_path = project_root.join("src/entry.ts");
+    fs::write(
+        &entry_path,
+        "import * as Misskey from 'misskey-js';\ntype File = Misskey.entities.DriveFile;\n",
+    )
+    .unwrap();
+    let manifest = r#"{
+  "type": "module",
+  "name": "misskey-js",
+  "exports": {
+    ".": {
+      "import": "./built/index.js",
+      "types": "./built/index.d.ts"
+    }
+  }
+}
+"#;
+    fs::write(package_root.join("package.json"), manifest).unwrap();
+    let index_contents = "export * as entities from \"./entities.js\";\n";
+    let entities_contents = "export type { DriveFile } from \"./autogen/models.js\";\n";
+    let models_contents = "export interface DriveFile { id: string }\n";
+    fs::write(package_root.join("src/index.ts"), index_contents).unwrap();
+    fs::write(package_root.join("src/entities.ts"), entities_contents).unwrap();
+    fs::write(package_root.join("src/autogen/models.ts"), models_contents).unwrap();
+
+    let project_root = project_root.canonicalize().unwrap();
+    let package_root = package_root.canonicalize().unwrap();
+    let entry_path = entry_path.canonicalize().unwrap();
+    let manifest_path = package_root.join("package.json");
+    let index_path = package_root.join("src/index.ts");
+    let entities_path = package_root.join("src/entities.ts");
+    let models_path = package_root.join("src/autogen/models.ts");
+    let route = PackageRoute {
+        source_paths: vec![index_path.clone()],
+        dependency_paths: vec![entities_path.clone()],
+        source_targets: vec![
+            crate::PackageRouteSource {
+                target_path: package_root.join("built/index.js"),
+                source_path: index_path.clone(),
+                native_probe_path: package_root.join("built/index.ts"),
+            },
+            crate::PackageRouteSource {
+                target_path: package_root.join("built/index.d.ts"),
+                source_path: index_path.clone(),
+                native_probe_path: package_root.join("built/index.ts"),
+            },
+        ],
+        package_root: package_root.clone(),
+        package_link_root: package_root.clone(),
+        manifest_path: manifest_path.clone(),
+        package_name: Some("misskey-js".into()),
+        workspace_source: true,
+        nested_routes: Vec::new(),
+    };
+    let mut project = VirtualProject::new(&project_root).unwrap();
+    project.set_package_routes([PackageRouteBinding {
+        importer_path: entry_path.clone(),
+        specifier: "misskey-js".into(),
+        occurrence_mode: crate::PackageResolutionMode::Import,
+        context: PackageResolutionContext::default(),
+        route: Some(route),
+        invalidation_paths: vec![manifest_path.clone(), index_path.clone()],
+    }]);
+    project.register_path(&entry_path).unwrap();
+    project.register_package_route_targets().unwrap();
+    project.register_reachable_dependencies().unwrap();
+    project.finalize_package_routes().unwrap();
+    project.materialize().unwrap();
+
+    let shadow_root = project
+        .find_by_original(&entry_path)
+        .unwrap()
+        .virtual_path
+        .parent()
+        .unwrap()
+        .join("node_modules/misskey-js");
+    assert_eq!(
+        fs::read_to_string(shadow_root.join("built/index.ts")).unwrap(),
+        index_contents
+    );
+    assert_eq!(
+        fs::read_to_string(shadow_root.join("built/index.d.ts")).unwrap(),
+        "export * from \"./index.js\";\n"
+    );
+    assert_eq!(
+        fs::read_to_string(shadow_root.join("built/entities.ts")).unwrap(),
+        entities_contents
+    );
+    assert_eq!(
+        fs::read_to_string(shadow_root.join("built/autogen/models.ts")).unwrap(),
+        models_contents
+    );
+    assert_eq!(
+        project
+            .find_by_virtual(&shadow_root.join("built/autogen/models.ts"))
+            .map(|file| file.original_path.as_path()),
+        Some(models_path.as_path())
+    );
+    assert_eq!(
+        project
+            .package_routes_snapshot()
+            .pop()
+            .unwrap()
+            .route
+            .as_ref()
+            .unwrap()
+            .source_for_native_shadow_path(&shadow_root, &shadow_root.join("built/index.d.ts"))
+            .map(PathBuf::as_path),
+        Some(index_path.as_path())
+    );
+
+    let _ = fs::remove_dir_all(&project_root);
+    let _ = fs::remove_dir_all(&package_root);
+}

--- a/crates/vize_canon/src/package_route/shadow_mapping.rs
+++ b/crates/vize_canon/src/package_route/shadow_mapping.rs
@@ -1,6 +1,6 @@
 //! Deterministic authored-source mapping for native package-shadow locations.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use super::{PackageRoute, PackageRouteSource};
 use vize_carton::cstr;
@@ -23,9 +23,16 @@ pub(super) fn source_for_native_shadow_path<'a>(
         (source
             .native_probe_relative_path(&route.package_root)
             .as_deref()
-            == Some(selected))
+            == Some(selected)
+            || source
+                .declaration_target_relative_path(&route.package_root)
+                .as_deref()
+                == Some(selected))
         .then_some(&source.source_path)
     }) {
+        return Some(source);
+    }
+    if let Some(source) = workspace_dependency_shadow(route, selected) {
         return Some(source);
     }
     for nested in &route.nested_routes {
@@ -41,6 +48,20 @@ pub(super) fn source_for_native_shadow_path<'a>(
         }
     }
     None
+}
+
+fn workspace_dependency_shadow<'a>(
+    route: &'a PackageRoute,
+    selected: &Path,
+) -> Option<&'a PathBuf> {
+    route.source_targets.iter().find_map(|source| {
+        route.dependency_paths.iter().find(|dependency| {
+            source
+                .workspace_dependency_probe_relative_path(&route.package_root, dependency)
+                .as_deref()
+                == Some(selected)
+        })
+    })
 }
 
 fn direct_source_shadow<'a>(route: &'a PackageRoute, selected: &Path) -> Option<&'a PathBuf> {
@@ -93,5 +114,59 @@ impl PackageRouteSource {
             .strip_prefix(package_root)
             .ok()
             .map(Path::to_path_buf)
+    }
+
+    pub(crate) fn declaration_target_relative_path(&self, package_root: &Path) -> Option<PathBuf> {
+        let relative = self.target_path.strip_prefix(package_root).ok()?;
+        is_declaration_path(relative).then(|| relative.to_path_buf())
+    }
+
+    pub(crate) fn workspace_dependency_probe_relative_path(
+        &self,
+        package_root: &Path,
+        dependency_path: &Path,
+    ) -> Option<PathBuf> {
+        if dependency_path
+            .extension()
+            .is_some_and(|extension| extension == "vue")
+        {
+            return None;
+        }
+        let source_relative = self.source_path.strip_prefix(package_root).ok()?;
+        let probe_relative = self.native_probe_path.strip_prefix(package_root).ok()?;
+        if source_relative == probe_relative {
+            return None;
+        }
+        let dependency_relative = dependency_path.strip_prefix(package_root).ok()?;
+        let source_root = first_normal_component(source_relative)?;
+        if source_root != "src" {
+            return None;
+        }
+        let output_root = first_normal_component(probe_relative)?;
+        if !matches!(output_root, "built" | "dist" | "lib") {
+            return None;
+        }
+        let dependency_suffix = dependency_relative
+            .strip_prefix(Path::new(source_root))
+            .ok()?;
+        if dependency_suffix.as_os_str().is_empty() {
+            return None;
+        }
+        Some(Path::new(output_root).join(dependency_suffix))
+    }
+}
+
+fn is_declaration_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            name.ends_with(".d.ts") || name.ends_with(".d.mts") || name.ends_with(".d.cts")
+        })
+}
+
+fn first_normal_component(path: &Path) -> Option<&str> {
+    match path.components().next()? {
+        Component::Normal(part) => part.to_str(),
+        _ => None,
     }
 }


### PR DESCRIPTION
## Summary
- register aliased type-import files when they introduce workspace package shadows
- mirror indexed workspace package sources under built/dist/lib output paths for raw package exports
- add declaration target forwarders and reverse source mapping for mirrored package output shadows

## Verification
- cargo test -p vize_canon workspace_build_shadow_mirrors_source_dependency_tree --lib
- cargo test -p vize_canon symlinked_workspace_build_export_falls_back_to_src_entry --lib -- --nocapture
- cargo test -p vize symlinked_workspace_build_output_package_gets_a_shadow_route --lib -- --nocapture
- cargo test -p vize wildcard_alias_js_type_import_registers_sources_that_need_package_shadows --lib
- cargo clippy -p vize_canon -p vize --lib -- -D warnings -D clippy::wildcard_imports
- cargo fmt --all -- --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --max-lines 350 --limit 5 --base-ref origin/main
- git diff --check origin/main..HEAD

## Real-project evidence
- Focused Misskey MkForm check removed the bare misskey-js module-surface errors and materialized deep built output shadows such as built/autogen/models.ts.
- The same focused run reduced MkForm diagnostics from 23 TS7006 callback implicit-any reports to 8 residual TS7015 indexed-access reports.

## Release impact
- Reduces the shard 12 Misskey release blocker by making raw workspace package exports resolve through the virtual output shadow instead of missing build artifacts.
- Leaves the remaining TS7015 indexed-access diagnostics for a follow-up template/script-context slice.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791307595&installation_model_id=422833&pr_number=5845&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5845&signature=0afd4c76d1df9875baf5323cd910ac0676d5f0a761f0c0d1d7b40008de5ab0e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace dependency resolution for projects using package aliases and type-only imports.
  * Workspace package shadows now better mirror dependency source files and preserve their expected paths.
  * Improved handling of declaration files, including generated forwarding between declaration files and their JavaScript counterparts.
  * Fixed registration of imported files that were missing from the virtual project.

* **Tests**
  * Added coverage for wildcard aliases, workspace dependency shadows, and declaration-file resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->