### PR TITLE
fix(lsp): dedupe auto-insert configuration sections

### DIFF
--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -240,7 +240,6 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
                         ["vize.autoInsert.bracketSpacing"],
                         ["vize.autoInsert.autoCreateQuotes"],
                         ["vize.autoInsert.autoClosingTags"],
-                        ["vize.autoInsert.autoClosingTags"],
                         ["vize.autoInsert.dotValue"]
                     ]
                 }

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -129,7 +129,6 @@ fn auto_insertion_advertises_positional_vscode_configuration_sections() {
                     ["vize.autoInsert.bracketSpacing"],
                     ["vize.autoInsert.autoCreateQuotes"],
                     ["vize.autoInsert.autoClosingTags"],
-                    ["vize.autoInsert.autoClosingTags"],
                     ["vize.autoInsert.dotValue"]
                 ]
             }

--- a/crates/vize_maestro/src/server/capabilities/tests.rs
+++ b/crates/vize_maestro/src/server/capabilities/tests.rs
@@ -204,6 +204,43 @@ fn all_features_skip_unimplemented_providers_and_keep_implemented_ones() {
 }
 
 #[test]
+fn auto_insert_experimental_sections_are_unique_and_complete() {
+    let experimental = server_capabilities(all_features())
+        .experimental
+        .expect("auto insert should advertise experimental capabilities");
+    let sections = experimental
+        .pointer("/autoInsertionProvider/configurationSections")
+        .and_then(serde_json::Value::as_array)
+        .expect("auto insert should advertise configuration sections");
+
+    let section_names: Vec<&str> = sections
+        .iter()
+        .map(|section| {
+            section
+                .as_array()
+                .and_then(|section| section.first())
+                .and_then(serde_json::Value::as_str)
+                .expect("configuration section should contain one setting key")
+        })
+        .collect();
+
+    assert_eq!(
+        section_names,
+        [
+            "vize.autoInsert.bracketSpacing",
+            "vize.autoInsert.autoCreateQuotes",
+            "vize.autoInsert.autoClosingTags",
+            "vize.autoInsert.dotValue",
+        ]
+    );
+
+    let mut unique_names = section_names.clone();
+    unique_names.sort_unstable();
+    unique_names.dedup();
+    assert_eq!(unique_names.len(), section_names.len());
+}
+
+#[test]
 fn file_rename_registration_mentions_declaration_files() {
     let options = file_rename_registration_options();
     let file_glob = &options.filters[0].pattern.glob;

--- a/tests/tooling/lsp-auto-insert-capabilities.test.ts
+++ b/tests/tooling/lsp-auto-insert-capabilities.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+import type { ServerCapabilities } from "./support/lsp/protocol.ts";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("auto-insert capability advertises each manifest sub-setting exactly once", async () => {
+  await withCapabilities((capabilities) => {
+    const sections = capabilities.experimental?.autoInsertionProvider?.configurationSections;
+    assert.ok(sections, "auto insert should advertise configuration sections");
+
+    const advertisedKeys = sections.flatMap((section) => section ?? []);
+    assert.deepEqual(advertisedKeys, Array.from(new Set(advertisedKeys)));
+    assert.deepEqual(advertisedKeys.toSorted(), manifestAutoInsertSubSettingKeys());
+  });
+});
+
+async function withCapabilities(run: (capabilities: ServerCapabilities) => void): Promise<void> {
+  const testRootDir = path.join(testOutputRoot, "lsp-auto-insert-capabilities");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    const init = (await session.initialize(workspaceDir, {
+      editor: true,
+      autoInsert: true,
+    })) as {
+      capabilities?: ServerCapabilities;
+    };
+    assert.ok(init.capabilities, "initialize result should advertise capabilities");
+    run(init.capabilities);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+}
+
+function manifestAutoInsertSubSettingKeys(): string[] {
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "editors", "vscode", "package.json"), "utf-8"),
+  ) as {
+    contributes?: {
+      configuration?: {
+        properties?: Record<string, unknown>;
+      };
+    };
+  };
+
+  return Object.keys(manifest.contributes?.configuration?.properties ?? {})
+    .filter((key) => key.startsWith("vize.autoInsert.") && key !== "vize.autoInsert.enable")
+    .sort();
+}

--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -204,7 +204,6 @@ test("vize lsp advertises the exact measured auto-insertion extension only when 
           ["vize.autoInsert.bracketSpacing"],
           ["vize.autoInsert.autoCreateQuotes"],
           ["vize.autoInsert.autoClosingTags"],
-          ["vize.autoInsert.autoClosingTags"],
           ["vize.autoInsert.dotValue"],
         ],
       },


### PR DESCRIPTION
## Summary
- remove the duplicate auto-insert configuration section advertised by the LSP experimental capability
- add a Maestro unit test for the exact unique section list
- add an initialize-level tooling test that matches advertised sections to the VS Code manifest sub-settings

## Verification
- `cargo test -p vize_maestro server::capabilities::tests::auto_insert_experimental_sections_are_unique_and_complete -- --exact`
- `cargo build -p vize`
- `node --test --test-concurrency=1 tests/tooling/lsp-capabilities.test.ts tests/tooling/lsp-auto-insert-capabilities.test.ts`
- `cargo fmt --check`
- `vp check tests/tooling/lsp-capabilities.test.ts tests/tooling/lsp-auto-insert-capabilities.test.ts crates/vize_maestro/src/server/capabilities.rs crates/vize_maestro/src/server/capabilities/tests.rs`
- `rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791347645&installation_model_id=422833&pr_number=5879&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5879&signature=c8ec84b7e8a4fa103f6af675420ee232039ce8aba3baae8af6511e0406f5c757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->