### PR TITLE
feat(jsx): route component v-model through s2 vdom

### DIFF
--- a/crates/vize_atelier_jsx/src/s2.rs
+++ b/crates/vize_atelier_jsx/src/s2.rs
@@ -19,6 +19,7 @@ use vize_s2::op::{
 };
 
 use self::directives::lower_vue_directive;
+use self::model::lower_model;
 use self::slots::{has_slot_content, lower_slot_content, slot_template_span};
 
 /// A JSX render root represented as S2 operations.
@@ -128,7 +129,7 @@ fn lower_element<'a>(
     op_count: &mut u32,
     features: &mut LoweringFeatures,
 ) -> Result<Op<'a>, S2Refusal> {
-    let props = lower_props(allocator, &element.props, element.tag_type)?;
+    let props = lower_props(allocator, &element.props, element.tag_type, features)?;
     *op_count = op_count.saturating_add(props.binding_count);
     let children = Region {
         ops: lower_children(allocator, &element.children, op_count, features)?,
@@ -187,6 +188,7 @@ fn lower_props<'a>(
     allocator: &'a Allocator,
     props: &[PropNode<'a>],
     element_type: ElementType,
+    features: &mut LoweringFeatures,
 ) -> Result<LoweredProps<'a>, S2Refusal> {
     let mut attributes = Vec::new_in(&allocator);
     let mut bindings = Vec::new_in(&allocator);
@@ -198,7 +200,7 @@ fn lower_props<'a>(
                 span: attribute.loc.span,
             }),
             PropNode::Directive(directive) => {
-                bindings.push(lower_binding(allocator, directive, element_type)?);
+                bindings.push(lower_binding(allocator, directive, element_type, features)?);
             }
         }
     }
@@ -214,9 +216,11 @@ fn lower_binding<'a>(
     allocator: &'a Allocator,
     directive: &vize_relief::DirectiveNode<'a>,
     element_type: ElementType,
+    features: &mut LoweringFeatures,
 ) -> Result<BindingOp<'a>, S2Refusal> {
     match directive.name {
         "bind" | "on" => lower_bind_or_on(allocator, directive),
+        "model" => lower_model(allocator, directive, element_type, features),
         "show" | "html" | "text" => lower_vue_directive(allocator, directive, element_type),
         "slot" => lower_slot_content(allocator, directive),
         _ => Err(S2Refusal::Directive),
@@ -269,7 +273,7 @@ fn lower_modifiers<'a>(
     modifiers
 }
 
-fn lower_dynamic_name<'a>(
+pub(super) fn lower_dynamic_name<'a>(
     allocator: &'a Allocator,
     name: Option<&ExpressionNode<'a>>,
 ) -> Result<Option<DynamicName<'a>>, S2Refusal> {
@@ -315,4 +319,5 @@ const fn namespace(namespace: ReliefNamespace) -> Namespace {
 mod tests;
 
 mod directives;
+mod model;
 mod slots;

--- a/crates/vize_atelier_jsx/src/s2/model.rs
+++ b/crates/vize_atelier_jsx/src/s2/model.rs
@@ -1,0 +1,50 @@
+use vize_relief::{DirectiveNode, ElementType};
+use vize_s0::{Allocator, Box, Vec};
+use vize_s1_to_s2::lower::{LoweringFeatures, OpFamily};
+use vize_s2::op::{Attribute, BindingContract, BindingOp, ModelOp};
+
+use super::{S2Refusal, lower_dynamic_name, lower_expression};
+
+pub(super) fn lower_model<'a>(
+    allocator: &'a Allocator,
+    directive: &DirectiveNode<'a>,
+    element_type: ElementType,
+    features: &mut LoweringFeatures,
+) -> Result<BindingOp<'a>, S2Refusal> {
+    if element_type != ElementType::Component {
+        return Err(S2Refusal::Directive);
+    }
+    let Some(expression) = directive.exp.as_ref() else {
+        return Err(S2Refusal::Directive);
+    };
+
+    let value = lower_expression(allocator, expression)?;
+    let argument = lower_dynamic_name(allocator, directive.arg.as_ref())?;
+    let mut attributes = Vec::new_in(&allocator);
+    attributes.push(Attribute {
+        name: "element-kind",
+        value: Some("component"),
+        span: directive.loc.span,
+    });
+    for modifier in &directive.modifiers {
+        attributes.push(Attribute {
+            name: modifier.content,
+            value: None,
+            span: modifier.loc.span,
+        });
+    }
+
+    *features = features.observing(OpFamily::Model);
+    Ok(BindingOp::Model(Box::new_in(
+        ModelOp {
+            contract: BindingContract {
+                read: value,
+                write: value,
+            },
+            argument,
+            attributes,
+            span: directive.loc.span,
+        },
+        &allocator,
+    )))
+}

--- a/crates/vize_atelier_jsx/src/s2/tests.rs
+++ b/crates/vize_atelier_jsx/src/s2/tests.rs
@@ -160,12 +160,70 @@ fn v_text_directive_projects_to_s2_vue_text() {
 }
 
 #[test]
+fn component_v_model_projects_to_s2_model() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <Input v-model={value} />";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("component v-model projects to S2");
+    assert!(s2.features.has_model_bindings());
+    let Op::Component(component) = &s2.root.ops[0] else {
+        panic!("root is a component");
+    };
+    let BindingOp::Model(model) = &component.bindings[0] else {
+        panic!("binding is ui.model");
+    };
+    assert_eq!(model.contract.read.source(), "value");
+    assert_eq!(model.contract.write.source(), "value");
+    assert!(model.argument.is_none());
+    assert_eq!(model.attributes[0].name, "element-kind");
+    assert_eq!(model.attributes[0].value, Some("component"));
+}
+
+#[test]
+fn component_v_model_static_arg_modifiers_project_to_s2_model() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <Input v-model={[value, \"foo\", [\"trim\"]]} />";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("component v-model projects to S2");
+    assert!(s2.features.has_model_bindings());
+    let Op::Component(component) = &s2.root.ops[0] else {
+        panic!("root is a component");
+    };
+    let BindingOp::Model(model) = &component.bindings[0] else {
+        panic!("binding is ui.model");
+    };
+    assert_eq!(model.contract.read.source(), "value");
+    assert!(matches!(model.argument, Some(DynamicName::Static("foo"))));
+    assert_eq!(model.attributes[0].value, Some("component"));
+    assert_eq!(model.attributes[1].name, "trim");
+    assert!(model.attributes[1].value.is_none());
+}
+
+#[test]
 fn v_show_without_value_stays_on_directive_refusal_path() {
     let allocator = Allocator::new();
     let lowered = lower_source(
         &allocator,
         allocator.as_oxc(),
         "const App = () => <div v-show />",
+        JsxLang::Jsx,
+    );
+    let root = lowered.roots.first().expect("one JSX root");
+
+    assert!(matches!(root.s2, Err(S2Refusal::Directive)));
+}
+
+#[test]
+fn element_v_model_stays_on_directive_refusal_path() {
+    let allocator = Allocator::new();
+    let lowered = lower_source(
+        &allocator,
+        allocator.as_oxc(),
+        "const App = () => <input v-model={value} />",
         JsxLang::Jsx,
     );
     let root = lowered.roots.first().expect("one JSX root");

--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -73,6 +73,16 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             JsxLang::Jsx,
         ),
         (
+            "component v-model",
+            "const A = () => <Input v-model={value} />;",
+            JsxLang::Jsx,
+        ),
+        (
+            "component v-model argument modifiers",
+            "const A = () => <Input v-model={[value, \"foo\", [\"trim\"]]} />;",
+            JsxLang::Jsx,
+        ),
+        (
             "component paramless named slots",
             "const A = () => <Comp>{{ header: () => <h1>Hi</h1>, footer: () => <p>Bye</p> \
              }}</Comp>;",

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -6,7 +6,10 @@ use vize_s1_to_s2::pass::{TransformProfile, run_transform_with_profile};
 use vize_s1_to_s2::{
     DomEmitMode, DomEmitOptions, LegacyCaps, Lowered as S2Lowered, emit_dom_with_options,
 };
-use vize_s2::op::{BindingOp, ComponentOp, DynamicName, ElementOp, Op, Region, SlotContentOp};
+use vize_s2::expr::ExprRef;
+use vize_s2::op::{
+    BindingOp, ComponentOp, DynamicName, ElementOp, ModelOp, Op, Region, SlotContentOp,
+};
 
 use crate::s2::{JsxS2Root, S2Refusal};
 
@@ -221,9 +224,30 @@ fn component_binding_is_supported(binding: &BindingOp<'_>, dynamic_component: bo
                 && event_option_modifiers_are_supported(&on.modifiers)
                 && matches!(on.name, Some(DynamicName::Static(_)))
         }
+        BindingOp::Model(model) => component_model_is_supported(model),
         BindingOp::VueShow(_) => true,
         _ => false,
     }
+}
+
+fn component_model_is_supported(model: &ModelOp<'_>) -> bool {
+    let has_component_kind = model
+        .attributes
+        .iter()
+        .any(|attribute| attribute.name == "element-kind" && attribute.value == Some("component"));
+    has_component_kind
+        && model.attributes.iter().all(|attribute| {
+            if attribute.name == "element-kind" {
+                attribute.value == Some("component")
+            } else {
+                attribute.value.is_none()
+            }
+        })
+        && model.contract.read.source() == model.contract.write.source()
+        && model.contract.read.span() == model.contract.write.span()
+        && matches!(model.contract.read, ExprRef::Js(_))
+        && matches!(model.contract.write, ExprRef::Js(_))
+        && matches!(model.argument, None | Some(DynamicName::Static(_)))
 }
 
 fn event_option_modifiers_are_supported(modifiers: &[&str]) -> bool {
@@ -234,6 +258,8 @@ fn event_option_modifiers_are_supported(modifiers: &[&str]) -> bool {
 
 #[cfg(test)]
 mod events_tests;
+#[cfg(test)]
+mod model_tests;
 #[cfg(test)]
 mod tests;
 #[cfg(test)]

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/model_tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/model_tests.rs
@@ -1,0 +1,91 @@
+use vize_croquis::Croquis;
+use vize_s0::{Allocator, String};
+
+use crate::s2::S2Refusal;
+use crate::{JsxLang, lower_source};
+
+use super::super::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
+
+#[test]
+fn component_v_model_emits_from_s2() {
+    let source = "const A = () => <Input v-model={value} />;";
+    let s2 = compile_case(
+        source,
+        EmitRoute::ForceS2,
+        "component v-model projects to S2",
+    );
+    let relief = compile_case(
+        source,
+        EmitRoute::ForceRelief,
+        "component v-model falls back to Relief",
+    );
+
+    assert_eq!(s2.preamble, relief.preamble);
+    assert_eq!(s2.code, relief.code);
+}
+
+#[test]
+fn component_v_model_static_arg_modifiers_emit_from_s2() {
+    let source = "const A = () => <Input v-model={[value, \"foo\", [\"trim\"]]} />;";
+    let s2 = compile_case(
+        source,
+        EmitRoute::ForceS2,
+        "component v-model argument with modifiers projects to S2",
+    );
+    let relief = compile_case(
+        source,
+        EmitRoute::ForceRelief,
+        "component v-model argument with modifiers falls back to Relief",
+    );
+
+    assert_eq!(s2.preamble, relief.preamble);
+    assert_eq!(s2.code, relief.code);
+}
+
+#[derive(Clone, Copy)]
+enum EmitRoute {
+    ForceS2,
+    ForceRelief,
+}
+
+struct Output {
+    preamble: String,
+    code: String,
+}
+
+fn compile_case(source: &str, route: EmitRoute, projection: &str) -> Output {
+    let allocator = Allocator::new();
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    assert!(!lowered.has_errors(), "{:?}", lowered.diagnostics);
+
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
+    assert!(lowered.roots.is_empty(), "expected exactly one JSX root");
+
+    match route {
+        EmitRoute::ForceS2 => {
+            let s2 = root.s2.as_ref().expect(projection);
+            assert_eq!(super::root_is_supported(s2), true);
+            root.root.children.clear();
+        }
+        EmitRoute::ForceRelief => root.s2 = Err(S2Refusal::UnsupportedChild),
+    }
+
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+
+    Output {
+        preamble: component.preamble,
+        code: component.code,
+    }
+}


### PR DESCRIPTION
## Summary
- lower component v-model into S2 ModelOp with component kind metadata and modifiers
- admit supported component model bindings through the JSX S2 VDOM bridge
- keep native element v-model on the directive refusal path and pin S2/Relief parity

## Verification
- cargo test -p vize_atelier_jsx --lib
- cargo test -p vize_atelier_jsx --features davinci-differential --lib vdom::s2_differential::s2_vdom_admitted_cases_match_relief_codegen -- --exact
- cargo test -p vize_atelier_jsx --test parity_vdom vdom_parity_matrix_snapshot -- --exact
- cargo fmt --check
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791398614&installation_model_id=422833&pr_number=5906&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5906&signature=07c49a91ff272b8e4968fd0354c311369112c0d1dea4e70e300ee25547ddf7a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for `v-model` bindings on JSX components.
  - Supports static argument names and directive modifiers.
  - Component model bindings now compile through the S2 VDOM emission path.

- **Bug Fixes**
  - Improved consistency between S2 and Relief compilation for supported component `v-model` usage.

- **Tests**
  - Added coverage for plain component models, arguments, modifiers, and cross-path output parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->