### PR TITLE
fix(atelier-jsx): admit component spreads to s2 vdom

### DIFF
--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -152,6 +152,9 @@ fn component_name_needs_component_semantics(name: &str) -> bool {
 
 fn component_binding_is_supported(binding: &BindingOp<'_>) -> bool {
     match binding {
+        BindingOp::Bind(bind) if bind.name.is_none() => {
+            bind.value.is_some() && bind.modifiers.is_empty()
+        }
         BindingOp::Bind(bind) => {
             bind.value.is_some()
                 && bind.modifiers.is_empty()
@@ -259,14 +262,42 @@ mod tests {
     }
 
     #[test]
-    fn component_spread_props_stay_on_relief_until_component_admission_widens() {
+    fn component_spread_props_emit_from_s2() {
         let allocator = Allocator::new();
-        let source = "const A = () => <B {...attrs} />";
+        let source = "const A = () => <B {...attrs} foo={f} title=\"ok\" />";
         let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
-        let root = lowered.roots.pop().expect("one JSX root");
+        let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+        let mut root = lowered.roots.pop().expect("one JSX root");
         let s2 = root.s2.as_ref().expect("component spread projects to S2");
 
-        assert_eq!(super::root_is_supported(s2), false);
+        assert_eq!(super::root_is_supported(s2), true);
+
+        root.root.children.clear();
+        let mut diagnostics = Vec::new();
+        let component = compile_root_to_vdom(
+            &allocator,
+            root,
+            analysis,
+            false,
+            &VdomCompileOptions::default(),
+            VdomCompatOptions::default(),
+            &mut diagnostics,
+            source,
+        );
+
+        assert!(diagnostics.is_empty(), "{diagnostics:?}");
+        assert_eq!(
+            component.preamble.as_str(),
+            "import { resolveComponent as _resolveComponent, mergeProps as _mergeProps, \
+             openBlock as _openBlock, createBlock as _createBlock } from \"vue\"\n"
+        );
+        assert_eq!(
+            component.code.as_str(),
+            "export function render(_ctx, _cache) {\n  const _component_B = \
+             _resolveComponent(\"B\")\n  \n  return (_openBlock(), _createBlock(_component_B, \
+             _mergeProps(attrs, {\n    foo: f,\n    title: \"ok\"\n  }), null, 16 /* FULL_PROPS */, \
+             [\"foo\"]))\n}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- admit value-bearing, modifier-free component prop spreads in the JSX S2 VDOM path
- pin the S2 emission witness for `_mergeProps(attrs, { ... })` and `FULL_PROPS`
- keep dynamic names, event object spreads, key/ref/is, dynamic tags, and slot children on the fallback path

## Verification
- cargo test -p vize_atelier_jsx vdom::s2_emit::tests::component_spread_props_emit_from_s2 -- --nocapture
- cargo test -p vize_atelier_jsx --test vdom -- --nocapture
- cargo test -p vize_atelier_jsx --test babel_compat_oracle -- --nocapture
- cargo fmt --check
- rust-script tools/commands/davinci/assertion-lint.rs
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791344310&installation_model_id=422833&pr_number=5875&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5875&signature=bb1e4c7661f87e8de59cfa2a90ea412af1f932eb83ae8b0131d4b2d161061023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Spread props with valid values are now supported for component rendering.
  - Generated Vue output correctly combines spread props with explicitly provided props.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->