### PR TITLE
test(davinci): gate p2 jsx corpus suite claim

### DIFF
--- a/davinci-road/plan/test-suites.md
+++ b/davinci-road/plan/test-suites.md
@@ -102,7 +102,7 @@
 | ----- | --------------------------------------------------------------------------- |
 | P0    | TS-1..9 (unchanged) + TS-10..16 established                                 |
 | P1    | all of P0 + TS-25, TS-26; TS-11 **empty**                                   |
-| P2    | all prior + TS-17..24, TS-52; TS-11 empty for DOM                           |
+| P2    | all prior + TS-17..24, TS-52; TS-11 empty for DOM and JSX                   |
 | P3    | all prior + TS-27..33; TS-11 empty for SSR (byte) / TS-33 for Vapor         |
 | P4    | all prior + TS-34..41; TS-37 at 100% recall per class, TS-38 zero untriaged |
 | P5    | all prior + TS-42..47                                                       |

--- a/tests/tooling/davinci-phase2-ledger.test.ts
+++ b/tests/tooling/davinci-phase2-ledger.test.ts
@@ -288,10 +288,13 @@ test("P2-11 records current installments without presenting stale remainders", (
 });
 test("suite registry debt and the TS-52 transport decision stay resolved", () => {
   const maximum = suiteMaximum(text.suites);
+  const p2Suites = requiredLine(text.suites, /^\| P2\s+\|[^\n]+$/mu, "P2 suite map row");
   assert.equal(maximum, 52);
   assertSuiteRange(text.readme, maximum);
   assert.match(text.suites, /^\| TS-25 \|[^\n]*P2-9[^\n]*P2-11[^\n]*P2-16/mu);
   assert.match(text.suites, /^\| TS-52 \|[^\n]*Spolvero feed payload/mu);
+  assert.match(p2Suites, /TS-11 empty for DOM and JSX/);
+  assert.match(taskSection(text.tasksLater, "P2-16"), /JSX corpus projects' rows in TS-11 empty/);
   assert.match(text.phase, /\*\*Registry maintenance this phase owes\*\*/);
   assert.match(text.phase, /P2-18 must add the entry in its own PR/);
   assert.match(text.phase, /Current resolution \(2026-08-25\): registry maintenance is resolved/);


### PR DESCRIPTION
## Summary
- update the P2 mandatory-suite map so TS-11 covers DOM and JSX
- pin that P2-16 corpus-suite claim in the phase ledger test

## Validation
- node --test tests/tooling/davinci-phase2-ledger.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5920"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791414332&installation_model_id=422833&pr_number=5920&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5920&signature=df161e4223675ec6afd1357523a35ec0fb0a0ca2650b7d11ed8c008e1178c726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->