### PR TITLE
fix(davinci): admit DOM optimize imports no-op

### DIFF
--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -96,7 +96,7 @@ pub(super) fn codegen_options(
 
 pub(super) fn s2_emit_supported(
     options: &DomCompilerOptions,
-    codegen: &CodegenOptions,
+    _codegen: &CodegenOptions,
     custom_elements: &CustomElementMatcher,
     template_syntax: TemplateSyntaxMode,
     has_croquis: bool,
@@ -115,7 +115,6 @@ pub(super) fn s2_emit_supported(
         && template_syntax == TemplateSyntaxMode::Standard
         && custom_elements.projectable_patterns().is_some()
         && !has_croquis
-        && !codegen.optimize_imports
 }
 
 /// The published DOM option surface projected onto the S2 emitter.

--- a/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
@@ -62,8 +62,8 @@ fn legacy_dialects_stay_on_the_compatibility_lane() {
 }
 
 #[test]
-fn ssr_optimize_imports_codegen_option_stays_on_the_compatibility_lane() {
-    assert!(!s2_emit_supported(
+fn optimize_imports_codegen_option_does_not_disarm_s2() {
+    assert!(s2_emit_supported(
         &DomCompilerOptions::default(),
         &CodegenOptions {
             optimize_imports: true,

--- a/crates/vize_atelier_dom/tests/davinci_s2_codegen_option_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_codegen_option_selector.rs
@@ -1,5 +1,5 @@
-//! P2-11 witness: backend-only codegen options stay on the compatibility lane
-//! until the DOM S2 selector owns their semantics.
+//! P2-11 witness: DOM-irrelevant codegen options keep the S2 production lane
+//! selected after the compatibility no-op is audited.
 
 #![allow(
     clippy::disallowed_macros,
@@ -16,40 +16,81 @@ use vize_s0::Allocator;
 use vize_s0::profiler::{CounterSummary, global_profiler};
 
 #[test]
-fn optimize_imports_stays_on_compatibility_when_profiled() {
+fn optimize_imports_uses_s2_after_legacy_noop_audit() {
+    let _env_guard = lock_env();
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
     profiler.clear();
-    profiler.enable();
 
-    let allocator = Allocator::new();
-    let (_, errors, result) =
-        compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
-            &allocator,
-            r#"<button @click="go">{{ label }}</button>"#,
-            DomCompilerOptions::default(),
-            TemplateSyntaxMode::Standard,
-            None,
+    let source = r#"<button @click="go">{{ label }}</button>"#;
+    let legacy_default = {
+        let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "legacy");
+        compile(source, CodegenOptions::default())
+    };
+    let legacy_optimized = {
+        let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "legacy");
+        compile(
+            source,
             CodegenOptions {
                 optimize_imports: true,
                 ..Default::default()
             },
-        );
+        )
+    };
+
+    assert_eq!(legacy_optimized.preamble, legacy_default.preamble);
+    assert_eq!(legacy_optimized.code, legacy_default.code);
+    assert_eq!(legacy_optimized.sections, legacy_default.sections);
+
+    profiler.enable();
+
+    let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "s2");
+    let selected = compile(
+        source,
+        CodegenOptions {
+            optimize_imports: true,
+            ..Default::default()
+        },
+    );
     let counters = profiler.counter_summary();
     profiler.disable();
     profiler.clear();
 
-    assert!(errors.is_empty(), "compile errors: {errors:?}");
-    assert!(
-        result.sections.is_some(),
-        "unsupported backend-only codegen options must keep compatibility sections"
-    );
+    assert_eq!(selected.preamble, legacy_optimized.preamble);
+    assert_eq!(selected.code, legacy_optimized.code);
+    assert_eq!(selected.sections, legacy_optimized.sections);
     assert_eq!(
         counter_total(&counters, "davinci.s2_dom.files"),
-        None,
-        "unsupported backend-only codegen options must not enter the S2 production selector"
+        Some(1),
+        "DOM-irrelevant optimize_imports must not disarm the S2 production selector"
     );
+}
+
+struct Compiled {
+    preamble: String,
+    code: String,
+    sections: Option<vize_atelier_core::CodegenSections>,
+}
+
+fn compile(source: &str, codegen: CodegenOptions) -> Compiled {
+    let allocator = Allocator::new();
+    let (_, errors, result) =
+        compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            source,
+            DomCompilerOptions::default(),
+            TemplateSyntaxMode::Standard,
+            None,
+            codegen,
+        );
+
+    assert!(errors.is_empty(), "compile errors: {errors:?}");
+    Compiled {
+        preamble: result.result.preamble.to_string(),
+        code: result.result.code.to_string(),
+        sections: result.sections,
+    }
 }
 
 fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
@@ -65,4 +106,39 @@ fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
     PROFILER_TEST_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ENV_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: This test holds the local environment lock for the full
+        // lifetime of the scoped override.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        // SAFETY: The guard is dropped before the local environment lock,
+        // restoring the process environment while mutations are serialized.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
 }

--- a/davinci-road/plan/phase-2-records/p2-11/installment-99.md
+++ b/davinci-road/plan/phase-2-records/p2-11/installment-99.md
@@ -7,7 +7,8 @@
 This installment lands `scope_id`, which completes the DOM-relevant half of
 `CodegenOptions` in `DomEmitOptions`. What remains outside the emitter's
 surface is deliberate: `source_map` / `filename` belong to the structured S4
-emitter (P3-9), and `ssr` / `optimize_imports` are the SSR lane's (phase 3).
+emitter (P3-9), and `ssr` belongs to the SSR lane (phase 3). A later selector
+audit confirmed `optimize_imports` is a stale DOM no-op and should not block S2.
 
 ## Why this one is wide
 

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -64,7 +64,7 @@ const codegenOptionsOwnedByDomCompiler = [
 ];
 const codegenOptionsProjectedToS2 = ["runtime_module_name", "runtime_global_name"];
 const codegenOptionsHandledAroundS2 = ["filename"];
-const codegenOptionsUnsupportedForS2 = ["optimize_imports"];
+const codegenOptionsNoopForDomS2 = ["optimize_imports"];
 
 test("DOM compiler keeps the published S2 renderer available for profiling", () => {
   const dependencies = workspacePackage(metadata, "vize_atelier_dom").dependencies;
@@ -171,7 +171,7 @@ test("DOM S2 production switch classifies every adapter codegen option", () => {
       ...codegenOptionsOwnedByDomCompiler,
       ...codegenOptionsProjectedToS2,
       ...codegenOptionsHandledAroundS2,
-      ...codegenOptionsUnsupportedForS2,
+      ...codegenOptionsNoopForDomS2,
     ]),
     [...fields].sort(),
   );


### PR DESCRIPTION
## Summary
- remove the stale `optimize_imports` guard from the S2 DOM selector
- pin legacy DOM parity for `optimize_imports: false/true`
- reclassify the adapter option as a DOM no-op in the production-boundary audit

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p vize_atelier_dom compile::stage_options::tests --lib`
- `cargo test -p vize_atelier_dom --test davinci_s2_codegen_option_selector`
- `cargo test -p vize_atelier_dom --test davinci_s2_production_selector`
- `node --test tests/tooling/davinci-dom-production-boundary.test.ts`
- `git diff --check origin/main...HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791314904&installation_model_id=422833&pr_number=5849&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5849&signature=20b73070168ada478724d9472f5b6e94e6366e04ccba039181fccbdfc8313222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - DOM compilation now remains on the S2 production path when import optimization is enabled.
  - Outputs remain consistent across legacy and S2 compilation lanes for this option.

- **Tests**
  - Added coverage confirming S2 selection and generated-output consistency across compilation modes.

- **Documentation**
  - Clarified that import optimization is a no-op for DOM S2 compilation, while other options apply to separate compilation lanes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->