### PR TITLE
fix(maestro): route JSX declaration navigation

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -65,8 +65,8 @@ pub use jsx::{
 };
 #[cfg(feature = "native")]
 pub use jsx::{
-    JsxImplementationService, JsxReferencesService, JsxRenameService, JsxService,
-    JsxTypeDefinitionService,
+    JsxDeclarationService, JsxImplementationService, JsxReferencesService, JsxRenameService,
+    JsxService, JsxTypeDefinitionService,
 };
 pub use references::ReferencesService;
 pub use rename::RenameService;

--- a/crates/vize_maestro/src/ide/jsx.rs
+++ b/crates/vize_maestro/src/ide/jsx.rs
@@ -34,6 +34,8 @@ pub use semantic_tokens::JsxSemanticTokensService;
 // (the bridge is a native-only feature) and reached only when
 // `typeChecker.jsxTypecheck` is enabled.
 #[cfg(feature = "native")]
+mod declaration;
+#[cfg(feature = "native")]
 mod implementation;
 #[cfg(feature = "native")]
 mod references;
@@ -48,6 +50,8 @@ mod signature_help_trace;
 #[cfg(feature = "native")]
 mod type_definition;
 
+#[cfg(feature = "native")]
+pub use declaration::JsxDeclarationService;
 #[cfg(feature = "native")]
 pub use implementation::JsxImplementationService;
 #[cfg(feature = "native")]

--- a/crates/vize_maestro/src/ide/jsx/declaration.rs
+++ b/crates/vize_maestro/src/ide/jsx/declaration.rs
@@ -1,0 +1,77 @@
+//! Go-to-declaration for `.jsx`/`.tsx` Vue components over the Corsa bridge.
+
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location};
+use vize_canon::CorsaBridge;
+
+use super::service::JsxService;
+use crate::ide::{IdeContext, TypeDefinitionService};
+
+/// Declaration navigation support for opt-in JSX/TSX virtual TypeScript.
+pub struct JsxDeclarationService;
+
+impl JsxDeclarationService {
+    /// Go-to-declaration on a `.jsx`/`.tsx` component, resolved through
+    /// virtual TS and mapped back to authored source.
+    pub async fn declaration(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> Option<GotoDefinitionResponse> {
+        let bridge = corsa_bridge?;
+        let (virtual_ts, request_uri, line, character) =
+            JsxService::prepare_request(ctx, &bridge).await?;
+
+        let locations = match bridge.declaration(&request_uri, line, character).await {
+            Ok(locations) if !locations.is_empty() => locations,
+            Ok(_) | Err(_) => bridge
+                .definition(&request_uri, line, character)
+                .await
+                .ok()?,
+        };
+        if locations.is_empty() {
+            return None;
+        }
+
+        let mapped: Vec<Location> = locations
+            .iter()
+            .filter_map(|location| {
+                JsxService::map_location(ctx, &virtual_ts, &request_uri, location)
+            })
+            .collect();
+
+        TypeDefinitionService::convert_locations(mapped)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::ServerState;
+    use tower_lsp::lsp_types::Url;
+
+    fn ctx_for<'a>(
+        state: &'a ServerState,
+        uri: &'a Url,
+        source: &str,
+        marker: &str,
+    ) -> IdeContext<'a> {
+        let offset = source.find(marker).expect("marker present") + marker.len();
+        IdeContext::with_content(state, uri, offset, source.to_string())
+    }
+
+    #[test]
+    fn declaration_without_bridge_returns_none() {
+        crate::runtime::block_on(async {
+            let source = "const C = (props: { msg: string }) => <div>{props.msg}</div>;\n";
+            let uri = Url::parse("file:///tmp/Comp.tsx").unwrap();
+            let state = ServerState::new();
+            let ctx = ctx_for(&state, &uri, source, "props.msg");
+            assert!(
+                JsxDeclarationService::declaration(&ctx, None)
+                    .await
+                    .is_none()
+            );
+        });
+    }
+}

--- a/crates/vize_maestro/src/server/handlers/navigation.rs
+++ b/crates/vize_maestro/src/server/handlers/navigation.rs
@@ -10,8 +10,8 @@ use tower_lsp::{
 use super::super::MaestroServer;
 #[cfg(feature = "native")]
 use crate::ide::{
-    DeclarationService, ImplementationService, JsxImplementationService, JsxService,
-    JsxTypeDefinitionService, TypeDefinitionService,
+    DeclarationService, ImplementationService, JsxDeclarationService, JsxImplementationService,
+    JsxService, JsxTypeDefinitionService, TypeDefinitionService,
 };
 use crate::ide::{DefinitionService, IdeContext, position_to_offset};
 
@@ -141,6 +141,10 @@ pub(super) async fn goto_declaration(
         let ctx = IdeContext::with_content(&server.state, uri, offset, content);
 
         if crate::utils::is_jsx_path(uri.path()) {
+            if server.state.jsx_typecheck_enabled() {
+                let corsa_bridge = server.state.get_corsa_bridge().await;
+                return Ok(JsxDeclarationService::declaration(&ctx, corsa_bridge).await);
+            }
             return Ok(None);
         }
 

--- a/tests/tooling/lsp-declaration-capability.test.ts
+++ b/tests/tooling/lsp-declaration-capability.test.ts
@@ -4,9 +4,13 @@ import path from "node:path";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
 import { firstLocation, isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
-import { testOutputRoot } from "./support/lsp/paths.ts";
+import { root, testOutputRoot } from "./support/lsp/paths.ts";
 import type { ServerCapabilities } from "./support/lsp/protocol.ts";
 import { LspSession } from "./support/lsp/session.ts";
+import {
+  requireTypecheckDependency,
+  resolveTypecheckRuntime,
+} from "./support/typecheck-dependency.ts";
 
 const source = `<script setup lang="ts">
 const message = "hello"
@@ -15,6 +19,11 @@ const message = "hello"
 <template>
   <span>{{ message }}</span>
 </template>
+`;
+
+const tsxSource = `const message = "hello"
+
+export const view = <span>{message}</span>
 `;
 
 type DeclarationCapabilities = ServerCapabilities & {
@@ -79,3 +88,105 @@ test("vize lsp maps textDocument/declaration from authored SFC template bindings
     fs.rmSync(testRootDir, { recursive: true, force: true });
   }
 });
+
+test("vize lsp maps textDocument/declaration from authored TSX expressions", async (t) => {
+  const corsaPath = requireTypecheckDependency(
+    t,
+    resolveTypecheckRuntime(root),
+    "TypeScript 7/Corsa runtime for TSX declaration navigation",
+    "TypeScript 7/Corsa runtime not found; skipping TSX declaration navigation test",
+  );
+  if (corsaPath == null) return;
+
+  const testRootDir = path.join(testOutputRoot, "lsp-tsx-declaration-capability");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const sourceDir = path.join(workspaceDir, "src");
+  fs.mkdirSync(sourceDir, { recursive: true });
+  writeVueShim(sourceDir);
+  fs.writeFileSync(
+    path.join(workspaceDir, "vize.config.json"),
+    JSON.stringify({
+      lsp: { lint: false, typecheck: true },
+      typeChecker: { corsaPath, jsxTypecheck: true },
+    }),
+    "utf8",
+  );
+  fs.writeFileSync(
+    path.join(workspaceDir, "tsconfig.json"),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          jsx: "preserve",
+          jsxImportSource: "vue",
+          module: "ESNext",
+          moduleResolution: "bundler",
+          noEmit: true,
+          strict: true,
+          target: "ES2022",
+        },
+        include: ["src/**/*"],
+      },
+      null,
+      2,
+    ),
+  );
+  const filePath = path.join(sourceDir, "Widget.tsx");
+  const uri = pathToFileURL(filePath).href;
+  const session = new LspSession();
+
+  try {
+    const init = (await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: true,
+    })) as { capabilities?: DeclarationCapabilities };
+    assert.equal(init.capabilities?.declarationProvider, true);
+
+    fs.writeFileSync(filePath, tsxSource, "utf8");
+    session.notify("textDocument/didOpen", {
+      textDocument: { uri, languageId: "typescriptreact", version: 1, text: tsxSource },
+    });
+    await session.waitForNotification(
+      "textDocument/publishDiagnostics",
+      (params) => isDiagnosticsForUri(params, uri),
+      60_000,
+    );
+
+    const position = offsetToPosition(tsxSource, tsxSource.lastIndexOf("message}</span>") + 3);
+    const declaration = (await session.request("textDocument/declaration", {
+      textDocument: { uri },
+      position,
+    })) as Array<{ uri: string; range: { start: { line: number; character: number } } }>;
+    const location = firstLocation(declaration);
+    assert.equal(location.uri, uri);
+    assert.deepEqual(
+      location.range.start,
+      offsetToPosition(tsxSource, tsxSource.indexOf("message =")),
+    );
+    assert.ok(!location.uri.endsWith(".jsx.ts"), JSON.stringify(declaration));
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});
+
+function writeVueShim(sourceDir: string): void {
+  fs.writeFileSync(
+    path.join(sourceDir, "vue-shim.d.ts"),
+    `declare namespace JSX {
+  interface IntrinsicElements {
+    span: { children?: unknown }
+  }
+}
+
+declare module "vue/jsx-runtime" {
+  export const Fragment: unique symbol
+  export function jsx(type: unknown, props: unknown): unknown
+  export function jsxs(type: unknown, props: unknown): unknown
+}
+`,
+    "utf8",
+  );
+}


### PR DESCRIPTION
## Summary
- route `textDocument/declaration` for opted-in JSX/TSX documents through the Corsa bridge
- map virtual TypeScript declaration results back to authored JSX/TSX locations
- add LSP coverage for authored TSX declaration navigation while preserving SFC declaration behavior

## Verification
- `cargo fmt --check`
- `cargo test -p vize_maestro --features native declaration_without_bridge_returns_none`
- `cargo test -p vize_maestro --features native jsx`
- `vp check tests/tooling/lsp-declaration-capability.test.ts`
- `VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/lsp-declaration-capability.test.ts`
- `VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/lsp-implementation-capability.test.ts tests/tooling/lsp-type-definition-capability.test.ts tests/tooling/lsp-declaration-capability.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791342094&installation_model_id=422833&pr_number=5873&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5873&signature=a94c200168c6962a8b26dc9836be6428839be71b72daf6bdc8f03190eec16440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added go-to-declaration navigation for JSX and TSX expressions when JSX type checking is enabled.
  * Declaration results now map back to the authored source, with definition results used as a fallback when needed.

* **Tests**
  * Added coverage for resolving authored TSX bindings through declaration navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->