### PR TITLE
fix(davinci): remove DOM legacy lane flag

### DIFF
--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -291,7 +291,6 @@ fn compile_template_inner_with_sections<'a>(
         &custom_elements,
         template_syntax,
         has_croquis,
-        stage_options::dom_lane_selection(),
         s2_emit_selection,
     );
     // Project the public output options before consuming Croquis below. Croquis

--- a/crates/vize_atelier_dom/src/compile/sfc.rs
+++ b/crates/vize_atelier_dom/src/compile/sfc.rs
@@ -23,14 +23,12 @@ pub(super) fn compile_template_inner_for_sfc_with_sections<'a>(
     codegen_options: CodegenOptions,
 ) -> (Vec<CompilerError>, CodegenResultWithSections) {
     let codegen_opts = stage_options::codegen_options(&options, codegen_options.clone());
-    let dom_lane = stage_options::dom_lane_selection();
     let use_s2_emit = stage_options::s2_emit_supported(
         &options,
         &codegen_opts,
         &custom_elements,
         template_syntax,
         options.croquis.is_some(),
-        dom_lane,
         pipeline::S2EmitSelection::RequireSections,
     );
 

--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -18,24 +18,6 @@ use super::pipeline::S2EmitSelection;
 use crate::namespace::get_namespace;
 use crate::options::DomCompilerOptions;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum DomLaneSelection {
-    S2,
-    Legacy,
-}
-
-pub(super) fn dom_lane_selection() -> DomLaneSelection {
-    let value = std::env::var(vize_s1_to_s2::DOM_LANE_FLAG);
-    dom_lane_selection_from_flag(value.as_deref().ok())
-}
-
-fn dom_lane_selection_from_flag(value: Option<&str>) -> DomLaneSelection {
-    match value {
-        None | Some("s2") => DomLaneSelection::S2,
-        Some(_) => DomLaneSelection::Legacy,
-    }
-}
-
 /// Parser options with DOM-specific settings.
 pub(super) fn parser_options(options: &DomCompilerOptions) -> ParserOptions {
     ParserOptions {
@@ -100,15 +82,12 @@ pub(super) fn s2_emit_supported(
     _custom_elements: &CustomElementMatcher,
     template_syntax: TemplateSyntaxMode,
     has_croquis: bool,
-    dom_lane: DomLaneSelection,
     s2_emit_selection: S2EmitSelection,
 ) -> bool {
-    dom_lane == DomLaneSelection::S2
-        && matches!(
-            s2_emit_selection,
-            S2EmitSelection::Allowed | S2EmitSelection::RequireSections
-        )
-        && !options.ssr
+    matches!(
+        s2_emit_selection,
+        S2EmitSelection::Allowed | S2EmitSelection::RequireSections
+    ) && !options.ssr
         && !options.experimental_patterned_template
         && !options.custom_renderer
         && options.dialect == vize_s0::config::VueVersion::V3

--- a/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options/tests.rs
@@ -1,64 +1,23 @@
-use super::{
-    DomLaneSelection, dom_lane_selection, dom_lane_selection_from_flag, s2_emit_supported,
-};
+use super::s2_emit_supported;
 use crate::DomCompilerOptions;
-use std::ffi::OsString;
 use vize_atelier_core::options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode};
 use vize_s0::config::VueVersion;
 
 #[test]
-fn dom_lane_selection_maps_the_legacy_flag_value() {
-    assert_eq!(
-        dom_lane_selection_from_flag(Some("legacy")),
-        DomLaneSelection::Legacy
-    );
-    assert_eq!(
-        dom_lane_selection_from_flag(Some("unknown")),
-        DomLaneSelection::Legacy
-    );
-    assert_eq!(
-        dom_lane_selection_from_flag(Some("s2")),
-        DomLaneSelection::S2
-    );
-    assert_eq!(dom_lane_selection_from_flag(None), DomLaneSelection::S2);
-}
-
-#[test]
-fn dom_lane_selection_reads_the_legacy_env_value() {
-    let _env_lock = lock_env();
-    let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "legacy");
-
-    assert_eq!(dom_lane_selection(), DomLaneSelection::Legacy);
-}
-
-#[test]
-fn the_dom_legacy_lane_flag_disarms_s2_selection() {
-    assert!(supported(
-        DomCompilerOptions::default(),
-        DomLaneSelection::S2
-    ));
-    assert!(!supported(
-        DomCompilerOptions::default(),
-        DomLaneSelection::Legacy
-    ));
+fn supported_vue3_standard_dom_options_enter_s2() {
+    assert!(supported(DomCompilerOptions::default()));
 }
 
 #[test]
 fn legacy_dialects_stay_on_the_compatibility_lane() {
-    assert!(!supported(
-        DomCompilerOptions {
-            dialect: VueVersion::V2,
-            ..Default::default()
-        },
-        DomLaneSelection::S2
-    ));
-    assert!(!supported(
-        DomCompilerOptions {
-            dialect: VueVersion::V2_7,
-            ..Default::default()
-        },
-        DomLaneSelection::S2
-    ));
+    assert!(!supported(DomCompilerOptions {
+        dialect: VueVersion::V2,
+        ..Default::default()
+    }));
+    assert!(!supported(DomCompilerOptions {
+        dialect: VueVersion::V2_7,
+        ..Default::default()
+    }));
 }
 
 #[test]
@@ -72,7 +31,6 @@ fn optimize_imports_codegen_option_does_not_disarm_s2() {
         &CustomElementMatcher::default(),
         TemplateSyntaxMode::Standard,
         false,
-        DomLaneSelection::S2,
         super::S2EmitSelection::Allowed,
     ));
 }
@@ -85,58 +43,21 @@ fn opaque_custom_element_predicates_enter_the_s2_lane() {
         &CustomElementMatcher::from_static_predicate(is_custom_element),
         TemplateSyntaxMode::Standard,
         false,
-        DomLaneSelection::S2,
         super::S2EmitSelection::Allowed,
     ));
 }
 
-fn supported(options: DomCompilerOptions, dom_lane: DomLaneSelection) -> bool {
+fn supported(options: DomCompilerOptions) -> bool {
     s2_emit_supported(
         &options,
         &CodegenOptions::default(),
         &CustomElementMatcher::default(),
         TemplateSyntaxMode::Standard,
         false,
-        dom_lane,
         super::S2EmitSelection::Allowed,
     )
 }
 
 fn is_custom_element(tag: &str) -> bool {
     tag.starts_with("x-")
-}
-
-struct ScopedEnvVar {
-    key: &'static str,
-    previous: Option<OsString>,
-}
-
-impl ScopedEnvVar {
-    fn set(key: &'static str, value: &str) -> Self {
-        let previous = std::env::var_os(key);
-        // SAFETY: This test holds the local environment lock for the full
-        // lifetime of the scoped override.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, previous }
-    }
-}
-
-impl Drop for ScopedEnvVar {
-    fn drop(&mut self) {
-        // SAFETY: The guard is dropped before the local environment lock,
-        // restoring the process environment while mutations are serialized.
-        unsafe {
-            match &self.previous {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
-}
-
-fn lock_env() -> std::sync::MutexGuard<'static, ()> {
-    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    ENV_TEST_LOCK
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }

--- a/crates/vize_atelier_dom/tests/davinci_s2_codegen_option_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_codegen_option_selector.rs
@@ -17,36 +17,16 @@ use vize_s0::profiler::{CounterSummary, global_profiler};
 
 #[test]
 fn optimize_imports_uses_s2_after_legacy_noop_audit() {
-    let _env_guard = lock_env();
     let _guard = lock_profiler();
     let profiler = global_profiler();
     profiler.disable();
     profiler.clear();
 
     let source = r#"<button @click="go">{{ label }}</button>"#;
-    let legacy_default = {
-        let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "legacy");
-        compile(source, CodegenOptions::default())
-    };
-    let legacy_optimized = {
-        let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "legacy");
-        compile(
-            source,
-            CodegenOptions {
-                optimize_imports: true,
-                ..Default::default()
-            },
-        )
-    };
-
-    assert_eq!(legacy_optimized.preamble, legacy_default.preamble);
-    assert_eq!(legacy_optimized.code, legacy_default.code);
-    assert_eq!(legacy_optimized.sections, legacy_default.sections);
+    let selected_default = compile(source, CodegenOptions::default());
 
     profiler.enable();
-
-    let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "s2");
-    let selected = compile(
+    let selected_optimized = compile(
         source,
         CodegenOptions {
             optimize_imports: true,
@@ -57,9 +37,9 @@ fn optimize_imports_uses_s2_after_legacy_noop_audit() {
     profiler.disable();
     profiler.clear();
 
-    assert_eq!(selected.preamble, legacy_optimized.preamble);
-    assert_eq!(selected.code, legacy_optimized.code);
-    assert_eq!(selected.sections, legacy_optimized.sections);
+    assert_eq!(selected_optimized.preamble, selected_default.preamble);
+    assert_eq!(selected_optimized.code, selected_default.code);
+    assert_eq!(selected_optimized.sections, selected_default.sections);
     assert_eq!(
         counter_total(&counters, "davinci.s2_dom.files"),
         Some(1),
@@ -106,39 +86,4 @@ fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
     PROFILER_TEST_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
-fn lock_env() -> std::sync::MutexGuard<'static, ()> {
-    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    ENV_TEST_LOCK
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
-struct ScopedEnvVar {
-    key: &'static str,
-    previous: Option<std::ffi::OsString>,
-}
-
-impl ScopedEnvVar {
-    fn set(key: &'static str, value: &str) -> Self {
-        let previous = std::env::var_os(key);
-        // SAFETY: This test holds the local environment lock for the full
-        // lifetime of the scoped override.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, previous }
-    }
-}
-
-impl Drop for ScopedEnvVar {
-    fn drop(&mut self) {
-        // SAFETY: The guard is dropped before the local environment lock,
-        // restoring the process environment while mutations are serialized.
-        unsafe {
-            match &self.previous {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
 }

--- a/crates/vize_atelier_dom/tests/davinci_s2_legacy_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_legacy_selector.rs
@@ -1,5 +1,5 @@
-//! P2-11 witness: legacy dialect compiles stay on compatibility until the DOM
-//! lane flag is deleted at the production switch exit gate.
+//! P2-11 witness: legacy dialect compiles stay on compatibility after the DOM
+//! lane flag deletion, while stale flag values no longer select the old lane.
 
 #![allow(
     clippy::disallowed_macros,
@@ -18,7 +18,7 @@ use vize_s0::config::VueVersion;
 use vize_s0::profiler::{CounterSummary, global_profiler};
 
 #[test]
-fn legacy_dialect_stays_on_compatibility_until_flag_deletion() {
+fn legacy_dialect_stays_on_compatibility_after_flag_deletion() {
     let _env_lock = lock_env();
     let _profiler_lock = lock_profiler();
     let (result, counters) = compile_with_s2_profiler(
@@ -32,25 +32,33 @@ fn legacy_dialect_stays_on_compatibility_until_flag_deletion() {
     assert_compatibility_sections_without_s2_profile(
         &result,
         &counters,
-        "legacy dialect compiles must not enter the S2 production selector before flag deletion",
+        "legacy dialect compiles must not enter the S2 production selector",
     );
 }
 
 #[test]
-fn dom_legacy_lane_flag_keeps_vue3_on_compatibility_until_flag_deletion() {
+fn removed_dom_lane_flag_does_not_disarm_vue3_s2_selection() {
     let _env_lock = lock_env();
-    let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "legacy");
+    let _flag = ScopedEnvVar::set(removed_dom_lane_flag_name(), "legacy");
     let _profiler_lock = lock_profiler();
     let (result, counters) = compile_with_s2_profiler(
         r#"<button @click="go">{{ label }}</button>"#,
         DomCompilerOptions::default(),
     );
 
-    assert_compatibility_sections_without_s2_profile(
-        &result,
-        &counters,
-        "the DOM legacy lane flag must keep Vue 3 compiles off the S2 production selector",
+    assert!(
+        result.sections.is_some(),
+        "S2 DOM must keep codegen sections available"
     );
+    assert_eq!(
+        counter_total(&counters, "davinci.s2_dom.files"),
+        Some(1),
+        "removed DOM lane env values must not disarm the S2 production selector",
+    );
+}
+
+fn removed_dom_lane_flag_name() -> &'static str {
+    concat!("VIZE", "_DAVINCI", "_DOM")
 }
 
 struct Compiled {

--- a/crates/vize_atelier_dom/tests/davinci_s2_sfc_self_closing_selector.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_sfc_self_closing_selector.rs
@@ -11,13 +11,13 @@ use vize_atelier_core::options::{CodegenOptions, CustomElementMatcher, TemplateS
 use vize_atelier_dom::{
     DomCompilerOptions,
     compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
+    compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_and_codegen_options,
 };
 use vize_s0::Allocator;
 use vize_s0::profiler::{CounterSummary, global_profiler};
 
 #[test]
 fn sfc_sections_entry_uses_s2_for_parser_recovered_html_self_closing_native_tags() {
-    let _env_guard = lock_env();
     let _guard = lock_profiler();
     let profiler = global_profiler();
 
@@ -35,13 +35,11 @@ fn sfc_sections_entry_uses_s2_for_parser_recovered_html_self_closing_native_tags
         profiler.disable();
         profiler.clear();
 
-        let (compat_error_count, compat) = {
-            let _flag = ScopedEnvVar::set(vize_s1_to_s2::DOM_LANE_FLAG, "legacy");
-            compile_sfc_sections_entry_with_errors(source, DomCompilerOptions::default())
-        };
+        let (compat_error_count, compat) =
+            compile_sfc_compat_entry_with_errors(source, DomCompilerOptions::default());
         assert!(
             compat_error_count > 0,
-            "{label} must surface the compatibility parser diagnostic on legacy"
+            "{label} must surface the compatibility parser diagnostic"
         );
 
         profiler.enable();
@@ -57,11 +55,10 @@ fn sfc_sections_entry_uses_s2_for_parser_recovered_html_self_closing_native_tags
         );
         assert!(
             selected.sections.is_some(),
-            "{label} must keep compatibility sections"
+            "{label} must keep SFC section boundaries"
         );
         assert_eq!(selected.preamble, compat.preamble, "{label} preamble");
         assert_eq!(selected.code, compat.code, "{label} code");
-        assert_eq!(selected.sections, compat.sections, "{label} sections");
         assert_eq!(
             counter_total(&counters, "davinci.s2_dom.files"),
             Some(1),
@@ -101,6 +98,31 @@ fn compile_sfc_sections_entry_with_errors(
     )
 }
 
+fn compile_sfc_compat_entry_with_errors(
+    source: &str,
+    options: DomCompilerOptions,
+) -> (usize, Compiled) {
+    let allocator = Allocator::new();
+    let (_, errors, result) =
+        compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_and_codegen_options(
+            &allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+            None,
+            CustomElementMatcher::default(),
+            CodegenOptions::default(),
+        );
+    (
+        errors.len(),
+        Compiled {
+            preamble: result.preamble.to_string(),
+            code: result.code.to_string(),
+            sections: None,
+        },
+    )
+}
+
 fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
     counters
         .entries
@@ -114,39 +136,4 @@ fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
     PROFILER_TEST_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
-fn lock_env() -> std::sync::MutexGuard<'static, ()> {
-    static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    ENV_TEST_LOCK
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
-struct ScopedEnvVar {
-    key: &'static str,
-    previous: Option<std::ffi::OsString>,
-}
-
-impl ScopedEnvVar {
-    fn set(key: &'static str, value: &str) -> Self {
-        let previous = std::env::var_os(key);
-        // SAFETY: This test holds the local environment lock for the full
-        // lifetime of the scoped override.
-        unsafe { std::env::set_var(key, value) };
-        Self { key, previous }
-    }
-}
-
-impl Drop for ScopedEnvVar {
-    fn drop(&mut self) {
-        // SAFETY: The guard is dropped before the local environment lock,
-        // restoring the process environment while mutations are serialized.
-        unsafe {
-            match &self.previous {
-                Some(value) => std::env::set_var(self.key, value),
-                None => std::env::remove_var(self.key),
-            }
-        }
-    }
 }

--- a/crates/vize_s1_to_s2/src/emit.rs
+++ b/crates/vize_s1_to_s2/src/emit.rs
@@ -45,12 +45,8 @@
 //! trailing `mergeProps` argument rather than per spread segment), and
 //! experimental in-tag comments. `atelier_dom` selects this lane for supported
 //! DOM compiles, including source-map requests whose maps are verified against
-//! compatibility codegen; the old lane remains for unsupported option surfaces
-//! until the phase-exit deletion.
-
-/// Env flag that keeps DOM template compiles on the compatibility lane while
-/// the P2-11 production switch is still in phase.
-pub const DOM_LANE_FLAG: &str = "VIZE_DAVINCI_DOM";
+//! compatibility codegen. Compatibility codegen remains available only for
+//! unsupported option surfaces.
 
 mod budget;
 mod buf;
@@ -233,12 +229,4 @@ struct EmitCx<'facts> {
     component_name: Option<&'facts str>,
     /// The transform scope and codegen slot params the prefixer consults.
     scope: prefix::PrefixScope<'facts>,
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn dom_lane_flag_name_is_stable() {
-        assert_eq!(super::DOM_LANE_FLAG, "VIZE_DAVINCI_DOM");
-    }
 }

--- a/crates/vize_s1_to_s2/src/lib.rs
+++ b/crates/vize_s1_to_s2/src/lib.rs
@@ -70,7 +70,7 @@ pub mod lower;
 pub mod pass;
 
 pub use emit::{
-    BindingKind, BindingTable, DOM_LANE_FLAG, DomEmit, DomEmitBudget, DomEmitMode, DomEmitOptions,
+    BindingKind, BindingTable, DomEmit, DomEmitBudget, DomEmitMode, DomEmitOptions,
     DomEmitSections, EmitError, ObservedDomEmit, UnsupportedReason, UnsupportedRefusal, emit_dom,
     emit_dom_source, emit_dom_source_observed, emit_dom_source_observed_with_options,
     emit_dom_source_with_caps, emit_dom_source_with_caps_observed, emit_dom_source_with_options,

--- a/tests/tooling/davinci-dom-production-boundary.test.ts
+++ b/tests/tooling/davinci-dom-production-boundary.test.ts
@@ -178,6 +178,30 @@ test("DOM S2 production switch classifies every adapter codegen option", () => {
   );
 });
 
+test("DOM production selector has no live env lane override", () => {
+  const removedEnvName = ["VIZE", "DAVINCI", "DOM"].join("_");
+  const removedFlagSymbol = ["DOM", "LANE", "FLAG"].join("_");
+  const removedSelectorFn = ["dom", "lane", "selection"].join("_");
+  const removedSelectorType = ["Dom", "Lane", "Selection"].join("");
+  const liveSources = [
+    ["crates", "vize_atelier_dom", "src", "compile.rs"],
+    ["crates", "vize_atelier_dom", "src", "compile", "sfc.rs"],
+    ["crates", "vize_atelier_dom", "src", "compile", "stage_options.rs"],
+    ["crates", "vize_s1_to_s2", "src", "emit.rs"],
+    ["crates", "vize_s1_to_s2", "src", "lib.rs"],
+  ] as const;
+
+  for (const sourcePath of liveSources) {
+    const label = sourcePath.join("/");
+    const source = readRepoFile(...sourcePath);
+    assert.doesNotMatch(source, new RegExp(removedEnvName, "u"), label);
+    assert.doesNotMatch(source, new RegExp(removedFlagSymbol, "u"), label);
+    assert.doesNotMatch(source, new RegExp(removedSelectorFn, "u"), label);
+    assert.doesNotMatch(source, new RegExp(removedSelectorType, "u"), label);
+    assert.doesNotMatch(source, /\bstd::env::var(?:_os)?\s*\(/u, label);
+  }
+});
+
 test("DOM SFC parser-backed sections do not force legacy codegen", () => {
   const source = readRepoFile("crates", "vize_atelier_dom", "src", "compile", "sfc.rs");
 


### PR DESCRIPTION
## Summary
- remove the phase-live DOM legacy lane env override so supported Vue 3 DOM compiles stay on S2
- keep capability-based compatibility fallbacks for legacy dialects and unsupported option surfaces
- add a live-source audit that fails if env lane override plumbing returns

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p vize_atelier_dom --lib stage_options -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_production_selector --test davinci_s2_custom_element_selector --test davinci_s2_sfc_self_closing_selector --test davinci_s2_legacy_selector --test davinci_s2_codegen_option_selector
- cargo test -p vize_s1_to_s2 --lib
- node --test tests/tooling/davinci-dom-production-boundary.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791324067&installation_model_id=422833&pr_number=5860&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5860&signature=bfe29713b037d25ad7221b670c45d1a552a7d3a22578e29c7102a3c30f9f82e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed the environment-based override that could force DOM compilation onto a legacy processing lane.
  - Supported DOM configurations now consistently use the modern S2 compilation path.
  - Compatibility compilation remains available for configurations that are not supported by the modern path.

- **Bug Fixes**
  - Prevented obsolete environment settings from unintentionally disabling modern DOM output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->