### PR TITLE
test(content-mapper): pin model event mapper spans

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/content_mapper_model_tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/content_mapper_model_tests.rs
@@ -36,13 +36,13 @@ defineModel<string>("title", { required: true });
         result.mappings
     );
 
-    let parent = r#"<script setup lang="ts">
+    let parent_source = r#"<script setup lang="ts">
 import ModelChild from "./ModelChild.vue";
 </script>
 <template><ModelChild @update:title="() => undefined" /></template>
 "#;
     let parent =
-        generate_vue_content_mapper_transform(Path::new("App.vue"), parent).expect("parent");
+        generate_vue_content_mapper_transform(Path::new("App.vue"), parent_source).expect("parent");
     let completion = parent
         .text
         .find("__vize_model_events_completion_0['update:title']")
@@ -53,12 +53,29 @@ import ModelChild from "./ModelChild.vue";
         .find("__vize_model_events_nav_0['update:title']")
         .expect("navigation projection")
         + "__vize_model_events_nav_0['".len();
-    assert!(parent.mappings.iter().any(|mapping| {
-        mapping.0[0] == completion && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_COMPLETION
-    }));
-    assert!(parent.mappings.iter().any(|mapping| {
-        mapping.0[0] == navigation && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL
-    }));
+    let original = parent_source.find("@update:title").unwrap() + 1;
+    assert!(
+        has_model_event_mapping(
+            &parent,
+            completion,
+            original,
+            CONTENT_MAPPER_SPAN_FEATURES_COMPLETION,
+        ),
+        "text:\n{}\n\nmappings:\n{:#?}",
+        parent.text,
+        parent.mappings
+    );
+    assert!(
+        has_model_event_mapping(
+            &parent,
+            navigation,
+            original,
+            CONTENT_MAPPER_SPAN_FEATURES_WHOLE_SYMBOL,
+        ),
+        "text:\n{}\n\nmappings:\n{:#?}",
+        parent.text,
+        parent.mappings
+    );
 }
 
 #[test]
@@ -132,5 +149,21 @@ fn has_exact_mapping(result: &ContentMapperTransform, generated: usize, original
             && mapping.0[3] == "\"title\"".len()
             && mapping.0[4] == ContentMapperSpanKind::Verbatim as usize
             && mapping.0[5] == CONTENT_MAPPER_SPAN_FEATURES_ALL
+    })
+}
+
+fn has_model_event_mapping(
+    result: &ContentMapperTransform,
+    generated: usize,
+    original: usize,
+    features: usize,
+) -> bool {
+    result.mappings.iter().any(|mapping| {
+        mapping.0[0] == generated
+            && mapping.0[1] == "update:title".len()
+            && mapping.0[2] == original
+            && mapping.0[3] == "update:title".len()
+            && mapping.0[4] == ContentMapperSpanKind::Verbatim as usize
+            && mapping.0[5] == features
     })
 }


### PR DESCRIPTION
## Summary
- pin `defineModel` parent event completion and navigation spans at the Content Mapper output level
- assert generated and authored `update:title` ranges carry the expected editor feature masks

## Validation
- cargo test -p vize_canon --lib batch::virtual_project::content_mapper -- --nocapture
- node --test tests/tooling/content-mapper-workflow.test.ts
- git diff --check origin/main...HEAD

## Notes
- local exact-tsgo LSP conformance still depends on `VIZE_TEST_CONTENT_MAPPER_TSGO`; the GitHub Content Mapper conformance lane remains the full upstream check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791434164&installation_model_id=422833&pr_number=5932&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5932&signature=e8248349fd643cf3a14e7310b7f25fb0ab9e6302fa5c835feb81e6810c2c9247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened model event mapping tests to verify generated and original source ranges, span types, and feature flags.
  * Added a reusable validation helper for complete mapping checks.
  * Clarified test setup by separating parent template source from its transformed result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->