### PR TITLE
fix(davinci): skip model pass for model-free S2 DOM builds

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_build_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_build_profile.rs
@@ -17,8 +17,8 @@ struct TraversalBudget {
     visits: u64,
 }
 
-const CURRENT_S2_OBSERVER_WALKS: u64 = 7;
-const CURRENT_BUILD_WALKS: u64 = 8;
+const CURRENT_S2_OBSERVER_WALKS: u64 = 6;
+const CURRENT_BUILD_WALKS: u64 = 7;
 
 #[test]
 fn profile_build_walks_report_the_current_p2_12b_gap() {

--- a/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
@@ -57,11 +57,11 @@ fn profile_reports_real_s2_dom_walks() {
     assert_eq!(result.code, unobserved.code);
     assert_eq!(result.preamble, unobserved.preamble);
     assert_eq!(counter(&counters, "davinci.s2_dom.files"), 1);
-    assert_eq!(counter(&counters, "davinci.s2_dom.transform.walks"), 6);
-    assert_eq!(counter(&counters, "davinci.s2_dom.transform.passes"), 6);
+    assert_eq!(counter(&counters, "davinci.s2_dom.transform.walks"), 5);
+    assert_eq!(counter(&counters, "davinci.s2_dom.transform.passes"), 5);
     assert_eq!(counter(&counters, "davinci.s2_dom.emit.walks"), 1);
     assert!(counter(&counters, "davinci.s2_dom.emit.visits") > 0);
-    assert_eq!(counter(&counters, "davinci.s2_dom.total.walks"), 7);
+    assert_eq!(counter(&counters, "davinci.s2_dom.total.walks"), 6);
 }
 
 #[test]
@@ -104,13 +104,13 @@ fn profile_reports_ladder_s2_dom_walk_budget() {
             fixture.name
         );
         assert_eq!(counter(&counters, "davinci.s2_dom.files"), 1);
-        assert_eq!(counter(&counters, "davinci.s2_dom.transform.walks"), 6);
-        assert_eq!(counter(&counters, "davinci.s2_dom.transform.passes"), 6);
+        assert_eq!(counter(&counters, "davinci.s2_dom.transform.walks"), 5);
+        assert_eq!(counter(&counters, "davinci.s2_dom.transform.passes"), 5);
         assert_eq!(counter(&counters, "davinci.s2_dom.emit.walks"), expected.0);
         assert_eq!(counter(&counters, "davinci.s2_dom.emit.visits"), expected.1);
         assert_eq!(
             counter(&counters, "davinci.s2_dom.total.walks"),
-            6 + expected.0
+            5 + expected.0
         );
     }
 }

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -1,6 +1,7 @@
 //! JSX VDOM bridge for the P2-16 S2 re-targeting slice.
 
 use vize_s0::{Allocator, String};
+use vize_s1_to_s2::lower::LoweringFeatures;
 use vize_s1_to_s2::pass::S2Facts;
 use vize_s1_to_s2::{
     DomEmitMode, DomEmitOptions, LegacyCaps, Lowered as S2Lowered, emit_dom_with_options,
@@ -50,6 +51,7 @@ pub(super) fn try_emit_s2_vdom<'a>(
         texts: Default::default(),
         wrappers: Default::default(),
         for_wrappers: Default::default(),
+        features: LoweringFeatures::EMPTY,
         caps: LegacyCaps::VUE3,
     };
     let facts = S2Facts::default();

--- a/crates/vize_s1_to_s2/src/lower.rs
+++ b/crates/vize_s1_to_s2/src/lower.rs
@@ -69,6 +69,43 @@ pub use structural::{ForWrapper, WrapperAttr, WrapperClass, WrapperKey, WrapperK
 pub use text::{TextPart, TextParts, rebuild_source};
 pub(crate) use text::{legacy_slot_filler_needs_props_placeholder, legacy_slot_filler_text};
 
+/// Feature bits the lowering observed while building S2.
+///
+/// These are not another tree scan: they are derived from the lowering's
+/// own decision stream so the pass planner can skip artifact-irrelevant
+/// mandatory passes without hiding traversal work.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LoweringFeatures {
+    model_bindings: bool,
+}
+
+impl LoweringFeatures {
+    pub const EMPTY: Self = Self {
+        model_bindings: false,
+    };
+
+    #[must_use]
+    pub const fn has_model_bindings(self) -> bool {
+        self.model_bindings
+    }
+
+    pub(crate) const fn with_model_bindings(self) -> Self {
+        Self {
+            model_bindings: true,
+        }
+    }
+
+    fn from_provenance(records: &[ProvenanceRecord]) -> Self {
+        let mut features = Self::EMPTY;
+        for record in records {
+            if record.rule.as_str() == "lower.model" {
+                features = features.with_model_bindings();
+            }
+        }
+        features
+    }
+}
+
 /// The S2 artifact one lowering produces: the op tree plus the three
 /// fact channels, all live even when diagnostics are present (the
 /// Lean-InfoTree survival property — kept fragments, not rollback).
@@ -106,6 +143,8 @@ pub struct Lowered<'a> {
     /// Captured `<template v-for>` unwrap facts, keyed by the `ui.for`
     /// op's page-order id. Presence means the carrier was a template.
     pub for_wrappers: SideTable<ForWrapper>,
+    /// Lowering-observed feature bits used by the S2 pass planner.
+    pub features: LoweringFeatures,
     /// Vue dialect sugar the lowering (and the legalizing pass) consult.
     /// [`LegacyCaps::VUE3`] unless the caller used [`lower_with_caps`].
     pub caps: LegacyCaps,
@@ -235,6 +274,7 @@ fn lower_source_block_with_caps_and_comment_policy<'a>(
         ));
     }
     let ops = structural::lower_children(&mut cx, &tree.children, Namespace::Html);
+    let features = LoweringFeatures::from_provenance(&cx.provenance);
     Lowered {
         allocator,
         source: block.root_source(),
@@ -246,6 +286,7 @@ fn lower_source_block_with_caps_and_comment_policy<'a>(
         texts: cx.texts,
         wrappers: cx.wrappers,
         for_wrappers: cx.for_wrappers,
+        features,
         caps,
     }
 }
@@ -273,6 +314,7 @@ impl fmt::Debug for Lowered<'_> {
             .field("texts", &self.texts)
             .field("wrappers", &self.wrappers)
             .field("for_wrappers", &self.for_wrappers)
+            .field("features", &self.features)
             .field("caps", &self.caps)
             .finish_non_exhaustive()
     }

--- a/crates/vize_s1_to_s2/src/pass.rs
+++ b/crates/vize_s1_to_s2/src/pass.rs
@@ -37,12 +37,13 @@
 //!
 //! # Driving a run
 //!
-//! [`run_transform`] executes [`TRANSFORM`] through the P2-2 pass
-//! manager (`vize_davinci::pass::run_pipeline`) with a caller-supplied
-//! observer, and wires the P2-6 [`VerifyObserver`] between passes in
-//! debug builds exactly as its module documents: `note` then `check` /
-//! `check_table` after every pass, so a broken invariant names the pass
-//! that broke it. Release builds make zero verifier calls (guardrail 5).
+//! [`run_transform`] executes the artifact-selected S2 plan through the
+//! P2-2 pass manager (`vize_davinci::pass::run_pipeline`) with a
+//! caller-supplied observer, and wires the P2-6 [`VerifyObserver`] between
+//! passes in debug builds exactly as its module documents: `note` then
+//! `check` / `check_table` after every pass, so a broken invariant names
+//! the pass that broke it. Release builds make zero verifier calls
+//! (guardrail 5).
 
 use vize_davinci::pass::{PassDesc, PassFailure, PassObserver, Pipeline, run_pipeline};
 use vize_davinci::side_table::SideTable;
@@ -51,6 +52,7 @@ use crate::lower::Lowered;
 
 pub mod hoist;
 pub mod legacy;
+mod plan;
 pub mod text;
 pub mod vfor;
 pub mod vif;
@@ -148,8 +150,8 @@ pub struct S2Facts {
     pub static_facts: SideTable<StaticFacts>,
 }
 
-/// Run the S2 transform pipeline over `lowered`, firing `observer`'s
-/// hooks around each pass.
+/// Run the artifact-selected S2 transform pipeline over `lowered`, firing
+/// `observer`'s hooks around each pass.
 ///
 /// Pass diagnostics and provenance append to `lowered`'s own channels —
 /// the unified-channel design; there is no second diagnostics stream.
@@ -167,7 +169,7 @@ pub fn run_transform<'a, O: PassObserver>(lowered: &mut Lowered<'a>, observer: &
     #[cfg(debug_assertions)]
     let mut verify = vize_s2::verify::VerifyObserver::new();
 
-    let pipeline = legacy::pipeline_for(lowered.caps);
+    let pipeline = plan::pipeline_for(lowered.caps, lowered.features);
     let outcome = run_pipeline(&pipeline, observer, |event| {
         let name = event.desc().name;
         if name == legacy::DESC.name {

--- a/crates/vize_s1_to_s2/src/pass/plan.rs
+++ b/crates/vize_s1_to_s2/src/pass/plan.rs
@@ -1,0 +1,86 @@
+//! Artifact-scoped S2 transform plans.
+//!
+//! The static six-pass table stays the review unit, but the build path
+//! should not pay a diagnostic pass for an op family the lowering did not
+//! produce. Feature bits come from lowering provenance, not a second S2 walk.
+
+use vize_davinci::pass::{PassDesc, Pipeline};
+
+use crate::lower::{LegacyCaps, LoweringFeatures};
+
+use super::{S2_STAGE, TRANSFORM, hoist, legacy, text, vfor, vif, vslot};
+
+pub(super) const TRANSFORM_WITHOUT_MODEL_PASSES: &[PassDesc] =
+    &[vif::DESC, vfor::DESC, vslot::DESC, text::DESC, hoist::DESC];
+
+pub(super) const TRANSFORM_WITHOUT_MODEL: Pipeline =
+    Pipeline::new(S2_STAGE, TRANSFORM_WITHOUT_MODEL_PASSES);
+
+pub(super) const LEGACY_WITHOUT_MODEL_PASSES: &[PassDesc] = &[
+    legacy::DESC,
+    vif::DESC,
+    vfor::DESC,
+    vslot::DESC,
+    text::DESC,
+    hoist::DESC,
+];
+
+pub(super) const LEGACY_WITHOUT_MODEL: Pipeline =
+    Pipeline::new(S2_STAGE, LEGACY_WITHOUT_MODEL_PASSES);
+
+const _: () = assert!(TRANSFORM_WITHOUT_MODEL.group_count() == 5);
+const _: () = assert!(LEGACY_WITHOUT_MODEL.group_count() == 6);
+
+pub(super) const fn pipeline_for(caps: LegacyCaps, features: LoweringFeatures) -> Pipeline {
+    match (caps.needs_sugar(), features.has_model_bindings()) {
+        (true, true) => legacy::LEGACY,
+        (true, false) => LEGACY_WITHOUT_MODEL,
+        (false, true) => TRANSFORM,
+        (false, false) => TRANSFORM_WITHOUT_MODEL,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LEGACY_WITHOUT_MODEL, TRANSFORM_WITHOUT_MODEL, pipeline_for};
+    use crate::lower::{LegacyCaps, LoweringFeatures};
+    use crate::pass::{TRANSFORM, hoist, legacy, vmodel};
+    use vize_s0::config::VueVersion;
+
+    fn with_model() -> LoweringFeatures {
+        LoweringFeatures::EMPTY.with_model_bindings()
+    }
+
+    #[test]
+    fn vue3_omits_the_model_pass_when_lowering_found_no_model_ops() {
+        let pipeline = pipeline_for(LegacyCaps::VUE3, LoweringFeatures::EMPTY);
+        assert_eq!(pipeline, TRANSFORM_WITHOUT_MODEL);
+        assert_eq!(pipeline.passes.len(), 5);
+        assert_eq!(pipeline.group_count(), 5);
+        assert_eq!(pipeline.passes[4], hoist::DESC);
+        assert!(!pipeline.passes.iter().any(|pass| pass.name == vmodel::NAME));
+    }
+
+    #[test]
+    fn vue3_keeps_the_model_pass_when_diagnostics_may_need_it() {
+        let pipeline = pipeline_for(LegacyCaps::VUE3, with_model());
+        assert_eq!(pipeline, TRANSFORM);
+        assert_eq!(pipeline.passes.len(), 6);
+        assert_eq!(pipeline.group_count(), 6);
+        assert_eq!(pipeline.passes[4], vmodel::DESC);
+    }
+
+    #[test]
+    fn vue2_legacy_sugar_still_prepends_the_selected_vue3_shape() {
+        let caps = LegacyCaps::for_version(VueVersion::V2);
+        let without_model = pipeline_for(caps, LoweringFeatures::EMPTY);
+        assert_eq!(without_model, LEGACY_WITHOUT_MODEL);
+        assert_eq!(without_model.passes.len(), 6);
+        assert_eq!(without_model.group_count(), 6);
+
+        let with_model = pipeline_for(caps, with_model());
+        assert_eq!(with_model, legacy::LEGACY);
+        assert_eq!(with_model.passes.len(), 7);
+        assert_eq!(with_model.group_count(), 7);
+    }
+}

--- a/crates/vize_s1_to_s2/tests/emit_budget_observer.rs
+++ b/crates/vize_s1_to_s2/tests/emit_budget_observer.rs
@@ -47,12 +47,12 @@ fn observed_dom_emit_keeps_output_and_walk_budget() {
             fixture.name
         );
         assert_eq!(
-            observed.budget.transform.walks, 6,
+            observed.budget.transform.walks, 5,
             "{} transform walks",
             fixture.name
         );
         assert_eq!(
-            observed.budget.transform.passes, 6,
+            observed.budget.transform.passes, 5,
             "{} transform passes",
             fixture.name
         );
@@ -115,6 +115,26 @@ fn observed_dom_emit_keeps_output_and_walk_budget() {
             baseline.visits
         );
     }
+}
+
+#[test]
+fn model_bindings_keep_the_model_diagnostic_pass_in_the_emit_budget() {
+    let observed_allocator = Allocator::new();
+    let plain_allocator = Allocator::new();
+    let source = r#"<input v-model="msg">"#;
+    let observed = emit_dom_source_observed(&observed_allocator, source)
+        .expect("observed model emit succeeds");
+    let plain = emit_dom_source(&plain_allocator, source).expect("plain model emit succeeds");
+
+    assert_eq!(
+        observed.emit.assembled(),
+        plain.assembled(),
+        "the profiling observer must not change model output"
+    );
+    assert_eq!(observed.budget.transform.walks, 6);
+    assert_eq!(observed.budget.transform.passes, 6);
+    assert_eq!(observed.budget.emit_walks, 1);
+    assert_eq!(observed.budget.total_walks(), 7);
 }
 
 fn s2_dom_emit_count(fixture: &str) -> TraversalBudget {

--- a/crates/vize_s1_to_s2/tests/emit_unsupported_direct.rs
+++ b/crates/vize_s1_to_s2/tests/emit_unsupported_direct.rs
@@ -11,7 +11,7 @@ use std::vec::Vec as StdVec;
 use vize_davinci::id::NodeId;
 use vize_davinci::side_table::SideTable;
 use vize_s0::{Allocator, Box as ArenaBox, Span, String as VString, Vec as ArenaVec};
-use vize_s1_to_s2::lower::{ForWrapper, WrapperKey};
+use vize_s1_to_s2::lower::{ForWrapper, LoweringFeatures, WrapperKey};
 use vize_s1_to_s2::pass::{
     S2Facts, SlotCarrier, SlotFacts, SlotGroup, SlotName, SlotParams, TextFacts,
 };
@@ -208,6 +208,7 @@ fn lowered<'a>(a: &'a Allocator, root: Region<'a>) -> Lowered<'a> {
         texts: SideTable::new(),
         wrappers: SideTable::new(),
         for_wrappers: SideTable::new(),
+        features: LoweringFeatures::EMPTY,
         caps: LegacyCaps::VUE3,
     }
 }

--- a/crates/vize_s1_to_s2/tests/hoist_pass_snapshot.rs
+++ b/crates/vize_s1_to_s2/tests/hoist_pass_snapshot.rs
@@ -43,11 +43,11 @@ fn the_levels_fixture_snapshots_the_post_pass_folio() {
         // mutates nothing.
         assert_folio_snapshot!(*folio);
 
-        // Supplements: six walks (five barriers plus the fusable
-        // analysis singleton).
+        // Supplements: five model-free walks (four barriers plus the
+        // fusable analysis singleton).
         assert_eq!(
             budget.print_to_string(FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=6\npasses=6\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         // The lattice, row by row: the section is dynamic (its children
         // are), the h1 subtree fully static with hoistable props, the

--- a/crates/vize_s1_to_s2/tests/legacy_pass.rs
+++ b/crates/vize_s1_to_s2/tests/legacy_pass.rs
@@ -1,6 +1,6 @@
 //! Vue 2 sugar legalization (P2-9 installment 7): the pass rewrites
-//! dialect payloads into the Vue 3 surface. Vue 3 stays on the 6-pass
-//! table (`walks=6`).
+//! dialect payloads into the Vue 3 surface. Vue 3 model-free artifacts
+//! skip the `v-model` diagnostic pass (`walks=5`).
 
 mod support;
 
@@ -17,7 +17,7 @@ fn vue2() -> LegacyCaps {
 }
 
 #[test]
-fn vue3_keeps_six_walks_on_legacy_spellings() {
+fn vue3_model_free_legacy_spellings_skip_the_model_pass() {
     let source = r#"<Comp :title.sync="heading"/>"#;
     with_transformed(source, |lowered, folio, _, budget| {
         assert_eq!(
@@ -33,7 +33,7 @@ fn vue3_keeps_six_walks_on_legacy_spellings() {
         assert_eq!(lowered.caps, LegacyCaps::VUE3);
         assert_eq!(
             Folio::print_to_string(budget, FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=6\npasses=6\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
     });
     assert_transformed_sound(source, "vue3-sync-inert-pass");
@@ -56,7 +56,7 @@ fn vue2_expands_sync_into_bind_plus_update_listener() {
         );
         assert_eq!(
             Folio::print_to_string(budget, FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=7\npasses=7\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=6\npasses=6\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         assert_eq!(u64::from(lowered.op_count), folio.op_count());
     });

--- a/crates/vize_s1_to_s2/tests/text_pass_snapshot.rs
+++ b/crates/vize_s1_to_s2/tests/text_pass_snapshot.rs
@@ -36,11 +36,10 @@ fn the_merge_fixture_snapshots_the_post_pass_folio() {
         // comment is a run boundary.
         assert_folio_snapshot!(*folio);
 
-        // Supplements: the plan's walk accounting (four barrier
-        // passes since this installment).
+        // Supplements: the model-free plan's walk accounting.
         assert_eq!(
             budget.print_to_string(FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=6\npasses=6\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         // Two compounds, five and two parts, all validated (the pass
         // count-matches the recorded table).

--- a/crates/vize_s1_to_s2/tests/vfor_pass_snapshot.rs
+++ b/crates/vize_s1_to_s2/tests/vfor_pass_snapshot.rs
@@ -37,11 +37,11 @@ fn the_loops_fixture_snapshots_the_post_pass_folio() {
         // The oracle: the full normalized folio after the pipeline ran.
         assert_folio_snapshot!(*folio);
 
-        // Supplements: the plan's walk accounting through the budget
-        // observer's own derived page (four barrier passes since the        // v-slot installment).
+        // Supplements: the model-free plan's walk accounting through
+        // the budget observer's own derived page.
         assert_eq!(
             budget.print_to_string(FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=6\npasses=6\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         // Three loops, consumed in document order with fresh tags: the
         // keyed `li`, the destructuring `<template v-for>`, the

--- a/crates/vize_s1_to_s2/tests/vif_pass.rs
+++ b/crates/vize_s1_to_s2/tests/vif_pass.rs
@@ -193,10 +193,9 @@ fn an_unwrapped_single_child_keeps_its_own_key() {
 
 #[test]
 fn the_pipeline_reports_one_walk_per_barrier_pass() {
-    // Five mandatory barriers plus the series-6 fusable singleton
-    // (v-if, v-for, v-slot, text, v-model, hoist-static): six walks —
-    // the const-pinned fusion plan as measured cost (the fusable pass
-    // still walks alone; no fusable neighbour exists yet).
+    // Four mandatory barriers plus the series-6 fusable singleton
+    // (v-if, v-for, v-slot, text, hoist-static): five walks for an
+    // artifact with no ui.model bindings.
     with_transformed(r#"<div v-if="a">x</div>"#, |_, _, _, budget| {
         assert_eq!(
             vize_davinci::folio::Folio::print_to_string(
@@ -204,7 +203,7 @@ fn the_pipeline_reports_one_walk_per_barrier_pass() {
                 vize_davinci::folio::FolioMode::Full
             )
             .as_str(),
-            "[budget-observer]\nwalks=6\npasses=6\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
     });
 }

--- a/crates/vize_s1_to_s2/tests/vif_pass_snapshot.rs
+++ b/crates/vize_s1_to_s2/tests/vif_pass_snapshot.rs
@@ -37,11 +37,11 @@ fn the_chain_fixture_snapshots_the_post_pass_folio() {
         // carrier op for the wrapper's attributes.
         assert_folio_snapshot!(*folio);
 
-        // Supplements: the plan's walk accounting through the budget
-        // observer's own derived page (series 5's five barrier passes).
+        // Supplements: the model-free plan's walk accounting through
+        // the budget observer's own derived page.
         assert_eq!(
             budget.print_to_string(FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=6\npasses=6\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         // One fact entry (the chain's `ui.if`), keys on branches 0 and 2.
         let entries = facts.if_facts.sorted_entries();

--- a/crates/vize_s1_to_s2/tests/vslot_pass_snapshot.rs
+++ b/crates/vize_s1_to_s2/tests/vslot_pass_snapshot.rs
@@ -38,11 +38,11 @@ fn the_groups_fixture_snapshots_the_post_pass_folio() {
         // The oracle: the full normalized folio after the pipeline ran.
         assert_folio_snapshot!(*folio);
 
-        // Supplements: the plan's walk accounting through the budget
-        // observer's own derived page (four barrier passes since installment 4).
+        // Supplements: the model-free plan's walk accounting through
+        // the budget observer's own derived page.
         assert_eq!(
             budget.print_to_string(FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=6\npasses=6\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         // Three components grouped in document order: Card (pattern
         // params slot, modifier-folded slot, implicit default), Panel

--- a/davinci-road/open-questions.md
+++ b/davinci-road/open-questions.md
@@ -52,9 +52,10 @@ serialized and the production build path is not switched.
 Prototype note (2026-09-07): profiled source-map-free DOM compiles now record
 the remaining pre-S2 template walk as `davinci.s2_dom.pre_s2.*` and reconcile
 `davinci.s2_dom.build.walks` as that walk plus the S2 observer total. Ladder
-evidence shows the emit walk is already at the one-walk target, while the
-build path remains at 8 walks (1 pre-S2 + 7 S2 observer) until parse-to-S2
-and S2 transform fusion land.
+evidence shows the emit walk is already at the one-walk target; model-free
+artifacts also skip the `v-model` diagnostic pass, dropping the observed
+build path to 7 walks (1 pre-S2 + 6 S2 observer). P2-12b still needs
+parse-to-S2 and S2 transform fusion to reach the phase target.
 
 ## Orphan analyses: productize or cut
 


### PR DESCRIPTION
## Summary
- derive lowering feature bits from provenance so model-free artifacts select a no-model S2 transform plan
- keep the v-model diagnostic pass when ui.model exists, preserving model diagnostics and DOM output
- update P2-12b profile and budget witnesses from 8 to 7 build walks for ladder compiles

## Verification
- cargo test -p vize_s1_to_s2 pass::plan --lib
- cargo test -p vize_s1_to_s2 --test emit_budget_observer --test legacy_pass --test vif_pass --test vif_pass_snapshot --test vfor_pass_snapshot --test vslot_pass_snapshot --test text_pass_snapshot --test hoist_pass_snapshot --test vmodel_pass_snapshot
- cargo test -p vize_s1_to_s2 --test emit_unsupported_direct
- cargo test -p vize_atelier_dom --test davinci_s2_build_profile --test davinci_s2_profile
- cargo fmt --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 50
- git diff --check

## Notes
P2-12b remains open: parse-to-S2 and S2 transform fusion are still required to hit the one-walk target.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791329588&installation_model_id=422833&pr_number=5866&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5866&signature=a756a8cf5052013672811c87ff1650e4fa6bef5d24762afd6b3ce05d7aa75e5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->