### PR TITLE
feat(jsx): route native v-model through s2 vdom

### DIFF
--- a/crates/vize_atelier_jsx/src/s2.rs
+++ b/crates/vize_atelier_jsx/src/s2.rs
@@ -19,6 +19,7 @@ use vize_s2::op::{
 };
 
 use self::directives::lower_vue_directive;
+use self::input_model::allows_plain_input_model;
 use self::model::lower_model;
 use self::slots::{has_slot_content, lower_slot_content, slot_template_span};
 
@@ -129,7 +130,14 @@ fn lower_element<'a>(
     op_count: &mut u32,
     features: &mut LoweringFeatures,
 ) -> Result<Op<'a>, S2Refusal> {
-    let props = lower_props(allocator, &element.props, element.tag_type, features)?;
+    let allow_native_input_model = allows_plain_input_model(element);
+    let props = lower_props(
+        allocator,
+        &element.props,
+        element.tag_type,
+        allow_native_input_model,
+        features,
+    )?;
     *op_count = op_count.saturating_add(props.binding_count);
     let children = Region {
         ops: lower_children(allocator, &element.children, op_count, features)?,
@@ -188,6 +196,7 @@ fn lower_props<'a>(
     allocator: &'a Allocator,
     props: &[PropNode<'a>],
     element_type: ElementType,
+    allow_native_input_model: bool,
     features: &mut LoweringFeatures,
 ) -> Result<LoweredProps<'a>, S2Refusal> {
     let mut attributes = Vec::new_in(&allocator);
@@ -200,7 +209,13 @@ fn lower_props<'a>(
                 span: attribute.loc.span,
             }),
             PropNode::Directive(directive) => {
-                bindings.push(lower_binding(allocator, directive, element_type, features)?);
+                bindings.push(lower_binding(
+                    allocator,
+                    directive,
+                    element_type,
+                    allow_native_input_model,
+                    features,
+                )?);
             }
         }
     }
@@ -216,11 +231,18 @@ fn lower_binding<'a>(
     allocator: &'a Allocator,
     directive: &vize_relief::DirectiveNode<'a>,
     element_type: ElementType,
+    allow_native_input_model: bool,
     features: &mut LoweringFeatures,
 ) -> Result<BindingOp<'a>, S2Refusal> {
     match directive.name {
         "bind" | "on" => lower_bind_or_on(allocator, directive),
-        "model" => lower_model(allocator, directive, element_type, features),
+        "model" => lower_model(
+            allocator,
+            directive,
+            element_type,
+            allow_native_input_model,
+            features,
+        ),
         "show" | "html" | "text" => lower_vue_directive(allocator, directive, element_type),
         "slot" => lower_slot_content(allocator, directive),
         _ => Err(S2Refusal::Directive),
@@ -319,5 +341,6 @@ const fn namespace(namespace: ReliefNamespace) -> Namespace {
 mod tests;
 
 mod directives;
+mod input_model;
 mod model;
 mod slots;

--- a/crates/vize_atelier_jsx/src/s2/input_model.rs
+++ b/crates/vize_atelier_jsx/src/s2/input_model.rs
@@ -1,0 +1,15 @@
+use vize_relief::{ElementNode, ElementType, ExpressionNode, PropNode};
+
+pub(super) fn allows_plain_input_model(element: &ElementNode<'_>) -> bool {
+    matches!(element.tag_type, ElementType::Element)
+        && element.tag == "input"
+        && !element.props.iter().any(blocks_plain_input_model)
+}
+
+fn blocks_plain_input_model(prop: &PropNode<'_>) -> bool {
+    matches!(prop, PropNode::Attribute(attribute) if attribute.name == "type")
+        || matches!(prop, PropNode::Directive(directive)
+            if directive.name == "bind"
+                && !matches!(directive.arg.as_ref(), Some(ExpressionNode::Simple(simple))
+                    if simple.is_static && simple.content != "type"))
+}

--- a/crates/vize_atelier_jsx/src/s2/model.rs
+++ b/crates/vize_atelier_jsx/src/s2/model.rs
@@ -1,7 +1,10 @@
-use vize_relief::{DirectiveNode, ElementType};
+use vize_relief::{DirectiveNode, ElementType, ExpressionNode};
 use vize_s0::{Allocator, Box, Vec};
 use vize_s1_to_s2::lower::{LoweringFeatures, OpFamily};
-use vize_s2::op::{Attribute, BindingContract, BindingOp, ModelOp};
+use vize_s2::{
+    expr::ExprRef,
+    op::{Attribute, BindingContract, BindingOp, DynamicName, ModelOp},
+};
 
 use super::{S2Refusal, lower_dynamic_name, lower_expression};
 
@@ -9,11 +12,23 @@ pub(super) fn lower_model<'a>(
     allocator: &'a Allocator,
     directive: &DirectiveNode<'a>,
     element_type: ElementType,
+    allow_native_input_model: bool,
     features: &mut LoweringFeatures,
 ) -> Result<BindingOp<'a>, S2Refusal> {
-    if element_type != ElementType::Component {
-        return Err(S2Refusal::Directive);
+    match element_type {
+        ElementType::Component => lower_component_model(allocator, directive, features),
+        ElementType::Element if allow_native_input_model => {
+            lower_native_input_model(allocator, directive, features)
+        }
+        _ => Err(S2Refusal::Directive),
     }
+}
+
+fn lower_component_model<'a>(
+    allocator: &'a Allocator,
+    directive: &DirectiveNode<'a>,
+    features: &mut LoweringFeatures,
+) -> Result<BindingOp<'a>, S2Refusal> {
     let Some(expression) = directive.exp.as_ref() else {
         return Err(S2Refusal::Directive);
     };
@@ -35,7 +50,48 @@ pub(super) fn lower_model<'a>(
     }
 
     *features = features.observing(OpFamily::Model);
-    Ok(BindingOp::Model(Box::new_in(
+    Ok(model_op(allocator, directive, value, argument, attributes))
+}
+
+fn lower_native_input_model<'a>(
+    allocator: &'a Allocator,
+    directive: &DirectiveNode<'a>,
+    features: &mut LoweringFeatures,
+) -> Result<BindingOp<'a>, S2Refusal> {
+    if directive.arg.is_some() || !directive.modifiers.is_empty() {
+        return Err(S2Refusal::Directive);
+    }
+    let Some(expression) = directive.exp.as_ref() else {
+        return Err(S2Refusal::Directive);
+    };
+    if is_jsx_model_tuple(expression) {
+        return Err(S2Refusal::Directive);
+    }
+
+    let value = lower_expression(allocator, expression)?;
+    let mut attributes = Vec::new_in(&allocator);
+    attributes.push(Attribute {
+        name: "element-kind",
+        value: Some("input"),
+        span: directive.loc.span,
+    });
+
+    *features = features.observing(OpFamily::Model);
+    Ok(model_op(allocator, directive, value, None, attributes))
+}
+
+fn is_jsx_model_tuple(expression: &ExpressionNode<'_>) -> bool {
+    matches!(expression, ExpressionNode::Simple(simple) if simple.content.trim_start().starts_with('['))
+}
+
+fn model_op<'a>(
+    allocator: &'a Allocator,
+    directive: &DirectiveNode<'a>,
+    value: ExprRef<'a>,
+    argument: Option<DynamicName<'a>>,
+    attributes: Vec<'a, Attribute<'a>>,
+) -> BindingOp<'a> {
+    BindingOp::Model(Box::new_in(
         ModelOp {
             contract: BindingContract {
                 read: value,
@@ -46,5 +102,5 @@ pub(super) fn lower_model<'a>(
             span: directive.loc.span,
         },
         &allocator,
-    )))
+    ))
 }

--- a/crates/vize_atelier_jsx/src/s2/tests.rs
+++ b/crates/vize_atelier_jsx/src/s2/tests.rs
@@ -204,6 +204,51 @@ fn component_v_model_static_arg_modifiers_project_to_s2_model() {
 }
 
 #[test]
+fn plain_input_v_model_projects_to_s2_model() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <input v-model={value} />";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("input v-model projects to S2");
+    assert_eq!(s2.op_count, 2);
+    let Op::Element(element) = &s2.root.ops[0] else {
+        panic!("root is an element");
+    };
+    assert_eq!(element.tag, "input");
+    assert_eq!(element.bindings.len(), 1);
+    let BindingOp::Model(model) = &element.bindings[0] else {
+        panic!("binding is ui.model");
+    };
+    assert_eq!(model.contract.read.source(), "value");
+    assert_eq!(model.contract.write.source(), "value");
+    assert!(model.argument.is_none());
+    assert_eq!(model.attributes.len(), 1);
+    assert_eq!(model.attributes[0].name, "element-kind");
+    assert_eq!(model.attributes[0].value, Some("input"));
+}
+
+#[test]
+fn unsupported_input_v_model_shapes_stay_on_directive_refusal_path() {
+    let allocator = Allocator::new();
+    let cases = [
+        "const App = () => <input v-model:checked={value} />",
+        "const App = () => <input v-model={[value, [\"trim\"]]} />",
+        "const App = () => <input v-model_lazy={value} />",
+        "const App = () => <input type=\"checkbox\" v-model={checked} />",
+        "const App = () => <input type={kind} v-model={value} />",
+        "const App = () => <input {...attrs} v-model={value} />",
+    ];
+
+    for source in cases {
+        let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+        let root = lowered.roots.first().expect("one JSX root");
+
+        assert!(matches!(root.s2, Err(S2Refusal::Directive)), "{source}");
+    }
+}
+
+#[test]
 fn v_show_without_value_stays_on_directive_refusal_path() {
     let allocator = Allocator::new();
     let lowered = lower_source(
@@ -218,12 +263,12 @@ fn v_show_without_value_stays_on_directive_refusal_path() {
 }
 
 #[test]
-fn element_v_model_stays_on_directive_refusal_path() {
+fn non_input_element_v_model_stays_on_directive_refusal_path() {
     let allocator = Allocator::new();
     let lowered = lower_source(
         &allocator,
         allocator.as_oxc(),
-        "const App = () => <input v-model={value} />",
+        "const App = () => <div v-model={value} />",
         JsxLang::Jsx,
     );
     let root = lowered.roots.first().expect("one JSX root");

--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -139,6 +139,11 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             JsxLang::Jsx,
         ),
         (
+            "element input v-model",
+            "const A = () => <input v-model={value} />;",
+            JsxLang::Jsx,
+        ),
+        (
             "component v-show",
             "const A = () => <B v-show={visible} />;",
             JsxLang::Jsx,

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -118,7 +118,7 @@ fn op_is_supported(op: &Op<'_>) -> bool {
             if element.tag == "template" && has_slot_content(&element.bindings) {
                 return slot_template_is_supported(element);
             }
-            bindings_are_supported(&element.bindings) && region_is_supported(&element.children)
+            element_bindings_are_supported(element) && region_is_supported(&element.children)
         }
         Op::Component(component) => component_is_supported(component),
         Op::Comment(_) | Op::If(_) | Op::For(_) | Op::Slot(_) => false,
@@ -146,17 +146,63 @@ fn slot_content_is_supported(content: &SlotContentOp<'_>) -> bool {
         && matches!(content.name, None | Some(DynamicName::Static(_)))
 }
 
-fn bindings_are_supported(bindings: &[BindingOp<'_>]) -> bool {
-    bindings.iter().all(|binding| {
-        matches!(
-            binding,
-            BindingOp::Bind(_)
-                | BindingOp::On(_)
-                | BindingOp::VueShow(_)
-                | BindingOp::VueHtml(_)
-                | BindingOp::VueText(_)
-        )
-    })
+fn element_bindings_are_supported(element: &ElementOp<'_>) -> bool {
+    element
+        .bindings
+        .iter()
+        .all(|binding| element_binding_is_supported(element, binding))
+}
+
+fn element_binding_is_supported(element: &ElementOp<'_>, binding: &BindingOp<'_>) -> bool {
+    match binding {
+        BindingOp::Bind(_)
+        | BindingOp::On(_)
+        | BindingOp::VueShow(_)
+        | BindingOp::VueHtml(_)
+        | BindingOp::VueText(_) => true,
+        BindingOp::Model(model) => input_model_is_supported(element, model),
+        _ => false,
+    }
+}
+
+fn input_model_is_supported(element: &ElementOp<'_>, model: &ModelOp<'_>) -> bool {
+    element.tag == "input"
+        && model.argument.is_none()
+        && model_is_bare_input(model)
+        && model.contract.read.source() == model.contract.write.source()
+        && model.contract.read.span() == model.contract.write.span()
+        && matches!(model.contract.read, ExprRef::Js(_))
+        && matches!(model.contract.write, ExprRef::Js(_))
+        && element
+            .attributes
+            .iter()
+            .all(|attribute| attribute.name != "type")
+        && element
+            .bindings
+            .iter()
+            .all(|binding| !bind_may_set_type(binding))
+}
+
+fn model_is_bare_input(model: &ModelOp<'_>) -> bool {
+    model
+        .attributes
+        .iter()
+        .any(|attribute| attribute.name == "element-kind" && attribute.value == Some("input"))
+        && model
+            .attributes
+            .iter()
+            .all(|attribute| attribute.name == "element-kind" && attribute.value == Some("input"))
+}
+
+fn bind_may_set_type(binding: &BindingOp<'_>) -> bool {
+    match binding {
+        BindingOp::Bind(bind) => match bind.name {
+            None | Some(DynamicName::Dynamic(_)) => true,
+            Some(DynamicName::Static("type")) => true,
+            Some(DynamicName::Static(_)) => false,
+        },
+        _ => false,
+    }
 }
 
 fn component_is_supported(component: &ComponentOp<'_>) -> bool {
@@ -260,6 +306,8 @@ fn event_option_modifiers_are_supported(modifiers: &[&str]) -> bool {
 mod compat_tests;
 #[cfg(test)]
 mod events_tests;
+#[cfg(test)]
+mod input_model_tests;
 #[cfg(test)]
 mod model_tests;
 #[cfg(test)]

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/input_model_tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/input_model_tests.rs
@@ -1,0 +1,45 @@
+use vize_croquis::Croquis;
+use vize_s0::Allocator;
+
+use crate::{JsxLang, lower_source};
+
+use super::super::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
+
+#[test]
+fn plain_input_v_model_emits_from_s2() {
+    let allocator = Allocator::new();
+    let source = "const A = () => <input v-model={value} />;";
+    let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
+    let mut root = lowered.roots.pop().expect("one JSX root");
+    let s2 = root.s2.as_ref().expect("input v-model projects to S2");
+
+    assert_eq!(super::root_is_supported(s2), true);
+
+    root.root.children.clear();
+    let mut diagnostics = Vec::new();
+    let component = compile_root_to_vdom(
+        &allocator,
+        root,
+        analysis,
+        false,
+        &VdomCompileOptions::default(),
+        VdomCompatOptions::default(),
+        &mut diagnostics,
+        source,
+    );
+
+    assert!(diagnostics.is_empty(), "{diagnostics:?}");
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { vModelText as _vModelText, withDirectives as _withDirectives, \
+         openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  return _withDirectives((_openBlock(), \
+         _createElementBlock(\"input\", {\n    \"onUpdate:modelValue\": $event => ((value) = \
+         $event)\n  }, null, 8 /* PROPS */, [\"onUpdate:modelValue\"])), [\n    \
+         [_vModelText, value]\n  ])\n}"
+    );
+}


### PR DESCRIPTION
Summary
- Project plain input v-model into the JSX S2 root as a native model binding.
- Admit that native input model through the S2 VDOM bridge while keeping argument, modifier, type, spread, and non-input shapes on the fallback path.
- Add S2, VDOM, differential, and target-validation coverage for the new route.

Tests
- cargo test -p vize_atelier_jsx --lib v_model -- --nocapture
- cargo test -p vize_atelier_jsx --lib
- cargo test -p vize_atelier_jsx --features davinci-differential --lib s2_vdom_admitted_cases_match_relief_codegen -- --nocapture
- cargo test -p vize_atelier_jsx --test v_model_target
- cargo fmt --all --check
- git diff --cached --check
- git diff --check origin/main...HEAD
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791405423&installation_model_id=422833&pr_number=5911&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5911&signature=24da4cd92b16ae3edac28678255becc4606de555a9f1eacf636db1620ce2b6a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `v-model` on plain `<input>` elements.
  * Generated output now uses Vue’s text-model binding with update handling.
  * Added support for validating and emitting eligible input model bindings.

* **Bug Fixes**
  * Unsupported input configurations, including types, arguments, modifiers, and dynamic bindings, continue to be rejected safely.

* **Tests**
  * Added coverage for successful plain-input model bindings and unsupported variants.
  * Added cross-compiler output consistency checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->