### PR TITLE
feat(jsx): admit text input v-model in s2

### DIFF
--- a/crates/vize_atelier_jsx/src/s2.rs
+++ b/crates/vize_atelier_jsx/src/s2.rs
@@ -19,7 +19,7 @@ use vize_s2::op::{
 };
 
 use self::directives::lower_vue_directive;
-use self::input_model::allows_plain_input_model;
+use self::input_model::allows_text_input_model;
 use self::model::lower_model;
 use self::slots::{has_slot_content, lower_slot_content, slot_template_span};
 
@@ -130,7 +130,7 @@ fn lower_element<'a>(
     op_count: &mut u32,
     features: &mut LoweringFeatures,
 ) -> Result<Op<'a>, S2Refusal> {
-    let allow_native_input_model = allows_plain_input_model(element);
+    let allow_native_input_model = allows_text_input_model(element);
     let props = lower_props(
         allocator,
         &element.props,

--- a/crates/vize_atelier_jsx/src/s2/input_model.rs
+++ b/crates/vize_atelier_jsx/src/s2/input_model.rs
@@ -1,15 +1,20 @@
 use vize_relief::{ElementNode, ElementType, ExpressionNode, PropNode};
 
-pub(super) fn allows_plain_input_model(element: &ElementNode<'_>) -> bool {
+pub(super) fn allows_text_input_model(element: &ElementNode<'_>) -> bool {
     matches!(element.tag_type, ElementType::Element)
         && element.tag == "input"
-        && !element.props.iter().any(blocks_plain_input_model)
+        && element.props.iter().all(preserves_text_input_model)
 }
 
-fn blocks_plain_input_model(prop: &PropNode<'_>) -> bool {
-    matches!(prop, PropNode::Attribute(attribute) if attribute.name == "type")
-        || matches!(prop, PropNode::Directive(directive)
-            if directive.name == "bind"
-                && !matches!(directive.arg.as_ref(), Some(ExpressionNode::Simple(simple))
-                    if simple.is_static && simple.content != "type"))
+fn preserves_text_input_model(prop: &PropNode<'_>) -> bool {
+    match prop {
+        PropNode::Attribute(attribute) if attribute.name == "type" => {
+            matches!(attribute.value.as_ref(), Some(value) if value.content == "text")
+        }
+        PropNode::Directive(directive) if directive.name == "bind" => {
+            matches!(directive.arg.as_ref(), Some(ExpressionNode::Simple(simple))
+                if simple.is_static && simple.content != "type")
+        }
+        _ => true,
+    }
 }

--- a/crates/vize_atelier_jsx/src/s2/tests.rs
+++ b/crates/vize_atelier_jsx/src/s2/tests.rs
@@ -229,6 +229,27 @@ fn plain_input_v_model_projects_to_s2_model() {
 }
 
 #[test]
+fn text_input_v_model_projects_to_s2_model() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <input type=\"text\" v-model={value} />";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("text input v-model projects to S2");
+    let Op::Element(element) = &s2.root.ops[0] else {
+        panic!("root is an element");
+    };
+    assert_eq!(element.attributes.len(), 1);
+    assert_eq!(element.attributes[0].name, "type");
+    assert_eq!(element.attributes[0].value, Some("text"));
+    let BindingOp::Model(model) = &element.bindings[0] else {
+        panic!("binding is ui.model");
+    };
+    assert_eq!(model.contract.read.source(), "value");
+    assert_eq!(model.attributes[0].value, Some("input"));
+}
+
+#[test]
 fn unsupported_input_v_model_shapes_stay_on_directive_refusal_path() {
     let allocator = Allocator::new();
     let cases = [
@@ -236,6 +257,7 @@ fn unsupported_input_v_model_shapes_stay_on_directive_refusal_path() {
         "const App = () => <input v-model={[value, [\"trim\"]]} />",
         "const App = () => <input v-model_lazy={value} />",
         "const App = () => <input type=\"checkbox\" v-model={checked} />",
+        "const App = () => <input type=\"email\" v-model={value} />",
         "const App = () => <input type={kind} v-model={value} />",
         "const App = () => <input {...attrs} v-model={value} />",
     ];

--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -144,6 +144,11 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             JsxLang::Jsx,
         ),
         (
+            "element text input v-model",
+            "const A = () => <input type=\"text\" v-model={value} />;",
+            JsxLang::Jsx,
+        ),
+        (
             "component v-show",
             "const A = () => <B v-show={visible} />;",
             JsxLang::Jsx,

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -173,10 +173,14 @@ fn input_model_is_supported(element: &ElementOp<'_>, model: &ModelOp<'_>) -> boo
         && model.contract.read.span() == model.contract.write.span()
         && matches!(model.contract.read, ExprRef::Js(_))
         && matches!(model.contract.write, ExprRef::Js(_))
-        && element
-            .attributes
-            .iter()
-            .all(|attribute| attribute.name != "type")
+        && input_type_is_text(element)
+}
+
+fn input_type_is_text(element: &ElementOp<'_>) -> bool {
+    element
+        .attributes
+        .iter()
+        .all(|attribute| attribute.name != "type" || attribute.value == Some("text"))
         && element
             .bindings
             .iter()

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/input_model_tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/input_model_tests.rs
@@ -3,18 +3,52 @@ use vize_s0::Allocator;
 
 use crate::{JsxLang, lower_source};
 
-use super::super::{VdomCompatOptions, VdomCompileOptions, compile_root_to_vdom};
+use super::super::{VdomCompatOptions, VdomCompileOptions, VdomComponent, compile_root_to_vdom};
 
 #[test]
 fn plain_input_v_model_emits_from_s2() {
-    let allocator = Allocator::new();
     let source = "const A = () => <input v-model={value} />;";
+    let component = compile_input_model_from_s2(source);
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { vModelText as _vModelText, withDirectives as _withDirectives, \
+         openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  return _withDirectives((_openBlock(), \
+         _createElementBlock(\"input\", {\n    \"onUpdate:modelValue\": $event => ((value) = \
+         $event)\n  }, null, 8 /* PROPS */, [\"onUpdate:modelValue\"])), [\n    \
+         [_vModelText, value]\n  ])\n}"
+    );
+}
+
+#[test]
+fn text_input_v_model_emits_from_s2() {
+    let source = "const A = () => <input type=\"text\" v-model={value} />;";
+    let component = compile_input_model_from_s2(source);
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { vModelText as _vModelText, withDirectives as _withDirectives, \
+         openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  return _withDirectives((_openBlock(), \
+         _createElementBlock(\"input\", {\n    type: \"text\",\n    \"onUpdate:modelValue\": \
+         $event => ((value) = $event)\n  }, null, 8 /* PROPS */, \
+         [\"onUpdate:modelValue\"])), [\n    [_vModelText, value]\n  ])\n}"
+    );
+}
+
+fn compile_input_model_from_s2(source: &str) -> VdomComponent {
+    let allocator = Allocator::new();
     let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
     let analysis: &Croquis = allocator.alloc_owned(lowered.analysis);
     let mut root = lowered.roots.pop().expect("one JSX root");
     let s2 = root.s2.as_ref().expect("input v-model projects to S2");
 
-    assert_eq!(super::root_is_supported(s2), true);
+    assert!(super::root_is_supported(s2));
 
     root.root.children.clear();
     let mut diagnostics = Vec::new();
@@ -30,16 +64,5 @@ fn plain_input_v_model_emits_from_s2() {
     );
 
     assert!(diagnostics.is_empty(), "{diagnostics:?}");
-    assert_eq!(
-        component.preamble.as_str(),
-        "import { vModelText as _vModelText, withDirectives as _withDirectives, \
-         openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n"
-    );
-    assert_eq!(
-        component.code.as_str(),
-        "export function render(_ctx, _cache) {\n  return _withDirectives((_openBlock(), \
-         _createElementBlock(\"input\", {\n    \"onUpdate:modelValue\": $event => ((value) = \
-         $event)\n  }, null, 8 /* PROPS */, [\"onUpdate:modelValue\"])), [\n    \
-         [_vModelText, value]\n  ])\n}"
-    );
+    component
 }


### PR DESCRIPTION
Summary
- Admit the static <input type="text" v-model={value} /> shape through JSX S2.
- Keep non-text and dynamic input type shapes on the fallback path.
- Add S2 projection, emission, and differential witnesses for the new native text input model case.

Tests
- cargo test -p vize_atelier_jsx --lib
- cargo test -p vize_atelier_jsx --features davinci-differential --lib s2_vdom_admitted_cases_match_relief_codegen -- --nocapture
- cargo fmt --all --check
- git diff --check origin/main...HEAD
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791408570&installation_model_id=422833&pr_number=5913&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5913&signature=db7dc42f2832b41426da8a17d804c6e00e58b71ca283e5aa98c0192052c78e86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `v-model` handling for text inputs.
  - Inputs with an explicit `type="text"` now retain their type and correctly generate model bindings.
  - Inputs with unsupported types, such as `email`, continue to be rejected where model handling is unavailable.

- **Tests**
  - Added coverage to verify text-input model behavior across supported compilation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->