### PR TITLE
test(jsx): cover s2 vdom scoped style emission

### DIFF
--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -114,6 +114,11 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             JsxLang::Jsx,
         ),
         (
+            "scoped style",
+            r#"const A = () => <><section class="box" /><style scoped>{`.box { color: red; }`}</style></>;"#,
+            JsxLang::Jsx,
+        ),
+        (
             "element v-html",
             "const A = () => <div v-html={raw} />;",
             JsxLang::Jsx,

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -261,6 +261,8 @@ mod events_tests;
 #[cfg(test)]
 mod model_tests;
 #[cfg(test)]
+mod scoped_tests;
+#[cfg(test)]
 mod tests;
 #[cfg(test)]
 mod vue_directives_tests;

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/scoped_tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/scoped_tests.rs
@@ -1,0 +1,58 @@
+use vize_croquis::Croquis;
+use vize_s0::Allocator;
+
+use crate::{JsxLang, lower_source};
+
+use super::super::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
+
+#[test]
+fn scoped_style_scope_id_emits_from_s2_vdom() {
+    let allocator = Allocator::new();
+    let source = r#"const A = () => <><section class="box" /><style scoped>{`.box { color: red; }`}</style></>;"#;
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
+    let s2 = root.s2.as_ref().expect("scoped style root projects to S2");
+
+    assert_eq!(super::root_is_supported(s2), true);
+
+    root.root.children.clear();
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert!(
+        component.map.is_none(),
+        "S2 VDOM emission is source-map-free"
+    );
+
+    let scoped_style = component
+        .scoped_style
+        .as_ref()
+        .expect("scoped style metadata");
+    let scope_id = scoped_style.scope_id.as_str();
+    let hash = scope_id.strip_prefix("data-v-").expect("scope id prefix");
+    assert_eq!(hash.len(), 8);
+    assert!(hash.chars().all(|ch| ch.is_ascii_hexdigit()));
+
+    assert!(component.code.contains("_createElementBlock(\"section\""));
+    assert!(
+        component.code.contains(&format!("\"{scope_id}\": \"\"")),
+        "{}",
+        component.code
+    );
+    assert!(
+        scoped_style.css.contains(&format!(".box[{scope_id}]")),
+        "{}",
+        scoped_style.css
+    );
+}


### PR DESCRIPTION
## Summary
- add a forced-S2 VDOM scoped-style test for scope id shape, render attr injection, and rewritten CSS
- add scoped style to the S2/Relief VDOM differential corpus

## Tests
- cargo test -p vize_atelier_jsx scoped_style_scope_id_emits_from_s2_vdom
- cargo test -p vize_atelier_jsx --features davinci-differential s2_vdom_admitted_cases_match_relief_codegen
- cargo test -p vize_atelier_jsx --lib
- cargo test -p vize_atelier_jsx --test style vdom_scoped_style_snapshot -- --exact
- cargo fmt --all --check
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791401239&installation_model_id=422833&pr_number=5908&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5908&signature=22475ed05569f2d72b1d6c14eae98dc365587f25e20f6869a7b9f0ca9c47087d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for scoped styles in JSX VDOM generation.
  - Verified consistent output between VDOM code-generation paths.
  - Confirmed scoped styles receive valid scope identifiers, apply correctly to elements, and generate the expected CSS selectors.
  - Added checks for emitted markup and style metadata to help prevent regressions in scoped-style behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->