### PR TITLE
feat(jsx): route dynamic components through s2 vdom

### DIFF
--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -28,6 +28,10 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             "const A = () => <B {...attrs} foo={f} title=\"ok\" />;",
         ),
         (
+            "dynamic component",
+            "const A = () => <Widget.Panel foo={1} />;",
+        ),
+        (
             "element v-show",
             "const A = () => <div v-show={visible} />;",
         ),

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -125,12 +125,19 @@ fn bindings_are_supported(bindings: &[BindingOp<'_>]) -> bool {
 }
 
 fn component_is_supported(component: &ComponentOp<'_>) -> bool {
+    let dynamic_component = component_is_dynamic(component);
     component.children.ops.is_empty()
-        && !component_name_needs_component_semantics(component.name)
+        && (dynamic_component || !component_name_needs_component_semantics(component.name))
         && component
             .bindings
             .iter()
-            .all(component_binding_is_supported)
+            .all(|binding| component_binding_is_supported(binding, dynamic_component))
+}
+
+fn component_is_dynamic(component: &ComponentOp<'_>) -> bool {
+    matches!(component.name, "component" | "Component")
+        && (component.attributes.iter().any(|attr| attr.name == "is")
+            || component.bindings.iter().any(binding_is_is))
 }
 
 fn component_name_needs_component_semantics(name: &str) -> bool {
@@ -153,10 +160,20 @@ fn component_name_needs_component_semantics(name: &str) -> bool {
     ) || name.contains('.')
 }
 
-fn component_binding_is_supported(binding: &BindingOp<'_>) -> bool {
+fn binding_is_is(binding: &BindingOp<'_>) -> bool {
+    matches!(
+        binding,
+        BindingOp::Bind(bind) if matches!(bind.name, Some(DynamicName::Static("is")))
+    )
+}
+
+fn component_binding_is_supported(binding: &BindingOp<'_>, dynamic_component: bool) -> bool {
     match binding {
         BindingOp::Bind(bind) if bind.name.is_none() => {
             bind.value.is_some() && bind.modifiers.is_empty()
+        }
+        BindingOp::Bind(bind) if binding_is_is(binding) => {
+            dynamic_component && bind.value.is_some() && bind.modifiers.is_empty()
         }
         BindingOp::Bind(bind) => {
             bind.value.is_some()

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/tests.rs
@@ -124,14 +124,40 @@ fn component_spread_props_emit_from_s2() {
 }
 
 #[test]
-fn dynamic_component_tags_stay_on_relief_until_component_admission_widens() {
+fn dynamic_component_tags_emit_from_s2() {
     let allocator = Allocator::new();
-    let source = "const A = () => <Widget.Panel active />";
+    let source = "const A = () => <Widget.Panel foo={1} />";
     let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
-    let root = lowered.roots.pop().expect("one JSX root");
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
     let s2 = root.s2.as_ref().expect("dynamic component projects to S2");
 
-    assert_eq!(super::root_is_supported(s2), false);
+    assert_eq!(super::root_is_supported(s2), true);
+
+    root.root.children.clear();
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, \
+         createBlock as _createBlock } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  return (_openBlock(), \
+         _createBlock(_resolveDynamicComponent(Widget.Panel), { foo: 1 }))\n}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- admit leaf JSX dynamic component tags through the S2 VDOM route when they lower to `component` plus an `is` binding
- keep component children and unsupported built-ins on the Relief fallback path
- add a P2-16 S2-vs-Relief differential witness for dynamic components

## Tests
- `cargo fmt --check`
- `cargo test -p vize_atelier_jsx --lib s2::tests -- --nocapture`
- `cargo test -p vize_atelier_jsx --lib vdom::s2_emit::tests -- --nocapture`
- `cargo test -p vize_atelier_jsx --features davinci-differential --lib vdom::s2_differential::s2_vdom_admitted_cases_match_relief_codegen -- --nocapture`
- `cargo test -p vize_atelier_jsx --test babel_compat_oracle -- --nocapture`
- `cargo test -p vize_atelier_jsx -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791379731&installation_model_id=422833&pr_number=5895&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5895&signature=37879977193c8b50af0653ef7ef773753eb43a29c10b889e87446d9158e35f58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for dynamic JSX components such as `<Widget.Panel />`.
  - Dynamic components can now receive properties and resolve to the appropriate component at runtime.

- **Bug Fixes**
  - Improved handling and validation of dynamic component bindings, including the `is` attribute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->