### PR TITLE
test(jsx): cover s2 projection regions

### DIFF
--- a/crates/vize_atelier_jsx/tests/s2_projection.rs
+++ b/crates/vize_atelier_jsx/tests/s2_projection.rs
@@ -2,7 +2,7 @@
 
 use vize_atelier_jsx::{JsxLang, lower_source};
 use vize_s0::Allocator;
-use vize_s2::op::{BindingOp, DynamicName, Op};
+use vize_s2::op::{BindingOp, DynamicName, Namespace, Op};
 
 #[test]
 fn dynamic_bind_props_project_to_s2_bindings() {
@@ -113,4 +113,62 @@ fn event_handler_directives_project_to_s2_on_bindings() {
     let event_attr_start = source.find(event_attr).unwrap() as u32;
     assert_eq!(click.span.start, event_attr_start);
     assert_eq!(click.span.end, event_attr_start + event_attr.len() as u32);
+}
+
+#[test]
+fn component_default_children_project_to_s2_regions() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <Panel title=\"Hi\"><span>{label}</span></Panel>;";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    assert!(!lowered.has_errors(), "{:?}", lowered.diagnostics);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("component children are admitted");
+    assert_eq!(s2.op_count, 3);
+    assert!(s2.features.has_slot_carriers());
+    let Op::Component(component) = &s2.root.ops[0] else {
+        panic!("root is a component");
+    };
+    assert_eq!(component.name, "Panel");
+    assert_eq!(component.attributes.len(), 1);
+    assert_eq!(component.attributes[0].name, "title");
+    assert_eq!(component.attributes[0].value, Some("Hi"));
+    assert_eq!(component.children.ops.len(), 1);
+
+    let Op::Element(span) = &component.children.ops[0] else {
+        panic!("default child is an element");
+    };
+    assert_eq!(span.tag, "span");
+    assert_eq!(span.namespace, Namespace::Html);
+    assert_eq!(span.children.ops.len(), 1);
+    let Op::Interpolation(label) = &span.children.ops[0] else {
+        panic!("span child is an interpolation");
+    };
+    assert_eq!(label.expression.source(), "label");
+    assert_eq!(
+        label.expression.span().start,
+        source.find("label").unwrap() as u32
+    );
+}
+
+#[test]
+fn fragment_children_project_to_one_s2_region() {
+    let allocator = Allocator::new();
+    let source = "const App = () => <><span />{count}</>;";
+    let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+    assert!(!lowered.has_errors(), "{:?}", lowered.diagnostics);
+    let root = lowered.roots.first().expect("one JSX root");
+
+    let s2 = root.s2.as_ref().expect("fragment children are admitted");
+    assert_eq!(s2.op_count, 2);
+    assert_eq!(s2.root.ops.len(), 2);
+    let Op::Element(span) = &s2.root.ops[0] else {
+        panic!("first fragment child is an element");
+    };
+    assert_eq!(span.tag, "span");
+    assert!(span.children.ops.is_empty());
+    let Op::Interpolation(count) = &s2.root.ops[1] else {
+        panic!("second fragment child is an interpolation");
+    };
+    assert_eq!(count.expression.source(), "count");
 }


### PR DESCRIPTION
## Summary
- add S2 projection witnesses for component default children
- add S2 projection witnesses for fragment root regions

## Validation
- cargo test -p vize_atelier_jsx --test s2_projection -- --nocapture
- cargo clippy -p vize_atelier_jsx --test s2_projection -- -D warnings -D clippy::wildcard_imports
- cargo test -p vize_atelier_jsx --test babel_compat_oracle -- --nocapture
- cargo test -p vize_atelier_jsx --features davinci-differential --lib s2_vdom_admitted_cases_match_relief_codegen -- --nocapture
- cargo fmt --all --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791415586&installation_model_id=422833&pr_number=5921&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5921&signature=9099ca78986af515d7dccdf60fd6934bfe05a58b55aa4d9daaf88d14f0d710d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for default component children, including nested elements and interpolated content.
  * Added coverage for fragments containing multiple operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->