### PR TITLE
perf(davinci): skip legacy DOM transform on S2 build path

### DIFF
--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -5,21 +5,18 @@ pub mod custom_elements;
 use vize_atelier_core::codegen::{CodegenResult, CodegenResultWithSections};
 use vize_atelier_core::{
     CompilerError, RootNode,
-    codegen::generate_with_sections,
-    lane::transform_with_custom_elements_and_template_syntax_quirks_and_hoisted_scope_id,
     options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode},
-    parser::parse_with_options_custom_elements_and_template_syntax,
-    walk_probe::WalkCounts,
 };
-use vize_croquis::Croquis;
-use vize_s0::{Allocator, String, profile, profiler::global_profiler};
+use vize_s0::{Allocator, String};
 
+mod inner;
 mod pipeline;
 mod sfc;
 mod source_map;
 mod stage_options;
 
 use crate::options::DomCompilerOptions;
+use inner::{compile_template_inner, compile_template_inner_with_sections};
 use pipeline::DomCompilePipelineOptions;
 
 /// Compile a Vue template for DOM with default options
@@ -212,139 +209,4 @@ pub fn compile_template_with_template_syntax_and_hoisted_scope_id_with_sections_
         hoisted_scope_id,
         DomCompilePipelineOptions::allow_s2(CustomElementMatcher::default(), codegen_options),
     )
-}
-
-fn compile_template_inner<'a>(
-    allocator: &'a Allocator,
-    source: &'a str,
-    options: DomCompilerOptions,
-    template_syntax: TemplateSyntaxMode,
-    hoisted_scope_id: Option<String>,
-    custom_elements: CustomElementMatcher,
-    codegen_options: CodegenOptions,
-) -> (RootNode<'a>, Vec<CompilerError>, CodegenResult) {
-    let (root, errors, codegen_result) = compile_template_inner_with_sections(
-        allocator,
-        source,
-        options,
-        template_syntax,
-        hoisted_scope_id,
-        DomCompilePipelineOptions::allow_s2(custom_elements, codegen_options),
-    );
-    (root, errors, codegen_result.into_result())
-}
-
-fn compile_template_inner_with_sections<'a>(
-    allocator: &'a Allocator,
-    source: &'a str,
-    options: DomCompilerOptions,
-    template_syntax: TemplateSyntaxMode,
-    hoisted_scope_id: Option<String>,
-    pipeline_options: DomCompilePipelineOptions,
-) -> (RootNode<'a>, Vec<CompilerError>, CodegenResultWithSections) {
-    let DomCompilePipelineOptions {
-        custom_elements,
-        codegen_options,
-        s2_emit_selection,
-    } = pipeline_options;
-    let parser_opts = stage_options::parser_options(&options);
-
-    let (mut root, errors) = profile!(
-        "atelier.dom.template.parse",
-        parse_with_options_custom_elements_and_template_syntax(
-            allocator,
-            source,
-            parser_opts,
-            custom_elements.clone(),
-            template_syntax,
-        )
-    );
-
-    // Parser-level diagnostics that are recoverable (e.g. duplicate
-    // attribute — Vue keeps the first and continues) must NOT gate
-    // codegen, or downstream callers see a 0-byte module reported as a
-    // success. (#958) The recoverable diagnostics still ride along in
-    // the returned errors vec so the caller can surface them as
-    // warnings or test for parity.
-    let fatal_count = errors.iter().filter(|e| !e.is_recoverable()).count();
-    if fatal_count > 0 {
-        let codegen_result = CodegenResult {
-            code: String::default(),
-            preamble: String::default(),
-            map: None,
-        };
-        return (
-            root,
-            errors.to_vec(),
-            CodegenResultWithSections {
-                result: codegen_result,
-                sections: None,
-            },
-        );
-    }
-
-    let has_croquis = options.croquis.is_some();
-    let codegen_opts = stage_options::codegen_options(&options, codegen_options);
-    let template_syntax_quirks = template_syntax.is_quirks();
-    let use_s2_emit = stage_options::s2_emit_supported(
-        &options,
-        &codegen_opts,
-        &custom_elements,
-        template_syntax,
-        has_croquis,
-        s2_emit_selection,
-    );
-    // Project output options before consuming Croquis; S2 only borrows them.
-    let s2_custom_elements = custom_elements.clone();
-    let s2_emit_source = use_s2_emit.then(|| (options.clone(), hoisted_scope_id.clone()));
-    let transform_opts = stage_options::transform_options(&options);
-    // Park the summary on the allocator so it shares the allocator lifetime.
-    let analysis: Option<&Croquis> = options.croquis.map(|c| allocator.alloc_owned(*c));
-    let profiling_s2 = use_s2_emit && global_profiler().is_enabled();
-    let template_walk_before = profiling_s2.then(WalkCounts::snapshot);
-    let transform_errors = profile!(
-        "atelier.dom.template.transform",
-        transform_with_custom_elements_and_template_syntax_quirks_and_hoisted_scope_id(
-            allocator,
-            &mut root,
-            transform_opts,
-            analysis,
-            custom_elements,
-            template_syntax_quirks,
-            hoisted_scope_id,
-        )
-    );
-    let template_walks = template_walk_before.map(|before| WalkCounts::snapshot().since(before));
-
-    // Surface transform diagnostics (e.g. invalid expressions) alongside
-    // parse errors instead of dropping them — the official compiler reports
-    // both through the same `errors` channel.
-    let mut errors = errors.to_vec();
-    errors.extend(transform_errors);
-
-    let s2_emit = s2_emit_source.and_then(|(s2_options_source, s2_hoisted_scope_id)| {
-        let binding_table =
-            stage_options::s2_binding_table(s2_options_source.binding_metadata.as_ref());
-        let s2_options = stage_options::s2_emit_options(
-            &s2_options_source,
-            &codegen_opts,
-            &s2_custom_elements,
-            binding_table.as_ref(),
-            s2_hoisted_scope_id.as_deref(),
-        )?;
-        let dialect = s2_options_source.dialect;
-        Some(profile!(
-            "atelier.dom.template.s2_codegen",
-            stage_options::emit_s2(allocator, source, dialect, &s2_options, template_walks)
-        ))
-    });
-    let codegen_result = match s2_emit {
-        Some(Ok(result)) => source_map::attach_compat_map(&root, &codegen_opts, result),
-        Some(Err(_)) | None => profile!(
-            "atelier.dom.template.codegen_compat",
-            generate_with_sections(&root, codegen_opts)
-        ),
-    };
-
-    (root, errors, codegen_result)
 }

--- a/crates/vize_atelier_dom/src/compile/inner.rs
+++ b/crates/vize_atelier_dom/src/compile/inner.rs
@@ -1,0 +1,158 @@
+use vize_atelier_core::{
+    CompilerError, RootNode,
+    codegen::{CodegenResult, CodegenResultWithSections, generate_with_sections},
+    lane::transform_with_custom_elements_and_template_syntax_quirks_and_hoisted_scope_id,
+    options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode},
+    parser::parse_with_options_custom_elements_and_template_syntax,
+    walk_probe::WalkCounts,
+};
+use vize_croquis::Croquis;
+use vize_s0::{Allocator, String, profile, profiler::global_profiler};
+
+use super::{pipeline::DomCompilePipelineOptions, source_map, stage_options};
+use crate::options::DomCompilerOptions;
+
+pub(super) fn compile_template_inner<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    options: DomCompilerOptions,
+    template_syntax: TemplateSyntaxMode,
+    hoisted_scope_id: Option<String>,
+    custom_elements: CustomElementMatcher,
+    codegen_options: CodegenOptions,
+) -> (RootNode<'a>, Vec<CompilerError>, CodegenResult) {
+    let (root, errors, codegen_result) = compile_template_inner_with_sections(
+        allocator,
+        source,
+        options,
+        template_syntax,
+        hoisted_scope_id,
+        DomCompilePipelineOptions::allow_s2(custom_elements, codegen_options),
+    );
+    (root, errors, codegen_result.into_result())
+}
+
+pub(super) fn compile_template_inner_with_sections<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    options: DomCompilerOptions,
+    template_syntax: TemplateSyntaxMode,
+    hoisted_scope_id: Option<String>,
+    pipeline_options: DomCompilePipelineOptions,
+) -> (RootNode<'a>, Vec<CompilerError>, CodegenResultWithSections) {
+    let DomCompilePipelineOptions {
+        custom_elements,
+        codegen_options,
+        s2_emit_selection,
+    } = pipeline_options;
+    let parser_opts = stage_options::parser_options(&options);
+
+    let (mut root, errors) = profile!(
+        "atelier.dom.template.parse",
+        parse_with_options_custom_elements_and_template_syntax(
+            allocator,
+            source,
+            parser_opts,
+            custom_elements.clone(),
+            template_syntax,
+        )
+    );
+
+    // Parser-level diagnostics that are recoverable (e.g. duplicate
+    // attribute — Vue keeps the first and continues) must NOT gate
+    // codegen, or downstream callers see a 0-byte module reported as a
+    // success. (#958) The recoverable diagnostics still ride along in
+    // the returned errors vec so the caller can surface them as
+    // warnings or test for parity.
+    let fatal_count = errors.iter().filter(|e| !e.is_recoverable()).count();
+    if fatal_count > 0 {
+        let codegen_result = CodegenResult {
+            code: String::default(),
+            preamble: String::default(),
+            map: None,
+        };
+        return (
+            root,
+            errors.to_vec(),
+            CodegenResultWithSections {
+                result: codegen_result,
+                sections: None,
+            },
+        );
+    }
+
+    let has_croquis = options.croquis.is_some();
+    let codegen_opts = stage_options::codegen_options(&options, codegen_options);
+    let template_syntax_quirks = template_syntax.is_quirks();
+    let use_s2_emit = stage_options::s2_emit_supported(
+        &options,
+        &codegen_opts,
+        &custom_elements,
+        template_syntax,
+        has_croquis,
+        s2_emit_selection,
+    );
+    let s2_custom_elements = custom_elements.clone();
+    if use_s2_emit
+        && !codegen_opts.source_map
+        && let Some(result) = stage_options::try_emit_s2(
+            allocator,
+            source,
+            &options,
+            &codegen_opts,
+            &s2_custom_elements,
+            hoisted_scope_id.as_deref(),
+            None,
+        )
+    {
+        return (root, errors.to_vec(), result);
+    }
+
+    let s2_emit_after_transform = (use_s2_emit && codegen_opts.source_map)
+        .then(|| (options.clone(), hoisted_scope_id.clone()));
+    let transform_opts = stage_options::transform_options(&options);
+    // Park the summary on the allocator so it shares the allocator lifetime.
+    let analysis: Option<&Croquis> = options.croquis.map(|c| allocator.alloc_owned(*c));
+    let profiling_s2 = use_s2_emit && global_profiler().is_enabled();
+    let template_walk_before = profiling_s2.then(WalkCounts::snapshot);
+    let transform_errors = profile!(
+        "atelier.dom.template.transform",
+        transform_with_custom_elements_and_template_syntax_quirks_and_hoisted_scope_id(
+            allocator,
+            &mut root,
+            transform_opts,
+            analysis,
+            custom_elements,
+            template_syntax_quirks,
+            hoisted_scope_id,
+        )
+    );
+    let template_walks = template_walk_before.map(|before| WalkCounts::snapshot().since(before));
+
+    // Surface transform diagnostics (e.g. invalid expressions) alongside
+    // parse errors instead of dropping them — the official compiler reports
+    // both through the same `errors` channel.
+    let mut errors = errors.to_vec();
+    errors.extend(transform_errors);
+
+    let s2_emit = s2_emit_after_transform.and_then(|(options, hoisted_scope_id)| {
+        stage_options::try_emit_s2(
+            allocator,
+            source,
+            &options,
+            &codegen_opts,
+            &s2_custom_elements,
+            hoisted_scope_id.as_deref(),
+            template_walks,
+        )
+    });
+    let codegen_result = match s2_emit {
+        Some(result) => source_map::attach_compat_map(&root, &codegen_opts, result),
+        None => profile!(
+            "atelier.dom.template.codegen_compat",
+            generate_with_sections(&root, codegen_opts)
+        ),
+    };
+
+    (root, errors, codegen_result)
+}

--- a/crates/vize_atelier_dom/src/compile/stage_options.rs
+++ b/crates/vize_atelier_dom/src/compile/stage_options.rs
@@ -9,8 +9,8 @@ use vize_atelier_core::options::{
     TemplateSyntaxMode, TransformOptions,
 };
 use vize_atelier_core::walk_probe::WalkCounts;
-use vize_s0::Allocator;
 use vize_s0::profiler::global_profiler;
+use vize_s0::{Allocator, profile};
 use vize_s1_to_s2::{
     BindingKind, BindingTable, DomEmitMode, DomEmitOptions, DomEmitSections, EmitError, LegacyCaps,
 };
@@ -149,6 +149,36 @@ pub(super) fn s2_binding_table(metadata: Option<&BindingMetadata>) -> Option<Bin
     })
 }
 
+pub(super) fn try_emit_s2(
+    allocator: &Allocator,
+    source: &str,
+    options: &DomCompilerOptions,
+    codegen: &CodegenOptions,
+    custom_elements: &CustomElementMatcher,
+    hoisted_scope_id: Option<&str>,
+    pre_s2_walks: Option<WalkCounts>,
+) -> Option<CodegenResultWithSections> {
+    let binding_table = s2_binding_table(options.binding_metadata.as_ref());
+    let emit_options = s2_emit_options(
+        options,
+        codegen,
+        custom_elements,
+        binding_table.as_ref(),
+        hoisted_scope_id,
+    )?;
+    profile!(
+        "atelier.dom.template.s2_codegen",
+        emit_s2(
+            allocator,
+            source,
+            options.dialect,
+            &emit_options,
+            pre_s2_walks
+        )
+    )
+    .ok()
+}
+
 /// Emit one ordinary DOM module through S2.
 pub(super) fn emit_s2(
     allocator: &Allocator,
@@ -182,15 +212,15 @@ pub(super) fn emit_s2(
             "davinci.s2_dom.total.walks",
             u64::from(budget.total_walks()),
         );
-        if let Some(pre_s2) = pre_s2_walks {
-            let pre_s2_walks = pre_s2.total_walks();
-            profiler.record_counter_enabled("davinci.s2_dom.pre_s2.walks", pre_s2_walks);
-            profiler.record_counter_enabled("davinci.s2_dom.pre_s2.visits", pre_s2.total_visits());
-            profiler.record_counter_enabled(
-                "davinci.s2_dom.build.walks",
-                pre_s2_walks + u64::from(budget.total_walks()),
-            );
-        }
+        let (pre_s2_walks, pre_s2_visits) = pre_s2_walks.map_or((0, 0), |counts| {
+            (counts.total_walks(), counts.total_visits())
+        });
+        profiler.record_counter_enabled("davinci.s2_dom.pre_s2.walks", pre_s2_walks);
+        profiler.record_counter_enabled("davinci.s2_dom.pre_s2.visits", pre_s2_visits);
+        profiler.record_counter_enabled(
+            "davinci.s2_dom.build.walks",
+            pre_s2_walks + u64::from(budget.total_walks()),
+        );
         observed.emit
     } else {
         vize_s1_to_s2::emit_dom_source_with_options(allocator, source, caps, options)?

--- a/crates/vize_atelier_dom/tests/davinci_expr_reparse_floor.rs
+++ b/crates/vize_atelier_dom/tests/davinci_expr_reparse_floor.rs
@@ -4,7 +4,7 @@
 //! expression re-parses via the P0-3 probe — the same sweep that produced
 //! `davinci-road/plan/expr-reparse-baseline.md`, pinned exactly at the
 //! post-P1-7 floor (the pre-P1-7 counts are the baseline doc's table). Any
-//! change means a retained-consumption gate or a legacy site moved:
+//! change means a retained-consumption gate, S2 selector, or legacy site moved:
 //! re-derive the floor deliberately and update the baseline doc's post-P1-7
 //! section with it.
 //!
@@ -23,7 +23,7 @@ use vize_s0::Allocator;
 const FLOOR: [(&str, u64); 6] = [
     ("small", 0),
     ("medium", 0),
-    ("large", 8),
+    ("large", 0),
     ("stress-deep", 0),
     ("stress-wide", 0),
     ("stress-interp", 0),

--- a/crates/vize_atelier_dom/tests/davinci_s2_build_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_build_profile.rs
@@ -22,25 +22,25 @@ struct TraversalBudget {
 /// Both columns are per fixture because the S2 pass planner declines a
 /// mandatory pass whose op family the lowering never built
 /// (`vize_s1_to_s2::lower::features`). The S2 column is the artifact's
-/// transform plan plus its one emit walk; the build column adds the one
-/// pre-S2 template walk the legacy transform still costs on this entry
-/// point. Closing *that* one is what the parse-to-S2 switch is for.
+/// transform plan plus its one emit walk; the build column now matches it
+/// because source-map-free DOM compiles no longer run the legacy pre-S2
+/// transform after S2 emission succeeds.
 ///
 /// | fixture       | families present                      | S2 | build |
 /// | ------------- | ------------------------------------- | -- | ----- |
-/// | small         | none                                  | 3  | 4     |
-/// | medium        | components                            | 4  | 5     |
-/// | large         | `v-if`, `v-for`, components, `<slot>` | 6  | 7     |
-/// | stress-deep   | `v-if`                                | 4  | 5     |
-/// | stress-wide   | none                                  | 3  | 4     |
-/// | stress-interp | none                                  | 3  | 4     |
+/// | small         | none                                  | 3  | 3     |
+/// | medium        | components                            | 4  | 4     |
+/// | large         | `v-if`, `v-for`, components, `<slot>` | 6  | 6     |
+/// | stress-deep   | `v-if`                                | 4  | 4     |
+/// | stress-wide   | none                                  | 3  | 3     |
+/// | stress-interp | none                                  | 3  | 3     |
 const CURRENT_WALKS: [(&str, u64, u64); 6] = [
-    ("small", 3, 4),
-    ("medium", 4, 5),
-    ("large", 6, 7),
-    ("stress-deep", 4, 5),
-    ("stress-wide", 3, 4),
-    ("stress-interp", 3, 4),
+    ("small", 3, 3),
+    ("medium", 4, 4),
+    ("large", 6, 6),
+    ("stress-deep", 4, 4),
+    ("stress-wide", 3, 3),
+    ("stress-interp", 3, 3),
 ];
 
 fn current_walks(fixture: &str) -> (u64, u64) {
@@ -81,8 +81,8 @@ fn profile_build_walks_report_the_current_p2_12b_gap() {
         let build_walks = counter(&counters, "davinci.s2_dom.build.walks");
 
         assert_eq!(
-            pre_s2_walks, 1,
-            "{} has one pre-S2 template walk",
+            pre_s2_walks, 0,
+            "{} no longer pays a pre-S2 template walk",
             fixture.name
         );
         assert!(
@@ -117,8 +117,8 @@ fn profile_build_walks_report_the_current_p2_12b_gap() {
             fixture.name
         );
         assert!(
-            build_walks > fused_walk_target,
-            "{} still needs the parse-to-S2/fusion switch before P2-12b can close",
+            build_walks >= fused_walk_target,
+            "{} build walk counter must stay above the emit floor",
             fixture.name
         );
     }

--- a/crates/vize_atelier_dom/tests/davinci_walk_baseline.rs
+++ b/crates/vize_atelier_dom/tests/davinci_walk_baseline.rs
@@ -39,12 +39,12 @@ const BASELINE: [(&str, u64, u64); 6] = [
 /// fixture name -> (stage tree-walks, template-node visits) after the
 /// source-map-free DOM production selector routes supported compiles through S2.
 const PRODUCTION_FLOOR: [(&str, u64, u64); 6] = [
-    ("small", 1, 8),
-    ("medium", 1, 33),
-    ("large", 1, 57),
-    ("stress-deep", 1, 72),
-    ("stress-wide", 1, 2),
-    ("stress-interp", 1, 1001),
+    ("small", 0, 0),
+    ("medium", 0, 0),
+    ("large", 0, 0),
+    ("stress-deep", 0, 0),
+    ("stress-wide", 0, 0),
+    ("stress-interp", 0, 0),
 ];
 
 #[test]

--- a/davinci-road/open-questions.md
+++ b/davinci-road/open-questions.md
@@ -82,6 +82,13 @@ fusion has to earn. **Skipping is not fusing**, and the walk counts above
 should not be read as evidence that fusion is unnecessary: an artifact
 that uses every family still pays six.
 
+Prototype note (2026-09-07, third): source-map-free DOM compiles now skip the
+legacy pre-S2 transform when S2 emission succeeds. The profiled build counter
+therefore matches the S2 observer total on the ladder set: small/stress-wide/
+stress-interp 3 walks, medium/stress-deep 4 walks, and large 6 walks. P2-12b's
+remaining work is S2 transform fusion for the genuinely required passes above
+the one-walk emit floor; source-map requests still use the compatibility path.
+
 One measured correction to the derivation: the first cut read the family
 bits off provenance rule names, which is wrong. Provenance records
 _decisions_, and a failed decision records a different rule while still

--- a/davinci-road/plan/expr-reparse-baseline.md
+++ b/davinci-road/plan/expr-reparse-baseline.md
@@ -43,7 +43,7 @@
   independently, which is fault line 1 of
   [motivation.md](../motivation.md) in number form.
 
-## Post-P1-7 floors (updated 2026-09-06, DOM selector on S2)
+## Post-P1-7 floors (updated 2026-09-07, DOM selector on S2)
 
 Same sweep, same probe, after P1-7 migrated the whole-expression consumers
 onto the parse-once retained ASTs (`SimpleExpressionNode::js_ast`, P1-5).
@@ -54,16 +54,17 @@ equality by `tests/davinci_expr_reparse_floor.rs` in each backend crate.
 | ------------- | --: | ----: | --: |
 | small         |   0 |     0 |   0 |
 | medium        |   0 |     0 |   0 |
-| large         |   8 |     8 |  27 |
+| large         |   0 |     8 |  27 |
 | stress-deep   |   0 |     0 |   0 |
 | stress-wide   |   0 |     0 |   0 |
 | stress-interp |   0 |     0 |   0 |
 
 Every migrated site is at zero on every fixture; the surviving counts are
 the kept-with-reason fallback classes on `large.vue` only (per-site record
-in `phase-1.md` P1-7): dom 8 = 8 slot-pattern parses
-(`extract_slot_prop_names`, synthesized `let <pattern> = __slotProps`);
-the source-map-free S2 selector no longer pays the 8 slot-default arrows
+in `phase-1.md` P1-7). The source-map-free DOM S2 selector skips the legacy
+pre-S2 transform when S2 emission succeeds, so it no longer pays the 8
+slot-pattern parses (`extract_slot_prop_names`, synthesized
+`let <pattern> = __slotProps`) or the 8 slot-default arrows
 (`prefix_slot_defaults`, synthesized `(props) => null`). ssr 27 = 8
 slot-pattern + 8 param-arrow validations (`parse_as_params`) + 10 SSR
 rendered-handler shape checks (transformed text, not node content) + 1


### PR DESCRIPTION
## Summary
- route source-map-free DOM compiles directly through S2 emission when the S2 lane succeeds
- keep source-map and unsupported-option cases on the compatibility path
- update Davinci traversal and expression re-parse witnesses for the new zero pre-S2 DOM floor

## Verification
- cargo test -p vize_atelier_dom
- cargo test -p vize_s1_to_s2
- cargo test -p vize_atelier_dom --test davinci_s2_build_profile --test davinci_walk_baseline --test davinci_expr_reparse_floor --test davinci_s2_profile --test davinci_s2_production_selector
- cargo test -p vize_s1_to_s2 --test emit_budget_observer
- cargo fmt --all --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

## Risk
- RootNode remains parsed but is not legacy-transformed on successful source-map-free S2 output; source-map compiles and S2 fallbacks still preserve the transformed compatibility path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791353953&installation_model_id=422833&pr_number=5884&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5884&signature=c0405284120ff02eda63b7f8e50c7479b3eb68c5f53c483256304a9265dc2a42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved source-map-free DOM compilation by using a streamlined compilation path when supported.
  * Reduced unnecessary legacy processing and expression re-parsing during compilation.
  * Preserved compatibility behavior for compilations requiring source maps.

* **Bug Fixes**
  * Compilation now avoids code generation when fatal parsing errors are present while retaining recoverable diagnostics.

* **Documentation**
  * Updated performance notes and baseline measurements to reflect reduced compilation work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->