### PR TITLE
test(davinci): cover assertion allowlist expiry

### DIFF
--- a/tests/tooling/davinci-assertion-lint.test.ts
+++ b/tests/tooling/davinci-assertion-lint.test.ts
@@ -7,6 +7,7 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -18,6 +19,36 @@ const allowlistPath = path.join(repoRoot, "davinci-road", "plan", "assertion-all
 
 function runLint(args: string[]) {
   return spawnSync("rust-script", [lintPath, ...args], { cwd: repoRoot, encoding: "utf8" });
+}
+
+function badFixtureFindings(): string[] {
+  const fixture = fs.readFileSync(path.join(fixtureDir, "bad_example.rs"), "utf8");
+  return fixture.split("\n").flatMap((line, index) => {
+    const marker = /\/\/ FLAG \[([a-z-]+)\]$/.exec(line.trim());
+    if (marker == null) return [];
+    return [`bad_example.rs:${index + 1} [${marker[1]}] ${line.trim()}`];
+  });
+}
+
+function temporaryAllowlist(expires: string, entries: string[]): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-davinci-assertion-lint-"));
+  const allowlist = path.join(dir, "allowlist.toml");
+  const paths = entries.map((entry) => `  "${entry}",`).join("\n");
+  fs.writeFileSync(
+    allowlist,
+    `[[allow]]
+justification = "fixture coverage"
+expires = "${expires}"
+paths = [
+${paths}
+]
+`,
+  );
+  return allowlist;
+}
+
+function removeTemporaryAllowlist(allowlist: string): void {
+  fs.rmSync(path.dirname(allowlist), { recursive: true, force: true });
 }
 
 // Paths listed by the committed allowlist: every `[[allow]]` group carries a
@@ -34,15 +65,10 @@ function allowlistPaths(): string[] {
 }
 
 test("assertion lint flags every marked weak assertion in the bad fixture, and only those", () => {
-  const fixture = fs.readFileSync(path.join(fixtureDir, "bad_example.rs"), "utf8");
   // The fixture is the ground truth: every line carrying a `// FLAG [category]`
   // marker must be reported as `bad_example.rs:<line> [<category>] <line text>`,
   // in file order, and nothing else may appear.
-  const expectedFindings = fixture.split("\n").flatMap((line, index) => {
-    const marker = /\/\/ FLAG \[([a-z-]+)\]$/.exec(line.trim());
-    if (marker == null) return [];
-    return [`bad_example.rs:${index + 1} [${marker[1]}] ${line.trim()}`];
-  });
+  const expectedFindings = badFixtureFindings();
   assert.equal(expectedFindings.length, 5, "fixture must carry all five banned categories");
 
   const result = runLint(["--root", fixtureDir]);
@@ -54,6 +80,37 @@ test("assertion lint flags every marked weak assertion in the bad fixture, and o
       "assertion-lint: 5 unlisted findings — fix the assertion (exact oracles only) " +
       "or triage via davinci-road/plan/assertion-allowlist.toml\n",
   );
+});
+
+test("explicit allowlist suppresses fixture findings only before expiry", () => {
+  const expectedFindings = badFixtureFindings();
+  const freshAllowlist = temporaryAllowlist("2999-12-31", ["bad_example.rs"]);
+  try {
+    const result = runLint(["--root", fixtureDir, "--allowlist", freshAllowlist]);
+    assert.equal(result.stderr, "");
+    assert.equal(result.status, 0, result.stdout);
+    assert.equal(
+      result.stdout,
+      `assertion-lint: OK (${expectedFindings.length} findings in 1 files suppressed by allowlist)\n`,
+    );
+  } finally {
+    removeTemporaryAllowlist(freshAllowlist);
+  }
+
+  const expiredAllowlist = temporaryAllowlist("1970-01-01", ["bad_example.rs"]);
+  try {
+    const result = runLint(["--root", fixtureDir, "--allowlist", expiredAllowlist]);
+    assert.equal(result.stderr, "");
+    assert.equal(result.status, 1, result.stdout);
+    assert.equal(
+      result.stdout,
+      expectedFindings.map((finding) => `${finding} (allowlist entry expired)`).join("\n") +
+        "\nassertion-lint: 5 unlisted findings — fix the assertion (exact oracles only) " +
+        "or triage via davinci-road/plan/assertion-allowlist.toml\n",
+    );
+  } finally {
+    removeTemporaryAllowlist(expiredAllowlist);
+  }
 });
 
 test("assertion lint exits 0 on the real tree under the committed allowlist", () => {


### PR DESCRIPTION
## Summary
- extract the bad fixture expectation helper for assertion-lint tests
- add a boundary test for fresh versus expired explicit allowlists
- pin the expired allowlist output so expiry handling keeps surfacing debt

## Validation
- node --test tests/tooling/davinci-assertion-lint.test.ts
- rust-script tools/commands/davinci/assertion-lint.rs
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791410118&installation_model_id=422833&pr_number=5915&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5915&signature=b4ab4a5c80a6480b2ac35927e3ccc6927714da7cdd0166f1c729c57b9c4f4820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for valid allowlists suppressing lint findings.
  - Added coverage confirming expired allowlists report findings as expired and fail linting.
  - Improved test setup and cleanup for temporary allowlist files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->