### PR TITLE
refactor(jsx): carry s2 lowering feature gates

### DIFF
--- a/crates/vize_atelier_jsx/src/s2.rs
+++ b/crates/vize_atelier_jsx/src/s2.rs
@@ -11,6 +11,7 @@ use vize_relief::{
     TemplateChildNode,
 };
 use vize_s0::{Allocator, Box, Vec};
+use vize_s1_to_s2::lower::{LoweringFeatures, OpFamily};
 use vize_s2::expr::ExprRef;
 use vize_s2::op::{
     Attribute, BindOp, BindingOp, ComponentOp, DynamicName, ElementOp, InterpolationOp, Namespace,
@@ -26,6 +27,8 @@ pub struct JsxS2Root<'a> {
     pub root: Region<'a>,
     /// Number of operations, including attached bindings when they land.
     pub op_count: u32,
+    /// S2 operation families observed while projecting this JSX root.
+    pub features: LoweringFeatures,
 }
 
 /// A construct which needs a dedicated S2 lowering and must not be silently
@@ -55,11 +58,13 @@ pub fn try_lower_root<'a>(
     root: &RootNode<'a>,
 ) -> Result<JsxS2Root<'a>, S2Refusal> {
     let mut op_count = 0;
-    let ops = lower_children(allocator, &root.children, &mut op_count)?;
+    let mut features = LoweringFeatures::EMPTY;
+    let ops = lower_children(allocator, &root.children, &mut op_count, &mut features)?;
     Ok(JsxS2Root {
         source,
         root: Region { ops },
         op_count,
+        features,
     })
 }
 
@@ -67,10 +72,11 @@ fn lower_children<'a>(
     allocator: &'a Allocator,
     children: &[TemplateChildNode<'a>],
     op_count: &mut u32,
+    features: &mut LoweringFeatures,
 ) -> Result<Vec<'a, Op<'a>>, S2Refusal> {
     let mut ops = Vec::new_in(&allocator);
     for child in children {
-        ops.push(lower_child(allocator, child, op_count)?);
+        ops.push(lower_child(allocator, child, op_count, features)?);
     }
     Ok(ops)
 }
@@ -79,6 +85,7 @@ fn lower_child<'a>(
     allocator: &'a Allocator,
     child: &TemplateChildNode<'a>,
     op_count: &mut u32,
+    features: &mut LoweringFeatures,
 ) -> Result<Op<'a>, S2Refusal> {
     *op_count = op_count.saturating_add(1);
     match child {
@@ -99,7 +106,9 @@ fn lower_child<'a>(
                 &allocator,
             )))
         }
-        TemplateChildNode::Element(element) => lower_element(allocator, element, op_count),
+        TemplateChildNode::Element(element) => {
+            lower_element(allocator, element, op_count, features)
+        }
         TemplateChildNode::If(_)
         | TemplateChildNode::IfBranch(_)
         | TemplateChildNode::For(_)
@@ -114,11 +123,12 @@ fn lower_element<'a>(
     allocator: &'a Allocator,
     element: &vize_relief::ElementNode<'a>,
     op_count: &mut u32,
+    features: &mut LoweringFeatures,
 ) -> Result<Op<'a>, S2Refusal> {
     let props = lower_props(allocator, &element.props)?;
     *op_count = op_count.saturating_add(props.binding_count);
     let children = Region {
-        ops: lower_children(allocator, &element.children, op_count)?,
+        ops: lower_children(allocator, &element.children, op_count, features)?,
     };
     match element.tag_type {
         ElementType::Element => Ok(Op::Element(Box::new_in(
@@ -132,16 +142,19 @@ fn lower_element<'a>(
             },
             &allocator,
         ))),
-        ElementType::Component => Ok(Op::Component(Box::new_in(
-            ComponentOp {
-                name: element.tag,
-                attributes: props.attributes,
-                bindings: props.bindings,
-                children,
-                span: element.loc.span,
-            },
-            &allocator,
-        ))),
+        ElementType::Component => {
+            *features = features.observing(OpFamily::SlotCarrier);
+            Ok(Op::Component(Box::new_in(
+                ComponentOp {
+                    name: element.tag,
+                    attributes: props.attributes,
+                    bindings: props.bindings,
+                    children,
+                    span: element.loc.span,
+                },
+                &allocator,
+            )))
+        }
         ElementType::Slot | ElementType::Template => Err(S2Refusal::UnsupportedElement),
     }
 }

--- a/crates/vize_atelier_jsx/src/s2/tests.rs
+++ b/crates/vize_atelier_jsx/src/s2/tests.rs
@@ -15,6 +15,11 @@ fn lower_source_attaches_static_intrinsic_s2_root() {
     let s2 = root.s2.as_ref().expect("static intrinsic S2 root");
     assert_eq!(s2.source, source);
     assert_eq!(s2.op_count, 4);
+    assert!(!s2.features.has_if_ops());
+    assert!(!s2.features.has_for_ops());
+    assert!(!s2.features.has_slot_carriers());
+    assert!(!s2.features.has_text_compounds());
+    assert!(!s2.features.has_model_bindings());
     let Op::Element(element) = &s2.root.ops[0] else {
         panic!("root is an element");
     };
@@ -39,6 +44,11 @@ fn lower_source_attaches_component_s2_root() {
     let root = lowered.roots.first().expect("one JSX root");
 
     let s2 = root.s2.as_ref().expect("component S2 root");
+    assert!(s2.features.has_slot_carriers());
+    assert!(!s2.features.has_if_ops());
+    assert!(!s2.features.has_for_ops());
+    assert!(!s2.features.has_text_compounds());
+    assert!(!s2.features.has_model_bindings());
     let Op::Component(component) = &s2.root.ops[0] else {
         panic!("root is a component");
     };

--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -14,6 +14,7 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
         ("element", "const A = () => <div class=\"card\" />;"),
         ("text", "const A = () => <p>Hello</p>;"),
         ("interpolation", "const A = () => <div>{count}</div>;"),
+        ("fragment root", "const A = () => <><i/><b/></>;"),
         ("element bind", "const A = () => <button disabled={off} />;"),
         (
             "element event",

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -2,7 +2,6 @@
 
 use vize_davinci::pass::NoObserver;
 use vize_s0::{Allocator, String};
-use vize_s1_to_s2::lower::{LoweringFeatures, OpFamily};
 use vize_s1_to_s2::pass::{TransformProfile, run_transform_with_profile};
 use vize_s1_to_s2::{
     DomEmitMode, DomEmitOptions, LegacyCaps, Lowered as S2Lowered, emit_dom_with_options,
@@ -41,7 +40,6 @@ pub(super) fn try_emit_s2_vdom<'a>(
         return None;
     }
 
-    let features = features_for_region(&s2.root);
     let mut lowered = S2Lowered {
         allocator,
         source: s2.source,
@@ -53,7 +51,7 @@ pub(super) fn try_emit_s2_vdom<'a>(
         texts: Default::default(),
         wrappers: Default::default(),
         for_wrappers: Default::default(),
-        features,
+        features: s2.features,
         caps: LegacyCaps::VUE3,
     };
     let mut observer = NoObserver;
@@ -198,65 +196,6 @@ fn component_binding_is_supported(binding: &BindingOp<'_>, dynamic_component: bo
         }
         BindingOp::VueShow(_) => true,
         _ => false,
-    }
-}
-
-fn features_for_region(region: &Region<'_>) -> LoweringFeatures {
-    let mut features = LoweringFeatures::EMPTY;
-    observe_region(region, &mut features);
-    features
-}
-
-fn observe_region(region: &Region<'_>, features: &mut LoweringFeatures) {
-    for op in &region.ops {
-        match op {
-            Op::Element(element) => {
-                observe_bindings(&element.bindings, features);
-                observe_region(&element.children, features);
-            }
-            Op::Component(component) => {
-                *features = features.observing(OpFamily::SlotCarrier);
-                observe_bindings(&component.bindings, features);
-                observe_region(&component.children, features);
-            }
-            Op::If(if_op) => {
-                *features = features.observing(OpFamily::If);
-                for branch in &if_op.branches {
-                    observe_region(&branch.region, features);
-                }
-            }
-            Op::For(for_op) => {
-                *features = features.observing(OpFamily::For);
-                observe_region(&for_op.region, features);
-            }
-            Op::Slot(slot) => {
-                *features = features.observing(OpFamily::SlotCarrier);
-                observe_bindings(&slot.bindings, features);
-                observe_region(&slot.fallback, features);
-            }
-            Op::Text(_) | Op::Interpolation(_) | Op::Comment(_) => {}
-        }
-    }
-}
-
-fn observe_bindings(bindings: &[BindingOp<'_>], features: &mut LoweringFeatures) {
-    for binding in bindings {
-        match binding {
-            BindingOp::Model(_) => *features = features.observing(OpFamily::Model),
-            BindingOp::SlotContent(_) => *features = features.observing(OpFamily::SlotCarrier),
-            BindingOp::Bind(_)
-            | BindingOp::On(_)
-            | BindingOp::VueDirective(_)
-            | BindingOp::VueCssBind(_)
-            | BindingOp::VueSync(_)
-            | BindingOp::VueSlotScope(_)
-            | BindingOp::VueOnce(_)
-            | BindingOp::VueMemo(_)
-            | BindingOp::VueShow(_)
-            | BindingOp::VueHtml(_)
-            | BindingOp::VueText(_)
-            | BindingOp::VueCloak(_) => {}
-        }
     }
 }
 


### PR DESCRIPTION
## Summary
- carry JSX S2 feature gates on JsxS2Root instead of rescanning the region in the VDOM emitter
- pin component slot-carrier features at projection time
- add a fragment-root witness to the S2/Relief VDOM differential lane

## Tests
- cargo fmt --check
- cargo test -p vize_atelier_jsx s2::tests --lib
- cargo test -p vize_atelier_jsx --features davinci-differential s2_vdom_admitted_cases_match_relief_codegen --lib
- cargo test -p vize_atelier_jsx vdom::s2_emit --lib
- cargo test -p vize_atelier_jsx
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791386925&installation_model_id=422833&pr_number=5898&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5898&signature=514587bbef2d3ee66e03d8d4c1da9a1c993daf595e9140cfd66abdde1296cdfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSX compilation consistency for component-based and fragment-root markup.
  - Preserved accurate handling of JSX features during virtual DOM generation.

- **Tests**
  - Expanded coverage for fragment-root JSX structures.
  - Added validation for feature detection across intrinsic elements and components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->