### PR TITLE
ci(real-projects): bound typecheck divergence step

### DIFF
--- a/.github/workflows/real-project-matrix.yml
+++ b/.github/workflows/real-project-matrix.yml
@@ -261,6 +261,7 @@ jobs:
         id: typecheck_divergence
         if: ${{ !cancelled() }}
         continue-on-error: true
+        timeout-minutes: 100
         env:
           BUDGET_MODE: ${{ inputs.typecheck_divergence_mode || 'enforce' }}
           VIZE_TYPECHECK_DIVERGENCE_PROGRESS: "1"
@@ -272,7 +273,6 @@ jobs:
             --budget-mode "$BUDGET_MODE" \
             --vize-bin target/ci/vize \
             --vue-tsc-bin tests/node_modules/.bin/vue-tsc
-
       - name: Enforce all real-project surface verdicts
         id: surface_verdict
         if: ${{ always() }}

--- a/tests/tooling/real-project-matrix-workflow.test.ts
+++ b/tests/tooling/real-project-matrix-workflow.test.ts
@@ -267,6 +267,7 @@ test("real-project workflow hydrates only its shard and runs every core tool", (
   assert.match(divergence.run ?? "", /--shard-count "\$FIXTURE_SHARD_COUNT"/);
   assert.match(divergence.run ?? "", /--budget-mode "\$BUDGET_MODE"/);
   assert.match(divergence.run ?? "", /--vue-tsc-bin tests\/node_modules\/\.bin\/vue-tsc/);
+  assert.equal(divergence["timeout-minutes"], 100);
   assert.equal(divergence.env?.BUDGET_MODE, "${{ inputs.typecheck_divergence_mode || 'enforce' }}");
 
   const surfaceVerdict = findStep(steps, "Enforce all real-project surface verdicts");


### PR DESCRIPTION
Summary:
- add a 100 minute step timeout to the real-project typechecker divergence gate
- keep the job-level 120 minute budget available for verdict publishing and artifact upload
- pin the workflow contract in the real-project matrix test

Verification:
- node --test tests/tooling/real-project-matrix-workflow.test.ts tests/tooling/real-project-matrix-summary.test.ts
- ./node_modules/.bin/oxfmt --check .github/workflows/real-project-matrix.yml tests/tooling/real-project-matrix-workflow.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791327358&installation_model_id=422833&pr_number=5862&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5862&signature=00c2476037b1bfe634d9fa8bc436379827531d4a29949bb2829b6a1ed523989f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->