### PR TITLE
test(lsp): guard disabled editor request routing

### DIFF
--- a/tests/_fixtures/maestro-vue-language-tools-scorecard.json
+++ b/tests/_fixtures/maestro-vue-language-tools-scorecard.json
@@ -378,6 +378,7 @@
         "textDocument/foldingRange",
         "textDocument/codeLens",
         "textDocument/documentColor",
+        "textDocument/colorPresentation",
         "textDocument/selectionRange"
       ],
       "mustInclude": [
@@ -411,11 +412,15 @@
       "mustExclude": [
         {
           "id": "document-feature-lifecycle",
-          "summary": "Unopened and empty documents return null or empty results instead of stale structure.",
+          "summary": "Unopened, empty, and disabled documents return null or empty results instead of stale structure.",
           "evidence": [
             {
               "file": "tests/tooling/lsp-document-features.test.ts",
               "contains": ["unopenedSymbols", "emptySymbols.length, 0"]
+            },
+            {
+              "file": "tests/tooling/lsp-editor-feature-routing.test.ts",
+              "contains": ["textDocument/documentColor", "textDocument/colorPresentation"]
             },
             {
               "file": "tests/tooling/lsp-smoke.test.ts",

--- a/tests/tooling/lsp-editor-feature-routing.test.ts
+++ b/tests/tooling/lsp-editor-feature-routing.test.ts
@@ -65,6 +65,10 @@ const DISABLED_REQUESTS: RequestCase[] = [
     params: (uri) => ({ textDocument: { uri }, position, context: { includeDeclaration: true } }),
   },
   {
+    method: "textDocument/documentHighlight",
+    params: (uri) => ({ textDocument: { uri }, position }),
+  },
+  {
     method: "textDocument/completion",
     params: (uri) => ({ textDocument: { uri }, position }),
   },
@@ -83,6 +87,20 @@ const DISABLED_REQUESTS: RequestCase[] = [
   {
     method: "textDocument/documentLink",
     params: (uri) => ({ textDocument: { uri } }),
+  },
+  {
+    method: "textDocument/documentColor",
+    params: (uri) => ({ textDocument: { uri } }),
+    expected: [],
+  },
+  {
+    method: "textDocument/colorPresentation",
+    params: (uri) => ({
+      textDocument: { uri },
+      color: { red: 1, green: 0, blue: 0, alpha: 1 },
+      range,
+    }),
+    expected: [],
   },
   {
     method: "textDocument/semanticTokens/full",
@@ -105,6 +123,10 @@ const DISABLED_REQUESTS: RequestCase[] = [
     params: (uri) => ({ textDocument: { uri } }),
   },
   {
+    method: "textDocument/selectionRange",
+    params: (uri) => ({ textDocument: { uri }, positions: [position] }),
+  },
+  {
     method: "textDocument/codeAction",
     params: (uri) => ({ textDocument: { uri }, range, context: { diagnostics: [] } }),
   },
@@ -117,6 +139,10 @@ const DISABLED_REQUESTS: RequestCase[] = [
     params: (uri) => ({ textDocument: { uri }, position, newName: "renamedMessage" }),
   },
   {
+    method: "textDocument/linkedEditingRange",
+    params: (uri) => ({ textDocument: { uri }, position }),
+  },
+  {
     method: "textDocument/formatting",
     params: (uri) => ({ textDocument: { uri }, options: { tabSize: 2, insertSpaces: true } }),
   },
@@ -126,6 +152,27 @@ const DISABLED_REQUESTS: RequestCase[] = [
       textDocument: { uri },
       range,
       options: { tabSize: 2, insertSpaces: true },
+    }),
+  },
+  {
+    method: "textDocument/onTypeFormatting",
+    params: (uri) => ({
+      textDocument: { uri },
+      position,
+      ch: "}",
+      options: { tabSize: 2, insertSpaces: true },
+    }),
+  },
+  {
+    method: "textDocument/prepareCallHierarchy",
+    params: (uri) => ({ textDocument: { uri }, position }),
+  },
+  {
+    method: "volar/client/autoInsert",
+    params: (uri) => ({
+      textDocument: { uri },
+      selection: position,
+      change: { rangeOffset: 0, rangeLength: 0, text: ">" },
     }),
   },
   {


### PR DESCRIPTION
## Summary
- Extend live LSP disabled-feature routing coverage across document highlight, color requests, selection ranges, linked editing, on-type formatting, call hierarchy, and auto-insert.
- Record color presentation in the Maestro Vue Language Server scorecard with executable disabled-request evidence.

## Verification
- cargo build -p vize
- vp fmt --check tests/tooling/lsp-editor-feature-routing.test.ts tests/_fixtures/maestro-vue-language-tools-scorecard.json
- cargo fmt --all --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350 --limit 50
- node --test --test-concurrency=1 tests/tooling/lsp-editor-feature-routing.test.ts tests/tooling/lsp-vue-language-tools-scorecard.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791329588&installation_model_id=422833&pr_number=5867&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5867&signature=0f6484aaf7ed6f4df825c8bae1d8d1cd01149f8adcc23f02822c7a4eb86dec22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->