### PR TITLE
feat(jsx): emit component default children from s2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3622,6 +3622,7 @@ dependencies = [
  "vize_atelier_vapor",
  "vize_carton",
  "vize_croquis",
+ "vize_davinci",
  "vize_relief",
  "vize_s1_to_s2",
  "vize_s2",

--- a/crates/vize_atelier_jsx/Cargo.toml
+++ b/crates/vize_atelier_jsx/Cargo.toml
@@ -11,6 +11,7 @@ metadata.vize.stability = "compatibility-preview"
 [dependencies]
 # Internal crates
 vize_s0 = { workspace = true }
+vize_davinci = { workspace = true }
 vize_s2 = { workspace = true }
 vize_relief = { workspace = true }
 vize_croquis = { workspace = true }

--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -28,6 +28,22 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             "const A = () => <B {...attrs} foo={f} title=\"ok\" />;",
         ),
         (
+            "component implicit default",
+            "const A = () => <Card><h1>Title</h1></Card>;",
+        ),
+        (
+            "component text default",
+            "const A = () => <Card>Title</Card>;",
+        ),
+        (
+            "component interpolation default",
+            "const A = () => <Card>{title}</Card>;",
+        ),
+        (
+            "component nested component default",
+            "const A = () => <Card><B foo={f}/></Card>;",
+        ),
+        (
             "dynamic component",
             "const A = () => <Widget.Panel foo={1} />;",
         ),

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -1,8 +1,9 @@
 //! JSX VDOM bridge for the P2-16 S2 re-targeting slice.
 
+use vize_davinci::pass::NoObserver;
 use vize_s0::{Allocator, String};
-use vize_s1_to_s2::lower::LoweringFeatures;
-use vize_s1_to_s2::pass::S2Facts;
+use vize_s1_to_s2::lower::{LoweringFeatures, OpFamily};
+use vize_s1_to_s2::pass::{TransformProfile, run_transform_with_profile};
 use vize_s1_to_s2::{
     DomEmitMode, DomEmitOptions, LegacyCaps, Lowered as S2Lowered, emit_dom_with_options,
 };
@@ -40,7 +41,8 @@ pub(super) fn try_emit_s2_vdom<'a>(
         return None;
     }
 
-    let lowered = S2Lowered {
+    let features = features_for_region(&s2.root);
+    let mut lowered = S2Lowered {
         allocator,
         source: s2.source,
         root: s2.root,
@@ -51,10 +53,15 @@ pub(super) fn try_emit_s2_vdom<'a>(
         texts: Default::default(),
         wrappers: Default::default(),
         for_wrappers: Default::default(),
-        features: LoweringFeatures::EMPTY,
+        features,
         caps: LegacyCaps::VUE3,
     };
-    let facts = S2Facts::default();
+    let mut observer = NoObserver;
+    let facts = run_transform_with_profile(
+        &mut lowered,
+        &mut observer,
+        TransformProfile::DEFAULT.without_static_analysis(),
+    );
     let emit = emit_dom_with_options(
         &lowered,
         &facts,
@@ -126,7 +133,7 @@ fn bindings_are_supported(bindings: &[BindingOp<'_>]) -> bool {
 
 fn component_is_supported(component: &ComponentOp<'_>) -> bool {
     let dynamic_component = component_is_dynamic(component);
-    component.children.ops.is_empty()
+    region_is_supported(&component.children)
         && (dynamic_component || !component_name_needs_component_semantics(component.name))
         && component
             .bindings
@@ -191,6 +198,65 @@ fn component_binding_is_supported(binding: &BindingOp<'_>, dynamic_component: bo
         }
         BindingOp::VueShow(_) => true,
         _ => false,
+    }
+}
+
+fn features_for_region(region: &Region<'_>) -> LoweringFeatures {
+    let mut features = LoweringFeatures::EMPTY;
+    observe_region(region, &mut features);
+    features
+}
+
+fn observe_region(region: &Region<'_>, features: &mut LoweringFeatures) {
+    for op in &region.ops {
+        match op {
+            Op::Element(element) => {
+                observe_bindings(&element.bindings, features);
+                observe_region(&element.children, features);
+            }
+            Op::Component(component) => {
+                *features = features.observing(OpFamily::SlotCarrier);
+                observe_bindings(&component.bindings, features);
+                observe_region(&component.children, features);
+            }
+            Op::If(if_op) => {
+                *features = features.observing(OpFamily::If);
+                for branch in &if_op.branches {
+                    observe_region(&branch.region, features);
+                }
+            }
+            Op::For(for_op) => {
+                *features = features.observing(OpFamily::For);
+                observe_region(&for_op.region, features);
+            }
+            Op::Slot(slot) => {
+                *features = features.observing(OpFamily::SlotCarrier);
+                observe_bindings(&slot.bindings, features);
+                observe_region(&slot.fallback, features);
+            }
+            Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
+        }
+    }
+}
+
+fn observe_bindings(bindings: &[BindingOp<'_>], features: &mut LoweringFeatures) {
+    for binding in bindings {
+        match binding {
+            BindingOp::Model(_) => *features = features.observing(OpFamily::Model),
+            BindingOp::SlotContent(_) => *features = features.observing(OpFamily::SlotCarrier),
+            BindingOp::Bind(_)
+            | BindingOp::On(_)
+            | BindingOp::VueDirective(_)
+            | BindingOp::VueCssBind(_)
+            | BindingOp::VueSync(_)
+            | BindingOp::VueSlotScope(_)
+            | BindingOp::VueOnce(_)
+            | BindingOp::VueMemo(_)
+            | BindingOp::VueShow(_)
+            | BindingOp::VueHtml(_)
+            | BindingOp::VueText(_)
+            | BindingOp::VueCloak(_) => {}
+        }
     }
 }
 

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/tests.rs
@@ -36,14 +36,43 @@ fn native_vdom_admitted_roots_emit_from_s2() {
 }
 
 #[test]
-fn component_slot_children_stay_on_relief_until_slot_facts_are_authoritative() {
+fn component_plain_children_emit_from_s2_with_slot_facts() {
     let allocator = Allocator::new();
     let source = "const A = () => <Card><h1>Title</h1></Card>;";
     let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
-    let root = lowered.roots.pop().expect("one JSX root");
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
     let s2 = root.s2.as_ref().expect("component child projects to S2");
 
-    assert_eq!(super::root_is_supported(s2), false);
+    assert_eq!(super::root_is_supported(s2), true);
+
+    root.root.children.clear();
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { resolveComponent as _resolveComponent, createElementVNode as \
+         _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as \
+         _withCtx } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  const _component_Card = \
+         _resolveComponent(\"Card\")\n  \n  return (_openBlock(), _createBlock(_component_Card, \
+         null, {\n    default: _withCtx(() => [\n      _createElementVNode(\"h1\", null, \
+         \"Title\")\n    ]),\n    _: 1 /* STABLE */\n  }))\n}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- run the JSX S2 VDOM bridge through S2 transform facts so component default children can emit from S2
- admit default-slot component children and pin representative Relief parity cases
- keep the v-slots refusal path unchanged

## Tests
- cargo fmt --check
- cargo test -p vize_atelier_jsx --test s2_projection
- cargo test -p vize_atelier_jsx s2::tests --lib
- cargo test -p vize_atelier_jsx vdom::s2_emit --lib
- cargo test -p vize_atelier_jsx --features davinci-differential s2_vdom_admitted_cases_match_relief_codegen --lib
- cargo test -p vize_atelier_jsx
- node --test tests/tooling/davinci-lowering-ci-lane.test.ts tests/tooling/davinci-stage-dependencies.test.ts tests/tooling/davinci-stage-release-firewall.test.ts
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791384633&installation_model_id=422833&pr_number=5897&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5897&signature=bc1d85ab17fa7e40004e1b64f59b4848e5416206fc09be237f0620aa41334936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved component rendering for plain child content, including default slots.
  * Added support for text, interpolated content, and nested components within component children.
  * Improved handling of component slot content during rendering.

* **Tests**
  * Added coverage to verify component children render correctly across supported content types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->