### PR TITLE
test(atelier-jsx): gate s2 vdom migration parity

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -381,7 +381,7 @@ jobs:
         run: npm install --global @pkl-community/pkl@0.27.2
       - name: Test
         env: { VIZE_TEST_REQUIRE_TSGO: "1" }
-        run: cargo test --workspace && cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus -- --nocapture && cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture && cargo test -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli && cargo test -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 && cargo test -p vize_vitrine --no-default-features --features wasm
+        run: cargo test --workspace && cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus -- --nocapture && cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture && cargo test -p vize_atelier_jsx --features davinci-differential --lib vdom::s2_differential::s2_vdom_admitted_cases_match_relief_codegen -- --exact && cargo test -p vize --features legacy --test check_nuxt_tsconfig_isolation_cli && cargo test -p vize_atelier_core --features legacy --test davinci_s2_transform_vue2 && cargo test -p vize_vitrine --no-default-features --features wasm
   coverage:
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 30

--- a/crates/vize_atelier_jsx/Cargo.toml
+++ b/crates/vize_atelier_jsx/Cargo.toml
@@ -44,6 +44,8 @@ serde_json = { workspace = true }
 
 [features]
 default = []
+# Arm the JSX P2-16 migration parity lane without changing default builds.
+davinci-differential = []
 # Mirror the legacy parser/AST surface across the SFC and SSR dependencies.
 legacy = ["vize_atelier_sfc/legacy", "vize_atelier_ssr/legacy"]
 

--- a/crates/vize_atelier_jsx/src/vdom.rs
+++ b/crates/vize_atelier_jsx/src/vdom.rs
@@ -11,6 +11,8 @@
 //! `_ctx.`. Static hoisting and handler caching default off for predictable,
 //! `@vue/babel-plugin-jsx`-shaped output; callers can opt in.
 
+#[cfg(all(test, feature = "davinci-differential"))]
+mod s2_differential;
 mod s2_emit;
 
 use vize_atelier_core::codegen::generate_with_vnode_factory_and_merge_props;

--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -1,0 +1,90 @@
+//! P2-16 differential witnesses for JSX VDOM S2 migration.
+
+use vize_croquis::Croquis;
+use vize_s0::{Allocator, String};
+
+use crate::s2::S2Refusal;
+use crate::{JsxLang, lower_source};
+
+use super::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
+
+#[test]
+fn s2_vdom_admitted_cases_match_relief_codegen() {
+    let cases = [
+        ("element", "const A = () => <div class=\"card\" />;"),
+        ("text", "const A = () => <p>Hello</p>;"),
+        ("interpolation", "const A = () => <div>{count}</div>;"),
+        ("element bind", "const A = () => <button disabled={off} />;"),
+        (
+            "element event",
+            "const A = () => <button onClick={save} />;",
+        ),
+        (
+            "leaf component",
+            "const A = () => <B foo={f} title=\"ok\" />;",
+        ),
+        (
+            "component spread",
+            "const A = () => <B {...attrs} foo={f} title=\"ok\" />;",
+        ),
+    ];
+
+    for (name, source) in cases {
+        let s2 = compile_case(source, EmitRoute::ForceS2);
+        let relief = compile_case(source, EmitRoute::ForceRelief);
+
+        assert_eq!(
+            s2.preamble, relief.preamble,
+            "{name}: S2 VDOM preamble diverged from Relief"
+        );
+        assert_eq!(
+            s2.code, relief.code,
+            "{name}: S2 VDOM code diverged from Relief"
+        );
+    }
+}
+
+#[derive(Clone, Copy)]
+enum EmitRoute {
+    ForceS2,
+    ForceRelief,
+}
+
+struct Output {
+    preamble: String,
+    code: String,
+}
+
+fn compile_case(source: &str, route: EmitRoute) -> Output {
+    let allocator = Allocator::new();
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    assert!(!lowered.has_errors(), "{:?}", lowered.diagnostics);
+
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
+    assert!(lowered.roots.is_empty(), "expected exactly one JSX root");
+
+    match route {
+        EmitRoute::ForceS2 => root.root.children.clear(),
+        EmitRoute::ForceRelief => root.s2 = Err(S2Refusal::UnsupportedChild),
+    }
+
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert!(component.map.is_none(), "S2 parity lane is source-map-free");
+
+    Output {
+        preamble: component.preamble,
+        code: component.code,
+    }
+}

--- a/tests/tooling/davinci-lowering-ci-lane.test.ts
+++ b/tests/tooling/davinci-lowering-ci-lane.test.ts
@@ -7,6 +7,8 @@ const s1ToS2LoweringCorpusCommand =
   "cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_lowering_corpus -- --nocapture";
 const s1ToS2DomCorpusCommand =
   "cargo test -p vize_s1_to_s2 --features davinci-differential --test davinci_dom_corpus -- --nocapture";
+const jsxS2VdomParityCommand =
+  "cargo test -p vize_atelier_jsx --features davinci-differential --lib vdom::s2_differential::s2_vdom_admitted_cases_match_relief_codegen -- --exact";
 
 test("feature-gated S1-to-S2 corpus lanes ride the required clippy-and-test job", () => {
   const workflow = readRepoFile(".github", "workflows", "check.yml");
@@ -40,5 +42,13 @@ test("feature-gated S1-to-S2 corpus lanes ride the required clippy-and-test job"
   assert.ok(
     clippyJob.includes(s1ToS2DomCorpusCommand),
     "the feature-gated DOM corpus entry must run explicitly after cargo test --workspace",
+  );
+  assert.match(
+    readRepoFile("crates", "vize_atelier_jsx", "Cargo.toml"),
+    /^davinci-differential = \[\]$/m,
+  );
+  assert.ok(
+    clippyJob.includes(jsxS2VdomParityCommand),
+    "the feature-gated JSX S2 VDOM parity entry must run explicitly after cargo test --workspace",
   );
 });


### PR DESCRIPTION
## Summary
- add a feature-gated JSX S2 VDOM parity witness for the admitted migration slice
- wire the exact parity witness into the required clippy-and-test job
- assert the workflow and feature wiring from the tooling lane

## Verification
- `cargo test -p vize_atelier_jsx --features davinci-differential --lib vdom::s2_differential::s2_vdom_admitted_cases_match_relief_codegen -- --exact`
- `cargo fmt --check`
- `node --test --test-concurrency=1 tests/tooling/davinci-lowering-ci-lane.test.ts tests/tooling/github-workflows-check.test.ts`
- `vp check tests/tooling/davinci-lowering-ci-lane.test.ts .github/workflows/check.yml crates/vize_atelier_jsx/Cargo.toml`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350`
- `git diff --cached --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5877"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791346289&installation_model_id=422833&pr_number=5877&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5877&signature=a8196834d843bfcc1b2c39765a3d22305e088b3d0180b1adff9ddc12eeec5ed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for JSX rendering parity across representative elements, text, interpolations, bindings, events, components, and spreads.
  * Added validation that alternate JSX rendering paths produce consistent output.
  * Integrated the new parity checks into continuous integration to help detect regressions earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->