### PR TITLE
test(davinci): enumerate `this.*` template expressions, the corpus's blindest spot

### DIFF
--- a/crates/vize_atelier_dom/tests/this_expression_shapes.rs
+++ b/crates/vize_atelier_dom/tests/this_expression_shapes.rs
@@ -1,0 +1,261 @@
+//! `this.*` in a template expression — the Options-API idiom the corpus
+//! does not have.
+//!
+//! Across the 13,050 hydrated corpus templates, `this` appears in a
+//! template expression exactly **once**, and never in an interpolation:
+//! primevue's `DesignColorPalette.vue`, as
+//! `:style="{ backgroundColor: this.designerService.resolveColorPlain(color) }"`.
+//! So every differential lane built on that corpus says essentially
+//! nothing about a construct every Options-API component may use. It is
+//! rare but trivially *enumerable*, which is the same shape of gap that
+//! `text_shape_matrix.rs` and `v_pre_freezes_its_subtree.rs` close.
+//!
+//! The oracle is `compile_template_legacy_with_options`, the shipped
+//! parse/transform/codegen lane, over the whole family in three option
+//! shapes. Every shape here was also run against `@vue/compiler-dom`
+//! 3.5.41 and 3.6.0-beta.10 (they agree with each other); where all of
+//! vize differs from Vue, `the_places_vize_and_vue_disagree` pins the
+//! difference rather than hiding it.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use vize_atelier_core::options::{BindingType, CodegenMode, CodegenOptions};
+use vize_atelier_dom::DomCompilerOptions;
+use vize_s0::Allocator;
+use vize_s1_to_s2::{DomEmitMode, DomEmitOptions, LegacyCaps, emit_dom_source_with_options};
+
+/// Every place a template expression can sit, carrying `this`.
+const SHAPES: &[(&str, &str)] = &[
+    ("bind_member", r#"<div :id="this.r">c</div>"#),
+    ("bind_deep", r#"<div :id="this.a.b">c</div>"#),
+    ("bind_call", r#"<div :id="this.f()">c</div>"#),
+    ("bind_dollar", r#"<div :id="this.$refs.x">c</div>"#),
+    ("bind_bare", r#"<div :id="this">c</div>"#),
+    ("bind_computed", r#"<div :id="this['r']">c</div>"#),
+    ("bind_dynamic_key", r#"<div :[this.k]="1">c</div>"#),
+    ("interp_member", "<div>{{ this.r }}</div>"),
+    ("interp_bare", "<div>{{ this }}</div>"),
+    ("interp_mixed", "<div>a {{ this.r }} b</div>"),
+    ("on_call", r#"<div @click="this.f()">c</div>"#),
+    ("on_assign", r#"<div @click="this.r = 1">c</div>"#),
+    (
+        "on_statements",
+        r#"<div @click="this.a(); this.b()">c</div>"#,
+    ),
+    ("if_member", r#"<p v-if="this.ok">c</p>"#),
+    (
+        "if_else_member",
+        r#"<p v-if="this.ok">c</p><p v-else>d</p>"#,
+    ),
+    (
+        "for_member",
+        r#"<li v-for="i in this.list" :key="i">{{ i }}</li>"#,
+    ),
+    (
+        "for_shadowed",
+        r#"<li v-for="this_ in this.list" :key="this_">x</li>"#,
+    ),
+    ("model_member", r#"<input v-model="this.r">"#),
+    ("show_member", r#"<div v-show="this.ok">c</div>"#),
+    ("style_object", r#"<div :style="{ color: this.c }">c</div>"#),
+    ("style_direct", r#"<div :style="this.s">c</div>"#),
+    ("class_direct", r#"<div :class="this.c">c</div>"#),
+    ("class_object", r#"<div :class="{ on: this.c }">c</div>"#),
+    ("text_member", r#"<p v-text="this.r"></p>"#),
+    ("html_member", r#"<div v-html="this.r"></div>"#),
+    ("memo_member", r#"<div v-memo="[this.r]">c</div>"#),
+    ("once_member", "<div v-once>{{ this.r }}</div>"),
+    ("spread_member", r#"<div v-bind="this.attrs">c</div>"#),
+    ("component_prop", r#"<MyComp :item="this.r" />"#),
+    ("component_array", r#"<MyComp :range="[this.a, this.b]" />"#),
+    ("slot_prop", r#"<slot :item="this.r">{{ this.r }}</slot>"#),
+    (
+        "nested",
+        r#"<div :id="this.a"><span :id="this.b">{{ this.c }}</span></div>"#,
+    ),
+];
+
+fn metadata() -> vize_atelier_core::options::BindingMetadata {
+    support::bindings::script_setup_metadata(&[
+        ("r", BindingType::SetupRef),
+        ("MyComp", BindingType::SetupConst),
+    ])
+}
+
+/// The three option shapes the DOM path actually ships in: the plain
+/// function-mode default, the module + `prefix_identifiers` shape, and
+/// the `<script setup>` production shape (`inline` + `cache_handlers`),
+/// which is what `compile_template_block` turns on.
+fn shape(name: &str) -> (DomCompilerOptions, DomEmitOptions<'static>) {
+    let base_emit = DomEmitOptions::DEFAULT;
+    match name {
+        "default" => (DomCompilerOptions::default(), base_emit),
+        "prefixed" => (
+            DomCompilerOptions {
+                mode: CodegenMode::Module,
+                prefix_identifiers: true,
+                ..Default::default()
+            },
+            DomEmitOptions {
+                mode: DomEmitMode::Module,
+                prefix_identifiers: true,
+                ..base_emit
+            },
+        ),
+        "production" => (
+            DomCompilerOptions {
+                mode: CodegenMode::Module,
+                prefix_identifiers: true,
+                inline: true,
+                cache_handlers: true,
+                ..Default::default()
+            },
+            DomEmitOptions {
+                mode: DomEmitMode::Module,
+                prefix_identifiers: true,
+                inline: true,
+                cache_handlers: true,
+                ..base_emit
+            },
+        ),
+        other => panic!("unknown option shape {other}"),
+    }
+}
+
+#[test]
+fn the_this_family_agrees_with_the_shipped_lane_in_every_option_shape() {
+    let metadata = metadata();
+    let table = support::bindings::binding_table(&metadata);
+    let mut compared = 0usize;
+
+    for shape_name in ["default", "prefixed", "production"] {
+        let (mut options, emit) = shape(shape_name);
+        options.binding_metadata = Some(metadata.clone());
+        let emit = DomEmitOptions {
+            bindings: Some(&table),
+            ..emit
+        };
+        support::assert_s2_matches_shipped_with_options(
+            SHAPES,
+            &options,
+            &CodegenOptions::default(),
+            &emit,
+        );
+        compared += SHAPES.len();
+    }
+
+    // The scope proof: a matrix that quietly stopped generating shapes
+    // would pass every assertion above.
+    assert_eq!(compared, SHAPES.len() * 3);
+    assert_eq!(compared, 96);
+}
+
+/// The render function's `return`, flattened — the import list's order is
+/// its own subject and would only couple this test to it.
+fn render_body(code: &str) -> String {
+    code.lines()
+        .map(str::trim)
+        .skip_while(|line| !line.starts_with("return "))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// The S2 emit's body under the module + `prefix_identifiers` shape,
+/// having first required the shipped lane to agree — so each expectation
+/// below pins **both** lanes, and says so if they ever part.
+fn prefixed_body(source: &str) -> String {
+    let metadata = metadata();
+    let table = support::bindings::binding_table(&metadata);
+    let (mut options, emit) = shape("prefixed");
+    options.binding_metadata = Some(metadata.clone());
+
+    let allocator = Allocator::new();
+    let s2 = render_body(
+        &emit_dom_source_with_options(
+            &allocator,
+            source,
+            LegacyCaps::for_version(options.dialect),
+            &DomEmitOptions {
+                bindings: Some(&table),
+                ..emit
+            },
+        )
+        .unwrap_or_else(|error| panic!("S2 emit refused {source:?}: {error:?}"))
+        .assembled(),
+    );
+    let shipped = render_body(&support::shipped_with_options(
+        source,
+        &options,
+        &CodegenOptions::default(),
+    ));
+    assert_eq!(s2, shipped, "the two lanes diverged on {source:?}");
+    s2
+}
+
+/// Where vize and `@vue/compiler-dom` part company on this family.
+///
+/// All three are the same disagreement seen from three sides: Vue's
+/// constant analysis calls a bare `this` **constant** and anything under
+/// it **dynamic**, and vize's calls a bare `this` dynamic and a member
+/// read off it constant. Neither is a miscompile — `normalizeStyle` is
+/// the identity on an object literal, and a hoisted-versus-inlined props
+/// object renders the same — but they are real output differences, and
+/// they are pinned here so that closing one is a decision rather than a
+/// surprise.
+///
+/// Every expectation below is required of the S2 emit **and** of the
+/// shipped lane, so none of this arrived with the S2 lane: the shipped
+/// transform has always read `this` this way.
+#[test]
+fn the_places_vize_and_vue_disagree() {
+    // 1. `:style` over a `this` member. Vue emits
+    //    `{ style: _normalizeStyle({ color: this.c }) }`; vize decides the
+    //    object is constant and drops the helper. This is the one shape
+    //    the corpus does have — primevue's `DesignColorPalette.vue`.
+    assert_eq!(
+        prefixed_body(r#"<div :style="{ color: this.c }">c</div>"#),
+        r#"return (_openBlock(), _createElementBlock("div", { style: { color: this.c } }, "c", 4 /* STYLE */)) }"#,
+    );
+
+    // …and vize is not simply eliding the helper everywhere: a *binding*
+    // read keeps it, which is what makes the `this` verdict a difference
+    // in the constant analysis rather than in the style printer.
+    assert_eq!(
+        prefixed_body(r#"<div :style="{ color: r }">c</div>"#),
+        r#"return (_openBlock(), _createElementBlock("div", { style: _normalizeStyle({ color: $setup.r }) }, "c", 4 /* STYLE */)) }"#,
+    );
+
+    // 2. A bare `this` as a bound value. Vue hoists the whole props
+    //    object (`_hoisted_1 = { id: this }`) and emits **no** patch flag;
+    //    vize keeps it a dynamic prop.
+    assert_eq!(
+        prefixed_body(r#"<div :id="this">c</div>"#),
+        r#"return (_openBlock(), _createElementBlock("div", { id: this }, "c", 8 /* PROPS */, ["id"])) }"#,
+    );
+
+    // 3. A bare `this` interpolated. Vue emits no patch flag for the same
+    //    reason; vize keeps `TEXT`.
+    assert_eq!(
+        prefixed_body("<div>{{ this }}</div>"),
+        r#"return (_openBlock(), _createElementBlock("div", null, _toDisplayString(this), 1 /* TEXT */)) }"#,
+    );
+
+    // The direction that matters for safety is the other one: a `this`
+    // read must never reach module scope, where `this` is `undefined`.
+    // It does not — the props hoist declines it, while the same shape
+    // over a literal is hoisted.
+    assert_eq!(
+        prefixed_body(r#"<div :style="{ color: 'red' }"></div>"#),
+        r#"return (_openBlock(), _createElementBlock("div", _hoisted_1)) }"#,
+    );
+    assert_eq!(
+        prefixed_body(r#"<MyComp :range="[this.a, this.b]" />"#),
+        r#"return (_openBlock(), _createBlock($setup.MyComp, { range: [this.a, this.b] }, null, 8 /* PROPS */, ["range"])) }"#,
+    );
+}


### PR DESCRIPTION
## The gap

Measured over the 13,050 hydrated corpus templates: `this` appears in a template expression **once**, and never in an interpolation.

| pattern | corpus files |
|---|---|
| `{{ … this.x … }}` | **0** |
| `:attr="… this.x …"` | **1** |
| `:attr="this"` | **0** |

The one hit is primevue `DesignColorPalette.vue`:

```html
<div :style="{ backgroundColor: this.designerService.resolveColorPlain(color) }" …>
```

So `davinci_dom_corpus`'s `compared=12062 divergences=0` is asserting essentially nothing about a construct any Options-API component may use. Same shape of gap as the ones `text_shape_matrix.rs` (comment-adjacent text) and `v_pre_freezes_its_subtree.rs` (`v-pre`, zero corpus templates) closed: rare in real code, trivially enumerable.

## What this adds

**`the_this_family_agrees_with_the_shipped_lane_in_every_option_shape`** — 32 shapes covering every place a template expression can sit (bindings incl. computed and dynamic keys, interpolations, handlers, `v-if`/`v-else`, `v-for` incl. a shadowing alias, `v-model`, `v-show`, class/style in both direct and object form, `v-text`/`v-html`, `v-memo`/`v-once`, object `v-bind`, component props, slot outlets, nesting) against the shipped lane in all three option shapes the DOM path ships in: the function-mode default, module + `prefix_identifiers`, and the `<script setup>` production shape (`inline` + `cache_handlers`, which is what `compile_template_block` turns on). 96 comparisons, count pinned so a matrix that stopped generating shapes fails.

**They all agree — there is no S2 defect in this family.** That is the result, not a disappointment: the blind spot is now covered.

**`the_places_vize_and_vue_disagree`** — the investigation that produced this test compared every shape against `@vue/compiler-dom` 3.5.41 and 3.6.0-beta.10 (which agree with each other). Three shapes differ, and are pinned rather than left to be rediscovered:

| shape | Vue | vize (both lanes) |
|---|---|---|
| `:style="{ color: this.c }"` | `_normalizeStyle({ color: this.c })` | `{ color: this.c }` |
| `:id="this"` | props object hoisted, **no** patch flag | `{ id: this }`, `8 /* PROPS */` |
| `{{ this }}` | **no** patch flag | `1 /* TEXT */` |

All three are one disagreement seen from three sides: **Vue's constant analysis calls a bare `this` constant and a member read off it dynamic; vize's calls a bare `this` dynamic and the member read constant.** (In `emit/constant_expr.rs`, `RuntimeDependencyVisitor` marks dynamic only from `visit_identifier_reference`, and a `ThisExpression` is not one.)

Neither is a miscompile — `normalizeStyle` is the identity on an object literal, and a hoisted-versus-inlined props object renders the same — and **both vize lanes do it**, so none of it arrived with S2. Each expectation is required of the S2 emit *and* the shipped lane, so if they ever part the test says so.

The direction that would actually matter is asserted not to happen: a `this` read never reaches module scope, where `this` is `undefined`. The test pins that the props hoist declines `[this.a, this.b]` while accepting the same shape over a literal.

## Also settled

This started from a 1-in-455 divergence in a production-option sweep, `<div :id="this.r">c</div>`, where the legacy lane hoisted `const _hoisted_1 = { id: this.r }` to module scope and S2 did not. Vue does not hoist it either — **S2 is right and the legacy lane is wrong**, and since P2-11 the DOM legacy lane is reachable only from tests behind `davinci-differential`, so nothing ships it. Recorded here so the next sweep does not re-investigate.

## Verification

- `cargo test -p vize_atelier_dom --test this_expression_shapes` — 2 tests, both green, with and without `--features davinci-differential`.
- `cargo fmt --check`, `cargo clippy --tests` clean for the new file.
- `source-file-lengths` ratchet: 246 lines, under the 350 budget.
- `davinci-assertion-lint`: 3/3 pass (exact oracles only, no `contains`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791374287&installation_model_id=422833&pr_number=5893&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5893&signature=ebdfb5892cec99a874e4d35758098fd6526ccb00abbeb63e1337fc9482008897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for Vue template expressions using `this` across bindings, interpolations, event handlers, directives, slots, and nested components.
  - Added validation across multiple compilation configurations to ensure consistent output.
  - Added compatibility checks for constant analysis and patch flags.
  - Confirmed that `this` references are not incorrectly moved to module scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->