### PR TITLE
feat(jsx): admit native v-model modifiers in s2

### DIFF
--- a/crates/vize_atelier_jsx/src/s2/model.rs
+++ b/crates/vize_atelier_jsx/src/s2/model.rs
@@ -62,7 +62,12 @@ fn lower_native_model<'a>(
     element_kind: &'a str,
     features: &mut LoweringFeatures,
 ) -> Result<BindingOp<'a>, S2Refusal> {
-    if directive.arg.is_some() || !directive.modifiers.is_empty() {
+    if directive.arg.is_some()
+        || !directive
+            .modifiers
+            .iter()
+            .all(|modifier| native_modifier_is_supported(modifier.content))
+    {
         return Err(S2Refusal::Directive);
     }
     let Some(expression) = directive.exp.as_ref() else {
@@ -79,9 +84,20 @@ fn lower_native_model<'a>(
         value: Some(element_kind),
         span: directive.loc.span,
     });
+    for modifier in &directive.modifiers {
+        attributes.push(Attribute {
+            name: modifier.content,
+            value: None,
+            span: modifier.loc.span,
+        });
+    }
 
     *features = features.observing(OpFamily::Model);
     Ok(model_op(allocator, directive, value, None, attributes))
+}
+
+fn native_modifier_is_supported(modifier: &str) -> bool {
+    matches!(modifier, "lazy" | "number" | "trim")
 }
 
 fn is_jsx_model_tuple(expression: &ExpressionNode<'_>) -> bool {

--- a/crates/vize_atelier_jsx/src/s2/native_model_tests.rs
+++ b/crates/vize_atelier_jsx/src/s2/native_model_tests.rs
@@ -52,6 +52,54 @@ fn text_input_v_model_projects_to_s2_model() {
 }
 
 #[test]
+fn native_model_modifiers_project_to_s2_attributes() {
+    let cases: &[(&str, &str, &[&str])] = &[
+        (
+            "const App = () => <input v-model={[value, [\"trim\"]]} />",
+            "input",
+            &["trim"],
+        ),
+        (
+            "const App = () => <input v-model_number_lazy={value} />",
+            "input",
+            &["number", "lazy"],
+        ),
+        (
+            "const App = () => <textarea v-model_lazy={value} />",
+            "textarea",
+            &["lazy"],
+        ),
+        (
+            "const App = () => <select v-model_number={value}></select>",
+            "select",
+            &["number"],
+        ),
+    ];
+
+    for (source, element_kind, modifiers) in cases {
+        let allocator = Allocator::new();
+        let lowered = lower_source(&allocator, allocator.as_oxc(), source, JsxLang::Jsx);
+        let root = lowered.roots.first().expect("one JSX root");
+
+        let s2 = root.s2.as_ref().expect("native v-model projects to S2");
+        let Op::Element(element) = &s2.root.ops[0] else {
+            panic!("root is an element");
+        };
+        let BindingOp::Model(model) = &element.bindings[0] else {
+            panic!("binding is ui.model");
+        };
+        let attributes: Vec<_> = model
+            .attributes
+            .iter()
+            .map(|attribute| (attribute.name, attribute.value))
+            .collect();
+        let mut expected = vec![("element-kind", Some(*element_kind))];
+        expected.extend(modifiers.iter().map(|modifier| (*modifier, None)));
+        assert_eq!(attributes, expected, "{source}");
+    }
+}
+
+#[test]
 fn choice_input_v_model_projects_to_s2_model() {
     for (input_type, value) in [("checkbox", "checked"), ("radio", "picked")] {
         let allocator = Allocator::new();
@@ -129,18 +177,16 @@ fn unsupported_native_model_shapes_stay_on_directive_refusal_path() {
     let allocator = Allocator::new();
     let cases = [
         "const App = () => <input v-model:checked={value} />",
-        "const App = () => <input v-model={[value, [\"trim\"]]} />",
-        "const App = () => <input v-model_lazy={value} />",
+        "const App = () => <input v-model_custom={value} />",
+        "const App = () => <input v-model={[value, [\"custom\"]]} />",
         "const App = () => <input type=\"checkbox\" type=\"radio\" v-model={picked} />",
         "const App = () => <input type=\"email\" v-model={value} />",
         "const App = () => <input type={kind} v-model={value} />",
         "const App = () => <input {...attrs} v-model={value} />",
         "const App = () => <textarea v-model:foo={value} />",
-        "const App = () => <textarea v-model={[value, [\"trim\"]]} />",
-        "const App = () => <textarea v-model_lazy={value} />",
+        "const App = () => <textarea v-model_custom={value} />",
         "const App = () => <select v-model:foo={value}></select>",
-        "const App = () => <select v-model={[value, [\"number\"]]}></select>",
-        "const App = () => <select v-model_number={value}></select>",
+        "const App = () => <select v-model={[value, [\"custom\"]]}></select>",
     ];
 
     for source in cases {

--- a/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_differential.rs
@@ -149,6 +149,16 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             JsxLang::Jsx,
         ),
         (
+            "element input v-model modifier array",
+            "const A = () => <input v-model={[value, [\"trim\"]]} />;",
+            JsxLang::Jsx,
+        ),
+        (
+            "element input v-model underscore modifiers",
+            "const A = () => <input v-model_number_lazy={value} />;",
+            JsxLang::Jsx,
+        ),
+        (
             "element checkbox input v-model",
             "const A = () => <input type=\"checkbox\" v-model={checked} />;",
             JsxLang::Jsx,
@@ -164,8 +174,18 @@ fn s2_vdom_admitted_cases_match_relief_codegen() {
             JsxLang::Jsx,
         ),
         (
+            "element textarea v-model modifier",
+            "const A = () => <textarea v-model_lazy={value} />;",
+            JsxLang::Jsx,
+        ),
+        (
             "element select v-model",
             "const A = () => <select v-model={value}></select>;",
+            JsxLang::Jsx,
+        ),
+        (
+            "element select v-model modifier",
+            "const A = () => <select v-model_number={value}></select>;",
             JsxLang::Jsx,
         ),
         (

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit.rs
@@ -207,8 +207,16 @@ fn model_is_bare_native_element(element: &ElementOp<'_>, model: &ModelOp<'_>) ->
         .iter()
         .any(|attribute| attribute.name == "element-kind" && attribute.value == Some(element.tag))
         && model.attributes.iter().all(|attribute| {
-            attribute.name == "element-kind" && attribute.value == Some(element.tag)
+            if attribute.name == "element-kind" {
+                attribute.value == Some(element.tag)
+            } else {
+                attribute.value.is_none() && native_model_modifier_is_supported(attribute.name)
+            }
         })
+}
+
+fn native_model_modifier_is_supported(modifier: &str) -> bool {
+    matches!(modifier, "lazy" | "number" | "trim")
 }
 
 fn bind_may_set_type(binding: &BindingOp<'_>) -> bool {

--- a/crates/vize_atelier_jsx/src/vdom/s2_emit/native_model_tests.rs
+++ b/crates/vize_atelier_jsx/src/vdom/s2_emit/native_model_tests.rs
@@ -42,6 +42,25 @@ fn text_input_v_model_emits_from_s2() {
 }
 
 #[test]
+fn input_v_model_modifiers_emit_from_s2() {
+    let source = "const A = () => <input v-model_number_lazy={value} />;";
+    let component = compile_native_model_from_s2(source);
+    assert_eq!(
+        component.preamble.as_str(),
+        "import { vModelText as _vModelText, withDirectives as _withDirectives, \
+         openBlock as _openBlock, createElementBlock as _createElementBlock } from \"vue\"\n"
+    );
+    assert_eq!(
+        component.code.as_str(),
+        "export function render(_ctx, _cache) {\n  return _withDirectives((_openBlock(), \
+         _createElementBlock(\"input\", {\n    \"onUpdate:modelValue\": $event => ((value) = \
+         $event)\n  }, null, 8 /* PROPS */, [\"onUpdate:modelValue\"])), [\n    [\n      \
+         _vModelText,\n      value,\n      void 0,\n      {\n        number: true,\n        lazy: \
+         true\n      }\n    ]\n  ])\n}"
+    );
+}
+
+#[test]
 fn checkbox_input_v_model_emits_from_s2() {
     let source = "const A = () => <input type=\"checkbox\" v-model={checked} />;";
     let component = compile_native_model_from_s2(source);


### PR DESCRIPTION
## Summary
- project standard native v-model modifiers into S2 model attributes
- keep native v-model arguments and custom modifiers on the existing refusal path
- add S2 emit and Relief differential coverage for modifier cases

## Verification
- cargo fmt --all --check
- cargo test -p vize_atelier_jsx --lib native_model -- --nocapture
- cargo test -p vize_atelier_jsx --lib input_v_model_modifiers_emit_from_s2 -- --nocapture
- cargo test -p vize_atelier_jsx --features davinci-differential --lib s2_vdom_admitted_cases_match_relief_codegen -- --nocapture
- cargo test -p vize_atelier_jsx --test parity_vdom vdom_parity_matrix_snapshot -- --nocapture
- cargo test -p vize_atelier_jsx --lib
- git diff --check
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791417314&installation_model_id=422833&pr_number=5922&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5922&signature=60654ffdf76964bc55e360c4b70441c812bac3c0ba175e0ae8060bfa77931e4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native `v-model` now supports the `lazy`, `number`, and `trim` modifiers.
  * Modifiers can be combined and used with `<input>`, `<textarea>`, and `<select>` elements.
  * Supported modifiers are correctly preserved in generated bindings and runtime behavior.

* **Bug Fixes**
  * Valid native model modifiers are no longer incorrectly rejected.
  * Unsupported custom modifiers continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->