### PR TITLE
test(jsx): pin s2 vdom model compat fallback

### DIFF
--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/compat_tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/compat_tests.rs
@@ -46,12 +46,12 @@ fn babel_compat_surface_options_decline_s2_emit() {
         "mergeProps false",
     );
     assert_s2_emit_declines_with_compat(
-        S2_SUPPORTED_SOURCE,
+        "const A = () => <input v-model={value} />;",
         VdomCompatOptions {
             allow_static_v_model_arg_on_element: true,
             ..Default::default()
         },
-        "static element v-model arguments",
+        "native input v-model with static element argument compat",
     );
 
     let custom_element_spans = [(0, 1)];


### PR DESCRIPTION
Summary
- Exercise the Babel static element v-model argument compat fallback with an S2-supported native input model source.
- Keep the native S2 surface pinned to decline when that compat option is active.

Tests
- cargo test -p vize_atelier_jsx --lib babel_compat_surface_options_decline_s2_emit -- --nocapture
- cargo test -p vize_atelier_jsx --lib
- cargo fmt --all --check
- git diff --check
- git diff --check origin/main...HEAD
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791407400&installation_model_id=422833&pr_number=5912&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5912&signature=cfb60792a7bf31fcd953db1f2c726691aba0f3e94da6201be189cb848f0ad709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated compatibility coverage for native input elements using `v-model`.
  * Refined the associated diagnostic label for clearer test reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->