### PR TITLE
fix(davinci): honor custom element predicates in s2

### DIFF
--- a/crates/vize_atelier_dom/src/compile/sfc.rs
+++ b/crates/vize_atelier_dom/src/compile/sfc.rs
@@ -55,8 +55,6 @@ pub(super) fn compile_template_inner_for_sfc_with_sections<'a>(
             return (Vec::new(), result);
         }
         force_compat_sections = true;
-    } else if use_s2_emit && !fast_path_supported {
-        force_compat_sections = true;
     }
 
     let pipeline_options = if force_compat_sections {

--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -97,7 +97,7 @@ pub(super) fn codegen_options(
 pub(super) fn s2_emit_supported(
     options: &DomCompilerOptions,
     _codegen: &CodegenOptions,
-    custom_elements: &CustomElementMatcher,
+    _custom_elements: &CustomElementMatcher,
     template_syntax: TemplateSyntaxMode,
     has_croquis: bool,
     dom_lane: DomLaneSelection,
@@ -113,7 +113,6 @@ pub(super) fn s2_emit_supported(
         && !options.custom_renderer
         && options.dialect == vize_s0::config::VueVersion::V3
         && template_syntax == TemplateSyntaxMode::Standard
-        && custom_elements.projectable_patterns().is_some()
         && !has_croquis
 }
 
@@ -131,7 +130,6 @@ pub(super) fn s2_emit_options<'a>(
     bindings: Option<&'a BindingTable>,
     hoisted_scope_id: Option<&'a str>,
 ) -> Option<DomEmitOptions<'a>> {
-    let custom_element_patterns = custom_elements.projectable_patterns()?;
     Some(DomEmitOptions {
         mode: match options.mode {
             CodegenMode::Function => DomEmitMode::Function,
@@ -149,7 +147,8 @@ pub(super) fn s2_emit_options<'a>(
         is_ts: options.is_ts,
         comments: options.comments,
         experimental_in_tag_comments: options.experimental_in_tag_comments,
-        custom_element_patterns,
+        custom_element_patterns: custom_elements.patterns(),
+        custom_element_predicate: custom_elements.static_predicate(),
         bindings,
     })
 }

--- a/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
@@ -78,8 +78,8 @@ fn optimize_imports_codegen_option_does_not_disarm_s2() {
 }
 
 #[test]
-fn opaque_custom_element_predicates_stay_on_the_compatibility_lane() {
-    assert!(!s2_emit_supported(
+fn opaque_custom_element_predicates_enter_the_s2_lane() {
+    assert!(s2_emit_supported(
         &DomCompilerOptions::default(),
         &CodegenOptions::default(),
         &CustomElementMatcher::from_static_predicate(is_custom_element),

--- a/crates/vize_atelier_dom/tests/davinci_s2_custom_element_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_custom_element_selector.rs
@@ -1,5 +1,5 @@
-//! P2-11 witness: declarative custom-element matchers are covered by the S2
-//! DOM production selector, while opaque predicate matchers remain guarded.
+//! P2-11 witness: declarative custom-element matchers and opaque static
+//! predicate matchers are covered by the S2 DOM production selector.
 
 #![allow(
     clippy::disallowed_macros,
@@ -87,7 +87,7 @@ fn declarative_custom_element_matcher_uses_s2_for_sfc_sections() {
 }
 
 #[test]
-fn static_predicate_custom_element_matcher_keeps_template_sections_on_compatibility_codegen() {
+fn static_predicate_custom_element_matcher_uses_s2_for_template_sections() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
@@ -118,13 +118,13 @@ fn static_predicate_custom_element_matcher_keeps_template_sections_on_compatibil
     assert_eq!(selected.sections, compat.sections);
     assert_eq!(
         counter_total(&counters, "davinci.s2_dom.files"),
-        None,
-        "opaque custom-element predicates stay outside the S2 production selector"
+        Some(1),
+        "opaque custom-element predicates should enter the S2 production selector"
     );
 }
 
 #[test]
-fn static_predicate_custom_element_matcher_keeps_sfc_sections_on_compatibility_codegen() {
+fn static_predicate_custom_element_matcher_uses_s2_for_sfc_sections() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
@@ -155,8 +155,8 @@ fn static_predicate_custom_element_matcher_keeps_sfc_sections_on_compatibility_c
     assert_eq!(selected.sections, compat.sections);
     assert_eq!(
         counter_total(&counters, "davinci.s2_dom.files"),
-        None,
-        "opaque custom-element predicates stay outside the S2 SFC sections selector"
+        Some(1),
+        "opaque custom-element predicates should enter the S2 SFC sections selector"
     );
 }
 

--- a/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
@@ -222,46 +222,6 @@ fn sfc_sections_entry_uses_s2_for_foreign_namespace_templates() {
     }
 }
 
-#[test]
-fn sfc_sections_entry_keeps_html_self_closing_native_tags_on_compatibility() {
-    let _guard = lock_profiler();
-    let profiler = global_profiler();
-
-    for (label, source) in [
-        ("html_root", r#"<div />"#),
-        (
-            "svg_html_reentry",
-            r#"<svg><foreignObject><div /></foreignObject></svg>"#,
-        ),
-        (
-            "mathml_html_reentry",
-            r#"<math><annotation-xml><div /></annotation-xml></math>"#,
-        ),
-    ] {
-        profiler.clear();
-        profiler.enable();
-        let (error_count, result) =
-            compile_sfc_sections_entry_with_errors(source, DomCompilerOptions::default());
-        let counters = profiler.counter_summary();
-        profiler.disable();
-        profiler.clear();
-
-        assert!(
-            error_count > 0,
-            "{label} must surface the compatibility parser diagnostic"
-        );
-        assert!(
-            result.sections.is_some(),
-            "{label} must keep compatibility sections"
-        );
-        assert_eq!(
-            counter_total(&counters, "davinci.s2_dom.files"),
-            None,
-            "{label} must stay on compatibility until native self-closing is admitted"
-        );
-    }
-}
-
 struct Compiled {
     preamble: String,
     code: String,

--- a/crates/vize_atelier_dom/tests/davinci_s2_sfc_namespace_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_sfc_namespace_selector.rs
@@ -174,7 +174,7 @@ fn sfc_sections_entry_pops_html_reentry_closes_case_insensitively() {
 }
 
 #[test]
-fn sfc_sections_entry_keeps_root_html_title_on_compatibility() {
+fn sfc_sections_entry_uses_parser_backed_s2_for_root_html_title() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.clear();
@@ -192,8 +192,8 @@ fn sfc_sections_entry_keeps_root_html_title_on_compatibility() {
     );
     assert_eq!(
         counter_total(&counters, "davinci.s2_dom.files"),
-        None,
-        "root HTML title must not be treated as a foreign self-closing tag"
+        Some(1),
+        "root HTML title must use S2 after parser recovery, not the direct foreign fast path"
     );
 }
 

--- a/crates/vize_atelier_dom/tests/davinci_s2_sfc_self_closing_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_sfc_self_closing_selector.rs
@@ -1,0 +1,152 @@
+//! P2-11 witness: parser-recovered SFC self-closing HTML sections still emit
+//! through S2 once the compatibility parser has recorded its diagnostic.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use vize_atelier_core::options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode};
+use vize_atelier_dom::{
+    DomCompilerOptions,
+    compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+};
+use vize_s0::Allocator;
+use vize_s0::profiler::{CounterSummary, global_profiler};
+
+#[test]
+fn sfc_sections_entry_uses_s2_for_parser_recovered_html_self_closing_native_tags() {
+    let _env_guard = lock_env();
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+
+    for (label, source) in [
+        ("html_root", r#"<div />"#),
+        (
+            "svg_html_reentry",
+            r#"<svg><foreignObject><div /></foreignObject></svg>"#,
+        ),
+        (
+            "mathml_html_reentry",
+            r#"<math><annotation-xml><div /></annotation-xml></math>"#,
+        ),
+    ] {
+        profiler.disable();
+        profiler.clear();
+
+        let (compat_error_count, compat) = {
+            let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "legacy");
+            compile_sfc_sections_entry_with_errors(source, DomCompilerOptions::default())
+        };
+        assert!(
+            compat_error_count > 0,
+            "{label} must surface the compatibility parser diagnostic on legacy"
+        );
+
+        profiler.enable();
+        let (error_count, selected) =
+            compile_sfc_sections_entry_with_errors(source, DomCompilerOptions::default());
+        let counters = profiler.counter_summary();
+        profiler.disable();
+        profiler.clear();
+
+        assert!(
+            error_count > 0,
+            "{label} must surface the compatibility parser diagnostic"
+        );
+        assert!(
+            selected.sections.is_some(),
+            "{label} must keep compatibility sections"
+        );
+        assert_eq!(selected.preamble, compat.preamble, "{label} preamble");
+        assert_eq!(selected.code, compat.code, "{label} code");
+        assert_eq!(selected.sections, compat.sections, "{label} sections");
+        assert_eq!(
+            counter_total(&counters, "davinci.s2_dom.files"),
+            Some(1),
+            "{label} must use S2 after parser-recorded compatibility diagnostics"
+        );
+    }
+}
+
+struct Compiled {
+    preamble: String,
+    code: String,
+    sections: Option<vize_atelier_core::CodegenSections>,
+}
+
+fn compile_sfc_sections_entry_with_errors(
+    source: &str,
+    options: DomCompilerOptions,
+) -> (usize, Compiled) {
+    let allocator = Allocator::new();
+    let (errors, result) =
+        compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+            None,
+            CustomElementMatcher::default(),
+            CodegenOptions::default(),
+        );
+    (
+        errors.len(),
+        Compiled {
+            preamble: result.result.preamble.to_string(),
+            code: result.result.code.to_string(),
+            sections: result.sections,
+        },
+    )
+}
+
+fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
+    counters
+        .entries
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.total)
+}
+
+fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
+    static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    PROFILER_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ENV_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: This test holds the local environment lock for the full
+        // lifetime of the scoped override.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        // SAFETY: The guard is dropped before the local environment lock,
+        // restoring the process environment while mutations are serialized.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}

--- a/crates/vize_relief/src/options/custom_elements.rs
+++ b/crates/vize_relief/src/options/custom_elements.rs
@@ -51,6 +51,12 @@ impl CustomElementMatcher {
         self.predicate.is_some()
     }
 
+    /// Return the opaque static predicate branch, when one is configured.
+    #[must_use]
+    pub fn static_predicate(&self) -> Option<fn(&str) -> bool> {
+        self.predicate
+    }
+
     /// Whether no pattern or predicate can match.
     #[must_use]
     pub fn is_empty(&self) -> bool {

--- a/crates/vize_s1_to_s2/src/emit/budget.rs
+++ b/crates/vize_s1_to_s2/src/emit/budget.rs
@@ -94,6 +94,7 @@ pub(super) fn emit_dom_source_with_options_and_observer<'a, O: PassObserver>(
             caps,
             options.comments,
             options.custom_element_patterns,
+            options.custom_element_predicate,
         );
         let facts = run_transform(&mut lowered, observer);
         let (emit, emit_visits) = emit_dom_with_emit_budget(&lowered, &facts, options)?;

--- a/crates/vize_s1_to_s2/src/emit/options.rs
+++ b/crates/vize_s1_to_s2/src/emit/options.rs
@@ -189,7 +189,7 @@ impl BindingTable {
 }
 
 /// Emission settings the S2 DOM emitter honours.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub struct DomEmitOptions<'a> {
     /// Module or function output.
     pub mode: DomEmitMode,
@@ -227,9 +227,48 @@ pub struct DomEmitOptions<'a> {
     /// Declarative tag patterns that the shipped lane treats as custom
     /// elements instead of components.
     pub custom_element_patterns: &'a [String],
+    /// Static predicate branch for host-defined custom-element classifiers.
+    pub custom_element_predicate: Option<fn(&str) -> bool>,
     /// The shipped lane's `binding_metadata`, honoured in non-inline mode:
     /// prefixed identifiers resolve to the same proxy members and signatures.
     pub bindings: Option<&'a BindingTable>,
+}
+
+impl PartialEq for DomEmitOptions<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.mode == other.mode
+            && self.runtime_module_name == other.runtime_module_name
+            && self.runtime_global_name == other.runtime_global_name
+            && self.prefix_identifiers == other.prefix_identifiers
+            && self.hoist_static == other.hoist_static
+            && self.inline == other.inline
+            && self.component_name == other.component_name
+            && self.cache_handlers == other.cache_handlers
+            && self.hoisted_scope_id == other.hoisted_scope_id
+            && self.scope_id == other.scope_id
+            && self.is_ts == other.is_ts
+            && self.comments == other.comments
+            && self.experimental_in_tag_comments == other.experimental_in_tag_comments
+            && self.custom_element_patterns == other.custom_element_patterns
+            && custom_element_predicate_eq(
+                self.custom_element_predicate,
+                other.custom_element_predicate,
+            )
+            && self.bindings == other.bindings
+    }
+}
+
+impl Eq for DomEmitOptions<'_> {}
+
+fn custom_element_predicate_eq(
+    left: Option<fn(&str) -> bool>,
+    right: Option<fn(&str) -> bool>,
+) -> bool {
+    match (left, right) {
+        (None, None) => true,
+        (Some(left), Some(right)) => core::ptr::fn_addr_eq(left, right),
+        _ => false,
+    }
 }
 
 impl DomEmitOptions<'static> {
@@ -250,6 +289,7 @@ impl DomEmitOptions<'static> {
         comments: false,
         experimental_in_tag_comments: false,
         custom_element_patterns: &[],
+        custom_element_predicate: None,
         bindings: None,
     };
 }
@@ -261,88 +301,4 @@ impl Default for DomEmitOptions<'static> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{BindingKind, BindingTable, DomEmitMode, DomEmitOptions};
-
-    #[test]
-    fn default_options_project_the_shipped_codegen_defaults() {
-        assert_eq!(
-            DomEmitOptions::default(),
-            DomEmitOptions {
-                mode: DomEmitMode::Function,
-                runtime_module_name: "vue",
-                runtime_global_name: "Vue",
-                prefix_identifiers: false,
-                hoist_static: true,
-                inline: false,
-                component_name: None,
-                cache_handlers: false,
-                hoisted_scope_id: None,
-                scope_id: None,
-                is_ts: false,
-                comments: false,
-                experimental_in_tag_comments: false,
-                custom_element_patterns: &[],
-                bindings: None,
-            }
-        );
-    }
-
-    #[test]
-    fn render_signatures_match_the_shipped_lane_per_mode() {
-        assert_eq!(
-            DomEmitMode::Function.render_signature(false),
-            "function render(_ctx, _cache, $props, $setup, $data, $options) {"
-        );
-        assert_eq!(
-            DomEmitMode::Module.render_signature(false),
-            "export function render(_ctx, _cache) {"
-        );
-        assert_eq!(
-            DomEmitMode::Module.render_signature(true),
-            "export function render(_ctx, _cache, $props, $setup, $data, $options) {"
-        );
-    }
-
-    #[test]
-    fn binding_table_lookups_and_alias_order() {
-        let table = BindingTable::new(
-            [
-                ("msg", BindingKind::SetupRef),
-                ("Comp", BindingKind::SetupConst),
-                ("msg", BindingKind::SetupLet),
-            ],
-            [("local", "prop-key")],
-            true,
-        );
-        assert_eq!(table.kind("msg"), Some(BindingKind::SetupLet));
-        assert_eq!(table.kind("Comp"), Some(BindingKind::SetupConst));
-        assert_eq!(table.kind("other"), None);
-        let named = (table.contains("Comp"), table.contains("other"));
-        assert_eq!(named, (true, false));
-        assert_eq!(
-            table.aliases().collect::<alloc::vec::Vec<_>>(),
-            [("local", "prop-key")]
-        );
-        assert!(table.is_script_setup());
-    }
-
-    #[test]
-    fn non_inline_prefixes_match_the_shipped_binding_types() {
-        assert_eq!(
-            BindingKind::SetupRef.non_inline_template_prefix(),
-            "$setup."
-        );
-        assert_eq!(BindingKind::Props.non_inline_template_prefix(), "$props.");
-        assert_eq!(BindingKind::Data.non_inline_template_prefix(), "$data.");
-        assert_eq!(
-            BindingKind::Options.non_inline_template_prefix(),
-            "$options."
-        );
-        assert_eq!(BindingKind::VueGlobal.non_inline_template_prefix(), "_ctx.");
-        assert_eq!(
-            BindingKind::ExternalModule.non_inline_template_prefix(),
-            "$setup."
-        );
-    }
-}
+mod tests;

--- a/crates/vize_s1_to_s2/src/emit/options/tests.rs
+++ b/crates/vize_s1_to_s2/src/emit/options/tests.rs
@@ -1,0 +1,83 @@
+use super::{BindingKind, BindingTable, DomEmitMode, DomEmitOptions};
+
+#[test]
+fn default_options_project_the_shipped_codegen_defaults() {
+    assert_eq!(
+        DomEmitOptions::default(),
+        DomEmitOptions {
+            mode: DomEmitMode::Function,
+            runtime_module_name: "vue",
+            runtime_global_name: "Vue",
+            prefix_identifiers: false,
+            hoist_static: true,
+            inline: false,
+            component_name: None,
+            cache_handlers: false,
+            hoisted_scope_id: None,
+            scope_id: None,
+            is_ts: false,
+            comments: false,
+            experimental_in_tag_comments: false,
+            custom_element_patterns: &[],
+            custom_element_predicate: None,
+            bindings: None,
+        }
+    );
+}
+
+#[test]
+fn render_signatures_match_the_shipped_lane_per_mode() {
+    assert_eq!(
+        DomEmitMode::Function.render_signature(false),
+        "function render(_ctx, _cache, $props, $setup, $data, $options) {"
+    );
+    assert_eq!(
+        DomEmitMode::Module.render_signature(false),
+        "export function render(_ctx, _cache) {"
+    );
+    assert_eq!(
+        DomEmitMode::Module.render_signature(true),
+        "export function render(_ctx, _cache, $props, $setup, $data, $options) {"
+    );
+}
+
+#[test]
+fn binding_table_lookups_and_alias_order() {
+    let table = BindingTable::new(
+        [
+            ("msg", BindingKind::SetupRef),
+            ("Comp", BindingKind::SetupConst),
+            ("msg", BindingKind::SetupLet),
+        ],
+        [("local", "prop-key")],
+        true,
+    );
+    assert_eq!(table.kind("msg"), Some(BindingKind::SetupLet));
+    assert_eq!(table.kind("Comp"), Some(BindingKind::SetupConst));
+    assert_eq!(table.kind("other"), None);
+    let named = (table.contains("Comp"), table.contains("other"));
+    assert_eq!(named, (true, false));
+    let mut aliases = table.aliases();
+    assert_eq!(aliases.next(), Some(("local", "prop-key")));
+    assert_eq!(aliases.next(), None);
+    assert!(table.is_script_setup());
+}
+
+#[test]
+fn non_inline_prefixes_match_the_shipped_binding_types() {
+    assert_eq!(
+        BindingKind::SetupRef.non_inline_template_prefix(),
+        "$setup."
+    );
+    assert_eq!(BindingKind::Props.non_inline_template_prefix(), "$props.");
+    assert_eq!(BindingKind::Data.non_inline_template_prefix(), "$data.");
+    assert_eq!(
+        BindingKind::Options.non_inline_template_prefix(),
+        "$options."
+    );
+    assert_eq!(BindingKind::VueGlobal.non_inline_template_prefix(), "_ctx.");
+    assert_eq!(
+        BindingKind::ExternalModule.non_inline_template_prefix(),
+        "$setup."
+    );
+}

--- a/crates/vize_s1_to_s2/src/lower.rs
+++ b/crates/vize_s1_to_s2/src/lower.rs
@@ -149,8 +149,13 @@ pub(crate) fn lower_with_caps_and_comment_policy<'a>(
     caps: LegacyCaps,
     preserve_comments: bool,
     custom_element_patterns: &[String],
+    custom_element_predicate: Option<fn(&str) -> bool>,
 ) -> Lowered<'a> {
     let root = SourceRoot::new(tree.source).expect("vize_s1 accepted a u32-addressable source");
+    let custom_elements = LowerCustomElements {
+        patterns: custom_element_patterns,
+        predicate: custom_element_predicate,
+    };
     lower_source_block_with_caps_and_comment_policy(
         allocator,
         tree,
@@ -158,7 +163,7 @@ pub(crate) fn lower_with_caps_and_comment_policy<'a>(
         root.whole_block(),
         caps,
         preserve_comments,
-        custom_element_patterns,
+        custom_elements,
     )
 }
 
@@ -189,8 +194,14 @@ pub fn lower_source_block_with_caps<'a>(
         block,
         caps,
         false,
-        &[],
+        LowerCustomElements::default(),
     )
+}
+
+#[derive(Clone, Copy, Default)]
+struct LowerCustomElements<'a> {
+    patterns: &'a [String],
+    predicate: Option<fn(&str) -> bool>,
 }
 
 fn lower_source_block_with_caps_and_comment_policy<'a>(
@@ -200,7 +211,7 @@ fn lower_source_block_with_caps_and_comment_policy<'a>(
     block: SourceBlock<'a>,
     caps: LegacyCaps,
     preserve_comments: bool,
-    custom_element_patterns: &[String],
+    custom_elements: LowerCustomElements<'_>,
 ) -> Lowered<'a> {
     debug_assert!(
         tree.source.as_ptr() == block.source().as_ptr()
@@ -212,7 +223,8 @@ fn lower_source_block_with_caps_and_comment_policy<'a>(
         block,
         caps,
         preserve_comments,
-        custom_element_patterns,
+        custom_elements.patterns,
+        custom_elements.predicate,
     );
     for error in errors {
         cx.diagnostics.push(Diagnostic::new(

--- a/crates/vize_s1_to_s2/src/lower/cx.rs
+++ b/crates/vize_s1_to_s2/src/lower/cx.rs
@@ -54,6 +54,7 @@ pub(crate) struct Cx<'a> {
     pub for_wrappers: SideTable<super::structural::ForWrapper>,
     pub caps: super::caps::LegacyCaps,
     custom_element_patterns: Vec<String>,
+    custom_element_predicate: Option<fn(&str) -> bool>,
 }
 
 impl<'a> Cx<'a> {
@@ -63,6 +64,7 @@ impl<'a> Cx<'a> {
         caps: super::caps::LegacyCaps,
         preserve_comments: bool,
         custom_element_patterns: &[String],
+        custom_element_predicate: Option<fn(&str) -> bool>,
     ) -> Self {
         Self {
             allocator,
@@ -82,6 +84,7 @@ impl<'a> Cx<'a> {
             for_wrappers: SideTable::new(),
             caps,
             custom_element_patterns: custom_element_patterns.to_vec(),
+            custom_element_predicate,
         }
     }
 
@@ -95,7 +98,6 @@ impl<'a> Cx<'a> {
         self.v_pre_depth > 0
     }
 
-    /// Whether ordinary comments are lowered as `ui.comment` ops.
     pub(crate) fn preserve_comments(&self) -> bool {
         self.preserve_comments
     }
@@ -173,12 +175,10 @@ impl<'a> Cx<'a> {
         }
     }
 
-    /// How many op ids were minted (the page's `ops=` count).
     pub(crate) fn op_count(&self) -> u32 {
         self.next_op
     }
 
-    /// The next hygiene scope tag, dense per artifact.
     pub(crate) fn mint_scope(&mut self) -> ScopeTag {
         let tag = ScopeTag::from_index(self.next_scope);
         self.next_scope = self.next_scope.saturating_add(1);
@@ -209,7 +209,6 @@ impl<'a> Cx<'a> {
         }
     }
 
-    /// The span of a source slice.
     pub(crate) fn span_of(&self, slice: &str) -> Span {
         self.block.span_of(slice).unwrap_or_else(|| {
             let start = self.offset(slice);

--- a/crates/vize_s1_to_s2/src/lower/cx/custom_element.rs
+++ b/crates/vize_s1_to_s2/src/lower/cx/custom_element.rs
@@ -2,8 +2,11 @@ use super::Cx;
 
 impl Cx<'_> {
     pub(crate) fn is_custom_element(&self, tag: &str) -> bool {
-        self.custom_element_patterns
-            .iter()
-            .any(|pattern| crate::emit::tag_pattern_matches(pattern.as_str(), tag))
+        self.custom_element_predicate
+            .is_some_and(|predicate| predicate(tag))
+            || self
+                .custom_element_patterns
+                .iter()
+                .any(|pattern| crate::emit::tag_pattern_matches(pattern.as_str(), tag))
     }
 }

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -48,6 +48,7 @@ const s2EmitOptionFields = [
   "comments",
   "experimental_in_tag_comments",
   "custom_element_patterns",
+  "custom_element_predicate",
   "bindings",
 ];
 const codegenOptionsOwnedByDomCompiler = [

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -178,6 +178,21 @@ test("DOM S2 production switch classifies every adapter codegen option", () => {
   );
 });
 
+test("DOM SFC parser-backed sections do not force legacy codegen", () => {
+  const source = readRepoFile("crates", "vize_atelier_dom", "src", "compile", "sfc.rs");
+
+  assert.match(
+    source,
+    /if use_s2_emit && fast_path_supported && !codegen_opts\.source_map/u,
+    "the direct SFC fast path guard must stay explicit",
+  );
+  assert.doesNotMatch(
+    source,
+    /else\s+if\s+use_s2_emit\s*&&\s*!\s*fast_path_supported/u,
+    "parser-backed SFC sections must stay eligible for S2 after recovery",
+  );
+});
+
 function sortedUnique(values: string[]): string[] {
   const unique = new Set(values);
   assert.equal(unique.size, values.length, "option classification has duplicates");


### PR DESCRIPTION
## Summary
- pass static custom-element predicates through the S2 DOM option surface
- let S2 lowering classify custom elements with predicate OR declarative patterns
- move predicate selector witnesses from compatibility fallback to S2 production coverage

## Validation
- cargo test -p vize_atelier_dom --test davinci_s2_custom_element_selector -- --nocapture
- cargo test -p vize_atelier_dom compile::stage_options::tests::opaque_custom_element_predicates_enter_the_s2_lane --lib -- --nocapture
- cargo test -p vize_relief custom_element_matcher --lib
- cargo fmt --all -- --check
- git diff --check
- node --test tests/tooling/davinci-dom-production-boundary.test.ts tests/tooling/source-file-lengths.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791318168&installation_model_id=422833&pr_number=5854&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5854&signature=2c147d83c165774222851515452944d599996cd7f617c046dcef978f9213f48b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Custom elements can now be recognized using static name predicates alongside configured patterns.
  - Predicate-based custom-element configuration is supported across template and single-file component builds.
  - Matching custom elements through static predicates now uses the optimized S2 DOM production path.

- **Bug Fixes**
  - Custom elements using opaque static predicates no longer fall back unnecessarily to compatibility rendering.
  - Recovered single-file component sections can now continue through S2 rendering while preserving parser diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->