### PR TITLE
fix(atelier-dom): fail closed unknown DOM lane flag

### DIFF
--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -31,8 +31,8 @@ pub(super) fn dom_lane_selection() -> DomLaneSelection {
 
 fn dom_lane_selection_from_flag(value: Option<&str>) -> DomLaneSelection {
     match value {
-        Some("legacy") => DomLaneSelection::Legacy,
-        _ => DomLaneSelection::S2,
+        None | Some("s2") => DomLaneSelection::S2,
+        Some(_) => DomLaneSelection::Legacy,
     }
 }
 

--- a/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
@@ -13,6 +13,10 @@ fn dom_lane_selection_maps_the_legacy_flag_value() {
         DomLaneSelection::Legacy
     );
     assert_eq!(
+        dom_lane_selection_from_flag(Some("unknown")),
+        DomLaneSelection::Legacy
+    );
+    assert_eq!(
         dom_lane_selection_from_flag(Some("s2")),
         DomLaneSelection::S2
     );


### PR DESCRIPTION
## Summary
- default the DOM lane to S2 only when the flag is unset or explicitly `s2`
- route unknown lane flag values to the compatibility lane
- cover the unknown-value mapping in stage option tests

## Validation
- `cargo test -p vize_atelier_dom stage_options`
- `cargo test -p vize_atelier_dom --test davinci_s2_production_selector`
- `cargo fmt --check`
- `git diff --check origin/main...HEAD`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated DOM lane selection so unrecognized configuration values use the Legacy lane.
  - Preserved explicit Legacy selection for the corresponding configuration value.
  - Updated handling for recognized lane-selection values to reflect the revised routing behavior.

- **Tests**
  - Added coverage confirming that unknown configuration values are routed to the Legacy lane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->