### PR TITLE
test(lsp): cover inert advanced editor requests

### DIFF
--- a/tests/tooling/support/lsp/assertions.ts
+++ b/tests/tooling/support/lsp/assertions.ts
@@ -102,6 +102,17 @@ export async function assertEmptyEditorRequests(
       },
     ],
     [
+      "textDocument/signatureHelp",
+      {
+        textDocument: { uri },
+        position,
+        context: {
+          triggerKind: 1,
+          isRetrigger: false,
+        },
+      },
+    ],
+    [
       "textDocument/documentSymbol",
       {
         textDocument: { uri },
@@ -171,6 +182,27 @@ export async function assertEmptyEditorRequests(
       },
     ],
     [
+      "textDocument/documentHighlight",
+      {
+        textDocument: { uri },
+        position,
+      },
+    ],
+    [
+      "textDocument/linkedEditingRange",
+      {
+        textDocument: { uri },
+        position,
+      },
+    ],
+    [
+      "textDocument/selectionRange",
+      {
+        textDocument: { uri },
+        positions: [position],
+      },
+    ],
+    [
       "textDocument/formatting",
       {
         textDocument: { uri },
@@ -189,6 +221,25 @@ export async function assertEmptyEditorRequests(
           tabSize: 2,
           insertSpaces: true,
         },
+      },
+    ],
+    [
+      "volar/client/autoInsert",
+      {
+        textDocument: { uri },
+        selection: position,
+        change: {
+          rangeOffset: 0,
+          rangeLength: 0,
+          text: ">",
+        },
+      },
+    ],
+    [
+      "textDocument/prepareCallHierarchy",
+      {
+        textDocument: { uri },
+        position,
       },
     ],
   ];


### PR DESCRIPTION
## Summary
- extend the empty editor document smoke contract to signature help, document highlight, linked editing, selection range, auto insert, and call hierarchy prepare requests
- keep stale unopened and closed Vue documents fail-closed across advanced editor features

## Validation
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check
- cargo fmt --all -- --check

## Local note
- node --test --test-name-pattern "empty results" tests/tooling/lsp-smoke.test.ts currently reaches the LSP server but times out during shutdown in this worktree because no local target vize binary exists and the harness falls back to cargo run; CI is the authoritative gate for the production LSP smoke path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791318085&installation_model_id=422833&pr_number=5853&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5853&signature=9cb3a61f96f579dda265b6691694d6ebdc94fdc6c6696d6e3c3ad805b53fd472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->