### PR TITLE
fix(release): fail preflight on red pending gate jobs

### DIFF
--- a/tests/tooling/release-preflight-runner.test.ts
+++ b/tests/tooling/release-preflight-runner.test.ts
@@ -229,6 +229,45 @@ test("verify-only mode reports failed matrix shard jobs for red release evidence
   }
 });
 
+test("bootstrap mode stops waiting when an in-progress gate has failed required jobs", () => {
+  const tempDir = fs.mkdtempSync(path.join(tmpdir(), "vize-release-red-pending-matrix-"));
+  try {
+    const fixture = createReleasePreflightVerifyOnlyFixture(tempDir, {
+      requireJobTimeoutArgs: true,
+      mutateRuns(runs) {
+        const matrix = runs.find((run) => run.name === "Real Project Matrix");
+        assert.ok(matrix);
+        matrix.status = "in_progress";
+        matrix.conclusion = null;
+      },
+      mutateJobs(jobs) {
+        const matrixJobs = jobs[106];
+        assert.ok(matrixJobs);
+        matrixJobs[0] = { ...matrixJobs[0], conclusion: "failure" };
+        matrixJobs[12] = { ...matrixJobs[12], status: "in_progress", conclusion: null };
+      },
+    });
+    const result = spawnSync("rust-script", ["tools/commands/ci/github/release-preflight.rs"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PATH: `${fixture.binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        ...fixture.env,
+      },
+      timeout: 10_000,
+    });
+
+    assert.ifError(result.error);
+    assert.equal(result.status, 1, `${result.stderr}\n${result.stdout}`.trim());
+    assert.match(result.stderr, /Real Project Matrix: in_progress\/no conclusion/);
+    assert.match(result.stderr, /real projects \(0\/22\)=completed\/failure/);
+    assert.match(result.stderr, /real projects \(12\/22\)=in_progress\/no conclusion/);
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("verify-only mode rejects mutation states with observed typecheck drift", () => {
   const tempDir = fs.mkdtempSync(path.join(tmpdir(), "vize-release-mutation-drift-"));
   try {

--- a/tools/commands/ci/github/release-preflight.rs
+++ b/tools/commands/ci/github/release-preflight.rs
@@ -624,7 +624,17 @@ fn bootstrap_required_workflow_runs(
             match run {
                 None => missing.push(*workflow_name),
                 Some(run) if run.get("status").and_then(Value::as_str) != Some("completed") => {
-                    pending.push(*workflow_name)
+                    if required_workflow_has_terminal_failed_job(
+                        api_url,
+                        repository,
+                        token,
+                        workflow_name,
+                        run,
+                    ) {
+                        failed = true;
+                    } else {
+                        pending.push(*workflow_name)
+                    }
                 }
                 Some(run) if run.get("conclusion").and_then(Value::as_str) != Some("success") => {
                     failed = true
@@ -846,6 +856,31 @@ fn collect_required_workflow_failure_details(
         }
     }
     details
+}
+
+fn required_workflow_has_terminal_failed_job(
+    api_url: &str,
+    repository: &str,
+    token: &str,
+    workflow_name: &str,
+    run: &Value,
+) -> bool {
+    if !workflow_requires_job_evidence(workflow_name) {
+        return false;
+    }
+    let Some(run_id) = run.get("id").and_then(Value::as_i64) else {
+        return false;
+    };
+    github_api_pages_with_timeouts(
+        api_url,
+        repository,
+        token,
+        &format!("actions/runs/{run_id}/jobs"),
+        None,
+        FAILURE_DETAIL_GITHUB_TIMEOUTS,
+    )
+    .ok()
+    .is_some_and(|jobs| required_jobs_contain_terminal_failure(workflow_name, &jobs))
 }
 
 fn latest_required_workflow_run<'a>(
@@ -1080,6 +1115,25 @@ fn summarize_required_workflow_job_failures(
         reported.push(format!("and {omitted} more"));
     }
     Some(format!("required jobs: {}", reported.join(", ")))
+}
+
+fn required_jobs_contain_terminal_failure(workflow_name: &str, jobs_response: &[Value]) -> bool {
+    let job_names = required_workflow_job_names(workflow_name);
+    if job_names.is_empty() {
+        return false;
+    }
+    let mut jobs = flatten_collection(jobs_response, "jobs");
+    if jobs.is_empty() && jobs_response.iter().all(Value::is_object) {
+        jobs.extend(jobs_response);
+    }
+    job_names.into_iter().any(|name| {
+        jobs.iter()
+            .filter(|job| job.get("name").and_then(Value::as_str) == Some(name.as_str()))
+            .any(|job| {
+                job.get("status").and_then(Value::as_str) == Some("completed")
+                    && job.get("conclusion").and_then(Value::as_str) != Some("success")
+            })
+    })
 }
 
 fn find_release_blockers(issues: &[Value], tag: Option<&str>) -> Result<Vec<Value>, String> {


### PR DESCRIPTION
## Summary
- fail release preflight immediately when an in-progress required gate already has a completed failed required job
- keep pending gates pending when required jobs are still running or unavailable
- add bootstrap coverage for an in-progress Real Project Matrix run with failed shard evidence

## Verification
- cargo fmt --check
- vp check tests/tooling/release-preflight-runner.test.ts
- git diff --check origin/main...HEAD
- node --test tests/tooling/release-preflight-runner.test.ts
- node --test tests/tooling/release-preflight-core.test.ts tests/tooling/release-preflight-artifact-download.test.ts tests/tooling/release-preflight-runner.test.ts tests/tooling/release-preflight-parent-evidence.test.ts tests/tooling/release-preflight-github.test.ts tests/tooling/release-preflight-evidence.test.ts tests/tooling/release-preflight-bootstrap-budget.test.ts tests/tooling/release-preflight-workflow.test.ts tests/tooling/release-preflight-matrix-evidence.test.ts tests/tooling/release-preflight-matrix-evidence-rejections.test.ts tests/tooling/release-preflight-bootstrap.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791338175&installation_model_id=422833&pr_number=5871&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5871&signature=695c4f2700896866bb88868f63b8f93c0eef5ceb5aabff72082ebbe49ec90e59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Release preflight checks now detect failed required jobs while a workflow run is still in progress.
  - Bootstrap checks stop waiting indefinitely and report failure when required jobs have already reached a failed state.
  - Failure output identifies the affected workflow and jobs, making issues easier to diagnose.
  - Added regression coverage to verify the command exits with an error under these conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->