### PR TITLE
test(vscode): guard host provider smoke coverage

### DIFF
--- a/tests/tooling/vscode-host-provider-smoke-coverage.test.ts
+++ b/tests/tooling/vscode-host-provider-smoke-coverage.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const require = createRequire(import.meta.url);
+
+type ExtensionHostFixtures = {
+  granularEditorCapabilitySettings: Array<[string, string]>;
+};
+
+type HostProviderSmokeContract = {
+  command: string;
+  method: string;
+  setting: string;
+};
+
+const hostProviderSmokeContracts: Record<string, HostProviderSmokeContract> = {
+  codeActions: {
+    command: "vscode.executeCodeActionProvider",
+    method: "textDocument/codeAction",
+    setting: "codeActions.enable",
+  },
+  codeLens: {
+    command: "vscode.executeCodeLensProvider",
+    method: "textDocument/codeLens",
+    setting: "codeLens.enable",
+  },
+  completion: {
+    command: "vscode.executeCompletionItemProvider",
+    method: "textDocument/completion",
+    setting: "completion.enable",
+  },
+  definition: {
+    command: "vscode.executeDefinitionProvider",
+    method: "textDocument/definition",
+    setting: "definition.enable",
+  },
+  documentLinks: {
+    command: "vscode.executeLinkProvider",
+    method: "textDocument/documentLink",
+    setting: "documentLinks.enable",
+  },
+  documentSymbols: {
+    command: "vscode.executeDocumentSymbolProvider",
+    method: "textDocument/documentSymbol",
+    setting: "documentSymbols.enable",
+  },
+  foldingRanges: {
+    command: "vscode.executeFoldingRangeProvider",
+    method: "textDocument/foldingRange",
+    setting: "foldingRanges.enable",
+  },
+  formatting: {
+    command: "vscode.executeFormatDocumentProvider",
+    method: "textDocument/formatting",
+    setting: "formatting.enable",
+  },
+  hover: {
+    command: "vscode.executeHoverProvider",
+    method: "textDocument/hover",
+    setting: "hover.enable",
+  },
+  inlayHints: {
+    command: "vscode.executeInlayHintProvider",
+    method: "textDocument/inlayHint",
+    setting: "inlayHints.enable",
+  },
+  references: {
+    command: "vscode.executeReferenceProvider",
+    method: "textDocument/references",
+    setting: "references.enable",
+  },
+  rename: {
+    command: "vscode.executeDocumentRenameProvider",
+    method: "textDocument/rename",
+    setting: "rename.enable",
+  },
+  semanticTokens: {
+    command: "vscode.provideDocumentSemanticTokens",
+    method: "textDocument/semanticTokens/full",
+    setting: "semanticTokens.enable",
+  },
+  signatureHelp: {
+    command: "vscode.executeSignatureHelpProvider",
+    method: "textDocument/signatureHelp",
+    setting: "signatureHelp.enable",
+  },
+  workspaceSymbols: {
+    command: "vscode.executeWorkspaceSymbolProvider",
+    method: "workspace/symbol",
+    setting: "workspaceSymbols.enable",
+  },
+};
+
+const intentionallyNonCommandProviderOptions = new Set(["fileRename"]);
+
+test("VS Code host provider smoke covers every command-addressable editor switch", () => {
+  const fixtures = require(
+    path.join(root, "editors/vscode/test/suite/extension-host-fixtures.cjs"),
+  ) as ExtensionHostFixtures;
+  const configured = new Map(
+    fixtures.granularEditorCapabilitySettings.map(([setting, option]) => [option, setting]),
+  );
+  const uncovered = [...configured.keys()].filter(
+    (option) =>
+      !Object.hasOwn(hostProviderSmokeContracts, option) &&
+      !intentionallyNonCommandProviderOptions.has(option),
+  );
+
+  assert.deepEqual(uncovered, []);
+  assert.ok(configured.has("fileRename"), "file rename remains covered by real-server LSP suites");
+
+  const smoke = readRepoFile("editors/vscode/test/suite/editor-capability-smoke.cjs");
+  const fakeServer = readRepoFile("editors/vscode/test/fixtures/fake-vize-server.cjs");
+  for (const [option, contract] of Object.entries(hostProviderSmokeContracts)) {
+    assert.equal(configured.get(option), contract.setting, `${option} fixture setting drifted`);
+    assert.ok(
+      smoke.includes(contract.command),
+      `${option} host smoke must execute VS Code command`,
+    );
+    assert.ok(smoke.includes(contract.method), `${option} host smoke must request LSP method`);
+    assert.ok(fakeServer.includes(contract.method), `${option} fake server must answer LSP method`);
+  }
+});
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf8");
+}


### PR DESCRIPTION
Summary:
- add a static guard tying VS Code granular editor provider switches to host-smoke coverage
- require each command-addressable provider to have a VS Code command, LSP method, and fake-server response anchor
- keep file rename explicitly outside this fake-host provider guard because it is covered through real-server LSP/editor suites

Verification:
- node --test tests/tooling/vscode-host-provider-smoke-coverage.test.ts tests/tooling/vscode-extension-manifest.test.ts tests/tooling/lsp-vue-language-tools-scorecard.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791327609&installation_model_id=422833&pr_number=5863&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5863&signature=e92c1980635453fb16475bcf8346bd9286014533c385831959407781d47dcfe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated smoke coverage for VS Code editor capabilities, including code actions, completion, navigation, formatting, symbols, and other language features.
  - Added validation to ensure configured capabilities remain aligned with their expected editor commands and language-server methods.
  - Expanded fixture checks for extension-host and simulated server behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->