### PR TITLE
docs(vscode): document editor feature switches

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -89,6 +89,36 @@ semantic tokens, links, folding ranges, inlay hints, and file rename handling. I
 individual switches, make sure to include `vize.completion.enable`, `vize.hover.enable`, and
 `vize.definition.enable` together when testing the core editor flow.
 
+Use individual switches when you want to compare one Vize surface against an existing Vue editor
+setup without changing the whole profile:
+
+| Setting                        | Default | Use                                                                         |
+| ------------------------------ | ------- | --------------------------------------------------------------------------- |
+| `vize.lint.enable`             | `true`  | Vue-aware diagnostics.                                                      |
+| `vize.diagnostics.enable`      | `false` | Deprecated alias for `vize.lint.enable`.                                    |
+| `vize.typecheck.enable`        | `true`  | Type checking diagnostics and type-aware backend features.                  |
+| `vize.editor.enable`           | `true`  | Main editor assistance bundle.                                              |
+| `vize.ecosystem.enable`        | `true`  | Router, I18n, Nuxt, and Void Vue helpers.                                   |
+| `vize.optionsApi.enable`       | `false` | Vue 3 Options API template bindings.                                        |
+| `vize.legacyVue2.enable`       | `false` | Vue 2.7 and Nuxt 2 helpers.                                                 |
+| `vize.completion.enable`       | `true`  | Completion provider; may overlap with `vuejs/language-tools`.               |
+| `vize.signatureHelp.enable`    | `true`  | Signature help provider; may overlap with `vuejs/language-tools`.           |
+| `vize.hover.enable`            | `true`  | Hover provider; may overlap with `vuejs/language-tools`.                    |
+| `vize.definition.enable`       | `true`  | Go-to-definition provider; may overlap with `vuejs/language-tools`.         |
+| `vize.references.enable`       | `true`  | Find-references provider; may overlap with `vuejs/language-tools`.          |
+| `vize.documentSymbols.enable`  | `true`  | Document symbols provider.                                                  |
+| `vize.workspaceSymbols.enable` | `true`  | Workspace symbols provider.                                                 |
+| `vize.codeActions.enable`      | `true`  | Lint quick fixes and suppressions; requires lint diagnostics.               |
+| `vize.rename.enable`           | `true`  | Rename provider; may overlap with `vuejs/language-tools`.                   |
+| `vize.codeLens.enable`         | `true`  | Code lens provider.                                                         |
+| `vize.formatting.enable`       | `false` | Formatting provider; keep off when another Vue formatter owns formatting.   |
+| `vize.semanticTokens.enable`   | `true`  | Semantic token provider; may overlap with theme or Vue-token providers.     |
+| `vize.documentLinks.enable`    | `true`  | Document link provider.                                                     |
+| `vize.foldingRanges.enable`    | `true`  | Folding range provider.                                                     |
+| `vize.inlayHints.enable`       | `true`  | Inlay hints provider.                                                       |
+| `vize.fileRename.enable`       | `true`  | File rename edits for Vue imports.                                          |
+| `vize.autoInsert.enable`       | `false` | Experimental automatic insertion for refs, interpolation, tags, and quotes. |
+
 `vize.ecosystem.enable` adds Vue Router route-name and file-route param completions, route-param
 diagnostics for `useRoute()`, Vue I18n key completions, workspace key validation, inlay previews,
 Void Vue route completions, and ecosystem lint diagnostics.

--- a/tests/tooling/vscode-extension-manifest.test.ts
+++ b/tests/tooling/vscode-extension-manifest.test.ts
@@ -4,6 +4,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { FEATURE_SETTING_KEYS } from "../../editors/vscode/src/extension-core.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const require = createRequire(import.meta.url);
@@ -81,9 +82,11 @@ test("multiline Vue script grammar preserves each declared dialect", () => {
 });
 
 function readManifest(): Manifest {
-  return JSON.parse(
-    fs.readFileSync(path.join(root, "editors/vscode/package.json"), "utf-8"),
-  ) as Manifest;
+  return JSON.parse(readText("editors/vscode/package.json")) as Manifest;
+}
+
+function readText(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf-8");
 }
 
 function readExtensionHostFixtures(): ExtensionHostFixtures {
@@ -228,6 +231,22 @@ test("configuration properties are well-formed and typed", () => {
       assert.equal(typeof property.default, "boolean", `${key} should default to a boolean`);
     }
   }
+});
+
+test("vscode README documents every published feature switch", () => {
+  const manifest = readManifest();
+  const properties = manifest.contributes?.configuration?.properties ?? {};
+  const readme = readText("editors/vscode/README.md");
+
+  for (const key of FEATURE_SETTING_KEYS) {
+    const setting = `vize.${key}`;
+    assert.ok(properties[setting], `manifest should publish ${setting}`);
+    assert.match(readme, new RegExp(`\\\`${setting}\\\``), `README should document ${setting}`);
+  }
+
+  assert.match(readme, /Deprecated alias for `vize\.lint\.enable`/);
+  assert.match(readme, /may overlap with `vuejs\/language-tools`/);
+  assert.match(readme, /Experimental automatic insertion/);
 });
 
 test("trace and server-path configuration keep their published contract", () => {


### PR DESCRIPTION
## Summary
- document every VS Code feature switch in the extension README
- add a tooling test that keeps the README aligned with the published manifest and initialization feature keys

## Verification
- node --test tests/tooling/vscode-extension-manifest.test.ts
- node --test tests/tooling/vscode-extension-core-behavior.test.ts tests/tooling/lsp-editor-feature-matrix.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791334020&installation_model_id=422833&pr_number=5868&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5868&signature=2d699a19509070c52a3c8ca84c7323f6c9b2da7080c647e33932ce626678ef4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded the VS Code extension README with a comprehensive configuration settings table, including defaults, provider behavior, deprecated aliases, Vue 2.7 and Options API support, formatting guidance, and experimental auto-insertion.

- **Tests**
  - Added validation ensuring all published feature switches are documented in the README and included in the extension manifest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->