### PR TITLE
fix(musea): inject axe-core's real bundle, and stop reporting audit failures as a11y violations

### DIFF
--- a/npm/builder/vite-musea/src/a11y/index.test.ts
+++ b/npm/builder/vite-musea/src/a11y/index.test.ts
@@ -2,7 +2,15 @@ import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 import test from "node:test";
 
-import { resolveAxeSource } from "./index.ts";
+import type { A11yResult } from "../types/index.ts";
+import type { MuseaVrtRunner } from "../vrt.ts";
+import {
+  MuseaA11yRunner,
+  computeA11ySummary,
+  generateA11yHtmlReport,
+  generateA11yJsonReport,
+  resolveAxeSource,
+} from "./index.ts";
 
 /**
  * axe-core ships CommonJS, so `(await import("axe-core")).source` is
@@ -26,4 +34,101 @@ void test("the injectable axe-core bundle survives the ESM interop", async () =>
   );
 
   assert.equal(await resolveAxeSource(), expected);
+});
+
+/**
+ * The other half of #5890: a variant whose audit never ran was recorded as a
+ * synthetic `critical` violation, so a completely broken run reported "79
+ * critical violations" and failed `--ci` citing accessibility. Nothing about
+ * accessibility had been measured. The failure has to read as a failure.
+ */
+const errored: A11yResult = {
+  artPath: "src/Button.art.vue",
+  variantName: "primary",
+  violations: [],
+  passes: 0,
+  incomplete: 0,
+  error: "page.evaluate: TypeError: axe is undefined",
+};
+
+const audited: A11yResult = {
+  artPath: "src/Card.art.vue",
+  variantName: "default",
+  violations: [],
+  passes: 12,
+  incomplete: 0,
+};
+
+void test("an audit that never ran is not counted as an accessibility violation", () => {
+  const summary = computeA11ySummary([errored]);
+
+  assert.equal(summary.erroredVariants, 1);
+  assert.equal(summary.totalViolations, 0);
+  assert.equal(summary.criticalCount, 0);
+  assert.equal(summary.totalVariants, 1);
+});
+
+void test("the HTML report neither hides an unaudited variant nor calls it all-clear", () => {
+  const html = generateA11yHtmlReport([errored], computeA11ySummary([errored]));
+
+  assert.equal(html.includes("No accessibility violations found"), false);
+  assert.equal(html.includes("audit did not run"), true);
+  assert.equal(html.includes("page.evaluate: TypeError: axe is undefined"), true);
+});
+
+void test("a genuinely clean run still reads as clean", () => {
+  const html = generateA11yHtmlReport([audited], computeA11ySummary([audited]));
+
+  assert.equal(computeA11ySummary([audited]).erroredVariants, 0);
+  assert.equal(html.includes("No accessibility violations found"), true);
+});
+
+void test("the JSON report carries the audit error through to CI", () => {
+  const parsed = JSON.parse(generateA11yJsonReport([errored, audited])) as {
+    summary: { erroredVariants: number; criticalCount: number };
+    results: Array<{ variant: string; error?: string; violations: unknown[] }>;
+  };
+
+  assert.equal(parsed.summary.erroredVariants, 1);
+  assert.equal(parsed.summary.criticalCount, 0);
+  assert.equal(parsed.results[0]?.error, errored.error);
+  assert.deepEqual(parsed.results[0]?.violations, []);
+  assert.equal(parsed.results[1]?.error, undefined);
+});
+
+/**
+ * The path the issue actually walked: `runAudits` catches a per-variant
+ * failure. It used to turn that into `{ id: "audit-error", impact:
+ * "critical" }`, which is how a broken run produced one "critical
+ * accessibility violation" per variant.
+ */
+void test("a failed audit is recorded as an error, not a fabricated violation", async () => {
+  const runner = new MuseaA11yRunner();
+  const failingVrtRunner = {
+    createPage: () => Promise.reject(new Error("browser is gone")),
+  } as unknown as MuseaVrtRunner;
+
+  const results = await runner.runAudits(
+    [
+      {
+        path: "src/Button.art.vue",
+        metadata: { title: "Button", tags: [], status: "ready" },
+        variants: [{ name: "primary", template: "<button />", isDefault: true, skipVrt: false }],
+        hasScriptSetup: false,
+        hasScript: false,
+        styleCount: 0,
+      },
+    ],
+    "http://localhost:5173/__musea__",
+    failingVrtRunner,
+  );
+
+  assert.equal(results.length, 1);
+  assert.deepEqual(results[0]?.violations, []);
+  assert.equal(results[0]?.error, "browser is gone");
+
+  const summary = runner.getSummary(results);
+  assert.equal(summary.criticalCount, 0);
+  assert.equal(summary.totalViolations, 0);
+  assert.equal(summary.erroredVariants, 1);
 });

--- a/npm/builder/vite-musea/src/a11y/index.test.ts
+++ b/npm/builder/vite-musea/src/a11y/index.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import test from "node:test";
+
+import { resolveAxeSource } from "./index.ts";
+
+/**
+ * axe-core ships CommonJS, so `(await import("axe-core")).source` is
+ * `undefined` under ESM — the named export is not interop-detected. The
+ * audit used to inject that `undefined`, which injected nothing and failed
+ * one step later as `Cannot read properties of undefined (reading 'run')`.
+ *
+ * The oracle is axe-core's own CommonJS export, which is what the bundle
+ * `axe.run` lives in; the ESM path has to produce exactly that string.
+ */
+void test("the injectable axe-core bundle survives the ESM interop", async () => {
+  const require = createRequire(import.meta.url);
+  const expected = (require("axe-core") as { source: string }).source;
+
+  // Guard against a vacuous comparison: an empty oracle would let a broken
+  // resolver pass by returning an empty string.
+  assert.equal(typeof expected, "string");
+  assert.ok(
+    expected.length > 10_000,
+    `axe-core's bundle looks truncated: ${expected.length} bytes`,
+  );
+
+  assert.equal(await resolveAxeSource(), expected);
+});

--- a/npm/builder/vite-musea/src/a11y/index.ts
+++ b/npm/builder/vite-musea/src/a11y/index.ts
@@ -47,6 +47,39 @@ interface AxeResult {
 }
 
 /**
+ * Read axe-core's injectable browser bundle.
+ *
+ * axe-core ships CommonJS (`"main": "axe.js"`, no `exports` map), so under
+ * ESM its exports arrive on the namespace's `default` and `source` is not
+ * interop-detected as a named export: `(await import("axe-core")).source`
+ * is `undefined`. Injecting that injects nothing, leaves `window.axe`
+ * undefined, and the audit dies later as `Cannot read properties of
+ * undefined (reading 'run')` — a failure that points at the wrong line. So
+ * read both shapes and fail here, where the cause is still legible.
+ */
+export async function resolveAxeSource(): Promise<string> {
+  let namespace: { source?: unknown; default?: { source?: unknown } };
+  try {
+    namespace = await import("axe-core");
+  } catch (cause) {
+    throw new Error(
+      "axe-core is not installed. Install it as a peer dependency: npm install axe-core",
+      { cause },
+    );
+  }
+
+  const source = namespace.source ?? namespace.default?.source;
+  if (typeof source !== "string" || source.length === 0) {
+    throw new Error(
+      "axe-core is installed but exposes no `source` bundle to inject. " +
+        "Expected a non-empty string on either the module namespace or its " +
+        "default export; check that the installed axe-core version is >= 4.",
+    );
+  }
+  return source;
+}
+
+/**
  * A11y runner using axe-core via Playwright.
  */
 export class MuseaA11yRunner {
@@ -134,7 +167,7 @@ export class MuseaA11yRunner {
    */
   async auditPage(page: Page, artPath: string, variantName: string): Promise<A11yResult> {
     // Inject axe-core into the page
-    const axeSource = await this.getAxeSource();
+    const axeSource = await resolveAxeSource();
     await page.evaluate(axeSource);
 
     // Build axe-core run options
@@ -184,20 +217,6 @@ export class MuseaA11yRunner {
    */
   generateJsonReport(results: A11yResult[]): string {
     return generateA11yJsonReport(results);
-  }
-
-  /**
-   * Get axe-core source code for injection.
-   */
-  private async getAxeSource(): Promise<string> {
-    try {
-      const axeCore = await import("axe-core");
-      return axeCore.source;
-    } catch {
-      throw new Error(
-        "axe-core is not installed. Install it as a peer dependency: npm install axe-core",
-      );
-    }
   }
 
   /**

--- a/npm/builder/vite-musea/src/a11y/index.ts
+++ b/npm/builder/vite-musea/src/a11y/index.ts
@@ -24,6 +24,8 @@ export { computeA11ySummary, generateA11yHtmlReport, generateA11yJsonReport } fr
 export interface A11ySummary {
   totalComponents: number;
   totalVariants: number;
+  /** Variants whose audit could not run at all; see `A11yResult.error`. */
+  erroredVariants: number;
   totalViolations: number;
   criticalCount: number;
   seriousCount: number;
@@ -139,17 +141,10 @@ export class MuseaA11yRunner {
           results.push({
             artPath: art.path,
             variantName: variant.name,
-            violations: [
-              {
-                id: "audit-error",
-                impact: "critical",
-                description: `Audit failed: ${error instanceof Error ? error.message : String(error)}`,
-                helpUrl: "",
-                nodes: 0,
-              },
-            ],
+            violations: [],
             passes: 0,
             incomplete: 0,
+            error: error instanceof Error ? error.message : String(error),
           });
         } finally {
           if (context) {

--- a/npm/builder/vite-musea/src/a11y/report.ts
+++ b/npm/builder/vite-musea/src/a11y/report.ts
@@ -19,6 +19,7 @@ export function computeA11ySummary(results: A11yResult[]): A11ySummary {
   return {
     totalComponents: components.size,
     totalVariants: results.length,
+    erroredVariants: results.filter((r) => r.error !== undefined).length,
     totalViolations: allViolations.length,
     criticalCount: allViolations.filter((v) => v.impact === "critical").length,
     seriousCount: allViolations.filter((v) => v.impact === "serious").length,
@@ -53,6 +54,22 @@ export function generateA11yHtmlReport(results: A11yResult[], summary: A11ySumma
         return "#7b8494";
     }
   };
+
+  const errorItems = results
+    .filter((r) => r.error !== undefined)
+    .map(
+      (r) => `
+        <div class="result">
+          <div class="result-header">
+            <div class="result-info">
+              <span class="result-name">${escapeHtml(path.basename(r.artPath, ".art.vue"))} / ${escapeHtml(r.variantName)}</span>
+              <span class="result-count">audit did not run</span>
+            </div>
+          </div>
+          <p style="padding:0.75rem 1rem;color:#f87171"><code>${escapeHtml(r.error ?? "")}</code></p>
+        </div>`,
+    )
+    .join("");
 
   const resultItems = results
     .filter((r) => r.violations.length > 0)
@@ -156,11 +173,12 @@ export function generateA11yHtmlReport(results: A11yResult[], summary: A11ySumma
       <div class="stat serious"><div class="stat-value">${summary.seriousCount}</div><div class="stat-label">Serious</div></div>
       <div class="stat moderate"><div class="stat-value">${summary.moderateCount}</div><div class="stat-label">Moderate</div></div>
       <div class="stat minor"><div class="stat-value">${summary.minorCount}</div><div class="stat-label">Minor</div></div>
+      <div class="stat critical"><div class="stat-value">${summary.erroredVariants}</div><div class="stat-label">Not audited</div></div>
     </div>
     ${
-      summary.totalViolations === 0
+      summary.totalViolations === 0 && summary.erroredVariants === 0
         ? `<div class="all-clear"><div class="all-clear-text">No accessibility violations found across ${summary.totalVariants} variant(s)</div></div>`
-        : `<div class="results">${resultItems}</div>`
+        : `<div class="results">${errorItems}${resultItems}</div>`
     }
   </main>
 </body>
@@ -182,6 +200,7 @@ export function generateA11yJsonReport(results: A11yResult[]): string {
         violations: r.violations,
         passes: r.passes,
         incomplete: r.incomplete,
+        ...(r.error === undefined ? {} : { error: r.error }),
       })),
     },
     null,

--- a/npm/builder/vite-musea/src/cli/commands.ts
+++ b/npm/builder/vite-musea/src/cli/commands.ts
@@ -81,7 +81,8 @@ export async function runVrt(options: CliOptions, artFiles: ArtFileInfo[]): Prom
         console.log(`    Variants:   ${a11ySummary.totalVariants}`);
         console.log(`    Violations: ${a11ySummary.totalViolations}`);
         console.log(`    Critical:   ${a11ySummary.criticalCount}`);
-        console.log(`    Serious:    ${a11ySummary.seriousCount}\n`);
+        console.log(`    Serious:    ${a11ySummary.seriousCount}`);
+        console.log(`    Not audited: ${a11ySummary.erroredVariants}\n`);
 
         // Generate a11y report
         const reportDir = options.output;
@@ -99,7 +100,16 @@ export async function runVrt(options: CliOptions, artFiles: ArtFileInfo[]): Prom
           console.log(`  A11y HTML report: ${a11yPath}\n`);
         }
 
-        // CI mode - exit with error on critical/serious violations
+        // CI mode - exit with error on critical/serious violations. A variant
+        // whose audit never ran fails too, but under its own message: it is
+        // not an accessibility finding, and reporting it as one sends people
+        // looking for a component defect that does not exist.
+        if (options.ci && a11ySummary.erroredVariants > 0) {
+          console.log(
+            `  CI mode: ${a11ySummary.erroredVariants} variant(s) could not be audited\n`,
+          );
+          process.exit(1);
+        }
         if (options.ci && (a11ySummary.criticalCount > 0 || a11ySummary.seriousCount > 0)) {
           console.log("  CI mode: Accessibility violations found\n");
           process.exit(1);

--- a/npm/builder/vite-musea/src/types/api.ts
+++ b/npm/builder/vite-musea/src/types/api.ts
@@ -80,6 +80,15 @@ export interface A11yResult {
   violations: A11yViolation[];
   passes: number;
   incomplete: number;
+  /**
+   * Why the audit could not run, when it could not run.
+   *
+   * A variant that failed to audit measured *nothing* about accessibility,
+   * so it reports no violations. Recording the failure here instead of as a
+   * synthetic `critical` violation keeps the counts honest: a broken run
+   * reads as broken rather than as a component with critical defects.
+   */
+  error?: string;
 }
 
 /**


### PR DESCRIPTION
Fixes #5890.

`musea-vrt --a11y` never ran an audit. Two independent defects, one per commit.

## 1. axe-core was never injected

`getAxeSource` read `(await import("axe-core")).source`. axe-core ships CommonJS (`"main": "axe.js"`, no `exports` map), so under ESM its exports arrive on the namespace's `default` and `source` is not interop-detected as a named export. Measured on the version this repo locks:

```
typeof axeCore.source          → undefined
typeof axeCore.default.source  → string
```

axe-core's `.d.ts` types the read as `string`, so nothing complained. `page.evaluate(undefined)` injected nothing, `window.axe` stayed undefined, and the audit died one line later at `window.axe.run(...)` — which is the `TypeError` in the issue, pointing at the wrong line.

Both shapes are now read, and a non-string is rejected where the cause is still legible. The blanket `catch` is narrowed too: it wrapped the whole body, so a failure *inside* a successful import was also reported as "axe-core is not installed"; it now covers only the import and carries the original error as `cause`.

## 2. A failed audit was reported as a critical accessibility violation

The issue's second complaint. `runAudits`'s catch synthesised `{ id: "audit-error", impact: "critical" }`, so the broken run reported **79 critical accessibility violations** across 79 variants that had measured nothing, and `--ci` failed citing accessibility.

`A11yResult` gains `error`; the failure goes there and `violations` stays empty. The summary counts `erroredVariants` separately, the HTML report lists unaudited variants (they were filtered out by `violations.length > 0`) and no longer prints "No accessibility violations found" over a run where nothing was audited, and the JSON report carries `error` through. `--ci` still fails — a broken audit passing silently would be worse — but under its own message and count.

## Supply chain

**No dependency change.** `axe-core@4.13.0` is already a resolved direct dependency of this package in `pnpm-lock.yaml` with its sha512 integrity hash, declared additionally as an optional peer. No new package, no lockfile edit, no new integrity hash.

## Tests

`src/a11y/index.test.ts`, 6 tests, no browser needed. `vite-musea` is in `testedPackages`, so these run in the `test-js-packages` job.

Each was mutation-checked against the pre-fix code:

| Test | Fails on old code with |
|---|---|
| the injectable axe-core bundle survives the ESM interop | `actual: undefined` — the reported bug exactly |
| a failed audit is recorded as an error, not a fabricated violation | one `critical` violation instead of an error |
| the HTML report neither hides an unaudited variant nor calls it all-clear | "No accessibility violations found" over a wholly failed run |

The interop test pins the ESM path against axe-core's own CommonJS export — the bundle `axe.run` lives in — with a length floor so an empty oracle cannot make the comparison vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791373344&installation_model_id=422833&pr_number=5892&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5892&signature=e2c5217922f53d1303c54d663abd345810cbe3af2ed0cd062ee925a7a3877e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Accessibility reports now clearly identify variants that could not be audited and include the relevant error details.
  - HTML and JSON reports distinguish audit errors from accessibility violations.
  - CLI output shows a separate “Not audited” count.

- **Bug Fixes**
  - Failed audits are no longer reported as fabricated critical violations.
  - CI now fails when any variant cannot be audited, improving the accuracy of accessibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->