### PR TITLE
test(davinci): reconcile s2 profile walk pins

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_profile.rs
@@ -7,6 +7,8 @@
     clippy::disallowed_types
 )]
 
+mod support;
+
 use davinci_harness::fixtures::{LADDER, template_block};
 use vize_atelier_core::options::{CodegenOptions, TemplateSyntaxMode};
 use vize_atelier_dom::{
@@ -19,23 +21,6 @@ use vize_s0::String;
 use vize_s0::profiler::{CounterSummary, global_profiler};
 
 static PROFILER_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-/// fixture -> S2 DOM emit walks, emit op visits, transform walks.
-///
-/// The transform column is per fixture because the S2 pass planner
-/// declines a mandatory pass whose op family the lowering never built
-/// (`vize_s1_to_s2::lower::features`): static analysis is the default
-/// floor, compound text and each structural family add one walk only when
-/// present. `medium` pays two for its kebab-case components, which are slot
-/// carriers even though it spells no `v-slot`.
-const S2_DOM_EMIT_COUNTS: [(&str, u64, u64, u64); 6] = [
-    ("small", 1, 5, 2),
-    ("medium", 1, 33, 2),
-    ("large", 1, 54, 4),
-    ("stress-deep", 1, 72, 2),
-    ("stress-wide", 1, 2, 1),
-    ("stress-interp", 1, 201, 2),
-];
 
 #[test]
 fn profile_reports_real_s2_dom_walks() {
@@ -80,11 +65,12 @@ fn profile_reports_ladder_s2_dom_walk_budget() {
     let profiler = global_profiler();
     profiler.disable();
     profiler.clear();
+    support::profile::assert_s2_dom_emit_counts_cover_ladder();
 
     for fixture in &LADDER {
         let template =
             template_block(fixture.source).expect("every ladder fixture has a template block");
-        let expected = s2_dom_emit_count(fixture.name);
+        let expected = support::profile::s2_dom_emit_count(fixture.name);
         let compat_allocator = Allocator::new();
         let (_, compat_errors, compat) = compile_template(&compat_allocator, template);
         assert!(
@@ -116,17 +102,23 @@ fn profile_reports_ladder_s2_dom_walk_budget() {
         assert_eq!(counter(&counters, "davinci.s2_dom.files"), 1);
         assert_eq!(
             counter(&counters, "davinci.s2_dom.transform.walks"),
-            expected.2
+            expected.transform_walks
         );
         assert_eq!(
             counter(&counters, "davinci.s2_dom.transform.passes"),
-            expected.2
+            expected.transform_walks
         );
-        assert_eq!(counter(&counters, "davinci.s2_dom.emit.walks"), expected.0);
-        assert_eq!(counter(&counters, "davinci.s2_dom.emit.visits"), expected.1);
+        assert_eq!(
+            counter(&counters, "davinci.s2_dom.emit.walks"),
+            expected.emit_walks
+        );
+        assert_eq!(
+            counter(&counters, "davinci.s2_dom.emit.visits"),
+            expected.emit_visits
+        );
         assert_eq!(
             counter(&counters, "davinci.s2_dom.total.walks"),
-            expected.2 + expected.0
+            expected.transform_walks + expected.emit_walks
         );
     }
 }
@@ -326,14 +318,6 @@ impl Drop for ProfileScope {
         profiler.disable();
         profiler.clear();
     }
-}
-
-fn s2_dom_emit_count(fixture: &str) -> (u64, u64, u64) {
-    S2_DOM_EMIT_COUNTS
-        .iter()
-        .find(|(name, ..)| *name == fixture)
-        .map(|(_, walks, visits, transform_walks)| (*walks, *visits, *transform_walks))
-        .unwrap_or_else(|| panic!("{fixture} has no pinned S2 DOM emit count"))
 }
 
 fn lock_profiler() -> std::sync::MutexGuard<'static, ()> {

--- a/crates/vize_atelier_dom/tests/support/mod.rs
+++ b/crates/vize_atelier_dom/tests/support/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod battery;
 pub mod bindings;
+pub mod profile;
 
 use vize_atelier_core::options::{CodegenOptions, TemplateSyntaxMode};
 use vize_atelier_dom::{

--- a/crates/vize_atelier_dom/tests/support/profile.rs
+++ b/crates/vize_atelier_dom/tests/support/profile.rs
@@ -1,0 +1,88 @@
+//! Shared profile-counter pins for P2-12b S2 DOM tests.
+
+#![allow(clippy::disallowed_types)]
+
+use davinci_harness::fixtures::LADDER;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct S2DomEmitCount {
+    pub emit_walks: u64,
+    pub emit_visits: u64,
+    pub transform_walks: u64,
+}
+
+/// fixture -> S2 DOM emit walks, emit op visits, transform walks.
+///
+/// The transform column is per fixture because the S2 pass planner
+/// declines a mandatory pass whose op family the lowering never built
+/// (`vize_s1_to_s2::lower::features`): static analysis is the default
+/// floor, compound text and each structural family add one walk only when
+/// present. `medium` pays two for its kebab-case components, which are slot
+/// carriers even though it spells no `v-slot`.
+const S2_DOM_EMIT_COUNTS: [(&str, S2DomEmitCount); 6] = [
+    (
+        "small",
+        S2DomEmitCount {
+            emit_walks: 1,
+            emit_visits: 5,
+            transform_walks: 2,
+        },
+    ),
+    (
+        "medium",
+        S2DomEmitCount {
+            emit_walks: 1,
+            emit_visits: 33,
+            transform_walks: 2,
+        },
+    ),
+    (
+        "large",
+        S2DomEmitCount {
+            emit_walks: 1,
+            emit_visits: 54,
+            transform_walks: 4,
+        },
+    ),
+    (
+        "stress-deep",
+        S2DomEmitCount {
+            emit_walks: 1,
+            emit_visits: 72,
+            transform_walks: 2,
+        },
+    ),
+    (
+        "stress-wide",
+        S2DomEmitCount {
+            emit_walks: 1,
+            emit_visits: 2,
+            transform_walks: 1,
+        },
+    ),
+    (
+        "stress-interp",
+        S2DomEmitCount {
+            emit_walks: 1,
+            emit_visits: 201,
+            transform_walks: 2,
+        },
+    ),
+];
+
+pub fn assert_s2_dom_emit_counts_cover_ladder() {
+    let pinned: Vec<&str> = S2_DOM_EMIT_COUNTS.iter().map(|(name, _)| *name).collect();
+    let ladder: Vec<&str> = LADDER.iter().map(|fixture| fixture.name).collect();
+    assert_eq!(
+        pinned, ladder,
+        "S2 DOM profile pins must match the ladder exactly, in order"
+    );
+}
+
+pub fn s2_dom_emit_count(fixture: &str) -> S2DomEmitCount {
+    S2_DOM_EMIT_COUNTS
+        .iter()
+        .find(|(name, _)| *name == fixture)
+        .map(|(_, count)| *count)
+        .unwrap_or_else(|| panic!("{fixture} has no pinned S2 DOM emit count"))
+}


### PR DESCRIPTION
## Summary
- move the S2 DOM profile walk-count pins into shared DOM test support
- assert the profile pin table matches the harness ladder exactly
- keep the P2-12b profile witness below the source-length guard

## Tests
- cargo test -p vize_atelier_dom --test davinci_s2_profile
- cargo test -p vize_atelier_dom --test davinci_s2_build_profile
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791388734&installation_model_id=422833&pr_number=5900&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5900&signature=0919997852b1a79d113c57b1871452a17903950242dd423290db305897f1310c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Centralized expected performance counters for S2 DOM ladder fixtures.
  * Added validation to ensure all ladder fixtures have corresponding counter profiles.
  * Updated counter assertions to use named metrics for transform walks, emit walks, and emit visits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->