### PR TITLE
feat(jsx): route tsx roots through s2 vdom

### DIFF
--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -11,56 +11,92 @@ use super::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
 #[test]
 fn s2_vdom_admitted_cases_match_relief_codegen() {
     let cases = [
-        ("element", "const A = () => <div class=\"card\" />;"),
-        ("text", "const A = () => <p>Hello</p>;"),
-        ("interpolation", "const A = () => <div>{count}</div>;"),
-        ("fragment root", "const A = () => <><i/><b/></>;"),
-        ("element bind", "const A = () => <button disabled={off} />;"),
+        (
+            "element",
+            "const A = () => <div class=\"card\" />;",
+            JsxLang::Jsx,
+        ),
+        ("text", "const A = () => <p>Hello</p>;", JsxLang::Jsx),
+        (
+            "interpolation",
+            "const A = () => <div>{count}</div>;",
+            JsxLang::Jsx,
+        ),
+        (
+            "fragment root",
+            "const A = () => <><i/><b/></>;",
+            JsxLang::Jsx,
+        ),
+        (
+            "element bind",
+            "const A = () => <button disabled={off} />;",
+            JsxLang::Jsx,
+        ),
         (
             "element event",
             "const A = () => <button onClick={save} />;",
+            JsxLang::Jsx,
         ),
         (
             "leaf component",
             "const A = () => <B foo={f} title=\"ok\" />;",
+            JsxLang::Jsx,
         ),
         (
             "component spread",
             "const A = () => <B {...attrs} foo={f} title=\"ok\" />;",
+            JsxLang::Jsx,
         ),
         (
             "component implicit default",
             "const A = () => <Card><h1>Title</h1></Card>;",
+            JsxLang::Jsx,
         ),
         (
             "component text default",
             "const A = () => <Card>Title</Card>;",
+            JsxLang::Jsx,
         ),
         (
             "component interpolation default",
             "const A = () => <Card>{title}</Card>;",
+            JsxLang::Jsx,
         ),
         (
             "component nested component default",
             "const A = () => <Card><B foo={f}/></Card>;",
+            JsxLang::Jsx,
         ),
         (
             "dynamic component",
             "const A = () => <Widget.Panel foo={1} />;",
+            JsxLang::Jsx,
         ),
         (
             "element v-show",
             "const A = () => <div v-show={visible} />;",
+            JsxLang::Jsx,
         ),
         (
             "component v-show",
             "const A = () => <B v-show={visible} />;",
+            JsxLang::Jsx,
+        ),
+        (
+            "tsx interpolation cast",
+            "const A = () => <div>{count as number}</div>;",
+            JsxLang::Tsx,
+        ),
+        (
+            "tsx typed event",
+            "const A = () => <button onClick={(event: MouseEvent) => save(event)} />;",
+            JsxLang::Tsx,
         ),
     ];
 
-    for (name, source) in cases {
-        let s2 = compile_case(source, EmitRoute::ForceS2);
-        let relief = compile_case(source, EmitRoute::ForceRelief);
+    for (name, source, lang) in cases {
+        let s2 = compile_case(source, lang, EmitRoute::ForceS2);
+        let relief = compile_case(source, lang, EmitRoute::ForceRelief);
 
         assert_eq!(
             s2.preamble, relief.preamble,
@@ -84,9 +120,9 @@ struct Output {
     code: String,
 }
 
-fn compile_case(source: &str, route: EmitRoute) -> Output {
+fn compile_case(source: &str, lang: JsxLang, route: EmitRoute) -> Output {
     let allocator = Allocator::new();
-    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, lang);
     assert!(!lowered.has_errors(), "{:?}", lowered.diagnostics);
 
     let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
@@ -103,7 +139,7 @@ fn compile_case(source: &str, route: EmitRoute) -> Output {
         &allocator,
         root,
         analysis,
-        false,
+        lang.is_typescript(),
         &VdomCompileOptions::default(),
         VdomCompatOptions::default(),
         &mut diagnostics,

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -30,7 +30,6 @@ pub(super) fn try_emit_s2_vdom<'a>(
         || options.source_map
         || options.hoist_static
         || options.cache_handlers
-        || is_ts
     {
         return None;
     }
@@ -74,7 +73,7 @@ pub(super) fn try_emit_s2_vdom<'a>(
             cache_handlers: false,
             hoisted_scope_id: None,
             scope_id,
-            is_ts: false,
+            is_ts,
             comments: false,
             experimental_in_tag_comments: false,
             custom_element_patterns: &[],

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/tests.rs
@@ -36,6 +36,39 @@ fn native_vdom_admitted_roots_emit_from_s2() {
 }
 
 #[test]
+fn tsx_admitted_roots_emit_from_s2() {
+    let allocator = Allocator::new();
+    let source = "const A = () => <div>{count as number}</div>;";
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Tsx);
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
+    let s2 = root.s2.as_ref().expect("TSX root projects to S2");
+
+    assert_eq!(super::root_is_supported(s2), true);
+
+    root.root.children.clear();
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        true,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert_eq!(component.mode, JsxOutputMode::Vdom);
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  return (_openBlock(), \
+         _createElementBlock(\"div\", null, _toDisplayString(count), 1 /* TEXT */))\n}"
+    );
+}
+
+#[test]
 fn component_plain_children_emit_from_s2_with_slot_facts() {
     let allocator = Allocator::new();
     let source = "const A = () => <Card><h1>Title</h1></Card>;";


### PR DESCRIPTION
Summary:
- allow TSX-admitted JSX roots to run through the S2 VDOM emitter
- preserve TS-aware DOM emit options when S2 renders TSX expressions
- extend S2/Relief differential coverage with TSX cast and typed handler cases

Validation:
- cargo test -p vize_atelier_jsx --lib vdom::s2_emit::tests::tsx_admitted_roots_emit_from_s2 -- --exact --nocapture
- cargo test -p vize_atelier_jsx --features davinci-differential --lib vdom::s2_differential::s2_vdom_admitted_cases_match_relief_codegen -- --exact
- cargo test -p vize_atelier_jsx --test parity_tsx tsx_vdom_codegen_matrix -- --exact
- cargo test -p vize_atelier_jsx
- cargo fmt
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791392300&installation_model_id=422833&pr_number=5902&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5902&signature=82b65d7200b0a205fed1f0d56990901c25ac21a75977f36fd620c3c8367900b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TSX compilation for supported JSX patterns, including typed interpolations and typed event handlers.
  - Prevented valid TypeScript syntax in JSX from being incorrectly rejected during rendering.
  - Added coverage to ensure supported TSX roots compile successfully and produce the expected virtual DOM output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->