### PR TITLE
feat(jsx): emit native vdom roots from s2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3622,6 +3622,7 @@ dependencies = [
  "vize_carton",
  "vize_croquis",
  "vize_relief",
+ "vize_s1_to_s2",
  "vize_s2",
 ]
 

--- a/crates/vize_atelier_jsx/Cargo.toml
+++ b/crates/vize_atelier_jsx/Cargo.toml
@@ -15,6 +15,7 @@ vize_s2 = { workspace = true }
 vize_relief = { workspace = true }
 vize_croquis = { workspace = true }
 vize_atelier_core = { workspace = true }
+vize_s1_to_s2 = { workspace = true }
 vize_atelier_vapor = { workspace = true }
 # Reused for the first-cut JSX Vapor SSR render path (#1533): the lowered
 # RootNode is the same `vize_relief` type the SSR codegen consumes, so the

--- a/crates/vize_atelier_jsx/src/vdom.rs
+++ b/crates/vize_atelier_jsx/src/vdom.rs
@@ -11,6 +11,8 @@
 //! `_ctx.`. Static hoisting and handler caching default off for predictable,
 //! `@vue/babel-plugin-jsx`-shaped output; callers can opt in.
 
+mod s2_emit;
+
 use vize_atelier_core::codegen::generate_with_vnode_factory_and_merge_props;
 use vize_atelier_core::lane::transform_with_jsx_compatibility;
 use vize_atelier_core::options::{CodegenMode, CodegenOptions, TransformOptions};
@@ -155,7 +157,7 @@ pub(crate) fn compile_root_to_vdom(
 ) -> VdomComponent {
     let LoweredRoot {
         mut root,
-        s2: _,
+        s2,
         mode,
         component_name,
         component_setup,
@@ -170,6 +172,26 @@ pub(crate) fn compile_root_to_vdom(
     // the codegen via `CodegenOptions.scope_id` below.
     let scoped_style =
         scoped_css.map(|css| build_scoped_style(component_name.as_deref(), css.as_str()));
+
+    if let Some(emit) = s2_emit::try_emit_s2_vdom(
+        allocator,
+        s2,
+        is_ts,
+        component_name.as_deref(),
+        scoped_style.as_ref().map(|style| style.scope_id.as_str()),
+        options,
+        &compat,
+    ) {
+        return VdomComponent {
+            component_name,
+            component_setup,
+            mode: mode.unwrap_or(JsxOutputMode::Vdom),
+            code: emit.code,
+            preamble: emit.preamble,
+            map: None,
+            scoped_style,
+        };
+    }
 
     let transform_opts = TransformOptions {
         // JSX render fns close over the setup scope; don't prefix `_ctx.`.

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -1,0 +1,171 @@
+//! JSX VDOM bridge for the P2-16 S2 re-targeting slice.
+
+use vize_s0::{Allocator, String};
+use vize_s1_to_s2::pass::S2Facts;
+use vize_s1_to_s2::{
+    DomEmitMode, DomEmitOptions, LegacyCaps, Lowered as S2Lowered, emit_dom_with_options,
+};
+use vize_s2::op::{BindingOp, Op, Region};
+
+use crate::s2::{JsxS2Root, S2Refusal};
+
+use super::{VdomCompatOptions, VdomCompileOptions};
+
+pub(super) struct S2VdomEmit {
+    pub code: String,
+    pub preamble: String,
+}
+
+pub(super) fn try_emit_s2_vdom<'a>(
+    allocator: &'a Allocator,
+    s2: Result<JsxS2Root<'a>, S2Refusal>,
+    is_ts: bool,
+    component_name: Option<&str>,
+    scope_id: Option<&str>,
+    options: &VdomCompileOptions,
+    compat: &VdomCompatOptions<'_>,
+) -> Option<S2VdomEmit> {
+    if !compat.is_native_s2_surface()
+        || options.source_map
+        || options.hoist_static
+        || options.cache_handlers
+        || is_ts
+    {
+        return None;
+    }
+
+    let s2 = s2.ok()?;
+    if !root_is_supported(&s2) {
+        return None;
+    }
+
+    let lowered = S2Lowered {
+        allocator,
+        source: s2.source,
+        root: s2.root,
+        op_count: s2.op_count,
+        diagnostics: Default::default(),
+        provenance: Default::default(),
+        scopes: Default::default(),
+        texts: Default::default(),
+        wrappers: Default::default(),
+        for_wrappers: Default::default(),
+        caps: LegacyCaps::VUE3,
+    };
+    let facts = S2Facts::default();
+    let emit = emit_dom_with_options(
+        &lowered,
+        &facts,
+        &DomEmitOptions {
+            mode: DomEmitMode::Module,
+            runtime_module_name: "vue",
+            runtime_global_name: "Vue",
+            prefix_identifiers: false,
+            hoist_static: false,
+            inline: false,
+            component_name,
+            cache_handlers: false,
+            hoisted_scope_id: None,
+            scope_id,
+            is_ts: false,
+            comments: false,
+            experimental_in_tag_comments: false,
+            custom_element_patterns: &[],
+            custom_element_predicate: None,
+            bindings: None,
+        },
+    )
+    .ok()?;
+
+    Some(S2VdomEmit {
+        code: emit.code,
+        preamble: emit.preamble,
+    })
+}
+
+impl VdomCompatOptions<'_> {
+    fn is_native_s2_surface(&self) -> bool {
+        self.transform_on_helper.is_none()
+            && self.object_slots_helpers.is_none()
+            && self.vnode_factory.is_none()
+            && self.merge_props
+            && !self.allow_static_v_model_arg_on_element
+            && self.custom_element_spans.is_empty()
+    }
+}
+
+fn root_is_supported(root: &JsxS2Root<'_>) -> bool {
+    region_is_supported(&root.root)
+}
+
+fn region_is_supported(region: &Region<'_>) -> bool {
+    region.ops.iter().all(op_is_supported)
+}
+
+fn op_is_supported(op: &Op<'_>) -> bool {
+    match op {
+        Op::Text(_) | Op::Interpolation(_) => true,
+        Op::Element(element) => {
+            bindings_are_supported(&element.bindings) && region_is_supported(&element.children)
+        }
+        Op::Component(_) => false,
+        Op::Comment(_) | Op::If(_) | Op::For(_) | Op::Slot(_) => false,
+    }
+}
+
+fn bindings_are_supported(bindings: &[BindingOp<'_>]) -> bool {
+    bindings
+        .iter()
+        .all(|binding| matches!(binding, BindingOp::Bind(_) | BindingOp::On(_)))
+}
+
+#[cfg(test)]
+mod tests {
+    use vize_croquis::Croquis;
+    use vize_s0::Allocator;
+
+    use crate::{JsxLang, JsxOutputMode, lower_source};
+
+    use super::super::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
+
+    #[test]
+    fn native_vdom_admitted_roots_emit_from_s2() {
+        let allocator = Allocator::new();
+        let source = "const A = () => <div>{count}</div>;";
+        let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+        let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+        let mut root = lowered.roots.pop().expect("one JSX root");
+        root.root.children.clear();
+
+        let mut diagnostics = Vec::new();
+        let component = compile_root_to_vdom(
+            &allocator,
+            root,
+            analysis,
+            false,
+            &VdomCompileOptions::default(),
+            VdomCompatOptions::default(),
+            &mut diagnostics,
+            source,
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+        assert_eq!(component.mode, JsxOutputMode::Vdom);
+        assert_eq!(
+            component.code.as_str(),
+            "export function render(_ctx, _cache) {\n  return (_openBlock(), \
+             _createElementBlock(\"div\", null, _toDisplayString(count), 1 /* TEXT */))\n}"
+        );
+    }
+
+    #[test]
+    fn component_slot_children_stay_on_relief_until_slot_facts_are_authoritative() {
+        let allocator = Allocator::new();
+        let source = "const A = () => <Card><h1>Title</h1></Card>;";
+        let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+        let root = lowered.roots.pop().expect("one JSX root");
+        let s2 = root.s2.as_ref().expect("component child projects to S2");
+
+        assert!(!super::root_is_supported(s2));
+    }
+}


### PR DESCRIPTION
## Summary
- route supported native JSX VDOM roots through the S2 DOM emitter before the existing fallback
- keep Babel compatibility options, TSX, source maps, hoist/cache flags, components, and slot-bearing shapes on the existing lane
- add guards proving admitted roots read S2 and component slot children remain excluded until slot facts are authoritative

## Validation
- `cargo fmt --check`
- `cargo test -p vize_atelier_jsx -- --nocapture`
- `node --test tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/babel-jsx-oracle.test.ts`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350`
- `rust-script tools/commands/davinci/assertion-lint.rs`
- `git diff --check -- Cargo.lock crates/vize_atelier_jsx/Cargo.toml crates/vize_atelier_jsx/src/vdom.rs crates/vize_atelier_jsx/src/vdom/s2_emit.rs`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5865"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791328304&installation_model_id=422833&pr_number=5865&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5865&signature=72955dc9b7d2b2cfada9960aa70881c2d148b3de9073d4dc3c855ff20902263f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->