### PR TITLE
docs: link typed dx roadmap to oracle matrix

### DIFF
--- a/docs/release/typed-dx-roadmap.md
+++ b/docs/release/typed-dx-roadmap.md
@@ -8,6 +8,13 @@ where applicable.
 Internal virtual-code snapshots are useful debugging evidence, but they do not
 complete a row. Every row must prove the authored user-facing behavior.
 
+## Current evidence
+
+`docs/release/typed-editor-oracle-matrix.md` is the machine-checked external
+behavior ledger for this roadmap. Keep this file focused on required invariants
+and delivery policy; record per-slice status, evidence paths, and CI wiring in
+the matrix.
+
 ## P0 matrix
 
 | issue | invariant                                                                                           | required oracle                                                                                                                                              | first fix target                     |
@@ -27,7 +34,7 @@ complete a row. Every row must prove the authored user-facing behavior.
    in a reviewed expected-failure ledger that names the P0 issue.
 3. Fix exactly that invariant.
 4. Promote the oracle into the relevant CI gate.
-5. Update this roadmap only with machine evidence.
+5. Update the external behavior ledger only with machine evidence.
 
 ## PR policy
 

--- a/tests/tooling/typed-dx-roadmap.test.ts
+++ b/tests/tooling/typed-dx-roadmap.test.ts
@@ -5,6 +5,7 @@ import { test } from "node:test";
 
 const repoRoot = path.resolve(import.meta.dirname, "../..");
 const roadmapPath = path.join(repoRoot, "docs/release/typed-dx-roadmap.md");
+const oracleMatrixPath = path.join(repoRoot, "docs/release/typed-editor-oracle-matrix.md");
 
 const requiredIssues = [4586, 4587, 4588, 4589, 4590, 4591, 4592] as const;
 
@@ -13,6 +14,7 @@ test("typed DX roadmap keeps every P0 child issue in the execution matrix", () =
 
   assert.match(roadmap, /^# Typed DX production roadmap$/m);
   assert.match(roadmap, /This is the P0 execution lane for #3957 and #4585\./);
+  assert.match(roadmap, /`docs\/release\/typed-editor-oracle-matrix\.md`/);
 
   for (const issue of requiredIssues) {
     assert.match(roadmap, new RegExp(`\\\\| #${issue} \\\\|`), `missing #${issue}`);
@@ -38,6 +40,20 @@ test("typed DX roadmap forbids umbrella implementation delivery", () => {
   assert.match(roadmap, /No umbrella implementation PRs\./);
   assert.match(roadmap, /external behavior oracle/);
   assert.match(roadmap, /body files and raw-checked/);
+});
+
+test("typed DX roadmap child issues have covered external behavior ledger rows", () => {
+  const matrix = fs.readFileSync(oracleMatrixPath, "utf8");
+  const rows = matrix.split("\n").filter((line) => line.startsWith("| "));
+
+  for (const issue of requiredIssues) {
+    const issueRows = rows.filter((line) => line.includes(`#${issue}`));
+    assert.ok(issueRows.length > 0, `missing external behavior ledger row for #${issue}`);
+    assert.ok(
+      issueRows.some((line) => /\|\s*Covered\s*\|/.test(line)),
+      `#${issue} must have at least one covered external behavior ledger row`,
+    );
+  }
 });
 
 function escapeRegExp(value: string): string {

--- a/tests/tooling/typed-dx-roadmap.test.ts
+++ b/tests/tooling/typed-dx-roadmap.test.ts
@@ -7,18 +7,14 @@ const repoRoot = path.resolve(import.meta.dirname, "../..");
 const roadmapPath = path.join(repoRoot, "docs/release/typed-dx-roadmap.md");
 const oracleMatrixPath = path.join(repoRoot, "docs/release/typed-editor-oracle-matrix.md");
 
-const requiredIssues = [4586, 4587, 4588, 4589, 4590, 4591, 4592] as const;
-
 test("typed DX roadmap keeps every P0 child issue in the execution matrix", () => {
   const roadmap = fs.readFileSync(roadmapPath, "utf8");
+  const roadmapIssues = roadmapP0IssueReferences(roadmap);
 
   assert.match(roadmap, /^# Typed DX production roadmap$/m);
   assert.match(roadmap, /This is the P0 execution lane for #3957 and #4585\./);
   assert.match(roadmap, /`docs\/release\/typed-editor-oracle-matrix\.md`/);
-
-  for (const issue of requiredIssues) {
-    assert.match(roadmap, new RegExp(`\\\\| #${issue} \\\\|`), `missing #${issue}`);
-  }
+  assert.equal(roadmapIssues.length, 7, "expected seven typed DX P0 roadmap rows");
 
   for (const phrase of [
     "authored template ranges",
@@ -43,19 +39,63 @@ test("typed DX roadmap forbids umbrella implementation delivery", () => {
 });
 
 test("typed DX roadmap child issues have covered external behavior ledger rows", () => {
+  const roadmap = fs.readFileSync(roadmapPath, "utf8");
   const matrix = fs.readFileSync(oracleMatrixPath, "utf8");
-  const rows = matrix.split("\n").filter((line) => line.startsWith("| "));
+  const requiredIssues = roadmapP0IssueReferences(roadmap);
+  const rows = markdownTableRows(matrix);
+  const header = rows.find((row) => row.includes("Status") && row.includes("Follow-up"));
+  assert.ok(header, "missing external behavior ledger header");
+
+  const statusIndex = header.indexOf("Status");
+  const followUpIndex = header.indexOf("Follow-up");
+  assert.notEqual(statusIndex, -1, "missing Status column");
+  assert.notEqual(followUpIndex, -1, "missing Follow-up column");
+
+  const dataRows = rows.filter((row) => row.length === header.length && row !== header);
 
   for (const issue of requiredIssues) {
-    const issueRows = rows.filter((line) => line.includes(`#${issue}`));
-    assert.ok(issueRows.length > 0, `missing external behavior ledger row for #${issue}`);
+    const issueRows = dataRows.filter((row) =>
+      issueReferences(row[followUpIndex] ?? "").includes(issue),
+    );
+    assert.ok(issueRows.length > 0, `missing external behavior ledger row for ${issue}`);
     assert.ok(
-      issueRows.some((line) => /\|\s*Covered\s*\|/.test(line)),
-      `#${issue} must have at least one covered external behavior ledger row`,
+      issueRows.some((row) => row[statusIndex] === "Covered"),
+      `${issue} must have at least one covered external behavior ledger row`,
     );
   }
 });
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function roadmapP0IssueReferences(roadmap: string): string[] {
+  return markdownTableRows(roadmap)
+    .map((row) => row[0] ?? "")
+    .filter((cell) => /^#\d+$/.test(cell));
+}
+
+function markdownTableRows(markdown: string): string[][] {
+  return markdown
+    .split("\n")
+    .map(markdownTableCells)
+    .filter((row) => row.length > 0 && !row.every((cell) => /^-+$/.test(cell)));
+}
+
+function markdownTableCells(line: string): string[] {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("|") || !trimmed.endsWith("|")) {
+    return [];
+  }
+  return trimmed
+    .slice(1, -1)
+    .split("|")
+    .map((cell) => cell.trim());
+}
+
+function issueReferences(cell: string): string[] {
+  return cell
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => /^#\d+$/.test(item));
 }


### PR DESCRIPTION
## Summary
- Link the typed-DX roadmap to the typed editor external-oracle ledger.
- Add a roadmap test that requires every P0 child issue to have a covered external behavior row.

## Validation
- node --test tests/tooling/typed-dx-roadmap.test.ts
- git diff --check
- vp fmt --check docs/release/typed-dx-roadmap.md tests/tooling/typed-dx-roadmap.test.ts (local runner unavailable: no project-local vite-plus install in this fresh worktree)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791320168&installation_model_id=422833&pr_number=5855&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5855&signature=f3cb14d0aecb2adbb6c1b5329f02e3e186754b8a223a06362bd7d65814b3c545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the typed development roadmap to direct behavior status, evidence, and CI tracking to a dedicated external behavior ledger.
  - Clarified that ledger updates should be based only on machine-generated evidence.

- **Tests**
  - Added validation that required priority items have corresponding “Covered” entries in the behavior ledger.
  - Expanded roadmap checks to confirm the external behavior ledger is referenced correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->