### PR TITLE
test(davinci): pin the SFC entry's walk count beside the build path

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_build_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_build_profile.rs
@@ -5,6 +5,8 @@
 use std::path::Path;
 
 use davinci_harness::fixtures::{LADDER, template_block};
+use vize_atelier_core::codegen::CodegenResultWithSections;
+use vize_atelier_core::options::{CodegenOptions, CustomElementMatcher, TemplateSyntaxMode};
 use vize_atelier_dom::compile_template;
 use vize_s0::Allocator;
 use vize_s0::profiler::{CounterSummary, global_profiler};
@@ -197,6 +199,97 @@ impl Drop for ProfileScope {
         profiler.disable();
         profiler.clear();
     }
+}
+
+/// fixture -> S2 walks on the **SFC** entry, the one a build actually
+/// calls (`vize_atelier_sfc::compile_template_block`).
+///
+/// One walk fewer than the `compile_template` row in [`CURRENT_WALKS`],
+/// every time: `compile/sfc.rs` takes the S2 fast path when the source
+/// clears `selector::s2_sfc_fast_path_supported_source` and no source
+/// map is asked for, and that path never parses or transforms through
+/// the legacy lane at all. So the pre-S2 template walk the build-path
+/// witness above still reports is **not** on the production path — it
+/// belongs to the public `compile_template` entry, which owes its caller
+/// the transformed AST.
+const CURRENT_SFC_WALKS: [(&str, u64); 6] = [
+    ("small", 3),
+    ("medium", 4),
+    ("large", 6),
+    ("stress-deep", 4),
+    ("stress-wide", 3),
+    ("stress-interp", 3),
+];
+
+#[test]
+fn the_sfc_entry_pays_no_pre_s2_walk() {
+    let _guard = lock_profiler();
+    for fixture in &LADDER {
+        let template =
+            template_block(fixture.source).expect("every ladder fixture has a template block");
+        let (_, expected_build_walks) = current_walks(fixture.name);
+        let expected = CURRENT_SFC_WALKS
+            .iter()
+            .find(|(name, _)| *name == fixture.name)
+            .map(|(_, walks)| *walks)
+            .unwrap_or_else(|| panic!("{} has no pinned SFC walk count", fixture.name));
+
+        let profile = ProfileScope::enable();
+        let allocator = Allocator::new();
+        let (errors, result) = compile_sfc(&allocator, template);
+        let counters = profile.finish();
+
+        assert!(errors.is_empty(), "{} should compile cleanly", fixture.name);
+        assert!(
+            !result.result.code.is_empty(),
+            "{} should emit code",
+            fixture.name
+        );
+        assert_eq!(
+            counter_total(&counters, "davinci.s2_dom.pre_s2.walks"),
+            None,
+            "{}: the SFC fast path must not run the legacy transform",
+            fixture.name
+        );
+        assert_eq!(
+            counter(&counters, "davinci.s2_dom.total.walks"),
+            expected,
+            "{} SFC S2 walks",
+            fixture.name
+        );
+        assert_eq!(
+            expected + 1,
+            expected_build_walks,
+            "{}: the build-path witness above is exactly this plus the pre-S2 walk",
+            fixture.name
+        );
+    }
+}
+
+fn compile_sfc<'a>(
+    allocator: &'a Allocator,
+    template: &'a str,
+) -> (
+    Vec<vize_atelier_core::CompilerError>,
+    CodegenResultWithSections,
+) {
+    vize_atelier_dom::compile_sfc_template_with_custom_elements_and_template_syntax_and_hoisted_scope_id_with_sections_and_codegen_options(
+        allocator,
+        template,
+        vize_atelier_dom::DomCompilerOptions::default(),
+        TemplateSyntaxMode::Standard,
+        None,
+        CustomElementMatcher::default(),
+        CodegenOptions::default(),
+    )
+}
+
+fn counter_total(counters: &CounterSummary, name: &str) -> Option<u64> {
+    counters
+        .entries
+        .iter()
+        .find(|entry| entry.name == name)
+        .map(|entry| entry.total)
 }
 
 fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {

--- a/davinci-road/open-questions.md
+++ b/davinci-road/open-questions.md
@@ -74,8 +74,16 @@ agree on the artifact, its diagnostics, its provenance and every fact
 table.
 
 This narrows the fusion question rather than answering it. What remains
-above the one-walk target is (a) the pre-S2 template walk, which
-parse-to-S2 removes, and (b) the passes an artifact genuinely owes —
+above the one-walk target is (a) the pre-S2 template walk — **which the
+production path has already stopped paying**: `vize_atelier_sfc` calls
+`compile_sfc_template_*`, whose S2 fast path
+(`vize_atelier_dom/src/compile/sfc.rs`) never parses or transforms
+through the legacy lane, so the ladder measures 3/4/6/4/3/3 S2 walks
+there against the `compile_template` entry's 4/5/7/5/4/4. That last walk
+is owed to `compile_template`'s public contract, which returns the
+transformed AST, not to any build; the witness is
+`the_sfc_entry_pays_no_pre_s2_walk`. And (b) the passes an artifact
+genuinely owes —
 `v-if`'s sibling lookahead and `v-slot`'s slot collection are the two the
 task contract already names as region-local, so those are the ones real
 fusion has to earn. **Skipping is not fusing**, and the walk counts above


### PR DESCRIPTION
Follow-up to #5878, on the same P2-12b measurement.

## What the build-path witness was measuring

`davinci_s2_build_profile` measures `vize_atelier_dom::compile_template`, and reports a pre-S2 template walk — the legacy parse + transform — on every ladder fixture. `open-questions.md`'s fusion-depth entry read that as the build path still paying for the legacy lane.

It is not what a build calls. `vize_atelier_sfc::compile_template_block` reaches `compile_sfc_template_*`, whose S2 fast path (`compile/sfc.rs`) returns before `compile_template_inner_with_sections` whenever the source clears `selector::s2_sfc_fast_path_supported_source` and no source map is asked for — so it never parses or transforms through the legacy lane at all.

Measured on the ladder:

| fixture | `compile_template` | **SFC entry** |
| --- | ---: | ---: |
| small | 4 | **3** |
| medium | 5 | **4** |
| large | 7 | **6** |
| stress-deep | 5 | **4** |
| stress-wide | 4 | **3** |
| stress-interp | 4 | **3** |

One walk fewer, every time. That walk is owed to `compile_template`'s public contract — it returns the transformed `RootNode` to its caller — not to any build.

## What this adds

`the_sfc_entry_pays_no_pre_s2_walk` asserts on the SFC entry that:

- the `davinci.s2_dom.pre_s2.walks` counter is **absent**, not merely small — the legacy transform did not run; and
- its total is exactly the build-path row minus one, so neither table can drift on its own.

`open-questions.md` is corrected to say where the remaining gap actually is: on the production path it is the S2 transform and emit walks, and (b) the passes an artifact genuinely owes. Nothing about the compiler changes here — this is the measurement catching up with what #5878 and the P2-11 switch already made true.

`cargo test -p vize_atelier_dom` green; `source-file-lengths` and `davinci-assertion-lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791354071&installation_model_id=422833&pr_number=5885&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5885&signature=735c7bb700c5d986b28df540c609015504f4c379f9a50c4247497e5cd69565ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->