### PR TITLE
feat(jsx): route html and text directives through s2 vdom

### DIFF
--- a/crates/vize_atelier_jsx/src/s2.rs
+++ b/crates/vize_atelier_jsx/src/s2.rs
@@ -15,9 +15,10 @@ use vize_s1_to_s2::lower::{LoweringFeatures, OpFamily};
 use vize_s2::expr::ExprRef;
 use vize_s2::op::{
     Attribute, BindOp, BindingOp, ComponentOp, DynamicName, ElementOp, InterpolationOp, Namespace,
-    OnOp, Op, Region, TextOp, VueShowOp,
+    OnOp, Op, Region, TextOp,
 };
 
+use self::directives::lower_vue_directive;
 use self::slots::{has_slot_content, lower_slot_content, slot_template_span};
 
 /// A JSX render root represented as S2 operations.
@@ -127,7 +128,7 @@ fn lower_element<'a>(
     op_count: &mut u32,
     features: &mut LoweringFeatures,
 ) -> Result<Op<'a>, S2Refusal> {
-    let props = lower_props(allocator, &element.props)?;
+    let props = lower_props(allocator, &element.props, element.tag_type)?;
     *op_count = op_count.saturating_add(props.binding_count);
     let children = Region {
         ops: lower_children(allocator, &element.children, op_count, features)?,
@@ -185,6 +186,7 @@ struct LoweredProps<'a> {
 fn lower_props<'a>(
     allocator: &'a Allocator,
     props: &[PropNode<'a>],
+    element_type: ElementType,
 ) -> Result<LoweredProps<'a>, S2Refusal> {
     let mut attributes = Vec::new_in(&allocator);
     let mut bindings = Vec::new_in(&allocator);
@@ -196,7 +198,7 @@ fn lower_props<'a>(
                 span: attribute.loc.span,
             }),
             PropNode::Directive(directive) => {
-                bindings.push(lower_binding(allocator, directive)?);
+                bindings.push(lower_binding(allocator, directive, element_type)?);
             }
         }
     }
@@ -211,10 +213,11 @@ fn lower_props<'a>(
 fn lower_binding<'a>(
     allocator: &'a Allocator,
     directive: &vize_relief::DirectiveNode<'a>,
+    element_type: ElementType,
 ) -> Result<BindingOp<'a>, S2Refusal> {
     match directive.name {
         "bind" | "on" => lower_bind_or_on(allocator, directive),
-        "show" => lower_show(allocator, directive),
+        "show" | "html" | "text" => lower_vue_directive(allocator, directive, element_type),
         "slot" => lower_slot_content(allocator, directive),
         _ => Err(S2Refusal::Directive),
     }
@@ -255,27 +258,6 @@ fn lower_bind_or_on<'a>(
     }
 }
 
-fn lower_show<'a>(
-    allocator: &'a Allocator,
-    directive: &vize_relief::DirectiveNode<'a>,
-) -> Result<BindingOp<'a>, S2Refusal> {
-    if directive.arg.is_some() || !directive.modifiers.is_empty() {
-        return Err(S2Refusal::Directive);
-    }
-    let Some(expression) = directive.exp.as_ref() else {
-        return Err(S2Refusal::Directive);
-    };
-    let value = lower_expression(allocator, expression)?;
-
-    Ok(BindingOp::VueShow(Box::new_in(
-        VueShowOp {
-            value,
-            span: directive.loc.span,
-        },
-        &allocator,
-    )))
-}
-
 fn lower_modifiers<'a>(
     allocator: &'a Allocator,
     directive: &vize_relief::DirectiveNode<'a>,
@@ -307,7 +289,7 @@ fn lower_dynamic_name<'a>(
     }
 }
 
-fn lower_expression<'a>(
+pub(super) fn lower_expression<'a>(
     allocator: &'a Allocator,
     expression: &ExpressionNode<'a>,
 ) -> Result<ExprRef<'a>, S2Refusal> {
@@ -332,4 +314,5 @@ const fn namespace(namespace: ReliefNamespace) -> Namespace {
 #[cfg(test)]
 mod tests;
 
+mod directives;
 mod slots;

--- a/crates/vize_atelier_jsx/src/s2/directives.rs
+++ b/crates/vize_atelier_jsx/src/s2/directives.rs
@@ -1,0 +1,78 @@
+use vize_relief::{DirectiveNode, ElementType};
+use vize_s0::{Allocator, Box};
+use vize_s2::expr::ExprRef;
+use vize_s2::op::{BindingOp, VueHtmlOp, VueShowOp, VueTextOp};
+
+use super::{S2Refusal, lower_expression};
+
+pub(super) fn lower_vue_directive<'a>(
+    allocator: &'a Allocator,
+    directive: &DirectiveNode<'a>,
+    element_type: ElementType,
+) -> Result<BindingOp<'a>, S2Refusal> {
+    if directive.arg.is_some() || !directive.modifiers.is_empty() {
+        return Err(S2Refusal::Directive);
+    }
+
+    match directive.name {
+        "show" => lower_show(allocator, directive),
+        "html" if element_type == ElementType::Element => lower_html(allocator, directive),
+        "text" if element_type == ElementType::Element => lower_text(allocator, directive),
+        _ => Err(S2Refusal::Directive),
+    }
+}
+
+fn lower_show<'a>(
+    allocator: &'a Allocator,
+    directive: &DirectiveNode<'a>,
+) -> Result<BindingOp<'a>, S2Refusal> {
+    let value = required_value(allocator, directive)?;
+
+    Ok(BindingOp::VueShow(Box::new_in(
+        VueShowOp {
+            value,
+            span: directive.loc.span,
+        },
+        &allocator,
+    )))
+}
+
+fn lower_html<'a>(
+    allocator: &'a Allocator,
+    directive: &DirectiveNode<'a>,
+) -> Result<BindingOp<'a>, S2Refusal> {
+    let value = required_value(allocator, directive)?;
+
+    Ok(BindingOp::VueHtml(Box::new_in(
+        VueHtmlOp {
+            value: Some(value),
+            span: directive.loc.span,
+        },
+        &allocator,
+    )))
+}
+
+fn lower_text<'a>(
+    allocator: &'a Allocator,
+    directive: &DirectiveNode<'a>,
+) -> Result<BindingOp<'a>, S2Refusal> {
+    let value = required_value(allocator, directive)?;
+
+    Ok(BindingOp::VueText(Box::new_in(
+        VueTextOp {
+            value: Some(value),
+            span: directive.loc.span,
+        },
+        &allocator,
+    )))
+}
+
+fn required_value<'a>(
+    allocator: &'a Allocator,
+    directive: &DirectiveNode<'a>,
+) -> Result<ExprRef<'a>, S2Refusal> {
+    let Some(expression) = directive.exp.as_ref() else {
+        return Err(S2Refusal::Directive);
+    };
+    lower_expression(allocator, expression)
+}

--- a/crates/vize_atelier_jsx/src/s2/tests.rs
+++ b/crates/vize_atelier_jsx/src/s2/tests.rs
@@ -124,12 +124,76 @@ fn v_show_directive_projects_to_s2_vue_show() {
 }
 
 #[test]
+fn v_html_directive_projects_to_s2_vue_html() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <div v-html={raw} />";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("v-html projects to S2");
+    let Op::Element(element) = &s2.root.ops[0] else {
+        panic!("root is an element");
+    };
+    let BindingOp::VueHtml(html) = &element.bindings[0] else {
+        panic!("binding is vue.html");
+    };
+    assert_eq!(html.value.as_ref().map(|value| value.source()), Some("raw"));
+    assert_eq!(html.span.start, source.find("v-html={raw}").unwrap() as u32);
+}
+
+#[test]
+fn v_text_directive_projects_to_s2_vue_text() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <div v-text={msg} />";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("v-text projects to S2");
+    let Op::Element(element) = &s2.root.ops[0] else {
+        panic!("root is an element");
+    };
+    let BindingOp::VueText(text) = &element.bindings[0] else {
+        panic!("binding is vue.text");
+    };
+    assert_eq!(text.value.as_ref().map(|value| value.source()), Some("msg"));
+    assert_eq!(text.span.start, source.find("v-text={msg}").unwrap() as u32);
+}
+
+#[test]
 fn v_show_without_value_stays_on_directive_refusal_path() {
     let allocator = Allocator::new();
     let lowered = lower_source(
         &allocator,
         allocator.as_oxc(),
         "const App = () => <div v-show />",
+        JsxLang::Jsx,
+    );
+    let root = lowered.roots.first().expect("one JSX root");
+
+    assert!(matches!(root.s2, Err(S2Refusal::Directive)));
+}
+
+#[test]
+fn v_html_without_value_stays_on_directive_refusal_path() {
+    let allocator = Allocator::new();
+    let lowered = lower_source(
+        &allocator,
+        allocator.as_oxc(),
+        "const App = () => <div v-html />",
+        JsxLang::Jsx,
+    );
+    let root = lowered.roots.first().expect("one JSX root");
+
+    assert!(matches!(root.s2, Err(S2Refusal::Directive)));
+}
+
+#[test]
+fn component_v_html_stays_on_directive_refusal_path() {
+    let allocator = Allocator::new();
+    let lowered = lower_source(
+        &allocator,
+        allocator.as_oxc(),
+        "const App = () => <Panel v-html={raw} />",
         JsxLang::Jsx,
     );
     let root = lowered.roots.first().expect("one JSX root");

--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -94,6 +94,26 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             JsxLang::Jsx,
         ),
         (
+            "element v-html",
+            "const A = () => <div v-html={raw} />;",
+            JsxLang::Jsx,
+        ),
+        (
+            "element v-html with children",
+            "const A = () => <div v-html={raw}>fallback</div>;",
+            JsxLang::Jsx,
+        ),
+        (
+            "element v-text",
+            "const A = () => <div v-text={msg} />;",
+            JsxLang::Jsx,
+        ),
+        (
+            "element v-text with children",
+            "const A = () => <div v-text={msg}>fallback</div>;",
+            JsxLang::Jsx,
+        ),
+        (
             "component v-show",
             "const A = () => <B v-show={visible} />;",
             JsxLang::Jsx,

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -147,7 +147,11 @@ fn bindings_are_supported(bindings: &[BindingOp<'_>]) -> bool {
     bindings.iter().all(|binding| {
         matches!(
             binding,
-            BindingOp::Bind(_) | BindingOp::On(_) | BindingOp::VueShow(_)
+            BindingOp::Bind(_)
+                | BindingOp::On(_)
+                | BindingOp::VueShow(_)
+                | BindingOp::VueHtml(_)
+                | BindingOp::VueText(_)
         )
     })
 }
@@ -232,3 +236,5 @@ fn event_option_modifiers_are_supported(modifiers: &[&str]) -> bool {
 mod events_tests;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod vue_directives_tests;

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/vue_directives_tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/vue_directives_tests.rs
@@ -1,0 +1,83 @@
+use vize_croquis::Croquis;
+use vize_s0::{Allocator, String};
+
+use crate::s2::S2Refusal;
+use crate::{JsxLang, lower_source};
+
+use super::super::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
+
+#[test]
+fn element_v_html_emits_from_s2() {
+    let source = "const A = () => <div v-html={raw} />;";
+    let s2 = compile_case(source, EmitRoute::ForceS2, "v-html projects to S2");
+    let relief = compile_case(
+        source,
+        EmitRoute::ForceRelief,
+        "v-html falls back to Relief",
+    );
+
+    assert_eq!(s2.preamble, relief.preamble);
+    assert_eq!(s2.code, relief.code);
+}
+
+#[test]
+fn element_v_text_emits_from_s2() {
+    let source = "const A = () => <div v-text={msg} />;";
+    let s2 = compile_case(source, EmitRoute::ForceS2, "v-text projects to S2");
+    let relief = compile_case(
+        source,
+        EmitRoute::ForceRelief,
+        "v-text falls back to Relief",
+    );
+
+    assert_eq!(s2.preamble, relief.preamble);
+    assert_eq!(s2.code, relief.code);
+}
+
+#[derive(Clone, Copy)]
+enum EmitRoute {
+    ForceS2,
+    ForceRelief,
+}
+
+struct Output {
+    preamble: String,
+    code: String,
+}
+
+fn compile_case(source: &str, route: EmitRoute, projection: &str) -> Output {
+    let allocator = Allocator::new();
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    assert!(!lowered.has_errors(), "{:?}", lowered.diagnostics);
+
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
+    assert!(lowered.roots.is_empty(), "expected exactly one JSX root");
+
+    match route {
+        EmitRoute::ForceS2 => {
+            let s2 = root.s2.as_ref().expect(projection);
+            assert_eq!(super::root_is_supported(s2), true);
+            root.root.children.clear();
+        }
+        EmitRoute::ForceRelief => root.s2 = Err(S2Refusal::UnsupportedChild),
+    }
+
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+
+    Output {
+        preamble: component.preamble,
+        code: component.code,
+    }
+}


### PR DESCRIPTION
Summary
- add JSX S2 lowering for element v-html and v-text via Vue dialect bindings
- admit those bindings in the S2 VDOM route while keeping component/invalid directive shapes on the refusal path
- extend S2 projection, VDOM emit, and differential parity coverage

Tests
- cargo test -p vize_atelier_jsx --lib
- cargo test -p vize_atelier_jsx --features davinci-differential --lib vdom::s2_differential::s2_vdom_admitted_cases_match_relief_codegen -- --exact
- cargo test -p vize_atelier_jsx --test parity_vdom vdom_parity_matrix_snapshot -- --exact
- cargo fmt --check
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791397479&installation_model_id=422833&pr_number=5905&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5905&signature=78f5dfb6b2ec21808ac274c538f6053ee3b9dad6d12c28bb47c718193265f40e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `v-html` and `v-text` directives in JSX templates.
  - These directives now work on supported HTML elements and produce consistent output across rendering paths.
  - Improved handling of Vue directives, including validation for unsupported arguments, modifiers, missing values, and component usage.

- **Bug Fixes**
  - Existing `v-show` directive handling continues to work through the updated directive processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->