### PR TITLE
feat(davinci): profile DOM build walk budget gap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3592,6 +3592,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+ "toml",
  "vize_atelier_core",
  "vize_carton",
  "vize_croquis",

--- a/crates/vize_atelier_dom/Cargo.toml
+++ b/crates/vize_atelier_dom/Cargo.toml
@@ -30,6 +30,7 @@ criterion = { workspace = true }
 davinci_harness = { workspace = true }
 insta = { workspace = true }
 serde_json = { workspace = true }
+toml = { workspace = true }
 
 # S2 test and benchmark fixtures still use the stage diagnostics/types.
 vize_davinci = { workspace = true }

--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -9,9 +9,10 @@ use vize_atelier_core::{
     lane::transform_with_custom_elements_and_template_syntax_quirks_and_hoisted_scope_id,
     options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode},
     parser::parse_with_options_custom_elements_and_template_syntax,
+    walk_probe::WalkCounts,
 };
 use vize_croquis::Croquis;
-use vize_s0::{Allocator, String, profile};
+use vize_s0::{Allocator, String, profile, profiler::global_profiler};
 
 mod pipeline;
 mod sfc;
@@ -293,14 +294,14 @@ fn compile_template_inner_with_sections<'a>(
         has_croquis,
         s2_emit_selection,
     );
-    // Project the public output options before consuming Croquis below. Croquis
-    // intentionally crosses the transform boundary by ownership and is not
-    // cloneable, while S2 only borrows the remaining compiler settings.
+    // Project output options before consuming Croquis; S2 only borrows them.
     let s2_custom_elements = custom_elements.clone();
     let s2_emit_source = use_s2_emit.then(|| (options.clone(), hoisted_scope_id.clone()));
     let transform_opts = stage_options::transform_options(&options);
     // Park the summary on the allocator so it shares the allocator lifetime.
     let analysis: Option<&Croquis> = options.croquis.map(|c| allocator.alloc_owned(*c));
+    let profiling_s2 = use_s2_emit && global_profiler().is_enabled();
+    let template_walk_before = profiling_s2.then(WalkCounts::snapshot);
     let transform_errors = profile!(
         "atelier.dom.template.transform",
         transform_with_custom_elements_and_template_syntax_quirks_and_hoisted_scope_id(
@@ -313,6 +314,7 @@ fn compile_template_inner_with_sections<'a>(
             hoisted_scope_id,
         )
     );
+    let template_walks = template_walk_before.map(|before| WalkCounts::snapshot().since(before));
 
     // Surface transform diagnostics (e.g. invalid expressions) alongside
     // parse errors instead of dropping them — the official compiler reports
@@ -320,7 +322,6 @@ fn compile_template_inner_with_sections<'a>(
     let mut errors = errors.to_vec();
     errors.extend(transform_errors);
 
-    // Codegen
     let s2_emit = s2_emit_source.and_then(|(s2_options_source, s2_hoisted_scope_id)| {
         let binding_table =
             stage_options::s2_binding_table(s2_options_source.binding_metadata.as_ref());
@@ -331,9 +332,10 @@ fn compile_template_inner_with_sections<'a>(
             binding_table.as_ref(),
             s2_hoisted_scope_id.as_deref(),
         )?;
+        let dialect = s2_options_source.dialect;
         Some(profile!(
             "atelier.dom.template.s2_codegen",
-            stage_options::emit_s2(allocator, source, s2_options_source.dialect, &s2_options)
+            stage_options::emit_s2(allocator, source, dialect, &s2_options, template_walks)
         ))
     });
     let codegen_result = match s2_emit {

--- a/crates/vize_atelier_dom/src/compile/sfc.rs
+++ b/crates/vize_atelier_dom/src/compile/sfc.rs
@@ -47,7 +47,7 @@ pub(super) fn compile_template_inner_for_sfc_with_sections<'a>(
         if let Some(s2_options) = s2_options
             && let Ok(result) = profile!(
                 "atelier.dom.template.s2_codegen_sfc_fast",
-                stage_options::emit_s2(allocator, source, options.dialect, &s2_options)
+                stage_options::emit_s2(allocator, source, options.dialect, &s2_options, None)
             )
         {
             return (Vec::new(), result);

--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -8,6 +8,7 @@ use vize_atelier_core::options::{
     BindingMetadata, BindingType, CodegenMode, CodegenOptions, CustomElementMatcher, ParserOptions,
     TemplateSyntaxMode, TransformOptions,
 };
+use vize_atelier_core::walk_probe::WalkCounts;
 use vize_s0::Allocator;
 use vize_s0::profiler::global_profiler;
 use vize_s1_to_s2::{
@@ -154,6 +155,7 @@ pub(super) fn emit_s2(
     source: &str,
     dialect: vize_s0::config::VueVersion,
     options: &DomEmitOptions<'_>,
+    pre_s2_walks: Option<WalkCounts>,
 ) -> Result<CodegenResultWithSections, EmitError> {
     let caps = LegacyCaps::for_version(dialect);
     let profiler = global_profiler();
@@ -180,6 +182,15 @@ pub(super) fn emit_s2(
             "davinci.s2_dom.total.walks",
             u64::from(budget.total_walks()),
         );
+        if let Some(pre_s2) = pre_s2_walks {
+            let pre_s2_walks = pre_s2.total_walks();
+            profiler.record_counter_enabled("davinci.s2_dom.pre_s2.walks", pre_s2_walks);
+            profiler.record_counter_enabled("davinci.s2_dom.pre_s2.visits", pre_s2.total_visits());
+            profiler.record_counter_enabled(
+                "davinci.s2_dom.build.walks",
+                pre_s2_walks + u64::from(budget.total_walks()),
+            );
+        }
         observed.emit
     } else {
         vize_s1_to_s2::emit_dom_source_with_options(allocator, source, caps, options)?

--- a/crates/vize_atelier_dom/tests/davinci_s2_build_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_build_profile.rs
@@ -1,0 +1,174 @@
+//! P2-12b build-path walk witness for profiled source-map-free DOM compiles.
+
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
+
+use std::path::Path;
+
+use davinci_harness::fixtures::{LADDER, template_block};
+use vize_atelier_dom::compile_template;
+use vize_s0::Allocator;
+use vize_s0::profiler::{CounterSummary, global_profiler};
+
+static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[derive(Debug, Clone, Copy)]
+struct TraversalBudget {
+    walks: u64,
+    visits: u64,
+}
+
+const CURRENT_S2_OBSERVER_WALKS: u64 = 7;
+const CURRENT_BUILD_WALKS: u64 = 8;
+
+#[test]
+fn profile_build_walks_report_the_current_p2_12b_gap() {
+    let _guard = lock_profiler();
+    let fused_walk_target = phase_2_dom_walk_target();
+    assert_eq!(
+        fused_walk_target, 1,
+        "P2-12a pins the phase-2 DOM fused-walk target"
+    );
+
+    for fixture in &LADDER {
+        let template =
+            template_block(fixture.source).expect("every ladder fixture has a template block");
+        let baseline = traversal_budget(fixture.name);
+        let profile = ProfileScope::enable();
+        let allocator = Allocator::new();
+        let (_, errors, result) = compile_template(&allocator, template);
+        let counters = profile.finish();
+
+        assert!(errors.is_empty(), "{} should compile cleanly", fixture.name);
+        assert!(!result.code.is_empty(), "{} should emit code", fixture.name);
+
+        let pre_s2_walks = counter(&counters, "davinci.s2_dom.pre_s2.walks");
+        let pre_s2_visits = counter(&counters, "davinci.s2_dom.pre_s2.visits");
+        let s2_walks = counter(&counters, "davinci.s2_dom.total.walks");
+        let emit_walks = counter(&counters, "davinci.s2_dom.emit.walks");
+        let emit_visits = counter(&counters, "davinci.s2_dom.emit.visits");
+        let build_walks = counter(&counters, "davinci.s2_dom.build.walks");
+
+        assert_eq!(
+            pre_s2_walks, 1,
+            "{} has one pre-S2 template walk",
+            fixture.name
+        );
+        assert!(
+            pre_s2_walks < baseline.walks && pre_s2_visits <= baseline.visits,
+            "{} pre-S2 walk stayed under the P2-12a DOM ceiling",
+            fixture.name
+        );
+        assert_eq!(
+            emit_walks, fused_walk_target,
+            "{} emit walk target",
+            fixture.name
+        );
+        assert!(
+            emit_visits <= baseline.visits,
+            "{} emit visits stayed under the P2-12a DOM ceiling",
+            fixture.name
+        );
+        assert_eq!(
+            s2_walks, CURRENT_S2_OBSERVER_WALKS,
+            "{} current S2 observer walk count",
+            fixture.name
+        );
+        assert_eq!(
+            build_walks,
+            pre_s2_walks + s2_walks,
+            "{} build walk counter must reconcile with its parts",
+            fixture.name
+        );
+        assert_eq!(
+            build_walks, CURRENT_BUILD_WALKS,
+            "{} current profiled DOM build walk gap",
+            fixture.name
+        );
+        assert!(
+            build_walks > fused_walk_target,
+            "{} still needs the parse-to-S2/fusion switch before P2-12b can close",
+            fixture.name
+        );
+    }
+}
+
+fn traversal_budget(fixture: &str) -> TraversalBudget {
+    let value = budgets();
+    let id = format!("dom_{fixture}");
+    let entry = value
+        .get("traversal")
+        .and_then(|traversal| traversal.get(&id))
+        .unwrap_or_else(|| panic!("budgets.toml [traversal] is missing {id}"));
+    TraversalBudget {
+        walks: required_u64(entry, &id, "walks"),
+        visits: required_u64(entry, &id, "visits"),
+    }
+}
+
+fn phase_2_dom_walk_target() -> u64 {
+    let value = budgets();
+    let entry = value
+        .get("target")
+        .and_then(|target| target.get("phase-2"))
+        .expect("budgets.toml has [target.phase-2]");
+    required_u64(entry, "target.phase-2", "dom_walks_max")
+}
+
+fn budgets() -> toml::Value {
+    let repo = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crate directory")
+        .parent()
+        .expect("repo root");
+    let text = std::fs::read_to_string(repo.join("davinci-road/plan/budgets.toml"))
+        .expect("budgets.toml reads");
+    toml::from_str(&text).expect("budgets.toml parses")
+}
+
+fn required_u64(entry: &toml::Value, id: &str, field: &str) -> u64 {
+    entry
+        .get(field)
+        .and_then(toml::Value::as_integer)
+        .and_then(|value| u64::try_from(value).ok())
+        .unwrap_or_else(|| panic!("budgets.toml [traversal.{id}] has no u64 {field}"))
+}
+
+fn counter(counters: &CounterSummary, name: &str) -> u64 {
+    counters
+        .entries
+        .iter()
+        .find(|entry| entry.name == name)
+        .unwrap_or_else(|| panic!("missing {name} profile counter"))
+        .total
+}
+
+struct ProfileScope;
+
+impl ProfileScope {
+    fn enable() -> Self {
+        let profiler = global_profiler();
+        profiler.clear();
+        profiler.enable();
+        Self
+    }
+
+    fn finish(self) -> CounterSummary {
+        let profiler = global_profiler();
+        profiler.disable();
+        profiler.counter_summary()
+    }
+}
+
+impl Drop for ProfileScope {
+    fn drop(&mut self) {
+        let profiler = global_profiler();
+        profiler.disable();
+        profiler.clear();
+    }
+}
+
+fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {
+    PROFILER_TEST_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}

--- a/davinci-road/open-questions.md
+++ b/davinci-road/open-questions.md
@@ -49,6 +49,13 @@ single code-producing emit walk over the ladder in `emit_budget_observer`.
 This does not answer the fusion policy yet: transform groups are still
 serialized and the production build path is not switched.
 
+Prototype note (2026-09-07): profiled source-map-free DOM compiles now record
+the remaining pre-S2 template walk as `davinci.s2_dom.pre_s2.*` and reconcile
+`davinci.s2_dom.build.walks` as that walk plus the S2 observer total. Ladder
+evidence shows the emit walk is already at the one-walk target, while the
+build path remains at 8 walks (1 pre-S2 + 7 S2 observer) until parse-to-S2
+and S2 transform fusion land.
+
 ## Orphan analyses: productize or cut
 
 `RaceConditionTracker` and `ProvideInjectTracker` have zero consumers;


### PR DESCRIPTION
## Summary
- record the remaining pre-S2 template walk for profiled source-map-free DOM compiles
- expose `davinci.s2_dom.build.walks` as pre-S2 walk + S2 observer total
- add an exact ladder witness for the current 8-walk build-path gap and record the P2-12b prototype note

## Verification
- `cargo fmt --check`
- `cargo test -p vize_atelier_dom --test davinci_s2_build_profile -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_s2_profile`
- `cargo test -p vize_s1_to_s2 --test emit_budget_observer -- --nocapture`
- `cargo test -p vize_atelier_dom --test davinci_walk_baseline -- --nocapture`
- `cargo test -p vize_atelier_dom --lib`
- `vp exec node --test --test-concurrency=1 tests/tooling/davinci-traversal-budgets.test.ts tests/tooling/davinci-dom-production-boundary.test.ts`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 5`
- `git diff --check`

## P2-12b State
The profiled DOM build path is still over target: 8 walks total, from 1 pre-S2 template walk plus 7 S2 observer walks. The emit walk itself is at the one-walk target; parse-to-S2 and S2 transform fusion remain follow-up work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791328064&installation_model_id=422833&pr_number=5864&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5864&signature=9ae0fc527c4e32cda5d52a1d3554ea06ae16c69a3f077f5cd58c8befdf666045"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->