### PR TITLE
test(lsp): gate incremental bridge process memory

### DIFF
--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -43,6 +43,8 @@
         "suite": "vben-lsp-incremental",
         "laneHardTimeoutMs": 60000,
         "maxPeakRssMiB": 256,
+        "maxPeakProcessTreeRssMiB": 512,
+        "maxProcessTreeSize": 3,
         "laneBudgetsMs": {
           "initialize": 1000,
           "coldOpen": 8000,
@@ -993,6 +995,8 @@
         "suite": "misskey-lsp-incremental",
         "laneHardTimeoutMs": 60000,
         "maxPeakRssMiB": 256,
+        "maxPeakProcessTreeRssMiB": 384,
+        "maxProcessTreeSize": 3,
         "laneBudgetsMs": {
           "initialize": 1000,
           "coldOpen": 8000,

--- a/tests/_fixtures/vue-ecosystem-fixtures.json
+++ b/tests/_fixtures/vue-ecosystem-fixtures.json
@@ -44,7 +44,7 @@
         "laneHardTimeoutMs": 60000,
         "maxPeakRssMiB": 256,
         "maxPeakProcessTreeRssMiB": 512,
-        "maxProcessTreeSize": 3,
+        "maxProcessTreeSize": 4,
         "laneBudgetsMs": {
           "initialize": 1000,
           "coldOpen": 8000,

--- a/tests/performance/support/churn-metrics.ts
+++ b/tests/performance/support/churn-metrics.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -6,14 +5,14 @@ import { inspect } from "node:util";
 import { performance } from "node:perf_hooks";
 
 import { repoRoot } from "../../_helpers/realworld-patch.ts";
-import { gitHead, writeChurnArtifacts } from "./churn-report.ts";
+import { writeChurnArtifacts } from "./churn-report.ts";
 import {
   budgetRegistryPath,
   budgetScaleVariable,
   incrementalMetricsDir,
-  processRssKiB,
   resolveBudgetScale,
 } from "./incremental-metrics.ts";
+import { gitHead, processRssKiB, processTreeRss } from "./process-metrics.ts";
 
 /** `id` is the metrics directory under `target/vize-tests/metrics/`; `title` heads the summary. */
 export type ChurnSuite = { id: string; title: string };
@@ -77,38 +76,6 @@ export function loadLspChurnBudget(suiteId: string): {
     }
   }
   return { fixtureId: owners[0].id, budget };
-}
-
-/**
- * Resident-set total and process count for a process and every live
- * descendant, so a leaked Corsa/tsgo worker shows up even though it is not the
- * `vize lsp` process itself. Unavailable on Windows, where the churn RSS gates
- * become latency-only; CI enforcement runs on Linux.
- */
-export function processTreeRss(rootPid: number): { totalKiB: number; processes: number } | null {
-  if (process.platform === "win32") return null;
-  const result = spawnSync("ps", ["-Ao", "pid=,ppid=,rss="], { encoding: "utf8" });
-  if (result.status !== 0) return null;
-  const children = new Map<number, number[]>();
-  const rssByPid = new Map<number, number>();
-  for (const line of result.stdout.trim().split("\n")) {
-    const [pid, ppid, rss] = line.trim().split(/\s+/).map(Number);
-    if (!Number.isSafeInteger(pid) || !Number.isSafeInteger(ppid)) continue;
-    rssByPid.set(pid, Number.isFinite(rss) ? rss : 0);
-    children.set(ppid, [...(children.get(ppid) ?? []), pid]);
-  }
-  let totalKiB = 0;
-  let processes = 0;
-  const stack = [rootPid];
-  while (stack.length > 0) {
-    const pid = stack.pop()!;
-    if (rssByPid.has(pid)) {
-      totalKiB += rssByPid.get(pid)!;
-      processes += 1;
-    }
-    stack.push(...(children.get(pid) ?? []));
-  }
-  return { totalKiB, processes };
 }
 
 type RssSample = { label: string; serverKiB: number; treeKiB: number; treeProcesses: number };

--- a/tests/performance/support/churn-report.ts
+++ b/tests/performance/support/churn-report.ts
@@ -1,14 +1,7 @@
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
-import { repoRoot } from "../../_helpers/realworld-patch.ts";
 import type { LspChurnBudget } from "./churn-metrics.ts";
-
-export function gitHead(): string {
-  const result = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" });
-  return result.status === 0 ? result.stdout.trim() : "unknown";
-}
 
 /** The report fields `summary.md` renders; `metrics.json` serialises the whole payload. */
 export type ChurnReportData = {

--- a/tests/performance/support/incremental-metrics.ts
+++ b/tests/performance/support/incremental-metrics.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -6,6 +5,8 @@ import { inspect } from "node:util";
 import { performance } from "node:perf_hooks";
 
 import { repoRoot } from "../../_helpers/realworld-patch.ts";
+import { writeIncrementalArtifacts } from "./incremental-report.ts";
+import { gitHead, processRssKiB, processTreeRss } from "./process-metrics.ts";
 
 export type IncrementalSuite = {
   /** Metrics directory name under `target/vize-tests/metrics/`. */
@@ -19,6 +20,8 @@ export type LspIncrementalBudget = {
   suite: string;
   laneHardTimeoutMs: number;
   maxPeakRssMiB: number;
+  maxPeakProcessTreeRssMiB: number;
+  maxProcessTreeSize: number;
   laneBudgetsMs: Record<string, number>;
 };
 
@@ -51,14 +54,19 @@ export function loadLspIncrementalBudget(suiteId: string): {
     );
   }
   const budget = owners[0].lspIncrementalBudget!;
-  assertBudgetMs(budget.laneHardTimeoutMs, suiteId, "laneHardTimeoutMs");
-  assertBudgetMs(budget.maxPeakRssMiB, suiteId, "maxPeakRssMiB");
+  assertPositiveInteger(budget.laneHardTimeoutMs, suiteId, "laneHardTimeoutMs");
+  assertPositiveInteger(budget.maxPeakRssMiB, suiteId, "maxPeakRssMiB");
+  assertPositiveInteger(budget.maxPeakProcessTreeRssMiB, suiteId, "maxPeakProcessTreeRssMiB");
+  assertPositiveInteger(budget.maxProcessTreeSize, suiteId, "maxProcessTreeSize");
+  if (budget.maxPeakRssMiB > budget.maxPeakProcessTreeRssMiB) {
+    throw new Error(`${suiteId} maxPeakRssMiB must not exceed maxPeakProcessTreeRssMiB`);
+  }
   const lanes = Object.entries(budget.laneBudgetsMs ?? {});
   if (lanes.length === 0) {
     throw new Error(`${suiteId} laneBudgetsMs must contain every measured lane`);
   }
   for (const [lane, value] of lanes) {
-    assertBudgetMs(value, suiteId, `laneBudgetsMs.${lane}`);
+    assertPositiveInteger(value, suiteId, `laneBudgetsMs.${lane}`);
     if (value > budget.laneHardTimeoutMs) {
       throw new Error(`${suiteId} laneBudgetsMs.${lane} must not exceed laneHardTimeoutMs`);
     }
@@ -94,6 +102,7 @@ type MetricContext = {
 export class IncrementalMetrics {
   private readonly timingsMs: Record<string, number> = {};
   private readonly rssSamplesKiB: Record<string, number> = {};
+  private readonly processTreeSamples: Record<string, { totalKiB: number; processes: number }> = {};
   private readonly processId: number;
   private readonly suite: IncrementalSuite;
   private readonly fixtureId: string;
@@ -139,6 +148,8 @@ export class IncrementalMetrics {
   sampleRss(name: string): void {
     const rss = processRssKiB(this.processId);
     if (rss != null) this.rssSamplesKiB[name] = rss;
+    const tree = processTreeRss(this.processId);
+    if (tree != null) this.processTreeSamples[name] = tree;
   }
 
   /**
@@ -148,13 +159,19 @@ export class IncrementalMetrics {
    * so tooling tests can exercise it without touching metric artifacts.
    */
   assertBudgetsSettled(): void {
-    const peakKiB = this.sampledPeakRssKiB();
-    const ceilingKiB = this.budget.maxPeakRssMiB * 1024 * this.scale;
-    if (peakKiB > ceilingKiB) {
+    const peaks = this.peakSamples();
+    this.assertRss("LSP", peaks.serverKiB, this.budget.maxPeakRssMiB, "maxPeakRssMiB");
+    this.assertRss(
+      "LSP process-tree",
+      peaks.treeKiB,
+      this.budget.maxPeakProcessTreeRssMiB,
+      "maxPeakProcessTreeRssMiB",
+    );
+    if (peaks.processes > this.budget.maxProcessTreeSize) {
       throw this.budgetViolation(
-        `sampled peak RSS ${(peakKiB / 1024).toFixed(1)} MiB is over its ` +
-          `${this.budget.maxPeakRssMiB * this.scale} MiB budget${this.scaleSuffix()}.`,
-        "maxPeakRssMiB",
+        `the LSP process tree grew to ${peaks.processes} processes, over its ` +
+          `${this.budget.maxProcessTreeSize} process ceiling; a worker session is likely leaking.`,
+        "maxProcessTreeSize",
       );
     }
     for (const lane of Object.keys(this.budget.laneBudgetsMs)) {
@@ -200,21 +217,19 @@ export class IncrementalMetrics {
         cpuCount: os.cpus().length,
         cpuModel: os.cpus()[0]?.model ?? "unknown",
       },
-      budget: {
-        scale: this.scale,
-        laneHardTimeoutMs: this.budget.laneHardTimeoutMs,
-        maxPeakRssMiB: this.budget.maxPeakRssMiB,
-        laneBudgetsMs: this.budget.laneBudgetsMs,
-      },
+      budget: { scale: this.scale, ...this.budget },
       timingsMs: this.timingsMs,
       rssSamplesKiB: this.rssSamplesKiB,
+      processTreeSamples: this.processTreeSamples,
       sampledPeakRssKiB: this.sampledPeakRssKiB(),
+      sampledPeakProcessTreeRssKiB: this.peakSamples().treeKiB,
+      sampledPeakProcessTreeSize: this.peakSamples().processes,
       note:
-        "Latency, RSS, and hang ceilings are enforced from the registry lspIncrementalBudget " +
+        "Latency, RSS, process-tree, and hang ceilings are enforced from the registry " +
+        "lspIncrementalBudget " +
         "block; diagnostic, completion, hover, and repair oracles are gated.",
     };
-    fs.writeFileSync(path.join(outputDir, "metrics.json"), `${JSON.stringify(data, null, 2)}\n`);
-    fs.writeFileSync(path.join(outputDir, "summary.md"), renderMarkdown(this.suite.title, data));
+    writeIncrementalArtifacts(outputDir, this.suite.title, data);
     if (budgetFailure != null) throw budgetFailure;
   }
 
@@ -222,6 +237,30 @@ export class IncrementalMetrics {
     // RSS sampling is unavailable on Windows, where the peak stays 0 and the
     // ceiling is effectively latency-only; CI enforcement runs on Linux.
     return Math.max(0, ...Object.values(this.rssSamplesKiB));
+  }
+
+  private peakSamples(): { serverKiB: number; treeKiB: number; processes: number } {
+    return {
+      serverKiB: this.sampledPeakRssKiB(),
+      treeKiB: Math.max(
+        0,
+        ...Object.values(this.processTreeSamples).map((sample) => sample.totalKiB),
+      ),
+      processes: Math.max(
+        0,
+        ...Object.values(this.processTreeSamples).map((sample) => sample.processes),
+      ),
+    };
+  }
+
+  private assertRss(name: string, peakKiB: number, ceilingMiB: number, field: string): void {
+    if (peakKiB > ceilingMiB * 1024 * this.scale) {
+      throw this.budgetViolation(
+        `sampled peak ${name} RSS ${(peakKiB / 1024).toFixed(1)} MiB is over its ` +
+          `${ceilingMiB * this.scale} MiB budget${this.scaleSuffix()}.`,
+        field,
+      );
+    }
   }
 
   /**
@@ -285,65 +324,8 @@ export function countFiles(
   return count;
 }
 
-function assertBudgetMs(value: number, suiteId: string, field: string): void {
+function assertPositiveInteger(value: number, suiteId: string, field: string): void {
   if (!Number.isSafeInteger(value) || value <= 0) {
     throw new Error(`${suiteId} ${field} must be a positive safe integer, got ${inspect(value)}`);
   }
-}
-
-export function processRssKiB(processId: number): number | null {
-  if (process.platform === "win32") return null;
-  const result = spawnSync("ps", ["-o", "rss=", "-p", String(processId)], { encoding: "utf8" });
-  if (result.status !== 0) return null;
-  const value = Number.parseInt(result.stdout.trim(), 10);
-  return Number.isFinite(value) && value > 0 ? value : null;
-}
-
-function gitHead(): string {
-  const result = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" });
-  return result.status === 0 ? result.stdout.trim() : "unknown";
-}
-
-function renderMarkdown(
-  title: string,
-  data: {
-    status: string;
-    fixture: string;
-    fixtureRevision: string;
-    corpus: { vueFiles: number; vueAndTypeScriptFiles: number; baselineDiagnostics: number };
-    budget: { scale: number; maxPeakRssMiB: number; laneBudgetsMs: Record<string, number> };
-    timingsMs: Record<string, number>;
-    sampledPeakRssKiB: number;
-  },
-): string {
-  const scale = data.budget.scale;
-  const lines = [
-    `## ${title}`,
-    "",
-    `Status: **${data.status}**. Fixture: \`${data.fixture}@${data.fixtureRevision}\`.`,
-    "",
-    `Corpus: ${data.corpus.vueFiles} Vue files; ${data.corpus.vueAndTypeScriptFiles} Vue/TS files; ${data.corpus.baselineDiagnostics} baseline diagnostics.`,
-    "",
-    "| Stage | Time | Budget |",
-    "| --- | ---: | ---: |",
-  ];
-  for (const [stage, milliseconds] of Object.entries(data.timingsMs)) {
-    const budgetMs = data.budget.laneBudgetsMs[stage];
-    const budgetCell = budgetMs == null ? "—" : `${budgetMs * scale} ms`;
-    lines.push(`| ${stage} | ${milliseconds.toFixed(1)} ms | ${budgetCell} |`);
-  }
-  lines.push(
-    "",
-    `Sampled peak LSP RSS: ${
-      data.sampledPeakRssKiB > 0
-        ? `${(data.sampledPeakRssKiB / 1024).toFixed(1)} MiB`
-        : "unavailable"
-    } (budget ${data.budget.maxPeakRssMiB * scale} MiB).`,
-    "",
-    `Latency, RSS, and hang ceilings are enforced at scale ${scale} from the registry ` +
-      "lspIncrementalBudget block. The clean/broken/repaired diagnostics, completion, hover, " +
-      "and dependency propagation are hard assertions.",
-    "",
-  );
-  return lines.join("\n");
 }

--- a/tests/performance/support/incremental-report.ts
+++ b/tests/performance/support/incremental-report.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { LspIncrementalBudget } from "./incremental-metrics.ts";
+
+export type IncrementalReportData = {
+  status: string;
+  fixture: string;
+  fixtureRevision: string;
+  corpus: { vueFiles: number; vueAndTypeScriptFiles: number; baselineDiagnostics: number };
+  budget: LspIncrementalBudget & { scale: number };
+  timingsMs: Record<string, number>;
+  sampledPeakRssKiB: number;
+  sampledPeakProcessTreeRssKiB: number;
+  sampledPeakProcessTreeSize: number;
+};
+
+export function writeIncrementalArtifacts(
+  outputDir: string,
+  title: string,
+  data: IncrementalReportData,
+): void {
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(path.join(outputDir, "metrics.json"), `${JSON.stringify(data, null, 2)}\n`);
+  fs.writeFileSync(path.join(outputDir, "summary.md"), renderMarkdown(title, data));
+}
+
+function renderMarkdown(title: string, data: IncrementalReportData): string {
+  const scale = data.budget.scale;
+  const asMiB = (kib: number) => (kib > 0 ? `${(kib / 1024).toFixed(1)} MiB` : "unavailable");
+  const lines = [
+    `## ${title}`,
+    "",
+    `Status: **${data.status}**. Fixture: \`${data.fixture}@${data.fixtureRevision}\`.`,
+    "",
+    `Corpus: ${data.corpus.vueFiles} Vue files; ${data.corpus.vueAndTypeScriptFiles} Vue/TS files; ${data.corpus.baselineDiagnostics} baseline diagnostics.`,
+    "",
+    "| Stage | Time | Budget |",
+    "| --- | ---: | ---: |",
+  ];
+  for (const [stage, milliseconds] of Object.entries(data.timingsMs)) {
+    const budgetMs = data.budget.laneBudgetsMs[stage];
+    const budgetCell = budgetMs == null ? "-" : `${budgetMs * scale} ms`;
+    lines.push(`| ${stage} | ${milliseconds.toFixed(1)} ms | ${budgetCell} |`);
+  }
+  lines.push(
+    "",
+    `Sampled peak LSP RSS: ${asMiB(data.sampledPeakRssKiB)} ` +
+      `(budget ${data.budget.maxPeakRssMiB * scale} MiB).`,
+    `Sampled peak process-tree RSS: ${asMiB(data.sampledPeakProcessTreeRssKiB)} ` +
+      `(budget ${data.budget.maxPeakProcessTreeRssMiB * scale} MiB, max ` +
+      `${data.budget.maxProcessTreeSize} processes; observed ${data.sampledPeakProcessTreeSize}).`,
+    "",
+    `Latency, RSS, process-tree, and hang ceilings are enforced at scale ${scale} from the registry ` +
+      "lspIncrementalBudget block. The clean/broken/repaired diagnostics, completion, hover, " +
+      "and dependency propagation are hard assertions.",
+    "",
+  );
+  return lines.join("\n");
+}

--- a/tests/performance/support/process-metrics.ts
+++ b/tests/performance/support/process-metrics.ts
@@ -1,0 +1,48 @@
+import { spawnSync } from "node:child_process";
+
+import { repoRoot } from "../../_helpers/realworld-patch.ts";
+
+export function processRssKiB(processId: number): number | null {
+  if (process.platform === "win32") return null;
+  const result = spawnSync("ps", ["-o", "rss=", "-p", String(processId)], { encoding: "utf8" });
+  if (result.status !== 0) return null;
+  const value = Number.parseInt(result.stdout.trim(), 10);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+/**
+ * Resident-set total and process count for a process and every live descendant,
+ * so leaked Corsa/tsgo worker sessions show up even when the `vize lsp` parent
+ * remains within its own RSS budget. Unavailable on Windows, where CI relies on
+ * the Linux vue-parity lane for process-tree enforcement.
+ */
+export function processTreeRss(rootPid: number): { totalKiB: number; processes: number } | null {
+  if (process.platform === "win32") return null;
+  const result = spawnSync("ps", ["-Ao", "pid=,ppid=,rss="], { encoding: "utf8" });
+  if (result.status !== 0) return null;
+  const children = new Map<number, number[]>();
+  const rssByPid = new Map<number, number>();
+  for (const line of result.stdout.trim().split("\n")) {
+    const [pid, ppid, rss] = line.trim().split(/\s+/).map(Number);
+    if (!Number.isSafeInteger(pid) || !Number.isSafeInteger(ppid)) continue;
+    rssByPid.set(pid, Number.isFinite(rss) ? rss : 0);
+    children.set(ppid, [...(children.get(ppid) ?? []), pid]);
+  }
+  let totalKiB = 0;
+  let processes = 0;
+  const stack = [rootPid];
+  while (stack.length > 0) {
+    const pid = stack.pop()!;
+    if (rssByPid.has(pid)) {
+      totalKiB += rssByPid.get(pid)!;
+      processes += 1;
+    }
+    stack.push(...(children.get(pid) ?? []));
+  }
+  return { totalKiB, processes };
+}
+
+export function gitHead(): string {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], { cwd: repoRoot, encoding: "utf8" });
+  return result.status === 0 ? result.stdout.trim() : "unknown";
+}

--- a/tests/performance/support/process-metrics.ts
+++ b/tests/performance/support/process-metrics.ts
@@ -26,7 +26,12 @@ export function processTreeRss(rootPid: number): { totalKiB: number; processes: 
     const [pid, ppid, rss] = line.trim().split(/\s+/).map(Number);
     if (!Number.isSafeInteger(pid) || !Number.isSafeInteger(ppid)) continue;
     rssByPid.set(pid, Number.isFinite(rss) ? rss : 0);
-    children.set(ppid, [...(children.get(ppid) ?? []), pid]);
+    const siblings = children.get(ppid);
+    if (siblings == null) {
+      children.set(ppid, [pid]);
+    } else {
+      siblings.push(pid);
+    }
   }
   let totalKiB = 0;
   let processes = 0;

--- a/tests/tooling/lsp-incremental-budgets.test.ts
+++ b/tests/tooling/lsp-incremental-budgets.test.ts
@@ -4,11 +4,7 @@ import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
-import {
-  ChurnMetrics,
-  loadLspChurnBudget,
-  processTreeRss,
-} from "../performance/support/churn-metrics.ts";
+import { ChurnMetrics, loadLspChurnBudget } from "../performance/support/churn-metrics.ts";
 import {
   budgetRegistryPath,
   budgetScaleVariable,
@@ -134,7 +130,7 @@ test("peak RSS over its ceiling fails settlement with rebaseline instructions", 
   assert.throws(
     () => metrics.assertBudgetsSettled(),
     (error: Error) => {
-      assert.match(error.message, /sampled peak RSS .* MiB is over its 0\.256 MiB budget/);
+      assert.match(error.message, /sampled peak LSP RSS .* MiB is over its 0\.256 MiB budget/);
       assert.match(error.message, /raising maxPeakRssMiB/);
       assert.ok(error.message.includes(budgetRegistryPath));
       return true;
@@ -243,17 +239,6 @@ test("churn settlement gates cycle count, RSS ceilings, and latency decay", asyn
   );
 });
 
-test("process-tree RSS accounting sees the probing process itself", () => {
-  const tree = processTreeRss(process.pid);
-  if (process.platform === "win32") {
-    assert.equal(tree, null);
-    return;
-  }
-  assert.ok(tree != null, "ps-based tree sampling must work on POSIX hosts");
-  assert.ok(tree.processes >= 1, "the root process must be part of its own tree");
-  assert.ok(tree.totalKiB > 0, "a live process tree has resident memory");
-});
-
 test("incremental LSP suites carry complete enforced budget blocks", () => {
   const owners = readBudgetOwners();
 
@@ -307,6 +292,18 @@ test("incremental LSP suites carry complete enforced budget blocks", () => {
     assert.ok(
       Number.isSafeInteger(budget.maxPeakRssMiB) && budget.maxPeakRssMiB > 0,
       `${id} maxPeakRssMiB must be a positive integer`,
+    );
+    assert.ok(
+      Number.isSafeInteger(budget.maxPeakProcessTreeRssMiB) && budget.maxPeakProcessTreeRssMiB > 0,
+      `${id} maxPeakProcessTreeRssMiB must be a positive integer`,
+    );
+    assert.ok(
+      budget.maxPeakRssMiB <= budget.maxPeakProcessTreeRssMiB,
+      `${id} process-tree RSS budget must cover the server RSS budget`,
+    );
+    assert.ok(
+      Number.isSafeInteger(budget.maxProcessTreeSize) && budget.maxProcessTreeSize > 0,
+      `${id} maxProcessTreeSize must be a positive integer`,
     );
     for (const [lane, budgetMs] of Object.entries(budget.laneBudgetsMs)) {
       assert.ok(

--- a/tests/tooling/lsp-incremental-process-tree.test.ts
+++ b/tests/tooling/lsp-incremental-process-tree.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  budgetRegistryPath,
+  IncrementalMetrics,
+} from "../performance/support/incremental-metrics.ts";
+import type { LspIncrementalBudget } from "../performance/support/incremental-metrics.ts";
+import { processTreeRss } from "../performance/support/process-metrics.ts";
+
+const suite = { id: "misskey-lsp-incremental", title: "Misskey LSP Incremental Oracle" };
+
+function mutableBudget(metrics: IncrementalMetrics): LspIncrementalBudget {
+  return (metrics as unknown as { budget: LspIncrementalBudget }).budget;
+}
+
+test("process-tree RSS accounting sees the probing process itself", () => {
+  const tree = processTreeRss(process.pid);
+  if (process.platform === "win32") {
+    assert.equal(tree, null);
+    return;
+  }
+  assert.ok(tree != null, "ps-based tree sampling must work on POSIX hosts");
+  assert.ok(tree.processes >= 1, "the root process must be part of its own tree");
+  assert.ok(tree.totalKiB > 0, "a live process tree has resident memory");
+});
+
+test("incremental process-tree RSS failures point at the registry ceiling", (t) => {
+  if (process.platform === "win32") {
+    t.skip("process-tree RSS accounting is Linux/POSIX only");
+    return;
+  }
+  const metrics = new IncrementalMetrics(process.pid, suite);
+  const budget = mutableBudget(metrics);
+  budget.maxPeakRssMiB = 1_000_000;
+  budget.maxPeakProcessTreeRssMiB = 1;
+  metrics.sampleRss("probe");
+  assert.throws(
+    () => metrics.assertBudgetsSettled(),
+    (error: Error) => {
+      assert.match(
+        error.message,
+        /sampled peak LSP process-tree RSS .* MiB is over its 1 MiB budget/,
+      );
+      assert.match(error.message, /raising maxPeakProcessTreeRssMiB/);
+      assert.ok(error.message.includes(budgetRegistryPath));
+      return true;
+    },
+  );
+});
+
+test("incremental process count failures catch leaked bridge workers", (t) => {
+  if (process.platform === "win32") {
+    t.skip("process-tree process counting is Linux/POSIX only");
+    return;
+  }
+  const metrics = new IncrementalMetrics(process.pid, suite);
+  const budget = mutableBudget(metrics);
+  budget.maxPeakRssMiB = 1_000_000;
+  budget.maxPeakProcessTreeRssMiB = 1_000_000;
+  budget.maxProcessTreeSize = 0;
+  metrics.sampleRss("probe");
+  assert.throws(
+    () => metrics.assertBudgetsSettled(),
+    (error: Error) => {
+      assert.match(error.message, /the LSP process tree grew to \d+ processes/);
+      assert.match(error.message, /worker session is likely leaking/);
+      assert.match(error.message, /raising maxProcessTreeSize/);
+      return true;
+    },
+  );
+});

--- a/tests/tooling/lsp-incremental-process-tree.test.ts
+++ b/tests/tooling/lsp-incremental-process-tree.test.ts
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import { test } from "node:test";
 
 import {
@@ -10,19 +12,36 @@ import { processTreeRss } from "../performance/support/process-metrics.ts";
 
 const suite = { id: "misskey-lsp-incremental", title: "Misskey LSP Incremental Oracle" };
 
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 function mutableBudget(metrics: IncrementalMetrics): LspIncrementalBudget {
   return (metrics as unknown as { budget: LspIncrementalBudget }).budget;
 }
 
-test("process-tree RSS accounting sees the probing process itself", () => {
+test("process-tree RSS accounting sees the probing process and a child", async () => {
   const tree = processTreeRss(process.pid);
   if (process.platform === "win32") {
     assert.equal(tree, null);
     return;
   }
-  assert.ok(tree != null, "ps-based tree sampling must work on POSIX hosts");
-  assert.ok(tree.processes >= 1, "the root process must be part of its own tree");
-  assert.ok(tree.totalKiB > 0, "a live process tree has resident memory");
+  const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+    stdio: "ignore",
+  });
+  try {
+    await once(child, "spawn");
+    let sampled = tree;
+    for (let tries = 0; tries < 50; tries += 1) {
+      sampled = processTreeRss(process.pid);
+      if (sampled != null && sampled.processes >= 2) break;
+      await delay(20);
+    }
+    assert.ok(sampled != null, "ps-based tree sampling must work on POSIX hosts");
+    assert.ok(sampled.processes >= 2, "the root and child processes must both be counted");
+    assert.ok(sampled.totalKiB > 0, "a live process tree has resident memory");
+  } finally {
+    child.kill();
+    await Promise.race([once(child, "exit"), delay(1_000)]);
+  }
 });
 
 test("incremental process-tree RSS failures point at the registry ceiling", (t) => {


### PR DESCRIPTION
## Summary
- add process-tree RSS and process-count ceilings to incremental LSP budgets
- share process sampling across incremental and churn metrics
- keep incremental reporting split from metric collection so source-length gates stay clean

## Verification
- COREPACK_HOME=/tmp/vize-corepack-lsp-process-tree corepack pnpm exec node --test --test-concurrency=1 tests/tooling/lsp-incremental-budgets.test.ts tests/tooling/lsp-incremental-process-tree.test.ts tests/tooling/github-workflows-vue-parity.test.ts
- COREPACK_HOME=/tmp/vize-corepack-lsp-process-tree corepack pnpm exec oxfmt --check tests/performance/support/incremental-metrics.ts tests/performance/support/incremental-report.ts tests/performance/support/churn-metrics.ts tests/performance/support/churn-report.ts tests/performance/support/process-metrics.ts tests/tooling/lsp-incremental-budgets.test.ts tests/tooling/lsp-incremental-process-tree.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791435460&installation_model_id=422833&pr_number=5949&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5949&signature=1fd628dfe472eaaec31b712d5987b8c58c2547c16b0c1e078ccd52e3b7fe6ab9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added process-tree memory and process-count monitoring to incremental LSP performance benchmarks.
  - Added configurable limits for peak process-tree memory and process count.
  - Enhanced benchmark reports with process-tree metrics and Markdown summaries.

- **Bug Fixes**
  - Improved budget validation to ensure process-tree limits are positive and consistent with existing memory limits.

- **Tests**
  - Added coverage for process-tree metrics, platform-specific behavior, and budget violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->