### PR TITLE
feat(jsx): admit select v-model in s2

### DIFF
--- a/crates/vize_atelier_jsx/src/s2.rs
+++ b/crates/vize_atelier_jsx/src/s2.rs
@@ -20,7 +20,7 @@ use vize_s2::op::{
 
 use self::directives::lower_vue_directive;
 use self::model::lower_model;
-use self::native_text_model::native_text_model_kind;
+use self::native_model::native_model_kind;
 use self::slots::{has_slot_content, lower_slot_content, slot_template_span};
 
 /// A JSX render root represented as S2 operations.
@@ -130,12 +130,12 @@ fn lower_element<'a>(
     op_count: &mut u32,
     features: &mut LoweringFeatures,
 ) -> Result<Op<'a>, S2Refusal> {
-    let native_model_kind = native_text_model_kind(element);
+    let native_element_model_kind = native_model_kind(element);
     let props = lower_props(
         allocator,
         &element.props,
         element.tag_type,
-        native_model_kind,
+        native_element_model_kind,
         features,
     )?;
     *op_count = op_count.saturating_add(props.binding_count);
@@ -196,7 +196,7 @@ fn lower_props<'a>(
     allocator: &'a Allocator,
     props: &[PropNode<'a>],
     element_type: ElementType,
-    native_text_model_kind: Option<&'a str>,
+    native_model_kind: Option<&'a str>,
     features: &mut LoweringFeatures,
 ) -> Result<LoweredProps<'a>, S2Refusal> {
     let mut attributes = Vec::new_in(&allocator);
@@ -213,7 +213,7 @@ fn lower_props<'a>(
                     allocator,
                     directive,
                     element_type,
-                    native_text_model_kind,
+                    native_model_kind,
                     features,
                 )?);
             }
@@ -231,7 +231,7 @@ fn lower_binding<'a>(
     allocator: &'a Allocator,
     directive: &vize_relief::DirectiveNode<'a>,
     element_type: ElementType,
-    native_text_model_kind: Option<&'a str>,
+    native_model_kind: Option<&'a str>,
     features: &mut LoweringFeatures,
 ) -> Result<BindingOp<'a>, S2Refusal> {
     match directive.name {
@@ -240,7 +240,7 @@ fn lower_binding<'a>(
             allocator,
             directive,
             element_type,
-            native_text_model_kind,
+            native_model_kind,
             features,
         ),
         "show" | "html" | "text" => lower_vue_directive(allocator, directive, element_type),
@@ -344,5 +344,5 @@ mod tests;
 
 mod directives;
 mod model;
-mod native_text_model;
+mod native_model;
 mod slots;

--- a/crates/vize_atelier_jsx/src/s2/model.rs
+++ b/crates/vize_atelier_jsx/src/s2/model.rs
@@ -12,16 +12,16 @@ pub(super) fn lower_model<'a>(
     allocator: &'a Allocator,
     directive: &DirectiveNode<'a>,
     element_type: ElementType,
-    native_text_model_kind: Option<&'a str>,
+    native_model_kind: Option<&'a str>,
     features: &mut LoweringFeatures,
 ) -> Result<BindingOp<'a>, S2Refusal> {
     match element_type {
         ElementType::Component => lower_component_model(allocator, directive, features),
         ElementType::Element => {
-            let Some(element_kind) = native_text_model_kind else {
+            let Some(element_kind) = native_model_kind else {
                 return Err(S2Refusal::Directive);
             };
-            lower_native_text_model(allocator, directive, element_kind, features)
+            lower_native_model(allocator, directive, element_kind, features)
         }
         _ => Err(S2Refusal::Directive),
     }
@@ -56,7 +56,7 @@ fn lower_component_model<'a>(
     Ok(model_op(allocator, directive, value, argument, attributes))
 }
 
-fn lower_native_text_model<'a>(
+fn lower_native_model<'a>(
     allocator: &'a Allocator,
     directive: &DirectiveNode<'a>,
     element_kind: &'a str,

--- a/crates/vize_atelier_jsx/src/s2/native_model.rs
+++ b/crates/vize_atelier_jsx/src/s2/native_model.rs
@@ -1,12 +1,12 @@
 use vize_relief::{ElementNode, ElementType, ExpressionNode, PropNode};
 
-pub(super) fn native_text_model_kind<'a>(element: &ElementNode<'a>) -> Option<&'a str> {
+pub(super) fn native_model_kind<'a>(element: &ElementNode<'a>) -> Option<&'a str> {
     if !matches!(element.tag_type, ElementType::Element) {
         return None;
     }
     match element.tag {
         "input" if element.props.iter().all(preserves_text_input_model) => Some("input"),
-        "textarea" => Some("textarea"),
+        "select" | "textarea" => Some(element.tag),
         _ => None,
     }
 }

--- a/crates/vize_atelier_jsx/src/s2/native_model_tests.rs
+++ b/crates/vize_atelier_jsx/src/s2/native_model_tests.rs
@@ -74,7 +74,29 @@ fn textarea_v_model_projects_to_s2_model() {
 }
 
 #[test]
-fn unsupported_native_text_model_shapes_stay_on_directive_refusal_path() {
+fn select_v_model_projects_to_s2_model() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <select v-model={value}></select>";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("select v-model projects to S2");
+    let Op::Element(element) = &s2.root.ops[0] else {
+        panic!("root is an element");
+    };
+    assert_eq!(element.tag, "select");
+    let BindingOp::Model(model) = &element.bindings[0] else {
+        panic!("binding is ui.model");
+    };
+    assert_eq!(model.contract.read.source(), "value");
+    assert!(model.argument.is_none());
+    assert_eq!(model.attributes.len(), 1);
+    assert_eq!(model.attributes[0].name, "element-kind");
+    assert_eq!(model.attributes[0].value, Some("select"));
+}
+
+#[test]
+fn unsupported_native_model_shapes_stay_on_directive_refusal_path() {
     let allocator = Allocator::new();
     let cases = [
         "const App = () => <input v-model:checked={value} />",
@@ -87,7 +109,9 @@ fn unsupported_native_text_model_shapes_stay_on_directive_refusal_path() {
         "const App = () => <textarea v-model:foo={value} />",
         "const App = () => <textarea v-model={[value, [\"trim\"]]} />",
         "const App = () => <textarea v-model_lazy={value} />",
-        "const App = () => <select v-model={value} />",
+        "const App = () => <select v-model:foo={value}></select>",
+        "const App = () => <select v-model={[value, [\"number\"]]}></select>",
+        "const App = () => <select v-model_number={value}></select>",
     ];
 
     for source in cases {

--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -154,6 +154,11 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             JsxLang::Jsx,
         ),
         (
+            "element select v-model",
+            "const A = () => <select v-model={value}></select>;",
+            JsxLang::Jsx,
+        ),
+        (
             "component v-show",
             "const A = () => <B v-show={visible} />;",
             JsxLang::Jsx,

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -160,15 +160,15 @@ fn element_binding_is_supported(element: &ElementOp<'_>, binding: &BindingOp<'_>
         | BindingOp::VueShow(_)
         | BindingOp::VueHtml(_)
         | BindingOp::VueText(_) => true,
-        BindingOp::Model(model) => native_text_model_is_supported(element, model),
+        BindingOp::Model(model) => native_model_is_supported(element, model),
         _ => false,
     }
 }
 
-fn native_text_model_is_supported(element: &ElementOp<'_>, model: &ModelOp<'_>) -> bool {
-    matches!(element.tag, "input" | "textarea")
+fn native_model_is_supported(element: &ElementOp<'_>, model: &ModelOp<'_>) -> bool {
+    matches!(element.tag, "input" | "select" | "textarea")
         && model.argument.is_none()
-        && model_is_bare_native_text(element, model)
+        && model_is_bare_native_element(element, model)
         && model.contract.read.source() == model.contract.write.source()
         && model.contract.read.span() == model.contract.write.span()
         && matches!(model.contract.read, ExprRef::Js(_))
@@ -187,7 +187,7 @@ fn input_type_is_text(element: &ElementOp<'_>) -> bool {
             .all(|binding| !bind_may_set_type(binding))
 }
 
-fn model_is_bare_native_text(element: &ElementOp<'_>, model: &ModelOp<'_>) -> bool {
+fn model_is_bare_native_element(element: &ElementOp<'_>, model: &ModelOp<'_>) -> bool {
     model
         .attributes
         .iter()

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/native_model_tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/native_model_tests.rs
@@ -59,6 +59,24 @@ fn textarea_v_model_emits_from_s2() {
     );
 }
 
+#[test]
+fn select_v_model_emits_from_s2() {
+    let source = "const A = () => <select v-model={value}></select>;";
+    let component = compile_native_model_from_s2(source);
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { vModelSelect as _vModelSelect, withDirectives as _withDirectives, \
+         openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  return _withDirectives((_openBlock(), \
+         _createElementBlock(\"select\", {\n    \"onUpdate:modelValue\": $event => ((value) = \
+         $event)\n  }, null, 8 /* PROPS */, [\"onUpdate:modelValue\"])), [\n    \
+         [_vModelSelect, value]\n  ])\n}"
+    );
+}
+
 fn compile_native_model_from_s2(source: &str) -> VdomComponent {
     let allocator = Allocator::new();
     let mut lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);


### PR DESCRIPTION
## Summary
- admit bare native `<select v-model>` through the JSX S2 projection
- route the S2 VDOM emitter to Vue's select model helper for admitted select models
- pin projection, emitted output, and S2/Relief differential parity

## Validation
- cargo fmt --all --check
- cargo test -p vize_atelier_jsx --lib select_v_model -- --nocapture
- cargo test -p vize_atelier_jsx --features davinci-differential --lib s2_vdom_admitted_cases_match_relief_codegen -- --nocapture
- cargo test -p vize_atelier_jsx --lib
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791411954&installation_model_id=422833&pr_number=5916&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5916&signature=254a0949a639d9e6ba7493a7ac4419a5d5d29c822d43c9f92f4bc041e10465eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using `v-model` with `<select>` elements in JSX.
  * Generated output now uses the appropriate select-specific model handling.

* **Tests**
  * Added coverage for select bindings, generated output, and differential rendering.
  * Added validation for unsupported select binding variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->