### PR TITLE
fix(typechecker): narrow divergence mutation oracle reruns

### DIFF
--- a/tests/tooling/typecheck-divergence-mutation-oracle.test.ts
+++ b/tests/tooling/typecheck-divergence-mutation-oracle.test.ts
@@ -9,6 +9,7 @@ import {
   run,
   setup,
   updateJson,
+  updateVizeOutput,
 } from "./_helpers/typecheck-divergence-report-fixture.ts";
 
 const outerHarnessTimeoutMs = 20_000;
@@ -43,6 +44,48 @@ test("seeded mutation oracle accepts a shared probe with shifted compiler coordi
     assert.equal(repairedState.messageMismatchCount, 0);
     assert.notEqual(brokenState.sourceSha256, cleanState.sourceSha256);
     assert.equal(repairedState.sourceSha256, cleanState.sourceSha256);
+  } finally {
+    cleanup(fixture);
+  }
+});
+
+test("seeded mutation oracle narrows checker reruns to the selected probe file", () => {
+  const fixture = setup({
+    baselineOutput: "",
+    baselineFiles: ["src/App.vue", "src/Other.vue"],
+    vizeDiagnostics: [],
+  });
+  try {
+    fs.writeFileSync(path.join(fixture.fixtureRoot, "src", "Other.vue"), "<template />\n");
+    updateVizeOutput(fixture, (parsed) => {
+      parsed.fileCount = 2;
+      parsed.files = [
+        { file: "src/App.vue", diagnostics: [] },
+        { file: "src/Other.vue", diagnostics: [] },
+      ];
+    });
+
+    const result = run(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const artifact = readJson(artifactPath(fixture, "json"));
+    const oracle = artifact.mutationOracle;
+    assert.equal(oracle.passed, true);
+
+    const fullBaselineConfig = readJson(
+      path.join(fixture.reportDir, "fixture-vue-tsc.tsconfig.json"),
+    );
+    assert.deepEqual(fullBaselineConfig.files, ["../src/App.vue", "../src/Other.vue"]);
+
+    const mutationConfig = readJson(
+      path.join(fixture.fixtureRoot, ".vize-baseline", "fixture-mutation-vue-tsc.tsconfig.json"),
+    );
+    assert.deepEqual(mutationConfig.files, [`../${oracle.file}`]);
+
+    for (const state of oracle.states) {
+      assert.match(state.vize.command, new RegExp(` check ${oracle.file.replace("/", "\\/")} `));
+      assert.doesNotMatch(state.vize.command, /src\/\*\*\/\*\.vue/u);
+      assert.match(state.baseline.command, /fixture-mutation-vue-tsc\.tsconfig\.json/u);
+    }
   } finally {
     cleanup(fixture);
   }

--- a/tests/tooling/typecheck-divergence-report-timeout.test.ts
+++ b/tests/tooling/typecheck-divergence-report-timeout.test.ts
@@ -177,7 +177,7 @@ test("typecheck divergence report drains verbose vue-tsc coverage output", () =>
   try {
     updateJson(
       fixture.registryPath,
-      (registry) => (registry.projects[0].typecheckPerformance.hangTimeoutMs = 1_000),
+      (registry) => (registry.projects[0].typecheckPerformance.hangTimeoutMs = 5_000),
     );
     writeVueTsc(
       fixture.vueTsc,

--- a/tests/tooling/typecheck-divergence-report.test.ts
+++ b/tests/tooling/typecheck-divergence-report.test.ts
@@ -162,7 +162,6 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       artifact.mutationOracle.states[2].sourceSha256,
       artifact.mutationOracle.states[0].sourceSha256,
     );
-    const invocation = readJson(fixture.invocationPath);
     const baselineProject = path.join(
       fixture.fixtureRoot,
       ".generated",
@@ -170,10 +169,7 @@ test("typecheck divergence report binds baseline evidence to the matrix artifact
       "fixture-vue-tsc.tsconfig.json",
     );
     const baselineArtifact = path.join(fixture.reportDir, "fixture-vue-tsc.tsconfig.json");
-    assert.deepEqual(invocation, {
-      cwd: fixture.fixtureRoot,
-      args: ["--noEmit", "--pretty", "false", "-p", baselineProject],
-    });
+    assert.equal(artifact.baseline.command.endsWith(` -p ${baselineProject}`), true);
     assert.match(artifact.baseline.coverageCommand, /--listFilesOnly/);
     assert.equal(
       fs.readFileSync(baselineArtifact, "utf8"),

--- a/tools/commands/fixtures/typecheck-divergence-report.rs
+++ b/tools/commands/fixtures/typecheck-divergence-report.rs
@@ -240,9 +240,9 @@ fn write_project_artifact(root: &Path, args: &Args, project: &Value) -> Result<V
         vize_report: &vize_run.payload["parsed"],
         coverage: &coverage,
         configuration: &configuration,
+        baseline_config: &baseline_config,
         vize_bin: &args.vize_bin,
         vue_tsc_bin: &args.vue_tsc_bin,
-        baseline_args: &baseline_args,
         documented_differences: &documented_differences,
     })?;
     reject_stale_documented_differences(
@@ -733,9 +733,9 @@ struct MutationContext<'a> {
     vize_report: &'a Value,
     coverage: &'a Value,
     configuration: &'a Value,
+    baseline_config: &'a BaselineConfig,
     vize_bin: &'a Path,
     vue_tsc_bin: &'a Path,
-    baseline_args: &'a [String],
     documented_differences: &'a [DocumentedDifference],
 }
 
@@ -1505,7 +1505,7 @@ fn run_vize_typecheck(
     ctx: &MutationContext<'_>,
     candidate: &MutationCandidate,
 ) -> Result<ToolRun, String> {
-    let args = tool_args(ctx.project)?;
+    let args = mutation_tool_args(ctx.project, candidate);
     let mut run = run_capture_limited(
         ctx.vize_bin,
         &args,
@@ -1520,7 +1520,7 @@ fn run_vize_typecheck(
     .map_err(mutation_run_error)?;
     let parsed = serde_json::from_str::<Value>(&run.stdout)
         .map_err(|error| format!("Vize mutation run emitted invalid JSON: {error}"))?;
-    let expected_files = expected_typecheck_vue_files(ctx.fixture_root, ctx.project, &parsed)?;
+    let expected_files = vec![candidate.file.clone()];
     let authored_files = collect_typechecker_authored_paths(ctx.fixture_root)?;
     validate_typechecker_output(
         ctx.project,
@@ -1538,10 +1538,10 @@ fn run_vue_tsc_mutation(
     ctx: &MutationContext<'_>,
     candidate: &MutationCandidate,
 ) -> Result<ToolRun, String> {
-    let _ = candidate;
+    let args = mutation_baseline_args(ctx, candidate)?;
     run_capture_limited(
         ctx.vue_tsc_bin,
-        ctx.baseline_args,
+        &args,
         ctx.fixture_root,
         ctx.project
             .pointer("/typecheckPerformance/hangTimeoutMs")
@@ -1551,6 +1551,56 @@ fn run_vue_tsc_mutation(
         &[0, 1, 2],
     )
     .map_err(mutation_run_error)
+}
+
+fn mutation_tool_args(project: &Value, candidate: &MutationCandidate) -> Vec<String> {
+    // The full matrix run already proved corpus coverage. Mutation probes only
+    // need the selected source file, and large fixtures can otherwise spend the
+    // release budget on repeated whole-project checks.
+    let mut args = vec![
+        "check".to_string(),
+        candidate.file.clone(),
+        "--format".to_string(),
+        "json".to_string(),
+        "--no-config".to_string(),
+    ];
+    if let Some(tsconfig) = typecheck_tsconfig_path(project) {
+        args.extend(["--tsconfig".to_string(), tsconfig]);
+    }
+    args
+}
+
+fn mutation_baseline_args(
+    ctx: &MutationContext<'_>,
+    candidate: &MutationCandidate,
+) -> Result<Vec<String>, String> {
+    let config_dir = ctx
+        .baseline_config
+        .path
+        .parent()
+        .ok_or_else(|| "baseline config path has no parent".to_string())?;
+    let project_id = project_string(ctx.project, "id")?;
+    let config_path = config_dir.join(format!("{project_id}-mutation-vue-tsc.tsconfig.json"));
+    let mut config = serde_json::from_str::<Value>(&ctx.baseline_config.source)
+        .map_err(|error| format!("baseline config source is invalid JSON: {error}"))?;
+    config["files"] = json!([config_relative_path(
+        config_dir,
+        &ctx.fixture_root.join(&candidate.file),
+    )]);
+    common::write_text(
+        &config_path,
+        &format!(
+            "{}\n",
+            serde_json::to_string_pretty(&config).map_err(|error| error.to_string())?
+        ),
+    )?;
+    Ok(vec![
+        "--noEmit".to_string(),
+        "--pretty".to_string(),
+        "false".to_string(),
+        "-p".to_string(),
+        config_path.display().to_string(),
+    ])
 }
 
 fn summarize_mutation_observations(
@@ -2698,25 +2748,6 @@ fn unusable_mutation(seed: &str, reason: &str) -> Value {
         "diagnostic": Value::Null,
         "states": [],
     })
-}
-
-fn tool_args(project: &Value) -> Result<Vec<String>, String> {
-    let mut args = vec!["check".to_string()];
-    args.extend(typecheck_corpus_globs(project)?);
-    args.extend([
-        "--format".to_string(),
-        "json".to_string(),
-        "--no-config".to_string(),
-    ]);
-    if let Some(tsconfig) = typecheck_tsconfig_path(project) {
-        args.extend(["--tsconfig".to_string(), tsconfig]);
-    }
-    Ok(args)
-}
-
-fn typecheck_corpus_globs(project: &Value) -> Result<Vec<String>, String> {
-    optional_typecheck_corpus_globs(project)
-        .ok_or_else(|| "project has no typecheck corpus globs".to_string())
 }
 
 fn optional_typecheck_corpus_globs(project: &Value) -> Option<Vec<String>> {


### PR DESCRIPTION
## Summary
- run seeded mutation probes against only the selected Vue source instead of the whole typecheck corpus
- materialize a candidate-only vue-tsc baseline config for mutation states while keeping the full baseline coverage artifact unchanged
- cover the narrowed rerun contract and keep timeout/drain tests aligned with the new oracle path

## Tests
- node --test tests/tooling/typecheck-divergence-mutation-oracle.test.ts tests/tooling/typecheck-divergence-report.test.ts tests/tooling/typecheck-divergence-baseline.test.ts tests/tooling/typecheck-divergence-budget.test.ts
- node --test tests/tooling/typecheck-divergence-report-rejections.test.ts tests/tooling/typecheck-divergence-baseline-configuration.test.ts tests/tooling/typecheck-divergence-baseline-ambient.test.ts tests/tooling/typecheck-divergence-report-timeout.test.ts tests/tooling/typecheck-divergence-mutation-oracle.test.ts
- node --test tests/tooling/release-preflight-matrix-evidence-rejections.test.ts tests/tooling/real-project-matrix-summary.test.ts tests/tooling/real-project-matrix-workflow.test.ts
- cargo fmt --check
- git diff --check
- rust-script tools/commands/fixtures/typecheck-divergence-report.rs --help
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791350224&installation_model_id=422833&pr_number=5881&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5881&signature=07389924d8bddd73f26fb06c7a913485802a1a5518b0406d9ccc6925871f7048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mutation-oracle type checks now run against only the selected mutated file, improving accuracy and avoiding unrelated project files affecting results.
  * Baseline artifact validation now confirms the generated project path is used correctly.
  * Increased the coverage-output hang timeout to reduce false failures during slower checks.

* **Tests**
  * Added coverage verifying mutation command scoping, baseline configuration, and checker behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->