### PR TITLE
test(jsx): cover s2 vdom event option parity

### DIFF
--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -73,6 +73,16 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             JsxLang::Jsx,
         ),
         (
+            "component once event",
+            "const A = () => <B onClickOnce={h} />;",
+            JsxLang::Jsx,
+        ),
+        (
+            "component passive capture event",
+            "const A = () => <B onInputPassiveCapture={h} />;",
+            JsxLang::Jsx,
+        ),
+        (
             "component v-model",
             "const A = () => <Input v-model={value} />;",
             JsxLang::Jsx,

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/events_tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/events_tests.rs
@@ -8,12 +8,19 @@ use super::super::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
 
 #[test]
 fn component_option_event_modifiers_emit_from_s2() {
-    let source = "const A = () => <B onClickCapture={h} />;";
-    let s2 = compile_case(source, EmitRoute::ForceS2);
-    let relief = compile_case(source, EmitRoute::ForceRelief);
+    let cases = [
+        "const A = () => <B onClickCapture={h} />;",
+        "const A = () => <B onClickOnce={h} />;",
+        "const A = () => <B onInputPassiveCapture={h} />;",
+    ];
 
-    assert_eq!(s2.preamble, relief.preamble);
-    assert_eq!(s2.code, relief.code);
+    for source in cases {
+        let s2 = compile_case(source, EmitRoute::ForceS2);
+        let relief = compile_case(source, EmitRoute::ForceRelief);
+
+        assert_eq!(s2.preamble, relief.preamble, "{source}");
+        assert_eq!(s2.code, relief.code, "{source}");
+    }
 }
 
 #[derive(Clone, Copy)]


### PR DESCRIPTION
## Summary
- cover component event option modifiers across forced S2 and forced Relief VDOM emit
- add differential witnesses for component once and passive-capture events

## Verification
- cargo test -p vize_atelier_jsx --lib vdom::s2_emit::events_tests -- --nocapture
- cargo test -p vize_atelier_jsx --features davinci-differential --lib vdom::s2_differential::s2_vdom_admitted_cases_match_relief_codegen -- --exact
- cargo test -p vize_atelier_jsx --lib
- cargo fmt --check
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791399760&installation_model_id=422833&pr_number=5907&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5907&signature=085054af748dbf821b7d6e77f60ce1fad01a55e6b08c38381776282486c9002a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded compatibility coverage for component event modifiers, including one-time, passive, capture, and passive-capture behaviors.
  - Added parity checks across supported virtual DOM implementations for these event configurations.
  - Improved test failure context by identifying the relevant JSX source case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->