### PR TITLE
fix(davinci): route parser-recovered sfc sections through s2

### DIFF
--- a/crates/vize_atelier_dom/src/compile/sfc.rs
+++ b/crates/vize_atelier_dom/src/compile/sfc.rs
@@ -55,8 +55,6 @@ pub(super) fn compile_template_inner_for_sfc_with_sections<'a>(
             return (Vec::new(), result);
         }
         force_compat_sections = true;
-    } else if use_s2_emit && !fast_path_supported {
-        force_compat_sections = true;
     }
 
     let pipeline_options = if force_compat_sections {

--- a/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_production_selector.rs
@@ -222,46 +222,6 @@ fn sfc_sections_entry_uses_s2_for_foreign_namespace_templates() {
     }
 }
 
-#[test]
-fn sfc_sections_entry_keeps_html_self_closing_native_tags_on_compatibility() {
-    let _guard = lock_profiler();
-    let profiler = global_profiler();
-
-    for (label, source) in [
-        ("html_root", r#"<div />"#),
-        (
-            "svg_html_reentry",
-            r#"<svg><foreignObject><div /></foreignObject></svg>"#,
-        ),
-        (
-            "mathml_html_reentry",
-            r#"<math><annotation-xml><div /></annotation-xml></math>"#,
-        ),
-    ] {
-        profiler.clear();
-        profiler.enable();
-        let (error_count, result) =
-            compile_sfc_sections_entry_with_errors(source, DomCompilerOptions::default());
-        let counters = profiler.counter_summary();
-        profiler.disable();
-        profiler.clear();
-
-        assert!(
-            error_count > 0,
-            "{label} must surface the compatibility parser diagnostic"
-        );
-        assert!(
-            result.sections.is_some(),
-            "{label} must keep compatibility sections"
-        );
-        assert_eq!(
-            counter_total(&counters, "davinci.s2_dom.files"),
-            None,
-            "{label} must stay on compatibility until native self-closing is admitted"
-        );
-    }
-}
-
 struct Compiled {
     preamble: String,
     code: String,

--- a/crates/vize_atelier_dom/tests/davinci_s2_sfc_namespace_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_sfc_namespace_selector.rs
@@ -174,7 +174,7 @@ fn sfc_sections_entry_pops_html_reentry_closes_case_insensitively() {
 }
 
 #[test]
-fn sfc_sections_entry_keeps_root_html_title_on_compatibility() {
+fn sfc_sections_entry_uses_parser_backed_s2_for_root_html_title() {
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.clear();
@@ -192,8 +192,8 @@ fn sfc_sections_entry_keeps_root_html_title_on_compatibility() {
     );
     assert_eq!(
         counter_total(&counters, "davinci.s2_dom.files"),
-        None,
-        "root HTML title must not be treated as a foreign self-closing tag"
+        Some(1),
+        "root HTML title must use S2 after parser recovery, not the direct foreign fast path"
     );
 }
 

--- a/crates/vize_atelier_dom/tests/davinci_s2_sfc_self_closing_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_sfc_self_closing_selector.rs
@@ -1,0 +1,152 @@
+//! P2-11 witness: parser-recovered SFC self-closing HTML sections still emit
+//! through S2 once the compatibility parser has recorded its diagnostic.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_methods,
+    clippy::disallowed_types
+)]
+
+use vize_atelier_core::options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode};
+use vize_atelier_dom::{
+    DomCompilerOptions,
+    compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+};
+use vize_s0::Allocator;
+use vize_s0::profiler::{CounterSummary, global_profiler};
+
+#[test]
+fn sfc_sections_entry_uses_s2_for_parser_recovered_html_self_closing_native_tags() {
+    let _env_guard = lock_env();
+    let _guard = lock_profiler();
+    let profiler = global_profiler();
+
+    for (label, source) in [
+        ("html_root", r#"<div />"#),
+        (
+            "svg_html_reentry",
+            r#"<svg><foreignObject><div /></foreignObject></svg>"#,
+        ),
+        (
+            "mathml_html_reentry",
+            r#"<math><annotation-xml><div /></annotation-xml></math>"#,
+        ),
+    ] {
+        profiler.disable();
+        profiler.clear();
+
+        let (compat_error_count, compat) = {
+            let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "legacy");
+            compile_sfc_sections_entry_with_errors(source, DomCompilerOptions::default())
+        };
+        assert!(
+            compat_error_count > 0,
+            "{label} must surface the compatibility parser diagnostic on legacy"
+        );
+
+        profiler.enable();
+        let (error_count, selected) =
+            compile_sfc_sections_entry_with_errors(source, DomCompilerOptions::default());
+        let counters = profiler.counter_summary();
+        profiler.disable();
+        profiler.clear();
+
+        assert!(
+            error_count > 0,
+            "{label} must surface the compatibility parser diagnostic"
+        );
+        assert!(
+            selected.sections.is_some(),
+            "{label} must keep compatibility sections"
+        );
+        assert_eq!(selected.preamble, compat.preamble, "{label} preamble");
+        assert_eq!(selected.code, compat.code, "{label} code");
+        assert_eq!(selected.sections, compat.sections, "{label} sections");
+        assert_eq!(
+            counter_total(&counters, "davinci.s2_dom.files"),
+            Some(1),
+            "{label} must use S2 after parser-recorded compatibility diagnostics"
+        );
+    }
+}
+
+struct Compiled {
+    preamble: String,
+    code: String,
+    sections: Option<vize_atelier_core::CodegenSections>,
+}
+
+fn compile_sfc_sections_entry_with_errors(
+    source: &str,
+    options: DomCompilerOptions,
+) -> (usize, Compiled) {
+    let allocator = Allocator::new();
+    let (errors, result) =
+        compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+            &allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+            None,
+            CustomElementMatcher::default(),
+            CodegenOptions::default(),
+        );
+    (
+        errors.len(),
+        Compiled {
+            preamble: result.result.preamble.to_string(),
+            code: result.result.code.to_string(),
+            sections: result.sections,
+        },
+    )
+}
+
+fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
+    counters
+        .entries
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.total)
+}
+
+fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
+    static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    PROFILER_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    ENV_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+struct ScopedEnvVar {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl ScopedEnvVar {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        // SAFETY: This test holds the local environment lock for the full
+        // lifetime of the scoped override.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvVar {
+    fn drop(&mut self) {
+        // SAFETY: The guard is dropped before the local environment lock,
+        // restoring the process environment while mutations are serialized.
+        unsafe {
+            match &self.previous {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -178,6 +178,21 @@ test("DOM S2 production switch classifies every adapter codegen option", () => {
   );
 });
 
+test("DOM SFC parser-backed sections do not force legacy codegen", () => {
+  const source = readRepoFile("crates", "vize_atelier_dom", "src", "compile", "sfc.rs");
+
+  assert.match(
+    source,
+    /if use_s2_emit && fast_path_supported && !codegen_opts\.source_map/u,
+    "the direct SFC fast path guard must stay explicit",
+  );
+  assert.doesNotMatch(
+    source,
+    /else\s+if\s+use_s2_emit\s*&&\s*!\s*fast_path_supported/u,
+    "parser-backed SFC sections must stay eligible for S2 after recovery",
+  );
+});
+
 function sortedUnique(values: string[]): string[] {
   const unique = new Set(values);
   assert.equal(unique.size, values.length, "option classification has duplicates");


### PR DESCRIPTION
## Summary
- stack on #5854 and let SFC sections that miss the direct fast path fall through to the parser-backed S2 sections pipeline instead of forcing legacy codegen
- add S2-vs-legacy coverage for parser-recovered non-void HTML self-closing sections and update the root `<title />` namespace selector expectation
- add a tooling guard so the old fast-path-negative legacy selector does not return

## Validation
- `cargo test -p vize_atelier_dom --test davinci_s2_production_selector --test davinci_s2_sfc_namespace_selector --test davinci_s2_sfc_self_closing_selector`
- `cargo test -p vize_atelier_dom --test davinci_s2_custom_element_selector`
- `node --test tests/tooling/davinci-dom-production-boundary.test.ts`
- `cargo fmt --all --check`
- `node legacy-tools/davinci/assertion-lint.mjs`
- `git diff --check`
- `git diff --cached --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791320624&installation_model_id=422833&pr_number=5856&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5856&signature=464625c7c501acbacf273d8ff94750175b9d42aae503b7a52963df5cd3abe298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->