### PR TITLE
test(lsp): fail closed on missing process tree samples

### DIFF
--- a/tests/performance/support/churn-metrics.ts
+++ b/tests/performance/support/churn-metrics.ts
@@ -193,6 +193,7 @@ export class ChurnMetrics {
         );
       }
     }
+    this.assertProcessTreeObserved(peakProcesses);
   }
 
   write(context: ChurnContext, failure?: unknown): void {
@@ -252,6 +253,15 @@ export class ChurnMetrics {
       treeKiB: Math.max(0, ...this.rssSamples.map((s) => s.treeKiB)),
       processes: Math.max(0, ...this.rssSamples.map((s) => s.treeProcesses)),
     };
+  }
+
+  private assertProcessTreeObserved(peakProcesses: number): void {
+    if (process.platform === "win32") return;
+    if (this.rssSamples.length > 0 && peakProcesses > 0) return;
+    throw new Error(
+      `${this.suite.title}: process-tree RSS sampling did not observe LSP server process ` +
+        `${this.processId}; cannot enforce maxPeakProcessTreeRssMiB or maxProcessTreeSize.`,
+    );
   }
 
   private assertRss(name: string, peakKiB: number, ceilingMiB: number, field: string): void {

--- a/tests/performance/support/incremental-metrics.ts
+++ b/tests/performance/support/incremental-metrics.ts
@@ -183,6 +183,7 @@ export class IncrementalMetrics {
         );
       }
     }
+    this.assertProcessTreeObserved(peaks);
   }
 
   write(context: MetricContext, failure?: unknown): void {
@@ -251,6 +252,15 @@ export class IncrementalMetrics {
         ...Object.values(this.processTreeSamples).map((sample) => sample.processes),
       ),
     };
+  }
+
+  private assertProcessTreeObserved(peaks: { processes: number }): void {
+    if (process.platform === "win32") return;
+    if (Object.keys(this.processTreeSamples).length > 0 && peaks.processes > 0) return;
+    throw new Error(
+      `${this.suite.title}: process-tree RSS sampling did not observe LSP server process ` +
+        `${this.processId}; cannot enforce maxPeakProcessTreeRssMiB or maxProcessTreeSize.`,
+    );
   }
 
   private assertRss(name: string, peakKiB: number, ceilingMiB: number, field: string): void {

--- a/tests/performance/support/process-metrics.ts
+++ b/tests/performance/support/process-metrics.ts
@@ -33,6 +33,7 @@ export function processTreeRss(rootPid: number): { totalKiB: number; processes: 
       siblings.push(pid);
     }
   }
+  if (!rssByPid.has(rootPid)) return null;
   let totalKiB = 0;
   let processes = 0;
   const stack = [rootPid];

--- a/tests/tooling/lsp-incremental-process-tree.test.ts
+++ b/tests/tooling/lsp-incremental-process-tree.test.ts
@@ -52,7 +52,7 @@ test("process-tree RSS accounting sees the probing process and a child", async (
   }
 });
 
-test("process-tree RSS accounting returns null when the root process is absent", (t) => {
+test("process-tree RSS accounting returns null when the root process is absent", () => {
   const tree = processTreeRss(absentPid);
   if (process.platform === "win32") {
     assert.equal(tree, null);

--- a/tests/tooling/lsp-incremental-process-tree.test.ts
+++ b/tests/tooling/lsp-incremental-process-tree.test.ts
@@ -3,6 +3,8 @@ import { spawn } from "node:child_process";
 import { once } from "node:events";
 import { test } from "node:test";
 
+import { ChurnMetrics } from "../performance/support/churn-metrics.ts";
+import type { LspChurnBudget } from "../performance/support/churn-metrics.ts";
 import {
   budgetRegistryPath,
   IncrementalMetrics,
@@ -11,11 +13,17 @@ import type { LspIncrementalBudget } from "../performance/support/incremental-me
 import { processTreeRss } from "../performance/support/process-metrics.ts";
 
 const suite = { id: "misskey-lsp-incremental", title: "Misskey LSP Incremental Oracle" };
+const churnSuite = { id: "misskey-lsp-churn", title: "Misskey LSP Churn Stress Oracle" };
+const absentPid = Number.MAX_SAFE_INTEGER;
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function mutableBudget(metrics: IncrementalMetrics): LspIncrementalBudget {
   return (metrics as unknown as { budget: LspIncrementalBudget }).budget;
+}
+
+function mutableChurnBudget(metrics: ChurnMetrics): LspChurnBudget {
+  return (metrics as unknown as { budget: LspChurnBudget }).budget;
 }
 
 test("process-tree RSS accounting sees the probing process and a child", async () => {
@@ -44,6 +52,15 @@ test("process-tree RSS accounting sees the probing process and a child", async (
   }
 });
 
+test("process-tree RSS accounting returns null when the root process is absent", (t) => {
+  const tree = processTreeRss(absentPid);
+  if (process.platform === "win32") {
+    assert.equal(tree, null);
+    return;
+  }
+  assert.equal(tree, null);
+});
+
 test("incremental process-tree RSS failures point at the registry ceiling", (t) => {
   if (process.platform === "win32") {
     t.skip("process-tree RSS accounting is Linux/POSIX only");
@@ -63,6 +80,51 @@ test("incremental process-tree RSS failures point at the registry ceiling", (t) 
       );
       assert.match(error.message, /raising maxPeakProcessTreeRssMiB/);
       assert.ok(error.message.includes(budgetRegistryPath));
+      return true;
+    },
+  );
+});
+
+test("incremental settlement fails when process-tree sampling misses the server pid", (t) => {
+  if (process.platform === "win32") {
+    t.skip("process-tree RSS accounting is Linux/POSIX only");
+    return;
+  }
+  const metrics = new IncrementalMetrics(absentPid, suite);
+  const budget = mutableBudget(metrics);
+  budget.maxPeakRssMiB = 1_000_000;
+  budget.maxPeakProcessTreeRssMiB = 1_000_000;
+  budget.maxProcessTreeSize = 1_000_000;
+  budget.laneBudgetsMs = {};
+  metrics.sampleRss("missing-server");
+  assert.throws(
+    () => metrics.assertBudgetsSettled(),
+    (error: Error) => {
+      assert.match(error.message, /process-tree RSS sampling did not observe LSP server process/);
+      assert.match(error.message, /cannot enforce maxPeakProcessTreeRssMiB or maxProcessTreeSize/);
+      return true;
+    },
+  );
+});
+
+test("churn settlement fails when process-tree sampling misses the server pid", (t) => {
+  if (process.platform === "win32") {
+    t.skip("process-tree RSS accounting is Linux/POSIX only");
+    return;
+  }
+  const metrics = new ChurnMetrics(absentPid, churnSuite);
+  const budget = mutableChurnBudget(metrics);
+  budget.cyclesPerPhase = 0;
+  budget.maxPeakRssMiB = 1_000_000;
+  budget.maxPeakProcessTreeRssMiB = 1_000_000;
+  budget.maxProcessTreeSize = 1_000_000;
+  budget.budgetsMs = {};
+  metrics.sampleRss("missing-server");
+  assert.throws(
+    () => metrics.assertSettled(),
+    (error: Error) => {
+      assert.match(error.message, /process-tree RSS sampling did not observe LSP server process/);
+      assert.match(error.message, /cannot enforce maxPeakProcessTreeRssMiB or maxProcessTreeSize/);
       return true;
     },
   );


### PR DESCRIPTION
## Summary
- return null when process-tree sampling cannot find the requested LSP server pid
- fail incremental and churn LSP perf settlement when no live process-tree sample was observed
- cover absent-pid sampling for incremental and churn budget guards

## Verification
- node --test --test-concurrency=1 tests/tooling/lsp-incremental-process-tree.test.ts tests/tooling/lsp-incremental-budgets.test.ts
- VIZE_TEST_REQUIRE_TSGO=1 node --test --test-concurrency=1 tests/tooling/lsp-incremental-process-tree.test.ts tests/tooling/lsp-incremental-budgets.test.ts
- COREPACK_HOME=/tmp/vize-corepack-lsp-process-tree corepack pnpm exec oxfmt --check tests/performance/support/process-metrics.ts tests/performance/support/incremental-metrics.ts tests/performance/support/churn-metrics.ts tests/tooling/lsp-incremental-process-tree.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791440668&installation_model_id=422833&pr_number=5955&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5955&signature=f65f4e0dcf1ffa75ecf8f4effb7e67fd2dcc73b3c591e04e37adf00721fe4816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->