### PR TITLE
test(vscode): cover signature help host smoke

### DIFF
--- a/editors/vscode/test/fixtures/fake-vize-server.cjs
+++ b/editors/vscode/test/fixtures/fake-vize-server.cjs
@@ -183,6 +183,9 @@ function createCapabilities() {
       },
       range: false,
     },
+    signatureHelpProvider: {
+      triggerCharacters: ["(", ","],
+    },
     textDocumentSync: 1,
     workspaceSymbolProvider: true,
   };
@@ -356,6 +359,18 @@ function createResponse(message) {
     case "textDocument/semanticTokens/full":
       return {
         data: [1, 6, 7, 0, 1, 4, 2, 4, 1, 0],
+      };
+
+    case "textDocument/signatureHelp":
+      return {
+        activeParameter: 0,
+        activeSignature: 0,
+        signatures: [
+          {
+            label: "fakeAction(value: string): void",
+            parameters: [{ label: "value" }],
+          },
+        ],
       };
 
     case "workspace/symbol":

--- a/editors/vscode/test/run-extension-host.mjs
+++ b/editors/vscode/test/run-extension-host.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { runTests } from "@vscode/test-electron";
@@ -50,19 +51,26 @@ if (process.platform === "win32") {
   );
 }
 
-await runTests({
-  extensionDevelopmentPath,
-  extensionTestsPath,
-  extensionTestsEnv: {
-    VIZE_TEST_SERVER_LOG: fakeServerLogPath,
-    VIZE_TEST_SERVER_PATH: fakeServerPath,
-    VIZE_TEST_SERVER_VERSION: packageJson.version,
-  },
-  launchArgs: [
-    "--disable-extensions",
-    "--disable-workspace-trust",
-    "--skip-welcome",
-    "--skip-release-notes",
-    workspacePath,
-  ],
-});
+const profilePath = fs.mkdtempSync(path.join(os.tmpdir(), "vize-host-"));
+try {
+  await runTests({
+    extensionDevelopmentPath,
+    extensionTestsPath,
+    extensionTestsEnv: {
+      VIZE_TEST_SERVER_LOG: fakeServerLogPath,
+      VIZE_TEST_SERVER_PATH: fakeServerPath,
+      VIZE_TEST_SERVER_VERSION: packageJson.version,
+    },
+    launchArgs: [
+      `--extensions-dir=${path.join(profilePath, "extensions")}`,
+      `--user-data-dir=${path.join(profilePath, "user-data")}`,
+      "--disable-extensions",
+      "--disable-workspace-trust",
+      "--skip-welcome",
+      "--skip-release-notes",
+      workspacePath,
+    ],
+  });
+} finally {
+  fs.rmSync(profilePath, { force: true, recursive: true });
+}

--- a/editors/vscode/test/suite/editor-capability-smoke.cjs
+++ b/editors/vscode/test/suite/editor-capability-smoke.cjs
@@ -60,6 +60,20 @@ async function runEditorCapabilityProviderSmoke({
   });
 
   await runProviderCommand(logPath, {
+    args: [document.uri, position, "("],
+    commandIds: ["vscode.executeSignatureHelpProvider"],
+    label: "signature help",
+    method: "textDocument/signatureHelp",
+    validate(result, request) {
+      assert.equal(result?.activeSignature, 0);
+      assert.equal(result?.activeParameter, 0);
+      assert.equal(result?.signatures?.[0]?.label, "fakeAction(value: string): void");
+      assert.deepEqual(result?.signatures?.[0]?.parameters?.[0]?.label, "value");
+      assertTextDocumentRequest(request, document.uri, position);
+    },
+  });
+
+  await runProviderCommand(logPath, {
     args: [document.uri, position],
     commandIds: ["vscode.executeDefinitionProvider"],
     label: "definition",

--- a/editors/vscode/test/suite/extension-host-fixtures.cjs
+++ b/editors/vscode/test/suite/extension-host-fixtures.cjs
@@ -79,6 +79,7 @@ const featureSettingKeys = [
 
 const granularEditorCapabilitySettings = [
   ["completion.enable", "completion"],
+  ["signatureHelp.enable", "signatureHelp"],
   ["hover.enable", "hover"],
   ["definition.enable", "definition"],
   ["references.enable", "references"],

--- a/tests/tooling/vscode-extension-manifest.test.ts
+++ b/tests/tooling/vscode-extension-manifest.test.ts
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const require = createRequire(import.meta.url);
 
 type ConfigurationProperty = {
   type?: string | string[];
@@ -34,6 +36,22 @@ type Manifest = {
     semanticTokenModifiers?: Array<{ id?: string; description?: string }>;
   };
 };
+
+type ExtensionHostFixtures = {
+  commandIds: string[];
+  granularEditorCapabilitySettings: Array<[string, string]>;
+};
+
+const NON_PROVIDER_FEATURE_SETTINGS = new Set([
+  "lint.enable",
+  "diagnostics.enable",
+  "typecheck.enable",
+  "editor.enable",
+  "ecosystem.enable",
+  "optionsApi.enable",
+  "legacyVue2.enable",
+  "autoInsert.enable",
+]);
 
 test("multiline Vue script grammar is contributed", () => {
   const grammar = readManifest().contributes?.grammars?.find(
@@ -68,6 +86,12 @@ function readManifest(): Manifest {
   ) as Manifest;
 }
 
+function readExtensionHostFixtures(): ExtensionHostFixtures {
+  return require(
+    path.join(root, "editors/vscode/test/suite/extension-host-fixtures.cjs"),
+  ) as ExtensionHostFixtures;
+}
+
 const LANGUAGE_SCOPED_COMMANDS = new Set([
   "vize.findReferences",
   "vize.restartServer",
@@ -88,6 +112,27 @@ test("every contributed command has a matching onCommand activation event", () =
   // A command without an activation event silently fails to start the extension
   // when invoked from a keybinding; an orphan activation event is dead config.
   assert.deepEqual(onCommandEvents, commands);
+});
+
+test("extension-host fixture mirrors published commands and provider settings", () => {
+  const manifest = readManifest();
+  const fixtures = readExtensionHostFixtures();
+  const properties = manifest.contributes?.configuration?.properties ?? {};
+  const commands = (manifest.contributes?.commands ?? [])
+    .map((command) => command.command)
+    .filter((command): command is string => typeof command === "string" && command.length > 0)
+    .sort();
+  const providerSettings = Object.keys(properties)
+    .map((key) => (key.startsWith("vize.") ? key.slice("vize.".length) : key))
+    .filter((key) => key.endsWith(".enable") && !NON_PROVIDER_FEATURE_SETTINGS.has(key))
+    .sort();
+  const fixtureSettings = fixtures.granularEditorCapabilitySettings.map(([setting]) => setting);
+  const fixtureOptions = fixtures.granularEditorCapabilitySettings.map(([, option]) => option);
+
+  assert.deepEqual([...fixtures.commandIds].sort(), commands);
+  assert.deepEqual([...fixtureSettings].sort(), providerSettings);
+  assert.equal(new Set(fixtureSettings).size, fixtureSettings.length);
+  assert.equal(new Set(fixtureOptions).size, fixtureOptions.length);
 });
 
 test("command palette menu only references declared commands", () => {


### PR DESCRIPTION
## Summary
- add signature help to the VS Code fake-server host smoke
- include signatureHelp.enable in the granular host capability profile
- guard host fixture commands and provider settings against manifest drift
- keep local VS Code host profiles in a short temp path on macOS

## Validation
- vp install --frozen-lockfile --prefer-offline
- vp check editors/vscode/test/run-extension-host.mjs editors/vscode/test/suite/extension-host-fixtures.cjs editors/vscode/test/fixtures/fake-vize-server.cjs editors/vscode/test/suite/editor-capability-smoke.cjs tests/tooling/vscode-extension-manifest.test.ts
- node --test --test-concurrency=1 tests/tooling/vscode-extension-manifest.test.ts tests/tooling/vscode-host-feature-reset.test.ts tests/tooling/vscode-extension-core-behavior.test.ts
- env COREPACK_HOME=/tmp/vize-corepack-test-traditional-editor-scorecard vp run --workspace-root test:vscode-extension:host

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791323912&installation_model_id=422833&pr_number=5859&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5859&signature=99c8ef92d67503f074d882c9202f805cd1f716c0f0dcb63f187e9624b1ef2a41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added VS Code coverage for signature help, including active signatures and parameters.
  - Added validation that extension-host capabilities and provider settings match the published extension manifest.
  - Improved test isolation by running each extension-host test with temporary profiles and cleanup.
  - Expanded test fixtures to simulate signature-help responses and capability settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->