### PR TITLE
fix(release): precheck manifest alignment before release commits

### DIFF
--- a/tests/tooling/moonbit-release.test.ts
+++ b/tests/tooling/moonbit-release.test.ts
@@ -301,7 +301,25 @@ test("release script explains cleanup after manifest verification fails", () => 
     assert.equal(fixture.result.status, 1);
     assert.match(fixture.result.stderr, /package manifest alignment tests failed/);
     assert.match(fixture.result.stderr, /git reset --hard origin\/main/);
+    assert.match(fixture.gitLog, /^commit --no-verify -m chore: release v0\.290\.1$/m);
     assert.doesNotMatch(fixture.gitLog, /^(?:tag|push)\b/m);
+  } finally {
+    fs.rmSync(fixture.tempDir, { recursive: true, force: true });
+  }
+});
+
+test("release script checks manifest alignment before repository mutation", () => {
+  const fixture = runRepositoryGuardFixture({ branch: "main", manifestPrecheckFails: true });
+
+  try {
+    assert.equal(fixture.result.status, 1);
+    assert.match(
+      fixture.result.stderr,
+      /package manifest alignment tests failed before repository mutation/,
+    );
+    assert.match(fixture.nodeLog, /^--test tests\/tooling\/package-manifests\.test\.ts$/m);
+    assert.doesNotMatch(fixture.gitLog, /^(?:add|commit|tag|push)\b/m);
+    assert.equal(fs.readFileSync(fixture.cargoTomlPath, "utf8"), fixture.cargoToml);
   } finally {
     fs.rmSync(fixture.tempDir, { recursive: true, force: true });
   }

--- a/tests/tooling/support/release-guard-fixture.ts
+++ b/tests/tooling/support/release-guard-fixture.ts
@@ -16,6 +16,7 @@ export interface RepositoryGuardOptions {
   remoteTagExists?: boolean;
   pushFails?: boolean;
   stagedFiles?: boolean;
+  manifestPrecheckFails?: boolean;
   manifestTestFails?: boolean;
   guardFails?: boolean;
 }
@@ -24,6 +25,8 @@ export function runRepositoryGuardFixture(options: RepositoryGuardOptions) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-release-guard-"));
   const binDir = path.join(tempDir, "bin");
   const gitLogPath = path.join(tempDir, "git.log");
+  const nodeLogPath = path.join(tempDir, "node.log");
+  const manifestTestCountPath = path.join(tempDir, "manifest-test-count.txt");
   const guardShimPath = path.join(tempDir, "release-local-guard-shim.mjs");
   const cargoTomlPath = path.join(tempDir, "Cargo.toml");
   const cargoToml = '[workspace.package]\nversion = "0.290.0"\n';
@@ -31,6 +34,8 @@ export function runRepositoryGuardFixture(options: RepositoryGuardOptions) {
   fs.mkdirSync(path.join(tempDir, "npm"));
   fs.mkdirSync(path.join(tempDir, "tests/tooling"), { recursive: true });
   fs.writeFileSync(gitLogPath, "");
+  fs.writeFileSync(nodeLogPath, "");
+  fs.writeFileSync(manifestTestCountPath, "0");
   fs.writeFileSync(cargoTomlPath, cargoToml);
   fs.writeFileSync(path.join(tempDir, "pnpm-workspace.yaml"), "");
   fs.writeFileSync(path.join(tempDir, "pnpm-lock.yaml"), "");
@@ -65,6 +70,22 @@ export function runRepositoryGuardFixture(options: RepositoryGuardOptions) {
       "process.exit(1);",
     ].join("\n"),
   );
+  writeFakeCommand(
+    binDir,
+    "fake-node",
+    [
+      "const fs = require('node:fs');",
+      "const args = process.argv.slice(2);",
+      "fs.appendFileSync(process.env.NODE_LOG, args.join(' ') + '\\n');",
+      "if (args[0] !== '--test' || args[1] !== 'tests/tooling/package-manifests.test.ts') process.exit(1);",
+      "const countPath = process.env.MANIFEST_TEST_COUNT;",
+      "const count = Number(fs.readFileSync(countPath, 'utf8')) + 1;",
+      "fs.writeFileSync(countPath, String(count));",
+      "if (process.env.TEST_MANIFEST_PRECHECK_FAILS === 'true' && count === 1) process.exit(1);",
+      "if (process.env.TEST_MANIFEST_TEST_FAILS === 'true' && count > 1) process.exit(1);",
+      "process.exit(0);",
+    ].join("\n"),
+  );
 
   const result = runMoonScript("release", ["patch", "-y"], {
     cwd: tempDir,
@@ -83,11 +104,17 @@ export function runRepositoryGuardFixture(options: RepositoryGuardOptions) {
       REMOTE_TAG_EXISTS: String(options.remoteTagExists),
       TEST_PUSH_FAIL: String(options.pushFails ?? false),
       TEST_STAGED_FILES: String(options.stagedFiles ?? true),
+      TEST_MANIFEST_PRECHECK_FAILS: String(options.manifestPrecheckFails ?? false),
+      TEST_MANIFEST_TEST_FAILS: String(options.manifestTestFails ?? false),
       TEST_GUARD_FAILS: String(options.guardFails ?? false),
       VIZE_RELEASE_GUARD_SCRIPT: guardShimPath,
       VIZE_RELEASE_GUARD_RUNNER: process.execPath,
+      VIZE_RELEASE_NODE: path.join(binDir, "fake-node"),
+      NODE_LOG: nodeLogPath,
+      MANIFEST_TEST_COUNT: manifestTestCountPath,
     },
   });
   const gitLog = fs.readFileSync(gitLogPath, "utf8");
-  return { cargoToml, cargoTomlPath, gitLog, result, tempDir };
+  const nodeLog = fs.readFileSync(nodeLogPath, "utf8");
+  return { cargoToml, cargoTomlPath, gitLog, nodeLog, result, tempDir };
 }

--- a/tools/moon/cmd/release/main.mbt
+++ b/tools/moon/cmd/release/main.mbt
@@ -535,6 +535,10 @@ async fn run_app() -> Int {
     return 1
   }
 
+  if !verify_manifest_alignment_before_mutation() {
+    return 1
+  }
+
   println("Updating Cargo.toml...")
   if !write_string_to_file(
     cargo_toml_path,
@@ -777,11 +781,7 @@ async fn run_app() -> Int {
     return 1
   }
 
-  println("Verifying manifest alignment with tests/tooling/package-manifests.test.ts...")
-  if @process.run("node", ["--test", "tests/tooling/package-manifests.test.ts"]) != 0 {
-    @stdio.stderr.write(
-      "Error: package manifest alignment tests failed against the release commit. Inspect tests/tooling/package-manifests.test.ts, then run `git reset --hard origin/main` after confirming there is no work to keep, fix the drift, and retry.\n",
-    )
+  if !verify_manifest_alignment_after_commit() {
     return 1
   }
 

--- a/tools/moon/cmd/release/manifest_alignment.mbt
+++ b/tools/moon/cmd/release/manifest_alignment.mbt
@@ -1,0 +1,37 @@
+/// Node runner used for release-side JS checks.
+fn release_node_bin() -> String {
+  match @env.get_env_var("VIZE_RELEASE_NODE") {
+    Some(value) if value != "" => value
+    _ => "node"
+  }
+}
+
+/// Runs the manifest alignment test before release files are mutated.
+async fn verify_manifest_alignment_before_mutation() -> Bool {
+  println("Verifying manifest alignment before repository mutation...")
+  if @process.run(
+    release_node_bin(),
+    ["--test", "tests/tooling/package-manifests.test.ts"],
+  ) != 0 {
+    @stdio.stderr.write(
+      "Error: package manifest alignment tests failed before repository mutation. Install JS dependencies or fix the manifest drift, then retry.\n",
+    )
+    return false
+  }
+  true
+}
+
+/// Runs the manifest alignment test against the generated release commit.
+async fn verify_manifest_alignment_after_commit() -> Bool {
+  println("Verifying manifest alignment with tests/tooling/package-manifests.test.ts...")
+  if @process.run(
+    release_node_bin(),
+    ["--test", "tests/tooling/package-manifests.test.ts"],
+  ) != 0 {
+    @stdio.stderr.write(
+      "Error: package manifest alignment tests failed against the release commit. Inspect tests/tooling/package-manifests.test.ts, then run `git reset --hard origin/main` after confirming there is no work to keep, fix the drift, and retry.\n",
+    )
+    return false
+  }
+  true
+}


### PR DESCRIPTION
## Summary
- run the package manifest alignment test before mutating release files
- keep the post-commit manifest verification as the release-commit guard
- let release fixtures inject a Node runner so precheck and post-commit failures are tested separately

## Verification
- node --test tests/tooling/moonbit-release.test.ts tests/tooling/release-local-guard.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791352061&installation_model_id=422833&pr_number=5883&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5883&signature=b78990bcc2a484133ea5e4d347fad24787fb3f503334b7fb56d2056b761555e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release manifest alignment is now validated before repository changes begin, preventing incomplete releases when verification fails.
  * Releases now perform a second manifest check after creating the release commit.
  * Failed post-commit verification provides clearer recovery guidance and cleanup handling.

* **Tests**
  * Added coverage confirming that failed pre-release validation leaves repository files and Git history unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->