### PR TITLE
perf(davinci): skip static analysis for no-hoist DOM emits

### DIFF
--- a/crates/vize_s1_to_s2/src/emit/budget.rs
+++ b/crates/vize_s1_to_s2/src/emit/budget.rs
@@ -3,7 +3,7 @@ use vize_s0::{Allocator, ensure_sufficient_stack};
 use vize_s1::{SurfaceParseOptions, parse_with_options};
 
 use crate::lower::{LegacyCaps, lower_with_caps_and_comment_policy};
-use crate::pass::run_transform;
+use crate::pass::{TransformProfile, run_transform_with_profile};
 
 use super::{DomEmit, DomEmitOptions, EmitError, emit_dom_with_emit_budget};
 
@@ -96,7 +96,11 @@ pub(super) fn emit_dom_source_with_options_and_observer<'a, O: PassObserver>(
             options.custom_element_patterns,
             options.custom_element_predicate,
         );
-        let facts = run_transform(&mut lowered, observer);
+        let mut profile = TransformProfile::DEFAULT;
+        if !options.hoist_static {
+            profile = profile.without_static_analysis();
+        }
+        let facts = run_transform_with_profile(&mut lowered, observer, profile);
         let (emit, emit_visits) = emit_dom_with_emit_budget(&lowered, &facts, options)?;
         Ok((emit, emit_visits))
     })

--- a/crates/vize_s1_to_s2/src/pass.rs
+++ b/crates/vize_s1_to_s2/src/pass.rs
@@ -61,6 +61,7 @@ pub mod vslot;
 pub(crate) mod walk;
 
 pub use hoist::{StaticFacts, StaticLevel};
+pub use plan::TransformProfile;
 pub use text::TextFacts;
 pub use vfor::{ForFacts, ForName};
 pub use vif::{BranchKey, BranchKeyKind, IfFacts};
@@ -165,11 +166,20 @@ pub struct S2Facts {
 ///
 /// [`VerifyObserver`]: vize_s2::verify::VerifyObserver
 pub fn run_transform<'a, O: PassObserver>(lowered: &mut Lowered<'a>, observer: &mut O) -> S2Facts {
+    run_transform_with_profile(lowered, observer, TransformProfile::DEFAULT)
+}
+
+/// [`run_transform`] under a product-selected optional-pass profile.
+pub fn run_transform_with_profile<'a, O: PassObserver>(
+    lowered: &mut Lowered<'a>,
+    observer: &mut O,
+    profile: TransformProfile,
+) -> S2Facts {
     let mut facts = S2Facts::default();
     #[cfg(debug_assertions)]
     let mut verify = vize_s2::verify::VerifyObserver::new();
 
-    let pipeline = plan::pipeline_for(lowered.caps, lowered.features);
+    let pipeline = plan::pipeline_for_profile(lowered.caps, lowered.features, profile);
     let outcome = run_pipeline(&pipeline, observer, |event| {
         let name = event.desc().name;
         if name == legacy::DESC.name {

--- a/crates/vize_s1_to_s2/src/pass/plan.rs
+++ b/crates/vize_s1_to_s2/src/pass/plan.rs
@@ -8,13 +8,56 @@ use vize_davinci::pass::{PassDesc, Pipeline};
 
 use crate::lower::{LegacyCaps, LoweringFeatures};
 
-use super::{S2_STAGE, TRANSFORM, hoist, legacy, text, vfor, vif, vslot};
+use super::{S2_STAGE, TRANSFORM, hoist, legacy, text, vfor, vif, vmodel, vslot};
+
+/// Product-facing selection for optional S2 transform work.
+///
+/// The transform catalogue stays the full review surface. One-shot DOM
+/// emission can still decline facts it cannot consume: with
+/// `hoist_static: false`, `hoist-static` would only spend an S2 walk to
+/// produce facts that the emitter is required to ignore.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransformProfile {
+    include_static_analysis: bool,
+}
+
+impl TransformProfile {
+    /// The full transform plan.
+    pub const DEFAULT: Self = Self {
+        include_static_analysis: true,
+    };
+
+    /// Drop the optional `hoist-static` analysis pass.
+    #[must_use]
+    pub const fn without_static_analysis(self) -> Self {
+        Self {
+            include_static_analysis: false,
+        }
+    }
+
+    #[must_use]
+    pub const fn includes_static_analysis(self) -> bool {
+        self.include_static_analysis
+    }
+}
 
 pub(super) const TRANSFORM_WITHOUT_MODEL_PASSES: &[PassDesc] =
     &[vif::DESC, vfor::DESC, vslot::DESC, text::DESC, hoist::DESC];
 
 pub(super) const TRANSFORM_WITHOUT_MODEL: Pipeline =
     Pipeline::new(S2_STAGE, TRANSFORM_WITHOUT_MODEL_PASSES);
+
+pub(super) const TRANSFORM_WITHOUT_HOIST_PASSES: &[PassDesc] =
+    &[vif::DESC, vfor::DESC, vslot::DESC, text::DESC, vmodel::DESC];
+
+pub(super) const TRANSFORM_WITHOUT_HOIST: Pipeline =
+    Pipeline::new(S2_STAGE, TRANSFORM_WITHOUT_HOIST_PASSES);
+
+pub(super) const TRANSFORM_WITHOUT_MODEL_OR_HOIST_PASSES: &[PassDesc] =
+    &[vif::DESC, vfor::DESC, vslot::DESC, text::DESC];
+
+pub(super) const TRANSFORM_WITHOUT_MODEL_OR_HOIST: Pipeline =
+    Pipeline::new(S2_STAGE, TRANSFORM_WITHOUT_MODEL_OR_HOIST_PASSES);
 
 pub(super) const LEGACY_WITHOUT_MODEL_PASSES: &[PassDesc] = &[
     legacy::DESC,
@@ -28,32 +71,77 @@ pub(super) const LEGACY_WITHOUT_MODEL_PASSES: &[PassDesc] = &[
 pub(super) const LEGACY_WITHOUT_MODEL: Pipeline =
     Pipeline::new(S2_STAGE, LEGACY_WITHOUT_MODEL_PASSES);
 
-const _: () = assert!(TRANSFORM_WITHOUT_MODEL.group_count() == 5);
-const _: () = assert!(LEGACY_WITHOUT_MODEL.group_count() == 6);
+pub(super) const LEGACY_WITHOUT_HOIST_PASSES: &[PassDesc] = &[
+    legacy::DESC,
+    vif::DESC,
+    vfor::DESC,
+    vslot::DESC,
+    text::DESC,
+    vmodel::DESC,
+];
 
-pub(super) const fn pipeline_for(caps: LegacyCaps, features: LoweringFeatures) -> Pipeline {
-    match (caps.needs_sugar(), features.has_model_bindings()) {
-        (true, true) => legacy::LEGACY,
-        (true, false) => LEGACY_WITHOUT_MODEL,
-        (false, true) => TRANSFORM,
-        (false, false) => TRANSFORM_WITHOUT_MODEL,
+pub(super) const LEGACY_WITHOUT_HOIST: Pipeline =
+    Pipeline::new(S2_STAGE, LEGACY_WITHOUT_HOIST_PASSES);
+
+pub(super) const LEGACY_WITHOUT_MODEL_OR_HOIST_PASSES: &[PassDesc] =
+    &[legacy::DESC, vif::DESC, vfor::DESC, vslot::DESC, text::DESC];
+
+pub(super) const LEGACY_WITHOUT_MODEL_OR_HOIST: Pipeline =
+    Pipeline::new(S2_STAGE, LEGACY_WITHOUT_MODEL_OR_HOIST_PASSES);
+
+const _: () = assert!(TRANSFORM_WITHOUT_MODEL.group_count() == 5);
+const _: () = assert!(TRANSFORM_WITHOUT_HOIST.group_count() == 5);
+const _: () = assert!(TRANSFORM_WITHOUT_MODEL_OR_HOIST.group_count() == 4);
+const _: () = assert!(LEGACY_WITHOUT_MODEL.group_count() == 6);
+const _: () = assert!(LEGACY_WITHOUT_HOIST.group_count() == 6);
+const _: () = assert!(LEGACY_WITHOUT_MODEL_OR_HOIST.group_count() == 5);
+
+pub(super) const fn pipeline_for_profile(
+    caps: LegacyCaps,
+    features: LoweringFeatures,
+    profile: TransformProfile,
+) -> Pipeline {
+    match (
+        caps.needs_sugar(),
+        features.has_model_bindings(),
+        profile.includes_static_analysis(),
+    ) {
+        (true, true, true) => legacy::LEGACY,
+        (true, true, false) => LEGACY_WITHOUT_HOIST,
+        (true, false, true) => LEGACY_WITHOUT_MODEL,
+        (true, false, false) => LEGACY_WITHOUT_MODEL_OR_HOIST,
+        (false, true, true) => TRANSFORM,
+        (false, true, false) => TRANSFORM_WITHOUT_HOIST,
+        (false, false, true) => TRANSFORM_WITHOUT_MODEL,
+        (false, false, false) => TRANSFORM_WITHOUT_MODEL_OR_HOIST,
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{LEGACY_WITHOUT_MODEL, TRANSFORM_WITHOUT_MODEL, pipeline_for};
+    use super::{
+        LEGACY_WITHOUT_HOIST, LEGACY_WITHOUT_MODEL, LEGACY_WITHOUT_MODEL_OR_HOIST,
+        TRANSFORM_WITHOUT_HOIST, TRANSFORM_WITHOUT_MODEL, TRANSFORM_WITHOUT_MODEL_OR_HOIST,
+        pipeline_for_profile,
+    };
     use crate::lower::{LegacyCaps, LoweringFeatures};
-    use crate::pass::{TRANSFORM, hoist, legacy, vmodel};
+    use crate::pass::{TRANSFORM, TransformProfile, hoist, legacy, vmodel};
     use vize_s0::config::VueVersion;
 
     fn with_model() -> LoweringFeatures {
         LoweringFeatures::EMPTY.with_model_bindings()
     }
 
+    fn default_pipeline_for(
+        caps: LegacyCaps,
+        features: LoweringFeatures,
+    ) -> vize_davinci::pass::Pipeline {
+        pipeline_for_profile(caps, features, TransformProfile::DEFAULT)
+    }
+
     #[test]
     fn vue3_omits_the_model_pass_when_lowering_found_no_model_ops() {
-        let pipeline = pipeline_for(LegacyCaps::VUE3, LoweringFeatures::EMPTY);
+        let pipeline = default_pipeline_for(LegacyCaps::VUE3, LoweringFeatures::EMPTY);
         assert_eq!(pipeline, TRANSFORM_WITHOUT_MODEL);
         assert_eq!(pipeline.passes.len(), 5);
         assert_eq!(pipeline.group_count(), 5);
@@ -63,7 +151,7 @@ mod tests {
 
     #[test]
     fn vue3_keeps_the_model_pass_when_diagnostics_may_need_it() {
-        let pipeline = pipeline_for(LegacyCaps::VUE3, with_model());
+        let pipeline = default_pipeline_for(LegacyCaps::VUE3, with_model());
         assert_eq!(pipeline, TRANSFORM);
         assert_eq!(pipeline.passes.len(), 6);
         assert_eq!(pipeline.group_count(), 6);
@@ -71,16 +159,67 @@ mod tests {
     }
 
     #[test]
+    fn vue3_omits_static_analysis_when_dom_emit_cannot_use_it() {
+        let profile = TransformProfile::DEFAULT.without_static_analysis();
+
+        let without_model =
+            pipeline_for_profile(LegacyCaps::VUE3, LoweringFeatures::EMPTY, profile);
+        assert_eq!(without_model, TRANSFORM_WITHOUT_MODEL_OR_HOIST);
+        assert_eq!(without_model.passes.len(), 4);
+        assert_eq!(without_model.group_count(), 4);
+        assert!(
+            !without_model
+                .passes
+                .iter()
+                .any(|pass| pass.name == hoist::NAME)
+        );
+        assert!(
+            !without_model
+                .passes
+                .iter()
+                .any(|pass| pass.name == vmodel::NAME)
+        );
+
+        let with_model = pipeline_for_profile(LegacyCaps::VUE3, with_model(), profile);
+        assert_eq!(with_model, TRANSFORM_WITHOUT_HOIST);
+        assert_eq!(with_model.passes.len(), 5);
+        assert_eq!(with_model.group_count(), 5);
+        assert_eq!(with_model.passes[4], vmodel::DESC);
+        assert!(
+            !with_model
+                .passes
+                .iter()
+                .any(|pass| pass.name == hoist::NAME)
+        );
+    }
+
+    #[test]
     fn vue2_legacy_sugar_still_prepends_the_selected_vue3_shape() {
         let caps = LegacyCaps::for_version(VueVersion::V2);
-        let without_model = pipeline_for(caps, LoweringFeatures::EMPTY);
+        let without_model = default_pipeline_for(caps, LoweringFeatures::EMPTY);
         assert_eq!(without_model, LEGACY_WITHOUT_MODEL);
         assert_eq!(without_model.passes.len(), 6);
         assert_eq!(without_model.group_count(), 6);
 
-        let with_model = pipeline_for(caps, with_model());
+        let with_model = default_pipeline_for(caps, with_model());
         assert_eq!(with_model, legacy::LEGACY);
         assert_eq!(with_model.passes.len(), 7);
         assert_eq!(with_model.group_count(), 7);
+    }
+
+    #[test]
+    fn vue2_legacy_sugar_preserves_the_dom_emit_static_analysis_choice() {
+        let caps = LegacyCaps::for_version(VueVersion::V2);
+        let profile = TransformProfile::DEFAULT.without_static_analysis();
+
+        let without_model = pipeline_for_profile(caps, LoweringFeatures::EMPTY, profile);
+        assert_eq!(without_model, LEGACY_WITHOUT_MODEL_OR_HOIST);
+        assert_eq!(without_model.passes.len(), 5);
+        assert_eq!(without_model.group_count(), 5);
+
+        let with_model = pipeline_for_profile(caps, with_model(), profile);
+        assert_eq!(with_model, LEGACY_WITHOUT_HOIST);
+        assert_eq!(with_model.passes.len(), 6);
+        assert_eq!(with_model.group_count(), 6);
     }
 }

--- a/crates/vize_s1_to_s2/tests/emit_budget_observer.rs
+++ b/crates/vize_s1_to_s2/tests/emit_budget_observer.rs
@@ -7,7 +7,10 @@ use std::path::Path;
 
 use davinci_harness::fixtures::{LADDER, template_block};
 use vize_s0::Allocator;
-use vize_s1_to_s2::{emit_dom_source, emit_dom_source_observed};
+use vize_s1_to_s2::{
+    DomEmitOptions, emit_dom_source, emit_dom_source_observed,
+    emit_dom_source_observed_with_options, emit_dom_source_with_options,
+};
 
 #[derive(Debug, Clone, Copy)]
 struct TraversalBudget {
@@ -135,6 +138,64 @@ fn model_bindings_keep_the_model_diagnostic_pass_in_the_emit_budget() {
     assert_eq!(observed.budget.transform.passes, 6);
     assert_eq!(observed.budget.emit_walks, 1);
     assert_eq!(observed.budget.total_walks(), 7);
+}
+
+#[test]
+fn disabled_static_hoist_skips_the_optional_analysis_walk() {
+    let source = r#"<section><span class="label">Static</span></section>"#;
+    let options = DomEmitOptions {
+        hoist_static: false,
+        ..DomEmitOptions::DEFAULT
+    };
+    let observed_allocator = Allocator::new();
+    let plain_allocator = Allocator::new();
+    let observed = emit_dom_source_observed_with_options(
+        &observed_allocator,
+        source,
+        vize_s1_to_s2::LegacyCaps::VUE3,
+        &options,
+    )
+    .expect("observed emit succeeds without static hoist");
+    let plain = emit_dom_source_with_options(
+        &plain_allocator,
+        source,
+        vize_s1_to_s2::LegacyCaps::VUE3,
+        &options,
+    )
+    .expect("plain emit succeeds without static hoist");
+
+    assert_eq!(observed.emit.assembled(), plain.assembled());
+    assert_eq!(
+        observed.emit.sections.imports_len,
+        observed.emit.preamble.len(),
+        "static-hoist-disabled preamble must not append hoist declarations"
+    );
+    assert_eq!(observed.budget.transform.walks, 4);
+    assert_eq!(observed.budget.transform.passes, 4);
+    assert_eq!(observed.budget.emit_walks, 1);
+    assert_eq!(observed.budget.total_walks(), 5);
+}
+
+#[test]
+fn disabled_static_hoist_keeps_model_diagnostics_when_models_exist() {
+    let source = r#"<input v-model="msg">"#;
+    let options = DomEmitOptions {
+        hoist_static: false,
+        ..DomEmitOptions::DEFAULT
+    };
+    let observed_allocator = Allocator::new();
+    let observed = emit_dom_source_observed_with_options(
+        &observed_allocator,
+        source,
+        vize_s1_to_s2::LegacyCaps::VUE3,
+        &options,
+    )
+    .expect("observed model emit succeeds without static hoist");
+
+    assert_eq!(observed.budget.transform.walks, 5);
+    assert_eq!(observed.budget.transform.passes, 5);
+    assert_eq!(observed.budget.emit_walks, 1);
+    assert_eq!(observed.budget.total_walks(), 6);
 }
 
 fn s2_dom_emit_count(fixture: &str) -> TraversalBudget {


### PR DESCRIPTION
## Summary
- add a transform profile for product-selected optional S2 work
- skip the optional `hoist-static` pass when DOM emit has `hoist_static: false`
- pin observed budgets for no-hoist model-free and model-bearing DOM emits

## Validation
- cargo fmt --check
- cargo test -p vize_s1_to_s2 --test emit_budget_observer
- cargo test -p vize_s1_to_s2 pass::tests
- cargo test -p vize_s1_to_s2
- cargo test -p vize_atelier_dom --test davinci_s2_option_matrix --test davinci_s2_hoist_static_selector
- node --test tests/tooling/davinci-traversal-budgets.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main
- cargo check -p vize_s1_to_s2 --no-default-features
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791334437&installation_model_id=422833&pr_number=5869&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5869&signature=9851ef8ddebaccf8af224c121165ffdbbc73a41a2de7c87773e0e3640bf2c1c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Static hoisting can now be disabled during rendering to reduce unnecessary processing while preserving rendered output.
  - Model-binding diagnostics continue to run when applicable, even when static hoisting is disabled.
  - Default rendering behavior remains unchanged unless a custom transformation profile is selected.

- **Tests**
  - Added coverage for rendering results, processing budgets, and diagnostic behavior across static-hoisting configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->