### PR TITLE
test(davinci): reject duplicate phase 2 evidence rows

### DIFF
--- a/tests/tooling/davinci-phase2-contract-status.test.ts
+++ b/tests/tooling/davinci-phase2-contract-status.test.ts
@@ -49,26 +49,40 @@ function taskSection(id: string): string {
   return next == null ? tail : tail.slice(0, next + 1);
 }
 
-function currentEvidenceIds(): string[] {
+function currentEvidenceIds(source: string = text.records): string[] {
   const section = sectionBetween(
-    text.records,
+    source,
     /^## Current completion evidence /mu,
     /^## Historical task records/mu,
     "current completion evidence",
   );
-  return [...section.matchAll(/^\| (?<id>P2-[^ |]+)\s+\| \[#\d+\]/gmu)].map(
-    (match) => match.groups!.id,
+  return uniqueTaskIds(
+    [...section.matchAll(/^\| (?<id>P2-[^ |]+)\s+\| \[#\d+\]/gmu)].map((match) => match.groups!.id),
+    "current completion evidence",
   );
 }
 
-function historicalRecordIds(): string[] {
+function historicalRecordIds(source: string = text.records): string[] {
   const section = sectionBetween(
-    text.records,
+    source,
     /^## Historical task records/mu,
     /$a/mu,
     "historical task records",
   );
-  return [...section.matchAll(/^\| \[(?<id>P2-[^\]]+)\]/gmu)].map((match) => match.groups!.id);
+  return uniqueTaskIds(
+    [...section.matchAll(/^\| \[(?<id>P2-[^\]]+)\]/gmu)].map((match) => match.groups!.id),
+    "historical task records",
+  );
+}
+
+function uniqueTaskIds(ids: string[], label: string): string[] {
+  const duplicates = ids.filter((id, index) => ids.indexOf(id) !== index);
+  assert.equal(
+    duplicates.length,
+    0,
+    `${label} has duplicate task id(s): ${[...new Set(duplicates)].join(", ")}`,
+  );
+  return ids;
 }
 
 function sectionBetween(source: string, start: RegExp, end: RegExp, label: string): string {
@@ -84,6 +98,12 @@ function recordFile(id: string): string {
   return fileURLToPath(
     new URL(`../../davinci-road/plan/phase-2-records/${id.toLowerCase()}.md`, import.meta.url),
   );
+}
+
+function duplicateLine(source: string, pattern: RegExp, label: string): string {
+  const match = pattern.exec(source);
+  assert.ok(match, `missing ${label}`);
+  return `${source.slice(0, match.index)}${match[0]}\n${source.slice(match.index)}`;
 }
 
 test("task contracts and record files reflect the current Phase 2 status", () => {
@@ -116,4 +136,26 @@ test("task contracts and record files reflect the current Phase 2 status", () =>
       assert.ok(!fs.existsSync(recordFile(id)), `${id} must not get a record file before landing`);
     }
   }
+});
+
+test("completion evidence tables reject duplicate task ids", () => {
+  const duplicatedCurrent = duplicateLine(
+    text.records,
+    /^\| P2-1\s+\| \[#4452\][^\n]+$/mu,
+    "P2-1 current evidence row",
+  );
+  const duplicatedHistorical = duplicateLine(
+    text.records,
+    /^\| \[P2-1\]\([^\n]+$/mu,
+    "P2-1 historical records row",
+  );
+
+  assert.throws(
+    () => currentEvidenceIds(duplicatedCurrent),
+    /current completion evidence has duplicate task id\(s\): P2-1/u,
+  );
+  assert.throws(
+    () => historicalRecordIds(duplicatedHistorical),
+    /historical task records has duplicate task id\(s\): P2-1/u,
+  );
 });


### PR DESCRIPTION
## Summary
- make Phase 2 evidence id extraction reject duplicate task rows
- add regression coverage for duplicate current and historical evidence rows

## Tests
- node --test tests/tooling/davinci-phase2-contract-status.test.ts
- node --test tests/tooling/davinci-phase2-contract-status.test.ts tests/tooling/davinci-phase2-ledger.test.ts
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791379503&installation_model_id=422833&pr_number=5894&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5894&signature=0b6c3e3cd4b8effadc85803675440b30efff0ab0811f30baa2065bcb8043c78a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completion evidence tables now reject duplicate task IDs, preventing ambiguous or inconsistent status reporting.
  * Current and historical completion records consistently validate task ID uniqueness before reporting status.
* **Tests**
  * Added coverage to verify duplicate task IDs are detected across current and historical records.
  * Expanded validation scenarios to confirm duplicate rows produce an appropriate error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->