### PR TITLE
test(jsx): lock s2 vdom option fallbacks

### DIFF
--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -261,6 +261,8 @@ mod events_tests;
 #[cfg(test)]
 mod model_tests;
 #[cfg(test)]
+mod options_tests;
+#[cfg(test)]
 mod scoped_tests;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/options_tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/options_tests.rs
@@ -1,0 +1,102 @@
+use vize_s0::Allocator;
+
+use crate::{JsxLang, lower_source};
+
+use super::super::{VdomCompatOptions, VdomCompileOptions, VdomComponent, compile_to_vdom};
+
+const SOURCE_MAP_SOURCE: &str = "const A = () => <div>{count}</div>;";
+const HOIST_STATIC_SOURCE: &str = "const A = () => <Card><span class=\"label\">Hi</span></Card>;";
+const CACHE_HANDLERS_SOURCE: &str = "const A = () => <button v-on:click={save()} />;";
+
+#[test]
+fn source_map_option_stays_on_relief_vdom_fallback() {
+    let options = VdomCompileOptions {
+        source_map: true,
+        ..Default::default()
+    };
+    assert_s2_emit_declines(SOURCE_MAP_SOURCE, &options, "source map");
+
+    let component = compile(SOURCE_MAP_SOURCE, options);
+    let map = component.map.as_deref().expect("Relief emits source maps");
+    let value: serde_json::Value = serde_json::from_str(map).expect("valid source-map JSON");
+    assert_eq!(value["version"], 3);
+    assert!(
+        value["mappings"]
+            .as_str()
+            .is_some_and(|mappings| !mappings.is_empty()),
+        "{map}"
+    );
+}
+
+#[test]
+fn hoist_static_option_stays_on_relief_vdom_fallback() {
+    let options = VdomCompileOptions {
+        hoist_static: true,
+        ..Default::default()
+    };
+    assert_s2_emit_declines(HOIST_STATIC_SOURCE, &options, "static hoisting");
+
+    let component = compile(HOIST_STATIC_SOURCE, options);
+    assert!(
+        component.preamble.contains("const _hoisted_1"),
+        "{}",
+        component.preamble
+    );
+    assert!(component.code.contains("_hoisted_1"), "{}", component.code);
+}
+
+#[test]
+fn cache_handlers_option_stays_on_relief_vdom_fallback() {
+    let default = compile(CACHE_HANDLERS_SOURCE, VdomCompileOptions::default());
+    assert!(
+        !default.code.contains("_cache[0] || (_cache[0] ="),
+        "{}",
+        default.code
+    );
+
+    let options = VdomCompileOptions {
+        cache_handlers: true,
+        ..Default::default()
+    };
+    assert_s2_emit_declines(CACHE_HANDLERS_SOURCE, &options, "handler caching");
+
+    let component = compile(CACHE_HANDLERS_SOURCE, options);
+    assert!(
+        component.code.contains("_cache[0] || (_cache[0] ="),
+        "{}",
+        component.code
+    );
+}
+
+fn assert_s2_emit_declines(source: &str, options: &VdomCompileOptions, projection: &str) {
+    let allocator = Allocator::new();
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    assert!(!lowered.has_errors(), "{:?}", lowered.diagnostics);
+
+    let root = lowered.roots.pop().expect("one JSX root");
+    assert!(lowered.roots.is_empty(), "expected exactly one JSX root");
+    let s2 = root.s2;
+    assert!(
+        super::root_is_supported(s2.as_ref().expect(projection)),
+        "{projection} should be S2-supported before option fallback"
+    );
+
+    let emit = super::try_emit_s2_vdom(
+        &allocator,
+        s2,
+        false,
+        None,
+        None,
+        options,
+        &VdomCompatOptions::default(),
+    );
+    assert!(emit.is_none(), "{projection} should stay on Relief");
+}
+
+fn compile(source: &str, options: VdomCompileOptions) -> VdomComponent {
+    let allocator = Allocator::new();
+    let out = compile_to_vdom(&allocator, source, JsxLang::Jsx, options);
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+    assert_eq!(out.components.len(), 1, "expected one component");
+    out.components.into_iter().next().unwrap()
+}


### PR DESCRIPTION
Summary:
- add S2 VDOM option fallback tests for source maps, static hoisting, and cached handlers
- assert S2-admitted roots stay on Relief when compile options require unsupported output features

Tests:
- cargo test -p vize_atelier_jsx --lib vdom::s2_emit::options_tests -- --nocapture
- cargo test -p vize_atelier_jsx --lib
- cargo fmt --all --check
- git diff --check origin/main...HEAD
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791402399&installation_model_id=422833&pr_number=5909&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5909&signature=06b3cb13f30f428504587659a8213980bc5f588e1e57031a6d1dba60d2bbc13e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage verifying fallback handling when supported JSX is declined during VDOM emission.
  - Confirmed source maps, static hoisting, and event-handler caching continue to work correctly in fallback scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->