### PR TITLE
feat(jsx): route paramless slots through s2 vdom

### DIFF
--- a/crates/vize_atelier_jsx/src/s2.rs
+++ b/crates/vize_atelier_jsx/src/s2.rs
@@ -18,6 +18,8 @@ use vize_s2::op::{
     OnOp, Op, Region, TextOp, VueShowOp,
 };
 
+use self::slots::{has_slot_content, lower_slot_content, slot_template_span};
+
 /// A JSX render root represented as S2 operations.
 #[derive(Debug)]
 pub struct JsxS2Root<'a> {
@@ -155,6 +157,21 @@ fn lower_element<'a>(
                 &allocator,
             )))
         }
+        ElementType::Template if has_slot_content(&props.bindings) => {
+            *features = features.observing(OpFamily::SlotCarrier);
+            let span = slot_template_span(element.loc.span, &props.bindings);
+            Ok(Op::Element(Box::new_in(
+                ElementOp {
+                    tag: element.tag,
+                    namespace: namespace(element.ns),
+                    attributes: props.attributes,
+                    bindings: props.bindings,
+                    children,
+                    span,
+                },
+                &allocator,
+            )))
+        }
         ElementType::Slot | ElementType::Template => Err(S2Refusal::UnsupportedElement),
     }
 }
@@ -198,6 +215,7 @@ fn lower_binding<'a>(
     match directive.name {
         "bind" | "on" => lower_bind_or_on(allocator, directive),
         "show" => lower_show(allocator, directive),
+        "slot" => lower_slot_content(allocator, directive),
         _ => Err(S2Refusal::Directive),
     }
 }
@@ -313,3 +331,5 @@ const fn namespace(namespace: ReliefNamespace) -> Namespace {
 
 #[cfg(test)]
 mod tests;
+
+mod slots;

--- a/crates/vize_atelier_jsx/src/s2/slots.rs
+++ b/crates/vize_atelier_jsx/src/s2/slots.rs
@@ -1,0 +1,50 @@
+use vize_relief::{DirectiveNode, ExpressionNode};
+use vize_s0::{Allocator, Box, Span, Vec};
+use vize_s2::op::{BindingOp, DynamicName, SlotContentOp};
+
+use super::S2Refusal;
+
+pub(super) fn has_slot_content(bindings: &[BindingOp<'_>]) -> bool {
+    bindings
+        .iter()
+        .any(|binding| matches!(binding, BindingOp::SlotContent(_)))
+}
+
+pub(super) fn slot_template_span(base: Span, bindings: &[BindingOp<'_>]) -> Span {
+    bindings.iter().fold(base, |span, binding| match binding {
+        BindingOp::SlotContent(content) => cover_span(span, content.span),
+        _ => span,
+    })
+}
+
+pub(super) fn lower_slot_content<'a>(
+    allocator: &'a Allocator,
+    directive: &DirectiveNode<'a>,
+) -> Result<BindingOp<'a>, S2Refusal> {
+    if directive.exp.is_some() || !directive.modifiers.is_empty() {
+        return Err(S2Refusal::Directive);
+    }
+    let name = match directive.arg.as_ref() {
+        Some(ExpressionNode::Simple(simple)) if simple.is_static => {
+            Some(DynamicName::Static(simple.content))
+        }
+        None => None,
+        Some(ExpressionNode::Simple(_)) | Some(ExpressionNode::Compound(_)) => {
+            return Err(S2Refusal::Directive);
+        }
+    };
+
+    Ok(BindingOp::SlotContent(Box::new_in(
+        SlotContentOp {
+            name,
+            modifiers: Vec::new_in(&allocator),
+            params: None,
+            span: directive.loc.span,
+        },
+        &allocator,
+    )))
+}
+
+fn cover_span(left: Span, right: Span) -> Span {
+    Span::new(left.start.min(right.start), left.end.max(right.end))
+}

--- a/crates/vize_atelier_jsx/src/s2/tests.rs
+++ b/crates/vize_atelier_jsx/src/s2/tests.rs
@@ -1,5 +1,5 @@
 use vize_s0::Allocator;
-use vize_s2::op::{BindingOp, Op};
+use vize_s2::op::{BindingOp, DynamicName, Op};
 
 use crate::{JsxLang, lower_source};
 
@@ -54,6 +54,46 @@ fn lower_source_attaches_component_s2_root() {
     };
     assert_eq!(component.name, "Panel");
     assert_eq!(component.attributes[0].name, "title");
+}
+
+#[test]
+fn paramless_static_slots_project_to_s2_slot_content() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <Comp>{{ header: () => <h1>Hi</h1> }}</Comp>;";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("paramless slot projects to S2");
+    assert!(s2.features.has_slot_carriers());
+    let Op::Component(component) = &s2.root.ops[0] else {
+        panic!("root is a component");
+    };
+    let Op::Element(template) = &component.children.ops[0] else {
+        panic!("slot carrier is a template element");
+    };
+    assert_eq!(template.tag, "template");
+    let BindingOp::SlotContent(content) = &template.bindings[0] else {
+        panic!("binding is ui.slot-content");
+    };
+    assert!(content.params.is_none());
+    assert!(content.modifiers.is_empty());
+    assert!(matches!(content.name, Some(DynamicName::Static("header"))));
+    assert!(template.span.start <= content.span.start);
+    assert!(template.span.end >= content.span.end);
+}
+
+#[test]
+fn scoped_slots_stay_on_directive_refusal_path() {
+    let allocator = Allocator::new();
+    let lowered = lower_source(
+        &allocator,
+        allocator.as_oxc(),
+        "const App = () => <Comp>{{ item: (row) => <span>{row}</span> }}</Comp>;",
+        JsxLang::Jsx,
+    );
+    let root = lowered.roots.first().expect("one JSX root");
+
+    assert!(matches!(root.s2, Err(S2Refusal::Directive)));
 }
 
 #[test]

--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -68,6 +68,17 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             JsxLang::Jsx,
         ),
         (
+            "component paramless named slots",
+            "const A = () => <Comp>{{ header: () => <h1>Hi</h1>, footer: () => <p>Bye</p> \
+             }}</Comp>;",
+            JsxLang::Jsx,
+        ),
+        (
+            "component paramless default slot",
+            "const A = () => <List>{() => <li>Empty</li>}</List>;",
+            JsxLang::Jsx,
+        ),
+        (
             "dynamic component",
             "const A = () => <Widget.Panel foo={1} />;",
             JsxLang::Jsx,

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -6,7 +6,7 @@ use vize_s1_to_s2::pass::{TransformProfile, run_transform_with_profile};
 use vize_s1_to_s2::{
     DomEmitMode, DomEmitOptions, LegacyCaps, Lowered as S2Lowered, emit_dom_with_options,
 };
-use vize_s2::op::{BindingOp, ComponentOp, DynamicName, Op, Region};
+use vize_s2::op::{BindingOp, ComponentOp, DynamicName, ElementOp, Op, Region, SlotContentOp};
 
 use crate::s2::{JsxS2Root, S2Refusal};
 
@@ -112,11 +112,35 @@ fn op_is_supported(op: &Op<'_>) -> bool {
     match op {
         Op::Text(_) | Op::Interpolation(_) => true,
         Op::Element(element) => {
+            if element.tag == "template" && has_slot_content(&element.bindings) {
+                return slot_template_is_supported(element);
+            }
             bindings_are_supported(&element.bindings) && region_is_supported(&element.children)
         }
         Op::Component(component) => component_is_supported(component),
         Op::Comment(_) | Op::If(_) | Op::For(_) | Op::Slot(_) => false,
     }
+}
+
+fn slot_template_is_supported(element: &ElementOp<'_>) -> bool {
+    element.attributes.is_empty()
+        && matches!(
+            element.bindings.as_slice(),
+            [BindingOp::SlotContent(content)] if slot_content_is_supported(content)
+        )
+        && region_is_supported(&element.children)
+}
+
+fn has_slot_content(bindings: &[BindingOp<'_>]) -> bool {
+    bindings
+        .iter()
+        .any(|binding| matches!(binding, BindingOp::SlotContent(_)))
+}
+
+fn slot_content_is_supported(content: &SlotContentOp<'_>) -> bool {
+    content.params.is_none()
+        && content.modifiers.is_empty()
+        && matches!(content.name, None | Some(DynamicName::Static(_)))
 }
 
 fn bindings_are_supported(bindings: &[BindingOp<'_>]) -> bool {

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/tests.rs
@@ -109,6 +109,58 @@ fn component_plain_children_emit_from_s2_with_slot_facts() {
 }
 
 #[test]
+fn component_paramless_static_slots_emit_from_s2() {
+    let allocator = Allocator::new();
+    let source = "const A = () => <Comp>{{ header: () => <h1>Hi</h1>, footer: () => \
+                  <p>Bye</p> }}</Comp>;";
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
+    let s2 = root.s2.as_ref().expect("paramless slots project to S2");
+
+    assert_eq!(super::root_is_supported(s2), true);
+
+    root.root.children.clear();
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { resolveComponent as _resolveComponent, createElementVNode as \
+         _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as \
+         _withCtx } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  const _component_Comp = \
+         _resolveComponent(\"Comp\")\n  \n  return (_openBlock(), _createBlock(_component_Comp, \
+         null, {\n    header: _withCtx(() => [\n      _createElementVNode(\"h1\", null, \
+         \"Hi\")\n    ]),\n    footer: _withCtx(() => [\n      _createElementVNode(\"p\", null, \
+         \"Bye\")\n    ]),\n    _: 1 /* STABLE */\n  }))\n}"
+    );
+}
+
+#[test]
+fn component_scoped_slots_still_refuse_s2_projection() {
+    let allocator = Allocator::new();
+    let source = "const A = () => <List>{{ item: ({ x }) => <li>{x}</li> }}</List>;";
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.pop().expect("one JSX root");
+
+    assert_eq!(root.s2.err(), Some(crate::s2::S2Refusal::Directive));
+}
+
+#[test]
 fn leaf_root_component_with_static_props_emits_from_s2() {
     let allocator = Allocator::new();
     let source = "const A = () => <B foo={f} title=\"ok\" />";


### PR DESCRIPTION
## Summary
- lower paramless JSX slot templates into S2 slot-content operations
- admit static/no-name slot templates in the S2 VDOM route while scoped slots remain on the refusal path
- extend the S2/Relief differential with named and default paramless slot cases

## Validation
- cargo test -p vize_atelier_jsx --lib vdom::s2_emit::tests::component_paramless_static_slots_emit_from_s2 -- --exact --nocapture
- cargo test -p vize_atelier_jsx --lib vdom::s2_emit::tests::component_scoped_slots_still_refuse_s2_projection -- --exact --nocapture
- cargo test -p vize_atelier_jsx --features davinci-differential --lib vdom::s2_differential::s2_vdom_admitted_cases_match_relief_codegen -- --exact
- cargo test -p vize_atelier_jsx --test slots
- cargo test -p vize_atelier_jsx --test parity_vdom vdom_parity_matrix_snapshot -- --exact
- cargo test -p vize_atelier_jsx --lib s2::tests::paramless_static_slots_project_to_s2_slot_content -- --exact --nocapture
- cargo test -p vize_atelier_jsx --lib s2::tests::scoped_slots_stay_on_directive_refusal_path -- --exact --nocapture
- cargo test -p vize_atelier_jsx
- cargo fmt --check
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791394042&installation_model_id=422833&pr_number=5903&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5903&signature=7712d6216909545cad123fc20bb04c4ce431b0bb2799726c7c627be5636b23dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for compiling static, parameterless named and default slots in JSX components.
  * Added support for slot-content directives and template elements carrying supported slot content.
  * Slot content is emitted with stable Vue slot metadata and context handling.

* **Bug Fixes**
  * Templates containing supported slot content are now processed instead of being rejected.

* **Tests**
  * Added coverage for named and default slots, including compatibility between compilation paths.
  * Confirmed scoped slots with parameters remain unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->