### PR TITLE
test: cover content mapper declaration tsc smoke

### DIFF
--- a/tests/tooling/content-mapper-package-contract.test.ts
+++ b/tests/tooling/content-mapper-package-contract.test.ts
@@ -3,8 +3,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
-import { assertInstalledMapperContract } from "../../legacy-tools/npm/smoke-release-runtime.mjs";
+import {
+  assertInstalledMapperContract,
+  runInstalledContentMapperChecks,
+} from "../../legacy-tools/npm/smoke-release-runtime.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
 function withInstalledMapper(run: (installDir: string, packageRoot: string) => void): void {
   const installDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-mapper-contract-"));
@@ -106,5 +112,63 @@ test("installed Content Mapper contract rejects a missing executable", () => {
   withInstalledMapper((installDir, packageRoot) => {
     fs.rmSync(path.join(packageRoot, "bin", "vize"));
     assert.throws(() => assertInstalledMapperContract(installDir), /bin[/\\]vize must exist/);
+  });
+});
+
+test("installed Content Mapper release smoke compares declarations with TypeScript 7 tsc", () => {
+  withInstalledMapper((installDir) => {
+    const tsgo = path.join(installDir, "tsgo-stub.mjs");
+    fs.writeFileSync(
+      tsgo,
+      [
+        "#!/usr/bin/env node",
+        "if (process.argv.includes('-p') && process.argv.includes('tsconfig.error.json')) {",
+        "  process.stdout.write('errors/Broken.vue TS2322\\n');",
+        "  process.stdout.write('errors/JavaScriptConsumer.js TS2322\\n');",
+        "  process.stdout.write('errors/JsxConsumer.jsx TS2322\\n');",
+        "  process.stdout.write('src/Unused.vue TS6133\\n');",
+        "  process.exit(1);",
+        "}",
+        "process.exit(0);",
+        "",
+      ].join("\n"),
+    );
+    fs.chmodSync(tsgo, 0o755);
+
+    const tscBin = path.join(installDir, "node_modules", "typescript", "bin", "tsc");
+    fs.mkdirSync(path.dirname(tscBin), { recursive: true });
+    fs.writeFileSync(tscBin, "#!/usr/bin/env node\n");
+    fs.chmodSync(tscBin, 0o755);
+
+    const calls: { args: string[]; command: string; cwd?: string }[] = [];
+    const before = process.env.VIZE_TEST_CONTENT_MAPPER_TSGO;
+    process.env.VIZE_TEST_CONTENT_MAPPER_TSGO = tsgo;
+    try {
+      runInstalledContentMapperChecks(installDir, root, (command, args, options) => {
+        calls.push({ args, command, cwd: options.cwd });
+        if (args.includes("tsconfig.emit.json")) {
+          const dist = path.join(options.cwd, "dist");
+          fs.mkdirSync(dist, { recursive: true });
+          fs.writeFileSync(path.join(dist, "App.vue.d.ts"), "export {}\n");
+          fs.writeFileSync(path.join(dist, "main.d.ts"), "export {}\n");
+        }
+      });
+    } finally {
+      if (before == null) {
+        delete process.env.VIZE_TEST_CONTENT_MAPPER_TSGO;
+      } else {
+        process.env.VIZE_TEST_CONTENT_MAPPER_TSGO = before;
+      }
+    }
+
+    assert.ok(
+      calls.some(
+        (call) =>
+          call.command === process.execPath &&
+          call.args[0] === tscBin &&
+          call.args.includes("dist/verify.ts"),
+      ),
+      "declaration consumer smoke must compare against the installed TypeScript 7 bin/tsc launcher",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add a release-smoke unit guard that exercises the installed Content Mapper helper with the real fixture copy path
- assert declaration-consumer verification still invokes the installed TypeScript 7 `node_modules/typescript/bin/tsc` launcher

## Validation
- `npm view vue-tsc@latest version peerDependencies --json`
- `npm view typescript@7.0.2 bin optionalDependencies version --json`
- `node --test tests/tooling/content-mapper-package-contract.test.ts`
- `node --test tests/tooling/content-mapper-manifest.test.ts tests/tooling/content-mapper-package-contract.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791441738&installation_model_id=422833&pr_number=5956&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5956&signature=0e97452c7d00059ae0ff2a43be3358a7cff58e085a8f3121b1aaf9d6611eb4d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage to verify that the installed Content Mapper release can compare declarations using the installed TypeScript 7 compiler launcher.
  - Expanded smoke-test validation for packaged release behavior and compatibility with the supported TypeScript tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->