### PR TITLE
test(typechecker): require benchmark comparison rows

### DIFF
--- a/tests/tooling/tool-benchmark-engine-classes.test.ts
+++ b/tests/tooling/tool-benchmark-engine-classes.test.ts
@@ -138,6 +138,7 @@ test("a cross-engine surface with no same-engine incumbent still publishes nothi
   const nativeIncumbents = ["verter-tsc", "golar-typecheck", "golar-default"];
   const surface = createSurface(
     checkSurfaceInput({
+      id: "custom-check",
       variants: CHECK_VARIANTS.filter((variant) => !nativeIncumbents.includes(variant.id)),
     }),
   );
@@ -177,7 +178,7 @@ test("a same-engine surface keeps its ranked primary speedup", () => {
 
 test("a surface without a measurable Vize lane reports no speedup at all", () => {
   const surface = createSurface({
-    id: "check",
+    id: "custom-check",
     label: "Type check",
     files: 1,
     bytes: 1,

--- a/tests/tooling/tool-benchmark-typecheck-coverage.test.ts
+++ b/tests/tooling/tool-benchmark-typecheck-coverage.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { createSurface } from "../../tools/benchmarks/scripts/compare-tools-report.mjs";
+
+const CHECK_ENGINE_CLASSES = {
+  "golar-default": "tsgo-native",
+  "golar-typecheck": "tsgo-native",
+  "verter-tsc": "tsgo-native",
+  "vue-tsc": "typescript-js",
+  "vize-check-1t": "tsgo-native",
+  "vize-check-max": "tsgo-native",
+};
+
+const CHECK_VARIANTS = [
+  { id: "vue-tsc", label: "vue-tsc", medianMs: 8000, throughput: "62.5 files/s", runs: [8000] },
+  {
+    id: "verter-tsc",
+    label: "verter-tsc",
+    medianMs: 1000,
+    throughput: "500 files/s",
+    runs: [1000],
+  },
+  {
+    id: "golar-typecheck",
+    label: "Golar typecheck",
+    medianMs: 1500,
+    throughput: "333 files/s",
+    runs: [1500],
+  },
+  {
+    id: "golar-default",
+    label: "Golar (lint+check)",
+    medianMs: 2500,
+    throughput: "200 files/s",
+    runs: [2500],
+  },
+  {
+    id: "vize-check-1t",
+    label: "Vize check (1T)",
+    medianMs: 2000,
+    throughput: "250 files/s",
+    runs: [2000],
+  },
+  {
+    id: "vize-check-max",
+    label: "Vize check (max)",
+    medianMs: 500,
+    throughput: "1k files/s",
+    runs: [500],
+  },
+];
+
+function checkSurface(variants = CHECK_VARIANTS) {
+  return {
+    id: "check",
+    label: "Type check",
+    files: 500,
+    bytes: 1_000_000,
+    baselineId: "vue-tsc",
+    vizeSingleId: "vize-check-1t",
+    vizeMaxId: "vize-check-max",
+    engineClasses: CHECK_ENGINE_CLASSES,
+    variants,
+  };
+}
+
+test("generated type-check benchmark surfaces require every engine-class row", () => {
+  for (const id of Object.keys(CHECK_ENGINE_CLASSES)) {
+    assert.throws(
+      () => createSurface(checkSurface(CHECK_VARIANTS.filter((variant) => variant.id !== id))),
+      new RegExp(`compare-tools: check is missing required engine-class variants: ${id}`),
+      id,
+    );
+  }
+});
+
+test("complete type-check benchmark surfaces still publish the in-class ratio", () => {
+  const surface = createSurface(checkSurface());
+
+  assert.equal(surface.speedupStatus, "in-class");
+  assert.equal(surface.speedupBaselineId, "verter-tsc");
+  assert.equal(surface.primarySpeedup, 2);
+});

--- a/tools/benchmarks/scripts/compare-tools-report.mjs
+++ b/tools/benchmarks/scripts/compare-tools-report.mjs
@@ -59,6 +59,25 @@ export const IN_CLASS_BASELINES_BY_SURFACE = {
   "large-check": ["verter-tsc", "golar-typecheck"],
 };
 
+function assertRequiredEngineVariants(surface) {
+  const expected = ENGINE_CLASSES_BY_SURFACE[surface.id];
+  if (expected == null && !surface.requireEngineVariants) {
+    return;
+  }
+  if (expected == null) {
+    throw new Error(
+      `compare-tools: ${surface.id} requested engine-variant coverage but has no engine class map`,
+    );
+  }
+  const actualIds = new Set(surface.variants.map((variant) => variant.id));
+  const missing = Object.keys(expected).filter((id) => !actualIds.has(id));
+  if (missing.length > 0) {
+    throw new Error(
+      `compare-tools: ${surface.id} is missing required engine-class variants: ${missing.join(", ")}`,
+    );
+  }
+}
+
 export function formatSpeedup(value) {
   if (!Number.isFinite(value)) {
     return "n/a";
@@ -144,6 +163,8 @@ export function rankWithinEngineClasses(surface) {
  * Attach the primary speedup, refusing to compute one across engine classes.
  */
 export function createSurface(surface) {
+  assertRequiredEngineVariants(surface);
+  const { requireEngineVariants: _requireEngineVariants, ...outputSurface } = surface;
   const vizeMax = getVariant(surface, surface.vizeMaxId);
   const comparable = vizeMax != null && vizeMax.medianMs > 0;
   const { crossEngine, inClass, baseline } = resolveSpeedupBaseline(surface);
@@ -156,7 +177,7 @@ export function createSurface(surface) {
   }
 
   return {
-    ...surface,
+    ...outputSurface,
     // `null`, not NaN: NaN serialises to `null` in the JSON artifact anyway, so
     // the in-memory value must say the same thing the artifact says.
     primarySpeedup: ranked ? baseline.medianMs / vizeMax.medianMs : null,


### PR DESCRIPTION
## Summary
- require the generated type-check benchmark surfaces to include every declared engine-class row
- add coverage tests for the vue-tsc, verter-tsc, Golar, and Vize check rows
- keep generic cross-engine rendering behavior covered separately

## Validation
- node --test tests/tooling/tool-benchmark-engine-classes.test.ts tests/tooling/tool-benchmark-typecheck-coverage.test.ts tests/tooling/tool-benchmark.test.ts tests/tooling/published-benchmark-ratios.test.ts
- vp check tools/benchmarks/scripts/compare-tools-report.mjs tests/tooling/tool-benchmark-engine-classes.test.ts tests/tooling/tool-benchmark-typecheck-coverage.test.ts
- rust-script tools/commands/ci/source-file-lengths.rs --check --base-ref origin/main --max-lines 350
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/5957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791441891&installation_model_id=422833&pr_number=5957&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F5957&signature=8df782cca7bf3bcd3589e26194182e0a42b0893c7d9004f482035016aa066370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Benchmark comparisons now reject incomplete engine-variant coverage, preventing misleading or incomplete speedup results.
  - Valid benchmark surfaces continue to report the correct baseline and in-class speedup status.

- **Tests**
  - Added coverage for missing engine variants across type-check benchmark scenarios.
  - Updated benchmark tests to verify behavior for custom surface identifiers and cases without measurable speedups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->