### PR TITLE
chore(deps): update vue-tsc to 3.3.11

### DIFF
--- a/docs/release/vue-parity-matrix.md
+++ b/docs/release/vue-parity-matrix.md
@@ -10,7 +10,7 @@ explicitly documents a narrower behavior.
 | ----------------- | -------------------------------------------------------------------------------- | ----------------------------------------------- |
 | Vue runtime       | `vue@3.5.34` for published runtime smoke, `vue@3.6.0-beta.10` for fixture parity | `fresh-install-smoke`, `vue-parity`             |
 | Vue compiler      | `@vue/compiler-sfc@3.6.0-beta.10`                                                | `vp run --filter './tests' test:check:fixtures` |
-| Vue type checking | `vue-tsc@3.3.4` with `typescript@6.0.3`                                          | `vp run --filter './tests' test:check:fixtures` |
+| Vue type checking | `vue-tsc@3.3.11` with `typescript@6.0.3`                                         | `vp run --filter './tests' test:check:fixtures` |
 | Vite              | `vite@npm:@voidzero-dev/vite-plus-core@0.1.21`                                   | `fresh-install-smoke`, app e2e                  |
 | Node.js           | `22` and `24`                                                                    | `node-engine-compat`, `fresh-install-smoke`     |
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,8 +305,8 @@ catalogs:
       specifier: 6.0.3
       version: 6.0.3
     vue-tsc:
-      specifier: 3.3.4
-      version: 3.3.4
+      specifier: 3.3.11
+      version: 3.3.11
   vite-stack:
     '@vitejs/plugin-vue':
       specifier: 6.0.7
@@ -485,54 +485,6 @@ importers:
       '@typescript/typescript-win32-x64':
         specifier: catalog:corsa-runtime
         version: 7.0.2
-
-  tools/benchmarks/scripts:
-    devDependencies:
-      '@golar/vue':
-        specifier: 0.1.10
-        version: 0.1.10
-      '@typescript-eslint/parser':
-        specifier: 8.65.0
-        version: 8.65.0(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      '@vitejs/plugin-vue':
-        specifier: catalog:vite-stack
-        version: 6.0.7(@voidzero-dev/vite-plus-core@0.1.24(@tsdown/css@0.22.14)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(vue@3.6.0-beta.10(typescript@6.0.3))
-      '@vue/compiler-sfc':
-        specifier: catalog:vue-beta
-        version: 3.6.0-beta.10
-      '@vue/compiler-vapor':
-        specifier: catalog:vue-beta
-        version: 3.6.0-beta.10
-      eslint:
-        specifier: 10.4.1
-        version: 10.4.1(jiti@2.7.0)(supports-color@10.2.2)
-      eslint-plugin-vue:
-        specifier: 10.9.2
-        version: 10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2)))(@typescript-eslint/parser@8.65.0(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))
-      golar:
-        specifier: 0.1.10
-        version: 0.1.10
-      prettier:
-        specifier: catalog:repo-tooling
-        version: 3.8.3
-      verter-tsc:
-        specifier: 0.0.1-beta.3
-        version: 0.0.1-beta.3
-      vite:
-        specifier: catalog:vite-stack
-        version: '@voidzero-dev/vite-plus-core@0.1.24(@tsdown/css@0.22.14)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)'
-      vite-plus:
-        specifier: catalog:vite-stack
-        version: 0.1.24(@tsdown/css@0.22.14)(@types/node@25.9.2)(@voidzero-dev/vite-plus-core@0.1.24(@tsdown/css@0.22.14)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)
-      vue:
-        specifier: catalog:vue-beta
-        version: 3.6.0-beta.10(typescript@6.0.3)
-      vue-eslint-parser:
-        specifier: 10.4.1
-        version: 10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
-      vue-tsc:
-        specifier: 3.3.4
-        version: 3.3.4(typescript@6.0.3)
 
   docs:
     devDependencies:
@@ -1189,7 +1141,7 @@ importers:
         version: 3.5.35(typescript@6.0.3)
       vue-tsc:
         specifier: catalog:typescript
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.11(typescript@6.0.3)
 
   npm/wasm: {}
 
@@ -1360,13 +1312,61 @@ importers:
         version: '@vue/compiler-sfc@2.7.16'
       vue-tsc:
         specifier: catalog:typescript
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.11(typescript@6.0.3)
       vue-virtual-scroller:
         specifier: 3.0.4
         version: 3.0.4(vue@3.6.0-beta.10(typescript@6.0.3))
       yaml:
         specifier: 2.9.0
         version: 2.9.0
+
+  tools/benchmarks/scripts:
+    devDependencies:
+      '@golar/vue':
+        specifier: 0.1.10
+        version: 0.1.10
+      '@typescript-eslint/parser':
+        specifier: 8.65.0
+        version: 8.65.0(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+      '@vitejs/plugin-vue':
+        specifier: catalog:vite-stack
+        version: 6.0.7(@voidzero-dev/vite-plus-core@0.1.24(@tsdown/css@0.22.14)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(vue@3.6.0-beta.10(typescript@6.0.3))
+      '@vue/compiler-sfc':
+        specifier: catalog:vue-beta
+        version: 3.6.0-beta.10
+      '@vue/compiler-vapor':
+        specifier: catalog:vue-beta
+        version: 3.6.0-beta.10
+      eslint:
+        specifier: 10.4.1
+        version: 10.4.1(jiti@2.7.0)(supports-color@10.2.2)
+      eslint-plugin-vue:
+        specifier: 10.9.2
+        version: 10.9.2(@stylistic/eslint-plugin@5.10.0(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2)))(@typescript-eslint/parser@8.65.0(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2))
+      golar:
+        specifier: 0.1.10
+        version: 0.1.10
+      prettier:
+        specifier: catalog:repo-tooling
+        version: 3.8.3
+      verter-tsc:
+        specifier: 0.0.1-beta.3
+        version: 0.0.1-beta.3
+      vite:
+        specifier: catalog:vite-stack
+        version: '@voidzero-dev/vite-plus-core@0.1.24(@tsdown/css@0.22.14)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)'
+      vite-plus:
+        specifier: catalog:vite-stack
+        version: 0.1.24(@tsdown/css@0.22.14)(@types/node@25.9.2)(@voidzero-dev/vite-plus-core@0.1.24(@tsdown/css@0.22.14)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(esbuild@0.28.1)(happy-dom@20.11.2)(jiti@2.7.0)(terser@5.49.2)(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)
+      vue:
+        specifier: catalog:vue-beta
+        version: 3.6.0-beta.10(typescript@6.0.3)
+      vue-eslint-parser:
+        specifier: 10.4.1
+        version: 10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@10.2.2))(supports-color@10.2.2)
+      vue-tsc:
+        specifier: 3.3.11
+        version: 3.3.11(typescript@6.0.3)
 
 packages:
 
@@ -6440,8 +6440,8 @@ packages:
   '@vue/devtools-shared@8.2.1':
     resolution: {integrity: sha512-Fkac7lUdGReh6pVOi3AYPRGe82LQqRmAfThW7RRligOAP0ZA/Z1z9XLHDM9dv34pV2HRc79DK8uKPeG2fLnA/g==}
 
-  '@vue/language-core@3.3.4':
-    resolution: {integrity: sha512-IuHqQ5zGGOE7CXP72VX6A42IVeIzYv4WAhO6arej11TRNqtdZfGyH8Yr2FOCaDX0dSQG+JwULLoFHGY1igYVjQ==}
+  '@vue/language-core@3.3.11':
+    resolution: {integrity: sha512-QJmpliwAVpC/OxubIByPAhNzsQPRc8/gxlN2qnVzVfIMjMDz/9RnXRFoetjz5yEgXVXyp4LqhXq3V53PjmNzFw==}
 
   '@vue/language-core@3.3.5':
     resolution: {integrity: sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==}
@@ -11625,8 +11625,8 @@ packages:
   vue-template-compiler@2.6.14:
     resolution: {integrity: sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==}
 
-  vue-tsc@3.3.4:
-    resolution: {integrity: sha512-XA/JqmQwS2GZmfgpjOEGdrKwaTSEuPwxpHa7/t6f4yiGrJb3gVHTPb9wBfByMNZwQ+xDXs41b8gaS2DKsOozUw==}
+  vue-tsc@3.3.11:
+    resolution: {integrity: sha512-gOb0B9rtU2+f1dszwPqSH5kAieIF9ReeLhD3kSRNHv5WZZUQz/JdVXW0RTdqhNTMlQkqKzrTTviqKr/4FYZraQ==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
@@ -17133,7 +17133,7 @@ snapshots:
 
   '@vue/devtools-shared@8.2.1': {}
 
-  '@vue/language-core@3.3.4':
+  '@vue/language-core@3.3.11':
     dependencies:
       '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.41
@@ -21663,7 +21663,7 @@ snapshots:
 
   robust-predicates@3.0.3: {}
 
-  rolldown-plugin-dts@0.27.14(@volar/typescript@2.4.28(typescript@6.0.3))(rolldown@1.2.3)(typescript@6.0.3)(vue-tsc@3.3.4(typescript@6.0.3)):
+  rolldown-plugin-dts@0.27.14(@volar/typescript@2.4.28(typescript@6.0.3))(rolldown@1.2.3)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3)):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
@@ -21675,7 +21675,7 @@ snapshots:
     optionalDependencies:
       '@volar/typescript': 2.4.28(typescript@6.0.3)
       typescript: 6.0.3
-      vue-tsc: 3.3.4(typescript@6.0.3)
+      vue-tsc: 3.3.11(typescript@6.0.3)
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -22254,7 +22254,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  tsdown@0.22.14(@tsdown/css@0.22.14)(@volar/typescript@2.4.28(typescript@6.0.3))(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.39)(vue-tsc@3.3.4(typescript@6.0.3)):
+  tsdown@0.22.14(@tsdown/css@0.22.14)(@volar/typescript@2.4.28(typescript@6.0.3))(tsx@4.23.12)(typescript@6.0.3)(unrun@0.2.39)(vue-tsc@3.3.11(typescript@6.0.3)):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -22265,7 +22265,7 @@ snapshots:
       obug: 2.1.4
       picomatch: 4.0.5
       rolldown: 1.2.3
-      rolldown-plugin-dts: 0.27.14(@volar/typescript@2.4.28(typescript@6.0.3))(rolldown@1.2.3)(typescript@6.0.3)(vue-tsc@3.3.4(typescript@6.0.3))
+      rolldown-plugin-dts: 0.27.14(@volar/typescript@2.4.28(typescript@6.0.3))(rolldown@1.2.3)(typescript@6.0.3)(vue-tsc@3.3.11(typescript@6.0.3))
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
@@ -23169,10 +23169,10 @@ snapshots:
       de-indent: 1.0.2
       he: 1.2.0
 
-  vue-tsc@3.3.4(typescript@6.0.3):
+  vue-tsc@3.3.11(typescript@6.0.3):
     dependencies:
       '@volar/typescript': 2.4.28(typescript@6.0.3)
-      '@vue/language-core': 3.3.4
+      '@vue/language-core': 3.3.11
       typescript: 6.0.3
 
   vue-tsc@3.3.9(typescript@6.0.3):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -112,7 +112,7 @@ catalogs:
     "@types/node": "25.9.2"
     tsx: "4.23.12"
     typescript: "6.0.3"
-    vue-tsc: "3.3.4"
+    vue-tsc: "3.3.11"
 
   # Corsa runtime shipped by the Vize CLI. Keep separate from the workspace
   # TypeScript toolchain so consumers and repo packages can stay on TS 6.

--- a/tests/_fixtures/compat-baseline.json
+++ b/tests/_fixtures/compat-baseline.json
@@ -1,7 +1,7 @@
 {
   "schema": "vize.compatBaseline",
   "version": 1,
-  "vueTsc": "3.3.4",
+  "vueTsc": "3.3.11",
   "projects": {
     "create-vue": {
       "revision": "3ee62adffdcdfa4a37b2ed4e9c30636655d5fcd1",

--- a/tests/_fixtures/maestro-vue-language-tools-scorecard.json
+++ b/tests/_fixtures/maestro-vue-language-tools-scorecard.json
@@ -8,7 +8,7 @@
     "versionEvidence": [
       {
         "file": "pnpm-workspace.yaml",
-        "contains": ["vue-tsc: \"3.3.4\"", "typescript: \"6.0.3\""]
+        "contains": ["vue-tsc: \"3.3.11\"", "typescript: \"6.0.3\""]
       },
       {
         "file": "tests/package.json",

--- a/tools/benchmarks/scripts/package.json
+++ b/tools/benchmarks/scripts/package.json
@@ -28,6 +28,6 @@
     "vite-plus": "catalog:vite-stack",
     "vue": "catalog:vue-beta",
     "vue-eslint-parser": "10.4.1",
-    "vue-tsc": "3.3.4"
+    "vue-tsc": "3.3.11"
   }
 }


### PR DESCRIPTION
## Summary
- update the workspace vue-tsc catalog and benchmark direct dependency to 3.3.11
- refresh compatibility baseline, Maestro scorecard evidence, and release parity docs for the new Vue typecheck baseline
- keep TypeScript pinned at 6.0.3 while vue-tsc resolves @vue/language-core 3.3.11

## Current upstream check
- npm reports vue-tsc latest as 3.3.11 and @vue/language-core latest as 3.3.11
- npm has no vue-tsc v4 or @vue/language-core v4 match at this time

## Validation
- COREPACK_HOME=/tmp/vize-corepack-vue-tsc corepack pnpm install --lockfile-only --frozen-lockfile
- COREPACK_HOME=/tmp/vize-corepack-vue-tsc corepack pnpm install --frozen-lockfile --prefer-offline
- COREPACK_HOME=/tmp/vize-corepack-vue-tsc corepack pnpm --filter ./tests exec node --test tooling/tool-benchmark.test.ts tooling/tool-benchmark-engine-classes.test.ts tooling/vscode-typescript-vue-plugin.test.ts tooling/lsp-vue-language-tools-scorecard.test.ts tooling/release-readiness.test.ts tooling/language-engineering-practices.test.ts tooling/compat-ratchet.test.ts
- git diff --check origin/main...HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791434358&installation_model_id=422833&pr_number=5933&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5933&signature=e870d94404faf355391bf7d12b21ff4f5c4764066faca94ee7c442a946662b8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->