### PR TITLE
fix(vscode): ship TypeScript plugin runtime closure

### DIFF
--- a/tests/tooling/vscode-typescript-plugin-staging.test.ts
+++ b/tests/tooling/vscode-typescript-plugin-staging.test.ts
@@ -15,7 +15,14 @@ const syncCommand = path.join(
   "vscode",
   "sync-typescript-plugin.rs",
 );
-const pluginFiles = ["index.cjs", "package.json", "virtual-modules.cjs"] as const;
+const pluginFiles = [
+  "component-contracts.cjs",
+  "import-resolution.cjs",
+  "index.cjs",
+  "module-resolution.cjs",
+  "package.json",
+  "virtual-modules.cjs",
+] as const;
 
 test("TypeScript Vue plugin staging refuses partial source packages without touching target", () => {
   const fixture = createFixture();
@@ -26,8 +33,9 @@ test("TypeScript Vue plugin staging refuses partial source packages without touc
   );
   fs.mkdirSync(source, { recursive: true });
   fs.mkdirSync(target, { recursive: true });
-  fs.writeFileSync(path.join(source, "index.cjs"), "new index\n");
-  fs.writeFileSync(path.join(source, "package.json"), "{}\n");
+  for (const file of pluginFiles.filter((file) => file !== "virtual-modules.cjs")) {
+    fs.writeFileSync(path.join(source, file), `new ${file}\n`);
+  }
   for (const file of pluginFiles) {
     fs.writeFileSync(path.join(target, file), `previous ${file}\n`);
   }

--- a/tests/tooling/vscode-vsix-policy.test.ts
+++ b/tests/tooling/vscode-vsix-policy.test.ts
@@ -42,6 +42,45 @@ test("VSIX package policy keeps the production CJS host entrypoint shippable", (
   assert.match(smoke, /"sourceMappingURL="/);
 });
 
+test("VSIX TypeScript plugin staging follows the runtime require closure", () => {
+  const pluginDir = "editors/vscode/typescript-vue-plugin";
+  const sync = readText("tools/commands/editors/vscode/sync-typescript-plugin.rs");
+  const smoke = readText("tools/commands/editors/vscode/assert-vsix-package.rs");
+  const runtimeFiles = new Set(["package.json"]);
+  const pending = ["index.cjs"];
+
+  while (pending.length > 0) {
+    const file = pending.pop();
+    assert.ok(file);
+    if (runtimeFiles.has(file)) {
+      continue;
+    }
+    runtimeFiles.add(file);
+
+    const source = readText(`${pluginDir}/${file}`);
+    for (const match of source.matchAll(/require\("\.\/([^"]+\.cjs)"\)/g)) {
+      pending.push(match[1]);
+    }
+  }
+
+  assert.deepEqual([...runtimeFiles].sort(), [
+    "component-contracts.cjs",
+    "import-resolution.cjs",
+    "index.cjs",
+    "module-resolution.cjs",
+    "package.json",
+    "virtual-modules.cjs",
+  ]);
+  for (const file of runtimeFiles) {
+    assert.match(sync, new RegExp(`"${escapeRegExp(file)}"`), `${file} is not staged`);
+    assert.match(
+      smoke,
+      new RegExp(`extension/node_modules/@vizejs/typescript-vue-plugin/${escapeRegExp(file)}`),
+      `${file} is not required by VSIX smoke`,
+    );
+  }
+});
+
 test("VSIX package policy excludes source-only extension host inputs", () => {
   const ignore = readText("editors/vscode/.vscodeignore");
   const smoke = readText("tools/commands/editors/vscode/assert-vsix-package.rs");

--- a/tools/commands/editors/vscode/assert-vsix-package.rs
+++ b/tools/commands/editors/vscode/assert-vsix-package.rs
@@ -47,7 +47,10 @@ fn run() -> Result<(), String> {
         "extension/dist/extension.cjs",
         "extension/icons/vue.svg",
         "extension/language-configuration.json",
+        "extension/node_modules/@vizejs/typescript-vue-plugin/component-contracts.cjs",
+        "extension/node_modules/@vizejs/typescript-vue-plugin/import-resolution.cjs",
         "extension/node_modules/@vizejs/typescript-vue-plugin/index.cjs",
+        "extension/node_modules/@vizejs/typescript-vue-plugin/module-resolution.cjs",
         "extension/node_modules/@vizejs/typescript-vue-plugin/package.json",
         "extension/node_modules/@vizejs/typescript-vue-plugin/virtual-modules.cjs",
         "extension/package.json",
@@ -216,7 +219,10 @@ fn assert_allowed_entries(entries: &[String]) -> Result<(), String> {
         "extension/icons/logo.png",
         "extension/icons/vue.svg",
         "extension/language-configuration.json",
+        "extension/node_modules/@vizejs/typescript-vue-plugin/component-contracts.cjs",
+        "extension/node_modules/@vizejs/typescript-vue-plugin/import-resolution.cjs",
         "extension/node_modules/@vizejs/typescript-vue-plugin/index.cjs",
+        "extension/node_modules/@vizejs/typescript-vue-plugin/module-resolution.cjs",
         "extension/node_modules/@vizejs/typescript-vue-plugin/package.json",
         "extension/node_modules/@vizejs/typescript-vue-plugin/virtual-modules.cjs",
         "extension/package.json",
@@ -247,7 +253,10 @@ fn assert_forbidden_entries(entries: &[String]) -> Result<(), String> {
             || (name.starts_with("extension/node_modules/")
                 && !matches!(
                     name.as_str(),
-                    "extension/node_modules/@vizejs/typescript-vue-plugin/index.cjs"
+                    "extension/node_modules/@vizejs/typescript-vue-plugin/component-contracts.cjs"
+                        | "extension/node_modules/@vizejs/typescript-vue-plugin/import-resolution.cjs"
+                        | "extension/node_modules/@vizejs/typescript-vue-plugin/index.cjs"
+                        | "extension/node_modules/@vizejs/typescript-vue-plugin/module-resolution.cjs"
                         | "extension/node_modules/@vizejs/typescript-vue-plugin/package.json"
                         | "extension/node_modules/@vizejs/typescript-vue-plugin/virtual-modules.cjs"
                 ))

--- a/tools/commands/editors/vscode/sync-typescript-plugin.rs
+++ b/tools/commands/editors/vscode/sync-typescript-plugin.rs
@@ -19,7 +19,14 @@ mod common;
 
 const USAGE: &str = "Usage: rust-script tools/commands/editors/vscode/sync-typescript-plugin.rs <stage|inject> [vsix]";
 const PACKAGE_PATH: &str = "node_modules/@vizejs/typescript-vue-plugin";
-const PLUGIN_FILES: [&str; 3] = ["index.cjs", "package.json", "virtual-modules.cjs"];
+const PLUGIN_FILES: [&str; 6] = [
+    "component-contracts.cjs",
+    "import-resolution.cjs",
+    "index.cjs",
+    "module-resolution.cjs",
+    "package.json",
+    "virtual-modules.cjs",
+];
 
 fn main() -> ExitCode {
     common::main_result(run())


### PR DESCRIPTION
## Summary

- ship the full TypeScript Vue plugin CJS runtime closure in staged and injected VSIX packages
- require `component-contracts.cjs`, `import-resolution.cjs` and `module-resolution.cjs` in the VSIX smoke policy
- add policy coverage for both the staging command and the static plugin require closure from `index.cjs`

## Verification

- `node --test tests/tooling/vscode-typescript-plugin-staging.test.ts tests/tooling/editor-package-tasks.test.ts tests/tooling/vscode-vsix-policy.test.ts`
- `./node_modules/.bin/vp run --workspace-root package:vscode-extension`
- `rust-script tools/commands/editors/vscode/assert-vsix-package.rs editors/vscode/dist/vize.vsix`
- `cargo fmt --all --check`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`
- `node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`