### PR TITLE
feat(jsx): admit input choice v-model in s2

### DIFF
--- a/crates/vize_atelier_jsx/src/s2/native_model.rs
+++ b/crates/vize_atelier_jsx/src/s2/native_model.rs
@@ -1,25 +1,45 @@
-use vize_relief::{ElementNode, ElementType, ExpressionNode, PropNode};
+use vize_relief::{DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode};
 
 pub(super) fn native_model_kind<'a>(element: &ElementNode<'a>) -> Option<&'a str> {
     if !matches!(element.tag_type, ElementType::Element) {
         return None;
     }
     match element.tag {
-        "input" if element.props.iter().all(preserves_text_input_model) => Some("input"),
+        "input" if input_model_is_admitted(element) => Some("input"),
         "select" | "textarea" => Some(element.tag),
         _ => None,
     }
 }
 
-fn preserves_text_input_model(prop: &PropNode<'_>) -> bool {
-    match prop {
-        PropNode::Attribute(attribute) if attribute.name == "type" => {
-            matches!(attribute.value.as_ref(), Some(value) if value.content == "text")
+fn input_model_is_admitted(element: &ElementNode<'_>) -> bool {
+    let mut static_type = None;
+    for prop in &element.props {
+        match prop {
+            PropNode::Attribute(attribute) if attribute.name == "type" => {
+                let Some(value) = attribute.value.as_ref().map(|value| value.content) else {
+                    return false;
+                };
+                if !input_type_is_admitted(value) || static_type.is_some_and(|seen| seen != value) {
+                    return false;
+                }
+                static_type = Some(value);
+            }
+            PropNode::Directive(directive)
+                if directive.name == "bind" && !bind_preserves_input_type(directive) =>
+            {
+                return false;
+            }
+            _ => {}
         }
-        PropNode::Directive(directive) if directive.name == "bind" => {
-            matches!(directive.arg.as_ref(), Some(ExpressionNode::Simple(simple))
-                if simple.is_static && simple.content != "type")
-        }
-        _ => true,
     }
+    true
+}
+
+fn bind_preserves_input_type(directive: &DirectiveNode<'_>) -> bool {
+    matches!(directive.arg.as_ref(), Some(ExpressionNode::Simple(simple))
+        if simple.is_static && simple.content != "type")
+}
+
+fn input_type_is_admitted(input_type: &str) -> bool {
+    matches!(input_type, "checkbox" | "radio" | "text")
 }

--- a/crates/vize_atelier_jsx/src/s2/native_model_tests.rs
+++ b/crates/vize_atelier_jsx/src/s2/native_model_tests.rs
@@ -52,6 +52,35 @@ fn text_input_v_model_projects_to_s2_model() {
 }
 
 #[test]
+fn choice_input_v_model_projects_to_s2_model() {
+    for (input_type, value) in [("checkbox", "checked"), ("radio", "picked")] {
+        let allocator = Allocator::new();
+        let source =
+            format!("const App = () => <input type=\"{input_type}\" v-model={{{value}}} />");
+        let lowered = lower_source(&allocator, allocator.as_oxc(), &source, JsxLang::Jsx);
+        let root = lowered.roots.first().expect("one JSX root");
+
+        let s2 = root
+            .s2
+            .as_ref()
+            .expect("choice input v-model projects to S2");
+        let Op::Element(element) = &s2.root.ops[0] else {
+            panic!("root is an element");
+        };
+        assert_eq!(element.tag, "input");
+        assert_eq!(element.attributes.len(), 1);
+        assert_eq!(element.attributes[0].name, "type");
+        assert_eq!(element.attributes[0].value, Some(input_type));
+        let BindingOp::Model(model) = &element.bindings[0] else {
+            panic!("binding is ui.model");
+        };
+        assert_eq!(model.contract.read.source(), value);
+        assert!(model.argument.is_none());
+        assert_eq!(model.attributes[0].value, Some("input"));
+    }
+}
+
+#[test]
 fn textarea_v_model_projects_to_s2_model() {
     let allocator = Allocator::new();
     let source = "const App = () => <textarea v-model={value} />";
@@ -102,7 +131,7 @@ fn unsupported_native_model_shapes_stay_on_directive_refusal_path() {
         "const App = () => <input v-model:checked={value} />",
         "const App = () => <input v-model={[value, [\"trim\"]]} />",
         "const App = () => <input v-model_lazy={value} />",
-        "const App = () => <input type=\"checkbox\" v-model={checked} />",
+        "const App = () => <input type=\"checkbox\" type=\"radio\" v-model={picked} />",
         "const App = () => <input type=\"email\" v-model={value} />",
         "const App = () => <input type={kind} v-model={value} />",
         "const App = () => <input {...attrs} v-model={value} />",

--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -149,6 +149,16 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             JsxLang::Jsx,
         ),
         (
+            "element checkbox input v-model",
+            "const A = () => <input type=\"checkbox\" v-model={checked} />;",
+            JsxLang::Jsx,
+        ),
+        (
+            "element radio input v-model",
+            "const A = () => <input type=\"radio\" v-model={picked} />;",
+            JsxLang::Jsx,
+        ),
+        (
             "element textarea v-model",
             "const A = () => <textarea v-model={value} />;",
             JsxLang::Jsx,

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -173,18 +173,32 @@ fn native_model_is_supported(element: &ElementOp<'_>, model: &ModelOp<'_>) -> bo
         && model.contract.read.span() == model.contract.write.span()
         && matches!(model.contract.read, ExprRef::Js(_))
         && matches!(model.contract.write, ExprRef::Js(_))
-        && (element.tag != "input" || input_type_is_text(element))
+        && (element.tag != "input" || input_type_is_supported(element))
 }
 
-fn input_type_is_text(element: &ElementOp<'_>) -> bool {
+fn input_type_is_supported(element: &ElementOp<'_>) -> bool {
+    let mut static_type = None;
+    for attribute in &element.attributes {
+        if attribute.name != "type" {
+            continue;
+        }
+        let Some(value) = attribute.value else {
+            return false;
+        };
+        if !input_type_value_is_supported(value) || static_type.is_some_and(|seen| seen != value) {
+            return false;
+        }
+        static_type = Some(value);
+    }
+
     element
-        .attributes
+        .bindings
         .iter()
-        .all(|attribute| attribute.name != "type" || attribute.value == Some("text"))
-        && element
-            .bindings
-            .iter()
-            .all(|binding| !bind_may_set_type(binding))
+        .all(|binding| !bind_may_set_type(binding))
+}
+
+fn input_type_value_is_supported(value: &str) -> bool {
+    matches!(value, "checkbox" | "radio" | "text")
 }
 
 fn model_is_bare_native_element(element: &ElementOp<'_>, model: &ModelOp<'_>) -> bool {

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/native_model_tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/native_model_tests.rs
@@ -42,6 +42,42 @@ fn text_input_v_model_emits_from_s2() {
 }
 
 #[test]
+fn checkbox_input_v_model_emits_from_s2() {
+    let source = "const A = () => <input type=\"checkbox\" v-model={checked} />;";
+    let component = compile_native_model_from_s2(source);
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { vModelCheckbox as _vModelCheckbox, withDirectives as _withDirectives, \
+         openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  return _withDirectives((_openBlock(), \
+         _createElementBlock(\"input\", {\n    type: \"checkbox\",\n    \
+         \"onUpdate:modelValue\": $event => ((checked) = $event)\n  }, null, 8 /* PROPS */, \
+         [\"onUpdate:modelValue\"])), [\n    [_vModelCheckbox, checked]\n  ])\n}"
+    );
+}
+
+#[test]
+fn radio_input_v_model_emits_from_s2() {
+    let source = "const A = () => <input type=\"radio\" v-model={picked} />;";
+    let component = compile_native_model_from_s2(source);
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { vModelRadio as _vModelRadio, withDirectives as _withDirectives, \
+         openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  return _withDirectives((_openBlock(), \
+         _createElementBlock(\"input\", {\n    type: \"radio\",\n    \"onUpdate:modelValue\": \
+         $event => ((picked) = $event)\n  }, null, 8 /* PROPS */, \
+         [\"onUpdate:modelValue\"])), [\n    [_vModelRadio, picked]\n  ])\n}"
+    );
+}
+
+#[test]
 fn textarea_v_model_emits_from_s2() {
     let source = "const A = () => <textarea v-model={value} />;";
     let component = compile_native_model_from_s2(source);


### PR DESCRIPTION
## Summary
- admit static checkbox and radio input v-model through JSX S2
- preserve refusal for dynamic, spread, modifier, tuple, and conflicting static type shapes
- pin checkbox/radio projection, VDOM helper emission, and differential parity

## Validation
- cargo fmt --all --check
- cargo test -p vize_atelier_jsx --lib native_model -- --nocapture
- cargo test -p vize_atelier_jsx --features davinci-differential --lib s2_vdom_admitted_cases_match_relief_codegen -- --nocapture
- cargo test -p vize_atelier_jsx --lib
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- node --test tests/tooling/source-file-lengths.test.ts tests/tooling/davinci-assertion-lint.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791413353&installation_model_id=422833&pr_number=5918&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5918&signature=4ef941a3aa19af05738432f4554cb3b3ff7bf85dae4740349b56e94ce6851638"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native `v-model` support for checkbox and radio inputs.
  - Checkbox bindings synchronize through the checked value, while radio bindings synchronize through the selected value.
  - Text input bindings remain supported.
  - Supported input types must be declared statically.
  - Conflicting duplicate `type` declarations are rejected.
  - Dynamic bindings that could change the input type are not accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->