### PR TITLE
test(benchmarks): trigger check gate on binary helper

### DIFF
--- a/.github/workflows/check-bench.yml
+++ b/.github/workflows/check-bench.yml
@@ -28,6 +28,7 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
+      - tools/benchmarks/scripts/benchmark-binary.mjs
       - tools/benchmarks/scripts/check-gate.mjs
       - tools/benchmarks/scripts/check-gate-env.mjs
       - tools/benchmarks/scripts/check-gate-plants.mjs

--- a/tests/tooling/check-bench-trigger.test.ts
+++ b/tests/tooling/check-bench-trigger.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const CHECK_BENCH_TRIGGER_PATHS = [
+  "tools/benchmarks/scripts/benchmark-binary.mjs",
+  "tools/benchmarks/scripts/check-gate.mjs",
+  "tools/benchmarks/scripts/check-gate-env.mjs",
+  "tools/benchmarks/scripts/check-gate-plants.mjs",
+  "tools/benchmarks/scripts/check-gate-report.mjs",
+  "tools/benchmarks/scripts/check-gate-report.test.mjs",
+  ".github/workflows/check-bench.yml",
+];
+
+function readCheckBenchPullRequestPaths(): string[] {
+  const workflow = fs
+    .readFileSync(path.join(root, ".github", "workflows", "check-bench.yml"), "utf8")
+    .replace(/\r\n?/g, "\n")
+    .split("\n");
+  const pullRequestIndex = workflow.findIndex((line) => line === "  pull_request:");
+  assert.notEqual(pullRequestIndex, -1, "check-bench.yml must declare a pull_request trigger");
+  const pathsIndex = workflow.findIndex(
+    (line, index) => index > pullRequestIndex && line === "    paths:",
+  );
+  assert.notEqual(pathsIndex, -1, "check-bench.yml pull_request trigger must declare paths");
+
+  const paths = [];
+  for (const line of workflow.slice(pathsIndex + 1)) {
+    if (!line.startsWith("      - ")) break;
+    paths.push(line.slice("      - ".length).replace(/^["']|["']$/g, ""));
+  }
+  return paths;
+}
+
+test("check-bench pull request trigger covers every fail-closed measurement helper", () => {
+  assert.deepEqual(readCheckBenchPullRequestPaths().sort(), CHECK_BENCH_TRIGGER_PATHS.toSorted());
+});


### PR DESCRIPTION
## Summary
- run Check Benchmark Gate when the benchmark binary pinning helper changes
- add a tooling test that keeps the pull request path filter aligned with every fail-closed gate helper

## Validation
- node --test tests/tooling/check-bench-gate.test.ts
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791434042&installation_model_id=422833&pr_number=5931&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5931&signature=e1c8d23ae69441a61639311746e5cc042424d7c0274e0412bfc37a1d07aa190f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->