### PR TITLE
fix(benchmarks): stop legacy typecheck cross-engine ratios

### DIFF
--- a/tests/tooling/tool-benchmark.test.ts
+++ b/tests/tooling/tool-benchmark.test.ts
@@ -169,6 +169,17 @@ test("the Nuxt fairness note states the Vue-compilation share and where the modu
   assert.equal(publishedDoc.includes(`- ${nuxtNotes[0]}`), true);
 });
 
+test("legacy typecheck benchmark does not publish cross-engine ratios", () => {
+  const script = fs.readFileSync(path.join(root, "tools/benchmarks/scripts/check.ts"), "utf-8");
+
+  assert.doesNotMatch(script, /\$\{[^}]+}x faster/);
+  assert.doesNotMatch(script, /user-facing speedup/);
+  assert.doesNotMatch(script, /vue-tsc ST vs Vize/);
+  assert.doesNotMatch(script, /vue-tsc MT vs Vize/);
+  assert.match(script, /This legacy local harness reports timings only/);
+  assert.match(script, /same-native-engine rows such as verter-tsc and\s+\*\s+Golar/);
+});
+
 test("native batch sequence variants require parallel capacity", () => {
   const options = {
     native: {},

--- a/tools/benchmarks/scripts/check.ts
+++ b/tools/benchmarks/scripts/check.ts
@@ -1,5 +1,10 @@
 /**
- * Type Check Benchmark: Vize (Corsa) vs vue-tsc
+ * Type Check Benchmark: Vize check and vue-tsc timings
+ *
+ * This legacy local harness reports timings only. Use compare-tools.mjs or
+ * check-gate.mjs when a publishable type-check ratio is needed: those harnesses
+ * rank vue-tsc separately from same-native-engine rows such as verter-tsc and
+ * Golar.
  *
  * Usage:
  *   1. Generate test files: node generate.mjs [count]
@@ -97,7 +102,7 @@ function runCommand(cmd: string, cwd: string = BENCH_INPUT_DIR): number {
   try {
     execSync(cmd, { stdio: "ignore", cwd });
   } catch {
-    // vue-tsc may exit non-zero on type errors; still measure time
+    // Type checkers may exit non-zero on type errors; still measure time.
   }
   return performance.now() - start;
 }
@@ -150,7 +155,7 @@ function runVizeCheckMultiThread(): number {
 // Main
 console.log();
 console.log("=".repeat(65));
-console.log(" Type Check Benchmark: Corsa vs vue-tsc");
+console.log(" Type Check Benchmark: Vize check and vue-tsc timings");
 console.log("=".repeat(65));
 console.log();
 console.log(` Files     : ${vueFiles.length.toLocaleString()} SFC files`);
@@ -175,16 +180,9 @@ if (vueTscSingle >= 0) {
 let vizeSingle = 0;
 if (existsSync(VIZE_BIN)) {
   vizeSingle = runVizeCheckSingleThread();
-  if (vueTscSingle >= 0) {
-    const speedup = (vueTscSingle / vizeSingle).toFixed(1);
-    console.log(
-      `   Vize (Corsa)  : ${formatTime(vizeSingle).padStart(8)}  (${formatThroughput(vueFiles.length, vizeSingle)})  ${speedup}x faster`,
-    );
-  } else {
-    console.log(
-      `   Vize (Corsa)  : ${formatTime(vizeSingle).padStart(8)}  (${formatThroughput(vueFiles.length, vizeSingle)})`,
-    );
-  }
+  console.log(
+    `   Vize (Corsa)  : ${formatTime(vizeSingle).padStart(8)}  (${formatThroughput(vueFiles.length, vizeSingle)})`,
+  );
 } else {
   console.log("   Vize (Corsa)  : SKIPPED (vize CLI not found)");
 }
@@ -206,33 +204,23 @@ if (vueTscMulti >= 0) {
 let vizeMulti = 0;
 if (existsSync(VIZE_BIN)) {
   vizeMulti = runVizeCheckMultiThread();
-  if (vueTscMulti >= 0) {
-    const speedup = (vueTscMulti / vizeMulti).toFixed(1);
-    console.log(
-      `   Vize (Corsa)  : ${formatTime(vizeMulti).padStart(8)}  (${formatThroughput(vueFiles.length, vizeMulti)})  ${speedup}x faster`,
-    );
-  } else {
-    console.log(
-      `   Vize (Corsa)  : ${formatTime(vizeMulti).padStart(8)}  (${formatThroughput(vueFiles.length, vizeMulti)})`,
-    );
-  }
+  console.log(
+    `   Vize (Corsa)  : ${formatTime(vizeMulti).padStart(8)}  (${formatThroughput(vueFiles.length, vizeMulti)})`,
+  );
 } else {
   console.log("   Vize (Corsa)  : SKIPPED (vize CLI not found)");
 }
 
-// Summary
-if (vueTscSingle >= 0 && vizeSingle > 0 && vizeMulti > 0) {
+if (vueTscSingle >= 0 || vueTscMulti >= 0) {
   console.log();
   console.log("-".repeat(65));
   console.log();
-  console.log(" Summary:");
+  console.log(" Note:");
   console.log();
-  const stSpeedup = (vueTscSingle / vizeSingle).toFixed(1);
-  const mtSpeedup = (vueTscMulti / vizeMulti).toFixed(1);
-  const crossSpeedup = (vueTscSingle / vizeMulti).toFixed(1);
-  console.log(`   vue-tsc ST vs Vize ST : ${stSpeedup}x`);
-  console.log(`   vue-tsc MT vs Vize MT : ${mtSpeedup}x`);
-  console.log(`   vue-tsc ST vs Vize MT : ${crossSpeedup}x  (user-facing speedup)`);
+  console.log("   vue-tsc runs the JavaScript TypeScript engine.");
+  console.log("   Vize check runs native tsgo/Corsa.");
+  console.log("   This legacy helper reports timings only.");
+  console.log("   Use compare-tools.mjs or check-gate.mjs for same-engine ratios.");
 }
 
 console.log();


### PR DESCRIPTION
## Summary
- stop the legacy local typecheck harness from printing cross-engine speedup ratios between vue-tsc and native Vize check
- keep the helper useful as a timings-only smoke benchmark
- add a tooling guard so publishable ratios stay routed through the same-engine benchmark report path for Verter/Golar-style comparisons

## Verification
- tsx --test tests/tooling/tool-benchmark.test.ts tests/tooling/tool-benchmark-engine-classes.test.ts
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791431833&installation_model_id=422833&pr_number=5929&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5929&signature=5d03057aa51875ce72b9356337eb3d3117997ac83be8d968a5b6a572c6101753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the legacy type-check benchmark output to report execution timings only.
  - Removed cross-engine speedup ratios and related comparison wording from benchmark results.
  - Clarified that publishable performance comparisons are handled by separate tooling.
  - Included same-engine benchmark rows, such as verter-tsc and Golar, in the timing output.

- **Tests**
  - Added coverage to ensure the legacy benchmark remains timing-only and does not publish speedup claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->