### PR TITLE
fix(jsx): admit component event option modifiers in s2 vdom

### DIFF
--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -68,6 +68,11 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             JsxLang::Jsx,
         ),
         (
+            "component capture event",
+            "const A = () => <B onClickCapture={h} />;",
+            JsxLang::Jsx,
+        ),
+        (
             "component paramless named slots",
             "const A = () => <Comp>{{ header: () => <h1>Hi</h1>, footer: () => <p>Bye</p> \
              }}</Comp>;",

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -214,7 +214,7 @@ fn component_binding_is_supported(binding: &BindingOp<'_>, dynamic_component: bo
         }
         BindingOp::On(on) => {
             on.handler.is_some()
-                && on.modifiers.is_empty()
+                && event_option_modifiers_are_supported(&on.modifiers)
                 && matches!(on.name, Some(DynamicName::Static(_)))
         }
         BindingOp::VueShow(_) => true,
@@ -222,5 +222,13 @@ fn component_binding_is_supported(binding: &BindingOp<'_>, dynamic_component: bo
     }
 }
 
+fn event_option_modifiers_are_supported(modifiers: &[&str]) -> bool {
+    modifiers
+        .iter()
+        .all(|modifier| matches!(*modifier, "capture" | "once" | "passive"))
+}
+
+#[cfg(test)]
+mod events_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/events_tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/events_tests.rs
@@ -1,0 +1,68 @@
+use vize_croquis::Croquis;
+use vize_s0::{Allocator, String};
+
+use crate::s2::S2Refusal;
+use crate::{JsxLang, lower_source};
+
+use super::super::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
+
+#[test]
+fn component_option_event_modifiers_emit_from_s2() {
+    let source = "const A = () => <B onClickCapture={h} />;";
+    let s2 = compile_case(source, EmitRoute::ForceS2);
+    let relief = compile_case(source, EmitRoute::ForceRelief);
+
+    assert_eq!(s2.preamble, relief.preamble);
+    assert_eq!(s2.code, relief.code);
+}
+
+#[derive(Clone, Copy)]
+enum EmitRoute {
+    ForceS2,
+    ForceRelief,
+}
+
+struct Output {
+    preamble: String,
+    code: String,
+}
+
+fn compile_case(source: &str, route: EmitRoute) -> Output {
+    let allocator = Allocator::new();
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    assert!(!lowered.has_errors(), "{:?}", lowered.diagnostics);
+
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
+    assert!(lowered.roots.is_empty(), "expected exactly one JSX root");
+
+    match route {
+        EmitRoute::ForceS2 => {
+            let s2 = root
+                .s2
+                .as_ref()
+                .expect("component event option modifiers project to S2");
+            assert_eq!(super::root_is_supported(s2), true);
+            root.root.children.clear();
+        }
+        EmitRoute::ForceRelief => root.s2 = Err(S2Refusal::UnsupportedChild),
+    }
+
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+
+    Output {
+        preamble: component.preamble,
+        code: component.code,
+    }
+}


### PR DESCRIPTION
## Summary
- allow component S2 VDOM event bindings to carry Vue event option modifiers
- keep the admitted modifier set limited to capture, once, and passive
- add a focused S2/Relief parity witness plus the differential case

## Validation
- cargo test -p vize_atelier_jsx --lib vdom::s2_emit::events_tests::component_option_event_modifiers_emit_from_s2 -- --exact --nocapture
- cargo test -p vize_atelier_jsx --features davinci-differential --lib vdom::s2_differential::s2_vdom_admitted_cases_match_relief_codegen -- --exact
- cargo test -p vize_atelier_jsx --test events event_modifier_codegen_snapshot -- --exact
- cargo fmt --check
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791395836&installation_model_id=422833&pr_number=5904&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5904&signature=3c132e7b04587cc3063cfb19c3b4cfd803312dec266020d8f91e7742e794a48d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for JSX component event handlers using `capture`, `once`, and `passive` options.
  * Event handlers with supported options now produce consistent output across compilation routes.

* **Tests**
  * Added coverage for capture-phase component event handling and consistency between supported compilation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->