### PR TITLE
feat(maestro): route JSX implementation navigation

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -64,7 +64,10 @@ pub use jsx::{
     JsxSemanticTokensService,
 };
 #[cfg(feature = "native")]
-pub use jsx::{JsxReferencesService, JsxRenameService, JsxService, JsxTypeDefinitionService};
+pub use jsx::{
+    JsxImplementationService, JsxReferencesService, JsxRenameService, JsxService,
+    JsxTypeDefinitionService,
+};
 pub use references::ReferencesService;
 pub use rename::RenameService;
 pub use selection_range::SelectionRangeService;

--- a/crates/vize_maestro/src/ide/jsx.rs
+++ b/crates/vize_maestro/src/ide/jsx.rs
@@ -34,6 +34,8 @@ pub use semantic_tokens::JsxSemanticTokensService;
 // (the bridge is a native-only feature) and reached only when
 // `typeChecker.jsxTypecheck` is enabled.
 #[cfg(feature = "native")]
+mod implementation;
+#[cfg(feature = "native")]
 mod references;
 #[cfg(feature = "native")]
 mod rename;
@@ -46,6 +48,8 @@ mod signature_help_trace;
 #[cfg(feature = "native")]
 mod type_definition;
 
+#[cfg(feature = "native")]
+pub use implementation::JsxImplementationService;
 #[cfg(feature = "native")]
 pub use references::JsxReferencesService;
 #[cfg(feature = "native")]

--- a/crates/vize_maestro/src/ide/jsx/implementation.rs
+++ b/crates/vize_maestro/src/ide/jsx/implementation.rs
@@ -1,0 +1,74 @@
+//! Go-to-implementation for `.jsx`/`.tsx` Vue components over the Corsa bridge.
+
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location};
+use vize_canon::CorsaBridge;
+
+use super::service::JsxService;
+use crate::ide::{IdeContext, TypeDefinitionService};
+
+/// Implementation navigation support for opt-in JSX/TSX virtual TypeScript.
+pub struct JsxImplementationService;
+
+impl JsxImplementationService {
+    /// Go-to-implementation on a `.jsx`/`.tsx` component, resolved through
+    /// virtual TS and mapped back to authored source.
+    pub async fn implementation(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> Option<GotoDefinitionResponse> {
+        let bridge = corsa_bridge?;
+        let (virtual_ts, request_uri, line, character) =
+            JsxService::prepare_request(ctx, &bridge).await?;
+
+        let locations = bridge
+            .implementation(&request_uri, line, character)
+            .await
+            .ok()?;
+        if locations.is_empty() {
+            return None;
+        }
+
+        let mapped: Vec<Location> = locations
+            .iter()
+            .filter_map(|location| {
+                JsxService::map_location(ctx, &virtual_ts, &request_uri, location)
+            })
+            .collect();
+
+        TypeDefinitionService::convert_locations(mapped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::ServerState;
+    use tower_lsp::lsp_types::Url;
+
+    fn ctx_for<'a>(
+        state: &'a ServerState,
+        uri: &'a Url,
+        source: &str,
+        marker: &str,
+    ) -> IdeContext<'a> {
+        let offset = source.find(marker).expect("marker present") + marker.len();
+        IdeContext::with_content(state, uri, offset, source.to_string())
+    }
+
+    #[test]
+    fn implementation_without_bridge_returns_none() {
+        crate::runtime::block_on(async {
+            let source = "interface Box { render(): string }\nclass Card implements Box { render() { return 'x'; } }\n";
+            let uri = Url::parse("file:///tmp/Comp.tsx").unwrap();
+            let state = ServerState::new();
+            let ctx = ctx_for(&state, &uri, source, "render");
+            assert!(
+                JsxImplementationService::implementation(&ctx, None)
+                    .await
+                    .is_none()
+            );
+        });
+    }
+}

--- a/crates/vize_maestro/src/server/handlers/navigation.rs
+++ b/crates/vize_maestro/src/server/handlers/navigation.rs
@@ -10,8 +10,8 @@ use tower_lsp::{
 use super::super::MaestroServer;
 #[cfg(feature = "native")]
 use crate::ide::{
-    DeclarationService, ImplementationService, JsxService, JsxTypeDefinitionService,
-    TypeDefinitionService,
+    DeclarationService, ImplementationService, JsxImplementationService, JsxService,
+    JsxTypeDefinitionService, TypeDefinitionService,
 };
 use crate::ide::{DefinitionService, IdeContext, position_to_offset};
 
@@ -178,6 +178,10 @@ pub(super) async fn goto_implementation(
         let ctx = IdeContext::with_content(&server.state, uri, offset, content);
 
         if crate::utils::is_jsx_path(uri.path()) {
+            if server.state.jsx_typecheck_enabled() {
+                let corsa_bridge = server.state.get_corsa_bridge().await;
+                return Ok(JsxImplementationService::implementation(&ctx, corsa_bridge).await);
+            }
             return Ok(None);
         }
 

--- a/tests/tooling/lsp-implementation-capability.test.ts
+++ b/tests/tooling/lsp-implementation-capability.test.ts
@@ -4,9 +4,13 @@ import path from "node:path";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
 import { firstLocation, isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
-import { testOutputRoot } from "./support/lsp/paths.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
 import type { ServerCapabilities } from "./support/lsp/protocol.ts";
 import { LspSession } from "./support/lsp/session.ts";
+import {
+  requireTypecheckDependency,
+  resolveTypecheckRuntime,
+} from "./support/typecheck-dependency.ts";
 
 const source = `<script setup lang="ts">
 interface Formatter {
@@ -26,6 +30,21 @@ const message = "hello"
 <template>
   <span>{{ formatter.format(message) }}</span>
 </template>
+`;
+
+const tsxSource = `interface Formatter {
+  format(value: string): string
+}
+
+class LabelFormatter implements Formatter {
+  format(value: string): string {
+    return value.toUpperCase()
+  }
+}
+
+const formatter: Formatter = new LabelFormatter()
+
+export const view = <span>{formatter.format("hello")}</span>
 `;
 
 type ImplementationCapabilities = ServerCapabilities & {
@@ -93,3 +112,108 @@ test("vize lsp maps textDocument/implementation from authored SFC interfaces", a
     fs.rmSync(testRootDir, { recursive: true, force: true });
   }
 });
+
+test("vize lsp maps textDocument/implementation from authored TSX interfaces", async (t) => {
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTypecheckRuntime(root),
+    "TypeScript 7/Corsa runtime for TSX implementation navigation",
+    "TypeScript 7/Corsa runtime not found; skipping TSX implementation navigation test",
+  );
+  if (corsaPath == null) return;
+
+  const testRootDir = path.join(testOutputRoot, "lsp-tsx-implementation-capability");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const sourceDir = path.join(workspaceDir, "src");
+  fs.mkdirSync(sourceDir, { recursive: true });
+  writeVueShim(sourceDir);
+  fs.writeFileSync(
+    path.join(workspaceDir, "vize.config.json"),
+    JSON.stringify({
+      lsp: { lint: false, typecheck: true },
+      typeChecker: { corsaPath, jsxTypecheck: true },
+    }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(workspaceDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          jsx: "preserve",
+          jsxImportSource: "vue",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src/**/*"],
+      },
+      null,
+      2,
+    ),
+  );
+  const filePath = path.join(sourceDir, "Widget.tsx");
+  const uri = pathToFileURL(filePath).href;
+  const session = new LspSession();
+
+  try {
+    const init = (await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: true,
+    })) as { capabilities?: ImplementationCapabilities };
+    assert.equal(init.capabilities?.implementationProvider, true);
+
+    fs.writeFileSync(filePath, tsxSource, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "typescriptreact", version: 1, text: tsxSource },
+    });
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri),
+      60_000,
+    );
+
+    const position = offsetToPosition(
+      tsxSource,
+      tsxSource.indexOf("format(value: string): string"),
+    );
+    const implementation = await session.request("textDocument/implementation", {
+      textDocument: { uri },
+      position,
+    });
+    const location = firstLocation(implementation as never);
+    assert.equal(location.uri, uri);
+    assert.deepEqual(
+      location.range.start,
+      offsetToPosition(tsxSource, tsxSource.indexOf("format(value: string): string {")),
+    );
+    assert.ok(!location.uri.endsWith(".jsx.ts"), JSON.stringify(implementation));
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+function writeVueShim(sourceDir: string): void {
+  fs.writeFileSync(
+    path.join(sourceDir, "vue-shim.d.ts"),
+    `declare namespace JSX {
+  interface IntrinsicElements {
+    span: { children?: unknown }
+  }
+}
+
+declare module "vue/jsx-runtime" {
+  export const Fragment: unique symbol
+  export function jsx(type: unknown, props: unknown): unknown
+  export function jsxs(type: unknown, props: unknown): unknown
+}
+`,
+    "utf8",
+  );
+}


### PR DESCRIPTION
Summary:
- add a JSX/TSX implementation navigation service over the existing virtual TypeScript Corsa path
- route textDocument/implementation through that service when jsxTypecheck is enabled
- cover authored TSX interface implementation ranges without leaking virtual .jsx.ts locations

Tests:
- cargo fmt --check
- cargo test -p vize_maestro --features native --lib implementation
- cargo test -p vize_maestro --features native --lib
- node --test tests/tooling/lsp-implementation-capability.test.ts
- node --test tests/tooling/lsp-capabilities.test.ts tests/tooling/lsp-editor-feature-routing.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791336211&installation_model_id=422833&pr_number=5870&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5870&signature=e01ca638037f2b35ba8c1dae3a0e4a31ee9f82af6a4929fb75b1d5820ca4a200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->