### PR TITLE
test(davinci): require budget pins cover ladder

### DIFF
--- a/crates/vize_atelier_dom/tests/davinci_s2_build_profile.rs
+++ b/crates/vize_atelier_dom/tests/davinci_s2_build_profile.rs
@@ -55,6 +55,7 @@ fn current_walks(fixture: &str) -> (u64, u64) {
 fn profile_build_walks_report_the_current_p2_12b_gap() {
     let _guard = lock_profiler();
     let fused_walk_target = phase_2_dom_walk_target();
+    assert_current_walks_cover_ladder();
     assert_eq!(
         fused_walk_target, 1,
         "P2-12a pins the phase-2 DOM fused-walk target"
@@ -122,6 +123,15 @@ fn profile_build_walks_report_the_current_p2_12b_gap() {
             fixture.name
         );
     }
+}
+
+fn assert_current_walks_cover_ladder() {
+    let pinned: Vec<&str> = CURRENT_WALKS.iter().map(|(name, ..)| *name).collect();
+    let ladder: Vec<&str> = LADDER.iter().map(|fixture| fixture.name).collect();
+    assert_eq!(
+        pinned, ladder,
+        "current P2-12b DOM build walk pins must match the ladder exactly, in order"
+    );
 }
 
 fn traversal_budget(fixture: &str) -> TraversalBudget {

--- a/crates/vize_s1_to_s2/tests/emit_budget_observer.rs
+++ b/crates/vize_s1_to_s2/tests/emit_budget_observer.rs
@@ -59,6 +59,7 @@ const S2_DOM_EMIT_COUNTS: [(&str, u32, u32, u32); 6] = [
 #[test]
 fn observed_dom_emit_keeps_output_and_walk_budget() {
     let fused_walk_target = phase_2_dom_walk_target();
+    assert_s2_dom_emit_counts_cover_ladder();
     for fixture in &LADDER {
         let template =
             template_block(fixture.source).expect("every ladder fixture has a template block");
@@ -229,6 +230,15 @@ fn disabled_static_hoist_keeps_model_diagnostics_when_models_exist() {
     assert_eq!(observed.budget.transform.passes, 1);
     assert_eq!(observed.budget.emit_walks, 1);
     assert_eq!(observed.budget.total_walks(), 2);
+}
+
+fn assert_s2_dom_emit_counts_cover_ladder() {
+    let pinned: Vec<&str> = S2_DOM_EMIT_COUNTS.iter().map(|(name, ..)| *name).collect();
+    let ladder: Vec<&str> = LADDER.iter().map(|fixture| fixture.name).collect();
+    assert_eq!(
+        pinned, ladder,
+        "S2 DOM emit budget pins must match the ladder exactly, in order"
+    );
 }
 
 fn s2_dom_emit_count(fixture: &str) -> EmitCount {


### PR DESCRIPTION
## Summary
- require S2 DOM emit budget pins to cover the fixture ladder exactly
- require current P2-12b build walk pins to cover the fixture ladder exactly

## Validation
- cargo fmt --all --check
- cargo test -p vize_s1_to_s2 --test emit_budget_observer -- --nocapture
- cargo test -p vize_atelier_dom --test davinci_s2_build_profile -- --nocapture
- cargo clippy -p vize_s1_to_s2 --test emit_budget_observer -- -D warnings -D clippy::wildcard_imports
- cargo clippy -p vize_atelier_dom --test davinci_s2_build_profile -- -D warnings -D clippy::wildcard_imports
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

Note: broad cargo clippy --tests currently hits existing unrelated test-lint debt outside this patch; targeted clippy for the touched test targets passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791414222&installation_model_id=422833&pr_number=5919&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5919&signature=3118784807760e817b698b0be5586b0076c66775daf8293e39534371dbdec88e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure profiling and DOM emission test fixtures remain aligned with their corresponding ladder fixtures.
  * Test coverage now detects missing, extra, or reordered fixture entries before running assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->