### PR TITLE
fix(davinci): reject non-normalized assertion allowlist paths

### DIFF
--- a/tests/tooling/davinci-assertion-lint.test.ts
+++ b/tests/tooling/davinci-assertion-lint.test.ts
@@ -113,6 +113,23 @@ test("explicit allowlist suppresses fixture findings only before expiry", () => 
   }
 });
 
+test("explicit allowlist rejects non-normalized paths", () => {
+  for (const entry of ["/bad_example.rs", "./bad_example.rs", "nested/../bad_example.rs"]) {
+    const allowlist = temporaryAllowlist("2999-12-31", [entry]);
+    try {
+      const result = runLint(["--root", fixtureDir, "--allowlist", allowlist]);
+      assert.equal(result.status, 2, result.stdout);
+      assert.equal(result.stdout, "");
+      assert.match(
+        result.stderr,
+        /paths must be normalized repo-root-relative forward-slash strings/,
+      );
+    } finally {
+      removeTemporaryAllowlist(allowlist);
+    }
+  }
+});
+
 test("assertion lint exits 0 on the real tree under the committed allowlist", () => {
   const entryCount = allowlistPaths().length;
   assert.ok(entryCount > 0, "committed allowlist must not be empty while the debt exists");

--- a/tools/commands/davinci/assertion-lint.rs
+++ b/tools/commands/davinci/assertion-lint.rs
@@ -303,9 +303,9 @@ fn load_allowlist(path: &Path) -> Result<BTreeMap<String, AllowEntry>, String> {
                     "{where_}: paths must be repo-root-relative forward-slash strings"
                 ));
             };
-            if entry_path.is_empty() || entry_path.contains('\\') {
+            if !is_allowlist_path(entry_path) {
                 return Err(format!(
-                    "{where_}: paths must be repo-root-relative forward-slash strings"
+                    "{where_}: paths must be normalized repo-root-relative forward-slash strings"
                 ));
             }
             if by_path
@@ -323,6 +323,15 @@ fn load_allowlist(path: &Path) -> Result<BTreeMap<String, AllowEntry>, String> {
         }
     }
     Ok(by_path)
+}
+
+fn is_allowlist_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.contains('\\')
+        && !path.starts_with('/')
+        && path
+            .split('/')
+            .all(|segment| !segment.is_empty() && segment != "." && segment != "..")
 }
 
 fn parse_toml_value(value: &str) -> Result<TomlValue, String> {


### PR DESCRIPTION
## Summary
- reject absolute and dot-segment assertion allowlist paths
- keep the allowlist contract normalized and repo-root-relative
- cover invalid explicit allowlist paths with a focused tooling test

## Validation
- node --test tests/tooling/davinci-assertion-lint.test.ts
- rust-script tools/commands/davinci/assertion-lint.rs
- rustfmt --check tools/commands/davinci/assertion-lint.rs
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791412031&installation_model_id=422833&pr_number=5917&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5917&signature=2a6ca6487c5292bc184ccc8710c7795c2788f527c99735f1f4a82477c83831cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->