### PR TITLE
fix(davinci): hoist constant svg bind props in s2 dom

### DIFF
--- a/crates/vize_s1_to_s2/src/emit/vnode_static.rs
+++ b/crates/vize_s1_to_s2/src/emit/vnode_static.rs
@@ -60,14 +60,7 @@ pub(super) fn can_whole_hoist_static_element(element: &ElementOp<'_>, is_ts: boo
 }
 
 fn can_whole_hoist_static_element_guarded(element: &ElementOp<'_>, is_ts: bool) -> bool {
-    if element.namespace != Namespace::Html
-        && element.tag == "svg"
-        && !element.bindings.is_empty()
-        && element
-            .children
-            .ops
-            .iter()
-            .any(|op| matches!(op, Op::Element(_)))
+    if element.namespace != Namespace::Html && element.tag == "svg" && !element.bindings.is_empty()
     {
         return false;
     }

--- a/crates/vize_s1_to_s2/tests/emit_svg_static_bind_hoist.rs
+++ b/crates/vize_s1_to_s2/tests/emit_svg_static_bind_hoist.rs
@@ -1,0 +1,49 @@
+//! Focused Davinci parity pins for bound literal SVG static-props hoists.
+
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+mod support;
+
+use support::with_transformed;
+use vize_s0::Allocator;
+use vize_s1_to_s2::emit_dom;
+
+fn shipped(source: &str) -> String {
+    let allocator = Allocator::new();
+    let (_, errors, old) = vize_atelier_dom::compile_template(&allocator, source);
+    let blocking: Vec<_> = errors
+        .iter()
+        .filter(|error| !error.is_compatibility_notice())
+        .collect();
+    assert!(blocking.is_empty(), "{source:?}: {blocking:?}");
+    format!("{}\n{}", old.preamble, old.code)
+}
+
+fn emitted(source: &str) -> String {
+    with_transformed(source, |lowered, _folio, facts, _budget| {
+        emit_dom(lowered, facts)
+            .unwrap_or_else(|error| panic!("emit refused {source:?}: {error:?}"))
+            .assembled()
+            .to_string()
+    })
+}
+
+fn assert_shipped_parity(source: &str) {
+    assert_eq!(emitted(source), shipped(source), "{source}");
+}
+
+#[test]
+fn root_svg_static_bind_props_use_legacy_hoist() {
+    assert_shipped_parity(r#"<svg xmlns="http://www.w3.org/2000/svg" :width="0"></svg>"#);
+}
+
+#[test]
+fn child_svg_static_bind_props_use_legacy_hoist() {
+    assert_shipped_parity(
+        r#"<div><svg xmlns="http://www.w3.org/2000/svg" :width="0"></svg></div>"#,
+    );
+}


### PR DESCRIPTION
## Summary
- align S2 whole-static-vnode gating with the existing bound literal svg hoist facts
- keep constant bound svg props on the legacy props-hoist path instead of static render-cache output
- add root and child parity pins for constant svg bind props

## Validation
- cargo fmt
- cargo test -p vize_s1_to_s2 --test emit_svg_static_bind_hoist -- --nocapture
- cargo test -p vize_s1_to_s2 --test emit_static_hoist
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts