### PR TITLE
fix(davinci): lower JSX v-show through S2

### DIFF
--- a/crates/vize_atelier_jsx/src/s2.rs
+++ b/crates/vize_atelier_jsx/src/s2.rs
@@ -14,7 +14,7 @@ use vize_s0::{Allocator, Box, Vec};
 use vize_s2::expr::ExprRef;
 use vize_s2::op::{
     Attribute, BindOp, BindingOp, ComponentOp, DynamicName, ElementOp, InterpolationOp, Namespace,
-    OnOp, Op, Region, TextOp,
+    OnOp, Op, Region, TextOp, VueShowOp,
 };
 
 /// A JSX render root represented as S2 operations.
@@ -182,10 +182,17 @@ fn lower_binding<'a>(
     allocator: &'a Allocator,
     directive: &vize_relief::DirectiveNode<'a>,
 ) -> Result<BindingOp<'a>, S2Refusal> {
-    if !matches!(directive.name, "bind" | "on") {
-        return Err(S2Refusal::Directive);
+    match directive.name {
+        "bind" | "on" => lower_bind_or_on(allocator, directive),
+        "show" => lower_show(allocator, directive),
+        _ => Err(S2Refusal::Directive),
     }
+}
 
+fn lower_bind_or_on<'a>(
+    allocator: &'a Allocator,
+    directive: &vize_relief::DirectiveNode<'a>,
+) -> Result<BindingOp<'a>, S2Refusal> {
     let name = lower_dynamic_name(allocator, directive.arg.as_ref())?;
     let modifiers = lower_modifiers(allocator, directive);
     let expression = directive
@@ -215,6 +222,27 @@ fn lower_binding<'a>(
         ))),
         _ => unreachable!("directive name was admitted above"),
     }
+}
+
+fn lower_show<'a>(
+    allocator: &'a Allocator,
+    directive: &vize_relief::DirectiveNode<'a>,
+) -> Result<BindingOp<'a>, S2Refusal> {
+    if directive.arg.is_some() || !directive.modifiers.is_empty() {
+        return Err(S2Refusal::Directive);
+    }
+    let Some(expression) = directive.exp.as_ref() else {
+        return Err(S2Refusal::Directive);
+    };
+    let value = lower_expression(allocator, expression)?;
+
+    Ok(BindingOp::VueShow(Box::new_in(
+        VueShowOp {
+            value,
+            span: directive.loc.span,
+        },
+        &allocator,
+    )))
 }
 
 fn lower_modifiers<'a>(
@@ -271,66 +299,4 @@ const fn namespace(namespace: ReliefNamespace) -> Namespace {
 }
 
 #[cfg(test)]
-mod tests {
-    use vize_s0::Allocator;
-    use vize_s2::op::Op;
-
-    use crate::{JsxLang, lower_source};
-
-    use super::S2Refusal;
-
-    #[test]
-    fn lower_source_attaches_static_intrinsic_s2_root() {
-        let allocator = Allocator::new();
-        let source = "const App = () => <div id=\"x\">hello {name}<span hidden /></div>";
-        let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
-        let root = lowered.roots.first().expect("one JSX root");
-
-        let s2 = root.s2.as_ref().expect("static intrinsic S2 root");
-        assert_eq!(s2.source, source);
-        assert_eq!(s2.op_count, 4);
-        let Op::Element(element) = &s2.root.ops[0] else {
-            panic!("root is an element");
-        };
-        assert_eq!(element.tag, "div");
-        assert_eq!(element.attributes[0].name, "id");
-        assert_eq!(element.attributes[0].value, Some("x"));
-        let Op::Interpolation(interpolation) = &element.children.ops[1] else {
-            panic!("second child is interpolation");
-        };
-        assert_eq!(interpolation.expression.source(), "name");
-        assert_eq!(
-            interpolation.expression.span().start,
-            source.find("name").unwrap() as u32
-        );
-    }
-
-    #[test]
-    fn lower_source_attaches_component_s2_root() {
-        let allocator = Allocator::new();
-        let source = "const App = () => <Panel title=\"x\" />";
-        let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
-        let root = lowered.roots.first().expect("one JSX root");
-
-        let s2 = root.s2.as_ref().expect("component S2 root");
-        let Op::Component(component) = &s2.root.ops[0] else {
-            panic!("root is a component");
-        };
-        assert_eq!(component.name, "Panel");
-        assert_eq!(component.attributes[0].name, "title");
-    }
-
-    #[test]
-    fn non_bind_directive_needs_its_own_s2_binding_lowering() {
-        let allocator = Allocator::new();
-        let lowered = lower_source(
-            &allocator,
-            allocator.as_oxc(),
-            "const App = () => <div v-show={visible} />",
-            JsxLang::Jsx,
-        );
-        let root = lowered.roots.first().expect("one JSX root");
-
-        assert!(matches!(root.s2, Err(S2Refusal::Directive)));
-    }
-}
+mod tests;

--- a/crates/vize_atelier_jsx/src/s2/tests.rs
+++ b/crates/vize_atelier_jsx/src/s2/tests.rs
@@ -1,0 +1,102 @@
+use vize_s0::Allocator;
+use vize_s2::op::{BindingOp, Op};
+
+use crate::{JsxLang, lower_source};
+
+use super::S2Refusal;
+
+#[test]
+fn lower_source_attaches_static_intrinsic_s2_root() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <div id=\"x\">hello {name}<span hidden /></div>";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("static intrinsic S2 root");
+    assert_eq!(s2.source, source);
+    assert_eq!(s2.op_count, 4);
+    let Op::Element(element) = &s2.root.ops[0] else {
+        panic!("root is an element");
+    };
+    assert_eq!(element.tag, "div");
+    assert_eq!(element.attributes[0].name, "id");
+    assert_eq!(element.attributes[0].value, Some("x"));
+    let Op::Interpolation(interpolation) = &element.children.ops[1] else {
+        panic!("second child is interpolation");
+    };
+    assert_eq!(interpolation.expression.source(), "name");
+    assert_eq!(
+        interpolation.expression.span().start,
+        source.find("name").unwrap() as u32
+    );
+}
+
+#[test]
+fn lower_source_attaches_component_s2_root() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <Panel title=\"x\" />";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("component S2 root");
+    let Op::Component(component) = &s2.root.ops[0] else {
+        panic!("root is a component");
+    };
+    assert_eq!(component.name, "Panel");
+    assert_eq!(component.attributes[0].name, "title");
+}
+
+#[test]
+fn v_show_directive_projects_to_s2_vue_show() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <div v-show={visible} />";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("v-show projects to S2");
+    assert_eq!(s2.op_count, 2);
+    let Op::Element(element) = &s2.root.ops[0] else {
+        panic!("root is an element");
+    };
+    assert_eq!(element.bindings.len(), 1);
+    let BindingOp::VueShow(show) = &element.bindings[0] else {
+        panic!("binding is vue.show");
+    };
+    assert_eq!(show.value.source(), "visible");
+    assert_eq!(
+        show.value.span().start,
+        source.find("visible").unwrap() as u32
+    );
+    assert_eq!(
+        show.span.start,
+        source.find("v-show={visible}").unwrap() as u32
+    );
+}
+
+#[test]
+fn v_show_without_value_stays_on_directive_refusal_path() {
+    let allocator = Allocator::new();
+    let lowered = lower_source(
+        &allocator,
+        allocator.as_oxc(),
+        "const App = () => <div v-show />",
+        JsxLang::Jsx,
+    );
+    let root = lowered.roots.first().expect("one JSX root");
+
+    assert!(matches!(root.s2, Err(S2Refusal::Directive)));
+}
+
+#[test]
+fn v_show_with_argument_stays_on_directive_refusal_path() {
+    let allocator = Allocator::new();
+    let lowered = lower_source(
+        &allocator,
+        allocator.as_oxc(),
+        "const App = () => <div v-show:display={visible} />",
+        JsxLang::Jsx,
+    );
+    let root = lowered.roots.first().expect("one JSX root");
+
+    assert!(matches!(root.s2, Err(S2Refusal::Directive)));
+}

--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -27,6 +27,14 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             "component spread",
             "const A = () => <B {...attrs} foo={f} title=\"ok\" />;",
         ),
+        (
+            "element v-show",
+            "const A = () => <div v-show={visible} />;",
+        ),
+        (
+            "component v-show",
+            "const A = () => <B v-show={visible} />;",
+        ),
     ];
 
     for (name, source) in cases {

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -116,9 +116,12 @@ fn op_is_supported(op: &Op<'_>) -> bool {
 }
 
 fn bindings_are_supported(bindings: &[BindingOp<'_>]) -> bool {
-    bindings
-        .iter()
-        .all(|binding| matches!(binding, BindingOp::Bind(_) | BindingOp::On(_)))
+    bindings.iter().all(|binding| {
+        matches!(
+            binding,
+            BindingOp::Bind(_) | BindingOp::On(_) | BindingOp::VueShow(_)
+        )
+    })
 }
 
 fn component_is_supported(component: &ComponentOp<'_>) -> bool {
@@ -169,155 +172,10 @@ fn component_binding_is_supported(binding: &BindingOp<'_>) -> bool {
                 && on.modifiers.is_empty()
                 && matches!(on.name, Some(DynamicName::Static(_)))
         }
+        BindingOp::VueShow(_) => true,
         _ => false,
     }
 }
 
 #[cfg(test)]
-mod tests {
-    use vize_croquis::Croquis;
-    use vize_s0::Allocator;
-
-    use crate::{JsxLang, JsxOutputMode, lower_source};
-
-    use super::super::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
-
-    #[test]
-    fn native_vdom_admitted_roots_emit_from_s2() {
-        let allocator = Allocator::new();
-        let source = "const A = () => <div>{count}</div>;";
-        let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
-        let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
-        let mut root = lowered.roots.pop().expect("one JSX root");
-        root.root.children.clear();
-
-        let mut diagnostics = Vec::new();
-        let component = compile_root_to_vdom(
-            &allocator,
-            root,
-            analysis,
-            false,
-            &VdomCompileOptions::default(),
-            VdomCompatOptions::default(),
-            &mut diagnostics,
-            source,
-        );
-
-        assert!(diagnostics.is_empty(), "{diagnostics:?}");
-        assert_eq!(component.mode, JsxOutputMode::Vdom);
-        assert_eq!(
-            component.code.as_str(),
-            "export function render(_ctx, _cache) {\n  return (_openBlock(), \
-             _createElementBlock(\"div\", null, _toDisplayString(count), 1 /* TEXT */))\n}"
-        );
-    }
-
-    #[test]
-    fn component_slot_children_stay_on_relief_until_slot_facts_are_authoritative() {
-        let allocator = Allocator::new();
-        let source = "const A = () => <Card><h1>Title</h1></Card>;";
-        let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
-        let root = lowered.roots.pop().expect("one JSX root");
-        let s2 = root.s2.as_ref().expect("component child projects to S2");
-
-        assert_eq!(super::root_is_supported(s2), false);
-    }
-
-    #[test]
-    fn leaf_root_component_with_static_props_emits_from_s2() {
-        let allocator = Allocator::new();
-        let source = "const A = () => <B foo={f} title=\"ok\" />";
-        let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
-        let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
-        let mut root = lowered.roots.pop().expect("one JSX root");
-        let s2 = root.s2.as_ref().expect("leaf component projects to S2");
-
-        assert_eq!(super::root_is_supported(s2), true);
-
-        root.root.children.clear();
-        let mut diagnostics = Vec::new();
-        let component = compile_root_to_vdom(
-            &allocator,
-            root,
-            analysis,
-            false,
-            &VdomCompileOptions::default(),
-            VdomCompatOptions::default(),
-            &mut diagnostics,
-            source,
-        );
-
-        assert!(diagnostics.is_empty(), "{diagnostics:?}");
-        assert_eq!(
-            component.preamble.as_str(),
-            "import { resolveComponent as _resolveComponent, openBlock as _openBlock, \
-             createBlock as _createBlock } from \"vue\"\n"
-        );
-        assert_eq!(
-            component.code.as_str(),
-            "export function render(_ctx, _cache) {\n  const _component_B = \
-             _resolveComponent(\"B\")\n  \n  return (_openBlock(), _createBlock(_component_B, \
-             {\n    foo: f,\n    title: \"ok\"\n  }, null, 8 /* PROPS */, [\"foo\"]))\n}"
-        );
-    }
-
-    #[test]
-    fn component_spread_props_emit_from_s2() {
-        let allocator = Allocator::new();
-        let source = "const A = () => <B {...attrs} foo={f} title=\"ok\" />";
-        let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
-        let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
-        let mut root = lowered.roots.pop().expect("one JSX root");
-        let s2 = root.s2.as_ref().expect("component spread projects to S2");
-
-        assert_eq!(super::root_is_supported(s2), true);
-
-        root.root.children.clear();
-        let mut diagnostics = Vec::new();
-        let component = compile_root_to_vdom(
-            &allocator,
-            root,
-            analysis,
-            false,
-            &VdomCompileOptions::default(),
-            VdomCompatOptions::default(),
-            &mut diagnostics,
-            source,
-        );
-
-        assert!(diagnostics.is_empty(), "{diagnostics:?}");
-        assert_eq!(
-            component.preamble.as_str(),
-            "import { resolveComponent as _resolveComponent, mergeProps as _mergeProps, \
-             openBlock as _openBlock, createBlock as _createBlock } from \"vue\"\n"
-        );
-        assert_eq!(
-            component.code.as_str(),
-            "export function render(_ctx, _cache) {\n  const _component_B = \
-             _resolveComponent(\"B\")\n  \n  return (_openBlock(), _createBlock(_component_B, \
-             _mergeProps(attrs, {\n    foo: f,\n    title: \"ok\"\n  }), null, 16 /* FULL_PROPS */, \
-             [\"foo\"]))\n}"
-        );
-    }
-
-    #[test]
-    fn dynamic_component_tags_stay_on_relief_until_component_admission_widens() {
-        let allocator = Allocator::new();
-        let source = "const A = () => <Widget.Panel active />";
-        let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
-        let root = lowered.roots.pop().expect("one JSX root");
-        let s2 = root.s2.as_ref().expect("dynamic component projects to S2");
-
-        assert_eq!(super::root_is_supported(s2), false);
-    }
-
-    #[test]
-    fn component_v_slots_still_refuses_s2_projection() {
-        let allocator = Allocator::new();
-        let source = "const A = () => <B v-slots={slots} />";
-        let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
-        let root = lowered.roots.pop().expect("one JSX root");
-
-        assert_eq!(root.s2.err(), Some(crate::s2::S2Refusal::Directive));
-    }
-}
+mod tests;

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/tests.rs
@@ -1,0 +1,183 @@
+use vize_croquis::Croquis;
+use vize_s0::Allocator;
+
+use crate::{JsxLang, JsxOutputMode, lower_source};
+
+use super::super::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
+
+#[test]
+fn native_vdom_admitted_roots_emit_from_s2() {
+    let allocator = Allocator::new();
+    let source = "const A = () => <div>{count}</div>;";
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
+    root.root.children.clear();
+
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert_eq!(component.mode, JsxOutputMode::Vdom);
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  return (_openBlock(), \
+         _createElementBlock(\"div\", null, _toDisplayString(count), 1 /* TEXT */))\n}"
+    );
+}
+
+#[test]
+fn component_slot_children_stay_on_relief_until_slot_facts_are_authoritative() {
+    let allocator = Allocator::new();
+    let source = "const A = () => <Card><h1>Title</h1></Card>;";
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.pop().expect("one JSX root");
+    let s2 = root.s2.as_ref().expect("component child projects to S2");
+
+    assert_eq!(super::root_is_supported(s2), false);
+}
+
+#[test]
+fn leaf_root_component_with_static_props_emits_from_s2() {
+    let allocator = Allocator::new();
+    let source = "const A = () => <B foo={f} title=\"ok\" />";
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
+    let s2 = root.s2.as_ref().expect("leaf component projects to S2");
+
+    assert_eq!(super::root_is_supported(s2), true);
+
+    root.root.children.clear();
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { resolveComponent as _resolveComponent, openBlock as _openBlock, \
+         createBlock as _createBlock } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  const _component_B = \
+         _resolveComponent(\"B\")\n  \n  return (_openBlock(), _createBlock(_component_B, \
+         {\n    foo: f,\n    title: \"ok\"\n  }, null, 8 /* PROPS */, [\"foo\"]))\n}"
+    );
+}
+
+#[test]
+fn component_spread_props_emit_from_s2() {
+    let allocator = Allocator::new();
+    let source = "const A = () => <B {...attrs} foo={f} title=\"ok\" />";
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
+    let s2 = root.s2.as_ref().expect("component spread projects to S2");
+
+    assert_eq!(super::root_is_supported(s2), true);
+
+    root.root.children.clear();
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { resolveComponent as _resolveComponent, mergeProps as _mergeProps, \
+         openBlock as _openBlock, createBlock as _createBlock } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  const _component_B = \
+         _resolveComponent(\"B\")\n  \n  return (_openBlock(), _createBlock(_component_B, \
+         _mergeProps(attrs, {\n    foo: f,\n    title: \"ok\"\n  }), null, 16 /* FULL_PROPS */, \
+         [\"foo\"]))\n}"
+    );
+}
+
+#[test]
+fn dynamic_component_tags_stay_on_relief_until_component_admission_widens() {
+    let allocator = Allocator::new();
+    let source = "const A = () => <Widget.Panel active />";
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.pop().expect("one JSX root");
+    let s2 = root.s2.as_ref().expect("dynamic component projects to S2");
+
+    assert_eq!(super::root_is_supported(s2), false);
+}
+
+#[test]
+fn element_v_show_emits_from_s2() {
+    let allocator = Allocator::new();
+    let source = "const A = () => <div v-show={visible} />";
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
+    let s2 = root.s2.as_ref().expect("v-show projects to S2");
+
+    assert_eq!(super::root_is_supported(s2), true);
+
+    root.root.children.clear();
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { withDirectives as _withDirectives, openBlock as _openBlock, \
+         createElementBlock as _createElementBlock, vShow as _vShow } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  return _withDirectives((_openBlock(), \
+         _createElementBlock(\"div\", null, null, 512 /* NEED_PATCH */)), [\n    \
+         [_vShow, visible]\n  ])\n}"
+    );
+}
+
+#[test]
+fn component_v_slots_still_refuses_s2_projection() {
+    let allocator = Allocator::new();
+    let source = "const A = () => <B v-slots={slots} />";
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.pop().expect("one JSX root");
+
+    assert_eq!(root.s2.err(), Some(crate::s2::S2Refusal::Directive));
+}


### PR DESCRIPTION
## Summary
- lower JSX v-show directives into the S2 VueShow binding when the value is explicit
- admit v-show in the JSX VDOM S2 fast path for supported elements and leaf components
- keep missing-value and argument forms on the explicit S2 refusal path

## Verification
- cargo fmt --all --check
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- cargo test -p vize_atelier_jsx s2 -- --nocapture
- cargo test -p vize_atelier_jsx vdom_parity_matrix_snapshot -- --nocapture
- cargo test -p vize_atelier_jsx --features davinci-differential s2_vdom_admitted_cases_match_relief_codegen -- --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791354504&installation_model_id=422833&pr_number=5886&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5886&signature=6b79720aa79dace9632bdc7d6062bdfbb84dc66d5fccf58b88efeb2e5075867f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->