### PR TITLE
fix(davinci): give the DOM corpus lanes a real old side

### DIFF
--- a/crates/vize_atelier_dom/Cargo.toml
+++ b/crates/vize_atelier_dom/Cargo.toml
@@ -11,6 +11,15 @@ metadata.vize.stability = "alpha-supported"
 [features]
 legacy = ["vize_atelier_core/legacy"]
 
+# Arms the Davinci DOM differential lanes by exposing
+# `compile_template_legacy_with_options` — the shipped parse/transform/codegen
+# lane with the S2 emitter declined. The corpus comparators need it as their
+# *old* side: since the P2-11 production switch the ordinary entry points
+# route through S2, so a differential built on them compares S2 to itself.
+# Adds no dependency and no production code path; off in production builds,
+# exactly like `vize_atelier_core`'s feature of the same name.
+davinci-differential = []
+
 [dependencies]
 vize_s0 = { workspace = true }
 vize_atelier_core = { workspace = true }

--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -10,6 +10,8 @@ use vize_atelier_core::{
 use vize_s0::{Allocator, String};
 
 mod inner;
+#[cfg(feature = "davinci-differential")]
+pub(crate) mod legacy;
 mod pipeline;
 mod sfc;
 mod source_map;

--- a/crates/vize_atelier_dom/src/compile/legacy.rs
+++ b/crates/vize_atelier_dom/src/compile/legacy.rs
@@ -1,0 +1,48 @@
+//! The differential lanes' old side.
+//!
+//! Gated behind `davinci-differential` so no production build can reach
+//! it: the legacy lane is the thing the strangler is replacing, and an
+//! ungated entry point would be a way back onto the old path rather than
+//! a measurement of it.
+
+use vize_atelier_core::codegen::CodegenResult;
+use vize_atelier_core::options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode};
+use vize_atelier_core::{CompilerError, RootNode};
+use vize_s0::Allocator;
+
+use super::inner::compile_template_inner_with_sections;
+use super::pipeline::DomCompilePipelineOptions;
+use crate::options::DomCompilerOptions;
+
+/// Compile a Vue template for DOM through the **legacy** lane: parse,
+/// transform, then `vize_atelier_core`'s codegen, with the S2 emitter
+/// declined.
+///
+/// This is the differential lanes' *old* side and has no other caller. The
+/// ordinary entry points above route through S2 wherever
+/// `stage_options::s2_emit_supported` allows it (the P2-11 production
+/// switch), so a comparator built on them compares S2 against itself and
+/// cannot fail — measured: renaming a core helper alias in the S2 emitter
+/// left `davinci_dom_corpus` at `divergences=0`.
+///
+/// Gated so no production build can reach it: the legacy lane is the thing
+/// being strangled, and an entry point that resurrects it would be a way
+/// back onto the old path rather than a measurement of it.
+pub fn compile_template_legacy_with_options<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    options: DomCompilerOptions,
+) -> (RootNode<'a>, Vec<CompilerError>, CodegenResult) {
+    let (root, errors, result) = compile_template_inner_with_sections(
+        allocator,
+        source,
+        options,
+        TemplateSyntaxMode::Standard,
+        None,
+        DomCompilePipelineOptions::deny_s2(
+            CustomElementMatcher::default(),
+            CodegenOptions::default(),
+        ),
+    );
+    (root, errors, result.into_result())
+}

--- a/crates/vize_atelier_dom/src/compile/pipeline.rs
+++ b/crates/vize_atelier_dom/src/compile/pipeline.rs
@@ -36,6 +36,19 @@ impl DomCompilePipelineOptions {
         }
     }
 
+    /// The legacy lane, S2 declined — the differential lanes' old side.
+    #[cfg(feature = "davinci-differential")]
+    pub(super) fn deny_s2(
+        custom_elements: CustomElementMatcher,
+        codegen_options: CodegenOptions,
+    ) -> Self {
+        Self {
+            custom_elements,
+            codegen_options,
+            s2_emit_selection: S2EmitSelection::Disabled,
+        }
+    }
+
     pub(super) fn require_sections_compat(
         custom_elements: CustomElementMatcher,
         codegen_options: CodegenOptions,

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -31,6 +31,10 @@ pub use compile::custom_elements::{
     compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_and_codegen_options,
     compile_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options,
 };
+/// The differential lanes' old side — see its own docs for why the ordinary
+/// entry points cannot serve as one.
+#[cfg(feature = "davinci-differential")]
+pub use compile::legacy::compile_template_legacy_with_options;
 pub use compile::{
     compile_template, compile_template_with_options,
     compile_template_with_options_and_hoisted_scope_id, compile_template_with_template_syntax,

--- a/crates/vize_s1_to_s2/Cargo.toml
+++ b/crates/vize_s1_to_s2/Cargo.toml
@@ -24,7 +24,7 @@ metadata.vize.stability = "experimental"
 # Arms the corpus-runnable TS-20 lane (`tests/davinci_lowering_corpus.rs`),
 # the P1-6/P1-7 differential-lane shape: committed battery with pinned
 # counts, plus `VIZE_DAVINCI_DIFFERENTIAL_CORPUS=<dir>` widening.
-davinci-differential = ["typescript"]
+davinci-differential = ["typescript", "vize_atelier_dom/davinci-differential"]
 
 # The `is_ts` lane erases types by running oxc's transformer, whose
 # `Transformer::new` takes a `&std::path::Path` — so it needs `std`. It stays

--- a/crates/vize_s1_to_s2/tests/davinci_dom_corpus_support/mod.rs
+++ b/crates/vize_s1_to_s2/tests/davinci_dom_corpus_support/mod.rs
@@ -7,7 +7,7 @@ use davinci_test_support::corpus::CorpusSweep;
 use sfc_inputs::{binding_table, sfc_bindings, sfc_is_ts};
 use vize_atelier_core::options::CodegenMode;
 use vize_atelier_dom::errors::ErrorCode;
-use vize_atelier_dom::{DomCompilerOptions, compile_template_with_options};
+use vize_atelier_dom::{DomCompilerOptions, compile_template_legacy_with_options};
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 use vize_s0::Allocator;
 use vize_s1_to_s2::{
@@ -118,10 +118,19 @@ pub fn compare_sfc_template_lane(name: &str, source: &str, report: &mut Report, 
     // `extract_component_name`: the SFC filename's stem.
     let component_name = matches!(lane, Lane::Bindings).then(|| component_name_of(name));
 
+    // The **legacy** lane, S2 declined. The ordinary `compile_template*`
+    // entry points route through the S2 emitter since the P2-11 production
+    // switch, so building the old side on them compares S2 against itself:
+    // measured, renaming `Helper::CreateElementVNode`'s alias in the S2
+    // emitter left this sweep at `compared=12062 divergences=0`.
     let old_allocator = Allocator::new();
     let (_, errors, old) = match lane {
-        Lane::Default => vize_atelier_dom::compile_template(&old_allocator, &template.content),
-        Lane::Prefixed => compile_template_with_options(
+        Lane::Default => compile_template_legacy_with_options(
+            &old_allocator,
+            &template.content,
+            DomCompilerOptions::default(),
+        ),
+        Lane::Prefixed => compile_template_legacy_with_options(
             &old_allocator,
             &template.content,
             DomCompilerOptions {
@@ -129,7 +138,7 @@ pub fn compare_sfc_template_lane(name: &str, source: &str, report: &mut Report, 
                 ..Default::default()
             },
         ),
-        Lane::Bindings => compile_template_with_options(
+        Lane::Bindings => compile_template_legacy_with_options(
             &old_allocator,
             &template.content,
             DomCompilerOptions {

--- a/tests/tooling/davinci-stage-release-firewall.test.ts
+++ b/tests/tooling/davinci-stage-release-firewall.test.ts
@@ -60,7 +60,18 @@ test("DOM production keeps the published S2 renderer available for profiling", (
   const dom = workspacePackage(metadata, "vize_atelier_dom");
   assert.deepEqual(dom.features, {
     legacy: ["vize_atelier_core/legacy"],
+    // Test-only surface: exposes `compile_template_legacy_with_options` so
+    // the DOM differential lanes have a real old side. Its value list is
+    // empty, so unlike `legacy` it selects nothing at all — it cannot pull
+    // an unpublished stage in, which is what this firewall exists to stop.
+    // Asserted below rather than trusted from the name.
+    "davinci-differential": [],
   });
+  assert.deepEqual(
+    dom.features["davinci-differential"],
+    [],
+    "a test-only feature must select nothing",
+  );
 
   const stageEdges = dom.dependencies
     .filter((dependency) => publishedDavinciStages.has(dependency.name))


### PR DESCRIPTION
## The problem

The three `davinci_dom_corpus*` differentials compare **S2 against itself**.

Their old side calls `vize_atelier_dom::compile_template*` (`davinci_dom_corpus_support/mod.rs:123`). Since the P2-11 production switch those entry points route through `stage_options::emit_s2` — the same `vize_s1_to_s2::emit_dom_source*` the new side calls — and with `source_map` off `attach_compat_map` returns the S2 result untouched. The two strings are equal by construction.

**Measured, before this PR.** Renaming `Helper::CreateElementVNode`'s alias to `_PROBE_createElementVNode` in the S2 emitter changes the generated code of essentially every element-bearing template. The lane's verdict:

```
davinci DOM corpus sweep: files=12215 ... compared=12062 s2_refusals=0 divergences=0
test result: ok.
```

Same for `_prefixed` (11,657 compared) and `_bindings` (12,062). `davinci_dom_corpus` is a **required** gate — `check.yml`'s `clippy-and-test` step runs it under `--features davinci-differential` — so a merge gate has been asserting nothing about legacy parity since the switch.

## The fix

`vize_atelier_dom` gains a `davinci-differential` feature exposing `compile_template_legacy_with_options`: the shipped parse → transform → `vize_atelier_core` codegen lane with the S2 emitter declined (`S2EmitSelection::Disabled`, which `require_sections_compat` already used internally). That is what an old side has to be.

It is **gated so no production build can reach it**. The legacy lane is the thing being strangled; an ungated entry point would be a way back onto the old path rather than a measurement of it. The feature mirrors `vize_atelier_core`'s feature of the same name — empty value list, no dependency edge, off in production builds.

`davinci-stage-release-firewall`'s exact feature pin for `vize_atelier_dom` is widened by one key. Because that gate exists to stop a production feature selecting an unpublished stage, the test now also asserts the new feature's value list is **empty** rather than trusting its name.

## Result

With the old side pointed at the legacy lane, all three sweeps still read zero:

| lane | compared | divergences |
| --- | --- | --- |
| default | 12,062 | **0** |
| prefixed | 11,657 | **0** |
| bindings | 12,062 | **0** |

So P2-11's parity claim holds — it simply was not being measured any more. And re-running the alias probe now **fails** the lane, which is the property that was missing.

## Notes

- The other Davinci differential, `vize_atelier_core`'s `davinci_s2_transform_corpus`, is genuinely comparing lanes (it runs `old_parse_with_options` + `transform` in-crate). It is **not** in CI and it is **red on main**: 11 of 12,017 compared templates, all one class — an interpolation next to an HTML comment, where Vue condenses the whitespace between them to `" "` and the S2 lowering drops it. Not addressed here; filing separately.
- Gates run locally: the three corpus lanes, `davinci-stage-release-firewall`, `davinci-portability-lane`, `davinci-stage-dependencies`, `davinci-storage-policy`, `source-file-lengths`. The MoonBit `moonbit-publish-crates*` failures reproduce unchanged on the parent commit (local toolchain: "Failed to resolve the module dependency graph").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791347912&installation_model_id=422833&pr_number=5880&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5880&signature=1030a860d6c4b7f53f47e198dcbc515f4c042de2797d592f7a65dcd95a60f77c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved DOM rendering differential comparisons with a dedicated legacy rendering path for side-by-side validation.
  * Expanded corpus comparisons across default, prefixed, and bindings configurations.
  * Added coverage confirming the comparison-only feature remains disabled in production builds.
* **Chores**
  * Added opt-in tooling support for validating differences between legacy and current rendering behavior without affecting standard compilation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->