### PR TITLE
perf(davinci): skip S2 structural passes for absent op families

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_build_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_build_profile.rs
@@ -17,8 +17,39 @@ struct TraversalBudget {
     visits: u64,
 }
 
-const CURRENT_S2_OBSERVER_WALKS: u64 = 6;
-const CURRENT_BUILD_WALKS: u64 = 7;
+/// fixture -> current S2 observer walks and profiled build walks.
+///
+/// Both columns are per fixture because the S2 pass planner declines a
+/// mandatory pass whose op family the lowering never built
+/// (`vize_s1_to_s2::lower::features`). The S2 column is the artifact's
+/// transform plan plus its one emit walk; the build column adds the one
+/// pre-S2 template walk the legacy transform still costs on this entry
+/// point. Closing *that* one is what the parse-to-S2 switch is for.
+///
+/// | fixture       | families present                      | S2 | build |
+/// | ------------- | ------------------------------------- | -- | ----- |
+/// | small         | none                                  | 3  | 4     |
+/// | medium        | components                            | 4  | 5     |
+/// | large         | `v-if`, `v-for`, components, `<slot>` | 6  | 7     |
+/// | stress-deep   | `v-if`                                | 4  | 5     |
+/// | stress-wide   | none                                  | 3  | 4     |
+/// | stress-interp | none                                  | 3  | 4     |
+const CURRENT_WALKS: [(&str, u64, u64); 6] = [
+    ("small", 3, 4),
+    ("medium", 4, 5),
+    ("large", 6, 7),
+    ("stress-deep", 4, 5),
+    ("stress-wide", 3, 4),
+    ("stress-interp", 3, 4),
+];
+
+fn current_walks(fixture: &str) -> (u64, u64) {
+    CURRENT_WALKS
+        .iter()
+        .find(|(name, ..)| *name == fixture)
+        .map(|(_, s2, build)| (*s2, *build))
+        .unwrap_or_else(|| panic!("{fixture} has no pinned walk counts"))
+}
 
 #[test]
 fn profile_build_walks_report_the_current_p2_12b_gap() {
@@ -33,6 +64,7 @@ fn profile_build_walks_report_the_current_p2_12b_gap() {
         let template =
             template_block(fixture.source).expect("every ladder fixture has a template block");
         let baseline = traversal_budget(fixture.name);
+        let (current_s2_walks, current_build_walks) = current_walks(fixture.name);
         let profile = ProfileScope::enable();
         let allocator = Allocator::new();
         let (_, errors, result) = compile_template(&allocator, template);
@@ -69,7 +101,7 @@ fn profile_build_walks_report_the_current_p2_12b_gap() {
             fixture.name
         );
         assert_eq!(
-            s2_walks, CURRENT_S2_OBSERVER_WALKS,
+            s2_walks, current_s2_walks,
             "{} current S2 observer walk count",
             fixture.name
         );
@@ -80,7 +112,7 @@ fn profile_build_walks_report_the_current_p2_12b_gap() {
             fixture.name
         );
         assert_eq!(
-            build_walks, CURRENT_BUILD_WALKS,
+            build_walks, current_build_walks,
             "{} current profiled DOM build walk gap",
             fixture.name
         );

--- a/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
@@ -20,13 +20,21 @@ use vize_s0::profiler::{CounterSummary, global_profiler};
 
 static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-const S2_DOM_EMIT_COUNTS: [(&str, u64, u64); 6] = [
-    ("small", 1, 5),
-    ("medium", 1, 33),
-    ("large", 1, 54),
-    ("stress-deep", 1, 72),
-    ("stress-wide", 1, 2),
-    ("stress-interp", 1, 201),
+/// fixture -> S2 DOM emit walks, emit op visits, transform walks.
+///
+/// The transform column is per fixture because the S2 pass planner
+/// declines a mandatory pass whose op family the lowering never built
+/// (`vize_s1_to_s2::lower::features`): two walks — the text pass and the
+/// static analysis — is the floor, and each family present adds one.
+/// `medium` pays three for its kebab-case components, which are slot
+/// carriers even though it spells no `v-slot`.
+const S2_DOM_EMIT_COUNTS: [(&str, u64, u64, u64); 6] = [
+    ("small", 1, 5, 2),
+    ("medium", 1, 33, 3),
+    ("large", 1, 54, 5),
+    ("stress-deep", 1, 72, 3),
+    ("stress-wide", 1, 2, 2),
+    ("stress-interp", 1, 201, 2),
 ];
 
 #[test]
@@ -57,11 +65,14 @@ fn profile_reports_real_s2_dom_walks() {
     assert_eq!(result.code, unobserved.code);
     assert_eq!(result.preamble, unobserved.preamble);
     assert_eq!(counter(&counters, "davinci.s2_dom.files"), 1);
-    assert_eq!(counter(&counters, "davinci.s2_dom.transform.walks"), 5);
-    assert_eq!(counter(&counters, "davinci.s2_dom.transform.passes"), 5);
+    // `<div>{{ msg }}</div>` builds no `ui.if`, no `ui.for`, no slot
+    // carrier and no `ui.model`, so the plan is the text pass plus the
+    // static analysis.
+    assert_eq!(counter(&counters, "davinci.s2_dom.transform.walks"), 2);
+    assert_eq!(counter(&counters, "davinci.s2_dom.transform.passes"), 2);
     assert_eq!(counter(&counters, "davinci.s2_dom.emit.walks"), 1);
     assert!(counter(&counters, "davinci.s2_dom.emit.visits") > 0);
-    assert_eq!(counter(&counters, "davinci.s2_dom.total.walks"), 6);
+    assert_eq!(counter(&counters, "davinci.s2_dom.total.walks"), 3);
 }
 
 #[test]
@@ -104,13 +115,19 @@ fn profile_reports_ladder_s2_dom_walk_budget() {
             fixture.name
         );
         assert_eq!(counter(&counters, "davinci.s2_dom.files"), 1);
-        assert_eq!(counter(&counters, "davinci.s2_dom.transform.walks"), 5);
-        assert_eq!(counter(&counters, "davinci.s2_dom.transform.passes"), 5);
+        assert_eq!(
+            counter(&counters, "davinci.s2_dom.transform.walks"),
+            expected.2
+        );
+        assert_eq!(
+            counter(&counters, "davinci.s2_dom.transform.passes"),
+            expected.2
+        );
         assert_eq!(counter(&counters, "davinci.s2_dom.emit.walks"), expected.0);
         assert_eq!(counter(&counters, "davinci.s2_dom.emit.visits"), expected.1);
         assert_eq!(
             counter(&counters, "davinci.s2_dom.total.walks"),
-            5 + expected.0
+            expected.2 + expected.0
         );
     }
 }
@@ -312,11 +329,11 @@ impl Drop for ProfileScope {
     }
 }
 
-fn s2_dom_emit_count(fixture: &str) -> (u64, u64) {
+fn s2_dom_emit_count(fixture: &str) -> (u64, u64, u64) {
     S2_DOM_EMIT_COUNTS
         .iter()
-        .find(|(name, _, _)| *name == fixture)
-        .map(|(_, walks, visits)| (*walks, *visits))
+        .find(|(name, ..)| *name == fixture)
+        .map(|(_, walks, visits, transform_walks)| (*walks, *visits, *transform_walks))
         .unwrap_or_else(|| panic!("{fixture} has no pinned S2 DOM emit count"))
 }
 

--- a/crates/vize_s1_to_s2/src/lib.rs
+++ b/crates/vize_s1_to_s2/src/lib.rs
@@ -77,6 +77,6 @@ pub use emit::{
     emit_dom_with_options,
 };
 pub use lower::{
-    LegacyCaps, Lowered, lower, lower_source_block, lower_source_block_with_caps,
-    lower_style_block, lower_style_block_in, lower_with_caps,
+    LegacyCaps, Lowered, LoweringFeatures, OpFamily, lower, lower_source_block,
+    lower_source_block_with_caps, lower_style_block, lower_style_block_in, lower_with_caps,
 };

--- a/crates/vize_s1_to_s2/src/lower.rs
+++ b/crates/vize_s1_to_s2/src/lower.rs
@@ -42,6 +42,7 @@ mod cx;
 mod directive;
 mod element;
 mod expr;
+mod features;
 mod forop;
 mod html;
 mod leaf;
@@ -56,6 +57,7 @@ mod vfor;
 mod vtext;
 
 pub use caps::LegacyCaps;
+pub use features::{LoweringFeatures, OpFamily};
 
 // The one-scanner rule (#4365): the S2 passes re-derive binding names
 // with exactly the enumeration the lowering used, never a second one.
@@ -68,43 +70,6 @@ pub use structural::{ForWrapper, WrapperAttr, WrapperClass, WrapperKey, WrapperK
 // compound's source with exactly the spelling the lowering minted.
 pub use text::{TextPart, TextParts, rebuild_source};
 pub(crate) use text::{legacy_slot_filler_needs_props_placeholder, legacy_slot_filler_text};
-
-/// Feature bits the lowering observed while building S2.
-///
-/// These are not another tree scan: they are derived from the lowering's
-/// own decision stream so the pass planner can skip artifact-irrelevant
-/// mandatory passes without hiding traversal work.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct LoweringFeatures {
-    model_bindings: bool,
-}
-
-impl LoweringFeatures {
-    pub const EMPTY: Self = Self {
-        model_bindings: false,
-    };
-
-    #[must_use]
-    pub const fn has_model_bindings(self) -> bool {
-        self.model_bindings
-    }
-
-    pub(crate) const fn with_model_bindings(self) -> Self {
-        Self {
-            model_bindings: true,
-        }
-    }
-
-    fn from_provenance(records: &[ProvenanceRecord]) -> Self {
-        let mut features = Self::EMPTY;
-        for record in records {
-            if record.rule.as_str() == "lower.model" {
-                features = features.with_model_bindings();
-            }
-        }
-        features
-    }
-}
 
 /// The S2 artifact one lowering produces: the op tree plus the three
 /// fact channels, all live even when diagnostics are present (the
@@ -274,7 +239,6 @@ fn lower_source_block_with_caps_and_comment_policy<'a>(
         ));
     }
     let ops = structural::lower_children(&mut cx, &tree.children, Namespace::Html);
-    let features = LoweringFeatures::from_provenance(&cx.provenance);
     Lowered {
         allocator,
         source: block.root_source(),
@@ -286,7 +250,7 @@ fn lower_source_block_with_caps_and_comment_policy<'a>(
         texts: cx.texts,
         wrappers: cx.wrappers,
         for_wrappers: cx.for_wrappers,
-        features,
+        features: cx.features,
         caps,
     }
 }

--- a/crates/vize_s1_to_s2/src/lower/binding.rs
+++ b/crates/vize_s1_to_s2/src/lower/binding.rs
@@ -18,6 +18,7 @@
 //! ops; only ill-formed spellings still defer. The remaining set is still
 //! DOM realization (P2-11).
 
+use super::features::OpFamily;
 use alloc::vec::Vec as StdVec;
 
 use vize_s0::{Box, Span, String, Vec, cstr};
@@ -181,6 +182,7 @@ fn lower_model<'a>(
             span,
         });
     }
+    cx.observe(OpFamily::Model);
     cx.record(
         "lower.model",
         node,
@@ -305,6 +307,7 @@ pub(crate) fn lower_slot_content<'a>(
         after,
         span,
     );
+    cx.observe(OpFamily::SlotCarrier);
     BindingOp::SlotContent(Box::new_in(
         SlotContentOp {
             name,

--- a/crates/vize_s1_to_s2/src/lower/cx.rs
+++ b/crates/vize_s1_to_s2/src/lower/cx.rs
@@ -24,11 +24,12 @@ use vize_davinci::diagnostic::{Diagnostic, Severity, Stage};
 use vize_davinci::id::NodeId;
 use vize_davinci::side_table::SideTable;
 use vize_s0::{Allocator, SourceBlock, Span, String};
-use vize_s1::{CloseTag, Element, ElementClose, SurfaceChild, Token};
+use vize_s1::{Element, ElementClose, Token};
 use vize_s2::provenance::ProvenanceRecord;
 use vize_s2::scope::{ScopeFacts, ScopeTag};
 
 mod custom_element;
+mod span;
 
 pub(crate) struct Cx<'a> {
     pub allocator: &'a Allocator,
@@ -53,6 +54,9 @@ pub(crate) struct Cx<'a> {
     pub wrappers: SideTable<super::structural::WrapperKeys>,
     pub for_wrappers: SideTable<super::structural::ForWrapper>,
     pub caps: super::caps::LegacyCaps,
+    /// Op families this lowering built, set where the op is minted —
+    /// see `lower::features`.
+    pub features: super::features::LoweringFeatures,
     custom_element_patterns: Vec<String>,
     custom_element_predicate: Option<fn(&str) -> bool>,
 }
@@ -83,9 +87,19 @@ impl<'a> Cx<'a> {
             wrappers: SideTable::new(),
             for_wrappers: SideTable::new(),
             caps,
+            features: super::features::LoweringFeatures::EMPTY,
             custom_element_patterns: custom_element_patterns.to_vec(),
             custom_element_predicate,
         }
+    }
+
+    /// Record that this lowering built an op of `family`.
+    ///
+    /// Called where the op is minted, never from a rule name: a decision
+    /// that *failed* still leaves an op behind (a malformed `v-for` keeps
+    /// its `ui.for` under the escape), and the planner must see it.
+    pub(crate) fn observe(&mut self, family: super::features::OpFamily) {
+        self.features = self.features.observing(family);
     }
 
     /// Whether the walk is inside a condense-suppressing subtree.
@@ -286,64 +300,4 @@ impl<'a> Cx<'a> {
     }
 }
 
-/// End offset of an element's extent: the last byte its subtree rendered.
-/// S1 is a contiguous partition of the source, so this is the end of the
-/// element's last present-or-hole token — a `Missing` close contributes
-/// its children's extent (the typed hole is zero-width by policy).
-pub(crate) fn element_end(cx: &Cx<'_>, element: &Element<'_>) -> u32 {
-    match &element.close {
-        ElementClose::Present(CloseTag { gt, .. }) => cx.token_span(gt).end,
-        ElementClose::NotExpected => cx.token_span(&element.open.gt).end,
-        ElementClose::Implicit | ElementClose::Missing => element
-            .children
-            .last()
-            .map(|child| child_end(cx, child))
-            .unwrap_or_else(|| cx.token_span(&element.open.gt).end),
-    }
-}
-
-/// End offset of any child's extent.
-pub(crate) fn child_end(cx: &Cx<'_>, child: &SurfaceChild<'_>) -> u32 {
-    match child {
-        SurfaceChild::Element(element) => element_end(cx, element),
-        SurfaceChild::Interpolation(node) => cx.token_span(&node.close).end,
-        SurfaceChild::Text(token)
-        | SurfaceChild::Comment(token)
-        | SurfaceChild::Cdata(token)
-        | SurfaceChild::ProcessingInstruction(token)
-        | SurfaceChild::Unexpected(token) => cx.token_span(token).end,
-    }
-}
-
-/// The span of an element's whole extent (open tag through close).
-pub(crate) fn element_span(cx: &Cx<'_>, element: &Element<'_>) -> Span {
-    Span::new(
-        cx.offset(element.open.lt_name.text),
-        element_end(cx, element),
-    )
-}
-
-/// The span of one authored attribute: name through the end of its value
-/// (closing quote included when present).
-pub(crate) fn attr_span(cx: &Cx<'_>, attr: &vize_s1::Attribute<'_>) -> Span {
-    let start = cx.offset(attr.name.text);
-    let end = match &attr.value {
-        Some(value) => match &value.close_quote {
-            Some(close) => cx.token_span(close).end,
-            None => cx.token_span(&value.content).end,
-        },
-        None => match &attr.eq {
-            Some(eq) => cx.token_span(eq).end,
-            None => cx.token_span(&attr.name).end,
-        },
-    };
-    Span::new(start, end)
-}
-
-/// The authored slice an attribute covers (for provenance `before`).
-pub(crate) fn attr_slice<'a>(cx: &Cx<'a>, attr: &vize_s1::Attribute<'a>) -> &'a str {
-    let span = attr_span(cx, attr);
-    cx.source
-        .get(span.start as usize..span.end as usize)
-        .unwrap_or(attr.name.text)
-}
+pub(crate) use span::{attr_slice, attr_span, element_span};

--- a/crates/vize_s1_to_s2/src/lower/cx/span.rs
+++ b/crates/vize_s1_to_s2/src/lower/cx/span.rs
@@ -1,0 +1,75 @@
+//! Span recovery over the S1 surface — the extent questions the lowering
+//! asks about an authored node, kept beside [`Cx`](super::Cx) rather than
+//! inside it.
+//!
+//! S1 is a contiguous partition of the source, so every extent here is
+//! recovered from the tokens the parser kept: a typed hole is zero-width
+//! by policy and contributes nothing, which is what makes a `Missing`
+//! close fall back to its children's extent instead of guessing.
+
+use vize_s0::Span;
+use vize_s1::{CloseTag, Element, ElementClose, SurfaceChild};
+
+use super::Cx;
+
+/// End offset of an element's extent: the last byte its subtree rendered.
+/// S1 is a contiguous partition of the source, so this is the end of the
+/// element's last present-or-hole token — a `Missing` close contributes
+/// its children's extent (the typed hole is zero-width by policy).
+fn element_end(cx: &Cx<'_>, element: &Element<'_>) -> u32 {
+    match &element.close {
+        ElementClose::Present(CloseTag { gt, .. }) => cx.token_span(gt).end,
+        ElementClose::NotExpected => cx.token_span(&element.open.gt).end,
+        ElementClose::Implicit | ElementClose::Missing => element
+            .children
+            .last()
+            .map(|child| child_end(cx, child))
+            .unwrap_or_else(|| cx.token_span(&element.open.gt).end),
+    }
+}
+
+/// End offset of any child's extent.
+fn child_end(cx: &Cx<'_>, child: &SurfaceChild<'_>) -> u32 {
+    match child {
+        SurfaceChild::Element(element) => element_end(cx, element),
+        SurfaceChild::Interpolation(node) => cx.token_span(&node.close).end,
+        SurfaceChild::Text(token)
+        | SurfaceChild::Comment(token)
+        | SurfaceChild::Cdata(token)
+        | SurfaceChild::ProcessingInstruction(token)
+        | SurfaceChild::Unexpected(token) => cx.token_span(token).end,
+    }
+}
+
+/// The span of an element's whole extent (open tag through close).
+pub(crate) fn element_span(cx: &Cx<'_>, element: &Element<'_>) -> Span {
+    Span::new(
+        cx.offset(element.open.lt_name.text),
+        element_end(cx, element),
+    )
+}
+
+/// The span of one authored attribute: name through the end of its value
+/// (closing quote included when present).
+pub(crate) fn attr_span(cx: &Cx<'_>, attr: &vize_s1::Attribute<'_>) -> Span {
+    let start = cx.offset(attr.name.text);
+    let end = match &attr.value {
+        Some(value) => match &value.close_quote {
+            Some(close) => cx.token_span(close).end,
+            None => cx.token_span(&value.content).end,
+        },
+        None => match &attr.eq {
+            Some(eq) => cx.token_span(eq).end,
+            None => cx.token_span(&attr.name).end,
+        },
+    };
+    Span::new(start, end)
+}
+
+/// The authored slice an attribute covers (for provenance `before`).
+pub(crate) fn attr_slice<'a>(cx: &Cx<'a>, attr: &vize_s1::Attribute<'a>) -> &'a str {
+    let span = attr_span(cx, attr);
+    cx.source
+        .get(span.start as usize..span.end as usize)
+        .unwrap_or(attr.name.text)
+}

--- a/crates/vize_s1_to_s2/src/lower/element.rs
+++ b/crates/vize_s1_to_s2/src/lower/element.rs
@@ -9,6 +9,7 @@
 //! their **children** to HTML. This approximates the HTML tree-construction
 //! namespace algorithm the way the shipped compiler-dom logic does.
 
+use super::features::OpFamily;
 use alloc::vec::Vec as StdVec;
 
 use vize_s0::{Box, Vec, cstr, is_math_ml_tag, is_native_tag, is_svg_tag};
@@ -151,6 +152,7 @@ pub(crate) fn element_core<'a>(
         .get(cx.offset(element.open.lt_name.text) as usize..open_end as usize)
         .unwrap_or(tag);
     if component {
+        cx.observe(OpFamily::SlotCarrier);
         cx.record(
             "lower.component",
             node,

--- a/crates/vize_s1_to_s2/src/lower/features.rs
+++ b/crates/vize_s1_to_s2/src/lower/features.rs
@@ -1,0 +1,163 @@
+//! The lowering's observed feature bits — what the S2 pass planner asks
+//! before it spends a mandatory pass's walk.
+//!
+//! # Why the bits exist
+//!
+//! Every mandatory S2 pass is the consumer of one op family:
+//! [`pass::vif`](crate::pass::vif) reads `ui.if`,
+//! [`pass::vfor`](crate::pass::vfor) reads `ui.for`,
+//! [`pass::vslot`](crate::pass::vslot) reads the slot carriers, and
+//! [`pass::vmodel`](crate::pass::vmodel) reads `ui.model`. Run against an
+//! artifact whose family the lowering never built, such a pass walks the
+//! whole tree to publish an empty fact table and raise no diagnostic — a
+//! walk the build path can decline without declining any product.
+//!
+//! # Why the bit is set at the op, not read off provenance
+//!
+//! The first cut derived these bits from the lowering's provenance rule
+//! names (`lower.for`, `lower.if`, …), which is one scan of a stream the
+//! lowering already wrote and costs no traversal. It is also **wrong**,
+//! and a committed test says so: `<p v-for="items">` cannot split under
+//! Vue's grammar, so `lower/forop.rs` takes the escape arm, records
+//! `error.v-for-malformed` instead of `lower.for` — and still leaves a
+//! `ui.for` op in the tree. Provenance records *decisions*; the planner
+//! is asking about *ops*, and a failed decision is exactly the case where
+//! the two diverge and the pass is still owed its walk.
+//!
+//! So [`Cx::observe`](super::cx::Cx::observe) sets the bit where the op is
+//! minted. There is no second scan and no name to keep in sync: the type
+//! system asks for an [`OpFamily`] at every construction site.
+//!
+//! # The one assumption left
+//!
+//! A family that gains a *new* construction site needs `observe` there
+//! too. `crates/vize_s1_to_s2/tests/lowering_features.rs` is the pin: it
+//! lowers a template per family — malformed spellings included — and
+//! fails if the bit is missing, then proves the planned run and the full
+//! six-pass table agree on every product an artifact has.
+
+/// An op family whose presence keeps a mandatory pass in the plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpFamily {
+    /// A `ui.if`, however malformed its branches.
+    If,
+    /// A `ui.for`, the undecomposable escape included.
+    For,
+    /// Anything [`pass::vslot`](crate::pass::vslot) can produce a fact or
+    /// a diagnostic at: a `ui.component` (the canonical grouping, the
+    /// implicit-default synthesis and three diagnostics), a `ui.slot`
+    /// outlet or a `ui.slot-content` binding (the two `VSlotMisplaced`
+    /// anchors, which fire with no component in sight).
+    SlotCarrier,
+    /// A `ui.model` binding.
+    Model,
+}
+
+/// Feature bits the lowering observed while building S2.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LoweringFeatures {
+    bits: u8,
+}
+
+impl LoweringFeatures {
+    /// No family built: the artifact every mandatory pass may decline.
+    pub const EMPTY: Self = Self { bits: 0 };
+
+    /// Whether the lowering built any `ui.if`.
+    #[must_use]
+    pub const fn has_if_ops(self) -> bool {
+        self.holds(OpFamily::If)
+    }
+
+    /// Whether the lowering built any `ui.for`.
+    #[must_use]
+    pub const fn has_for_ops(self) -> bool {
+        self.holds(OpFamily::For)
+    }
+
+    /// Whether the lowering built any slot carrier.
+    #[must_use]
+    pub const fn has_slot_carriers(self) -> bool {
+        self.holds(OpFamily::SlotCarrier)
+    }
+
+    /// Whether the lowering built any `ui.model` binding.
+    #[must_use]
+    pub const fn has_model_bindings(self) -> bool {
+        self.holds(OpFamily::Model)
+    }
+
+    /// The same bits with `family` observed.
+    #[must_use]
+    pub const fn observing(self, family: OpFamily) -> Self {
+        Self {
+            bits: self.bits | family.bit(),
+        }
+    }
+
+    const fn holds(self, family: OpFamily) -> bool {
+        self.bits & family.bit() != 0
+    }
+}
+
+impl OpFamily {
+    const fn bit(self) -> u8 {
+        match self {
+            OpFamily::If => 1 << 0,
+            OpFamily::For => 1 << 1,
+            OpFamily::SlotCarrier => 1 << 2,
+            OpFamily::Model => 1 << 3,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LoweringFeatures, OpFamily};
+
+    const EVERY: [OpFamily; 4] = [
+        OpFamily::If,
+        OpFamily::For,
+        OpFamily::SlotCarrier,
+        OpFamily::Model,
+    ];
+
+    #[test]
+    fn empty_holds_no_family() {
+        let features = LoweringFeatures::EMPTY;
+        assert!(!features.has_model_bindings());
+        assert!(!features.has_if_ops());
+        assert!(!features.has_for_ops());
+        assert!(!features.has_slot_carriers());
+        assert_eq!(features, LoweringFeatures::default());
+    }
+
+    /// Every family owns a distinct bit, so observing one can never
+    /// answer for another — the property the planner's declines rest on.
+    #[test]
+    fn each_family_owns_one_distinct_bit() {
+        let mut seen = 0u8;
+        for family in EVERY {
+            let bit = family.bit();
+            assert_eq!(bit.count_ones(), 1, "{family:?} must name one bit");
+            assert_eq!(seen & bit, 0, "{family:?} shares a bit with an earlier one");
+            seen |= bit;
+        }
+    }
+
+    #[test]
+    fn observing_is_additive_and_idempotent() {
+        let once = LoweringFeatures::EMPTY.observing(OpFamily::For);
+        assert_eq!(once.observing(OpFamily::For), once);
+        assert!(once.has_for_ops());
+        assert!(!once.has_if_ops());
+        assert!(!once.has_slot_carriers());
+        assert!(!once.has_model_bindings());
+
+        let all = EVERY
+            .into_iter()
+            .fold(LoweringFeatures::EMPTY, LoweringFeatures::observing);
+        assert!(all.has_if_ops() && all.has_for_ops());
+        assert!(all.has_slot_carriers() && all.has_model_bindings());
+    }
+}

--- a/crates/vize_s1_to_s2/src/lower/forop.rs
+++ b/crates/vize_s1_to_s2/src/lower/forop.rs
@@ -2,6 +2,7 @@
 //! position, the whole value escape-classified when it cannot split, and
 //! the hygiene scope minted for every iteration region.
 
+use super::features::OpFamily;
 use alloc::vec::Vec as StdVec;
 
 use vize_s0::{Box, String, Vec, cstr};
@@ -153,6 +154,7 @@ pub(crate) fn lower_for<'a>(
             ops
         },
     };
+    cx.observe(OpFamily::For);
     Op::For(Box::new_in(
         ForOp {
             binding,

--- a/crates/vize_s1_to_s2/src/lower/slot.rs
+++ b/crates/vize_s1_to_s2/src/lower/slot.rs
@@ -15,6 +15,7 @@
 //! still-deferred built-ins keep their counted `defer.slot-directive`
 //! records with realization (P2-11) as the named owner.
 
+use super::features::OpFamily;
 use vize_s0::{Box, String, Vec, cstr};
 use vize_s1::Element;
 
@@ -160,6 +161,7 @@ pub(crate) fn lower_slot<'a>(
     let fallback = Region {
         ops: lower_children(cx, &element.children, ns),
     };
+    cx.observe(OpFamily::SlotCarrier);
     Op::Slot(Box::new_in(
         SlotOp {
             name,

--- a/crates/vize_s1_to_s2/src/lower/structural.rs
+++ b/crates/vize_s1_to_s2/src/lower/structural.rs
@@ -13,6 +13,7 @@
 //! conditional evaluates outside the iteration, so the branch region
 //! holds the `ui.for` which holds the element.
 
+use super::features::OpFamily;
 use alloc::vec::Vec as StdVec;
 
 use vize_s0::{Box, Span, String, Vec, cstr, ensure_sufficient_stack};
@@ -264,6 +265,7 @@ fn lower_if_group<'a>(
             },
         );
     }
+    cx.observe(OpFamily::If);
     out.push(Op::If(Box::new_in(
         IfOp {
             branches: lowered,

--- a/crates/vize_s1_to_s2/src/pass/plan.rs
+++ b/crates/vize_s1_to_s2/src/pass/plan.rs
@@ -2,7 +2,8 @@
 //!
 //! The static seven-pass table stays the review unit, but the build path
 //! should not pay a diagnostic pass for an op family the lowering did not
-//! produce. Feature bits come from lowering provenance, not a second S2 walk.
+//! produce. Feature bits come from the lowering construction sites, not a
+//! second S2 walk.
 //!
 //! # Why the plan is a mask, not a match arm
 //!

--- a/crates/vize_s1_to_s2/src/pass/plan.rs
+++ b/crates/vize_s1_to_s2/src/pass/plan.rs
@@ -1,14 +1,41 @@
 //! Artifact-scoped S2 transform plans.
 //!
-//! The static six-pass table stays the review unit, but the build path
+//! The static seven-pass table stays the review unit, but the build path
 //! should not pay a diagnostic pass for an op family the lowering did not
 //! produce. Feature bits come from lowering provenance, not a second S2 walk.
+//!
+//! # Why the plan is a mask, not a match arm
+//!
+//! Each selectable pass is declined independently — its own op family is
+//! absent, or the DOM emit declared it cannot consume the pass's product —
+//! so the reachable plans are the *subsets* of [`SELECTABLE`], not a short
+//! list of shapes. Enumerating them as named `const` pipelines cost one
+//! item per combination and doubled with every pass that learned to
+//! decline; at four selectable passes it was already sixteen names for one
+//! rule. [`plan_for_mask`] states the rule once instead, and [`PLANS`]
+//! holds its answer for every mask so a [`Pipeline`]'s
+//! `&'static [PassDesc]` still points at data nobody built at run time.
+//!
+//! The `const fn` is what keeps the compile-time pins available: the
+//! `const _: () = assert!(…)` items below evaluate [`plan_for_mask`]
+//! directly, so a plan-shape regression is a **compile error** exactly as
+//! it was when each shape had a name (the P2-2 convention).
+//!
+//! # What a decline may cost
+//!
+//! Nothing the artifact can observe. A declined pass is one whose op
+//! family the lowering never built, so its walk would publish an empty
+//! fact table and raise no diagnostic — see each pass's `run` for the
+//! `if let Op::…` that is its whole body, and
+//! `tests/lowering_features.rs` for the behavioural pin. `hoist` is the
+//! one decline made for a different reason: it is `Optional`, and the DOM
+//! emit declines its product outright under `hoist_static: false`.
 
 use vize_davinci::pass::{PassDesc, Pipeline};
 
 use crate::lower::{LegacyCaps, LoweringFeatures};
 
-use super::{S2_STAGE, TRANSFORM, hoist, legacy, text, vfor, vif, vmodel, vslot};
+use super::{S2_STAGE, hoist, legacy, text, vfor, vif, vmodel, vslot};
 
 /// Product-facing selection for optional S2 transform work.
 ///
@@ -41,185 +68,138 @@ impl TransformProfile {
     }
 }
 
-pub(super) const TRANSFORM_WITHOUT_MODEL_PASSES: &[PassDesc] =
-    &[vif::DESC, vfor::DESC, vslot::DESC, text::DESC, hoist::DESC];
-
-pub(super) const TRANSFORM_WITHOUT_MODEL: Pipeline =
-    Pipeline::new(S2_STAGE, TRANSFORM_WITHOUT_MODEL_PASSES);
-
-pub(super) const TRANSFORM_WITHOUT_HOIST_PASSES: &[PassDesc] =
-    &[vif::DESC, vfor::DESC, vslot::DESC, text::DESC, vmodel::DESC];
-
-pub(super) const TRANSFORM_WITHOUT_HOIST: Pipeline =
-    Pipeline::new(S2_STAGE, TRANSFORM_WITHOUT_HOIST_PASSES);
-
-pub(super) const TRANSFORM_WITHOUT_MODEL_OR_HOIST_PASSES: &[PassDesc] =
-    &[vif::DESC, vfor::DESC, vslot::DESC, text::DESC];
-
-pub(super) const TRANSFORM_WITHOUT_MODEL_OR_HOIST: Pipeline =
-    Pipeline::new(S2_STAGE, TRANSFORM_WITHOUT_MODEL_OR_HOIST_PASSES);
-
-pub(super) const LEGACY_WITHOUT_MODEL_PASSES: &[PassDesc] = &[
-    legacy::DESC,
-    vif::DESC,
-    vfor::DESC,
-    vslot::DESC,
-    text::DESC,
-    hoist::DESC,
+/// One selectable pass and the mask bit that keeps it.
+///
+/// Order here is the pipeline's execution order, so a plan is this table
+/// filtered — never reordered. The passes touch disjoint op families and
+/// carry no semantic dependency on one another (`super::TRANSFORM`'s
+/// docs), which is what makes an arbitrary subset a legal pipeline.
+const SELECTABLE: [(PassDesc, u8); 6] = [
+    (legacy::DESC, LEGACY_SUGAR),
+    (vif::DESC, IF_OPS),
+    (vfor::DESC, FOR_OPS),
+    (vslot::DESC, SLOT_CARRIERS),
+    (vmodel::DESC, MODEL_BINDINGS),
+    (hoist::DESC, STATIC_ANALYSIS),
 ];
 
-pub(super) const LEGACY_WITHOUT_MODEL: Pipeline =
-    Pipeline::new(S2_STAGE, LEGACY_WITHOUT_MODEL_PASSES);
+const LEGACY_SUGAR: u8 = 1 << 0;
+const IF_OPS: u8 = 1 << 1;
+const FOR_OPS: u8 = 1 << 2;
+const SLOT_CARRIERS: u8 = 1 << 3;
+const MODEL_BINDINGS: u8 = 1 << 4;
+const STATIC_ANALYSIS: u8 = 1 << 5;
 
-pub(super) const LEGACY_WITHOUT_HOIST_PASSES: &[PassDesc] = &[
-    legacy::DESC,
-    vif::DESC,
-    vfor::DESC,
-    vslot::DESC,
-    text::DESC,
-    vmodel::DESC,
-];
+/// Every mask, hence every plan.
+const PLAN_COUNT: usize = 1 << SELECTABLE.len();
 
-pub(super) const LEGACY_WITHOUT_HOIST: Pipeline =
-    Pipeline::new(S2_STAGE, LEGACY_WITHOUT_HOIST_PASSES);
+/// The text pass is not selectable: besides consuming compounds it
+/// asserts the adjacency law over *every* region, and that check is
+/// owed by artifacts with no compound at all — precisely the artifacts a
+/// "no compound recorded" bit would have declined it for.
+const ALWAYS: PassDesc = text::DESC;
 
-pub(super) const LEGACY_WITHOUT_MODEL_OR_HOIST_PASSES: &[PassDesc] =
-    &[legacy::DESC, vif::DESC, vfor::DESC, vslot::DESC, text::DESC];
+/// The bit whose pass [`ALWAYS`] immediately precedes in the landed
+/// pipeline. Splicing there is what keeps every plan a *subsequence* of
+/// `TRANSFORM_PASSES` rather than a re-ordering of it — pinned by
+/// `every_plan_is_a_subsequence_of_the_full_pipeline`.
+const ALWAYS_PRECEDES: u8 = MODEL_BINDINGS;
 
-pub(super) const LEGACY_WITHOUT_MODEL_OR_HOIST: Pipeline =
-    Pipeline::new(S2_STAGE, LEGACY_WITHOUT_MODEL_OR_HOIST_PASSES);
+/// The passes one mask selects, in execution order.
+///
+/// `passes` is fixed-capacity because a [`Pipeline`] borrows
+/// `&'static [PassDesc]`; slots past `len` are filler and never exposed —
+/// [`Plan::pipeline`] is the only reader and it slices to `len`.
+#[derive(Debug, Clone, Copy)]
+struct Plan {
+    passes: [PassDesc; SELECTABLE.len() + 1],
+    len: usize,
+}
 
-const _: () = assert!(TRANSFORM_WITHOUT_MODEL.group_count() == 5);
-const _: () = assert!(TRANSFORM_WITHOUT_HOIST.group_count() == 5);
-const _: () = assert!(TRANSFORM_WITHOUT_MODEL_OR_HOIST.group_count() == 4);
-const _: () = assert!(LEGACY_WITHOUT_MODEL.group_count() == 6);
-const _: () = assert!(LEGACY_WITHOUT_HOIST.group_count() == 6);
-const _: () = assert!(LEGACY_WITHOUT_MODEL_OR_HOIST.group_count() == 5);
+impl Plan {
+    const EMPTY: Self = Self {
+        passes: [ALWAYS; SELECTABLE.len() + 1],
+        len: 0,
+    };
 
-pub(super) const fn pipeline_for_profile(
+    fn pipeline(&'static self) -> Pipeline {
+        Pipeline::new(S2_STAGE, &self.passes[..self.len])
+    }
+}
+
+/// The plan `mask` selects: [`SELECTABLE`] filtered, with [`ALWAYS`]
+/// spliced in at the position it holds in the full pipeline.
+const fn plan_for_mask(mask: u8) -> Plan {
+    let mut plan = Plan::EMPTY;
+    let mut index = 0;
+    while index < SELECTABLE.len() {
+        let (desc, bit) = SELECTABLE[index];
+        if bit == ALWAYS_PRECEDES {
+            plan.passes[plan.len] = ALWAYS;
+            plan.len += 1;
+        }
+        if mask & bit != 0 {
+            plan.passes[plan.len] = desc;
+            plan.len += 1;
+        }
+        index += 1;
+    }
+    plan
+}
+
+const fn all_plans() -> [Plan; PLAN_COUNT] {
+    let mut plans = [Plan::EMPTY; PLAN_COUNT];
+    let mut mask = 0;
+    while mask < PLAN_COUNT {
+        // `mask` is bounded by `PLAN_COUNT`, which is `1 << 6`.
+        #[expect(clippy::cast_possible_truncation)]
+        let bits = mask as u8;
+        plans[mask] = plan_for_mask(bits);
+        mask += 1;
+    }
+    plans
+}
+
+/// Every plan, so a selected [`Pipeline`] borrows rather than builds.
+static PLANS: [Plan; PLAN_COUNT] = all_plans();
+
+// The full plan is still the six-pass table the series landed, and the
+// empty plan is still the text pass alone: a plan-shape regression is a
+// compile error, not a test failure.
+const _: () = assert!(plan_for_mask(u8::MAX).len == 7);
+const _: () = assert!(plan_for_mask(0).len == 1);
+const _: () = assert!(plan_for_mask(STATIC_ANALYSIS).len == 2);
+
+fn mask_for(caps: LegacyCaps, features: LoweringFeatures, profile: TransformProfile) -> u8 {
+    let mut mask = 0;
+    if caps.needs_sugar() {
+        mask |= LEGACY_SUGAR;
+    }
+    if features.has_if_ops() {
+        mask |= IF_OPS;
+    }
+    if features.has_for_ops() {
+        mask |= FOR_OPS;
+    }
+    if features.has_slot_carriers() {
+        mask |= SLOT_CARRIERS;
+    }
+    if features.has_model_bindings() {
+        mask |= MODEL_BINDINGS;
+    }
+    if profile.includes_static_analysis() {
+        mask |= STATIC_ANALYSIS;
+    }
+    mask
+}
+
+pub(super) fn pipeline_for_profile(
     caps: LegacyCaps,
     features: LoweringFeatures,
     profile: TransformProfile,
 ) -> Pipeline {
-    match (
-        caps.needs_sugar(),
-        features.has_model_bindings(),
-        profile.includes_static_analysis(),
-    ) {
-        (true, true, true) => legacy::LEGACY,
-        (true, true, false) => LEGACY_WITHOUT_HOIST,
-        (true, false, true) => LEGACY_WITHOUT_MODEL,
-        (true, false, false) => LEGACY_WITHOUT_MODEL_OR_HOIST,
-        (false, true, true) => TRANSFORM,
-        (false, true, false) => TRANSFORM_WITHOUT_HOIST,
-        (false, false, true) => TRANSFORM_WITHOUT_MODEL,
-        (false, false, false) => TRANSFORM_WITHOUT_MODEL_OR_HOIST,
-    }
+    PLANS[usize::from(mask_for(caps, features, profile))].pipeline()
 }
 
 #[cfg(test)]
-mod tests {
-    use super::{
-        LEGACY_WITHOUT_HOIST, LEGACY_WITHOUT_MODEL, LEGACY_WITHOUT_MODEL_OR_HOIST,
-        TRANSFORM_WITHOUT_HOIST, TRANSFORM_WITHOUT_MODEL, TRANSFORM_WITHOUT_MODEL_OR_HOIST,
-        pipeline_for_profile,
-    };
-    use crate::lower::{LegacyCaps, LoweringFeatures};
-    use crate::pass::{TRANSFORM, TransformProfile, hoist, legacy, vmodel};
-    use vize_s0::config::VueVersion;
-
-    fn with_model() -> LoweringFeatures {
-        LoweringFeatures::EMPTY.with_model_bindings()
-    }
-
-    fn default_pipeline_for(
-        caps: LegacyCaps,
-        features: LoweringFeatures,
-    ) -> vize_davinci::pass::Pipeline {
-        pipeline_for_profile(caps, features, TransformProfile::DEFAULT)
-    }
-
-    #[test]
-    fn vue3_omits_the_model_pass_when_lowering_found_no_model_ops() {
-        let pipeline = default_pipeline_for(LegacyCaps::VUE3, LoweringFeatures::EMPTY);
-        assert_eq!(pipeline, TRANSFORM_WITHOUT_MODEL);
-        assert_eq!(pipeline.passes.len(), 5);
-        assert_eq!(pipeline.group_count(), 5);
-        assert_eq!(pipeline.passes[4], hoist::DESC);
-        assert!(!pipeline.passes.iter().any(|pass| pass.name == vmodel::NAME));
-    }
-
-    #[test]
-    fn vue3_keeps_the_model_pass_when_diagnostics_may_need_it() {
-        let pipeline = default_pipeline_for(LegacyCaps::VUE3, with_model());
-        assert_eq!(pipeline, TRANSFORM);
-        assert_eq!(pipeline.passes.len(), 6);
-        assert_eq!(pipeline.group_count(), 6);
-        assert_eq!(pipeline.passes[4], vmodel::DESC);
-    }
-
-    #[test]
-    fn vue3_omits_static_analysis_when_dom_emit_cannot_use_it() {
-        let profile = TransformProfile::DEFAULT.without_static_analysis();
-
-        let without_model =
-            pipeline_for_profile(LegacyCaps::VUE3, LoweringFeatures::EMPTY, profile);
-        assert_eq!(without_model, TRANSFORM_WITHOUT_MODEL_OR_HOIST);
-        assert_eq!(without_model.passes.len(), 4);
-        assert_eq!(without_model.group_count(), 4);
-        assert!(
-            !without_model
-                .passes
-                .iter()
-                .any(|pass| pass.name == hoist::NAME)
-        );
-        assert!(
-            !without_model
-                .passes
-                .iter()
-                .any(|pass| pass.name == vmodel::NAME)
-        );
-
-        let with_model = pipeline_for_profile(LegacyCaps::VUE3, with_model(), profile);
-        assert_eq!(with_model, TRANSFORM_WITHOUT_HOIST);
-        assert_eq!(with_model.passes.len(), 5);
-        assert_eq!(with_model.group_count(), 5);
-        assert_eq!(with_model.passes[4], vmodel::DESC);
-        assert!(
-            !with_model
-                .passes
-                .iter()
-                .any(|pass| pass.name == hoist::NAME)
-        );
-    }
-
-    #[test]
-    fn vue2_legacy_sugar_still_prepends_the_selected_vue3_shape() {
-        let caps = LegacyCaps::for_version(VueVersion::V2);
-        let without_model = default_pipeline_for(caps, LoweringFeatures::EMPTY);
-        assert_eq!(without_model, LEGACY_WITHOUT_MODEL);
-        assert_eq!(without_model.passes.len(), 6);
-        assert_eq!(without_model.group_count(), 6);
-
-        let with_model = default_pipeline_for(caps, with_model());
-        assert_eq!(with_model, legacy::LEGACY);
-        assert_eq!(with_model.passes.len(), 7);
-        assert_eq!(with_model.group_count(), 7);
-    }
-
-    #[test]
-    fn vue2_legacy_sugar_preserves_the_dom_emit_static_analysis_choice() {
-        let caps = LegacyCaps::for_version(VueVersion::V2);
-        let profile = TransformProfile::DEFAULT.without_static_analysis();
-
-        let without_model = pipeline_for_profile(caps, LoweringFeatures::EMPTY, profile);
-        assert_eq!(without_model, LEGACY_WITHOUT_MODEL_OR_HOIST);
-        assert_eq!(without_model.passes.len(), 5);
-        assert_eq!(without_model.group_count(), 5);
-
-        let with_model = pipeline_for_profile(caps, with_model(), profile);
-        assert_eq!(with_model, LEGACY_WITHOUT_HOIST);
-        assert_eq!(with_model.passes.len(), 6);
-        assert_eq!(with_model.group_count(), 6);
-    }
-}
+mod tests;

--- a/crates/vize_s1_to_s2/src/pass/plan/tests.rs
+++ b/crates/vize_s1_to_s2/src/pass/plan/tests.rs
@@ -1,0 +1,229 @@
+//! The plan rule's suite: the static table against the rule, every
+//! plan against the landed pipeline's order, and one case per decline.
+
+use super::{
+    ALWAYS, FOR_OPS, IF_OPS, LEGACY_SUGAR, MODEL_BINDINGS, PLAN_COUNT, PLANS, SELECTABLE,
+    SLOT_CARRIERS, STATIC_ANALYSIS, mask_for, pipeline_for_profile, plan_for_mask,
+};
+use crate::lower::{LegacyCaps, LoweringFeatures, OpFamily};
+use crate::pass::{TRANSFORM, TRANSFORM_PASSES, TransformProfile, hoist, legacy, vmodel};
+use vize_s0::config::VueVersion;
+
+const EVERY: [OpFamily; 4] = [
+    OpFamily::If,
+    OpFamily::For,
+    OpFamily::SlotCarrier,
+    OpFamily::Model,
+];
+
+fn every_family() -> LoweringFeatures {
+    EVERY
+        .into_iter()
+        .fold(LoweringFeatures::EMPTY, LoweringFeatures::observing)
+}
+
+fn only(family: OpFamily) -> LoweringFeatures {
+    LoweringFeatures::EMPTY.observing(family)
+}
+
+fn default_pipeline_for(
+    caps: LegacyCaps,
+    features: LoweringFeatures,
+) -> vize_davinci::pass::Pipeline {
+    pipeline_for_profile(caps, features, TransformProfile::DEFAULT)
+}
+
+/// Assert a pipeline's pass names, in order. Spelled as a zip rather
+/// than a collected `Vec` so this suite owns no storage — the file is a
+/// separate module, so `davinci-storage-policy`'s `cfg(test)` masking
+/// does not reach it.
+#[track_caller]
+fn assert_names(pipeline: &vize_davinci::pass::Pipeline, expected: &[&str]) {
+    assert_eq!(
+        pipeline.passes.len(),
+        expected.len(),
+        "pass count: {:?} vs {expected:?}",
+        pipeline.passes.iter().map(|pass| pass.name),
+    );
+    for (index, (pass, name)) in pipeline.passes.iter().zip(expected).enumerate() {
+        assert_eq!(pass.name, *name, "pass {index}");
+    }
+}
+
+#[test]
+fn the_static_table_agrees_with_the_rule_for_every_mask() {
+    for (mask, plan) in PLANS.iter().enumerate() {
+        let computed = plan_for_mask(u8::try_from(mask).expect("PLAN_COUNT fits u8"));
+        assert_eq!(plan.len, computed.len, "mask {mask} length");
+        assert_eq!(
+            plan.passes[..plan.len],
+            computed.passes[..computed.len],
+            "mask {mask} passes"
+        );
+    }
+}
+
+/// Every plan is a subsequence of the landed table, never a
+/// reordering of it: declining a pass may not move another one.
+#[test]
+fn every_plan_is_a_subsequence_of_the_full_pipeline() {
+    for (mask, plan) in PLANS.iter().enumerate() {
+        let selected = &plan.passes[..plan.len];
+        // The Vue 2 sugar pass leads or is absent; it is not part of the
+        // Vue 3 table, so the order check below skips it.
+        assert!(
+            selected
+                .iter()
+                .skip(1)
+                .all(|pass| pass.name != legacy::DESC.name),
+            "mask {mask}: sugar may only lead",
+        );
+        let mut next = 0;
+        for pass in selected
+            .iter()
+            .filter(|pass| pass.name != legacy::DESC.name)
+        {
+            let found = TRANSFORM_PASSES[next..]
+                .iter()
+                .position(|full| full.name == pass.name)
+                .unwrap_or_else(|| panic!("mask {mask}: {} out of pipeline order", pass.name));
+            next += found + 1;
+        }
+    }
+}
+
+/// One walk per pass today, so a plan's group count is its length —
+/// the honest reading of "declining a pass saves a walk".
+#[test]
+fn a_plans_walk_count_is_its_pass_count() {
+    for (mask, plan) in PLANS.iter().enumerate() {
+        let pipeline = plan.pipeline();
+        assert_eq!(pipeline.passes.len(), plan.len, "mask {mask} length");
+        assert_eq!(pipeline.group_count(), plan.len, "mask {mask} groups");
+    }
+}
+
+#[test]
+fn vue3_with_every_family_is_the_landed_six_pass_table() {
+    let pipeline = default_pipeline_for(LegacyCaps::VUE3, every_family());
+    assert_eq!(pipeline, TRANSFORM);
+    assert_eq!(pipeline.passes.len(), 6);
+    assert_eq!(pipeline.group_count(), 6);
+}
+
+#[test]
+fn vue3_omits_the_model_pass_when_lowering_found_no_model_ops() {
+    let features = every_family();
+    let pipeline = default_pipeline_for(
+        LegacyCaps::VUE3,
+        only(OpFamily::If)
+            .observing(OpFamily::For)
+            .observing(OpFamily::SlotCarrier),
+    );
+    assert!(features.has_model_bindings());
+    assert_names(
+        &pipeline,
+        &["v-if", "v-for", "v-slot", ALWAYS.name, hoist::NAME],
+    );
+    assert!(!pipeline.passes.iter().any(|pass| pass.name == vmodel::NAME));
+}
+
+#[test]
+fn vue3_keeps_the_model_pass_when_diagnostics_may_need_it() {
+    let pipeline = default_pipeline_for(LegacyCaps::VUE3, every_family());
+    assert_eq!(pipeline.passes[4], vmodel::DESC);
+}
+
+/// The headline of this installment: an artifact with none of the
+/// three structural families pays neither their walks nor the model
+/// pass's — two walks where the landed table charged six.
+#[test]
+fn vue3_omits_every_structural_pass_when_no_family_was_lowered() {
+    let pipeline = default_pipeline_for(LegacyCaps::VUE3, LoweringFeatures::EMPTY);
+    assert_names(&pipeline, &[ALWAYS.name, hoist::NAME]);
+    assert_eq!(pipeline.group_count(), 2);
+}
+
+#[test]
+fn each_structural_family_buys_back_exactly_its_own_pass() {
+    let cases = [
+        (only(OpFamily::If), "v-if"),
+        (only(OpFamily::For), "v-for"),
+        (only(OpFamily::SlotCarrier), "v-slot"),
+    ];
+    for (features, expected) in cases {
+        let pipeline = default_pipeline_for(LegacyCaps::VUE3, features);
+        assert_names(&pipeline, &[expected, ALWAYS.name, hoist::NAME]);
+    }
+}
+
+#[test]
+fn vue3_omits_static_analysis_when_dom_emit_cannot_use_it() {
+    let profile = TransformProfile::DEFAULT.without_static_analysis();
+    let pipeline = pipeline_for_profile(LegacyCaps::VUE3, every_family(), profile);
+    assert_eq!(pipeline.passes.len(), 5);
+    assert!(!pipeline.passes.iter().any(|pass| pass.name == hoist::NAME));
+    assert_eq!(pipeline.passes[4], vmodel::DESC);
+
+    let bare = pipeline_for_profile(LegacyCaps::VUE3, LoweringFeatures::EMPTY, profile);
+    assert_names(&bare, &[ALWAYS.name]);
+    assert_eq!(bare.group_count(), 1);
+}
+
+#[test]
+fn vue2_legacy_sugar_still_prepends_the_selected_vue3_shape() {
+    let caps = LegacyCaps::for_version(VueVersion::V2);
+    let full = default_pipeline_for(caps, every_family());
+    assert_eq!(full.passes.len(), 7);
+    assert_eq!(full.group_count(), 7);
+    assert_eq!(full.passes[0], legacy::DESC);
+
+    let bare = default_pipeline_for(caps, LoweringFeatures::EMPTY);
+    assert_names(&bare, &[legacy::DESC.name, ALWAYS.name, hoist::NAME]);
+}
+
+#[test]
+fn vue2_legacy_sugar_preserves_the_dom_emit_static_analysis_choice() {
+    let caps = LegacyCaps::for_version(VueVersion::V2);
+    let profile = TransformProfile::DEFAULT.without_static_analysis();
+
+    let full = pipeline_for_profile(caps, every_family(), profile);
+    assert_eq!(full.passes.len(), 6);
+    assert!(!full.passes.iter().any(|pass| pass.name == hoist::NAME));
+
+    let bare = pipeline_for_profile(caps, LoweringFeatures::EMPTY, profile);
+    assert_names(&bare, &[legacy::DESC.name, ALWAYS.name]);
+}
+
+#[test]
+fn the_mask_reads_one_bit_per_selectable_pass() {
+    assert_eq!(SELECTABLE.len(), 6);
+    assert_eq!(PLAN_COUNT, 64);
+    let bits = [
+        LEGACY_SUGAR,
+        IF_OPS,
+        FOR_OPS,
+        SLOT_CARRIERS,
+        MODEL_BINDINGS,
+        STATIC_ANALYSIS,
+    ];
+    for (index, (_, bit)) in SELECTABLE.iter().enumerate() {
+        assert_eq!(*bit, bits[index], "SELECTABLE order must match the bits");
+    }
+    assert_eq!(
+        mask_for(
+            LegacyCaps::for_version(VueVersion::V2),
+            every_family(),
+            TransformProfile::DEFAULT
+        ),
+        u8::try_from(PLAN_COUNT - 1).expect("six bits"),
+    );
+    assert_eq!(
+        mask_for(
+            LegacyCaps::VUE3,
+            LoweringFeatures::EMPTY,
+            TransformProfile::DEFAULT.without_static_analysis()
+        ),
+        0
+    );
+}

--- a/crates/vize_s1_to_s2/tests/emit_budget_observer.rs
+++ b/crates/vize_s1_to_s2/tests/emit_budget_observer.rs
@@ -18,14 +18,42 @@ struct TraversalBudget {
     visits: u32,
 }
 
-/// fixture name -> current S2 DOM emit-only walks and op visits.
-const S2_DOM_EMIT_COUNTS: [(&str, u32, u32); 6] = [
-    ("small", 1, 5),
-    ("medium", 1, 33),
-    ("large", 1, 54),
-    ("stress-deep", 1, 72),
-    ("stress-wide", 1, 2),
-    ("stress-interp", 1, 201),
+/// One fixture's pinned S2 DOM counts.
+#[derive(Debug, Clone, Copy)]
+struct EmitCount {
+    walks: u32,
+    visits: u32,
+    transform_walks: u32,
+}
+
+/// fixture name -> current S2 DOM emit-only walks and op visits, and the
+/// transform walks the artifact's own op families buy.
+///
+/// The transform column is per fixture rather than a constant because the
+/// planner declines a mandatory pass whose op family the lowering never
+/// built (`lower::features`). Two walks — the text pass and the static
+/// analysis — is the floor every artifact pays; each structural family
+/// present adds its own:
+///
+/// | fixture       | families present                      | transform walks |
+/// | ------------- | ------------------------------------- | --------------- |
+/// | small         | none                                  | 2               |
+/// | medium        | components (`el-row`, `svg-icon`, ...)| 3               |
+/// | large         | `v-if`, `v-for`, components, `<slot>` | 5               |
+/// | stress-deep   | `v-if`                                | 3               |
+/// | stress-wide   | none                                  | 2               |
+/// | stress-interp | none                                  | 2               |
+///
+/// `medium` is the reminder that a slot carrier is any non-native tag,
+/// kebab-case included — it has no `v-slot` anywhere and still owes the
+/// slot pass its grouping walk.
+const S2_DOM_EMIT_COUNTS: [(&str, u32, u32, u32); 6] = [
+    ("small", 1, 5, 2),
+    ("medium", 1, 33, 3),
+    ("large", 1, 54, 5),
+    ("stress-deep", 1, 72, 3),
+    ("stress-wide", 1, 2, 2),
+    ("stress-interp", 1, 201, 2),
 ];
 
 #[test]
@@ -50,12 +78,12 @@ fn observed_dom_emit_keeps_output_and_walk_budget() {
             fixture.name
         );
         assert_eq!(
-            observed.budget.transform.walks, 5,
+            observed.budget.transform.walks, expected.transform_walks,
             "{} transform walks",
             fixture.name
         );
         assert_eq!(
-            observed.budget.transform.passes, 5,
+            observed.budget.transform.passes, expected.transform_walks,
             "{} transform passes",
             fixture.name
         );
@@ -134,10 +162,11 @@ fn model_bindings_keep_the_model_diagnostic_pass_in_the_emit_budget() {
         plain.assembled(),
         "the profiling observer must not change model output"
     );
-    assert_eq!(observed.budget.transform.walks, 6);
-    assert_eq!(observed.budget.transform.passes, 6);
+    // `v-model` alone: the model pass rejoins the two-walk floor.
+    assert_eq!(observed.budget.transform.walks, 3);
+    assert_eq!(observed.budget.transform.passes, 3);
     assert_eq!(observed.budget.emit_walks, 1);
-    assert_eq!(observed.budget.total_walks(), 7);
+    assert_eq!(observed.budget.total_walks(), 4);
 }
 
 #[test]
@@ -170,10 +199,11 @@ fn disabled_static_hoist_skips_the_optional_analysis_walk() {
         observed.emit.preamble.len(),
         "static-hoist-disabled preamble must not append hoist declarations"
     );
-    assert_eq!(observed.budget.transform.walks, 4);
-    assert_eq!(observed.budget.transform.passes, 4);
+    // No structural family, no model, no analysis: the text pass alone.
+    assert_eq!(observed.budget.transform.walks, 1);
+    assert_eq!(observed.budget.transform.passes, 1);
     assert_eq!(observed.budget.emit_walks, 1);
-    assert_eq!(observed.budget.total_walks(), 5);
+    assert_eq!(observed.budget.total_walks(), 2);
 }
 
 #[test]
@@ -192,19 +222,22 @@ fn disabled_static_hoist_keeps_model_diagnostics_when_models_exist() {
     )
     .expect("observed model emit succeeds without static hoist");
 
-    assert_eq!(observed.budget.transform.walks, 5);
-    assert_eq!(observed.budget.transform.passes, 5);
+    // The analysis is declined by the option, the model pass is not:
+    // declining a pass may never decline a diagnostic.
+    assert_eq!(observed.budget.transform.walks, 2);
+    assert_eq!(observed.budget.transform.passes, 2);
     assert_eq!(observed.budget.emit_walks, 1);
-    assert_eq!(observed.budget.total_walks(), 6);
+    assert_eq!(observed.budget.total_walks(), 3);
 }
 
-fn s2_dom_emit_count(fixture: &str) -> TraversalBudget {
+fn s2_dom_emit_count(fixture: &str) -> EmitCount {
     S2_DOM_EMIT_COUNTS
         .iter()
-        .find(|(name, _, _)| *name == fixture)
-        .map(|(_, walks, visits)| TraversalBudget {
+        .find(|(name, ..)| *name == fixture)
+        .map(|(_, walks, visits, transform_walks)| EmitCount {
             walks: *walks,
             visits: *visits,
+            transform_walks: *transform_walks,
         })
         .unwrap_or_else(|| panic!("{fixture} has no pinned S2 DOM emit count"))
 }

--- a/crates/vize_s1_to_s2/tests/hoist_pass_snapshot.rs
+++ b/crates/vize_s1_to_s2/tests/hoist_pass_snapshot.rs
@@ -43,11 +43,13 @@ fn the_levels_fixture_snapshots_the_post_pass_folio() {
         // mutates nothing.
         assert_folio_snapshot!(*folio);
 
-        // Supplements: five model-free walks (four barriers plus the
-        // fusable analysis singleton).
+        // Supplements: two walks. The fixture builds none of the
+        // structural families and no model, so the planner
+        // (`lower::features`) declines those four barriers and the run
+        // is the text pass plus the fusable analysis singleton.
         assert_eq!(
             budget.print_to_string(FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=2\npasses=2\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         // The lattice, row by row: the section is dynamic (its children
         // are), the h1 subtree fully static with hoistable props, the

--- a/crates/vize_s1_to_s2/tests/legacy_pass.rs
+++ b/crates/vize_s1_to_s2/tests/legacy_pass.rs
@@ -31,9 +31,12 @@ fn vue3_model_free_legacy_spellings_skip_the_model_pass() {
              \n"
         );
         assert_eq!(lowered.caps, LegacyCaps::VUE3);
+        // `Comp` is a slot carrier, so the slot pass is planned; the
+        // `.sync` spelling lowers to no `ui.model`, so the model pass is
+        // not. Three walks: slot, text, analysis.
         assert_eq!(
             Folio::print_to_string(budget, FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=3\npasses=3\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
     });
     assert_transformed_sound(source, "vue3-sync-inert-pass");
@@ -54,9 +57,10 @@ fn vue2_expands_sync_into_bind_plus_update_listener() {
              \x20 ui.on name=\"update:title\" handler=js(\"$event => ((heading) = $event)\" @6:27) @6:27\n\
              \n"
         );
+        // The Vue 2 sugar pass leads the same three.
         assert_eq!(
             Folio::print_to_string(budget, FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=6\npasses=6\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=4\npasses=4\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         assert_eq!(u64::from(lowered.op_count), folio.op_count());
     });

--- a/crates/vize_s1_to_s2/tests/lowering_features.rs
+++ b/crates/vize_s1_to_s2/tests/lowering_features.rs
@@ -1,0 +1,240 @@
+//! The behavioural pin for `lower::features` and the plans it selects.
+//!
+//! Two claims are load-bearing and neither is checkable by reading the
+//! planner, so both are asserted against real lowerings here:
+//!
+//! 1. **The bit is set whenever the op is built**, including by the paths
+//!    that build it while *reporting an error*. An unset bit silently
+//!    retires a mandatory pass — a lost fact or a lost diagnostic, not a
+//!    slow compile. Every family gets a well-formed template and, where
+//!    one exists, a malformed spelling that still mints the op: those are
+//!    the cases a provenance-rule-name derivation got wrong.
+//! 2. **Declining a pass costs no product.** For each family-free template
+//!    the planned run is compared against the same artifact re-run with the
+//!    features widened to every family, which forces the full table. The
+//!    two must agree on the artifact, its diagnostics, its provenance and
+//!    every fact table — while the pass counts differ, so the comparison
+//!    cannot pass vacuously.
+
+mod support;
+
+use vize_davinci::diagnostic::Diagnostic;
+use vize_davinci::folio::{Folio, FolioMode};
+use vize_davinci::pass::BudgetObserver;
+use vize_s0::Allocator;
+use vize_s1::parse;
+use vize_s1_to_s2::pass::{S2Facts, run_transform};
+use vize_s1_to_s2::{LegacyCaps, LoweringFeatures, OpFamily, lower, lower_with_caps};
+use vize_s2::folio::DisegnoFolio;
+
+/// One template per family, plus the family-free controls the planner is
+/// supposed to save walks on.
+const FAMILY_FREE: &[(&str, &str)] = &[
+    ("plain element", "<div class=\"a\">text</div>"),
+    ("nested elements", "<section><p>a</p><p>b</p></section>"),
+    ("interpolation", "<p>{{ msg }} tail</p>"),
+    ("bind and on", "<button :id=\"id\" @click=\"go\">x</button>"),
+    ("comment", "<div><!-- note --><span>x</span></div>"),
+    ("show directive", "<div v-show=\"open\">x</div>"),
+    ("html directive", "<div v-html=\"raw\"></div>"),
+];
+
+fn features_of(source: &str) -> LoweringFeatures {
+    let allocator = Allocator::new();
+    let (tree, errors) = parse(&allocator, source);
+    lower(&allocator, &tree, &errors).features
+}
+
+#[test]
+fn each_family_sets_exactly_its_own_bit() {
+    let cases: &[(&str, &str, fn(LoweringFeatures) -> bool)] = &[
+        (
+            "v-if",
+            "<div v-if=\"ok\">y</div>",
+            LoweringFeatures::has_if_ops,
+        ),
+        (
+            "v-else chain",
+            "<div v-if=\"ok\">y</div><div v-else>n</div>",
+            LoweringFeatures::has_if_ops,
+        ),
+        (
+            "v-for",
+            "<li v-for=\"item in items\">{{ item }}</li>",
+            LoweringFeatures::has_for_ops,
+        ),
+        (
+            "component",
+            "<MyThing>child</MyThing>",
+            LoweringFeatures::has_slot_carriers,
+        ),
+        (
+            "slot outlet",
+            "<slot name=\"head\"><b>fallback</b></slot>",
+            LoweringFeatures::has_slot_carriers,
+        ),
+        (
+            "v-slot on a template",
+            "<MyThing><template #head>h</template></MyThing>",
+            LoweringFeatures::has_slot_carriers,
+        ),
+        (
+            "misplaced v-slot on a plain element",
+            "<div v-slot:head>h</div>",
+            LoweringFeatures::has_slot_carriers,
+        ),
+        (
+            "v-model",
+            "<input v-model=\"text\" />",
+            LoweringFeatures::has_model_bindings,
+        ),
+        // The malformed spellings are the reason the bit is set at the op
+        // and not read off a provenance rule name: each of these lowers
+        // under an `error.*` rule and still leaves its op in the tree, so
+        // the pass that reads that op is still owed its walk.
+        (
+            "undecomposable v-for",
+            "<p v-for=\"items\">kept</p>",
+            LoweringFeatures::has_for_ops,
+        ),
+        (
+            "v-if with no expression",
+            "<p v-if>kept</p>",
+            LoweringFeatures::has_if_ops,
+        ),
+    ];
+
+    for (name, source, holds) in cases {
+        let features = features_of(source);
+        assert!(
+            holds(features),
+            "{name}: the lowering built the family but set no bit — \
+             an op construction site is missing its `cx.observe`",
+        );
+    }
+}
+
+/// The boundary the positive cases cannot show: a spelling that errors
+/// *without* minting the op leaves the bit clear, and should — declining
+/// the pass there costs nothing, because there is no op to visit.
+#[test]
+fn an_erroring_spelling_that_mints_no_op_leaves_the_bit_clear() {
+    // Both fall back to a plain element: the diagnostic is the
+    // lowering's own and no region op survives to be visited.
+    for source in ["<p v-for>kept</p>", "<p v-else>kept</p>"] {
+        assert_eq!(
+            features_of(source),
+            LoweringFeatures::EMPTY,
+            "{source} mints no region op",
+        );
+    }
+
+    // The asymmetry worth knowing: `v-if` with no expression *does* mint
+    // its `ui.if` (the branch is kept under the escape), so unlike the
+    // two above it keeps the pass.
+    assert!(features_of("<p v-if>kept</p>").has_if_ops());
+}
+
+#[test]
+fn a_family_free_template_sets_no_bit() {
+    for (name, source) in FAMILY_FREE {
+        let features = features_of(source);
+        assert_eq!(
+            features,
+            LoweringFeatures::EMPTY,
+            "{name} should reach the planner with no family claimed",
+        );
+    }
+}
+
+/// The products a run is allowed to be judged by: the artifact itself,
+/// every user-visible channel, and the size of each fact table.
+#[derive(Debug, PartialEq, Eq)]
+struct Products {
+    folio: String,
+    diagnostics: Vec<String>,
+    provenance: usize,
+    if_facts: usize,
+    for_facts: usize,
+    slot_facts: usize,
+    text_facts: usize,
+    model_faults: usize,
+    static_facts: usize,
+}
+
+fn products(
+    folio: &DisegnoFolio,
+    diagnostics: &[Diagnostic],
+    provenance: usize,
+    facts: &S2Facts,
+) -> Products {
+    Products {
+        folio: folio.print_to_string(FolioMode::Full).as_str().to_owned(),
+        diagnostics: diagnostics
+            .iter()
+            .map(|diagnostic| format!("{diagnostic:?}"))
+            .collect(),
+        provenance,
+        if_facts: facts.if_facts.len(),
+        for_facts: facts.for_facts.len(),
+        slot_facts: facts.slot_facts.len(),
+        text_facts: facts.text_facts.len(),
+        model_faults: facts.model_faults.len(),
+        static_facts: facts.static_facts.len(),
+    }
+}
+
+/// Run `source` through the pipeline, optionally widening the features
+/// first so every mandatory pass is planned.
+fn run(source: &str, force_every_pass: bool) -> (Products, u32) {
+    let allocator = Allocator::new();
+    let (tree, errors) = parse(&allocator, source);
+    let mut lowered = lower_with_caps(&allocator, &tree, &errors, LegacyCaps::VUE3);
+    if force_every_pass {
+        lowered.features = [
+            OpFamily::If,
+            OpFamily::For,
+            OpFamily::SlotCarrier,
+            OpFamily::Model,
+        ]
+        .into_iter()
+        .fold(LoweringFeatures::EMPTY, LoweringFeatures::observing);
+    }
+    let mut budget = BudgetObserver::new();
+    let facts = run_transform(&mut lowered, &mut budget);
+    let folio = DisegnoFolio::of(&lowered.root.ops);
+    let provenance = lowered.provenance.len();
+    (
+        products(&folio, &lowered.diagnostics, provenance, &facts),
+        budget.passes,
+    )
+}
+
+#[test]
+fn declining_a_pass_changes_no_product() {
+    for (name, source) in FAMILY_FREE {
+        let (planned, planned_passes) = run(source, false);
+        let (forced, forced_passes) = run(source, true);
+        assert_eq!(
+            planned, forced,
+            "{name}: the planned run and the full table disagreed",
+        );
+        assert!(
+            planned_passes < forced_passes,
+            "{name}: the planner declined nothing ({planned_passes} of {forced_passes} passes), \
+             so the comparison proves nothing",
+        );
+        assert_eq!(
+            planned_passes, 2,
+            "{name}: a family-free artifact should plan the text pass and the analysis pass alone",
+        );
+        assert_eq!(forced_passes, 6, "{name}: the full table is six passes");
+    }
+}
+
+/// The headline measurement, kept beside the claim it supports.
+#[test]
+fn a_family_free_template_plans_two_passes_not_six() {
+    let (_, passes) = run("<div class=\"a\"><span>b</span></div>", false);
+    assert_eq!(passes, 2);
+}

--- a/crates/vize_s1_to_s2/tests/text_pass_snapshot.rs
+++ b/crates/vize_s1_to_s2/tests/text_pass_snapshot.rs
@@ -36,10 +36,11 @@ fn the_merge_fixture_snapshots_the_post_pass_folio() {
         // comment is a run boundary.
         assert_folio_snapshot!(*folio);
 
-        // Supplements: the model-free plan's walk accounting.
+        // Supplements: the planned walk accounting. The fixture is text
+        // and comments only, so the plan is this pass plus the analysis.
         assert_eq!(
             budget.print_to_string(FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=2\npasses=2\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         // Two compounds, five and two parts, all validated (the pass
         // count-matches the recorded table).

--- a/crates/vize_s1_to_s2/tests/vfor_pass_snapshot.rs
+++ b/crates/vize_s1_to_s2/tests/vfor_pass_snapshot.rs
@@ -37,11 +37,13 @@ fn the_loops_fixture_snapshots_the_post_pass_folio() {
         // The oracle: the full normalized folio after the pipeline ran.
         assert_folio_snapshot!(*folio);
 
-        // Supplements: the model-free plan's walk accounting through
-        // the budget observer's own derived page.
+        // Supplements: the planned walk accounting through the budget
+        // observer's own derived page. The fixture builds `v-if` and
+        // `v-for` but no slot carrier and no model, so the plan is those
+        // two plus the text pass and the analysis.
         assert_eq!(
             budget.print_to_string(FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=4\npasses=4\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         // Three loops, consumed in document order with fresh tags: the
         // keyed `li`, the destructuring `<template v-for>`, the

--- a/crates/vize_s1_to_s2/tests/vif_pass.rs
+++ b/crates/vize_s1_to_s2/tests/vif_pass.rs
@@ -193,9 +193,10 @@ fn an_unwrapped_single_child_keeps_its_own_key() {
 
 #[test]
 fn the_pipeline_reports_one_walk_per_barrier_pass() {
-    // Four mandatory barriers plus the series-6 fusable singleton
-    // (v-if, v-for, v-slot, text, hoist-static): five walks for an
-    // artifact with no ui.model bindings.
+    // One walk per planned pass, still: the artifact builds a `ui.if`
+    // and nothing else, so the plan is the v-if barrier, the text
+    // barrier and the series-6 fusable singleton — three walks, and no
+    // group holds two passes.
     with_transformed(r#"<div v-if="a">x</div>"#, |_, _, _, budget| {
         assert_eq!(
             vize_davinci::folio::Folio::print_to_string(
@@ -203,9 +204,19 @@ fn the_pipeline_reports_one_walk_per_barrier_pass() {
                 vize_davinci::folio::FolioMode::Full
             )
             .as_str(),
-            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=3\npasses=3\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
     });
+
+    // The law is walks == passes, not a fixed number: an artifact with
+    // every family pays six, and still one walk each.
+    with_transformed(
+        r#"<Comp v-if="a"><template #s="p">{{ p }}</template></Comp><input v-else v-model="m" v-for="m in ms">"#,
+        |_, _, _, budget| {
+            assert_eq!(budget.walks, budget.passes);
+            assert_eq!(budget.walks, 6);
+        },
+    );
 }
 
 #[test]

--- a/crates/vize_s1_to_s2/tests/vif_pass_snapshot.rs
+++ b/crates/vize_s1_to_s2/tests/vif_pass_snapshot.rs
@@ -37,11 +37,13 @@ fn the_chain_fixture_snapshots_the_post_pass_folio() {
         // carrier op for the wrapper's attributes.
         assert_folio_snapshot!(*folio);
 
-        // Supplements: the model-free plan's walk accounting through
-        // the budget observer's own derived page.
+        // Supplements: the planned walk accounting through the budget
+        // observer's own derived page. The fixture builds `ui.if` ops and
+        // slot carriers but no `ui.for` and no model, so the v-for pass
+        // is the one the plan declines.
         assert_eq!(
             budget.print_to_string(FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=4\npasses=4\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         // One fact entry (the chain's `ui.if`), keys on branches 0 and 2.
         let entries = facts.if_facts.sorted_entries();

--- a/crates/vize_s1_to_s2/tests/vmodel_pass_snapshot.rs
+++ b/crates/vize_s1_to_s2/tests/vmodel_pass_snapshot.rs
@@ -37,11 +37,13 @@ fn the_bindings_fixture_snapshots_the_post_pass_folio() {
         // contracts stand unexpanded.
         assert_folio_snapshot!(*folio);
 
-        // Supplements: five barrier passes plus the fusable analysis
-        // singleton, six walks.
+        // Supplements: the model pass and the slot carriers' pass are
+        // both bought by this fixture; `v-if` and `v-for` are not, so the
+        // plan is four walks — three barriers plus the fusable analysis
+        // singleton.
         assert_eq!(
             budget.print_to_string(FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=6\npasses=6\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=4\npasses=4\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         // Both models are valid: the fault table is empty, and the only
         // diagnostics are none at all.

--- a/crates/vize_s1_to_s2/tests/vslot_pass_snapshot.rs
+++ b/crates/vize_s1_to_s2/tests/vslot_pass_snapshot.rs
@@ -38,11 +38,13 @@ fn the_groups_fixture_snapshots_the_post_pass_folio() {
         // The oracle: the full normalized folio after the pipeline ran.
         assert_folio_snapshot!(*folio);
 
-        // Supplements: the model-free plan's walk accounting through
-        // the budget observer's own derived page.
+        // Supplements: the planned walk accounting through the budget
+        // observer's own derived page. Slot carriers are what this
+        // fixture buys; with no `v-if`, no `v-for` and no model the plan
+        // is three walks.
         assert_eq!(
             budget.print_to_string(FolioMode::Full).as_str(),
-            "[budget-observer]\nwalks=5\npasses=5\nanalyses=0\npipelines=1\nfailures=0\n\n"
+            "[budget-observer]\nwalks=3\npasses=3\nanalyses=0\npipelines=1\nfailures=0\n\n"
         );
         // Three components grouped in document order: Card (pattern
         // params slot, modifier-folded slot, implicit default), Panel

--- a/davinci-road/open-questions.md
+++ b/davinci-road/open-questions.md
@@ -84,7 +84,7 @@ that uses every family still pays six.
 
 One measured correction to the derivation: the first cut read the family
 bits off provenance rule names, which is wrong. Provenance records
-*decisions*, and a failed decision records a different rule while still
+_decisions_, and a failed decision records a different rule while still
 leaving its op behind — `<p v-for="items">` records
 `error.v-for-malformed` and keeps its `ui.for`, so the pass that reads
 that op was skipped and its facts lost. `vfor_pass.rs`'s

--- a/davinci-road/open-questions.md
+++ b/davinci-road/open-questions.md
@@ -57,6 +57,40 @@ artifacts also skip the `v-model` diagnostic pass, dropping the observed
 build path to 7 walks (1 pre-S2 + 6 S2 observer). P2-12b still needs
 parse-to-S2 and S2 transform fusion to reach the phase target.
 
+Prototype note (2026-09-07, second): **most of the transform's walks were
+not fusion's to save.** Each mandatory S2 pass consumes exactly one op
+family, so against an artifact whose family the lowering never built it
+walks the whole tree to publish an empty fact table and raise no
+diagnostic. The lowering now records the families it built
+(`vize_s1_to_s2::lower::features`, one bit set where the op is minted) and
+the planner drops those passes. Ladder evidence, transform walks per
+fixture: small 5 -> 2, medium 5 -> 3, large 5 -> 5, stress-deep 5 -> 3,
+stress-wide 5 -> 2, stress-interp 5 -> 2; the profiled build path falls
+from 7 walks to 4/5/7/5/4/4. Four corpus lanes (default, prefixed,
+bindings over 12,062 hydrated templates; the lowering lane over 12,215
+files) stay at zero divergence, and `tests/lowering_features.rs` pins the
+stronger claim per artifact: the planned run and the forced six-pass table
+agree on the artifact, its diagnostics, its provenance and every fact
+table.
+
+This narrows the fusion question rather than answering it. What remains
+above the one-walk target is (a) the pre-S2 template walk, which
+parse-to-S2 removes, and (b) the passes an artifact genuinely owes —
+`v-if`'s sibling lookahead and `v-slot`'s slot collection are the two the
+task contract already names as region-local, so those are the ones real
+fusion has to earn. **Skipping is not fusing**, and the walk counts above
+should not be read as evidence that fusion is unnecessary: an artifact
+that uses every family still pays six.
+
+One measured correction to the derivation: the first cut read the family
+bits off provenance rule names, which is wrong. Provenance records
+*decisions*, and a failed decision records a different rule while still
+leaving its op behind — `<p v-for="items">` records
+`error.v-for-malformed` and keeps its `ui.for`, so the pass that reads
+that op was skipped and its facts lost. `vfor_pass.rs`'s
+`an_undecomposable_value_is_pessimally_pending` caught it. The bits are
+set at the op's construction site instead.
+
 ## Orphan analyses: productize or cut
 
 `RaceConditionTracker` and `ProvideInjectTracker` have zero consumers;


### PR DESCRIPTION
## What

Each mandatory S2 pass consumes exactly one op family, so against an artifact whose family the lowering never built it walks the whole tree to publish an empty fact table and raise no diagnostic. `v-model` (#5866) and the static analysis (#5869) already declined on that argument; this extends it to the three structural passes, and replaces the hand-written plan table with the rule it was enumerating.

The lowering records the families it built at the op's own construction site (`lower::features`, one bit per family) and `pass::plan` turns the bits into a mask over `SELECTABLE`. The 8 named `const` pipelines became 64 plans computed once by a `const fn`; the compile-time pins stay, because the `const _: () = assert!(...)` items evaluate that same `const fn`.

## Why not provenance

The first cut derived the bits from provenance rule names, which is **wrong**, and a committed test says so. Provenance records *decisions*, and a failed decision records a different rule while still leaving its op behind: `<p v-for="items">` cannot split under Vue's grammar, so `lower/forop.rs` records `error.v-for-malformed` and still keeps its `ui.for`. `vfor_pass.rs`'s `an_undecomposable_value_is_pessimally_pending` caught it — the pass was skipped and its `ForFacts` lost.

## Measurement

Ladder transform walks, before → after:

| fixture | families present | before | after |
| --- | --- | --- | --- |
| small | none | 5 | **2** |
| medium | components | 5 | **3** |
| large | `v-if`, `v-for`, components, `<slot>` | 5 | 5 |
| stress-deep | `v-if` | 5 | **3** |
| stress-wide | none | 5 | **2** |
| stress-interp | none | 5 | **2** |

The profiled DOM build path (`davinci_s2_build_profile`) falls from 7 walks to 4/5/7/5/4/4. Recorded in `open-questions.md` under "Fusion depth for the build path" — with the caveat that **skipping is not fusing**: an artifact using every family still pays six, so this narrows the P2-12b question rather than answering it.

## Evidence that declining costs no product

**`davinci_s2_transform_corpus` (`vize_atelier_core`, `--features davinci-differential`) is the lane that covers this change** — it runs the genuine legacy parse+transform against the S2 lowering+passes in-crate. Over **12,017 compared corpus templates** this branch and its parent (`485ab8297`) produce:

- the **same 11 divergences**, all pre-existing (see below), and
- **byte-identical counters** — every `if_ops` / `branches` / `for_ops` / slot group / text unit / text part / hoist fact / surface count.

So the whole published fact output of the S2 transform is unchanged across the corpus.

Per-artifact, `tests/lowering_features.rs` proves the stronger claim directly: the planned run and the same artifact re-run with its features widened to every family agree on the artifact, its diagnostics, its provenance and every fact table — while the pass counts differ (2 vs 6), so the comparison cannot pass vacuously. It also pins the malformed spellings that mint an op, and the boundary ones that do not (`<p v-for>`, `<p v-else>` fall back to a plain element; `<p v-if>` does mint its `ui.if`).

The **text pass stays unconditional on purpose**: besides consuming compounds it asserts the adjacency law over every region, and that check is owed precisely by the artifacts a "no compound recorded" bit would have declined it for. Moving that law to the S2 verifier is its own installment.

### Correction to an earlier version of this description

An earlier draft cited the three `davinci_dom_corpus*` lanes as evidence. **They cannot support that claim, and I withdraw it.** Their "old lane" side calls `vize_atelier_dom::compile_template*`, which since the P2-11 production switch routes through the S2 emitter itself — so both sides of those differentials are S2. Measured: renaming `Helper::CreateElementVNode`'s alias to `_PROBE_createElementVNode` — which changes the generated code of essentially every element-bearing template — still leaves `davinci_dom_corpus` reporting `compared=12062 divergences=0`. I am filing that separately; it is not caused by this PR, and `davinci_dom_corpus` is a required `clippy-and-test` gate today.

## Notes for review

- `plan.rs` and `cx.rs` are split to stay under the 350-line budget. The `cx` split moves the span-recovery helpers to `lower/cx/span.rs` with no call-site change; `element_end` / `child_end` had no user outside that file and are now private.
- Every walk-count pin in the suite moved from a single number to a per-fixture table, which is what makes the numbers legible rather than magic.
- Gates run locally: `cargo test --workspace` (only pre-existing environment failures — the `pkl` server and the "workspace Vue package missing" CLI tests, both reproduced on the parent commit), clippy on the changed crates, `davinci-storage-policy`, `source-file-lengths`, `davinci-budgets`, `davinci-traversal-budgets`, `davinci-assertion-lint`, `davinci-v-on-storage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
